### PR TITLE
Make material arbitrage test ignore price of contained entities

### DIFF
--- a/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
+++ b/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
@@ -359,7 +359,7 @@ public sealed class MaterialArbitrageTest
                 {
                     var ent = entManager.SpawnEntity(id, testMap.GridCoords);
                     stackSys.SetCount(ent, 1);
-                    priceCache[id] = price = pricing.GetPrice(ent);
+                    priceCache[id] = price = pricing.GetPrice(ent, false);
                     entManager.DeleteEntity(ent);
                 });
             }

--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -199,7 +199,7 @@ public sealed class PricingSystem : EntitySystem
     /// This fires off an event to calculate the price.
     /// Calculating the price of an entity that somehow contains itself will likely hang.
     /// </remarks>
-    public double GetPrice(EntityUid uid)
+    public double GetPrice(EntityUid uid, bool includeContents = true)
     {
         var ev = new PriceCalculationEvent();
         RaiseLocalEvent(uid, ref ev);
@@ -222,7 +222,7 @@ public sealed class PricingSystem : EntitySystem
             price += GetStaticPrice(uid);
         }
 
-        if (TryComp<ContainerManagerComponent>(uid, out var containers))
+        if (includeContents && TryComp<ContainerManagerComponent>(uid, out var containers))
         {
             foreach (var container in containers.Containers.Values)
             {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The NoMaterialArbitrage CI test now only compares the base price of the tested entity with the price of the entities created on destruction/deconstruction. Entities contained inside the tested entity are not included in the price.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This is the source of the "heisentest" that has been showing up recently with the DresserFilled entity. The test was comparing the value of the dresser (nothing) and its randomized contents (random) with the value of the items it drops on destruction (3 wooden planks, worth 15 spesos). Whenever the randomly selected contents were worth less than 15 spesos total, the test would trigger.

I can't think of a good reason to include the price of contained entities for this test. They're not included in the appraisal of entities spawned on destruction, so it seems weird to include them only on one side of the comparison.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds an optional bool parameter to PricingSystem.GetPrice to include contained entities (defaults to true). The test calls the method passing false, and everywhere else still uses the default true value.