### PR TITLE
The potassium explosion can also be done with blood, blue blood, slime, and sap.

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -101,7 +101,7 @@
     FluorosulfuricAcid: 4
 
 - type: reaction
-  id: PotassiumExplosion
+  id: PotassiumExplosionWithWater
   impact: High
   priority: 20
   reactants:
@@ -114,6 +114,88 @@
       explosionType: Default
       maxIntensity: 100
       intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
+      intensitySlope: 4
+      maxTotalIntensity: 100
+
+- type: reaction
+  id: PotassiumExplosionWithBlood
+  impact: High
+  priority: 20
+  reactants:
+    Blood:
+      amount: 1.81
+    Potassium:
+      amount: 1
+  products:
+    Iron: 0.045
+    Sugar: 0.181
+    CarbonDioxide: 0.272
+    Protein: 0.362
+  effects:
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 100
+      intensityPerUnit: 0.5 
+      intensitySlope: 4
+      maxTotalIntensity: 100
+
+- type: reaction
+  id: PotassiumExplosionWithCopperBlood
+  impact: High
+  priority: 20
+  reactants:
+    CopperBlood:
+      amount: 1.81
+    Potassium:
+      amount: 1
+  products:
+    Copper: 0.045
+    Sugar: 0.181
+    CarbonDioxide: 0.272
+    Protein: 0.362
+  effects:
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 100
+      intensityPerUnit: 0.5 
+      intensitySlope: 4
+      maxTotalIntensity: 100
+
+- type: reaction
+  id: PotassiumExplosionWithSlime
+  impact: High
+  priority: 20
+  reactants:
+    Slime:
+      amount: 1.25
+    Potassium:
+      amount: 1
+  products:
+    Nitrogen: 0.25
+  effects:
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 100
+      intensityPerUnit: 0.5 
+      intensitySlope: 4
+      maxTotalIntensity: 100
+
+- type: reaction
+  id: PotassiumExplosionWithSap
+  impact: High
+  priority: 20
+  reactants:
+    Sap:
+      amount: 1.11
+    Potassium:
+      amount: 1
+  products:
+    Sugar: 0.111
+  effects:
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 100
+      intensityPerUnit: 0.5 
       intensitySlope: 4
       maxTotalIntensity: 100
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added four more reactions, potassium with blood, potassium with blue blood, potassium with slime, and potassium with sap. They all produce an explosion, which is identical in strength to that of potassium with water.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Adds more realism, but also now scientists cant just have the arti room filled with blood from the poor monkeys. They actually have to call a janitor to get that cleaned(or do it themselves), else the artifact may just generate potassium and blow up the lab.

- [x]  This PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Potassium now explodes on contact with blood, blue blood, slime blood, and sap.
