### PR TITLE
fix duplicate science backpack for reserach assistant

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
@@ -19,7 +19,6 @@
 - type: startingGear
   id: ResearchAssistantGear
   equipment:
-    back: ClothingBackpackScienceFilled
     shoes: ClothingShoesColorWhite
     id: ResearchAssistantPDA
     ears: ClothingHeadsetScience


### PR DESCRIPTION
bugfix, reason why this happened is because the roel starting gear had a backpack and you get a backpack through loadouts, so it duped