### PR TITLE
Reduces reflect chance for syndie swords to remain consistent with other melee reflect chances.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -78,6 +78,8 @@
     malus: 0
   - type: Reflect
     enabled: false
+    reflectProb: .1
+    spread: 90
   - type: IgnitionSource
     temperature: 700
 
@@ -269,8 +271,9 @@
     size: Small
     sprite: Objects/Weapons/Melee/e_sword_double-inhands.rsi
   - type: Reflect
-    reflectProb: .75
-    spread: 75
+    enabled: true
+    reflectProb: .20
+    spread: 90
   - type: UseDelay
     delay: 1
   - type: ToggleableLightVisuals


### PR DESCRIPTION


<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Reduces reflect chance for syndicate swords to in order to be consistent with other reflecting melee weapons.  Energy sword now has a 10% chance of reflection, and the double energy sword now has a 20% reflection chance.
<!-- What did you change in this PR? -->

## Why / Balance
I was against cap's saber reflect nerf, but now that it's been merged its only natural for the two syndicate energy swords to also be nerfed in this regard to better conform to the new balancing direction set by #26969 that does not like constant and random deflect chance.  Should a new reflect system emerge it can easily overwrite this change and return sword reflection back into the game in a more effective but still balanced state, otherwise its a very rare occurrence that should not be relied upon.  Otherwise from now on if a player wants a reliable reflect chance they must seek such in armor and shields.

I purposefully did not touch the Energy Katana, as Ninja is arguably the only human character in the game who reasonably deserves a decent reflect chance given their need for a defensive option. 
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
simple yml changes
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
no cl no fun
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
