### PR TITLE
Add Nun Hood to Chaplain loadout options

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/chaplain.yml
@@ -9,6 +9,15 @@
     head: ClothingHeadHatFez
 
 - type: loadout
+  id: ChaplainNunHood
+  equipment: ChaplainNunHood
+
+- type: startingGear
+  id: ChaplainNunHood
+  equipment:
+    head: ClothingHeadHatHoodNunHood
+
+- type: loadout
   id: ChaplainPlagueHat
   equipment: ChaplainPlagueHat
 

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -202,6 +202,7 @@
   minLimit: 0
   loadouts:
   - ChaplainHead
+  - ChaplainNunHood
   - ChaplainPlagueHat
   - ChaplainWitchHat
   - ChaplainWitchHatAlt


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added the nun hood to the Chaplain's loadout options.

## Why / Balance
Nuns deserve headwear too 

## Media
![nun hood screenshot](https://github.com/space-wizards/space-station-14/assets/157836624/272794ce-3974-43df-a5d5-5f0340a364fd)


**Changelog**
:cl: Bellwether
- tweak: The nun hood now appears in the Chaplain's loadout.