### PR TITLE
Fix botany bugs

### DIFF
--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -186,10 +186,16 @@ public sealed class MutationSystem : EntitySystem
         if (!Random(probBitflip))
             return;
 
+        // Starting number of bits that are high, between 0 and bits.
+        // In other words, it's val mapped linearly from range [min, max] to range [0, bits], and then rounded.
+        int valInt = (int) MathF.Round((val - min) / (max - min) * bits);
+        // val may be outside the range of min/max due to starting prototype values, so clamp.
+        valInt = Math.Clamp(valInt, 0, bits);
+
         // Probability that the bit flip increases n.
-        // The higher the current value is, the lower the probability of increasing value is, and the higher the probability of decreasive it it.
+        // The higher the current value is, the lower the probability of increasing value is, and the higher the probability of decreasing it.
         // In other words, it tends to go to the middle.
-        float probIncrease = 1 - (float)val / bits;
+        float probIncrease = 1 - (float) valInt / bits;
         int valMutated;
         if (Random(probIncrease))
         {

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -153,6 +153,12 @@ public sealed class MutationSystem : EntitySystem
         if (!Random(probBitflip))
             return;
 
+        if (min == max)
+        {
+            val = min;
+            return;
+        }
+
         // Starting number of bits that are high, between 0 and bits.
         // In other words, it's val mapped linearly from range [min, max] to range [0, bits], and then rounded.
         int valInt = (int)MathF.Round((val - min) / (max - min) * bits);
@@ -185,6 +191,12 @@ public sealed class MutationSystem : EntitySystem
         probBitflip = Math.Clamp(probBitflip, 0, 1);
         if (!Random(probBitflip))
             return;
+
+        if (min == max)
+        {
+            val = min;
+            return;
+        }
 
         // Starting number of bits that are high, between 0 and bits.
         // In other words, it's val mapped linearly from range [min, max] to range [0, bits], and then rounded.

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -200,14 +200,14 @@ public sealed class MutationSystem : EntitySystem
 
         // Starting number of bits that are high, between 0 and bits.
         // In other words, it's val mapped linearly from range [min, max] to range [0, bits], and then rounded.
-        int valInt = (int) MathF.Round((val - min) / (max - min) * bits);
+        int valInt = (int)MathF.Round((val - min) / (max - min) * bits);
         // val may be outside the range of min/max due to starting prototype values, so clamp.
         valInt = Math.Clamp(valInt, 0, bits);
 
         // Probability that the bit flip increases n.
         // The higher the current value is, the lower the probability of increasing value is, and the higher the probability of decreasing it.
         // In other words, it tends to go to the middle.
-        float probIncrease = 1 - (float) valInt / bits;
+        float probIncrease = 1 - (float)valInt / bits;
         int valMutated;
         if (Random(probIncrease))
         {

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -525,10 +525,9 @@ public sealed class PlantHolderSystem : EntitySystem
 
         var environment = _atmosphere.GetContainingMixture(uid, true, true) ?? GasMixture.SpaceGas;
 
+        component.MissingGas = 0;
         if (component.Seed.ConsumeGasses.Count > 0)
         {
-            component.MissingGas = 0;
-
             foreach (var (gas, amount) in component.Seed.ConsumeGasses)
             {
                 if (environment.GetMoles(gas) < amount)


### PR DESCRIPTION
## About the PR
Botany bugfixes:

* Fix MutateInt code so it takes min/max into account 
See: #21085, #25100
* Fix missing gas warning getting stuck on hydroponics tray
* Set correct number of totalBits
* Add division by zero check