### PR TITLE
Wallmount substations can once again be created

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -155,6 +155,7 @@
       - APCElectronics
       - SMESMachineCircuitboard
       - SubstationMachineCircuitboard
+      - WallmountSubstationElectronics
       - CellRechargerCircuitboard
       - BorgChargerCircuitboard
       - WeaponCapacitorRechargerCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -241,6 +241,16 @@
   - type: Battery
     maxCharge: 2000000
     startingCharge: 2000000
+  - type: ContainerFill
+    containers:
+      board: [ WallmountSubstationElectronics ]
+      capacitor: [ CapacitorStockPart ]
+      powercell: [ PowerCellSmall ]
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
+      capacitor: !type:Container
+      powercell: !type:Container
 
 # Construction Frame
 - type: entity

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
@@ -26,7 +26,13 @@
         steps:
         - material: Cable
           amount: 5
-          doAfter: 2
+          doAfter: 0.5
+        - material: CableMV
+          amount: 5
+          doAfter: 0.5
+        - material: CableHV
+          amount: 5
+          doAfter: 0.5
         - tool: Screwing
           doAfter: 2
 
@@ -41,11 +47,33 @@
           icon:
             sprite: "Objects/Misc/module.rsi"
             state: "charger_APC"
-          doAfter: 1
+          doAfter: 0.5
+        - anyTags:
+            - PowerCell
+            - PowerCellSmall
+          store: powercell
+          name: a powercell
+          icon:
+            sprite: "Objects/Power/power_cells.rsi"
+            state: "medium"
+          doAfter: 0.5
+        - tag: CapacitorStockPart
+          name: a capacitor
+          store: capacitor
+          icon:
+            sprite: "Objects/Misc/stock_parts.rsi"
+            state: "capacitor"
+          doAfter: 0.5
       - to: frame
         completed:
         - !type:GivePrototype
           prototype: CableApcStack1
+          amount: 5
+        - !type:GivePrototype
+          prototype: CableMVStack1
+          amount: 5
+        - !type:GivePrototype
+          prototype: CableHVStack1
           amount: 5
         steps:
         - tool: Cutting

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -604,7 +604,7 @@
   completetime: 4
   materials:
      Steel: 50
-     Glass: 350
+     Glass: 450
 
 - type: latheRecipe
   id: SMESMachineCircuitboard


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Now the station crew can create additional wallmounted substations.

## Why / Balance
PR #24558 removed a tech, which allowed us to create wallmount substation electronics. After this tech was removed, the only source of additional wallmount substations was circuits either found somewhere or salvaged from existing shuttles. 

The construction costs were updated to roughly match what standard substations have, with the wallmount using 5 LV Cable instead of 1. We can call this a tradeoff between space and cost. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

The following video is about constructing them, and demonstrating how any kind of power cell can be used, like with standard substations.

https://github.com/space-wizards/space-station-14/assets/62134478/d7d1546e-9cab-41f7-a979-474e8bb458ea

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Wallmount substation electronics can now be created at an autolathe.
