### PR TITLE
Chemists now start with chemical analysis goggles

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -22,4 +22,4 @@
     ears: ClothingHeadsetMedical
     belt: ChemBag
     pocket1: HandLabeler
-    # the purple glasses?
+    eyes: ClothingEyesGlassesChemical


### PR DESCRIPTION
## Why / Balance
this type of equipment was granted roundstart to bartenders, which is strange
chemists would need chemical analysis goggles more often than bartenders

also, other jobs start with their hud, so why can't chemists?
medical doctors start with medical huds
sec starts with sec glasses
roboticists have the diagnostic huds
bartenders have beer goggles

## Media
![image](https://github.com/space-wizards/space-station-14/assets/45323883/f90b58c5-ca21-450a-bc8e-d8075479faf8)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Chemists now start with chemical analysis goggles.
