### PR TITLE
add roboticist gear to science loadout

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -114,6 +114,7 @@ loadout-group-research-director-neck = Research Director neck
 loadout-group-research-director-jumpsuit = Research Director jumpsuit
 loadout-group-research-director-backpack = Research Director backpack
 loadout-group-research-director-outerclothing = Research Director outer clothing
+loadout-group-research-director-gloves = Scientist gloves
 loadout-group-research-director-shoes = Research Director shoes
 
 loadout-group-scientist-head = Scientist head
@@ -121,6 +122,7 @@ loadout-group-scientist-neck = Scientist neck
 loadout-group-scientist-jumpsuit = Scientist jumpsuit
 loadout-group-scientist-backpack = Scientist backpack
 loadout-group-scientist-outerclothing = Scientist outer clothing
+loadout-group-scientist-gloves = Scientist gloves
 loadout-group-scientist-shoes = Scientist shoes
 loadout-group-scientist-id = Scientist ID
 

--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -114,7 +114,6 @@ loadout-group-research-director-neck = Research Director neck
 loadout-group-research-director-jumpsuit = Research Director jumpsuit
 loadout-group-research-director-backpack = Research Director backpack
 loadout-group-research-director-outerclothing = Research Director outer clothing
-loadout-group-research-director-gloves = Scientist gloves
 loadout-group-research-director-shoes = Research Director shoes
 
 loadout-group-scientist-head = Scientist head

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -29,29 +29,29 @@
 
 # Gloves
 - type: loadout
-  id: JanitorGlovesRubber
-  equipment: JanitorGlovesRubber
+  id: JanitorRubberGloves
+  equipment: JanitorRubberGloves
 
 - type: startingGear
-  id: JanitorGlovesRubber
+  id: JanitorRubberGloves
   equipment:
     gloves: ClothingHandsGlovesJanitor
 
 - type: loadout
-  id: JanitorGlovesOrange
-  equipment: JanitorGlovesOrange
+  id: OrangeGloves
+  equipment: OrangeGloves
 
 - type: startingGear
-  id: JanitorGlovesOrange
+  id: OrangeGloves
   equipment:
     gloves: ClothingHandsGlovesColorOrange
 
 - type: loadout
-  id: JanitorGlovesPurple
-  equipment: JanitorGlovesPurple
+  id: PurpleGloves
+  equipment: PurpleGloves
 
 - type: startingGear
-  id: JanitorGlovesPurple
+  id: PurpleGloves
   equipment:
     gloves: ClothingHandsGlovesColorPurple
 

--- a/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
@@ -89,16 +89,3 @@
   id: ResearchDirectorWintercoat
   equipment:
     outerClothing: ClothingOuterWinterRD
-
-# Gloves
-- type: loadout
-  id: PassengerGloves
-  equipment: FingerlessInsulatedGloves
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: GreyTider
-
-- type: startingGear
-  id: FingerlessInsulatedGloves
-  equipment:
-    gloves: ClothingHandsGlovesFingerlessInsulated

--- a/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
@@ -89,3 +89,16 @@
   id: ResearchDirectorWintercoat
   equipment:
     outerClothing: ClothingOuterWinterRD
+
+# Gloves
+- type: loadout
+  id: PassengerGloves
+  equipment: FingerlessInsulatedGloves
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: GreyTider
+
+- type: startingGear
+  id: FingerlessInsulatedGloves
+  equipment:
+    gloves: ClothingHandsGlovesFingerlessInsulated

--- a/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
@@ -22,6 +22,24 @@
   equipment:
     head: ClothingHeadHatBeretRND
 
+- type: loadout
+  id: RoboticistCap
+  equipment: RoboticistCap
+
+- type: startingGear
+  id: RoboticistCap
+  equipment:
+    head: ClothingHeadHatCorpsoft
+
+- type: loadout
+  id: SkullBandana
+  equipment: SkullBandana
+
+- type: startingGear
+  id: SkullBandana
+  equipment:
+    head: ClothingHeadBandSkull
+
 # Neck
 
 - type: loadout
@@ -51,6 +69,24 @@
   id: ScientistJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtScientist
+
+- type: loadout
+  id: RoboticistJumpsuit
+  equipment: RoboticistJumpsuit
+
+- type: startingGear
+  id: RoboticistJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitRoboticist
+
+- type: loadout
+  id: RoboticistJumpskirt
+  equipment: RoboticistJumpskirt
+
+- type: startingGear
+  id: RoboticistJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtRoboticist
 
 - type: loadout
   id: SeniorResearcherJumpsuit
@@ -133,6 +169,24 @@
     outerClothing: ClothingOuterWinterSci
 
 - type: loadout
+  id: RoboticistLabCoat
+  equipment: RoboticistLabCoat
+
+- type: startingGear
+  id: RoboticistLabCoat
+  equipment:
+    outerClothing: ClothingOuterCoatRobo
+
+- type: loadout
+  id: RoboticistWintercoat
+  equipment: RoboticistWintercoat
+
+- type: startingGear
+  id: RoboticistWintercoat
+  equipment:
+    outerClothing: ClothingOuterWinterRobo
+
+- type: loadout
   id: SeniorResearcherLabCoat
   equipment: SeniorResearcherLabCoat
   effects:
@@ -143,6 +197,25 @@
   id: SeniorResearcherLabCoat
   equipment:
     outerClothing: ClothingOuterCoatLabSeniorResearcher
+
+# Gloves
+- type: loadout
+  id: LatexGloves
+  equipment: LatexGloves
+
+- type: startingGear
+  id: LatexGloves
+  equipment:
+    gloves: ClothingHandsGlovesLatex
+
+- type: loadout
+  id: RobohandsGloves
+  equipment: RobohandsGloves
+
+- type: startingGear
+  id: RobohandsGloves
+  equipment:
+    gloves: ClothingHandsGlovesRobohands
 
 # Shoes
 - type: loadout

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -778,6 +778,7 @@
 - type: loadoutGroup
   id: ScientistGloves
   name: loadout-group-scientist-gloves
+  minLimit: 0
   loadouts:
   - LatexGloves
   - PurpleGloves
@@ -785,7 +786,7 @@
 
 - type: loadoutGroup
   id: ScientistShoes
-  name: loadout-group-scientist-gloves
+  name: loadout-group-scientist-shoes
   loadouts:
   - WhiteShoes
   - BlackShoes

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -785,14 +785,6 @@
   - RobohandsGloves
 
 - type: loadoutGroup
-  id: ScientistShoes
-  name: loadout-group-scientist-shoes
-  loadouts:
-  - WhiteShoes
-  - BlackShoes
-  - ScienceWinterBoots
-
-- type: loadoutGroup
   id: ScientistPDA
   name: loadout-group-scientist-id
   loadouts:

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -300,9 +300,9 @@
   name: loadout-group-janitor-gloves
   minLimit: 0
   loadouts:
-  - JanitorGlovesRubber
-  - JanitorGlovesOrange
-  - JanitorGlovesPurple
+  - JanitorRubberGloves
+  - OrangeGloves
+  - PurpleGloves
 
 - type: loadoutGroup
   id: JanitorOuterClothing
@@ -725,6 +725,8 @@
   name: loadout-group-scientist-head
   minLimit: 0
   loadouts:
+  - RoboticistCap
+  - SkullBandana
   - ScientificBeret
 
 - type: loadoutGroup
@@ -740,6 +742,8 @@
   loadouts:
   - ScientistJumpsuit
   - ScientistJumpskirt
+  - RoboticistJumpsuit
+  - RoboticistJumpskirt
   - SeniorResearcherJumpsuit
   - SeniorResearcherJumpskirt
 
@@ -759,13 +763,32 @@
   - RegularLabCoat
   - ScienceLabCoat
   - ScienceWintercoat
+  - RoboticistLabCoat
+  - RoboticistWintercoat
   - SeniorResearcherLabCoat
 
 - type: loadoutGroup
   id: ScientistShoes
-  name: loadout-group-scientist-shoes
+  name: loadout-group-scientist-gloves
   loadouts:
   - WhiteShoes
+  - BlackShoes
+  - ScienceWinterBoots
+
+- type: loadoutGroup
+  id: ScientistGloves
+  name: loadout-group-scientist-gloves
+  loadouts:
+  - LatexGloves
+  - PurpleGloves
+  - RobohandsGloves
+
+- type: loadoutGroup
+  id: ScientistShoes
+  name: loadout-group-scientist-gloves
+  loadouts:
+  - WhiteShoes
+  - BlackShoes
   - ScienceWinterBoots
 
 - type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -769,7 +769,7 @@
 
 - type: loadoutGroup
   id: ScientistShoes
-  name: loadout-group-scientist-gloves
+  name: loadout-group-scientist-shoes
   loadouts:
   - WhiteShoes
   - BlackShoes

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -207,6 +207,7 @@
   - ResearchDirectorJumpsuit
   - ResearchDirectorBackpack
   - ResearchDirectorOuterClothing
+  - ScientistGloves
   - ResearchDirectorShoes
   - Trinkets
 
@@ -218,6 +219,7 @@
   - ScientistJumpsuit
   - ScientistBackpack
   - ScientistOuterClothing
+  - ScientistGloves
   - ScientistShoes
   - ScientistPDA
   - Trinkets


### PR DESCRIPTION
## Why / Balance
was requested by a few people, also very good

## Technical details
changes the janitor gloves to just PurpleGloves and OrangeGloves so it makes sense to be used for different loadouts

## Media
![image](https://github.com/space-wizards/space-station-14/assets/45323883/ef7c1e94-155e-41cc-bf24-f31bf70d475c)

![image](https://github.com/space-wizards/space-station-14/assets/45323883/7d7d7f52-80fd-452f-8735-8a18c67261ff)
![image](https://github.com/space-wizards/space-station-14/assets/45323883/1df0d53d-6b66-412d-83d9-7c7ad3d4aa86)
![image](https://github.com/space-wizards/space-station-14/assets/45323883/ee851980-ae90-4fee-9eb7-6828bb08b1de)

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- tweak: Roboticist gear in now available in the scientist loadout.
