### PR TITLE
Raise difficulty class of RD hardsuit objective

### DIFF
--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -191,6 +191,9 @@
   components:
   - type: StealCondition
     stealGroup: ClothingOuterHardsuitRd
+  - type: Objective
+    # This item must be worn or stored in a slowing duffelbag, very hard to hide.
+    difficulty: 3
 
 - type: entity
   noSpawn: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

- Raises RD hardsuit objective from 2.75 to 3 difficulty class

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

- In current state, objectives can only add up to a total of 5 difficulty, all other steal objectives are 2.75 unless specified otherwise
    - head of security papers: 3
    - Nuke disk: 4
- #27094.
- This item must be worn or stored in a slowing duffelbag, very hard to hide, unlike all other steal objectives.
- Allows traitors to get a more balanced set of tasks.

**Changelog**

:cl: Whisper

- tweak: Raised the difficulty class of RD hardsuit objective, it will be less likely to get it with other hard objectives.
