### PR TITLE
Allow advertisement timers to prewarm

### DIFF
--- a/Content.Server/Advertise/Components/AdvertiseComponent.cs
+++ b/Content.Server/Advertise/Components/AdvertiseComponent.cs
@@ -25,6 +25,14 @@ public sealed partial class AdvertiseComponent : Component
     public int MaximumWait { get; private set; } = 10 * 60;
 
     /// <summary>
+    /// If true, the delay before the first advertisement (at MapInit) will ignore <see cref="MinimumWait"/>
+    /// and instead be rolled between 0 and <see cref="MaximumWait"/>. This only applies to the initial delay;
+    /// <see cref="MinimumWait"/> will be respected after that.
+    /// </summary>
+    [DataField]
+    public bool Prewarm = true;
+
+    /// <summary>
     /// The identifier for the advertisements pack prototype.
     /// </summary>
     [DataField(required: true)]

--- a/Content.Server/Advertise/EntitySystems/AdvertiseSystem.cs
+++ b/Content.Server/Advertise/EntitySystems/AdvertiseSystem.cs
@@ -37,13 +37,14 @@ public sealed class AdvertiseSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, AdvertiseComponent advert, MapInitEvent args)
     {
-        RandomizeNextAdvertTime(advert);
+        var prewarm = advert.Prewarm;
+        RandomizeNextAdvertTime(advert, prewarm);
         _nextCheckTime = MathHelper.Min(advert.NextAdvertisementTime, _nextCheckTime);
     }
 
-    private void RandomizeNextAdvertTime(AdvertiseComponent advert)
+    private void RandomizeNextAdvertTime(AdvertiseComponent advert, bool prewarm = false)
     {
-        var minDuration = Math.Max(1, advert.MinimumWait);
+        var minDuration = prewarm ? 0 : Math.Max(1, advert.MinimumWait);
         var maxDuration = Math.Max(minDuration, advert.MaximumWait);
         var waitDuration = TimeSpan.FromSeconds(_random.Next(minDuration, maxDuration));
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added the ability for objects that advertise (vending machines, arcade machines) to ignore the minimum delay time before playing their first advertisement.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Because of the minimum wait time, there's a guaranteed period of silence at the start of the round before any ads can be played. This makes the station seem kinda dead, and also means that ads tend to come in somewhat synchronized waves as the timers cycle, drifting farther apart over the round. "Prewarming" the timers breaks things up more right from the start.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a boolean field `Prewarm` to `AdvertiseComponent` (defaults to true). Adds an optional `prewarm` bool parameter (defaulting to false) to `AdvertiseSystem.RandomizeNextAdvertTime` that ignores the minimum wait time. On MapInit, the call to `RandomizeNextAdvertTime` is passed the component's `Prewarm` value.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
