### PR TITLE
Fix senior ID cards and other loadout shit

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -802,7 +802,7 @@
   - type: Unremoveable
 
 - type: entity
-  parent: IDCardStandard
+  parent: EngineeringIDCard
   id: SeniorEngineerIDCard
   name: senior engineer ID card
   components:
@@ -812,7 +812,7 @@
     - state: idseniorengineer
 
 - type: entity
-  parent: IDCardStandard
+  parent: ResearchIDCard
   id: SeniorResearcherIDCard
   name: senior researcher ID card
   components:
@@ -822,7 +822,7 @@
     - state: idseniorresearcher
 
 - type: entity
-  parent: IDCardStandard
+  parent: MedicalIDCard
   id: SeniorPhysicianIDCard
   name: senior physician ID card
   components:
@@ -832,7 +832,7 @@
     - state: idseniorphysician
 
 - type: entity
-  parent: IDCardStandard
+  parent: SecurityIDCard
   id: SeniorOfficerIDCard
   name: senior officer ID card
   components:

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/atmospheric_technician.yml
@@ -43,7 +43,7 @@
 - type: startingGear
   id: AtmosphericTechnicianSatchel
   equipment:
-    back: ClothingBackpackSatchelEngineeringFilled
+    back: ClothingBackpackSatchelAtmosphericsFilled
 
 - type: loadout
   id: AtmosphericTechnicianDuffel

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -120,42 +120,6 @@
   equipment:
     back: ClothingBackpackDuffelEngineeringFilled
 
-- type: loadout
-  id: SeniorEngineerBackpack
-  equipment: SeniorEngineerBackpack
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorEngineering
-
-- type: startingGear
-  id: SeniorEngineerBackpack
-  equipment:
-    back: ClothingBackpackEngineeringFilled
-
-- type: loadout
-  id: SeniorEngineerSatchel
-  equipment: SeniorEngineerSatchel
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorEngineering
-
-- type: startingGear
-  id: SeniorEngineerSatchel
-  equipment:
-    back: ClothingBackpackSatchelEngineeringFilled
-
-- type: loadout
-  id: SeniorEngineerDuffel
-  equipment: SeniorEngineerDuffel
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorEngineering
-
-- type: startingGear
-  id: SeniorEngineerDuffel
-  equipment:
-    back: ClothingBackpackDuffelEngineeringFilled
-
 # OuterClothing
 - type: loadout
   id: StationEngineerOuterVest

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -166,42 +166,6 @@
   equipment:
     back: ClothingBackpackDuffelMedicalFilled
 
-- type: loadout
-  id: SeniorPhysicianBackpack
-  equipment: SeniorPhysicianBackpack
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
-
-- type: startingGear
-  id: SeniorPhysicianBackpack
-  equipment:
-    back: ClothingBackpackDuffelMedicalFilled
-
-- type: loadout
-  id: SeniorPhysicianSatchel
-  equipment: SeniorPhysicianSatchel
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
-
-- type: startingGear
-  id: SeniorPhysicianSatchel
-  equipment:
-    back: ClothingBackpackSatchelMedicalFilled
-
-- type: loadout
-  id: SeniorPhysicianDuffel
-  equipment: SeniorPhysicianDuffel
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician
-
-- type: startingGear
-  id: SeniorPhysicianDuffel
-  equipment:
-    back: ClothingBackpackDuffelMedicalFilled
-
 # OuterClothing
 
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
@@ -104,42 +104,6 @@
   equipment:
     back: ClothingBackpackDuffelScienceFilled
 
-- type: loadout
-  id: SeniorResearcherBackpack
-  equipment: SeniorResearcherBackpack
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorResearcher
-
-- type: startingGear
-  id: SeniorResearcherBackpack
-  equipment:
-    back: ClothingBackpackScienceFilled
-
-- type: loadout
-  id: SeniorResearcherSatchel
-  equipment: SeniorResearcherSatchel
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorResearcher
-
-- type: startingGear
-  id: SeniorResearcherSatchel
-  equipment:
-    back: ClothingBackpackSatchelScienceFilled
-
-- type: loadout
-  id: SeniorResearcherDuffel
-  equipment: SeniorResearcherDuffel
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorResearcher
-
-- type: startingGear
-  id: SeniorResearcherDuffel
-  equipment:
-    back: ClothingBackpackDuffelScienceFilled
-
 # OuterClothing
 - type: loadout
   id: RegularLabCoat

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -112,42 +112,6 @@
   equipment:
     back: ClothingBackpackDuffelSecurityFilled
 
-- type: loadout
-  id: SeniorOfficerBackpack
-  equipment: SeniorOfficerBackpack
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorOfficer
-
-- type: startingGear
-  id: SeniorOfficerBackpack
-  equipment:
-    back: ClothingBackpackSecurityFilled
-
-- type: loadout
-  id: SeniorOfficerSatchel
-  equipment: SeniorOfficerSatchel
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorOfficer
-
-- type: startingGear
-  id: SeniorOfficerSatchel
-  equipment:
-    back: ClothingBackpackSatchelSecurityFilled
-
-- type: loadout
-  id: SeniorOfficerDuffel
-  equipment: SeniorOfficerDuffel
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorOfficer
-
-- type: startingGear
-  id: SeniorOfficerDuffel
-  equipment:
-    back: ClothingBackpackDuffelSecurityFilled
-
 # PDA
 - type: loadout
   id: SecurityPDA

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -492,9 +492,6 @@
   - StationEngineerBackpack
   - StationEngineerSatchel
   - StationEngineerDuffel
-  - SeniorEngineerBackpack
-  - SeniorEngineerSatchel
-  - SeniorEngineerDuffel
 
 - type: loadoutGroup
   id: StationEngineerOuterClothing
@@ -594,9 +591,6 @@
   - ScientistBackpack
   - ScientistSatchel
   - ScientistDuffel
-  - SeniorResearcherBackpack
-  - SeniorResearcherSatchel
-  - SeniorResearcherDuffel
 
 - type: loadoutGroup
   id: ScientistOuterClothing
@@ -705,9 +699,6 @@
   - SecurityBackpack
   - SecuritySatchel
   - SecurityDuffel
-  - SeniorOfficerBackpack
-  - SeniorOfficerSatchel
-  - SeniorOfficerDuffel
 
 - type: loadoutGroup
   id: SecurityPDA
@@ -839,9 +830,6 @@
   - MedicalDoctorBackpack
   - MedicalDoctorSatchel
   - MedicalDoctorDuffel
-  - SeniorPhysicianBackpack
-  - SeniorPhysicianSatchel
-  - SeniorPhysicianDuffel
 
 - type: loadoutGroup
   id: MedicalDoctorPDA


### PR DESCRIPTION
fixes the atmos satchel being an engineer satchel
fixes senior ID cards not working (they now inherit from their base ID, so senior engineer inherits from station engineer ID)
removes the senior backpacks as they are not any different from the normal departmental backpacks

resolves #27015 

:cl:
- fix: Senior role ID cards now function properly.
