### PR TITLE
Allow the Command & Super door remotes to use the access of their user again.

### DIFF
--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -40,6 +40,7 @@ namespace Content.Shared.Remotes
             }
 
             args.Handled = true;
+            
             if (!this.IsPowered(args.Target.Value, EntityManager))
             {
                 Popup.PopupEntity(Loc.GetString("door-remote-no-power"), args.User, args.User);

--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -40,7 +40,7 @@ namespace Content.Shared.Remotes
             }
 
             args.Handled = true;
-            
+
             if (!this.IsPowered(args.Target.Value, EntityManager))
             {
                 Popup.PopupEntity(Loc.GetString("door-remote-no-power"), args.User, args.User);

--- a/Content.Shared/Remotes/Components/DoorRemoteComponent.cs
+++ b/Content.Shared/Remotes/Components/DoorRemoteComponent.cs
@@ -8,6 +8,9 @@ public sealed partial class DoorRemoteComponent : Component
     [AutoNetworkedField]
     [DataField]
     public OperatingMode Mode = OperatingMode.OpenClose;
+    [DataField]
+    [AutoNetworkedField]
+    public bool ExtendedByID = false;
 }
 
 public enum OperatingMode : byte

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -176,7 +176,7 @@
     - state: door_remotescreencolour
       color: "#22871a"
   - type: DoorRemote
-    ExtendedByID: true
+    extendedByID: true
   - type: Access
     groups:
     - AllAccess

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -29,6 +29,8 @@
   - type: Access
     groups:
     - Command
+  - type: DoorRemote
+    extendedByID: true
 
 - type: entity
   parent: DoorRemoteDefault
@@ -173,6 +175,8 @@
       color: "#2eba22"
     - state: door_remotescreencolour
       color: "#22871a"
+  - type: DoorRemote
+    ExtendedByID: true
   - type: Access
     groups:
     - AllAccess


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The Command & Super door remote return to their old behaviour of using the access of the remote + the access of the user.

## Why / Balance
This was removed because it made remotes too OP, however now the captains door remote cannot edit most doors while it should be able to. So then somebody made a PR to give caps remote AA, but this was rejected due to making the captain have 2 AA items to loot. This solution takes the best from each, allowing the captain to use his remote alongside his access, meaning he can bolt or emergency access any door so long as he also has his AA ID.

## Technical details
Added a datafield to the DoorRemote component which is false by default, but true for the Command & Super Remotes.
The code now checks for the access of Args.Used (the remote itself) if the field is false, like it does right now, while checking the access of Args.User (the person using the remote, who has the access of the remote due to holding it but also the access of any potential IDs.) if the field is true, which it only is for the command & super remotes (unless the component is changed in VV.)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: BramvanZijp
- tweak: The Command Door Remote can now effect doors that the user (but not the remote) has access to again.
