### PR TITLE
Add station/space coords toggle to handheld GPS

### DIFF
--- a/Content.Client/GPS/Components/HandheldGPSComponent.cs
+++ b/Content.Client/GPS/Components/HandheldGPSComponent.cs
@@ -1,9 +1,0 @@
-using Content.Shared.GPS;
-
-namespace Content.Client.GPS.Components
-{
-    [RegisterComponent]
-    public sealed partial class HandheldGPSComponent : SharedHandheldGPSComponent
-    {
-    }
-}

--- a/Content.Client/GPS/Systems/HandheldGpsSystem.cs
+++ b/Content.Client/GPS/Systems/HandheldGpsSystem.cs
@@ -1,6 +1,6 @@
-using Content.Client.GPS.Components;
 using Content.Client.GPS.UI;
 using Content.Client.Items;
+using Content.Shared.Tools.Components;
 
 namespace Content.Client.GPS.Systems;
 
@@ -9,7 +9,6 @@ public sealed class HandheldGpsSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-
-        Subs.ItemStatus<HandheldGPSComponent>(ent => new HandheldGpsStatusControl(ent));
+        Subs.ItemStatus<HandheldGpsComponent>(ent => new HandheldGpsStatusControl(ent));
     }
 }

--- a/Content.Client/GPS/UI/HandheldGpsStatusControl.cs
+++ b/Content.Client/GPS/UI/HandheldGpsStatusControl.cs
@@ -1,6 +1,9 @@
-using Content.Client.GPS.Components;
 using Content.Client.Message;
 using Content.Client.Stylesheets;
+using Content.Shared.Input;
+using Content.Shared.Tools.Components;
+using Robust.Client.GameObjects;
+using Robust.Client.Input;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Timing;
@@ -9,15 +12,22 @@ namespace Content.Client.GPS.UI;
 
 public sealed class HandheldGpsStatusControl : Control
 {
-    private readonly Entity<HandheldGPSComponent> _parent;
+    private readonly Entity<HandheldGpsComponent> _parent;
     private readonly RichTextLabel _label;
-    private float _updateDif;
-    private readonly IEntityManager _entMan;
+    private float _accumulator;
+    private readonly IInputManager _inputManager;
+    private readonly IEntityManager _entityManager;
+    private readonly TransformSystem _transformSystem;
+    private bool _lastMode;
 
-    public HandheldGpsStatusControl(Entity<HandheldGPSComponent> parent)
+    public HandheldGpsStatusControl(Entity<HandheldGpsComponent> parent)
     {
         _parent = parent;
-        _entMan = IoCManager.Resolve<IEntityManager>();
+        _inputManager = IoCManager.Resolve<IInputManager>();
+        _entityManager = IoCManager.Resolve<IEntityManager>();
+        var entitySystemManager = IoCManager.Resolve<IEntitySystemManager>();
+        _transformSystem = entitySystemManager.GetEntitySystem<TransformSystem>();
+        _lastMode = parent.Comp.DisplayMode;
         _label = new RichTextLabel { StyleClasses = { StyleNano.StyleClassItemStatus } };
         AddChild(_label);
         UpdateGpsDetails();
@@ -27,25 +37,65 @@ public sealed class HandheldGpsStatusControl : Control
     {
         base.FrameUpdate(args);
 
-        _updateDif += args.DeltaSeconds;
-        if (_updateDif < _parent.Comp.UpdateRate)
+        // has the mode been changed? if so, immediately display new coord mode
+        if (_parent.Comp.DisplayMode != _lastMode)
+        {
+            _lastMode = _parent.Comp.DisplayMode;
+            _accumulator = 0;
+            UpdateGpsDetails();
+            return;
+        }
+
+        _accumulator += args.DeltaSeconds;
+
+        if (_accumulator < _parent.Comp.UpdateRate)
             return;
 
-        _updateDif -= _parent.Comp.UpdateRate;
+        _accumulator -= _parent.Comp.UpdateRate;
 
         UpdateGpsDetails();
     }
 
     private void UpdateGpsDetails()
     {
-        var posText = "Error";
-        if (_entMan.TryGetComponent(_parent, out TransformComponent? transComp))
+        if (!_entityManager.TryGetComponent<HandheldGpsComponent>(_parent, out var gpsComponent))
         {
-            var pos =  transComp.MapPosition;
-            var x = (int) pos.X;
-            var y = (int) pos.Y;
-            posText = $"({x}, {y})";
+            // if the component is gone we outlived our usefulness
+            Parent?.RemoveChild(this);
+            return;
         }
-        _label.SetMarkup(Loc.GetString("handheld-gps-coordinates-title", ("coordinates", posText)));
+
+        string coordsText;
+        if (gpsComponent.DisplayMode)
+        {
+            // station coordinates mode
+            if (_entityManager.TryGetComponent<TransformComponent>(_parent, out var transform) &&
+                _transformSystem.TryGetGridTilePosition((_parent, transform), out var gridPos))
+            {
+                coordsText = $"({gridPos.X}, {gridPos.Y})";
+            }
+            else
+            {
+                coordsText = Loc.GetString("handheld-gps-coordinates-unknown");
+            }
+        }
+        else
+        {
+            // space  coordinates mode
+            var mapCoordinates = _transformSystem.GetMapCoordinates(_parent);
+            var x = MathF.Round(mapCoordinates.X);
+            var y = MathF.Round(mapCoordinates.Y);
+            coordsText = $"({x}, {y})";
+        }
+
+        var keybind = _inputManager.TryGetKeyBinding((ContentKeyFunctions.UseItemInHand), out var binding)
+            ? binding.GetKeyString()
+            : Loc.GetString("handheld-gps-coordinates-no-bind");
+
+        _label.SetMarkup(Loc.GetString("handheld-gps-coordinates",
+            ("mode", gpsComponent.DisplayMode),
+            ("coords", coordsText),
+            ("keybind", keybind)
+        ));
     }
 }

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -12,7 +12,6 @@ namespace Content.Server.Entry
             "GuideHelp",
             "Clickable",
             "Icon",
-            "HandheldGPS",
             "CableVisualizer",
             "UIFragment",
             "PdaBorderColor",

--- a/Content.Server/GPS/Systems/HandheldGpsSystem.cs
+++ b/Content.Server/GPS/Systems/HandheldGpsSystem.cs
@@ -1,0 +1,30 @@
+﻿using Content.Shared.Interaction;
+using Content.Shared.Timing;
+using Content.Shared.Tools.Components;
+
+namespace Content.Server.GPS.Systems;
+
+public sealed class HandheldGpsSystem : EntitySystem
+{
+    [Dependency] private readonly UseDelaySystem _useDelaySystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<HandheldGpsComponent, ActivateInWorldEvent>(OnActivate);
+    }
+
+    private void OnActivate(EntityUid uid, HandheldGpsComponent component, ActivateInWorldEvent args)
+    {
+        // if it has a delay component, try delaying, and return if it's already delaying
+        if (TryComp(uid, out UseDelayComponent? useDelay)
+            && !_useDelaySystem.TryResetDelay(uid, true, useDelay))
+        {
+            return;
+        }
+
+        component.DisplayMode = !component.DisplayMode;
+        Dirty(uid, component);
+    }
+}
+

--- a/Content.Shared/Tools/Components/HandheldGpsComponent.cs
+++ b/Content.Shared/Tools/Components/HandheldGpsComponent.cs
@@ -1,0 +1,19 @@
+
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Tools.Components
+{
+    [RegisterComponent, NetworkedComponent, ComponentProtoName("HandheldGPS"), AutoGenerateComponentState]
+    public sealed partial class HandheldGpsComponent : Component
+    {
+        [DataField]
+        public float UpdateRate = 1.5f;
+
+        /// <summary>
+        /// Display mode: If false displays space coordinates, if true station coordinates
+        /// </summary>
+        [DataField]
+        [AutoNetworkedField]
+        public bool DisplayMode;
+    }
+}

--- a/Content.Shared/Tools/Components/SharedHandheldGPSComponent.cs
+++ b/Content.Shared/Tools/Components/SharedHandheldGPSComponent.cs
@@ -1,9 +1,0 @@
-
-namespace Content.Shared.GPS
-{
-    public abstract partial class SharedHandheldGPSComponent : Component
-    {
-        [DataField("updateRate")]
-        public float UpdateRate = 1.5f;
-    }
-}

--- a/Resources/Locale/en-US/GPS/handheld-gps.ftl
+++ b/Resources/Locale/en-US/GPS/handheld-gps.ftl
@@ -2,7 +2,7 @@ handheld-gps-coordinates = [color=white]Mode:[/color] {$mode ->
         *[false] Space coords
         [true] Station coords
     }
-    {"[color]Position:[/color]"} {$coords}
+    {"[color=white]Position:[/color]"} {$coords}
     {$keybind} to switch mode
 
 handheld-gps-coordinates-unknown = no signal

--- a/Resources/Locale/en-US/GPS/handheld-gps.ftl
+++ b/Resources/Locale/en-US/GPS/handheld-gps.ftl
@@ -1,1 +1,9 @@
-handheld-gps-coordinates-title = Coords: {$coordinates}
+handheld-gps-coordinates = [color=white]Mode:[/color] {$mode ->
+        *[false] Space coords
+        [true] Station coords
+    }
+    {"[color]Position:[/color]"} {$coords}
+    {$keybind} to switch mode
+
+handheld-gps-coordinates-unknown = no signal
+handheld-gps-coordinates-no-bind = (unknown)

--- a/Resources/Prototypes/Entities/Objects/Tools/gps.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gps.yml
@@ -15,3 +15,5 @@
   - type: Tag
     tags:
     - GPS
+  - type: UseDelay
+    delay: 1.5  # prevents cheating the coords update rate by spamming use


### PR DESCRIPTION
## About the PR
Fixes #13468.

## Why / Balance
The coordinates in the crew monitor weren't really useable before this change. Now they are.

## Technical details
It's mostly self explanatory.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/165581243/480febd7-52d0-4345-9295-2204efccfa5a)
![image](https://github.com/space-wizards/space-station-14/assets/165581243/476d8c05-a8ed-40c0-b828-47514dc84e1d)


## Breaking changes
None.

**Changelog**
:cl:
- add: The handheld GPS can now toggle between space coordinates and station (crew monitor) coordinates.