### PR TITLE
Windoors now contain proper electronics

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
@@ -1,68 +1,4 @@
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsService
-  suffix: Service, Locked
-  components:
-  - type: AccessReader
-    access: [["Service"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsTheatre
-  suffix: Theatre, Locked
-  components:
-  - type: AccessReader
-    access: [["Theatre"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsChapel
-  suffix: Chapel, Locked
-  components:
-  - type: AccessReader
-    access: [["Chapel"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsJanitor
-  suffix: Janitor, Locked
-  components:
-  - type: AccessReader
-    access: [["Janitor"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsKitchen
-  suffix: Kitchen, Locked
-  components:
-  - type: AccessReader
-    access: [["Kitchen"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsBar
-  suffix: Bar, Locked
-  components:
-  - type: AccessReader
-    access: [["Bar"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsHydroponics
-  suffix: Hydroponics, Locked
-  components:
-  - type: AccessReader
-    access: [["Hydroponics"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsLawyer
-  suffix: Lawyer, Locked
-  components:
-  - type: AccessReader
-    access: [["Lawyer"]]
-
+# Command
 - type: entity
   parent: DoorElectronics
   id: DoorElectronicsCaptain
@@ -70,134 +6,6 @@
   components:
   - type: AccessReader
     access: [["Captain"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsExternal
-  suffix: External, Locked
-  components:
-  - type: AccessReader
-    access: [["External"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsCargo
-  suffix: Cargo, Locked
-  components:
-  - type: AccessReader
-    access: [["Cargo"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsEngineering
-  suffix: Engineering, Locked
-  components:
-  - type: AccessReader
-    access: [["Engineering"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsAtmospherics
-  suffix: Atmospherics, Locked
-  components:
-  - type: AccessReader
-    access: [["Atmospherics"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsFreezer
-  suffix: Freezer, Locked
-  components:
-  - type: AccessReader
-    access: [["Kitchen"], ["Hydroponics"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsSalvage
-  suffix: Salvage, Locked
-  components:
-  - type: AccessReader
-    access: [["Salvage"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsMedical
-  suffix: Medical, Locked
-  components:
-  - type: AccessReader
-    access: [["Medical"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsChemistry
-  suffix: Chemistry, Locked
-  components:
-  - type: AccessReader
-    access: [["Chemistry"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsResearch
-  suffix: Research, Locked
-  components:
-  - type: AccessReader
-    access: [["Research"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsScience
-  suffix: Science, Locked
-  components:
-  - type: AccessReader
-    access: [["Research"], ["Medical"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsCommand
-  suffix: Command, Locked
-  components:
-  - type: AccessReader
-    access: [["Command"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsCentralCommand
-  suffix: CentralCommand, Locked
-  components:
-  - type: AccessReader
-    access: [["CentralCommand"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsChiefMedicalOfficer
-  suffix: ChiefMedicalOfficer, Locked
-  components:
-  - type: AccessReader
-    access: [["ChiefMedicalOfficer"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsChiefEngineer
-  suffix: ChiefEngineer, Locked
-  components:
-  - type: AccessReader
-    access: [["ChiefEngineer"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsHeadOfSecurity
-  suffix: HeadOfSecurity, Locked
-  components:
-  - type: AccessReader
-    access: [["HeadOfSecurity"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsResearchDirector
-  suffix: ResearchDirector, Locked
-  components:
-  - type: AccessReader
-    access: [["ResearchDirector"]]
 
 - type: entity
   parent: DoorElectronics
@@ -209,11 +17,192 @@
 
 - type: entity
   parent: DoorElectronics
+  id: DoorElectronicsCommand
+  suffix: Command, Locked
+  components:
+  - type: AccessReader
+    access: [["Command"]]
+
+# Service
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsBar
+  suffix: Bar, Locked
+  components:
+  - type: AccessReader
+    access: [["Bar"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsBarKitchen
+  suffix: Bar, Locked
+  components:
+  - type: AccessReader
+    access: [["Bar"], ["Kitchen"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsHydroponics
+  suffix: Hydroponics, Locked
+  components:
+  - type: AccessReader
+    access: [["Hydroponics"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsChapel
+  suffix: Chapel, Locked
+  components:
+  - type: AccessReader
+    access: [["Chapel"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsTheatre
+  suffix: Theatre, Locked
+  components:
+  - type: AccessReader
+    access: [["Theatre"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsKitchen
+  suffix: Kitchen, Locked
+  components:
+  - type: AccessReader
+    access: [["Kitchen"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsKitchenHydroponics
+  suffix: Freezer, Locked
+  components:
+  - type: AccessReader
+    access: [["Kitchen"], ["Hydroponics"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsJanitor
+  suffix: Janitor, Locked
+  components:
+  - type: AccessReader
+    access: [["Janitor"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsLawyer
+  suffix: Lawyer, Locked
+  components:
+  - type: AccessReader
+    access: [["Lawyer"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsService
+  suffix: Service, Locked
+  components:
+  - type: AccessReader
+    access: [["Service"]]
+
+# Cargo
+- type: entity
+  parent: DoorElectronics
   id: DoorElectronicsQuartermaster
   suffix: Quartermaster, Locked
   components:
   - type: AccessReader
     access: [["Quartermaster"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsSalvage
+  suffix: Salvage, Locked
+  components:
+  - type: AccessReader
+    access: [["Salvage"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsCargo
+  suffix: Cargo, Locked
+  components:
+  - type: AccessReader
+    access: [["Cargo"]]
+
+# Engineering
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsChiefEngineer
+  suffix: ChiefEngineer, Locked
+  components:
+  - type: AccessReader
+    access: [["ChiefEngineer"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsAtmospherics
+  suffix: Atmospherics, Locked
+  components:
+  - type: AccessReader
+    access: [["Atmospherics"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsEngineering
+  suffix: Engineering, Locked
+  components:
+  - type: AccessReader
+    access: [["Engineering"]]
+
+# Science
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsResearchDirector
+  suffix: ResearchDirector, Locked
+  components:
+  - type: AccessReader
+    access: [["ResearchDirector"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsMedicalResearch
+  suffix: Medical/Science, Locked
+  components:
+  - type: AccessReader
+    access: [["Research"], ["Medical"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsResearch
+  suffix: Research, Locked
+  components:
+  - type: AccessReader
+    access: [["Research"]]
+
+# Security
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsHeadOfSecurity
+  suffix: HeadOfSecurity, Locked
+  components:
+  - type: AccessReader
+    access: [["HeadOfSecurity"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsArmory
+  suffix: Armory, Locked
+  components:
+  - type: AccessReader
+    access: [["Armory"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsDetective
+  suffix: Detective, Locked
+  components:
+  - type: AccessReader
+    access: [["Detective"]]
 
 - type: entity
   parent: DoorElectronics
@@ -233,35 +222,70 @@
 
 - type: entity
   parent: DoorElectronics
-  id: DoorElectronicsDetective
-  suffix: Detective, Locked
-  components:
-  - type: AccessReader
-    access: [["Detective"]]
-
-- type: entity
-  parent: DoorElectronics
   id: DoorElectronicsBrig
   suffix: Brig, Locked
   components:
   - type: AccessReader
     access: [["Brig"]]
 
+# Medical
 - type: entity
   parent: DoorElectronics
-  id: DoorElectronicsArmory
-  suffix: Armory, Locked
+  id: DoorElectronicsChiefMedicalOfficer
+  suffix: ChiefMedicalOfficer, Locked
   components:
   - type: AccessReader
-    access: [["Armory"]]
+    access: [["ChiefMedicalOfficer"]]
 
 - type: entity
   parent: DoorElectronics
-  id: DoorElectronicsVault
-  suffix: Vault, Locked
+  id: DoorElectronicsChemistry
+  suffix: Chemistry, Locked
   components:
   - type: AccessReader
-    access: [["Security"], ["Command"]]
+    access: [["Chemistry"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsMedical
+  suffix: Medical, Locked
+  components:
+  - type: AccessReader
+    access: [["Medical"]]
+
+# Syndicate
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsNukeop
+  suffix: Nukeop, Locked
+  components:
+  - type: AccessReader
+    access: [["NuclearOperative"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsSyndicateAgent
+  suffix: SyndicateAgent, Locked
+  components:
+  - type: AccessReader
+    access: [["SyndicateAgent"]]
+
+# Misc
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsCentralCommand
+  suffix: CentralCommand, Locked
+  components:
+  - type: AccessReader
+    access: [["CentralCommand"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsExternal
+  suffix: External, Locked
+  components:
+  - type: AccessReader
+    access: [["External"]]
 
 - type: entity
   parent: DoorElectronics
@@ -273,24 +297,8 @@
 
 - type: entity
   parent: DoorElectronics
-  id: DoorElectronicsSyndicateAgent
-  suffix: SyndicateAgent, Locked
+  id: DoorElectronicsVault
+  suffix: Vault, Locked
   components:
   - type: AccessReader
-    access: [["SyndicateAgent"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsNukeop
-  suffix: Nukeop, Locked
-  components:
-  - type: AccessReader
-    access: [["NuclearOperative"]]
-
-- type: entity
-  parent: DoorElectronics
-  id: DoorElectronicsRnDMed
-  suffix: Medical/Science, Locked
-  components:
-  - type: AccessReader
-    access: [["Research"], ["Medical"]]
+    access: [["Security"], ["Command"]]

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
@@ -75,7 +75,7 @@
 - type: entity
   parent: DoorElectronics
   id: DoorElectronicsKitchenHydroponics
-  suffix: Freezer, Locked
+  suffix: Kitchen/Hydroponics, Locked
   components:
   - type: AccessReader
     access: [["Kitchen"], ["Hydroponics"]]

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -152,7 +152,7 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsFreezer ]
+      board: [ DoorElectronicsKitchenHydroponics ]
 
 - type: entity
   parent: AirlockFreezer
@@ -251,7 +251,7 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsScience ]
+      board: [ DoorElectronicsMedicalResearch ]
 
 - type: entity
   parent: AirlockCentralCommand
@@ -616,7 +616,7 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsScience ]
+      board: [ DoorElectronicsMedicalResearch ]
 
 - type: entity
   parent: AirlockCentralCommandGlass
@@ -965,7 +965,7 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsRnDMed ]
+      board: [ DoorElectronicsMedicalResearch ]
 
 - type: entity
   parent: AirlockMaint

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -93,10 +93,11 @@
             max: 4
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: AccessReader
   - type: ContainerFill
     containers:
       board: [ DoorElectronics ]
+  - type: AccessReader
+    containerAccessProvider: board
   - type: ContainerContainer
     containers:
       board: !type:Container

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -48,88 +48,99 @@
   id: WindoorBarLocked
   suffix: Bar, Locked
   components:
-  - type: AccessReader
-    access: [["Bar"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBar ]
 
 - type: entity
   parent: Windoor
   id: WindoorBarKitchenLocked
   suffix: Bar&Kitchen, Locked
   components:
-  - type: AccessReader
-    access: [["Bar"], ["Kitchen"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBarKitchen ]
 
 - type: entity
   parent: Windoor
   id: WindoorCargoLocked
   suffix: Cargo, Locked
   components:
-  - type: AccessReader
-    access: [["Cargo"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCargo ]
 
 - type: entity
   parent: Windoor
   id: WindoorChapelLocked
   suffix: Chapel, Locked
   components:
-  - type: AccessReader
-    access: [["Chapel"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsChapel ]
 
 - type: entity
   parent: Windoor
   id: WindoorHydroponicsLocked
   suffix: Hydroponics, Locked
   components:
-  - type: AccessReader
-    access: [["Hydroponics"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsHydroponics ]
 
 - type: entity
   parent: Windoor
   id: WindoorJanitorLocked
   suffix: Janitor, Locked
   components:
-  - type: AccessReader
-    access: [["Janitor"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsJanitor ]
 
 - type: entity
   parent: WindoorPlasma
   id: PlasmaWindoorJanitorLocked
   suffix: Janitor, Locked, Plasma
   components:
-  - type: AccessReader
-    access: [["Janitor"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsJanitor ]
 
 - type: entity
   parent: Windoor
   id: WindoorKitchenLocked
   suffix: Kitchen, Locked
   components:
-  - type: AccessReader
-    access: [["Kitchen"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsKitchen ]
 
 - type: entity
   parent: Windoor
   id: WindoorKitchenHydroponicsLocked
   suffix: Kitchen&Hydroponics, Locked
   components:
-  - type: AccessReader
-    access: [["Kitchen"], ["Hydroponics"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsKitchenHydroponics ]
 
 - type: entity
   parent: Windoor
   id: WindoorServiceLocked
   suffix: Service, Locked
   components:
-  - type: AccessReader
-    access: [["Service"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsService ]
 
 - type: entity
   parent: Windoor
   id: WindoorTheatreLocked
   suffix: Theatre, Locked
   components:
-  - type: AccessReader
-    access: [["Theatre"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsTheatre ]
 
 # Secure
 
@@ -138,253 +149,285 @@
   id: WindoorSecureArmoryLocked
   suffix: Armory, Locked
   components:
-  - type: AccessReader
-    access: [["Armory"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsArmory ]
 
 - type: entity
   parent: WindoorSecurePlasma
   id: PlasmaWindoorSecureArmoryLocked
   suffix: Armory, Locked, Plasma
   components:
-  - type: AccessReader
-    access: [["Armory"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsArmory ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureAtmosphericsLocked
   suffix: Atmospherics, Locked
   components:
-  - type: AccessReader
-    access: [["Atmospherics"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsAtmospherics ]
 
 - type: entity
   parent: WindoorSecurePlasma
   id: PlasmaWindoorSecureAtmosphericsLocked
   suffix: Atmospherics, Locked, Plasma
   components:
-  - type: AccessReader
-    access: [["Atmospherics"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsAtmospherics ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureBarLocked
   suffix: Bar, Locked
   components:
-  - type: AccessReader
-    access: [["Bar"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBar ]
 
 - type: entity
   parent: WindoorSecureSecurityLocked
   id: WindoorSecureBrigLocked
   suffix: Brig, Locked
   components:
-  - type: AccessReader
-    access: [["Brig"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBrig ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureCargoLocked
   suffix: Cargo, Locked
   components:
-  - type: AccessReader
-    access: [["Cargo"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCargo ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureChapelLocked
   suffix: Chapel, Locked
   components:
-  - type: AccessReader
-    access: [["Chapel"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsChapel ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureChemistryLocked
   suffix: Chemistry, Locked
   components:
-  - type: AccessReader
-    access: [["Chemistry"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsChemistry ]
 
 - type: entity
   parent: WindoorSecurePlasma
   id: PlasmaWindoorSecureChemistryLocked
   suffix: Chemistry, Locked, Plasma
   components:
-  - type: AccessReader
-    access: [["Chemistry"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsChemistry ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureCentralCommandLocked
   suffix: Central Command, Locked
   components:
-  - type: AccessReader
-    access: [["CentralCommand"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCentralCommand ]
 
 - type: entity
   parent: WindoorSecurePlasma
   id: PlasmaWindoorSecureCentralCommandLocked
   suffix: Central Command, Locked, Plasma
   components:
-  - type: AccessReader
-    access: [["CentralCommand"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCentralCommand ]
 
 - type: entity
   parent: WindoorSecureUranium
   id: UraniumWindoorSecureCentralCommandLocked
   suffix: Central Command, Locked, Uranium
   components:
-  - type: AccessReader
-    access: [["CentralCommand"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCentralCommand ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureCommandLocked
   suffix: Command, Locked
   components:
-  - type: AccessReader
-    access: [["Command"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCommand ]
 
 - type: entity
   parent: WindoorSecurePlasma
   id: PlasmaWindoorSecureCommandLocked
   suffix: Command, Locked, Plasma
   components:
-  - type: AccessReader
-    access: [["Command"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCommand ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureDetectiveLocked
   suffix: Detective, Locked
   components:
-  - type: AccessReader
-    access: [["Detective"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsDetective ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureEngineeringLocked
   suffix: Engineering, Locked
   components:
-  - type: AccessReader
-    access: [["Engineering"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsEngineering ]
 
 - type: entity
   parent: WindoorSecurePlasma
   id: PlasmaWindoorSecureEngineeringLocked
   suffix: Engineering, Locked, Plasma
   components:
-  - type: AccessReader
-    access: [["Engineering"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsEngineering ]
 
 - type: entity
   parent: WindoorSecureUranium
   id: UraniumWindoorSecureEngineeringLocked
   suffix: Engineering, Locked, Uranium
   components:
-  - type: AccessReader
-    access: [["Engineering"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsEngineering ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureExternalLocked
   suffix: External, Locked
   components:
-  - type: AccessReader
-    access: [["External"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsExternal ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureJanitorLocked
   suffix: Janitor, Locked
   components:
-  - type: AccessReader
-    access: [["Janitor"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsJanitor ]
 
 - type: entity
   parent: WindoorSecurePlasma
   id: PlasmaWindoorSecureJanitorLocked
   suffix: Janitor, Locked, Plasma
   components:
-  - type: AccessReader
-    access: [["Janitor"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsJanitor ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureKitchenLocked
   suffix: Kitchen, Locked
   components:
-  - type: AccessReader
-    access: [["Kitchen"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsKitchen ]
 
 - type: entity
   parent: WindoorSecureSecurityLocked
   id: WindoorSecureSecurityLawyerLocked
   suffix: Security/Lawyer, Locked
   components:
-  - type: AccessReader
-    access: [["Security"], ["Lawyer"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSecurityLawyer ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureMedicalLocked
   suffix: Medical, Locked
   components:
-  - type: AccessReader
-    access: [["Medical"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsMedical ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureSalvageLocked
   suffix: Salvage, Locked
   components:
-  - type: AccessReader
-    access: [["Salvage"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSalvage ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureSecurityLocked
   suffix: Security, Locked
   components:
-  - type: AccessReader
-    access: [["Security"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSecurity ]
 
 - type: entity
   parent: WindoorSecurePlasma
   id: PlasmaWindoorSecureSecurityLocked
   suffix: Security, Locked, Plasma
   components:
-  - type: AccessReader
-    access: [["Security"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSecurity ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureScienceLocked
   suffix: Science, Locked
   components:
-  - type: AccessReader
-    access: [["Research"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsResearch ]
 
 - type: entity
   parent: WindoorSecurePlasma
   id: PlasmaWindoorSecureScienceLocked
   suffix: Science, Locked, Plasma
   components:
-  - type: AccessReader
-    access: [["Research"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsResearch ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureServiceLocked
   suffix: Service, Locked
   components:
-  - type: AccessReader
-    access: [["Service"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsService ]
 
 - type: entity
   parent: WindoorSecure
   id: WindoorSecureHeadOfPersonnelLocked
   suffix: HeadOfPersonnel, Locked
   components:
-  - type: AccessReader
-    access: [["HeadOfPersonnel"]]
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsHeadOfPersonnel ]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The title.
Electronics `DoorElectronicsScience` had the same acceses as `DoorElectronicsRnDMed`, so it was removed.
`DoorElectronicsBarKitchen` was added for `WindoorBarKitchenLocked`.

`DoorElectronicsRnDMed` was renamed to `DoorElectronicsMedicalResearch`.
`DoorElectronicsFreezer` was renamed to `DoorElectronicsKitchenHydroponics`.

Door electronics in `.yml` file was sorted by department.

## Why / Balance
Deconstructing windoor will now give electronics with proper accesses.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Everything works fine, tested.
![Content Client_N1VeODeFpj](https://github.com/space-wizards/space-station-14/assets/63782763/061d5d9d-664d-41a9-9434-2453808308f7)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Electronics inside windoors now has proper accesses.
