### PR TITLE
Nerfs the Experimental Research Hardsuit's size

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -368,7 +368,7 @@
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitRd
   name: experimental research hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor. Able to be compressed to small sizes.
+  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/rd.rsi
@@ -392,8 +392,6 @@
     walkModifier: 0.75
     sprintModifier: 0.75
   - type: HeldSpeedModifier
-  - type: Item
-    size: Normal
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -368,7 +368,7 @@
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitRd
   name: experimental research hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor.
+  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor. Able to be compressed to small sizes.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/rd.rsi
@@ -392,6 +392,10 @@
     walkModifier: 0.75
     sprintModifier: 0.75
   - type: HeldSpeedModifier
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4 #5X5, can fit in a duffel bag but nothing smaller.
   - type: Tag
     tags:
     - WhitelistChameleon


### PR DESCRIPTION
## About the PR
Nerfs the Experimental Research Hardsuit from Medium (2x2) to Huge (5x5.) This puts it above the blood-red, and is big enough to where it won't fit in anything smaller then a duffelbag.

Fixes #27091

## Why / Balance
This is a steal objective for a reason, and should *not* be piss easy to carry around. It makes the objective a lot more interesting and forces you to either carry around a duffel bag, make massive storage sacrifices, or wear it yourself.

Additionally, at Medium size, RDs can also just carry this around willy nilly with basically no downside, which is probably not good since hardsuits are generally meant to be a commitment.

Less importantly, there is also the logic angle of it: it makes no damn sense for a bombsuit to be *2x2*. The RD's hardsuit is visually the most bulky hardsuit in the game. While this means that maybe the RD's hardsuit should not be storable at *all* like the other hardsuits, it is at least more logical that it is one of the biggest items in the game despite being storable.

## Media
![Content Client_NMJUX2c2qS](https://github.com/space-wizards/space-station-14/assets/78941145/5710a42e-d6ec-4d5d-b667-5b5d17543bba)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The Research Director's hardsuit is now 5x5 in the inventory instead of 2x2. You'll need a duffelbag to store it now.
