### PR TITLE
make fire spreading scale with mass

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -47,6 +47,8 @@ namespace Content.Server.Atmos.EntitySystems
         [Dependency] private readonly AudioSystem _audio = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
 
+        private EntityQuery<PhysicsComponent> _physicsQuery;
+
         public const float MinimumFireStacks = -10f;
         public const float MaximumFireStacks = 20f;
         private const float UpdateTime = 1f;
@@ -61,6 +63,8 @@ namespace Content.Server.Atmos.EntitySystems
         public override void Initialize()
         {
             UpdatesAfter.Add(typeof(AtmosphereSystem));
+
+            _physicsQuery = GetEntityQuery<PhysicsComponent>();
 
             SubscribeLocalEvent<FlammableComponent, MapInitEvent>(OnMapInit);
             SubscribeLocalEvent<FlammableComponent, InteractUsingEvent>(OnInteractUsing);
@@ -203,7 +207,17 @@ namespace Content.Server.Atmos.EntitySystems
             if (flammable.OnFire && otherFlammable.OnFire)
             {
                 // Both are on fire -> equalize fire stacks.
-                var avg = (flammable.FireStacks + otherFlammable.FireStacks) / 2;
+                // Weight each thing's firestacks by its mass
+                var mass1 = 1f;
+                var mass2 = 1f;
+                if (_physicsQuery.TryComp(uid, out var physics) && _physicsQuery.TryComp(otherUid, out var otherPhys))
+                {
+                    mass1 = physics.Mass;
+                    mass2 = otherPhys.Mass;
+                }
+
+                var total = mass1 + mass2;
+                var avg = (flammable.FireStacks * mass1 + otherFlammable.FireStacks * mass2) / total;
                 flammable.FireStacks = flammable.CanExtinguish ? avg : Math.Max(flammable.FireStacks, avg);
                 otherFlammable.FireStacks = otherFlammable.CanExtinguish ? avg : Math.Max(otherFlammable.FireStacks, avg);
                 UpdateAppearance(uid, flammable);
@@ -212,25 +226,23 @@ namespace Content.Server.Atmos.EntitySystems
             }
 
             // Only one is on fire -> attempt to spread the fire.
-            if (flammable.OnFire)
+            var (srcUid, srcFlammable, destUid, destFlammable) = flammable.OnFire
+                ? (uid, flammable, otherUid, otherFlammable)
+                : (otherUid, otherFlammable, uid, flammable);
+
+            // if the thing on fire has less mass, spread less firestacks and vice versa
+            var ratio = 1f;
+            if (_physicsQuery.TryComp(srcUid, out var srcPhysics) && _physicsQuery.TryComp(destUid, out var destPhys))
             {
-                otherFlammable.FireStacks += flammable.FireStacks / 2;
-                Ignite(otherUid, uid, otherFlammable);
-                if (flammable.CanExtinguish)
-                {
-                    flammable.FireStacks /= 2;
-                    UpdateAppearance(uid, flammable);
-                }
+                ratio = srcPhysics.Mass / destPhys.Mass;
             }
-            else
+
+            destFlammable.FireStacks += (srcFlammable.FireStacks / 2) * ratio;
+            Ignite(destUid, srcUid, destFlammable);
+            if (srcFlammable.CanExtinguish)
             {
-                flammable.FireStacks += otherFlammable.FireStacks / 2;
-                Ignite(uid, otherUid, flammable);
-                if (otherFlammable.CanExtinguish)
-                {
-                    otherFlammable.FireStacks /= 2;
-                    UpdateAppearance(otherUid, otherFlammable);
-                }
+                srcFlammable.FireStacks /= 2;
+                UpdateAppearance(srcUid, srcFlammable);
             }
         }
 

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -231,17 +231,18 @@ namespace Content.Server.Atmos.EntitySystems
                 : (otherUid, otherFlammable, uid, flammable);
 
             // if the thing on fire has less mass, spread less firestacks and vice versa
-            var ratio = 1f;
+            var ratio = 0.5f;
             if (_physicsQuery.TryComp(srcUid, out var srcPhysics) && _physicsQuery.TryComp(destUid, out var destPhys))
             {
-                ratio = srcPhysics.Mass / destPhys.Mass;
+                ratio *= srcPhysics.Mass / destPhys.Mass;
             }
 
-            destFlammable.FireStacks += (srcFlammable.FireStacks / 2) * ratio;
+            var lost = srcFlammable.FireStacks * ratio;
+            destFlammable.FireStacks += lost;
             Ignite(destUid, srcUid, destFlammable);
             if (srcFlammable.CanExtinguish)
             {
-                srcFlammable.FireStacks /= 2;
+                srcFlammable.FireStacks -= lost;
                 UpdateAppearance(srcUid, srcFlammable);
             }
         }


### PR DESCRIPTION
## About the PR
when spreading fire if you have more mass than the thing being spreaded to it gets more firestacks, if you have less mass the thing being spreaded to gets less firestacks.
this means getting caught by a flaming mouse no longer gives 10 firestacks, and standing next to one for a while wont do much

## Why / Balance
resolves #27052

## Technical details
removed a copy pasted section which just swapped src and dest entities

## Media

https://github.com/space-wizards/space-station-14/assets/39013340/b0f14414-3b47-48a5-bac9-cb67ab649bec


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Flaming mice no longer completely engulf people they touch.
