### PR TITLE
Emergency Lights now changes color depending on alert level and whether or not the light is powered.

### DIFF
--- a/Content.Server/Light/Components/EmergencyLightComponent.cs
+++ b/Content.Server/Light/Components/EmergencyLightComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class EmergencyLightComponent : SharedEmergencyLightCompon
 
     /// <summary>
     ///     Is this emergency light forced on for some reason and cannot be disabled through normal means
-    ///     (i.e. delta alert level?)
+    ///     (i.e. blue alert or higher?)
     /// </summary>
     public bool ForciblyEnabled = false;
 

--- a/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
@@ -176,15 +176,18 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
             return;
 
         if (alerts.AlertLevels == null || !alerts.AlertLevels.Levels.TryGetValue(alerts.CurrentLevel, out var details))
+        {
+            TurnOff(uid, component, Color.Red); // if no alert, default to off red state
             return;
+        }
 
-        if (receiver.Powered && !component.ForciblyEnabled) // Green alert/empty battery 
+        if (receiver.Powered && !component.ForciblyEnabled) // Green alert
         {
             receiver.Load = (int) Math.Abs(component.Wattage);
             TurnOff(uid, component, details.Color);
             SetState(uid, component, EmergencyLightState.Charging);
         }
-        else if (!receiver.Powered)
+        else if (!receiver.Powered) // If internal battery runs out it will end in off red state
         {
             TurnOn(uid, component, Color.Red);
             SetState(uid, component, EmergencyLightState.On);
@@ -203,7 +206,9 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
         _ambient.SetAmbience(uid, false);
     }
 
-    // Turn off and set color
+    /// <summary>
+    ///     Turn off emergency light and set color.
+    /// </summary>
     private void TurnOff(EntityUid uid, EmergencyLightComponent component, Color color)
     {
         _pointLight.SetEnabled(uid, false);
@@ -220,7 +225,9 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
         _ambient.SetAmbience(uid, true);
     }
 
-    // Turn on and set color
+    /// <summary>
+    ///     Turn on emergency light and set color.
+    /// </summary>
     private void TurnOn(EntityUid uid, EmergencyLightComponent component, Color color)
     {
         _pointLight.SetEnabled(uid, true);

--- a/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
@@ -31,9 +31,9 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
         SubscribeLocalEvent<EmergencyLightComponent, PowerChangedEvent>(OnEmergencyPower);
     }
 
-    private void OnEmergencyPower(EntityUid uid, EmergencyLightComponent component, ref PowerChangedEvent args)
+    private void OnEmergencyPower(Entity<EmergencyLightComponent> entity, ref PowerChangedEvent args)
     {
-        var meta = MetaData(uid);
+        var meta = MetaData(entity.Owner);
 
         // TODO: PowerChangedEvent shouldn't be issued for paused ents but this is the world we live in.
         if (meta.EntityLifeStage >= EntityLifeStage.Terminating ||
@@ -42,7 +42,7 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
             return;
         }
 
-        UpdateState(uid, component);
+        UpdateState(entity);
     }
 
     private void OnEmergencyExamine(EntityUid uid, EmergencyLightComponent component, ExaminedEvent args)
@@ -111,13 +111,13 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
             if (details.ForceEnableEmergencyLights && !light.ForciblyEnabled)
             {
                 light.ForciblyEnabled = true;
-                TurnOn(uid, light);
+                TurnOn((uid, light));
             }
             else if (!details.ForceEnableEmergencyLights && light.ForciblyEnabled)
             {
                 // Previously forcibly enabled, and we went down an alert level.
                 light.ForciblyEnabled = false;
-                UpdateState(uid, light);
+                UpdateState((uid, light));
             }
         }
     }
@@ -135,31 +135,31 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
         var query = EntityQueryEnumerator<ActiveEmergencyLightComponent, EmergencyLightComponent, BatteryComponent>();
         while (query.MoveNext(out var uid, out _, out var emergencyLight, out var battery))
         {
-            Update(uid, emergencyLight, battery, frameTime);
+            Update((uid, emergencyLight), battery, frameTime);
         }
     }
 
-    private void Update(EntityUid uid, EmergencyLightComponent component, BatteryComponent battery, float frameTime)
+    private void Update(Entity<EmergencyLightComponent> entity, BatteryComponent battery, float frameTime)
     {
-        if (component.State == EmergencyLightState.On)
+        if (entity.Comp.State == EmergencyLightState.On)
         {
-            if (!_battery.TryUseCharge(uid, component.Wattage * frameTime, battery))
+            if (!_battery.TryUseCharge(entity.Owner, entity.Comp.Wattage * frameTime, battery))
             {
-                SetState(uid, component, EmergencyLightState.Empty);
-                TurnOff(uid, component);
+                SetState(entity.Owner, entity.Comp, EmergencyLightState.Empty);
+                TurnOff(entity);
             }
         }
         else
         {
-            _battery.SetCharge(uid, battery.CurrentCharge + component.ChargingWattage * frameTime * component.ChargingEfficiency, battery);
+            _battery.SetCharge(entity.Owner, battery.CurrentCharge + entity.Comp.ChargingWattage * frameTime * entity.Comp.ChargingEfficiency, battery);
             if (battery.IsFullyCharged)
             {
-                if (TryComp<ApcPowerReceiverComponent>(uid, out var receiver))
+                if (TryComp<ApcPowerReceiverComponent>(entity.Owner, out var receiver))
                 {
                     receiver.Load = 1;
                 }
 
-                SetState(uid, component, EmergencyLightState.Full);
+                SetState(entity.Owner, entity.Comp, EmergencyLightState.Full);
             }
         }
     }
@@ -167,73 +167,73 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
     /// <summary>
     ///     Updates the light's power drain, battery drain, sprite and actual light state.
     /// </summary>
-    public void UpdateState(EntityUid uid, EmergencyLightComponent component)
+    public void UpdateState(Entity<EmergencyLightComponent> entity)
     {
-        if (!TryComp<ApcPowerReceiverComponent>(uid, out var receiver))
+        if (!TryComp<ApcPowerReceiverComponent>(entity.Owner, out var receiver))
             return;
 
-        if (!TryComp<AlertLevelComponent>(_station.GetOwningStation(uid), out var alerts))
+        if (!TryComp<AlertLevelComponent>(_station.GetOwningStation(entity.Owner), out var alerts))
             return;
 
         if (alerts.AlertLevels == null || !alerts.AlertLevels.Levels.TryGetValue(alerts.CurrentLevel, out var details))
         {
-            TurnOff(uid, component, Color.Red); // if no alert, default to off red state
+            TurnOff(entity, Color.Red); // if no alert, default to off red state
             return;
         }
 
-        if (receiver.Powered && !component.ForciblyEnabled) // Green alert
+        if (receiver.Powered && !entity.Comp.ForciblyEnabled) // Green alert
         {
-            receiver.Load = (int) Math.Abs(component.Wattage);
-            TurnOff(uid, component, details.Color);
-            SetState(uid, component, EmergencyLightState.Charging);
+            receiver.Load = (int) Math.Abs(entity.Comp.Wattage);
+            TurnOff(entity, details.Color);
+            SetState(entity.Owner, entity.Comp, EmergencyLightState.Charging);
         }
         else if (!receiver.Powered) // If internal battery runs out it will end in off red state
         {
-            TurnOn(uid, component, Color.Red);
-            SetState(uid, component, EmergencyLightState.On);
+            TurnOn(entity, Color.Red);
+            SetState(entity.Owner, entity.Comp, EmergencyLightState.On);
         }
         else // Powered and enabled
         {
-            TurnOn(uid, component, details.Color);
-            SetState(uid, component, EmergencyLightState.On);
+            TurnOn(entity, details.Color);
+            SetState(entity.Owner, entity.Comp, EmergencyLightState.On);
         }
     }
 
-    private void TurnOff(EntityUid uid, EmergencyLightComponent component)
+    private void TurnOff(Entity<EmergencyLightComponent> entity)
     {
-        _pointLight.SetEnabled(uid, false);
-        _appearance.SetData(uid, EmergencyLightVisuals.On, false);
-        _ambient.SetAmbience(uid, false);
+        _pointLight.SetEnabled(entity.Owner, false);
+        _appearance.SetData(entity.Owner, EmergencyLightVisuals.On, false);
+        _ambient.SetAmbience(entity.Owner, false);
     }
 
     /// <summary>
     ///     Turn off emergency light and set color.
     /// </summary>
-    private void TurnOff(EntityUid uid, EmergencyLightComponent component, Color color)
+    private void TurnOff(Entity<EmergencyLightComponent> entity, Color color)
     {
-        _pointLight.SetEnabled(uid, false);
-        _pointLight.SetColor(uid, color);
-        _appearance.SetData(uid, EmergencyLightVisuals.Color, color);
-        _appearance.SetData(uid, EmergencyLightVisuals.On, false);
-        _ambient.SetAmbience(uid, false);
+        _pointLight.SetEnabled(entity.Owner, false);
+        _pointLight.SetColor(entity.Owner, color);
+        _appearance.SetData(entity.Owner, EmergencyLightVisuals.Color, color);
+        _appearance.SetData(entity.Owner, EmergencyLightVisuals.On, false);
+        _ambient.SetAmbience(entity.Owner, false);
     }
 
-    private void TurnOn(EntityUid uid, EmergencyLightComponent component)
+    private void TurnOn(Entity<EmergencyLightComponent> entity)
     {
-        _pointLight.SetEnabled(uid, true);
-        _appearance.SetData(uid, EmergencyLightVisuals.On, true);
-        _ambient.SetAmbience(uid, true);
+        _pointLight.SetEnabled(entity.Owner, true);
+        _appearance.SetData(entity.Owner, EmergencyLightVisuals.On, true);
+        _ambient.SetAmbience(entity.Owner, true);
     }
 
     /// <summary>
     ///     Turn on emergency light and set color.
     /// </summary>
-    private void TurnOn(EntityUid uid, EmergencyLightComponent component, Color color)
+    private void TurnOn(Entity<EmergencyLightComponent> entity, Color color)
     {
-        _pointLight.SetEnabled(uid, true);
-        _pointLight.SetColor(uid, color);
-        _appearance.SetData(uid, EmergencyLightVisuals.Color, color);
-        _appearance.SetData(uid, EmergencyLightVisuals.On, true);
-        _ambient.SetAmbience(uid, true); 
+        _pointLight.SetEnabled(entity.Owner, true);
+        _pointLight.SetColor(entity.Owner, color);
+        _appearance.SetData(entity.Owner, EmergencyLightVisuals.Color, color);
+        _appearance.SetData(entity.Owner, EmergencyLightVisuals.On, true);
+        _ambient.SetAmbience(entity.Owner, true); 
     }
 }

--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -5,28 +5,35 @@
     green:
       announcement: alert-level-green-announcement
       color: Green
+      emergencyLightColor: LawnGreen
       shuttleTime: 600
     blue:
       announcement: alert-level-blue-announcement
       sound: /Audio/Misc/bluealert.ogg
       color: DodgerBlue
+      forceEnableEmergencyLights: true
+      emergencyLightColor: DodgerBlue
       shuttleTime: 600
     violet:
       announcement: alert-level-violet-announcement
       sound: /Audio/Misc/notice1.ogg
       color: Violet
       emergencyLightColor: Violet
+      forceEnableEmergencyLights: true
       shuttleTime: 600
     yellow:
       announcement: alert-level-yellow-announcement
       sound: /Audio/Misc/notice1.ogg
       color: Yellow
       emergencyLightColor: Goldenrod
+      forceEnableEmergencyLights: true
       shuttleTime: 600
     red:
       announcement: alert-level-red-announcement
       sound: /Audio/Misc/redalert.ogg
       color: Red
+      emergencyLightColor: Red
+      forceEnableEmergencyLights: true
       shuttleTime: 600 #No reduction in time as we don't have swiping for red alert like in /tg/. Shuttle times are intended to create friction, so having a way to brainlessly bypass that would be dumb.
     gamma:
       announcement: alert-level-gamma-announcement

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -360,7 +360,7 @@
     radius: 5
     energy: 0.6
     offset: "0, 0.4"
-    color: "#FF4020"
+    color: "#7CFC00"
     mask: /Textures/Effects/LightMasks/double_cone.png
   - type: ApcPowerReceiver
   - type: ExtensionCableReceiver
@@ -377,10 +377,10 @@
       map: [ "enum.EmergencyLightVisualLayers.Base" ]
     - state: emergency_light_off
       map: [ "enum.EmergencyLightVisualLayers.LightOff" ]
-      color: "#FF4020"
+      color: "#7CFC00"
     - state: emergency_light_on
       map: [ "enum.EmergencyLightVisualLayers.LightOn" ]
-      color: "#FF4020"
+      color: "#7CFC00"
       shader: "unshaded"
       visible: false
   - type: Appearance


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Emergency lights now light up depending on the alert level of the station and better visually display the state of the station.  When green, emergency lights will appear unlit and green, alerts higher than green all have their own colored lights.  When power is cut to the lights and they are put on internal battery power they will default to red.
<!-- What did you change in this PR? -->

## Why / Balance
This is a flavor change which helps to better communicate the state of the station to crew.  A red alert will have flashing red lights, a blue alert will have blue flashing lights, and so on and so forth with all other alert levels aside from green given they are being powered.  This not only creates contextual ambient lighting setting the tone for emergency situations, it also serves as a reminder to command to downgrade alert level back to green when threats have passed.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
Modified the emergency lighting logic, changed the starting color to #7CFC00 LawnGreen(green only appears unlit, so lawngreen makes it easier to see that it is green with the unlit shader).
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
https://github.com/space-wizards/space-station-14/assets/8095092/4279c17e-1f63-475e-b498-bbfc82490534

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None that I am aware of
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- tweak: Emergency lighting now changes based on station alert level!
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
