### PR TITLE
WT550 Buffs + Burst Mode for WT550 & C-20R

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -94,6 +94,11 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/SMGs/c20r.rsi
   - type: Gun
+    shotsPerBurst: 5
+    availableModes:
+    - SemiAuto
+    - Burst
+    - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/c-20r.ogg
   - type: ChamberMagazineAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -20,7 +20,7 @@
     maxAngle: 16
     fireRate: 8
     angleIncrease: 3
-    angleDecay: 16
+    angleDecay: 16  
     selectedMode: FullAuto
     availableModes:
     - SemiAuto
@@ -221,9 +221,16 @@
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
   - type: Gun
-    fireRate: 5
+    fireRate: 5.5
+    minAngle: 1
+    maxAngle: 6
+    angleIncrease: 1.5
+    angleDecay: 6  
     selectedMode: FullAuto
+    shotsPerBurst: 5
     availableModes:
+    - SemiAuto
+    - Burst
     - FullAuto
   - type: ItemSlots
     slots:


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The following stat changes have been made to the WT550:
Firerate: 5 > 5.5
Firemodes: Semi, Full > Semi, Burst (5), Full
MinAngle:  2 > 1
MaxAngle: 16 > 6
AngleIncrease: 3 > 1.5
AngleDecay: 16 > 6

It also gives the C-20R the same 5 round burst firemode option.
<!-- What did you change in this PR? -->

## Why / Balance
Currently, the WT550, which is the standard weapon for a Head of Security, is a worse drozd.
This PR aims to have its DPS be slightly better then a pistol, while still worse then the drozd, and in exchange, buffing the accuracy.
While it is still quite far from lecter-level precision, it should now be able to engage better on medium ranges as opposed to only close.
Lastly, the Burst firemode, which I see rarely used in weapons, is now available in 5 shot bursts, just to give the weapon a unique identity and maybe further help with recoil control.

In general, this PR would make the weapon feel unique, since while it is still slower then a drozd, its easier to hit more of your shots. Making it a more balanced weapon, having solid but not amazing damage and accuracy.

As for the C-20R, the 5 mode burst should help with trigger & recoil control, allowing you to not quite fire semi without going into spray and pray level accuracy due to firing for an extended period of time.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: BramvanZijp
- tweak: Nanotrasen's Small Arms Division has slightly improved the firerate and drastically improved the accuracy on its WT550 SMGs.
- add: The WT550 and C-20R SMGs can now fire in a 5 round burst-fire mode, making it easier for their users to control the recoil on these weapons.
