### PR TITLE
Fixed cybersun pen attacking noise

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -351,6 +351,8 @@
     damage:
       types:
         Piercing: 15
+    soundHit:
+      path: /Audio/Weapons/bladeslice.ogg
   - type: Tool
     qualities:
       - Screwing

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -356,6 +356,13 @@
       - Screwing
     useSound:
       collection: Screwdriver
+  - type: UnpoweredFlashlight
+  - type: PointLight
+    enabled: false
+    mask: /Textures/Effects/LightMasks/cone.png
+    radius: 12
+    energy: 2
+    autoRot: true
   - type: Item
     sprite: Objects/Misc/bureaucracy.rsi
     heldPrefix: overpriced_pen

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -358,13 +358,6 @@
       - Screwing
     useSound:
       collection: Screwdriver
-  - type: UnpoweredFlashlight
-  - type: PointLight
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    radius: 12
-    energy: 2
-    autoRot: true
   - type: Item
     sprite: Objects/Misc/bureaucracy.rsi
     heldPrefix: overpriced_pen


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The cybersun pen now uses the correct noise when doing damage.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Cybersun pen now makes a slashing noise when doing damage.

