### PR TITLE
Fix crates masks

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -48,6 +48,9 @@ public enum CollisionGroup
     MachineLayer = Opaque | MidImpassable | LowImpassable | BulletImpassable,
     ConveyorMask = Impassable | MidImpassable | LowImpassable | DoorPassable,
 
+    // Crates
+    CrateMask = Impassable | HighImpassable | LowImpassable,
+
     // Tables that SmallMobs can go under
     TableMask = Impassable | MidImpassable,
     TableLayer = MidImpassable,

--- a/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
@@ -30,7 +30,7 @@
           radius: 0.45
         density: 25
         mask:
-        - SmallMobMask
+        - ItemMask
         layer:
         - MachineLayer
   - type: EntityStorage

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -36,7 +36,7 @@
             radius: 0.45
           density: 50
           mask:
-          - SmallMobMask #this is so they can go under plastic flaps
+          - CrateMask #this is so they can go under plastic flaps
           layer:
           - MachineLayer
     - type: Icon

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -34,7 +34,7 @@
           bounds: "-0.4,-0.4,0.4,0.29"
         density: 50
         mask:
-        - SmallMobMask #this is so they can go under plastic flaps
+        - CrateMask #this is so they can go under plastic flaps
         layer:
         - MachineLayer
   - type: EntityStorage

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -356,7 +356,7 @@
           bounds: "-0.4,-0.4,0.4,0.29"
         density: 135
         mask:
-        - SmallMobMask #this is so they can go under plastic flaps
+        - CrateMask #this is so they can go under plastic flaps
         layer:
         - LargeMobLayer
   - type: Construction
@@ -413,7 +413,7 @@
           bounds: "-0.4,-0.4,0.4,0.29"
         density: 80
         mask:
-        - LargeMobMask
+        - CrateMask
         layer:
         - LargeMobLayer
   - type: StaticPrice

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -23,7 +23,7 @@
           bounds: "-0.49,-0.49,0.49,0.49"
         density: 100
         mask:
-        - TabletopMachineMask
+        - Impassable
         layer:
         - MidImpassable
   - type: Damageable
@@ -61,7 +61,7 @@
           bounds: "-0.49,-0.49,0.49,0.49"
         density: 100
         mask:
-        - TabletopMachineMask
+        - Impassable
         layer:
         - Opaque
         - MidImpassable


### PR DESCRIPTION
Fixes crates masks not allowing them to go under plastic flaps + crates can no longer go trough windoors.

## About the PR
Fixes #25603
Fixes #25457

## Technical details
Added new mask `CrateMask`.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Most crates can now go through plastic flaps.
