### PR TITLE
add greysec and bluesec loaduts

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -61,6 +61,33 @@
     jumpsuit: ClothingUniformJumpskirtSec
 
 - type: loadout
+  id: SecurityJumpsuitGrey
+  equipment: SecurityJumpsuitGrey
+
+- type: startingGear
+  id: SecurityJumpsuitGrey
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSecGrey
+
+- type: loadout
+  id: SecurityJumpskirtGrey
+  equipment: SecurityJumpskirtGrey
+
+- type: startingGear
+  id: SecurityJumpskirtGrey
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtSecGrey
+
+- type: loadout
+  id: SecurityJumpsuitBlue
+  equipment: SecurityJumpsuitBlue
+
+- type: startingGear
+  id: SecurityJumpsuitBlue
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSecBlue
+
+- type: loadout
   id: SeniorOfficerJumpsuit
   equipment: SeniorOfficerJumpsuit
   effects:

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -695,6 +695,9 @@
   loadouts:
   - SecurityJumpsuit
   - SecurityJumpskirt
+  - SecurityJumpsuitGrey
+  - SecurityJumpskirtGrey
+  - SecurityJumpsuitBlue
   - SeniorOfficerJumpsuit
   - SeniorOfficerJumpskirt
 


### PR DESCRIPTION
## Why / Balance
it's good
resolves #27018 

## Media
![image](https://github.com/space-wizards/space-station-14/assets/45323883/2080146d-3c46-4dd7-9876-184dda5451c2)


:cl:
- tweak: Grey and blue security jumpsuits are now available in the security officer loadout.
