### PR TITLE
Fix door electronics configurator usage

### DIFF
--- a/Content.Server/UserInterface/ActivatableUISystem.cs
+++ b/Content.Server/UserInterface/ActivatableUISystem.cs
@@ -93,6 +93,9 @@ public sealed partial class ActivatableUISystem : EntitySystem
         if (component.InHandsOnly)
             return;
 
+        if (component.AllowedItems != null)
+            return;
+
         args.Handled = InteractUI(args.User, uid, component);
     }
 
@@ -102,6 +105,9 @@ public sealed partial class ActivatableUISystem : EntitySystem
             return;
 
         if (component.RightClickOnly)
+            return;
+
+        if (component.AllowedItems != null)
             return;
 
         args.Handled = InteractUI(args.User, uid, component);

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
@@ -18,7 +18,7 @@
       key: enum.DoorElectronicsConfigurationUiKey.Key
       allowedItems:
         tags:
-        - Multitool
+        - DoorElectronicsConfigurator
     - type: UserInterface
       interfaces:
       - key: enum.DoorElectronicsConfigurationUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -225,6 +225,7 @@
   - type: Tag
     tags:
       - Multitool
+      - DoorElectronicsConfigurator
   - type: PhysicalComposition
     materialComposition:
       Steel: 100
@@ -266,6 +267,9 @@
     - type: ActivatableUI
       key: enum.NetworkConfiguratorUiKey.List
       inHandsOnly: true
+    - type: Tag
+      tags:
+        - DoorElectronicsConfigurator
     - type: UserInterface
       interfaces:
         - key: enum.NetworkConfiguratorUiKey.List
@@ -343,13 +347,13 @@
   description: The rapid construction device can be used to quickly place and remove various station structures and fixtures. Requires compressed matter to function.
   components:
   - type: RCD
-    availablePrototypes:   
+    availablePrototypes:
     - WallSolid
     - FloorSteel
     - Plating
     - Catwalk
     - Grille
-    - Window    
+    - Window
     - WindowDirectional
     - WindowReinforcedDirectional
     - ReinforcedWindow
@@ -398,7 +402,7 @@
   - type: LimitedCharges
     charges: 0
   - type: RCD
-    availablePrototypes:   
+    availablePrototypes:
     - WallSolid
     - FloorSteel
     - Plating

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -524,6 +524,9 @@
   id: DoorElectronics
 
 - type: Tag
+  id: DoorElectronicsConfigurator
+
+- type: Tag
   id: DrinkBottle
 
 - type: Tag
@@ -1177,7 +1180,7 @@
 
 - type: Tag
   id: SuitEVA
-  
+
 - type: Tag
   id: Sunglasses
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes #26869 by allowing usage of network configurator and disallowing usage of hands.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Original changelog stated that it should be made with multitool or network configurator.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added tag `DoorElectronicsConfigurator` and added it to multitool and network configurator. After that door electronics just checks for that tag.

Also had to modify `Content.Server.UserInterface.ActivatableUISystem`, so it checks for `AllowedItems` in `OnActivate` and `OnUseInHand`. Otherwise it just ignored it. Also IMHO, docs say that `AllowedItems` set entities "required", but the field is "allowed", maybe it should be renamed?

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: NT removed developers' configuration device from all doors electronics and patched network configurators to work with them
