### PR TITLE
Add events for custom action target validation

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -200,7 +200,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         var coords = args.Coordinates;
 
-        if (!_actionsSystem.ValidateWorldTarget(user, coords, action))
+        if (!_actionsSystem.ValidateWorldTarget(user, coords, (actionId, action)))
         {
             // Invalid target.
             if (action.DeselectOnMiss)
@@ -235,7 +235,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         var entity = args.EntityUid;
 
-        if (!_actionsSystem.ValidateEntityTarget(user, entity, action))
+        if (!_actionsSystem.ValidateEntityTarget(user, entity, (actionId, action)))
         {
             if (action.DeselectOnMiss)
                 StopTargeting();

--- a/Content.Server/Actions/ActionOnInteractSystem.cs
+++ b/Content.Server/Actions/ActionOnInteractSystem.cs
@@ -64,7 +64,7 @@ public sealed class ActionOnInteractSystem : EntitySystem
             var entOptions = GetValidActions<EntityTargetActionComponent>(component.ActionEntities, args.CanReach);
             for (var i = entOptions.Count - 1; i >= 0; i--)
             {
-                var action = entOptions[i].Comp;
+                var action = entOptions[i];
                 if (!_actions.ValidateEntityTarget(args.User, args.Target.Value, action))
                     entOptions.RemoveAt(i);
             }
@@ -88,7 +88,7 @@ public sealed class ActionOnInteractSystem : EntitySystem
         var options = GetValidActions<WorldTargetActionComponent>(component.ActionEntities, args.CanReach);
         for (var i = options.Count - 1; i >= 0; i--)
         {
-            var action = options[i].Comp;
+            var action = options[i];
             if (!_actions.ValidateWorldTarget(args.User, args.ClickLocation, action))
                 options.RemoveAt(i);
         }

--- a/Content.Shared/Actions/Events/ValidateActionEntityTargetEvent.cs
+++ b/Content.Shared/Actions/Events/ValidateActionEntityTargetEvent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Shared.Actions.Events;
+
+[ByRefEvent]
+public record struct ValidateActionEntityTargetEvent(EntityUid User, EntityUid Target, bool Cancelled = false);

--- a/Content.Shared/Actions/Events/ValidateActionWorldTargetEvent.cs
+++ b/Content.Shared/Actions/Events/ValidateActionWorldTargetEvent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.Map;
+
+namespace Content.Shared.Actions.Events;
+
+[ByRefEvent]
+public record struct ValidateActionWorldTargetEvent(EntityUid User, EntityCoordinates Target, bool Cancelled = false);


### PR DESCRIPTION
## About the PR
This is for any validation more complicated than what actions normally allow.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
- SharedActionsSystem ValidateEntityTarget and ValidateWorldTarget now take an Entity<T> for the action, instead of just the component alone.