### PR TITLE
Bug fix for deconstructing tiles and lattice with RCDs

### DIFF
--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -175,7 +175,7 @@ public class RCDSystem : EntitySystem
                 else
                 {
                     var deconstructedTile = _mapSystem.GetTileRef(mapGridData.Value.GridUid, mapGridData.Value.Component, mapGridData.Value.Location);
-                    var protoName = deconstructedTile.IsSpace() ? _deconstructTileProto : _deconstructLatticeProto;
+                    var protoName = !deconstructedTile.IsSpace() ? _deconstructTileProto : _deconstructLatticeProto;
 
                     if (_protoManager.TryIndex(protoName, out var deconProto))
                     {

--- a/Resources/Prototypes/Entities/Structures/Power/cable_terminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cable_terminal.yml
@@ -19,8 +19,8 @@
       damageModifierSet: Metallic
     - type: RCDDeconstructable
       cost: 2
-      delay: 2
-      fx: EffectRCDDeconstruct2  
+      delay: 0
+      fx: EffectRCDConstruct0  
     - type: Destructible
       thresholds:
         - trigger:

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -45,8 +45,8 @@
     node: power
   - type: RCDDeconstructable
     cost: 2
-    delay: 2
-    fx: EffectRCDDeconstruct2  
+    delay: 0
+    fx: EffectRCDConstruct0  
 
 - type: entity
   parent: CableBase

--- a/Resources/Prototypes/RCD/rcd.yml
+++ b/Resources/Prototypes/RCD/rcd.yml
@@ -17,9 +17,9 @@
   name: rcd-component-deconstruct
   mode: Deconstruct
   cost: 2
-  delay: 1
+  delay: 0
   rotation: Camera
-  fx: EffectRCDDeconstruct2
+  fx: EffectRCDConstruct0
     
 - type: rcd
   id: DeconstructTile      # Hidden prototype - do not add to RCDs


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Fixed a bug that was swapping the deconstruction time and costs of tiles and lattice

Also made the deconstruction of lattice and power cables instant

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Closes #26850 

The deconstruction times for lattice and power cables were made instant because if you're resorting to using the RCD to remove them instead of wire cutters you might as well get some benefit out of it, as you need to spend charges to get rid of them

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

N/A

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

N/A

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

- fix: Fixed bug that was swapping the time and costs of deconstructing tiles and lattice with an RCD
- tweak: Lattice and power cables can now be deconstructed instantly with an RCD