### PR TITLE
Fix cryostorage identifying unknown characters as captain

### DIFF
--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -225,13 +225,16 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
         if (!TryComp<StationRecordsComponent>(station, out var stationRecords))
             return;
 
-        var key = new StationRecordKey(_stationRecords.GetRecordByName(station.Value, name) ?? default(uint), station.Value);
-        var jobName = "Unknown";
+        var jobName = Loc.GetString("earlyleave-cryo-job-unknown");
+        var recordId = _stationRecords.GetRecordByName(station.Value, name);
+        if (recordId != null)
+        {
+            var key = new StationRecordKey(recordId.Value, station.Value);
+            if (_stationRecords.TryGetRecord<GeneralStationRecord>(key, out var entry, stationRecords))
+                jobName = entry.JobTitle;
 
-        if (_stationRecords.TryGetRecord<GeneralStationRecord>(key, out var entry, stationRecords))
-            jobName = entry.JobTitle;
-
-        _stationRecords.RemoveRecord(key, stationRecords);
+            _stationRecords.RemoveRecord(key, stationRecords);
+        }
 
         _chatSystem.DispatchStationAnnouncement(station.Value,
             Loc.GetString(

--- a/Resources/Locale/en-US/bed/cryostorage/cryogenic-storage.ftl
+++ b/Resources/Locale/en-US/bed/cryostorage/cryogenic-storage.ftl
@@ -1,5 +1,6 @@
 ﻿
 ### Announcement
 
+earlyleave-cryo-job-unknown = Unknown
 earlyleave-cryo-announcement = {$character} ({$job}) has entered cryogenic storage!
 earlyleave-cryo-sender = Station


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes #26913.
Also adds localization to "Unknown" string used for announcing jobless characters going into cryostorage.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bug fix.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
See https://github.com/space-wizards/space-station-14/issues/26913#issuecomment-2053417858
When the system failed to find a record for the inserted character, it defaulted to getting the record with ID 0, which was the station's captain. The logic has been reworked so it doesn't look for the station record if there isn't an entry with the character's name.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Placing a player with no entry in the manifest into cryostorage no longer removes the captain from the crew manifest.