### PR TITLE
Make lockers can be deconstructed only when unlocked now

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -44,6 +44,11 @@
           SheetSteel1:
             min: 1
             max: 2
+  - type: Construction
+    graph: ClosetSteel
+    node: done
+    containers:
+    - entity_storage
 
 - type: entity
   id: LockerBaseSecure

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -44,11 +44,6 @@
           SheetSteel1:
             min: 1
             max: 2
-  - type: Construction
-    graph: ClosetSteel
-    node: done
-    containers:
-    - entity_storage
 
 - type: entity
   id: LockerBaseSecure

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/tallbox.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/tallbox.yml
@@ -19,6 +19,8 @@
       conditions:
       - !type:StorageWelded
         welded: false
+      - !type:Locked
+        locked: false
       completed:
       - !type:SpawnPrototype
         prototype: SheetSteel1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixed lockers that was deconstructable even when they closed and locked and you didn't have access to them. In short - get stuff by 5 seconds, 5 sec it's time to screw down any locker, except LockerBaseSecure one. From this issue #26955
Now they are deconstructable only if they're opened/unlocked (like crates)
<!-- What did you change in this PR? -->

## Why / Balance
Get stuff "stealthy" in 5 sec? It's OP too much.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
Basically revert #24942 of the LockerBase. It's had broken graph node, needs fix in future if you would like to destruct locker ability.
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/56667933/58cebb3f-e07f-4aeb-9ef8-a084d2fcc4fd



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Lockers cannot be deconstructed with a screwdriver when locked now.
