### PR TITLE
Collision groups separation

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -498,7 +498,7 @@ public sealed partial class ChatSystem : SharedChatSystem
                 _chatManager.ChatMessageToOne(ChatChannel.Whisper, message, wrappedMessage, source, false, session.Channel);
             //If listener is too far, they only hear fragments of the message
             //Collisiongroup.Opaque is not ideal for this use. Preferably, there should be a check specifically with "Can Ent1 see Ent2" in mind
-            else if (_interactionSystem.InRangeUnobstructed(source, listener, WhisperMuffledRange, Shared.Physics.CollisionGroup.Opaque)) //Shared.Physics.CollisionGroup.Opaque
+            else if (_interactionSystem.InRangeUnobstructed(source, listener, WhisperMuffledRange, Shared.Physics.CollisionGroup.FullOpaque)) //Shared.Physics.CollisionGroup.Opaque
                 _chatManager.ChatMessageToOne(ChatChannel.Whisper, obfuscatedMessage, wrappedobfuscatedMessage, source, false, session.Channel);
             //If listener is too far and has no line of sight, they can't identify the whisperer's identity
             else

--- a/Content.Server/Instruments/InstrumentSystem.cs
+++ b/Content.Server/Instruments/InstrumentSystem.cs
@@ -253,7 +253,7 @@ public sealed partial class InstrumentSystem : SharedInstrumentSystem
             // Maybe a bit expensive but oh well GetBands is queued and has a timer anyway.
             // Make sure the instrument is visible, uses the Opaque collision group so this works across windows etc.
             if (!_interactions.InRangeUnobstructed(uid, entity, MaxInstrumentBandRange,
-                    CollisionGroup.Opaque, e => e == playerUid || e == originPlayer))
+                    CollisionGroup.FullOpaque, e => e == playerUid || e == originPlayer))
                 continue;
 
             if (!metadataQuery.TryGetComponent(playerUid, out var playerMetadata)

--- a/Content.Server/Solar/EntitySystems/PowerSolarSystem.cs
+++ b/Content.Server/Solar/EntitySystems/PowerSolarSystem.cs
@@ -153,7 +153,7 @@ namespace Content.Server.Solar.EntitySystems
             if (coverage > 0)
             {
                 // Determine if the solar panel is occluded, and zero out coverage if so.
-                var ray = new CollisionRay(xform.WorldPosition, TowardsSun.ToWorldVec(), (int) CollisionGroup.Opaque);
+                var ray = new CollisionRay(xform.WorldPosition, TowardsSun.ToWorldVec(), (int) CollisionGroup.FullOpaque);
                 var rayCastResults = _physicsSystem.IntersectRayWithPredicate(
                     xform.MapID,
                     ray,

--- a/Content.Shared/Flash/FlashableComponent.cs
+++ b/Content.Shared/Flash/FlashableComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Flash
         public TimeSpan LastFlash;
 
         [DataField]
-        public CollisionGroup CollisionGroup = CollisionGroup.Opaque;
+        public CollisionGroup CollisionGroup = CollisionGroup.FullOpaque;
 
         public override bool SendOnlyToOwner => true;
     }

--- a/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
+++ b/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
@@ -83,7 +83,7 @@ public sealed class DashAbilitySystem : EntitySystem
         var origin = Transform(user).MapPosition;
         var target = args.Target.ToMap(EntityManager, _transform);
         // prevent collision with the user duh
-        if (!_interaction.InRangeUnobstructed(origin, target, 0f, CollisionGroup.Opaque, uid => uid == user))
+        if (!_interaction.InRangeUnobstructed(origin, target, 0f, CollisionGroup.FullOpaque, uid => uid == user))
         {
             // can only dash if the destination is visible on screen
             _popup.PopupClient(Loc.GetString("dash-ability-cant-see", ("item", uid)), user, user);

--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -23,6 +23,8 @@ public enum CollisionGroup
     BulletImpassable   = 1 << 6, // 64 Can be hit by bullets
     InteractImpassable = 1 << 7, // 128 Blocks interaction/InRangeUnobstructed
     DoorPassable       = 1 << 8, // 256 Allows door to close over top, Like blast doors over conveyors for disposals rooms/cargo.
+    BulletLowImpassable = 1 << 9, //
+    BulletHighImpassable = 1 << 10, //
 
     MapGrid = MapGridHelpers.CollisionGroup, // Map grids, like shuttles. This is the actual grid itself, not the walls or other entities connected to the grid.
 
@@ -31,21 +33,21 @@ public enum CollisionGroup
 
     // Humanoids, etc.
     MobMask = Impassable | HighImpassable | MidImpassable | LowImpassable,
-    MobLayer = Opaque | BulletImpassable,
+    MobLayer = Opaque | BulletLowImpassable| BulletImpassable,
     // Mice, drones
     SmallMobMask = Impassable | LowImpassable,
-    SmallMobLayer = Opaque | BulletImpassable,
+    SmallMobLayer = Opaque | BulletLowImpassable,
     // Birds/other small flyers
     FlyingMobMask = Impassable | HighImpassable,
-    FlyingMobLayer = Opaque | BulletImpassable,
+    FlyingMobLayer = Opaque | BulletHighImpassable,
 
     // Mechs
     LargeMobMask = Impassable | HighImpassable | MidImpassable | LowImpassable,
-    LargeMobLayer = Opaque | HighImpassable | MidImpassable | LowImpassable | BulletImpassable,
+    LargeMobLayer = Opaque | HighImpassable | MidImpassable | LowImpassable | BulletLowImpassable| BulletImpassable| BulletHighImpassable,
 
     // Machines, computers
     MachineMask = Impassable | MidImpassable | LowImpassable,
-    MachineLayer = Opaque | MidImpassable | LowImpassable | BulletImpassable,
+    MachineLayer = Opaque | MidImpassable | LowImpassable | BulletLowImpassable| BulletImpassable,
     ConveyorMask = Impassable | MidImpassable | LowImpassable | DoorPassable,
 
     // Tables that SmallMobs can go under
@@ -58,7 +60,7 @@ public enum CollisionGroup
     TabletopMachineLayer = Opaque | HighImpassable | BulletImpassable,
 
     // Airlocks, windoors, firelocks
-    GlassAirlockLayer = HighImpassable | MidImpassable | BulletImpassable | InteractImpassable,
+    GlassAirlockLayer = HighImpassable | MidImpassable | BulletHighImpassable | BulletImpassable | BulletLowImpassable | InteractImpassable,
     AirlockLayer = Opaque | GlassAirlockLayer,
 
     // Airlock assembly
@@ -68,14 +70,14 @@ public enum CollisionGroup
     SlipLayer = MidImpassable | LowImpassable,
     ItemMask = Impassable | HighImpassable,
     ThrownItem = Impassable | HighImpassable | BulletImpassable,
-    WallLayer = Opaque | Impassable | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,
-    GlassLayer = Impassable | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,
+    WallLayer = Opaque | Impassable | HighImpassable | MidImpassable | LowImpassable | BulletHighImpassable | BulletImpassable | BulletLowImpassable | InteractImpassable,
+    GlassLayer = Impassable | HighImpassable | MidImpassable | LowImpassable | BulletHighImpassable | BulletLowImpassable | BulletImpassable | InteractImpassable,
     HalfWallLayer = MidImpassable | LowImpassable,
 
     // Statue, monument, airlock, window
     FullTileMask = Impassable | HighImpassable | MidImpassable | LowImpassable | InteractImpassable,
     // FlyingMob can go past
-    FullTileLayer = Opaque | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,
+    FullTileLayer = Opaque | HighImpassable | MidImpassable | LowImpassable | BulletHighImpassable | BulletLowImpassable | BulletImpassable | InteractImpassable,
 
     SubfloorMask = Impassable | LowImpassable
 }

--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -13,41 +13,60 @@ namespace Content.Shared.Physics;
 [FlagsFor(typeof(CollisionLayer)), FlagsFor(typeof(CollisionMask))]
 public enum CollisionGroup
 {
-    None               = 0,
-    Opaque             = 1 << 0, // 1 Blocks light, can be hit by lasers
-    Impassable         = 1 << 1, // 2 Walls, objects impassable by any means
-    MidImpassable      = 1 << 2, // 4 Mobs, players, crabs, etc
-    HighImpassable     = 1 << 3, // 8 Things on top of tables and things that block tall/large mobs.
-    LowImpassable      = 1 << 4, // 16 For things that can fit under a table or squeeze under an airlock
-    GhostImpassable    = 1 << 5, // 32 Things impassible by ghosts/observers, ie blessed tiles or forcefields
-    BulletImpassable   = 1 << 6, // 64 Can be hit by bullets
-    InteractImpassable = 1 << 7, // 128 Blocks interaction/InRangeUnobstructed
-    DoorPassable       = 1 << 8, // 256 Allows door to close over top, Like blast doors over conveyors for disposals rooms/cargo.
-    BulletLowImpassable = 1 << 9, //
-    BulletHighImpassable = 1 << 10, //
+    None                  = 0,
+    LowOpaque             = 1 << 0, // 1 Blocks light and lasers close to the ground (most entities except those on top of tables or flying)
+    MidOpaque             = 1 << 1, // 2 Blocks light and lasers at normal height (any entities that are not small and don't fly)
+    HighOpaque            = 1 << 2, // 4 Blocks light and lasers high up (large or flying entities)
+    Impassable            = 1 << 3, // 2 Walls, objects impassable by any means
+    LowImpassable         = 1 << 4, // 8 Blocks passage close to the ground. (Such as squeezing under a table or airlock)
+    MidImpassable         = 1 << 5, // 16 Blocks passage at normal height (Most mobs, players, crabs, etc)
+    HighImpassable        = 1 << 6, // 32 Blocks passage high up (Things on top of tables, tall/large mobs, flying mobs)
+    GhostImpassable       = 1 << 7, // 64 Things impassible by ghosts/observers, ie blessed tiles or forcefields
+    LowBulletImpassable   = 1 << 8, // 128 Blocks bullets and projectiles close to the ground (most entities except those on top of tables or flying)
+    MidBulletImpassable   = 1 << 9, // 256 Blocks bullets and projectiles at normal height (any entities that are not small and don't fly)
+    HighBulletImpassable  = 1 << 10, // 512 Blocks bullets and projectiles high up (large or flying entities)
+    InteractImpassable    = 1 << 11, // 1024 Blocks interaction/InRangeUnobstructed
+    DoorPassable          = 1 << 12, // 2048 Allows door to close over top, Like blast doors over conveyors for disposals rooms/cargo.
+
+    FullOpaque = LowOpaque | MidOpaque | HighOpaque,
+    FullBulletImpassable = LowBulletImpassable | MidBulletImpassable | HighBulletImpassable,
+
+    // Legacy
+    Opaque = FullOpaque,
+    BulletImpassable = FullBulletImpassable,
 
     MapGrid = MapGridHelpers.CollisionGroup, // Map grids, like shuttles. This is the actual grid itself, not the walls or other entities connected to the grid.
 
     // 32 possible groups
     AllMask = -1,
 
+
+    //TODO: Kill these, test stuff
+    BulletMask_Low = Impassable | LowBulletImpassable,
+    BulletMask_High = Impassable | HighImpassable,
+
+
+
+    // Projectiles
+    BulletMask = Impassable | FullBulletImpassable,
+
     // Humanoids, etc.
-    MobMask = Impassable | HighImpassable | MidImpassable | LowImpassable,
-    MobLayer = Opaque | BulletLowImpassable| BulletImpassable,
+    MobMask = Impassable | HighImpassable | MidImpassable | LowImpassable, // why are they high?
+    MobLayer = FullOpaque | FullBulletImpassable,
     // Mice, drones
     SmallMobMask = Impassable | LowImpassable,
-    SmallMobLayer = Opaque | BulletLowImpassable,
+    SmallMobLayer = FullOpaque | FullBulletImpassable,
     // Birds/other small flyers
     FlyingMobMask = Impassable | HighImpassable,
-    FlyingMobLayer = Opaque | BulletHighImpassable,
+    FlyingMobLayer = FullOpaque | FullBulletImpassable,
 
     // Mechs
     LargeMobMask = Impassable | HighImpassable | MidImpassable | LowImpassable,
-    LargeMobLayer = Opaque | HighImpassable | MidImpassable | LowImpassable | BulletLowImpassable| BulletImpassable| BulletHighImpassable,
+    LargeMobLayer = FullOpaque | HighImpassable | MidImpassable | LowImpassable | FullBulletImpassable,
 
     // Machines, computers
     MachineMask = Impassable | MidImpassable | LowImpassable,
-    MachineLayer = Opaque | MidImpassable | LowImpassable | BulletLowImpassable| BulletImpassable,
+    MachineLayer = FullOpaque | MidImpassable | LowImpassable | FullBulletImpassable,
     ConveyorMask = Impassable | MidImpassable | LowImpassable | DoorPassable,
 
     // Tables that SmallMobs can go under
@@ -57,11 +76,11 @@ public enum CollisionGroup
     // Tabletop machines, windoors, firelocks
     TabletopMachineMask = Impassable | HighImpassable,
     // Tabletop machines
-    TabletopMachineLayer = Opaque | HighImpassable | BulletImpassable,
+    TabletopMachineLayer = FullOpaque | HighImpassable | FullBulletImpassable,
 
     // Airlocks, windoors, firelocks
-    GlassAirlockLayer = HighImpassable | MidImpassable | BulletHighImpassable | BulletImpassable | BulletLowImpassable | InteractImpassable,
-    AirlockLayer = Opaque | GlassAirlockLayer,
+    GlassAirlockLayer = HighImpassable | MidImpassable | FullBulletImpassable | InteractImpassable,
+    AirlockLayer = FullOpaque | GlassAirlockLayer,
 
     // Airlock assembly
     HumanoidBlockLayer = HighImpassable | MidImpassable,
@@ -69,15 +88,15 @@ public enum CollisionGroup
     // Soap, spills
     SlipLayer = MidImpassable | LowImpassable,
     ItemMask = Impassable | HighImpassable,
-    ThrownItem = Impassable | HighImpassable | BulletImpassable,
-    WallLayer = Opaque | Impassable | HighImpassable | MidImpassable | LowImpassable | BulletHighImpassable | BulletImpassable | BulletLowImpassable | InteractImpassable,
-    GlassLayer = Impassable | HighImpassable | MidImpassable | LowImpassable | BulletHighImpassable | BulletLowImpassable | BulletImpassable | InteractImpassable,
-    HalfWallLayer = MidImpassable | LowImpassable,
+    ThrownItem = Impassable | HighImpassable | FullBulletImpassable,
+    WallLayer = FullOpaque | Impassable | HighImpassable | MidImpassable | LowImpassable | FullBulletImpassable | InteractImpassable,
+    GlassLayer = Impassable | HighImpassable | MidImpassable | LowImpassable | FullBulletImpassable | InteractImpassable,
+    HalfWallLayer = MidImpassable | LowImpassable, // probably make this low-mid opaque?
 
     // Statue, monument, airlock, window
     FullTileMask = Impassable | HighImpassable | MidImpassable | LowImpassable | InteractImpassable,
     // FlyingMob can go past
-    FullTileLayer = Opaque | HighImpassable | MidImpassable | LowImpassable | BulletHighImpassable | BulletLowImpassable | BulletImpassable | InteractImpassable,
+    FullTileLayer = FullOpaque |  HighImpassable | MidImpassable | LowImpassable | FullBulletImpassable | InteractImpassable,
 
     SubfloorMask = Impassable | LowImpassable
 }

--- a/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
+++ b/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
@@ -85,7 +85,7 @@ public sealed partial class ContainmentFieldGeneratorComponent : Component
     /// The masks the raycast should not go through
     /// </summary>
     [DataField("collisionMask")]
-    public int CollisionMask = (int) (CollisionGroup.MobMask | CollisionGroup.Impassable | CollisionGroup.MachineMask | CollisionGroup.Opaque);
+    public int CollisionMask = (int) (CollisionGroup.MobMask | CollisionGroup.Impassable | CollisionGroup.MachineMask | CollisionGroup.FullOpaque);
 
     /// <summary>
     /// A collection of connections that the generator has based on direction.

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -49,7 +49,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] private   readonly IPrototypeManager       _protoManager    = default!;
     [Dependency] private   readonly StaminaSystem           _stamina         = default!;
 
-    private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
+    private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.FullOpaque);
 
     /// <summary>
     /// Maximum amount of targets allowed for a wide-attack.

--- a/Content.Shared/Weapons/Ranged/HitscanPrototype.cs
+++ b/Content.Shared/Weapons/Ranged/HitscanPrototype.cs
@@ -30,7 +30,7 @@ public sealed partial class HitscanPrototype : IPrototype, IShootable
     public SpriteSpecifier? ImpactFlash;
 
     [DataField("collisionMask")]
-    public int CollisionMask = (int) CollisionGroup.Opaque;
+    public int CollisionMask = (int) CollisionGroup.FullOpaque;
 
     /// <summary>
     /// What we count as for reflection.

--- a/Resources/Maps/Shuttles/emergency_meta.yml
+++ b/Resources/Maps/Shuttles/emergency_meta.yml
@@ -4571,9 +4571,9 @@ entities:
           - TableLayer
           - HighImpassable
           - LowImpassable
-          - BulletImpassable
+          - FullBulletImpassable
           - InteractImpassable
-          - Opaque
+          - FullOpaque
           layer: []
           density: 1
           hard: False

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -128,7 +128,7 @@
           mask:
             - MobMask
           layer:
-            - Opaque
+            - FullOpaque
     - type: TypingIndicator
       proto: robot
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
@@ -57,7 +57,7 @@
         mask:
           - MobMask
         layer:
-          - Opaque
+          - FullOpaque
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: LivingLight

--- a/Resources/Prototypes/Entities/Mobs/NPCs/shadows.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/shadows.yml
@@ -19,7 +19,7 @@
           radius: 0.35
         density: 120
         mask:
-        - Opaque
+        - FullOpaque
         layer:
         - None
   - type: StandingState
@@ -36,7 +36,7 @@
     speedModifierThresholds:
       60: 0.7
       80: 0.5
-      
+
 - type: entity
   name: shadow cat
   parent: BaseShadowMob

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -19,7 +19,7 @@
         density: 1000
         layer:
         - HalfWallLayer
-        - Opaque
+        - FullOpaque
   - type: Climbable
   - type: Damageable
     damageContainer: Inorganic

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/base_instruments.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/base_instruments.yml
@@ -65,10 +65,10 @@
         - HighImpassable
         - MidImpassable
         layer:
-        - Opaque
+        - FullOpaque
         - HighImpassable
         - MidImpassable
-        - BulletImpassable
+        - FullBulletImpassable
   - type: StaticPrice
     price: 300
 

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
@@ -120,10 +120,10 @@
         - HighImpassable
         - MidImpassable
         layer:
-        - Opaque
+        - FullOpaque
         - HighImpassable
         - MidImpassable
-        - BulletImpassable
+        - FullBulletImpassable
 
 - type: entity
   name: minimoog

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -30,7 +30,7 @@
         hard: false
         layer:
         - Impassable
-        - Opaque
+        - FullOpaque
   - type: WarpPoint
     follow: true
     location: immovable rod

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -205,8 +205,7 @@
           bounds: "-0.1,-0.1,0.1,0.1"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - BulletMask
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/pop.ogg
     embedOnThrow: True

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -121,7 +121,7 @@
         hard: false
         mask:
         - FullTileMask
-        - Opaque
+        - FullOpaque
   - type: Appearance
   - type: VaporVisuals
 
@@ -146,4 +146,4 @@
         hard: false
         mask:
         - FullTileMask
-        - Opaque
+        - FullOpaque

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
@@ -32,7 +32,7 @@
         mask:
         - ItemMask
         layer:
-        - Opaque
+        - FullOpaque
         restitution: 0.3  # fite me
         friction: 0.2
   - type: Artifact

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
@@ -41,7 +41,7 @@
             radius: 0.45
           density: 75
           layer: # doesn't collide with artifact storage
-          - Opaque
+          - FullOpaque
           mask:
           - MachineMask
     - type: InteractionOutline

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -23,8 +23,7 @@
     fixtures:
       projectile:
         mask:
-        - Impassable
-        - BulletLowImpassable
+        - BulletMask_Low
 
 - type: entity
   id: BulletPistolRubber
@@ -44,8 +43,7 @@
           bounds: "-0.1,-0.1,0.1,0.1"
         hard: false
         mask:
-        - Impassable
-        - BulletHighImpassable
+        - BulletMask_High
 
 - type: entity
   id: BulletPistolIncendiary

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -19,6 +19,12 @@
     damage:
       types:
         Blunt: 2
+  - type: Fixtures
+    fixtures:
+      projectile:
+        mask:
+        - Impassable
+        - BulletLowImpassable
 
 - type: entity
   id: BulletPistolRubber
@@ -30,6 +36,16 @@
     damage:
       types:
         Blunt: 3
+  - type: Fixtures
+    fixtures:
+      projectile:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.1,-0.1,0.1,0.1"
+        hard: false
+        mask:
+        - Impassable
+        - BulletHighImpassable
 
 - type: entity
   id: BulletPistolIncendiary

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -133,7 +133,7 @@
           !type:PhysShapeAabb
           bounds: "-0.1,-0.1,0.1,0.1"
         mask:
-          - BulletImpassable
+          - FullBulletImpassable
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
     state: buckshot-flare

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/arrows.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/arrows.yml
@@ -23,8 +23,7 @@
           bounds: "-0.1,-0.1,0.1,0.1"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - BulletMask
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/star_hit.ogg
     embedOnThrow: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -36,5 +36,4 @@
         layer:
         - LargeMobLayer
         mask:
-        - Impassable
-        - BulletImpassable
+        - BulletMask

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -45,8 +45,7 @@
           bounds: "-0.1,-0.1,0.1,0.1"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - BulletMask
       fly-by: &flybyfixture
         shape: !type:PhysShapeCircle
           radius: 1.5
@@ -85,8 +84,7 @@
           bounds: "-0.15,-0.45,0.15,0.15"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - BulletMask
       fly-by: *flybyfixture
 
 - type: entity
@@ -200,8 +198,7 @@
           bounds: "-0.15,-0.45,0.15,0.15"
         hard: false
         mask:
-          - Impassable
-          - BulletImpassable
+          - BulletMask
       fly-by: *flybyfixture
   - type: Ammo
   - type: Projectile
@@ -243,8 +240,7 @@
           bounds: "-0.15,-0.3,0.15,0.3"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - BulletMask
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
@@ -283,8 +279,7 @@
           bounds: "-0.15,-0.3,0.15,0.3"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - BulletMask
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
@@ -320,7 +315,7 @@
           bounds: "-0.2,-0.2,0.2,0.2"
         hard: false
         mask:
-        - Opaque
+        - FullOpaque
       fly-by: *flybyfixture
   - type: Projectile
 #   soundHit:  Waiting on serv3
@@ -362,7 +357,7 @@
           bounds: "-0.2,-0.2,0.2,0.2"
         hard: false
         mask:
-        - Opaque
+        - FullOpaque
       fly-by: *flybyfixture
   - type: StaminaDamageOnCollide
     damage: 40
@@ -510,7 +505,7 @@
           bounds: "-0.2,-0.2,0.2,0.2"
         hard: false
         mask:
-        - Opaque
+        - FullOpaque
       fly-by: *flybyfixture
   - type: Projectile
     damage:
@@ -858,8 +853,7 @@
           bounds: "-0.10,-0.30,0.10,0.15"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - BulletMask
   - type: Vapor
     active: true
   - type: Appearance
@@ -950,8 +944,7 @@
           bounds: "-0.15,-0.3,0.15,0.3"
         hard: false
         mask:
-        - Impassable
-        - BulletImpassable
+        - BulletMask
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide

--- a/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
@@ -21,10 +21,10 @@
         mask:
         - MachineMask
         layer:
-        - Opaque
+        - FullOpaque
         - MidImpassable
         - HighImpassable
-        - BulletImpassable
+        - FullBulletImpassable
   - type: InteractionOutline
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Decoration/crystals.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/crystals.yml
@@ -31,8 +31,8 @@
           layer:
             - MidImpassable
             - LowImpassable
-            - BulletImpassable
-            - Opaque
+            - FullBulletImpassable
+            - FullOpaque
     - type: PointLight
       radius: 3
       energy: 3

--- a/Resources/Prototypes/Entities/Structures/Decoration/curtains.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/curtains.yml
@@ -19,7 +19,7 @@
         mask:
         - FullTileMask
         layer:
-        - Opaque
+        - FullOpaque
   - type: Door
     canCrush: false
     performCollisionCheck: false
@@ -36,7 +36,7 @@
   - type: Appearance
   - type: Damageable
     damageContainer: Inorganic
-    damageModifierSet: Wood  
+    damageModifierSet: Wood
   - type: Destructible
     thresholds:
     - trigger:
@@ -52,7 +52,7 @@
             max: 2
   - type: WallMount
     arc: 360
-        
+
 - type: entity
   id: HospitalCurtains
   parent: BaseCurtains

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -28,8 +28,8 @@
         mask:
         - Impassable
         layer:
-        - Opaque
-        - BulletImpassable
+        - FullOpaque
+        - FullBulletImpassable
       conveyor:
         shape: !type:PolygonShape
           vertices:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -30,7 +30,7 @@
           layer: [None]
           mask:
           # Has to hit mobs, singularity, and singularity generator
-          - Opaque
+          - FullOpaque
           - FullTileMask
     - type: ParticleProjectile
     - type: SinguloFood

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
@@ -25,7 +25,7 @@
         mask:
         - MachineMask
         layer:
-        - Opaque
+        - FullOpaque
   - type: Transform
     anchored: true
     noRot: true

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
@@ -47,7 +47,7 @@
         restitution: 0.8
         density: 99999
         mask:
-        - Opaque
+        - FullOpaque
         layer:
         - GlassLayer
       EventHorizonConsumer:
@@ -56,7 +56,7 @@
             radius: 0.65
         hard: false
         mask:
-        - Opaque
+        - FullOpaque
         layer:
         - GlassLayer
   - type: EventHorizon

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     noRot: true
     sprite: Structures/Power/Generation/Tesla/generator.rsi
-    state: icon 
+    state: icon
   - type: SingularityGenerator #To do: rename the generator
     spawnId: TeslaEnergyBall
   - type: InteractionOutline
@@ -23,7 +23,7 @@
         mask:
         - MachineMask
         layer:
-        - Opaque
+        - FullOpaque
   - type: Anchorable
   #- type: GuideHelp #   To Do - add Tesla Guide
 

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
@@ -25,7 +25,7 @@
         mask:
         - MachineMask
         layer:
-        - MidImpassable, LowImpassable, BulletImpassable
+        - MidImpassable, LowImpassable, FullBulletImpassable
   - type: Sprite
     sprite: Structures/Power/Generation/solar_panel.rsi
     state: normal

--- a/Resources/Prototypes/Entities/Structures/Power/debug_power.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/debug_power.yml
@@ -30,7 +30,7 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.5,-0.5,0.5,0.5"
-        layer: [MobMask, Opaque]
+        layer: [MobMask, FullOpaque]
   - type: Transform
     anchored: true
   - type: Sprite
@@ -75,7 +75,7 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.5,-0.5,0.5,0.5"
-        layer: [MobMask, Opaque]
+        layer: [MobMask, FullOpaque]
   - type: Transform
     anchored: true
   - type: Sprite
@@ -109,7 +109,7 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.5,-0.5,0.5,0.5"
-        layer: [MobMask, Opaque]
+        layer: [MobMask, FullOpaque]
   - type: Transform
     anchored: true
   - type: Sprite
@@ -170,7 +170,7 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.5,-0.5,0.5,0.5"
-        layer: [MobMask, Opaque]
+        layer: [MobMask, FullOpaque]
   - type: Transform
     anchored: true
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -63,7 +63,7 @@
         mask:
         - TabletopMachineMask
         layer:
-        - Opaque
+        - FullOpaque
         - MidImpassable
   - type: Occluder
   - type: Construction


### PR DESCRIPTION
## About the PR
Splitting BulletImpassable and Opaque into 3 separate layers each, like how Low- Mid- and HighImpassable already are.
This will make it possible for shots to "travel at different heights" to introduce aiming up-down

## Why / Balance
This will allow us to have projectiles/beams (and possibly even explosions) "fly at different levels" so we can do things like aiming up-down, so bullets could be flying over prone mobs (and perhaps the Rat army rushing at you, too). Low cover. Being able to shoot over people to hit a Tall target etc. 


## Technical details
This will be fully backwards compatible if any references to the old Opaque or B.I. are left in the code, but I am replacing all instances in our own code with FullOpaque and FullBulletImpassable because searching for just "Opaque" and "BulletImpassable" will be much less useful with three variants of each. This causes a lot of touched files

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase