### PR TITLE
Add Hardhats to Station Engineer Loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -38,15 +38,6 @@
     head: ClothingHeadHatHardhatOrange
 
 - type: loadout
-  id: StationEngineerHardhatBlue
-  equipment: StationEngineerHardhatBlue
-
-- type: startingGear
-  id: StationEngineerHardhatBlue
-  equipment:
-    head: ClothingHeadHatHardhatBlue
-
-- type: loadout
   id: StationEngineerHardhatRed
   equipment: StationEngineerHardhatRed
 

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -20,13 +20,40 @@
 
 # Head
 - type: loadout
-  id: StationEngineerHead
-  equipment: StationEngineerHead
+  id: StationEngineerHardhatYellow
+  equipment: StationEngineerHardhatYellow
 
 - type: startingGear
-  id: StationEngineerHead
+  id: StationEngineerHardhatYellow
   equipment:
     head: ClothingHeadHatHardhatYellow
+
+- type: loadout
+  id: StationEngineerHardhatOrange
+  equipment: StationEngineerHardhatOrange
+
+- type: startingGear
+  id: StationEngineerHardhatOrange
+  equipment:
+    head: ClothingHeadHatHardhatOrange
+
+- type: loadout
+  id: StationEngineerHardhatBlue
+  equipment: StationEngineerHardhatBlue
+
+- type: startingGear
+  id: StationEngineerHardhatBlue
+  equipment:
+    head: ClothingHeadHatHardhatBlue
+
+- type: loadout
+  id: StationEngineerHardhatRed
+  equipment: StationEngineerHardhatRed
+
+- type: startingGear
+  id: StationEngineerHardhatRed
+  equipment:
+    head: ClothingHeadHatHardhatRed
 
 - type: loadout
   id: SeniorEngineerBeret

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -601,7 +601,10 @@
   id: StationEngineerHead
   name: loadout-group-station-engineer-head
   loadouts:
-  - StationEngineerHead
+  - StationEngineerHardhatYellow
+  - StationEngineerHardhatOrange
+  - StationEngineerHardhatBlue
+  - StationEngineerHardhatRed
   - SeniorEngineerBeret
 
 - type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -603,7 +603,6 @@
   loadouts:
   - StationEngineerHardhatYellow
   - StationEngineerHardhatOrange
-  - StationEngineerHardhatBlue
   - StationEngineerHardhatRed
   - SeniorEngineerBeret
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

Adds the orange, red, and blue hardhats to the Station Engineer loadout.

## Media


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/space-wizards/space-station-14/assets/7548248/f04fb5f8-3757-4400-91e1-51787f664372)

