### PR TITLE
add ancient jumpsuit to passenger loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -40,6 +40,18 @@
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorGrey
 
+- type: loadout
+  id: AncientJumpsuit
+  equipment: AncientJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: GreyTider
+
+- type: startingGear
+  id: AncientJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitAncient
+
 # Back
 - type: loadout
   id: CommonBackpack

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -91,6 +91,7 @@
   loadouts:
   - GreyJumpsuit
   - GreyJumpskirt
+  - AncientJumpsuit
 
 - type: loadoutGroup
   id: PassengerFace


### PR DESCRIPTION
## Why / Balance
funny thing for passenger loadout, time-gated so it's a reward

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no