### PR TITLE
Make CLF3 reaction require heating first.

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
+++ b/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
@@ -31,6 +31,7 @@
 
 - type: reaction
   id: ChlorineTrifluoride
+  minTemp: 370
   priority: 20
   reactants:
     Chlorine:

--- a/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
+++ b/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
@@ -39,7 +39,6 @@
     Fluorine:
       amount: 3
   effects:
-  # TODO solution temperature!!
   - !type:ExplosionReactionEffect
     explosionType: Default # 15 damage per intensity.
     maxIntensity: 200


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
CLF3 must now be heated to 370K before the reaction takes place

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
A couple reasons
1) Bombs and dangerous reagents should require some level of complexity to make. I know potassium+water bombs still exist but I feel like having 1 dangerous "cold" mix reaction is fine
2) Prevents easy chem bombing by just grabbing and throwing jugs onto the floor in quick succession (chemmasters should be locked behind chem access anyways - but with newmed coming chemistrys role as a whole will be shifting so it will be interesting to see what becomes of the chem machines)
3) This prevents new chemists destroying half of chem as easily by misclicking. It takes intentional actions on the chemists behalf to create a large CLF3 explosion in the middle of the lab.


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
funny 1 yaml line added
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl: Weax
- tweak: The CLF3 reaction now requires heating first before you can engulf chemistry in fiery death.
