### PR TITLE
Snake skin boots are no longer no slips

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -83,7 +83,6 @@
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
-  - type: NoSlip
 
 - type: entity
   parent: [ClothingShoesBase, PowerCellSlotSmallItem]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
I made it so snake skins boots no longer have no slip properties. 

## Why / Balance
Due to oasis now being in the map pool we have a case of 2-3 free pairs of noslips sitting in the zoo.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl:
- tweak: Snake skin boots are no longer no-slips.

