### PR TITLE
Add a trash bag to the advanced cleaning borg module.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -318,6 +318,7 @@
     - HoloprojectorBorg
     - SprayBottleSpaceCleaner
     - Dropper
+    - TrashBag
 
 # medical modules
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds a trash bag to the advanced cleaning module.

## Why / Balance
It's annoying to switch between two different modules just to use a trash bag.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/147350443/6c0c9c51-b140-4fa1-ac38-a81cfc5c5164)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**



:cl:
- add: Adds a trash bag to the advanced cleaning module.

