### PR TITLE
Fixed magboot activation distance

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactMagnetTriggerSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactMagnetTriggerSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server.Salvage;
 using Content.Server.Xenoarchaeology.XenoArtifacts.Triggers.Components;
 using Content.Shared.Clothing;
@@ -42,7 +42,7 @@ public sealed class ArtifactMagnetTriggerSystem : EntitySystem
                 if (!magXform.Coordinates.TryDistance(EntityManager, xform.Coordinates, out var distance))
                     continue;
 
-                if (distance > trigger.Range)
+                if (distance > trigger.MagbootRange)
                     continue;
 
                 _toActivate.Add(artifactUid);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Made artifact magnet trigger use the correct range for magboots. 

## Why / Balance
Isn't it annoying how your environmental disruption artifact is activated by that salv walking through the corridor 30 tiles away?
Also most likely this range is the intended behaviour for this trigger, as is written in the component responsible for this system. [ArtifactMagnetTriggerComponent.cs](https://github.com/space-wizards/space-station-14/blob/24b6456735ae83dd9de53097d625f20b723c578f/Content.Server/Xenoarchaeology/XenoArtifacts/Triggers/Components/ArtifactMagnetTriggerComponent.cs#L15-L21)

## Technical details
Just replaced a variable

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->a

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame

https://github.com/space-wizards/space-station-14/assets/62134478/68fa25a8-f15a-4208-8ace-0f727005f3c3

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Magboots no longer activate artifacts from salvage magnet ranges.
