### PR TITLE
dirty after calling SetAccesses

### DIFF
--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -318,6 +318,7 @@ public sealed class AccessReaderSystem : EntitySystem
         {
             component.AccessLists.Add(new HashSet<ProtoId<AccessLevelPrototype>>(){access});
         }
+        Dirty(uid, component);
         RaiseLocalEvent(uid, new AccessReaderConfigurationChangedEvent());
     }
 


### PR DESCRIPTION
## About the PR
title

## Why / Balance
fixes #26837

## Technical details
it was missing dirty call for a networked field

side notes:
- AccessReader should have autogenerated state probably
- DoorElectronicsComponent should be called ConfigurableAccessReaderComponent, a tag should then be added for whitelists to switch to
- most of the stuff in DoorElectronicsSystem could be done in shared
- the window has no title and no min size real
![11:44:23](https://github.com/space-wizards/space-station-14/assets/39013340/e1e57c07-870b-4118-8077-3fd5865dd8bb)


## Media
client vv confirming it now knows the access
![11:45:12](https://github.com/space-wizards/space-station-14/assets/39013340/d89b8adb-47a4-4aec-8fbe-63c572702c79)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun