### PR TITLE
Adds the option to fit the viewport to vertical screenspace

### DIFF
--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
@@ -36,6 +36,9 @@
             <CheckBox Name="IntegerScalingCheckBox"
                       Text="{Loc 'ui-options-vp-integer-scaling'}"
                       ToolTip="{Loc 'ui-options-vp-integer-scaling-tooltip'}" />
+            <CheckBox Name="ViewportVerticalFitCheckBox"
+                      Text="{Loc 'ui-options-vp-vertical-fit'}"
+                      ToolTip="{Loc 'ui-options-vp-vertical-fit-tooltip'}" />
             <CheckBox Name="ViewportLowResCheckBox" Text="{Loc 'ui-options-vp-low-res'}" />
             <CheckBox Name="ParallaxLowQualityCheckBox" Text="{Loc 'ui-options-parallax-low-quality'}" />
             <CheckBox Name="FpsCounterCheckBox" Text="{Loc 'ui-options-fps-counter'}" />

--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
@@ -68,6 +68,7 @@ namespace Content.Client.Options.UI.Tabs
             };
 
             IntegerScalingCheckBox.OnToggled += OnCheckBoxToggled;
+            ViewportVerticalFitCheckBox.OnToggled += OnCheckBoxToggled;
             ViewportLowResCheckBox.OnToggled += OnCheckBoxToggled;
             ParallaxLowQualityCheckBox.OnToggled += OnCheckBoxToggled;
             FpsCounterCheckBox.OnToggled += OnCheckBoxToggled;
@@ -79,6 +80,7 @@ namespace Content.Client.Options.UI.Tabs
             ViewportScaleSlider.Value = _cfg.GetCVar(CCVars.ViewportFixedScaleFactor);
             ViewportStretchCheckBox.Pressed = _cfg.GetCVar(CCVars.ViewportStretch);
             IntegerScalingCheckBox.Pressed = _cfg.GetCVar(CCVars.ViewportSnapToleranceMargin) != 0;
+            ViewportVerticalFitCheckBox.Pressed = _cfg.GetCVar(CCVars.ViewportVerticalFit);
             ViewportLowResCheckBox.Pressed = !_cfg.GetCVar(CCVars.ViewportScaleRender);
             ParallaxLowQualityCheckBox.Pressed = _cfg.GetCVar(CCVars.ParallaxLowQuality);
             FpsCounterCheckBox.Pressed = _cfg.GetCVar(CCVars.HudFpsCounterVisible);
@@ -111,6 +113,7 @@ namespace Content.Client.Options.UI.Tabs
             _cfg.SetCVar(CCVars.ViewportFixedScaleFactor, (int) ViewportScaleSlider.Value);
             _cfg.SetCVar(CCVars.ViewportSnapToleranceMargin,
                          IntegerScalingCheckBox.Pressed ? CCVars.ViewportSnapToleranceMargin.DefaultValue : 0);
+            _cfg.SetCVar(CCVars.ViewportVerticalFit, ViewportVerticalFitCheckBox.Pressed);
             _cfg.SetCVar(CCVars.ViewportScaleRender, !ViewportLowResCheckBox.Pressed);
             _cfg.SetCVar(CCVars.ParallaxLowQuality, ParallaxLowQualityCheckBox.Pressed);
             _cfg.SetCVar(CCVars.HudFpsCounterVisible, FpsCounterCheckBox.Pressed);
@@ -140,6 +143,7 @@ namespace Content.Client.Options.UI.Tabs
             var isVPStretchSame = ViewportStretchCheckBox.Pressed == _cfg.GetCVar(CCVars.ViewportStretch);
             var isVPScaleSame = (int) ViewportScaleSlider.Value == _cfg.GetCVar(CCVars.ViewportFixedScaleFactor);
             var isIntegerScalingSame = IntegerScalingCheckBox.Pressed == (_cfg.GetCVar(CCVars.ViewportSnapToleranceMargin) != 0);
+            var isVPVerticalFitSame = ViewportVerticalFitCheckBox.Pressed == _cfg.GetCVar(CCVars.ViewportVerticalFit);
             var isVPResSame = ViewportLowResCheckBox.Pressed == !_cfg.GetCVar(CCVars.ViewportScaleRender);
             var isPLQSame = ParallaxLowQualityCheckBox.Pressed == _cfg.GetCVar(CCVars.ParallaxLowQuality);
             var isFpsCounterVisibleSame = FpsCounterCheckBox.Pressed == _cfg.GetCVar(CCVars.HudFpsCounterVisible);
@@ -152,6 +156,7 @@ namespace Content.Client.Options.UI.Tabs
                                    isVPStretchSame &&
                                    isVPScaleSame &&
                                    isIntegerScalingSame &&
+                                   isVPVerticalFitSame &&
                                    isVPResSame &&
                                    isPLQSame &&
                                    isFpsCounterVisibleSame &&
@@ -235,6 +240,7 @@ namespace Content.Client.Options.UI.Tabs
         {
             ViewportScaleBox.Visible = !ViewportStretchCheckBox.Pressed;
             IntegerScalingCheckBox.Visible = ViewportStretchCheckBox.Pressed;
+            ViewportVerticalFitCheckBox.Visible = ViewportStretchCheckBox.Pressed;
             ViewportScaleText.Text = Loc.GetString("ui-options-vp-scale", ("scale", ViewportScaleSlider.Value));
         }
 

--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
@@ -67,8 +67,13 @@ namespace Content.Client.Options.UI.Tabs
                 UpdateApplyButton();
             };
 
+            ViewportVerticalFitCheckBox.OnToggled += _ =>
+            {
+                UpdateViewportScale();
+                UpdateApplyButton();
+            };
+
             IntegerScalingCheckBox.OnToggled += OnCheckBoxToggled;
-            ViewportVerticalFitCheckBox.OnToggled += OnCheckBoxToggled;
             ViewportLowResCheckBox.OnToggled += OnCheckBoxToggled;
             ParallaxLowQualityCheckBox.OnToggled += OnCheckBoxToggled;
             FpsCounterCheckBox.OnToggled += OnCheckBoxToggled;
@@ -241,6 +246,7 @@ namespace Content.Client.Options.UI.Tabs
             ViewportScaleBox.Visible = !ViewportStretchCheckBox.Pressed;
             IntegerScalingCheckBox.Visible = ViewportStretchCheckBox.Pressed;
             ViewportVerticalFitCheckBox.Visible = ViewportStretchCheckBox.Pressed;
+            ViewportWidthSlider.Visible = ViewportWidthSliderDisplay.Visible = !ViewportStretchCheckBox.Pressed || ViewportStretchCheckBox.Pressed && !ViewportVerticalFitCheckBox.Pressed;
             ViewportScaleText.Text = Loc.GetString("ui-options-vp-scale", ("scale", ViewportScaleSlider.Value));
         }
 

--- a/Content.Client/UserInterface/Controls/MainViewport.cs
+++ b/Content.Client/UserInterface/Controls/MainViewport.cs
@@ -55,7 +55,6 @@ namespace Content.Client.UserInterface.Controls
 
             if (stretch)
             {
-                //var snapFactor = verticalFit ? null : CalcSnappingFactor();
                 var snapFactor = CalcSnappingFactor();
                 if (snapFactor == null)
                 {

--- a/Content.Client/UserInterface/Controls/MainViewport.cs
+++ b/Content.Client/UserInterface/Controls/MainViewport.cs
@@ -51,15 +51,18 @@ namespace Content.Client.UserInterface.Controls
             var stretch = _cfg.GetCVar(CCVars.ViewportStretch);
             var renderScaleUp = _cfg.GetCVar(CCVars.ViewportScaleRender);
             var fixedFactor = _cfg.GetCVar(CCVars.ViewportFixedScaleFactor);
+            var verticalFit = _cfg.GetCVar(CCVars.ViewportVerticalFit);
 
             if (stretch)
             {
+                //var snapFactor = verticalFit ? null : CalcSnappingFactor();
                 var snapFactor = CalcSnappingFactor();
                 if (snapFactor == null)
                 {
                     // Did not find a snap, enable stretching.
                     Viewport.FixedStretchSize = null;
                     Viewport.StretchMode = ScalingViewportStretchMode.Bilinear;
+                    Viewport.IgnoreDimension = verticalFit ? ScalingViewportIgnoreDimension.Horizontal : ScalingViewportIgnoreDimension.None;
 
                     if (renderScaleUp)
                     {
@@ -104,6 +107,8 @@ namespace Content.Client.UserInterface.Controls
             // where we are clipping the viewport to make it fit.
             var cfgToleranceClip = _cfg.GetCVar(CCVars.ViewportSnapToleranceClip);
 
+            var cfgVerticalFit = _cfg.GetCVar(CCVars.ViewportVerticalFit);
+
             // Calculate if the viewport, when rendered at an integer scale,
             // is close enough to the control size to enable "snapping" to NN,
             // potentially cutting a tiny bit off/leaving a margin.
@@ -123,7 +128,8 @@ namespace Content.Client.UserInterface.Controls
                 // The rule for which snap fits is that at LEAST one axis needs to be in the tolerance size wise.
                 // One axis MAY be larger but not smaller than tolerance.
                 // Obviously if it's too small it's bad, and if it's too big on both axis we should stretch up.
-                if (Fits(dx) && Fits(dy) || Fits(dx) && Larger(dy) || Larger(dx) && Fits(dy))
+                // Additionally, if the viewport's supposed  to be vertically fit, then the horizontal scale should just be ignored where appropriate.
+                if ((Fits(dx) || cfgVerticalFit) && Fits(dy) || !cfgVerticalFit && Fits(dx) && Larger(dy) || Larger(dx) && Fits(dy))
                 {
                     // Found snap that fits.
                     return i;

--- a/Content.Client/UserInterface/Systems/Viewport/ViewportUIController.cs
+++ b/Content.Client/UserInterface/Systems/Viewport/ViewportUIController.cs
@@ -25,6 +25,7 @@ public sealed class ViewportUIController : UIController
         _configurationManager.OnValueChanged(CCVars.ViewportMinimumWidth, _ => UpdateViewportRatio());
         _configurationManager.OnValueChanged(CCVars.ViewportMaximumWidth, _ => UpdateViewportRatio());
         _configurationManager.OnValueChanged(CCVars.ViewportWidth, _ => UpdateViewportRatio());
+        _configurationManager.OnValueChanged(CCVars.ViewportVerticalFit, _ => UpdateViewportRatio());
 
         var gameplayStateLoad = UIManager.GetUIController<GameplayStateLoadController>();
         gameplayStateLoad.OnScreenLoad += OnScreenLoad;
@@ -45,13 +46,19 @@ public sealed class ViewportUIController : UIController
         var min = _configurationManager.GetCVar(CCVars.ViewportMinimumWidth);
         var max = _configurationManager.GetCVar(CCVars.ViewportMaximumWidth);
         var width = _configurationManager.GetCVar(CCVars.ViewportWidth);
+        var verticalfit = _configurationManager.GetCVar(CCVars.ViewportVerticalFit) && _configurationManager.GetCVar(CCVars.ViewportStretch);
 
-        if (width < min || width > max)
+        if (verticalfit)
+        {
+            width = max;
+        }
+        else if (width < min || width > max)
         {
             width = CCVars.ViewportWidth.DefaultValue;
         }
 
         Viewport.Viewport.ViewportSize = (EyeManager.PixelsPerMeter * width, EyeManager.PixelsPerMeter * ViewportHeight);
+        Viewport.UpdateCfg();
     }
 
     public void ReloadViewport()

--- a/Content.Client/Viewport/ScalingViewport.cs
+++ b/Content.Client/Viewport/ScalingViewport.cs
@@ -388,17 +388,17 @@ namespace Content.Client.Viewport
     public enum ScalingViewportIgnoreDimension
     {
         /// <summary>
-        ///     <see cref="ScalingViewport.FixedRenderScale"/> is used.
+        ///     The viewport won't ignore any dimension.
         /// </summary>
         None = 0,
 
         /// <summary>
-        ///     Floor to the closest integer scale possible.
+        ///     The viewport will ignore the horizontal dimension, and will exclusively consider the vertical dimension for scaling.
         /// </summary>
         Horizontal,
 
         /// <summary>
-        ///     Ceiling to the closest integer scale possible.
+        ///     The viewport will ignore the vertical dimension, and will exclusively consider the horizontal dimension for scaling.
         /// </summary>
         Vertical
     }

--- a/Content.Client/Viewport/ViewportManager.cs
+++ b/Content.Client/Viewport/ViewportManager.cs
@@ -21,8 +21,6 @@ namespace Content.Client.Viewport
             _cfg.OnValueChanged(CCVars.ViewportSnapToleranceMargin, _ => UpdateCfg());
             _cfg.OnValueChanged(CCVars.ViewportScaleRender, _ => UpdateCfg());
             _cfg.OnValueChanged(CCVars.ViewportFixedScaleFactor, _ => UpdateCfg());
-            //_cfg.OnValueChanged(CCVars.ViewportWidth, _ => UpdateCfg());
-            //_cfg.OnValueChanged(CCVars.ViewportVerticalFit, _ => UpdateCfg());
         }
 
         private void UpdateCfg()

--- a/Content.Client/Viewport/ViewportManager.cs
+++ b/Content.Client/Viewport/ViewportManager.cs
@@ -21,7 +21,8 @@ namespace Content.Client.Viewport
             _cfg.OnValueChanged(CCVars.ViewportSnapToleranceMargin, _ => UpdateCfg());
             _cfg.OnValueChanged(CCVars.ViewportScaleRender, _ => UpdateCfg());
             _cfg.OnValueChanged(CCVars.ViewportFixedScaleFactor, _ => UpdateCfg());
-            _cfg.OnValueChanged(CCVars.ViewportVerticalFit, _ => UpdateCfg());
+            //_cfg.OnValueChanged(CCVars.ViewportWidth, _ => UpdateCfg());
+            //_cfg.OnValueChanged(CCVars.ViewportVerticalFit, _ => UpdateCfg());
         }
 
         private void UpdateCfg()

--- a/Content.Client/Viewport/ViewportManager.cs
+++ b/Content.Client/Viewport/ViewportManager.cs
@@ -21,6 +21,7 @@ namespace Content.Client.Viewport
             _cfg.OnValueChanged(CCVars.ViewportSnapToleranceMargin, _ => UpdateCfg());
             _cfg.OnValueChanged(CCVars.ViewportScaleRender, _ => UpdateCfg());
             _cfg.OnValueChanged(CCVars.ViewportFixedScaleFactor, _ => UpdateCfg());
+            _cfg.OnValueChanged(CCVars.ViewportVerticalFit, _ => UpdateCfg());
         }
 
         private void UpdateCfg()

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1554,6 +1554,9 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<int> ViewportWidth =
             CVarDef.Create("viewport.width", 21, CVar.CLIENTONLY | CVar.ARCHIVE);
 
+        public static readonly CVarDef<bool> ViewportVerticalFit =
+            CVarDef.Create("viewport.vertical_fit", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
         /*
          * UI
          */

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -83,6 +83,10 @@ ui-options-vp-integer-scaling-tooltip = If this option is enabled, the viewport 
                                         at specific resolutions. While this results in crisp textures, it also often
                                         means that black bars appear at the top/bottom of the screen or that part
                                         of the viewport is not visible.
+ui-options-vp-vertical-fit = Vertical viewport fitting
+ui-options-vp-vertical-fit-tooltip = When enabled, the main viewport will ignore the horizontal axis entirely when
+                                     fitting to your screen. If your screen is smaller than the viewport, then this
+                                     will cause the viewport to be cut off on the horizontal axis.
 ui-options-vp-low-res = Low-resolution viewport
 ui-options-parallax-low-quality = Low-quality Parallax (background)
 ui-options-fps-counter = Show FPS counter


### PR DESCRIPTION
## About the PR
This PR is quite straight-forward: it adds an option to the settings that allows locking your viewport to your vertical screenspace. In [FILM notation](https://www.kovaak.com/film-notation/), this makes the viewport vML. In common gamer lingo, this makes the viewport Hor+ (except it's not really Hor+ since it doesn't actually expand the viewport width). In explicit technical terms, the option makes the viewport ignore the horizontal axis during all scaling calculations, allowing the viewport to be cut off if it's too tight horizontally, instead of squishing and letterboxing vertically. This is enabled by default.

## Why / Balance
This makes it *far* more comfortable to play on aspect ratios tighter than 16:9, as this means you don't have to fiddle with the viewport width slider in order to get your viewport to fit snug within your game window. This also benefits forks that wish to roll with PVS-performance-hammering expanded viewport widths, which would otherwise be simply impractical due to the intense letterboxing that'd otherwise be caused.

This is enabled by default primarily for the sake of new players, to match with the centered viewport UI being the default. This strengthens the default settings as being a one-size-fits-all preset, wherein the screen will behave exactly as a new player would expect it to right out of the box no matter what odd display hardware they're working with.

## Technical details
The main thing that makes this PR tick is a simple addition to `ScalingViewport`: the `IgnoreDimension` variable, which is used in `GetDrawBox` to ignore either one or none dimension. If set to `None`, it'll behave exactly as viewports currently do, opting to letterbox if the viewport can't completely fit into the control. If set to either `Vertical` or `Horizontal`, then it'll instead only fit the viewport to either the horizontal or vertical width of the control, respectively.

The new CVar, `viewport.vertical_fit`, is similarly quite simple. If true (the default), then in `MainViewport`, the Viewport's `IgnoreDimension` will be set to `Horizontal`, and the viewport snapping function will bypass the checks that care about whether the viewport fits the control horizontally.

## Media

https://github.com/space-wizards/space-station-14/assets/6356337/2537f825-1629-4c3a-90d5-6b548305ab9b



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- add: An option to tie your viewport's scaling to your vertical screenspace has been added, enabled by default! In laymen's terms, this means that manual configuration is no longer necessary to avoid letterboxing on aspect ratios tighter than 16:9, as the viewport will now default to cutting off any excess horizontal width instead of letterboxing vertically when the screen is too tight.

