### PR TITLE
Try fix emergency shuttle not spawning

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -145,11 +145,15 @@ namespace Content.Server.RoundEnd
 
         public void RequestRoundEnd(TimeSpan countdownTime, EntityUid? requester = null, bool checkCooldown = true, string text = "round-end-system-shuttle-called-announcement", string name = "Station")
         {
-            if (_gameTicker.RunLevel != GameRunLevel.InRound) return;
+            if (_gameTicker.RunLevel != GameRunLevel.InRound)
+                return;
 
-            if (checkCooldown && _cooldownTokenSource != null) return;
+            if (checkCooldown && _cooldownTokenSource != null)
+                return;
 
-            if (_countdownTokenSource != null) return;
+            if (_countdownTokenSource != null)
+                return;
+
             _countdownTokenSource = new();
 
             if (requester != null)

--- a/Content.Server/Shuttles/Components/StationEmergencyShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/StationEmergencyShuttleComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class StationEmergencyShuttleComponent : Component
     /// <summary>
     /// The emergency shuttle assigned to this station.
     /// </summary>
-    [ViewVariables, Access(typeof(ShuttleSystem), typeof(EmergencyShuttleSystem), Friend = AccessPermissions.ReadWrite)]
+    [DataField, Access(typeof(ShuttleSystem), typeof(EmergencyShuttleSystem), Friend = AccessPermissions.ReadWrite)]
     public EntityUid? EmergencyShuttle;
 
     /// <summary>

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -259,10 +259,13 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
     /// </summary>
     public void CallEmergencyShuttle(EntityUid stationUid, StationEmergencyShuttleComponent? stationShuttle = null)
     {
-        if (!Resolve(stationUid, ref stationShuttle) ||
-            !TryComp<TransformComponent>(stationShuttle.EmergencyShuttle, out var xform) ||
+        if (!Resolve(stationUid, ref stationShuttle))
+            return;
+
+        if (!TryComp<TransformComponent>(stationShuttle.EmergencyShuttle, out var xform) ||
             !TryComp<ShuttleComponent>(stationShuttle.EmergencyShuttle, out var shuttle))
         {
+            Log.Error($"Attempted to call an emergency shuttle for an uninitialized station? Station: {ToPrettyString(stationUid)}. Shuttle: {ToPrettyString(stationShuttle.EmergencyShuttle)}");
             return;
         }
 

--- a/Content.Server/Station/Events/StationPostInitEvent.cs
+++ b/Content.Server/Station/Events/StationPostInitEvent.cs
@@ -4,6 +4,8 @@ namespace Content.Server.Station.Events;
 
 /// <summary>
 /// Raised directed on a station after it has been initialized, as well as broadcast.
+/// This gets raised after the entity has been map-initialized, and the station's centcomm map/entity (if any) has been
+/// set up.
 /// </summary>
 [ByRefEvent]
 public readonly record struct StationPostInitEvent(Entity<StationDataComponent> Station);

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -294,8 +294,6 @@ public sealed class StationSystem : EntitySystem
         // Use overrides for setup.
         var station = EntityManager.SpawnEntity(stationConfig.StationPrototype, MapCoordinates.Nullspace, stationConfig.StationComponentOverrides);
 
-
-
         if (name is not null)
             RenameStation(station, name, false);
 
@@ -345,6 +343,9 @@ public sealed class StationSystem : EntitySystem
                 }
             }
         }
+
+        if (LifeStage(station) < EntityLifeStage.MapInitialized)
+            throw new Exception($"Station must be man-initialized");
 
         var ev = new StationPostInitEvent((station, data));
         RaiseLocalEvent(station, ref ev, true);


### PR DESCRIPTION
Fixes emergency shuttles silently failing to spawn on centcomm due to broken component initialization ordering, and adds various logs to try help prevent it from reoccurring.

**Changelog**

:cl:

Fix: Fixed a bug causing the emergency shuttle to not spawn