### PR TITLE
Make sterile masks a tiny item

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -278,7 +278,7 @@
     sprite: Clothing/Mask/sterile.rsi
   - type: IngestionBlocker
   - type: Item
-    storedRotation: -90
+    size: Tiny
   - type: IdentityBlocker
     coverage: MOUTH
 


### PR DESCRIPTION
This minorly annoyed me because breath masks are tiny too, so if I swapped them I may run out of inventory space.
