### PR TITLE
Reduced Pneumatic Cannon inventory space by 75%, removed cannon blacklist

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/arrows.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/arrows.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: BaseItem
   id: BaseArrow
   abstract: true
@@ -35,7 +35,6 @@
   - type: Tag
     tags:
     - Arrow
-    - CannonRestrict
   - type: Projectile
     deleteOnCollide: false
     onlyCollideWhenShot: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
@@ -22,7 +22,6 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
-    - FullAuto
     soundGunshot:
       path: /Audio/Effects/thunk.ogg
     soundEmpty:
@@ -34,10 +33,7 @@
   - type: Storage
     maxItemSize: Normal
     grid:
-    - 0,0,3,3
-    blacklist:
-      tags:
-        - CannonRestrict
+    - 0,0,1,1
   - type: Appearance
   - type: ItemMapper
     containerWhitelist: [gas_tank]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -263,7 +263,6 @@
     tags:
     - CombatKnife
     - Knife
-    - CannonRestrict
   - type: Sprite
     sprite: Objects/Weapons/Melee/throwing_knife.rsi
     state: icon

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -262,9 +262,6 @@
   id: CannonBall
 
 - type: Tag
-  id: CannonRestrict
-
-- type: Tag
   id: CannotSuicide
 
 - type: Tag


### PR DESCRIPTION
Reduced Pneumatic Cannon inventory space by 75%, removed cannon blacklist.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Reduced Pneumatic Cannon inventory space from 4x4 to 2x2.  Removed cannon blacklist
<!-- What did you change in this PR? -->

## Why / Balance
There have been numerous discussions related to this item, and I think blacklisting items is ignoring the the reason why this item has caused issues.  The improvised pneumatic cannon, is essentially a breech-loaded [potato cannon](https://en.wikipedia.org/wiki/Potato_cannon), and has no business with a 4x4 inventory capable of holding 16 individual tiny items, 8 small items(8 potatoes), or 4 medium items.  Reducing the inventory now allows payloads of either 1 medium item, 2 small items, or 4 tiny items before it needs to be reloaded.  At absolute worst, a syndicate with throwing knives can turn the pneumatic cannon into the equivalent of a double barrel shotgun that fires knives, strong, but reasonably so for a robust syndicate combo that launches a knife into someone's face.

This allows for fun combat interactions including the cannon, without having to blacklist items that would arguably make sense to cause harm if launched into someone's face.

Discussion can be found on discord in https://discord.com/channels/310555209753690112/1226338518603665520
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
Simple changes to the ymls
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/8095092/72c26fa7-75e9-4063-8b6c-6e64a34c0c6a)


- [x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None that I am aware of, does however conflict with #26860 which is a currently open PR
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- tweak: Pneumatic cannon inventory reduced in size to 2x2, item blacklist removed
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
