### PR TITLE
Use round time instead of server time for criminal history

### DIFF
--- a/Content.Server/CriminalRecords/Systems/CriminalRecordsSystem.cs
+++ b/Content.Server/CriminalRecords/Systems/CriminalRecordsSystem.cs
@@ -3,7 +3,7 @@ using Content.Server.StationRecords.Systems;
 using Content.Shared.CriminalRecords;
 using Content.Shared.Security;
 using Content.Shared.StationRecords;
-using Robust.Shared.Timing;
+using Content.Server.GameTicking;
 
 namespace Content.Server.CriminalRecords.Systems;
 
@@ -17,7 +17,7 @@ namespace Content.Server.CriminalRecords.Systems;
 /// </summary>
 public sealed class CriminalRecordsSystem : EntitySystem
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly GameTicker _ticker = default!;
     [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
 
     public override void Initialize()
@@ -71,7 +71,7 @@ public sealed class CriminalRecordsSystem : EntitySystem
     /// </summary>
     public bool TryAddHistory(StationRecordKey key, string line)
     {
-        var entry = new CrimeHistory(_timing.CurTime, line);
+        var entry = new CrimeHistory(_ticker.RoundDuration(), line);
         return TryAddHistory(key, entry);
     }
 


### PR DESCRIPTION
## About the PR
Title. Made the criminal record computers use round time instead of server time.

## Why / Balance
Fixes #26909.

## Technical details
I've looked into and mimicked the way the news console does it (e.g. I used a method of `GameTicker` instead of Robust's `Timing`)

## Media
![2024-04-14_13-19](https://github.com/space-wizards/space-station-14/assets/37904672/8c29d354-ef02-484f-8044-07a656879cad)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None.

**Changelog**
- fix: Round time is now used instead of server time in criminal records.
