### PR TITLE
Low-Key Zombie Rebalance

### DIFF
--- a/Content.Server/Zombies/PendingZombieComponent.cs
+++ b/Content.Server/Zombies/PendingZombieComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class PendingZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Poison", 0.3 },
+            { "Poison", 0.2 },
         }
     };
 

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -27,7 +27,7 @@ public sealed partial class ZombieComponent : Component, IAntagStatusIconCompone
     /// being invincible by bundling up.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float MinZombieInfectionChance = 0.50f;
+    public float MinZombieInfectionChance = 0.25f;
 
     [ViewVariables(VVAccess.ReadWrite)]
     public float ZombieMovementSpeedDebuff = 0.70f;

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -402,7 +402,7 @@
   - type: StationEvent
     earliestStart: 50
     minimumPlayers: 15
-    weight: 5
+    weight: 3
     duration: 1
   - type: ZombieRule
     minStartDelay: 0 #let them know immediately


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Lowers the chance that a midround zombie outbreak will occur, makes infection per zombie attack less likely, and slows down the progress of the zombie infection once infection has set in. 

## Why / Balance
Zombies are presently an instant round-ender in Survival. This PR is intended to make them a little less of a final boss call-the-shuttle-right-now scenario. Since two changes also affect Zombie game mode, it'll necessitate just a little more planning and setup on the part of initial infected antags as well. 

Reducing infection chance makes zombies still very threatening but not effectively a coinflip if a single wideswing will round-remove you even if you're fully armored. This is intended to be a temporary fix for the lack of item weighting in the ProtectiveSlots equation. 

Lowering event weight makes zombie outbreaks a little less likely to happen than, say, spiders, which have a much lower chance of round-removing half the station. This makes it more likely that a Survival round will end for reasons besides it becoming a very hectic zombie round with a very slow Initial Infected timer. 

Lowering the poison damage extends survival time, making it a little more likely that infected individuals will live long enough to get ambuzol, which presently is extremely difficult given that anyone infected has, by definition, already taken damage (especially with the recent bleeding changes). This is still a guaranteed kill in only a few minutes if medical care isn't available, but gives a little bit longer for the infected to RP out being That Guy Who Got Bitten, which is part of the fun of zombies, so why not draw it out just a little? 

## Technical details
I made three very simple numerical changes: 
+ Reduced MinZombieInfectionChance from 50% to 25%.
+ Reduced weight of midround zombie outbreak from 5 to 3. 
+ Reduced poison damage caused by zombie infection from 0.3 to 0.2. 

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Bellwether
- tweak: Midround zombie outbreaks are less common and spread more slowly. 
