### PR TITLE
Server-only component YAML cleanup

### DIFF
--- a/Resources/Prototypes/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/slimes.yml
@@ -37,7 +37,7 @@
         - state: lung-l-slime
         - state: lung-r-slime
     - type: Lung
-      Alert: LowNitrogen
+      alert: LowNitrogen
     - type: Metabolizer
       removeEmpty: true
       solutionOnBody: false

--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -46,7 +46,7 @@
         - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: Metabolizer
-    updateFrequency: 1.5
+    updateInterval: 1.5
 
 - type: entity
   id: OrganArachnidLungs

--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -60,7 +60,7 @@
       - state: lung-r
   - type: Lung
   - type: Metabolizer
-    updateFrequency: 1.5
+    updateInterval: 1.5
     removeEmpty: true
     solutionOnBody: false
     solution: "Lung"
@@ -92,7 +92,7 @@
   - type: Sprite
     state: heart-on
   - type: Metabolizer
-    updateFrequency: 1.5
+    updateInterval: 1.5
     maxReagents: 2
     metabolizerTypes: [Arachnid]
     groups:
@@ -110,7 +110,7 @@
   - type: Sprite
     state: liver
   - type: Metabolizer # The liver metabolizes certain chemicals only, like alcohol.
-    updateFrequency: 1.5
+    updateInterval: 1.5
     maxReagents: 1
     metabolizerTypes: [Animal]
     groups:
@@ -130,7 +130,7 @@
       - state: kidney-r
   # The kidneys just remove anything that doesn't currently have any metabolisms, as a stopgap.
   - type: Metabolizer
-    updateFrequency: 1.5
+    updateInterval: 1.5
     maxReagents: 5
     metabolizerTypes: [Animal]
     removeEmpty: true

--- a/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
@@ -28,4 +28,3 @@
   suffix: Voice Mask, Chameleon
   components:
     - type: VoiceMasker
-      default: ClothingMaskGas

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -902,9 +902,8 @@
         maxVol: 250
   - type: Udder
     reagentId: MilkGoat
-    targetSolution: udder
-    quantity: 25
-    updateRate: 20
+    quantityPerUpdate: 25
+    growthDelay: 20
   - type: Wooly
   - type: Food
     solution: wool

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -84,7 +84,7 @@
         500: Dead
     - type: Metabolizer
       solutionOnBody: false
-      updateFrequency: 0.25
+      updateInterval: 0.25
       metabolizerTypes: [ Dragon ]
       groups:
         - id: Medicine
@@ -165,7 +165,6 @@
     explosionMaxTileIntensity: 10
   - type: ProjectileAnomaly
     projectilePrototype: ProjectileIcicle
-    targetNonSentientChance: 0.1
   - type: TempAffectingAnomaly
     tempChangePerSecond: -25
     hotspotExposeTemperature: -1000

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -60,7 +60,6 @@
   - type: NameIdentifier
     group: GenericNumber
   - type: Repairable
-    fuelcost: 15
     doAfterDelay: 8
   - type: Pullable
   - type: Tag

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -86,7 +86,7 @@
       methods: [ Touch ]
       effects:
       - !type:HealthChange
-        scaled: true
+        scaleByQuantity: true
         damage:
           types:
             Heat: 3

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -69,8 +69,6 @@
     followEntity: true
   - type: CargoOrderConsole
   - type: CrewMonitoringConsole
-    snap: false
-    precision: 3
   - type: GeneralStationRecordConsole
   - type: DeviceNetwork
     deviceNetId: Wireless

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -87,7 +87,7 @@
       500: Dead
   - type: Metabolizer
     solutionOnBody: false
-    updateFrequency: 0.25
+    updateInterval: 0.25
     metabolizerTypes: [ Dragon ]
     groups:
     - id: Medicine
@@ -132,8 +132,6 @@
   id: MobDragon
   components:
   - type: Dragon
-    spawnsLeft: 2
-    spawnsProto: MobCarpDragon
     spawnRiftAction: ActionSpawnRift
   - type: GenericAntag
     rule: Dragon

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -61,7 +61,7 @@
       methods: [ Touch ]
       effects:
       - !type:HealthChange
-        scaled: true
+        scaleByQuantity: true
         damage:
           types:
             Poison: 5

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -46,7 +46,7 @@
       methods: [ Touch ]
       effects:
       - !type:HealthChange
-        scaled: true
+        scaleByQuantity: true
         damage:
           types:
             Blunt: 2

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -52,7 +52,7 @@
       methods: [ Touch ]
       effects:
       - !type:HealthChange
-        scaled: true
+        scaleByQuantity: true
         damage:
           types:
             Heat: 2

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -711,7 +711,7 @@
     state: suppermatter
   - type: SliceableFood
     slice: FoodCakeSuppermatterSlice
-    TotalCount: 8
+    count: 8
   - type: SolutionContainerManager
     solutions:
       food:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -32,7 +32,6 @@
     size: Tiny
   - type: Drink
     solution: food
-    refillable: false
   - type: Openable
     sound:
       collection: packetOpenSounds

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
@@ -35,6 +35,5 @@
         acts: [ "Destruction" ]
   - type: ApcPowerReceiver
     powerLoad: 15000
-    priority: High
   - type: StaticPrice
     price: 1500

--- a/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
@@ -90,5 +90,6 @@
         sprite: Structures/Doors/Airlocks/Standard/security.rsi
         state: closed
     - type: LogProbeCartridge
+    - type: GuideHelp
       guides:
         - Forensics

--- a/Resources/Prototypes/Entities/Objects/Devices/payload.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/payload.yml
@@ -33,7 +33,6 @@
     maxIntensity: 10
     intensitySlope: 3
     totalIntensity: 120 # about a ~4 tile radius
-    flashRange: 7
   - type: ExplodeOnTrigger
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1177,7 +1177,6 @@
   description: New Sandy-Cat plastic sword! Comes with realistic sound and full color! Looks almost like the real thing!
   components:
     - type: EnergySword
-      isSharp: false
       colorOptions:
         - DodgerBlue
     - type: ItemToggle

--- a/Resources/Prototypes/Entities/Objects/Misc/desk_bell.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/desk_bell.yml
@@ -14,9 +14,9 @@
     successChance: 1
     interactSuccessSound:
       collection: DeskBell
-    params:
-      variation: 0.03
-      volume: 3
+      params:
+        variation: 0.03
+        volume: 3
     onActivate: true
   - type: EmitSoundOnUse
     sound:

--- a/Resources/Prototypes/Entities/Objects/Misc/ice_crust.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/ice_crust.yml
@@ -48,6 +48,5 @@
         types:
           Heat: 5
       coldDamage: {}
-      ColdDamageThreshold: 0
+      coldDamageThreshold: 0
     - type: FrictionContacts
-      

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -58,11 +58,9 @@
         types:
           Heat: 5
       coldDamage: {}
-      ColdDamageThreshold: 0
+      coldDamageThreshold: 0
     - type: Flammable
       fireSpread: true #If you walk into incredibly dense, flaming vines, you can expect to burn.
-      cold:
-        types: {}
       damage:
         types:
           Heat: 3
@@ -75,11 +73,12 @@
         methods: [Touch]
         effects:
         - !type:HealthChange
-          scaled: true
+          scaleByQuantity: true
           damage:
             types:
               Heat: 10
     - type: AtmosExposed
+    - type: Kudzu
       growthTickChance: 0.3
       spreadChance: 0.4
     - type: SpeedModifierContacts
@@ -235,7 +234,6 @@
       damage:
        types:
          Heat: 3
-      growthTickChance: 0.3
     - type: AtmosExposed
     - type: SpeedModifierContacts
       walkSpeedModifier: 0.3

--- a/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
@@ -144,11 +144,9 @@
         types:
           Heat: 5
       coldDamage: {}
-      ColdDamageThreshold: 0
+      coldDamageThreshold: 0
     - type: Flammable
       fireSpread: true
-      cold:
-        types: {}
       damage:
         types:
           Heat: 5

--- a/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
@@ -59,11 +59,9 @@
         types:
           Heat: 5
       coldDamage: {}
-      ColdDamageThreshold: 0
+      coldDamageThreshold: 0
     - type: Flammable
       fireSpread: true
-      cold:
-        types: {}
       damage:
         types:
           Heat: 5

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -189,7 +189,6 @@
       implantAction: ActionActivateScramImplant
     - type: TriggerImplantAction
     - type: ScramImplant
-      teleportAttempts: 10 # small amount of risk of being teleported into space and lets you teleport off shuttles
 
 - type: entity
   parent: BaseSubdermalImplant

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -68,7 +68,6 @@
     failChance: 0
     locPrefix: "necro"
     healSound: "/Audio/Effects/lightburn.ogg"
-    cooldownTime: 1.3
   - type: Summonable
     specialItem: SpawnPointGhostCerberus
     respawnTime: 300

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -475,7 +475,6 @@
       behaviors:
       - !type:SpillBehavior
         solution: food
-        transferForensics: true
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -154,7 +154,6 @@
     sprite: Objects/Tools/Toolboxes/toolbox_thief.rsi
     state: icon
   - type: ThiefUndeterminedBackpack
-    transformAfterSelect: AlwaysPoweredWallLight
     possibleSets:
     # - TO DO Thief pinpointer needed
     - ChemistrySet

--- a/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
@@ -23,8 +23,8 @@
           !type:DamageTrigger
           damage: 50
         behaviors:
-          - !type:DoActsBehavior
-        acts: [ "Destruction" ]
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
   - type: AmbientSound
     volume: -5
     range: 5

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -282,6 +282,7 @@
           MaterialWoodPlank:
             min: 1
             max: 1
+  - type: Construction
     graph: RitualSeat
     node: chairCursed
 

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -7,7 +7,6 @@
   components:
   - type: ApcPowerReceiver
     powerLoad: 350
-    priority: Low
   - type: ExtensionCableReceiver
   - type: PointLight
     radius: 1.8
@@ -70,7 +69,8 @@
   - type: PointLight
     color: "#e3a136"
   - type: SpaceVillainArcade
-    rewardAmount: 0
+    rewardMinAmount: 0
+    rewardMaxAmount: 0
     possibleRewards:
     - ToyMouse
     - ToyAi
@@ -146,8 +146,8 @@
     board: SpaceVillainArcadeComputerCircuitboard
   - type: Advertise
     pack: SpaceVillainAds
-    minWait: 60 # Arcades are noisy
-    maxWait: 240
+    minimumWait: 60 # Arcades are noisy
+    maximumWait: 240
   - type: SpeakOnUIClosed
     pack: SpaceVillainGoodbyes
 
@@ -190,7 +190,7 @@
     board: BlockGameArcadeComputerCircuitboard
   - type: Advertise
     pack: BlockGameAds
-    minWait: 60 # Arcades are noisy
-    maxWait: 240
+    minimumWait: 60 # Arcades are noisy
+    maximumWait: 240
   - type: SpeakOnUIClosed
     pack: BlockGameGoodbyes

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -422,7 +422,6 @@
       type: ResearchClientBoundUserInterface
   - type: ApcPowerReceiver
     powerLoad: 1000
-    priority: Low
   - type: Computer
     board: ResearchComputerCircuitboard
   - type: AccessReader
@@ -955,7 +954,6 @@
     speechVerb: Robotic
   - type: SurveillanceCameraSpeaker
   - type: SurveillanceCameraMonitor
-    speechEnabled: true
   - type: ActivatableUI
     key: enum.SurveillanceCameraMonitorUiKey.Key
   - type: ActivatableUIRequiresVision

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -470,7 +470,6 @@
       type: ResearchClientBoundUserInterface
   - type: ApcPowerReceiver
     powerLoad: 1000
-    priority: Low
   - type: Computer
     board: AnalysisComputerCircuitboard
   - type: PointLight

--- a/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
@@ -34,7 +34,6 @@
     - type: StationLimitedNetwork
     - type: ApcPowerReceiver
       powerLoad: 200
-      priority: Low
     - type: ExtensionCableReceiver
     - type: Destructible
       thresholds:

--- a/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
@@ -23,7 +23,6 @@
         machine_parts: !type:Container
     - type: CrewMonitoringServer
     - type: SingletonDeviceNetServer
-      ServerType: CrewMonitoringServer
     - type: DeviceNetwork
       deviceNetId: Wireless
       transmitFrequencyId: CrewMonitor

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -55,7 +55,7 @@
     activePower: 2500
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
-    spritemap:
+    spriteMap:
       broken: "broken"
       unpowered: "off"
       off: "off"

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -20,7 +20,6 @@
     - CivilianServices
   - type: ApcPowerReceiver
     powerLoad: 200
-    priority: Low
   - type: ExtensionCableReceiver
   - type: WiresPanel
   - type: WiresVisuals

--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -52,7 +52,6 @@
   description: Locates salvage.
   components:
   - type: SalvageMagnet
-    offsetRadiusMax: 32
   - type: ApcPowerReceiver
     powerLoad: 1000
 

--- a/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
@@ -5,7 +5,6 @@
   description: A bed that massively slows down the patient's metabolism and prevents bodily decay, allowing more time to administer a proper treatment for stabilization.
   components:
   - type: StasisBed
-    baseMultiplier: 10
   - type: AntiRotOnBuckle
   - type: HealOnBuckle
     damage:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -93,7 +93,6 @@
   - type: LitOnPowered
   - type: ApcPowerReceiver
     powerLoad: 200
-    priority: Low
   - type: Actions
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-mechanical

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -64,9 +64,6 @@
     - type: Construction
       graph: GasTrinary
       node: filter
-      conditions:
-        - !type:TileNotBlocked
-        - !type:NoUnstackableInTile
     - type: AmbientSound
       enabled: false
       volume: -9

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -348,7 +348,6 @@
   suffix: Enabled
   components:
   - type: GasThermoMachine
-    enabled: true
   - type: ApcPowerReceiver
     powerDisabled: false
 

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -304,7 +304,6 @@
   suffix: Enabled
   components:
   - type: GasThermoMachine
-    enabled: true
   - type: ApcPowerReceiver
     powerDisabled: false
 

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -59,7 +59,6 @@
     maxCharge: 1000000
     startingCharge: 0
   - type: BatteryDischarger
-    activeSupplyRate: 15000
   - type: TeslaCoil
     chargeFromLightning: 500000
   - type: LightningTarget

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
@@ -85,7 +85,6 @@
   - type: ChaoticJump
     jumpMinInterval: 8
     jumpMaxInterval: 15
-    offset: 1
   - type: WarpPoint
     follow: true
     location: tesla ball

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -329,7 +329,6 @@
     explosionMaxTileIntensity: 20
   - type: ProjectileAnomaly
     projectilePrototype: ProjectileIcicle
-    targetNonSentientChance: 0.1
   - type: EntitySpawnAnomaly
     entries:
     - settings:

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -90,7 +90,6 @@
     tempChange: 420
   - type: ProjectileAnomaly
     projectilePrototype: ProjectileAnomalyFireball
-    targetNonSentientChance: 0.6
     projectileSpeed: 0.5
     minProjectiles: 3
     maxProjectiles: 6

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/station_map.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/station_map.yml
@@ -59,7 +59,6 @@
         board: !type:Container
     - type: ApcPowerReceiver
       powerLoad: 200
-      priority: Low
     - type: WallMount
       arc: 360
     - type: ExtensionCableReceiver

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -455,7 +455,6 @@
   nutrientConsumption: 0.70
   idealLight: 8
   idealHeat: 298
-  juicy: true
   splatPrototype: PuddleSplatter
   chemicals:
     Nutriment:
@@ -490,7 +489,6 @@
   nutrientConsumption: 0.70
   idealLight: 8
   idealHeat: 298
-  juicy: true
   splatPrototype: PuddleSplatter
   chemicals:
     Blood:

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -421,7 +421,6 @@
   nutrientConsumption: 0.40
   idealLight: 8
   idealHeat: 298
-  juicy: true
   splatPrototype: PuddleSplatter
   chemicals:
     Nutriment:

--- a/Resources/Prototypes/NPCs/Combat/melee.yml
+++ b/Resources/Prototypes/NPCs/Combat/melee.yml
@@ -74,8 +74,7 @@
     - preconditions:
       - !type:KeyExistsPrecondition
         key: Target
-    # Move to melee range and hit them
-    - tasks:
+      tasks:
         - !type:HTNPrimitiveTask
           operator: !type:MoveToOperator
             shutdownState: PlanFinished
@@ -104,11 +103,11 @@
 
 - type: htnCompound
   id: MeleeAttackOrderedTargetCompound
-  preconditions:
-    - !type:KeyExistsPrecondition
-      key: Target
   branches:
-    - tasks:
+    - preconditions:
+      - !type:KeyExistsPrecondition
+        key: Target
+      tasks:
         - !type:HTNPrimitiveTask
           operator: !type:MoveToOperator
             shutdownState: PlanFinished

--- a/Resources/Prototypes/NPCs/Combat/melee.yml
+++ b/Resources/Prototypes/NPCs/Combat/melee.yml
@@ -70,10 +70,10 @@
 # Tries to melee attack our target.
 - type: htnCompound
   id: MeleeAttackTargetCompound
-  preconditions:
-    - !type:KeyExistsPrecondition
-      key: Target
   branches:
+    - preconditions:
+      - !type:KeyExistsPrecondition
+        key: Target
     # Move to melee range and hit them
     - tasks:
         - !type:HTNPrimitiveTask

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -72,7 +72,7 @@
     Medicine:
       effects:
       - !type:ModifyBloodLevel
-        condition:
+        conditions:
         - !type:OrganType
           type: Arachnid
           shouldHave: true

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -163,7 +163,7 @@
     Medicine:
       effects:
       - !type:ModifyBloodLevel
-        condition:
+        conditions:
         - !type:OrganType
           type: Arachnid
           shouldHave: false

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -234,7 +234,7 @@
           types:
             Asphyxiation: 1
             Cold: 2
-        groups:
+          groups:
             Brute: 0.5
       - !type:Jitter
         conditions:
@@ -1044,7 +1044,7 @@
     Medicine:
       effects:
       - !type:HealthChange
-        condition:
+        conditions:
         - !type:TotalDamage
           max: 50
         damage:

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -480,7 +480,6 @@
         conditions:
           - !type:OrganType
             type: Human
-        reagent: Protein
         type: Local
         visualType: MediumCaution
         messages: [ "generic-reagent-effect-sick" ]

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -161,7 +161,6 @@
     actions:
     - !type:SetWiresPanelSecurity
       wiresAccessible: true
-      weldingAllowed: true
     edges:
     - to: wired
       conditions:
@@ -200,7 +199,6 @@
     actions:
     - !type:SetWiresPanelSecurity
       wiresAccessible: true
-      weldingAllowed: true
     edges:
     - to: medSecurityUnfinished
       conditions:
@@ -224,7 +222,6 @@
     - !type:SetWiresPanelSecurity
       examine: wires-panel-component-on-examine-security-level1
       wiresAccessible: false
-      weldingAllowed: false
     edges:
     - to: glassAirlock
       completed:
@@ -277,7 +274,6 @@
     - !type:SetWiresPanelSecurity
       examine: wires-panel-component-on-examine-security-level2
       wiresAccessible: false
-      weldingAllowed: false
     edges:
     - to: medSecurityUnfinished
       conditions:
@@ -292,7 +288,6 @@
     - !type:SetWiresPanelSecurity
       examine: wires-panel-component-on-examine-security-level3
       wiresAccessible: false
-      weldingAllowed: false
     edges:
     - to: glassAirlock
       completed:
@@ -345,7 +340,6 @@
     - !type:SetWiresPanelSecurity
       examine: wires-panel-component-on-examine-security-level4
       wiresAccessible: false
-      weldingAllowed: false
     edges:
     - to: highSecurityUnfinished
       conditions:
@@ -368,7 +362,6 @@
     - !type:SetWiresPanelSecurity
       examine: wires-panel-component-on-examine-security-level5
       wiresAccessible: false
-      weldingAllowed: true
     edges:
     - to: highSecurity
       completed:
@@ -396,7 +389,6 @@
     - !type:SetWiresPanelSecurity
       examine: wires-panel-component-on-examine-security-level6
       wiresAccessible: false
-      weldingAllowed: false
     edges:
     - to: maxSecurity
       completed:
@@ -421,7 +413,6 @@
     - !type:SetWiresPanelSecurity
       examine: wires-panel-component-on-examine-security-level7
       wiresAccessible: false
-      weldingAllowed: false
     edges:
     - to: superMaxSecurityUnfinished
       conditions:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -121,7 +121,6 @@
     actions:
     - !type:SetWiresPanelSecurity
       wiresAccessible: true
-      weldingAllowed: true
     edges:
     - to: glassElectronics
       conditions:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock_clockwork.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock_clockwork.yml
@@ -121,7 +121,6 @@
     actions:
     - !type:SetWiresPanelSecurity
       wiresAccessible: true
-      weldingAllowed: true
     edges:
     - to: glassElectronics
       conditions:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock_clockwork.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock_clockwork.yml
@@ -145,7 +145,6 @@
     actions:
     - !type:SetWiresPanelSecurity
       wiresAccessible: true
-      weldingAllowed: true
     edges:
     - to: wired
       conditions:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/conveyor.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/conveyor.yml
@@ -23,7 +23,6 @@
         - !type:SetAnchor
           value: true
         - !type:SnapToGrid
-          offset: Center
       edges:
         - to: item
           steps:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
@@ -37,7 +37,6 @@
         - to: solartracker
           conditions:
             - !type:EntityAnchored
-              value: true
           steps:
             - tag: SolarTrackerElectronics
               name: Solar Tracker Electronics
@@ -50,7 +49,6 @@
               doAfter: 2
           completed:
             - !type:SnapToGrid
-              offset: Center
 
     - node: solarpanel
       entity: SolarPanel

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
@@ -28,14 +28,12 @@
         - to: solarpanel
           conditions:
             - !type:EntityAnchored
-              value: true
           steps:
             - material: Glass
               amount: 2
               doAfter: 0.5
           completed:
             - !type:SnapToGrid
-              offset: Center
         - to: solartracker
           conditions:
             - !type:EntityAnchored

--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -106,7 +106,6 @@
   - type: SolutionTransfer
     canChangeTransferAmount: true
   - type: Drink
-    isOpen: true
     solution: beaker
 
 - type: artifactEffect


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes a bunch of YAML errors in server-only components.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Server-only component errors were previously ignored by the YAML linter. #26809 fixes this, but the existing errors need to be fixed before that can be merged. This (hopefully) fixes all of the errors.

Some things are going to be working now that weren't before, which might have some effects on gameplay.

Notably:
- A bunch of reagent reactions that use HeathChange now use scaleByQuantity (which enables damage scaling by quantity of reagent)
- Kudzu growth and spread should now be slower.
- Desk bells have consistent variation and volume in all interactions.
- Ice crust, Kudzu, spider web cold damage thresholds are lower (so they survive cold better).
- Bonfire destruction might be working now? (not sure if it wasn't before)
- Cursed chairs should be constructible now? (not sure if they weren't before)
- Slimes should have a low N2 alert now
- Dragon and Behonker metabolism update intervals are now 0.25 instead of 1 (they metabolize things faster)
- Goats produce milk at 3x rate
- Arachnid organs have slower metabolism update intervals (they metabolize things slower)
- Copper now only restores arachnid blood level (I think it worked on anyone before?)
- Dermaline now deals 0.5 brute
- Holy water no longer works if total damage is over 50
- NPC attack logic might be affected by target existing precondition now working. 


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Deleted a bunch of outdated entries and adjusted others to correctly refer to what seemed to be the intended fields.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Fixes
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
