### PR TITLE
SS14-26950 Fix Waddling During Improper States

### DIFF
--- a/Content.Client/Movement/Systems/WaddleAnimationSystem.cs
+++ b/Content.Client/Movement/Systems/WaddleAnimationSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Numerics;
 using Content.Client.Buckle;
 using Content.Client.Gravity;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Components;
@@ -19,7 +20,7 @@ public sealed class WaddleAnimationSystem : EntitySystem
     [Dependency] private readonly AnimationPlayerSystem _animation = default!;
     [Dependency] private readonly GravitySystem _gravity = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly BuckleSystem _buckle = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
 
@@ -72,12 +73,8 @@ public sealed class WaddleAnimationSystem : EntitySystem
         if (_gravity.IsWeightless(uid))
             return;
 
-        // Do nothing if affected by stun system
-        if (
-            _statusEffects.HasStatusEffect(uid, "KnockedDown") ||
-            _statusEffects.HasStatusEffect(uid, "Stun") ||
-            _statusEffects.HasStatusEffect(uid, "SlowedDown")
-        )
+
+        if (!_actionBlocker.CanMove(uid, mover))
             return;
 
         // Do nothing if buckled in

--- a/Content.Client/Movement/Systems/WaddleAnimationSystem.cs
+++ b/Content.Client/Movement/Systems/WaddleAnimationSystem.cs
@@ -1,7 +1,12 @@
 ﻿using System.Numerics;
+using Content.Client.Buckle;
 using Content.Client.Gravity;
+using Content.Shared.Buckle.Components;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
+using Content.Shared.StatusEffect;
+using Content.Shared.Stunnable;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
 using Robust.Shared.Animations;
@@ -14,6 +19,9 @@ public sealed class WaddleAnimationSystem : EntitySystem
     [Dependency] private readonly AnimationPlayerSystem _animation = default!;
     [Dependency] private readonly GravitySystem _gravity = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly BuckleSystem _buckle = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
 
     public override void Initialize()
     {
@@ -21,6 +29,9 @@ public sealed class WaddleAnimationSystem : EntitySystem
         SubscribeLocalEvent<WaddleAnimationComponent, StartedWaddlingEvent>(OnStartedWalking);
         SubscribeLocalEvent<WaddleAnimationComponent, StoppedWaddlingEvent>(OnStoppedWalking);
         SubscribeLocalEvent<WaddleAnimationComponent, AnimationCompletedEvent>(OnAnimationCompleted);
+        SubscribeLocalEvent<WaddleAnimationComponent, StunnedEvent>(OnStunned);
+        SubscribeLocalEvent<WaddleAnimationComponent, KnockedDownEvent>(OnKnockedDown);
+        SubscribeLocalEvent<WaddleAnimationComponent, BuckleChangeEvent>(OnBuckleChange);
     }
 
     private void OnMovementInput(EntityUid entity, WaddleAnimationComponent component, MoveInputEvent args)
@@ -34,8 +45,6 @@ public sealed class WaddleAnimationSystem : EntitySystem
 
         if (!args.HasDirectionalMovement && component.IsCurrentlyWaddling)
         {
-            component.IsCurrentlyWaddling = false;
-
             var stopped = new StoppedWaddlingEvent(entity);
 
             RaiseLocalEvent(entity, ref stopped);
@@ -47,8 +56,6 @@ public sealed class WaddleAnimationSystem : EntitySystem
         if (component.IsCurrentlyWaddling || !args.HasDirectionalMovement)
             return;
 
-        component.IsCurrentlyWaddling = true;
-
         var started = new StartedWaddlingEvent(entity);
 
         RaiseLocalEvent(entity, ref started);
@@ -57,19 +64,29 @@ public sealed class WaddleAnimationSystem : EntitySystem
     private void OnStartedWalking(EntityUid uid, WaddleAnimationComponent component, StartedWaddlingEvent args)
     {
         if (_animation.HasRunningAnimation(uid, component.KeyName))
-        {
             return;
-        }
 
         if (!TryComp<InputMoverComponent>(uid, out var mover))
-        {
             return;
-        }
 
         if (_gravity.IsWeightless(uid))
-        {
             return;
-        }
+
+        // Do nothing if affected by stun system
+        if (
+            _statusEffects.HasStatusEffect(uid, "KnockedDown") ||
+            _statusEffects.HasStatusEffect(uid, "Stun") ||
+            _statusEffects.HasStatusEffect(uid, "SlowedDown")
+        )
+            return;
+
+        // Do nothing if buckled in
+        if (_buckle.IsBuckled(uid))
+            return;
+
+        // Do nothing if crit or dead (for obvious reasons)
+        if (_mobState.IsIncapacitated(uid))
+            return;
 
         var tumbleIntensity = component.LastStep ? 360 - component.TumbleIntensity : component.TumbleIntensity;
         var len = mover.Sprinting ? component.AnimationLength * component.RunAnimationLengthMultiplier : component.AnimationLength;
@@ -114,6 +131,36 @@ public sealed class WaddleAnimationSystem : EntitySystem
 
     private void OnStoppedWalking(EntityUid uid, WaddleAnimationComponent component, StoppedWaddlingEvent args)
     {
+        StopWaddling(uid, component);
+    }
+
+    private void OnAnimationCompleted(EntityUid uid, WaddleAnimationComponent component, AnimationCompletedEvent args)
+    {
+        var started = new StartedWaddlingEvent(uid);
+
+        RaiseLocalEvent(uid, ref started);
+    }
+
+    private void OnStunned(EntityUid uid, WaddleAnimationComponent component, StunnedEvent args)
+    {
+        StopWaddling(uid, component);
+    }
+
+    private void OnKnockedDown(EntityUid uid, WaddleAnimationComponent component, KnockedDownEvent args)
+    {
+        StopWaddling(uid, component);
+    }
+
+    private void OnBuckleChange(EntityUid uid, WaddleAnimationComponent component, BuckleChangeEvent args)
+    {
+        StopWaddling(uid, component);
+    }
+
+    private void StopWaddling(EntityUid uid, WaddleAnimationComponent component)
+    {
+        if (!component.IsCurrentlyWaddling)
+            return;
+
         _animation.Stop(uid, component.KeyName);
 
         if (!TryComp<SpriteComponent>(uid, out var sprite))
@@ -123,13 +170,7 @@ public sealed class WaddleAnimationSystem : EntitySystem
 
         sprite.Offset = new Vector2();
         sprite.Rotation = Angle.FromDegrees(0);
+
         component.IsCurrentlyWaddling = false;
-    }
-
-    private void OnAnimationCompleted(EntityUid uid, WaddleAnimationComponent component, AnimationCompletedEvent args)
-    {
-        var started = new StartedWaddlingEvent(uid);
-
-        RaiseLocalEvent(uid, ref started);
     }
 }


### PR DESCRIPTION
## About the PR
Fix some states when a clown can waddle when no clown should be able to waddle, no-matter their clowning powers.

## Why / Balance

1. You cannot waddle whilst weightless
2. You cannot waddle whilst stunned
3. You cannot waddle whilst slowed down due to stam damage
4. You cannot waddle whilst you're knocked down
5. You cannot waddle whilst you're buckled
6. You cannot waddle whilst crit
7. You cannot waddle whilst dead

## Technical details
There's some argument for being able to waddle whilst on the floor and doing some bizarre floor-humping exercise but I'm not coding an animation layer system just to handle clowns doing the worm.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
no cl no fun
