### PR TITLE
Reduces the captain's sabre reflect chance to 10%

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -18,7 +18,7 @@
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect
     enabled: true
-    reflectProb: .5
+    reflectProb: .1
     spread: 90
   - type: Item
     size: Normal


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Captain's sabre reflect was reduced from 50% to 10% for balance. This WILL need discussion to come to a proper consensus if this is the right choice or not. It might be better to remove it entirely.

## Why / Balance
The reflect chance of 50% is too powerful. While this is good in the hands of the captain who can use it well, the moment an antagonist gets their hands on this, if they are remotely good at combat, they will effectively be immune to ranged stun weaponry. Balance teeters on player skill, and when a good, capable player gets their hands on a sabre, it is basically game over for any forces that try to stop them. This should not happen if the sabre was properly balanced.
I will also state that it is not a challenge to obtain this item. The viper, a 3TC purchase, 4TC if you buy an extra mag to secure a kill, can take down the captain with one magdump, but this is assuming you landed all shots. If not, you can slap that extra mag in and finish the job. 
Melee weapons have the distinct disadvantage that they are well, melee. Therefore, extra values are added to them so they are worth using, namely reflect chance. In the [PR](https://github.com/space-wizards/space-station-14/pull/18133) that buffed the reflect chance, it made a comparison to the DESWORD, which is now removed from uplinks entirely due to how broken it was. This reflect chance is from an era where 50% seemed "weaker," when it is in fact not.
We already have systems for damage reduction called armor. We do not need 50% reflect chance on the sword of a person who boasts arguably the best roundstart armor in the game, and in the hands of an antag, it makes them virtually invulnerable. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun
