### PR TITLE
Add Spanish and French accents as traits. 

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -38,3 +38,9 @@ trait-southern-desc = You have a different way of speakin'.
 
 trait-snoring-name = Snoring
 trait-snoring-desc = You will snore while sleeping.
+
+trait-french-accent-name = French Accent
+trait-french-accent-desc = You have a French accent.
+
+trait-spanish-accent-name = Spanish Accent
+trait-spanish-accent-desc = You have a Spanish accent.

--- a/Resources/Prototypes/Traits/neutral.yml
+++ b/Resources/Prototypes/Traits/neutral.yml
@@ -23,3 +23,17 @@
   description: trait-southern-desc
   components:
     - type: SouthernAccent
+
+- type: trait
+  id: FrenchAccent
+  name: trait-french-accent-name
+  description: trait-french-accent-desc
+  components:
+    - type: FrenchAccent
+
+- type: trait
+  id: SpanishAccent
+  name: trait-spanish-accent-name
+  description: trait-spanish-accent-desc
+  components:
+    - type: SpanishAccent  


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added Spanish and French accents to the trait menu.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Diversity in accents without needing your Spanish engineer to wear a cowboy hat to be Spanish or your French doctor to wear a beret to be French. Maybe pave the way for other world accents as traits and clothing accents.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/78222136/d1f01fff-7533-4717-bd8f-ed4fd6c7238c)
![image](https://github.com/space-wizards/space-station-14/assets/78222136/fa691442-8e8f-468d-82f9-a353612505b2)
![image](https://github.com/space-wizards/space-station-14/assets/78222136/9fc12032-b4d3-4abd-ae14-d1249d335932)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
🆑 
 - tweak: French and Spanish accents are now selectable traits in the character editor. 
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
