### PR TITLE
Make remaining IPrototypes partial

### DIFF
--- a/Content.Client/Guidebook/GuideEntry.cs
+++ b/Content.Client/Guidebook/GuideEntry.cs
@@ -42,7 +42,7 @@ public class GuideEntry
 }
 
 [Prototype("guideEntry")]
-public sealed class GuideEntryPrototype : GuideEntry, IPrototype
+public sealed partial class GuideEntryPrototype : GuideEntry, IPrototype
 {
     public string ID => Id;
 }

--- a/Content.Server/Botany/SeedPrototype.cs
+++ b/Content.Server/Botany/SeedPrototype.cs
@@ -2,16 +2,16 @@ using Content.Server.Botany.Components;
 using Content.Server.Botany.Systems;
 using Content.Shared.Atmos;
 using Content.Shared.Chemistry.Reagent;
+using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 using Robust.Shared.Utility;
-using Robust.Shared.Audio;
 
 namespace Content.Server.Botany;
 
 [Prototype("seed")]
-public sealed class SeedPrototype : SeedData, IPrototype
+public sealed partial class SeedPrototype : SeedData, IPrototype
 {
     [IdDataField] public string ID { get; private init; } = default!;
 }

--- a/Content.Server/Worldgen/Prototypes/NoiseChannelPrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/NoiseChannelPrototype.cs
@@ -80,7 +80,7 @@ public class NoiseChannelConfig
 }
 
 [Prototype("noiseChannel")]
-public sealed class NoiseChannelPrototype : NoiseChannelConfig, IPrototype, IInheritingPrototype
+public sealed partial class NoiseChannelPrototype : NoiseChannelConfig, IPrototype, IInheritingPrototype
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<EntityPrototype>))]

--- a/Content.Shared/Audio/Jukebox/JukeboxPrototype.cs
+++ b/Content.Shared/Audio/Jukebox/JukeboxPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Audio.Jukebox;
 /// Soundtrack that's visible on the jukebox list.
 /// </summary>
 [Prototype]
-public sealed class JukeboxPrototype : IPrototype
+public sealed partial class JukeboxPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; } = string.Empty;

--- a/Content.Shared/Damage/Prototypes/DamageModifierSetPrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageModifierSetPrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Damage.Prototypes
     ///     just want normal data to be deserialized.
     /// </remarks>
     [Prototype("damageModifierSet")]
-    public sealed class DamageModifierSetPrototype : DamageModifierSet, IPrototype
+    public sealed partial class DamageModifierSetPrototype : DamageModifierSet, IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/DeviceLinking/DevicePortPrototype.cs
+++ b/Content.Shared/DeviceLinking/DevicePortPrototype.cs
@@ -29,13 +29,13 @@ public abstract class DevicePortPrototype
 
 [Prototype("sinkPort")]
 [Serializable, NetSerializable]
-public sealed class SinkPortPrototype : DevicePortPrototype, IPrototype
+public sealed partial class SinkPortPrototype : DevicePortPrototype, IPrototype
 {
 }
 
 [Prototype("sourcePort")]
 [Serializable, NetSerializable]
-public sealed class SourcePortPrototype : DevicePortPrototype, IPrototype
+public sealed partial class SourcePortPrototype : DevicePortPrototype, IPrototype
 {
     /// <summary>
     ///     This is a set of sink ports that this source port will attempt to link to when using the

--- a/Content.Shared/Preferences/Loadouts/Effects/LoadoutEffectGroupPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/LoadoutEffectGroupPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Preferences.Loadouts.Effects;
 /// Stores a group of loadout effects in a prototype for re-use.
 /// </summary>
 [Prototype]
-public sealed class LoadoutEffectGroupPrototype : IPrototype
+public sealed partial class LoadoutEffectGroupPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; } = string.Empty;

--- a/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Preferences.Loadouts;
 /// Corresponds to a set of loadouts for a particular slot.
 /// </summary>
 [Prototype("loadoutGroup")]
-public sealed class LoadoutGroupPrototype : IPrototype
+public sealed partial class LoadoutGroupPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; } = string.Empty;

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Preferences.Loadouts;
 /// Individual loadout item to be applied.
 /// </summary>
 [Prototype]
-public sealed class LoadoutPrototype : IPrototype
+public sealed partial class LoadoutPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; } = string.Empty;

--- a/Content.Shared/Preferences/Loadouts/RoleLoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadoutPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Preferences.Loadouts;
 /// Corresponds to a Job / Antag prototype and specifies loadouts
 /// </summary>
 [Prototype]
-public sealed class RoleLoadoutPrototype : IPrototype
+public sealed partial class RoleLoadoutPrototype : IPrototype
 {
     /*
      * Separate to JobPrototype / AntagPrototype as they are turning into messy god classes.

--- a/Content.Shared/RCD/RCDPrototype.cs
+++ b/Content.Shared/RCD/RCDPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.RCD;
 /// Contains the parameters for a RCD construction / operation
 /// </summary>
 [Prototype("rcd")]
-public sealed class RCDPrototype : IPrototype
+public sealed partial class RCDPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;
@@ -51,7 +51,7 @@ public sealed class RCDPrototype : IPrototype
     public int Cost { get; private set; } = 1;
 
     /// <summary>
-    /// The length of the operation 
+    /// The length of the operation
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly)]
     public float Delay { get; private set; } = 1f;
@@ -75,7 +75,7 @@ public sealed class RCDPrototype : IPrototype
     public CollisionGroup CollisionMask { get; private set; } = CollisionGroup.None;
 
     /// <summary>
-    /// Specifies a set of custom collision bounds for determining whether the entity prototype will fit into a target tile 
+    /// Specifies a set of custom collision bounds for determining whether the entity prototype will fit into a target tile
     /// </summary>
     /// <remarks>
     /// Should be set assuming that the entity faces south.
@@ -106,7 +106,7 @@ public sealed class RCDPrototype : IPrototype
     private Box2? _collisionBounds = null;
 
     /// <summary>
-    /// The polygon shape associated with the prototype CollisionBounds (if set) 
+    /// The polygon shape associated with the prototype CollisionBounds (if set)
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]
     public PolygonShape? CollisionPolygon { get; private set; } = null;

--- a/Content.Shared/Salvage/SalvageMapPrototype.cs
+++ b/Content.Shared/Salvage/SalvageMapPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Salvage;
 
 [Prototype]
-public sealed class SalvageMapPrototype : IPrototype
+public sealed partial class SalvageMapPrototype : IPrototype
 {
     [ViewVariables] [IdDataField] public string ID { get; } = default!;
 

--- a/Content.Shared/Silicons/Laws/SiliconLawPrototype.cs
+++ b/Content.Shared/Silicons/Laws/SiliconLawPrototype.cs
@@ -58,7 +58,7 @@ public partial class SiliconLaw : IComparable<SiliconLaw>
 /// </summary>
 [Prototype("siliconLaw")]
 [Serializable, NetSerializable]
-public sealed class SiliconLawPrototype : SiliconLaw, IPrototype
+public sealed partial class SiliconLawPrototype : SiliconLaw, IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]

--- a/Content.Shared/SprayPainter/Prototypes/AirlockDepartmentsPrototype.cs
+++ b/Content.Shared/SprayPainter/Prototypes/AirlockDepartmentsPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.SprayPainter.Prototypes;
 /// Maps airlock style names to department ids.
 /// </summary>
 [Prototype("airlockDepartments")]
-public sealed class AirlockDepartmentsPrototype : IPrototype
+public sealed partial class AirlockDepartmentsPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/StatusIcon/StatusIconPrototype.cs
+++ b/Content.Shared/StatusIcon/StatusIconPrototype.cs
@@ -58,7 +58,7 @@ public partial class StatusIconData : IComparable<StatusIconData>
 /// <see cref="StatusIconData"/> but in new convenient prototype form!
 /// </summary>
 [Prototype("statusIcon")]
-public sealed class StatusIconPrototype : StatusIconData, IPrototype, IInheritingPrototype
+public sealed partial class StatusIconPrototype : StatusIconData, IPrototype, IInheritingPrototype
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<StatusIconPrototype>))]


### PR DESCRIPTION
## About the PR
In the interest of not wanting to shoot myself when I make source gen serialization copying support prototypes.
I made the rest partial a while ago (see https://github.com/space-wizards/space-station-14/pull/21374) and I think the serialization source gen should be able to support prototypes, but having multiple user-defined partials of the same type makes it bug out at the moment, so waiting to sort that out (see https://github.com/space-wizards/RobustToolbox/issues/5054)


## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
