### PR TITLE
nerf incendiary grenade

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
@@ -50,7 +50,7 @@
         Blunt: 1
         Heat: 2
   - type: IgniteOnCollide
-    fireStacks: 3
+    fireStacks: 1
     count: 10
   - type: TimedDespawn
     lifetime: 0.25


### PR DESCRIPTION
## About the PR
3 -> 1 firestack per pellet
probably affects incendiary shotgun ammo which is also stupid op

## Why / Balance
round removal grenade bad

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun