### PR TITLE
Fixed grammar when drinking empty drink

### DIFF
--- a/Resources/Locale/en-US/nutrition/components/drink-component.ftl
+++ b/Resources/Locale/en-US/nutrition/components/drink-component.ftl
@@ -1,4 +1,4 @@
-drink-component-on-use-is-empty = {$owner} is empty!
+drink-component-on-use-is-empty = {CAPITALIZE(THE($owner))} is empty!
 drink-component-on-examine-is-empty = [color=gray]Empty[/color]
 drink-component-on-examine-is-opened = [color=yellow]Opened[/color]
 drink-component-on-examine-is-sealed = The seal is intact.
@@ -10,7 +10,7 @@ drink-component-on-examine-is-half-empty = Halfway Empty
 drink-component-on-examine-is-mostly-empty = Mostly Empty
 drink-component-on-examine-exact-volume = It contains {$amount}u.
 drink-component-try-use-drink-not-open = Open {$owner} first!
-drink-component-try-use-drink-is-empty = {$entity} is empty!
+drink-component-try-use-drink-is-empty = {CAPITALIZE(THE($entity))} is empty!
 drink-component-try-use-drink-cannot-drink = You can't drink anything!
 drink-component-try-use-drink-had-enough = You can't drink more!
 drink-component-try-use-drink-cannot-drink-other = They can't drink anything!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The grammar was weird I don't know what the name of the rule broken is but it was wrong 😆

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Before:
![Screenshot 2024-04-21 114836](https://github.com/space-wizards/space-station-14/assets/107373427/29930ccc-bf54-462e-a8a7-b3f50b029d4c)

After:
![image](https://github.com/space-wizards/space-station-14/assets/107373427/714cf06a-a0e9-4714-a8f8-ee83fc6fed1c)