### PR TITLE
Fixed potential duplicate engraved lighter steal objective

### DIFF
--- a/Resources/Maps/Dungeon/lava_brig.yml
+++ b/Resources/Maps/Dungeon/lava_brig.yml
@@ -7345,7 +7345,7 @@ entities:
     - type: Transform
       pos: 18.47467,24.458666
       parent: 588
-- proto: ClothingOuterCoatDetective
+- proto: ClothingOuterCoatDetectiveLoadout
   entities:
   - uid: 574
     components:

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
@@ -4,7 +4,7 @@
     ClothingUniformJumpsuitDetective: 2
     ClothingUniformJumpskirtDetective: 2
     ClothingShoesColorBrown: 2
-    ClothingOuterCoatDetective: 2
+    ClothingOuterCoatDetectiveLoadout: 2
     ClothingHeadHatFedoraBrown: 2
     ClothingUniformJumpsuitDetectiveGrey: 2
     ClothingUniformJumpskirtDetectiveGrey: 2

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -33,6 +33,28 @@
 
 - type: entity
   parent: ClothingOuterStorageBase
+  id: ClothingOuterCoatDetectiveLoadout
+  name: detective trenchcoat
+  description: A rugged canvas trenchcoat, designed and created by TX Fabrication Corp. Wearing it makes you feel for the plight of the Tibetans.
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Coats/detective.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Coats/detective.rsi
+  - type: StorageFill
+    contents:
+    - id: SmokingPipeFilledTobacco
+    - id: FlippoLighter #Not the steal objective, only difference from normal detective trenchcoat
+  - type: Armor #same as regular sec armor
+    modifiers:
+      coefficients:
+        Blunt: 0.70
+        Slash: 0.70
+        Piercing: 0.70
+        Heat: 0.80
+
+- type: entity
+  parent: ClothingOuterStorageBase
   id: ClothingOuterCoatGentle
   name: gentle coat
   description: A gentle coat for a gentle man, or woman.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -32,26 +32,13 @@
         Heat: 0.80
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ClothingOuterCoatDetective
   id: ClothingOuterCoatDetectiveLoadout
-  name: detective trenchcoat
-  description: A rugged canvas trenchcoat, designed and created by TX Fabrication Corp. Wearing it makes you feel for the plight of the Tibetans.
   components:
-  - type: Sprite
-    sprite: Clothing/OuterClothing/Coats/detective.rsi
-  - type: Clothing
-    sprite: Clothing/OuterClothing/Coats/detective.rsi
   - type: StorageFill
     contents:
     - id: SmokingPipeFilledTobacco
     - id: FlippoLighter #Not the steal objective, only difference from normal detective trenchcoat
-  - type: Armor #same as regular sec armor
-    modifiers:
-      coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.80
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
@@ -109,4 +109,4 @@
 - type: startingGear
   id: DetectiveCoat
   equipment:
-    outerClothing: ClothingOuterCoatDetective
+    outerClothing: ClothingOuterCoatDetectiveLoadout


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This would make the Detective Trench-coat currently available as a loadout option spawn with a normal flippo lighter instead of Det's signature engraved one.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The engraved lighter is a steal objective. I love the trenchcoat and want it to be part of the loadouts system but steal objectives being duplicated in the loadouts doesn't make gameplay sense to me. Especially since technically with cryo there can be an infinite series of detectives, each with their own copy of the steal objective.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Created duplicate version of the detective trenchcoat, only difference being the engraved flippo lighter is now a regular flippo lighter, replaced the trenchcoat in the loadouts with this new version, left trenchcoats in detective locker alone (they still have the engraved one).
Also replaces the detective trenchcoat in the DetDrobe and one that spawns in a possible expedition room.
I became aware of this after playing detective with this selected as my loadout option. (And wrote (most of) this PR in between events in the same round :wink: )
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
no cl no fun
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
