### PR TITLE
Hide some map related logs from clients

### DIFF
--- a/Content.Client/Administration/Managers/ClientAdminManager.cs
+++ b/Content.Client/Administration/Managers/ClientAdminManager.cs
@@ -126,12 +126,15 @@ namespace Content.Client.Administration.Managers
 
         public AdminData? GetAdminData(EntityUid uid, bool includeDeAdmin = false)
         {
-            return uid == _player.LocalEntity ? _adminData : null;
+            if (uid == _player.LocalEntity && (_adminData?.Active ?? includeDeAdmin))
+                return _adminData;
+
+            return null;
         }
 
         public AdminData? GetAdminData(ICommonSession session, bool includeDeAdmin = false)
         {
-            if (_player.LocalUser == session.UserId)
+            if (_player.LocalUser == session.UserId && (_adminData?.Active ?? includeDeAdmin))
                 return _adminData;
 
             return null;

--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -1,3 +1,4 @@
+using Content.Client.Administration.Managers;
 using Content.Client.Gameplay;
 using Content.Client.Lobby;
 using Content.Client.RoundEnd;
@@ -14,7 +15,9 @@ namespace Content.Client.GameTicking.Managers
     public sealed class ClientGameTicker : SharedGameTicker
     {
         [Dependency] private readonly IStateManager _stateManager = default!;
-        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IClientAdminManager _admin = default!;
+        [Dependency] private readonly IClyde _clyde = default!;
+        [Dependency] private readonly SharedMapSystem _map = default!;
 
         [ViewVariables] private bool _initialized;
         private Dictionary<NetEntity, Dictionary<string, uint?>>  _jobsAvailable = new();
@@ -44,8 +47,6 @@ namespace Content.Client.GameTicking.Managers
 
         public override void Initialize()
         {
-            DebugTools.Assert(!_initialized);
-
             SubscribeNetworkEvent<TickerJoinLobbyEvent>(JoinLobby);
             SubscribeNetworkEvent<TickerJoinGameEvent>(JoinGame);
             SubscribeNetworkEvent<TickerConnectionStatusEvent>(ConnectionStatus);
@@ -53,14 +54,31 @@ namespace Content.Client.GameTicking.Managers
             SubscribeNetworkEvent<TickerLobbyInfoEvent>(LobbyInfo);
             SubscribeNetworkEvent<TickerLobbyCountdownEvent>(LobbyCountdown);
             SubscribeNetworkEvent<RoundEndMessageEvent>(RoundEnd);
-            SubscribeNetworkEvent<RequestWindowAttentionEvent>(msg =>
-            {
-                IoCManager.Resolve<IClyde>().RequestWindowAttention();
-            });
+            SubscribeNetworkEvent<RequestWindowAttentionEvent>(OnAttentionRequest);
             SubscribeNetworkEvent<TickerLateJoinStatusEvent>(LateJoinStatus);
             SubscribeNetworkEvent<TickerJobsAvailableEvent>(UpdateJobsAvailable);
 
-            _initialized = true;
+            _admin.AdminStatusUpdated += OnAdminUpdated;
+            OnAdminUpdated();
+        }
+
+        public override void Shutdown()
+        {
+            _admin.AdminStatusUpdated -= OnAdminUpdated;
+            base.Shutdown();
+        }
+
+        private void OnAdminUpdated()
+        {
+            // Hide some map/grid related logs to clients.
+            // This is to try prevent some easy metagaming by just reading the console. E.g., logs like this one could leak the nuke station/grid:
+            // > Grid NT-Arrivals 1101 (122/n25896) changed parent. Old parent: map 10 (121/n25895). New parent: FTL (123/n26470)
+            _map.Log.Level = _admin.IsAdmin() ? LogLevel.Info : LogLevel.Warning;
+        }
+
+        private void OnAttentionRequest(RequestWindowAttentionEvent ev)
+        {
+            _clyde.RequestWindowAttention();
         }
 
         private void LateJoinStatus(TickerLateJoinStatusEvent message)
@@ -137,7 +155,7 @@ namespace Content.Client.GameTicking.Managers
                 return;
 
             //This is not ideal at all, but I don't see an immediately better fit anywhere else.
-            _window = new RoundEndSummaryWindow(message.GamemodeTitle, message.RoundEndText, message.RoundDuration, message.RoundId, message.AllPlayersEndInfo, _entityManager);
+            _window = new RoundEndSummaryWindow(message.GamemodeTitle, message.RoundEndText, message.RoundDuration, message.RoundId, message.AllPlayersEndInfo, EntityManager);
         }
     }
 }

--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -70,8 +70,8 @@ namespace Content.Client.GameTicking.Managers
 
         private void OnAdminUpdated()
         {
-            // Hide some map/grid related logs to clients.
-            // This is to try prevent some easy metagaming by just reading the console. E.g., logs like this one could leak the nuke station/grid:
+            // Hide some map/grid related logs from clients. This is to try prevent some easy metagaming by just
+            // reading the console. E.g., logs like this one could leak the nuke station/grid:
             // > Grid NT-Arrivals 1101 (122/n25896) changed parent. Old parent: map 10 (121/n25895). New parent: FTL (123/n26470)
 #if !DEBUG
             _map.Log.Level = _admin.IsAdmin() ? LogLevel.Info : LogLevel.Warning;

--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -73,7 +73,9 @@ namespace Content.Client.GameTicking.Managers
             // Hide some map/grid related logs to clients.
             // This is to try prevent some easy metagaming by just reading the console. E.g., logs like this one could leak the nuke station/grid:
             // > Grid NT-Arrivals 1101 (122/n25896) changed parent. Old parent: map 10 (121/n25895). New parent: FTL (123/n26470)
+#if !DEBUG
             _map.Log.Level = _admin.IsAdmin() ? LogLevel.Info : LogLevel.Warning;
+#endif
         }
 
         private void OnAttentionRequest(RequestWindowAttentionEvent ev)


### PR DESCRIPTION
This PR changes the log-level of the map system for non-admin clients to remove some trivial metagaming / information leaking.
It also fixes `ClientAdminManager` not respecting the `includeDeAdmin` option.