### PR TITLE
Fix some airlocks with multiple access types

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
@@ -229,7 +229,7 @@
   suffix: Security/Lawyer, Locked
   components:
   - type: AccessReader
-    access: [["Security", "Lawyer"]]
+    access: [["Security"], ["Lawyer"]]
 
 - type: entity
   parent: DoorElectronics
@@ -261,7 +261,7 @@
   suffix: Vault, Locked
   components:
   - type: AccessReader
-    access: [["Security", "Command"]]
+    access: [["Security"], ["Command"]]
 
 - type: entity
   parent: DoorElectronics


### PR DESCRIPTION
## About the PR
A couple airlocks were broken because the electronics had missing brackets. This fixes the issue.

## Why / Balance
Bug fix

## Technical details
n/a

## Media
n/a

- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- fix: Fixed sec/lawyer and vault airlocks
