### PR TITLE
Add two-message overload to PopupPredicted

### DIFF
--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -184,6 +184,12 @@ namespace Content.Client.Popups
                 PopupEntity(message, uid, recipient.Value, type);
         }
 
+        public override void PopupPredicted(string? recipientMessage, string? othersMessage, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
+        {
+            if (recipient != null && _timing.IsFirstTimePredicted)
+                PopupEntity(recipientMessage, uid, recipient.Value, type);
+        }
+
         #endregion
 
         #region Network Event Handlers

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -126,5 +126,10 @@ namespace Content.Server.Popups
                 RaiseNetworkEvent(new PopupEntityEvent(message, type, GetNetEntity(uid)));
             }
         }
+
+        public override void PopupPredicted(string? recipientMessage, string? othersMessage, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
+        {
+            PopupPredicted(othersMessage, uid, recipient, type);
+        }
     }
 }

--- a/Content.Shared/Burial/BurialSystem.cs
+++ b/Content.Shared/Burial/BurialSystem.cs
@@ -116,8 +116,9 @@ public sealed class BurialSystem : EntitySystem
     {
         if (used != null)
         {
-            _popupSystem.PopupClient(Loc.GetString("grave-start-digging-user", ("grave", uid), ("tool", used)), user, user);
-            _popupSystem.PopupEntity(Loc.GetString("grave-start-digging-others", ("user", user), ("grave", uid), ("tool", used)), user, Filter.PvsExcept(user), true);
+            var selfMessage = Loc.GetString("grave-start-digging-user", ("grave", uid), ("tool", used));
+            var othersMessage = Loc.GetString("grave-start-digging-others", ("user", user), ("grave", uid), ("tool", used));
+            _popupSystem.PopupPredicted(selfMessage, othersMessage, user, user);
             component.ActiveShovelDigging = true;
             Dirty(uid, component);
         }

--- a/Content.Shared/Climbing/Systems/BonkSystem.cs
+++ b/Content.Shared/Climbing/Systems/BonkSystem.cs
@@ -57,9 +57,11 @@ public sealed partial class BonkSystem : EntitySystem
         if (user == source)
         {
             // Non-local, non-bonking players
-            _popupSystem.PopupEntity(Loc.GetString("bonkable-success-message-others", ("user", userName), ("bonkable", bonkableName)), user, Filter.PvsExcept(user), true);
+            var othersMessage = Loc.GetString("bonkable-success-message-others", ("user", userName), ("bonkable", bonkableName));
             // Local, bonking player
-            _popupSystem.PopupClient(Loc.GetString("bonkable-success-message-user", ("user", userName), ("bonkable", bonkableName)), user, user);
+            var selfMessage = Loc.GetString("bonkable-success-message-user", ("user", userName), ("bonkable", bonkableName));
+
+            _popupSystem.PopupPredicted(selfMessage, othersMessage, user, user);
         }
         else if (source != null)
         {

--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -307,8 +307,7 @@ public sealed partial class ClimbSystem : VirtualController
                 ("climbable", climbable));
         }
 
-        _popupSystem.PopupEntity(othersMessage, uid, Filter.PvsExcept(user, entityManager: EntityManager), true);
-        _popupSystem.PopupClient(selfMessage, uid, user);
+        _popupSystem.PopupPredicted(selfMessage, othersMessage, uid, user);
     }
 
     /// <summary>

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -94,6 +94,12 @@ namespace Content.Shared.Popups
         /// will do nothing and the server will show the message to every player in PVS range.
         /// </summary>
         public abstract void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small);
+
+        /// <summary>
+        /// Variant of <see cref="PopupPredicted(string?, EntityUid, EntityUid?, PopupType)"/> that displays <paramref name="recipientMessage"/>
+        /// to the recipient and <paramref name="othersMessage"/> to everyone else in PVS range.
+        /// </summary>
+        public abstract void PopupPredicted(string? recipientMessage, string? othersMessage, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small);
     }
 
     /// <summary>

--- a/Content.Shared/Wieldable/WieldableSystem.cs
+++ b/Content.Shared/Wieldable/WieldableSystem.cs
@@ -195,8 +195,9 @@ public sealed class WieldableSystem : EntitySystem
             && !_delay.TryResetDelay((used, useDelay), true))
             return false;
 
-        _popupSystem.PopupClient(Loc.GetString("wieldable-component-successful-wield", ("item", used)), user, user);
-        _popupSystem.PopupEntity(Loc.GetString("wieldable-component-successful-wield-other", ("user", user), ("item", used)), user, Filter.PvsExcept(user), true);
+        var selfMessage = Loc.GetString("wieldable-component-successful-wield", ("item", used));
+        var othersMessage = Loc.GetString("wieldable-component-successful-wield-other", ("user", user), ("item", used));
+        _popupSystem.PopupPredicted(selfMessage, othersMessage, user, user);
 
         var targEv = new ItemWieldedEvent();
         RaiseLocalEvent(used, ref targEv);
@@ -239,10 +240,9 @@ public sealed class WieldableSystem : EntitySystem
             if (component.UnwieldSound != null)
                 _audioSystem.PlayPredicted(component.UnwieldSound, uid, args.User);
 
-            _popupSystem.PopupClient(Loc.GetString("wieldable-component-failed-wield",
-                ("item", uid)), args.User.Value, args.User.Value);
-            _popupSystem.PopupEntity(Loc.GetString("wieldable-component-failed-wield-other",
-                ("user", args.User.Value), ("item", uid)), args.User.Value, Filter.PvsExcept(args.User.Value), true);
+            var selfMessage = Loc.GetString("wieldable-component-failed-wield", ("item", uid));
+            var othersMessage = Loc.GetString("wieldable-component-failed-wield-other", ("user", args.User.Value), ("item", uid));
+            _popupSystem.PopupPredicted(selfMessage, othersMessage, args.User.Value, args.User.Value);
         }
 
         _appearance.SetData(uid, WieldableVisuals.Wielded, false);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added an overload to SharedPopupSystem.PopupPredicted that displays one message to the predicting client and a different message to everyone else.

Also used it in three places to very slightly clean up the code.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Convenience. PopupPredicted is nice, but it's much more common to want to display "you do a thing" to the predicting client and "(username) does a thing" to others. This lets you do that in one line, instead of having to call PopupClient and PopupEntity (with the predicting client filtered out) separately.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
It's exactly the same as the other PopupPredicted, but it takes two strings and the client and server implementations just use the right one.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Code
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
