### PR TITLE
"make thief" admin action: fix missing icon

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
@@ -111,7 +111,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = Loc.GetString("admin-verb-text-make-thief"),
             Category = VerbCategory.Antag,
-            Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/Clothing/Hands/Gloves/ihscombat.rsi"), "icon"),
+            Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/Clothing/Hands/Gloves/Color/black.rsi"), "icon"),
             Act = () =>
             {
                 _thief.AdminMakeThief(args.Target, false); //Midround add pacified is bad


### PR DESCRIPTION
## About the PR
Fixes #27109 by showing black gloves.

## Technical details
Regression bug due to #26943 deleting the icon originally used.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/165581243/6ee9ea5c-8fa6-43ac-9d70-07dae0daaefc)


**Changelog**
None