### PR TITLE
Use Door Electronics as the access provider of secure crates

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -91,6 +91,7 @@
   - type: Lock
   - type: LockVisuals
   - type: AccessReader
+    containerAccessProvider: board
   - type: Icon
     sprite: Structures/Storage/Crates/secure.rsi
     state: icon

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
@@ -8,9 +8,13 @@
           steps:
             - material: Steel
               amount: 5
-            - material: Cable
-              amount: 2
-              doAfter: 5
+            - component: DoorElectronics
+              store: board
+              name: "door electronics circuit board"
+              icon:
+                sprite: "Objects/Misc/module.rsi"
+                state: "door_electronics"
+              doAfter: 3
 
 
     - node: cratesecure


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Re-use Door Electronics as the access provider of secure crates. 
I've decided to just use Door Electronics because aren't crates mechanically really similar to doors? Just remove the motor responsible for opening the door and suddenly you've got yourself a crate. 

For now this PR is in an incomplete state, only the constructable form of secure crates uses this behaviour. 
I'm thinking of putting this proposal out there, and upon getting any affirmations of this being an acceptable idea, begin to implement rest of this PR.

## Why / Balance
In order to utilize self-constructed secure crates you need an Access Configurator, and assistance from either HoP or the Captain if you want cross-departmental secure crates. 
With this change, science for example can build secure crates that can only be unlocked by science and cargo, stopping random bystanders from opening the crate during shipment and stealing all your precious plasma. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/62134478/ade628ff-8ca9-4ceb-8510-030a15db053a

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.

- add: Added fun!
- remove: Removed fun!

- fix: Fixed fun!
-->

:cl:
- tweak: NT has decided to retrofit secure crates with Door Electronics.