### PR TITLE
Fix truncheon wideswing, remove usages of BluntStaminaDamageFactor

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -76,7 +76,7 @@ public sealed partial class MeleeWeaponComponent : Component
 
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
-    public FixedPoint2 BluntStaminaDamageFactor = FixedPoint2.New(0.5f);
+    public FixedPoint2 BluntStaminaDamageFactor = FixedPoint2.New(0.0f);
 
     /// <summary>
     /// Multiplies damage by this amount for single-target attacks.

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -34,7 +34,6 @@
     damage:
       types:
         Blunt: 7
-    bluntStaminaDamageFactor: 2.0
     angle: 60
     animation: WeaponArcSlash
   - type: StaminaDamageOnHit
@@ -96,10 +95,11 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 20
+        Blunt: 15
     soundHit:
       collection: MetalThud
-    bluntStaminaDamageFactor: 1.5
+  - type: StaminaDamageOnHit
+    damage: 20
   - type: Item
     size: Normal
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -99,7 +99,7 @@
     soundHit:
       collection: MetalThud
   - type: StaminaDamageOnHit
-    damage: 20
+    damage: 25
   - type: Item
     size: Normal
   - type: Clothing


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

- Changes the truncheon to use the better StaminaDamageOnHit, which works with both types of swings.
- BluntStaminaDamageFactor has been disabled entirely and removed from these two weapons that actually use it (stunbaton and truncheon), the other use case was to add 0.5 stamina damage per blunt to all weapons, which didn't really add anything to the game besides making your stamina bar flash a little while you're being beat to death.
- Does not affect the stamina balance of both tools, but does fix a bug of the truncheon.
- Truncheon lowered to 15 blunt, still stuns at 4 hits, with 60 blunt damage on unarmored at time of stun. (Does not include the bleed wounds that are also inflicted)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

This will affect any downstreams using BluntStaminaDamageFactor field default, but can easily be changed back to whatever they choose.

**Changelog**

:cl: Whisper

- fix: Fixed truncheon wideswing not doing stamina damage
- tweak: Lowered truncheon damage (20>15).

