### PR TITLE
pinpointer can now be reconfigured. any pinpointer can't be emagged

### DIFF
--- a/Content.Shared/Pinpointer/PinpointerComponent.cs
+++ b/Content.Shared/Pinpointer/PinpointerComponent.cs
@@ -40,13 +40,13 @@ public sealed partial class PinpointerComponent : Component
     ///     Whether or not the target name should be updated when the target is updated.
     /// </summary>
     [DataField("updateTargetName"), ViewVariables(VVAccess.ReadWrite)]
-    public bool UpdateTargetName;
+    public bool UpdateTargetName = true;
 
     /// <summary>
     ///     Whether or not the target can be reassigned.
     /// </summary>
     [DataField("canRetarget"), ViewVariables(VVAccess.ReadWrite)]
-    public bool CanRetarget;
+    public bool CanRetarget = true;
 
     [ViewVariables]
     public EntityUid? Target = null;

--- a/Content.Shared/Pinpointer/SharedPinpointerSystem.cs
+++ b/Content.Shared/Pinpointer/SharedPinpointerSystem.cs
@@ -14,7 +14,6 @@ public abstract class SharedPinpointerSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<PinpointerComponent, GotEmaggedEvent>(OnEmagged);
         SubscribeLocalEvent<PinpointerComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<PinpointerComponent, ExaminedEvent>(OnExamined);
     }
@@ -133,11 +132,5 @@ public abstract class SharedPinpointerSystem : EntitySystem
         var isActive = !pinpointer.IsActive;
         SetActive(uid, isActive, pinpointer);
         return isActive;
-    }
-
-    private void OnEmagged(EntityUid uid, PinpointerComponent component, ref GotEmaggedEvent args)
-    {
-        args.Handled = true;
-        component.CanRetarget = true;
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: pinpointer
-  description: A handheld tracking device. While typically far more capable, this one has been configured to lock onto certain signals. Keep upright to retain accuracy.
+  description: A handheld tracking device. You can safely readjust the signals it picks up. Keep upright to retain accuracy.
   parent: BaseItem
   id: PinpointerBase
   abstract: true
@@ -62,6 +62,7 @@
   - type: Pinpointer
     component: NukeDisk
     targetName: nuclear authentication disk
+    canRetarget: false
 
 - type: entity
   name: universal pinpointer
@@ -74,9 +75,6 @@
     - state: pinpointer-way
   - type: Icon
     state: pinpointer-way
-  - type: Pinpointer
-    updateTargetName: true
-    canRetarget: true
 
 - type: entity
   parent: PinpointerBase
@@ -93,3 +91,4 @@
   - type: Pinpointer
     component: BecomesStation
     targetName: the station
+    canRetarget: false

--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -62,6 +62,7 @@
   - type: Pinpointer
     component: NukeDisk
     targetName: nuclear authentication disk
+    canRetarget: false
 
 - type: entity
   name: universal pinpointer

--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -62,7 +62,6 @@
   - type: Pinpointer
     component: NukeDisk
     targetName: nuclear authentication disk
-    canRetarget: false
 
 - type: entity
   name: universal pinpointer


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
removed `OnEmagged` method for pinpointer
now all pinpointers except ninja (it literally only needs it to find a station) can be reconfigured

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The pinpointer was very rarely what the emag was applied to, also according to #8524 we should abbreviate EMAG INTERACTIONS.
this pinpointer change, in my opinion, would make it more interesting, and the objective of **hidden** disk theft would become at least somewhat real.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Now according to the standard:
`UpdateTargetName = true`
`CanRetarget = true`
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- remove: Any pinpointer can't be emagged
- tweak: Now the regular pinpointer can be reconfigured to a different object
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
