### PR TITLE
Fix StepTrigger blacklist not working

### DIFF
--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -59,7 +59,7 @@ public sealed class StepTriggerSystem : EntitySystem
 
         if (component.Blacklist != null && TryComp<MapGridComponent>(transform.GridUid, out var grid))
         {
-            var positon = _map.LocalToTile(uid, grid, transform.Coordinates);
+            var positon = _map.LocalToTile(transform.GridUid.Value, grid, transform.Coordinates);
             var anch = _map.GetAnchoredEntitiesEnumerator(uid, grid, positon);
 
             while (anch.MoveNext(out var ent))


### PR DESCRIPTION
## About the PR
Fixes being able to use catwalks to walk over lava/plasma/chasms, with caveats.

## Technical details
Fixes regression that was probably introduced by #22962. Partially fixes #26643 but you have to map catwalks in a way that ensures you are very unlikely to touch an exposed lava/chasm tile with your hitbox, because #26967. But that probably was an issue before the regression too.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/165581243/2a785b24-b135-4243-82aa-90a4432e5fce)
They also still work if you walk off of the catwalk. (Or slightly touch them with your hitbox because #26967)

## Breaking changes
None.

**Changelog**
:cl:
- fix: Catwalks over lava are slightly less likely to catch you on fire again.