### PR TITLE
Fix options menu crashing in replays

### DIFF
--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -59,8 +59,10 @@ namespace Content.Client.Options.UI.Tabs
                 UpdateApplyButton();
             };
 
-            ShowOocPatronColor.Visible = _playerManager.LocalSession?.Channel.UserData.PatronTier is { } patron;
-            
+            // Channel can be null in replays so.
+            // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
+            ShowOocPatronColor.Visible = _playerManager.LocalSession?.Channel?.UserData.PatronTier is { };
+
             HudThemeOption.OnItemSelected += OnHudThemeChanged;
             DiscordRich.OnToggled += OnCheckBoxToggled;
             ShowOocPatronColor.OnToggled += OnCheckBoxToggled;


### PR DESCRIPTION
Not having the nullable set properly is annoying but fixing that would probably be a significant amount of work.