### PR TITLE
Fix the stripping menu being openable without StrippingComponent

### DIFF
--- a/Content.Server/Strip/StrippableSystem.cs
+++ b/Content.Server/Strip/StrippableSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Ensnaring;
 using Content.Shared.CombatMode;
@@ -20,7 +21,6 @@ using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
-using System.Linq;
 
 namespace Content.Server.Strip
 {
@@ -111,7 +111,7 @@ namespace Content.Server.Strip
             if (TryComp<CombatModeComponent>(user, out var mode) && mode.IsInCombatMode && !openInCombat)
                 return;
 
-            if (TryComp<ActorComponent>(user, out var actor))
+            if (TryComp<ActorComponent>(user, out var actor) && HasComp<StrippingComponent>(user))
             {
                 if (_userInterfaceSystem.SessionHasOpenUi(strippable, StrippingUiKey.Key, actor.PlayerSession))
                     return;

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -43,14 +43,16 @@ public abstract class SharedStrippableSystem : EntitySystem
         args.Handled = true;
         args.CanDrop |= uid == args.User &&
                         HasComp<StrippableComponent>(args.Dragged) &&
-                        HasComp<HandsComponent>(args.User);
+                        HasComp<HandsComponent>(args.User) &&
+                        HasComp<StrippingComponent>(args.User);
     }
 
     private void OnCanDrop(EntityUid uid, StrippableComponent component, ref CanDropDraggedEvent args)
     {
         args.CanDrop |= args.Target == args.User &&
                         HasComp<StrippingComponent>(args.User) &&
-                        HasComp<HandsComponent>(args.User);
+                        HasComp<HandsComponent>(args.User) &&
+                        HasComp<StrippingComponent>(args.User);
 
         if (args.CanDrop)
             args.Handled = true;


### PR DESCRIPTION
## About the PR
Previously you could open the window, then when trying to strip anything it would popup "You can't reach there".
Also it was inconsistent since it would let you equip an item onto someone, but not remove it.

## Media
https://github.com/space-wizards/space-station-14/assets/10968691/c0377efb-595f-460f-b402-bc43f0e44d19

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
