### PR TITLE
Removed CC and recall reference in pallet descriptions

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: CargoPallet
   name: cargo pallet
-  description: Designates valid items to sell to CentCom when a shuttle is recalled.
+  description: Common fixture of logistics and cargo. Subtle reminder where crates go during transport to avoid bruised shins.
   parent: BaseStructure
   components:
   - type: InteractionOutline
@@ -58,7 +58,7 @@
 - type: entity
   id: CargoPalletSell
   name: cargo selling pallet
-  description: Designates valid items to sell with a selling computer, or to CentCom when a shuttle is recalled.
+  description: Designates valid items to sell.
   parent: CargoPallet
   components:
   - type: CargoPallet


### PR DESCRIPTION
## About the PR
Removes references to CC and shuttle recall in cargo pallet descriptions.

## Why / Balance
Partly resolves #24260, does not adjust pallet purchasing price or crafting

## Technical details
yaml change to cargo pallet and cargo sell pallet descriptions

## Media
This PR does not require an ingame showcase

**Changelog**
n/a
