### PR TITLE
Fixed debug assert while getting network state in ClothingSystem

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -131,10 +131,6 @@ public abstract class ClothingSystem : EntitySystem
     private void OnGetState(EntityUid uid, ClothingComponent component, ref ComponentGetState args)
     {
         args.State = new ClothingComponentState(component.EquippedPrefix);
-        if (component.InSlot != null && _containerSys.TryGetContainingContainer(uid, out var container))
-        {
-            CheckEquipmentForLayerHide(uid, container.Owner);
-        }
     }
 
     private void OnHandleState(EntityUid uid, ClothingComponent component, ref ComponentHandleState args)


### PR DESCRIPTION
ClothingSystem's ComponentGetState handler attempts to update clothing visuals and calls SharedContainerSystem.TryGetContainingContainer. This winds up throwing an exception in debug, since ContainerSlot.Contains tries to do a couple of IoC Resolves in debug builds. Network state is apparently gathered in a different thread, so IoC doesn't have the right context and throws an exception.

I don't see a good reason to call CheckEquipmentForLayerHide in ComponentGetState anyway, since the event meant to gather state and shouldn't be changing anything. So this just removes that bit of code.