### PR TITLE
fix cryopod volume

### DIFF
--- a/Content.Server/Medical/Components/CryoPodAirComponent.cs
+++ b/Content.Server/Medical/Components/CryoPodAirComponent.cs
@@ -11,5 +11,5 @@ public sealed partial class CryoPodAirComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("gasMixture")]
-    public GasMixture Air { get; set; } = new(Atmospherics.OneAtmosphere);
+    public GasMixture Air { get; set; } = new GasMixture(1000f);
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixed a small error giving the cryopod an internal volume of one standard atmosphere (101.325) for some reason.

## Why / Balance
The new value is 1000L since it should be significantly bigger than that of a pipe (100L), but smaller than a whole environment tile (2500L). This is the same as a canister.

## Media
before:
![before](https://github.com/space-wizards/space-station-14/assets/161409025/f529ce26-7268-45f5-a31e-ded118b601a9)

after:
![after](https://github.com/space-wizards/space-station-14/assets/161409025/4e7e363c-7104-4c69-8653-c801eff804d5)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- tweak: The internal volume of cryopods has been increased from 101.3 to 1000L. This speeds up cooling patients inside.
