### PR TITLE
Possible fix for evac shuttle test failures

### DIFF
--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -416,6 +416,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
             }
 
             component.MapEntity = otherComp.MapEntity;
+            component.Entity = otherComp.Entity;
             component.ShuttleIndex = otherComp.ShuttleIndex;
             return;
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I'm skeptical that it could be this easy, but this seems like it could be the issue.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
When enabling the evac shuttle, if a Centcomm entity already exists, EmergencyShuttleSystem tries to use it instead of spawning a new one. To do so, it copies a few values over from the old one. It looks like copying the grid Entity was missed though, which seems to be what's triggering the error. This PR just makes the grid entity reference get copied too.