### PR TITLE
Adds non randomized rod velocity

### DIFF
--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -60,15 +60,18 @@ public sealed class ImmovableRodSystem : EntitySystem
             _physics.SetFriction(uid, phys, 0f);
             _physics.SetBodyStatus(uid, phys, BodyStatus.InAir);
 
-            if (!component.RandomizeVelocity)
-                return;
-
             var xform = Transform(uid);
-            var vel = component.DirectionOverride.Degrees switch
+            var worldRot = _transform.GetWorldRotation(uid);
+            var vel = worldRot.ToWorldVec() * component.MaxSpeed;
+
+            if (component.RandomizeVelocity)
             {
-                0f => _random.NextVector2(component.MinSpeed, component.MaxSpeed),
-                _ => _transform.GetWorldRotation(uid).RotateVec(component.DirectionOverride.ToVec()) * _random.NextFloat(component.MinSpeed, component.MaxSpeed)
-            };
+                vel = component.DirectionOverride.Degrees switch
+                {
+                    0f => _random.NextVector2(component.MinSpeed, component.MaxSpeed),
+                    _ => worldRot.RotateVec(component.DirectionOverride.ToVec()) * _random.NextFloat(component.MinSpeed, component.MaxSpeed)
+                };
+            }
 
             _physics.ApplyLinearImpulse(uid, vel, body: phys);
             xform.LocalRotation = (vel - _transform.GetWorldPosition(uid)).ToWorldAngle() + MathHelper.PiOver2;

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -35,6 +35,7 @@
 
 - type: entity
   id: ImmovableRodDespawn
+  suffix: Despawn
   parent: ImmovableRod
   components:
   - type: TimedDespawn


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Changed the check for randomized velocity so non-randomized velocity rods will fire in the direction they're facing when fired.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Needed for Wizard Rod polymorph

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Velocity by default will be set to world rotation vec * max speed. If Randomize velocity is enabled, it will behave as it did before.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

OnMapInit for immovable rod system, the check was changed for randomized velocity so if it's not randomized velocity by default will be set to world rotation vec * max speed. If Randomize velocity is enabled, it will behave as it did before.