### PR TITLE
Make guitars playayble only if wielded

### DIFF
--- a/Content.Server/UserInterface/ActivatableUIComponent.cs
+++ b/Content.Server/UserInterface/ActivatableUIComponent.cs
@@ -16,6 +16,10 @@ namespace Content.Server.UserInterface
         [DataField]
         public bool InHandsOnly { get; set; } = false;
 
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
+        public bool IsWieldedOnly { get; set; } = false;
+
         [DataField]
         public bool SingleUser { get; set; } = false;
 

--- a/Content.Server/UserInterface/ActivatableUISystem.cs
+++ b/Content.Server/UserInterface/ActivatableUISystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.UserInterface;
 using Content.Shared.Verbs;
+using Content.Shared.Wieldable.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 
@@ -74,6 +75,12 @@ public sealed partial class ActivatableUISystem : EntitySystem
 
         if (component.InHandsOnly && args.Using != uid)
             return;
+
+        if (TryComp<WieldableComponent>(uid, out var wieldable) && component.IsWieldedOnly)
+        {
+            if (!wieldable.Wielded)
+            return;
+        }
 
         if (!args.CanInteract && (!component.AllowSpectator || !HasComp<GhostComponent>(args.User)))
             return;

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
@@ -1,5 +1,33 @@
-- type: entity
+﻿- type: entity
   parent: BaseHandheldInstrument
+  id: BaseGuitarInstrument
+  components:
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - back
+  - type: ActivatableUI
+    isWieldedOnly: true
+  - type: Sprite
+    state: icon
+  - type: Item
+    size: Normal
+  - type: Wieldable
+  - type: Tag
+    tags:
+    - StringInstrument
+  - type: MeleeWeapon
+    wideAnimationRotation: 45
+    damage:
+      types:
+        Blunt: 5
+  - type: IncreaseDamageOnWield
+    damage:
+      types:
+        Blunt: 5
+
+- type: entity
+  parent: BaseGuitarInstrument
   id: ElectricGuitarInstrument
   name: electric guitar
   description: Now this makes you feel like a rock star!
@@ -13,21 +41,13 @@
       "Muted": {28: 0}
   - type: Sprite
     sprite: Objects/Fun/Instruments/eguitar.rsi
-    state: icon
   - type: Item
-    size: Normal
     sprite: Objects/Fun/Instruments/eguitar.rsi
   - type: Clothing
-    quickEquip: false
-    slots:
-    - back
     sprite: Objects/Fun/Instruments/eguitar.rsi
-  - type: Tag
-    tags:
-    - StringInstrument
 
 - type: entity
-  parent: BaseHandheldInstrument
+  parent: BaseGuitarInstrument
   id: BassGuitarInstrument
   name: bass guitar
   description: You feel really cool holding this. Shame you're the only one that thinks that.
@@ -42,21 +62,13 @@
       "Slap (XTra Funky)": {37: 0}
   - type: Sprite
     sprite: Objects/Fun/Instruments/bassguitar.rsi
-    state: icon
   - type: Item
-    size: Normal
     sprite: Objects/Fun/Instruments/bassguitar.rsi
   - type: Clothing
-    quickEquip: false
-    slots:
-    - back
     sprite: Objects/Fun/Instruments/bassguitar.rsi
-  - type: Tag
-    tags:
-    - StringInstrument
 
 - type: entity
-  parent: BaseHandheldInstrument
+  parent: BaseGuitarInstrument
   id: RockGuitarInstrument
   name: rock guitar
   description: What an axe!
@@ -70,25 +82,16 @@
       "Harmonics": {31: 0}
   - type: Sprite
     sprite: Objects/Fun/Instruments/rockguitar.rsi
-    state: icon
   - type: Item
-    size: Normal
     sprite: Objects/Fun/Instruments/rockguitar.rsi
   - type: Clothing
-    quickEquip: false
-    slots:
-    - back
     sprite: Objects/Fun/Instruments/rockguitar.rsi
-  - type: Tag
-    tags:
-    - StringInstrument
   - type: MeleeWeapon
     wideAnimationRotation: 45
     damage:
       types:
         Blunt: 6
         Slash: 2
-  - type: Wieldable
   - type: IncreaseDamageOnWield #they don't call it an axe for nothing
     damage:
       types:
@@ -96,7 +99,7 @@
         Slash: 2
 
 - type: entity
-  parent: BaseHandheldInstrument
+  parent: BaseGuitarInstrument
   id: AcousticGuitarInstrument
   name: acoustic guitar
   description: Anyway, here's Wonderwall.
@@ -109,19 +112,10 @@
       "Steel": {25: 0}
   - type: Sprite
     sprite: Objects/Fun/Instruments/guitar.rsi
-    state: icon
-  - type: Tag
-    tags:
-    - StringInstrument
   - type: Item
     sprite: Objects/Fun/Instruments/guitar.rsi
-    size: Normal
   - type: Clothing
-    quickEquip: false
-    slots:
-    - back
     sprite: Objects/Fun/Instruments/guitar.rsi
-  - type: Wieldable
   - type: Damageable # Smash it! Does 20 damage a hit, but breaks after 1 hit.
     damageContainer: Inorganic
   - type: Destructible
@@ -144,15 +138,22 @@
     damage:
       types:
         Blunt: 20
-  - type: MeleeWeapon
-    wideAnimationRotation: 45
-    damage:
-      types:
-        Blunt: 5
   - type: IncreaseDamageOnWield
     damage:
       types:
         Blunt: 15
+
+- type: entity
+  parent: BaseGuitarInstrument
+  id: BanjoInstrument
+  name: banjo
+  components:
+  - type: Instrument
+    program: 105
+  - type: Sprite
+    sprite: Objects/Fun/Instruments/banjo.rsi
+  - type: Item
+    sprite: Objects/Fun/Instruments/banjo.rsi
 
 - type: entity
   parent: BaseHandheldInstrument
@@ -166,23 +167,6 @@
   - type: Sprite
     sprite: Objects/Fun/Instruments/guitarlessfrets.rsi
     state: icon
-
-- type: entity
-  parent: BaseHandheldInstrument
-  id: BanjoInstrument
-  name: banjo
-  components:
-  - type: Instrument
-    program: 105
-  - type: Sprite
-    sprite: Objects/Fun/Instruments/banjo.rsi
-    state: icon
-  - type: Item
-    size: Normal
-    sprite: Objects/Fun/Instruments/banjo.rsi
-  - type: Tag
-    tags:
-    - StringInstrument
 
 - type: entity
   parent: BaseHandheldInstrument


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title
opened as draft now for any feedback

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
You need two hands to play guitar

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added new boolean IsWieldedOnly for ActivatableUIComponent

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
will be when sprites will be

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Guitars now need to be wielded to play.
- tweak: All guitars can be used as weapons now and can be weared at your back.