### PR TITLE
[Admin QOL] +Adminchat flag

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -546,7 +546,7 @@ public sealed class ChatUIController : UIController
         }
 
         // only admins can see / filter asay
-        if (_admin.HasFlag(AdminFlags.Admin))
+        if (_admin.HasFlag(AdminFlags.Adminchat))
         {
             FilterableChannels |= ChatChannel.Admin;
             FilterableChannels |= ChatChannel.AdminAlert;

--- a/Content.Server/Chat/Commands/AdminChatCommand.cs
+++ b/Content.Server/Chat/Commands/AdminChatCommand.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Console;
 
 namespace Content.Server.Chat.Commands
 {
-    [AdminCommand(AdminFlags.Admin)]
+    [AdminCommand(AdminFlags.Adminchat)]
     internal sealed class AdminChatCommand : IConsoleCommand
     {
         public string Command => "asay";

--- a/Content.Shared/Administration/AdminFlags.cs
+++ b/Content.Shared/Administration/AdminFlags.cs
@@ -99,6 +99,11 @@
         /// </summary>
         Stealth = 1 << 16,
 
+        ///<summary>
+		/// Allows you to use Admin chat
+		///</summary>
+		Adminchat = 1 << 17,
+
         /// <summary>
         ///     Dangerous host permissions like scsi.
         /// </summary>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Thanks moonheart08 for the idea. This PR adds +ADMINCHAT flag. This flag grants permissions to use ingame admin chat.

## Why / Balance
So, as i explained in previous [#26897] PR, Admin chat is a powerful communication tool, which is locked behind +Admin flag.
This is not very convenient IMO. For now, if you want to grant access to Admin chat for any user (for any reason), you should give him +Admin flag, which in addition to chat, gives him many unnecessary commands, accesses and capabilities.

With this flag, you can simply give access to the chat. Here are some examples where this might be useful:

Mentor system. As i said before, on Corvax, we have Mentors, which help newbies get used to the game and answer questions in adminhelp. Only thing they need is +Adminhelp and +Adminchat, to quickly contact mods ingame and solve problems.

Events. For some prepared global events you could grant some ppl access to adminchat in order to coordinate flow of the event and communicate without delays.
## Technical details
New flag +Adminchat added in Adminflags.cs. +Adminchat flag set to filter chat in ChatUIController.cs. +Adminchat grants access to command "asay" in AdminChatCommand.cs

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
ADMIN:

- add: +Adminchat flag is added. Now to gain access to the admin chat you will need this flag.

