### PR TITLE
No More Bartender Incendiaries on Meta

### DIFF
--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -15599,13 +15599,6 @@ entities:
       parent: 5350
 - proto: BoxShotgunIncendiary
   entities:
-  - uid: 3116
-    components:
-    - type: Transform
-      pos: 21.56827,-12.3393
-      parent: 5350
-    - type: BallisticAmmoProvider
-      unspawnedCount: 12
   - uid: 10381
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removed incendiary rounds from the bartender's room on Meta.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
There is no reason bartender's should have access to extra-deadly lethal shells on roundstart. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Aexxie
ADMIN:
- remove: Removed the bartender's roundstart incendiary shells on Meta.