### PR TITLE
Fix incorrect "Cycled" and "Bolted" popups when (un)wielding a gun

### DIFF
--- a/Content.Shared/Wieldable/WieldableSystem.cs
+++ b/Content.Shared/Wieldable/WieldableSystem.cs
@@ -34,7 +34,7 @@ public sealed class WieldableSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<WieldableComponent, UseInHandEvent>(OnUseInHand);
+        SubscribeLocalEvent<WieldableComponent, UseInHandEvent>(OnUseInHand, before: [typeof(SharedGunSystem)]);
         SubscribeLocalEvent<WieldableComponent, ItemUnwieldedEvent>(OnItemUnwielded);
         SubscribeLocalEvent<WieldableComponent, GotUnequippedHandEvent>(OnItemLeaveHand);
         SubscribeLocalEvent<WieldableComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);


### PR DESCRIPTION
## About the PR
The behavior stays the same (it doesn't actually cycle or bolt, just wield/unwield), but the incorrect popup is no longer there.

## Media
https://github.com/space-wizards/space-station-14/assets/10968691/618b6b0a-1ba3-4b9f-8c6d-41780683a81c

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed incorrect "Cycled" and "Bolted" popups when wielding and unwielding some guns.