### PR TITLE
Fix some TryGetMind overrides relying on player data

### DIFF
--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -357,16 +357,17 @@ public sealed class MindSystem : SharedMindSystem
         mind.UserId = userId;
         mind.OriginalOwnerUserId ??= userId;
 
+        // The UserId may not have a current session, but user data may still exist for disconnected players.
+        // So we cannot combine this with the TryGetSessionById() check below.
+        if (_players.GetPlayerData(userId.Value).ContentData() is { } data)
+            data.Mind = mindId;
+
         if (_players.TryGetSessionById(userId.Value, out var ret))
         {
             mind.Session = ret;
             _pvsOverride.AddSessionOverride(netMind, ret);
             _players.SetAttachedEntity(ret, mind.CurrentEntity);
         }
-
-        // session may be null, but user data may still exist for disconnected players.
-        if (_players.GetPlayerData(userId.Value).ContentData() is { } data)
-            data.Mind = mindId;
     }
 
     public void ControlMob(EntityUid user, EntityUid target)

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -110,7 +110,7 @@ public abstract class SharedMindSystem : EntitySystem
             DebugTools.Assert(mind.UserId == user);
 #if DEBUG
             if (_playerMan.GetPlayerData(user).ContentDataUncast is ContentPlayerData data)
-                DebugTools.AssertEqual(data.Mind, GetMind(mindIdValue));
+                DebugTools.AssertEqual(data.Mind, mindIdValue);
 #endif
             mindId = mindIdValue;
             return true;

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -102,24 +102,17 @@ public abstract class SharedMindSystem : EntitySystem
         return mind;
     }
 
-    public bool TryGetMind(NetUserId user, [NotNullWhen(true)] out EntityUid? mindId, [NotNullWhen(true)] out MindComponent? mind)
+    public virtual bool TryGetMind(NetUserId user, [NotNullWhen(true)] out EntityUid? mindId, [NotNullWhen(true)] out MindComponent? mind)
     {
         if (UserMinds.TryGetValue(user, out var mindIdValue) &&
             TryComp(mindIdValue, out mind))
         {
             DebugTools.Assert(mind.UserId == user);
-#if DEBUG
-            if (_playerMan.GetPlayerData(user).ContentDataUncast is ContentPlayerData data)
-                DebugTools.AssertEqual(data.Mind, mindIdValue);
-#endif
+
             mindId = mindIdValue;
             return true;
         }
 
-#if DEBUG
-        if (_playerMan.GetPlayerData(user).ContentDataUncast is ContentPlayerData data2)
-            DebugTools.AssertNull(data2.Mind);
-#endif
         mindId = null;
         mind = null;
         return false;


### PR DESCRIPTION
This PR changes the `TryGetMind(ICommonSession, ....)` and `TryGetMind(NetUserId, ...)` methods behave in the same way. It shouldn't affect anything currently, but would be required for persistence and is related to #20773
