### PR TITLE
Snake Skin Boots are No Longer No-slips

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -83,7 +83,6 @@
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
-  - type: NoSlip
 
 - type: entity
   parent: [ClothingShoesBase, PowerCellSlotSmallItem]

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -83,6 +83,7 @@
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
+  - type: NoSlips
 
 - type: entity
   parent: [ClothingShoesBase, PowerCellSlotSmallItem]

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -83,7 +83,6 @@
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Misc/snakeskin.rsi
-  - type: NoSlips
 
 - type: entity
   parent: [ClothingShoesBase, PowerCellSlotSmallItem]


### PR DESCRIPTION
About the PR

I made it so snake skins boots no longer have no slip properties.

Why / Balance

Due to oasis now being in the map pool we have 2-3 free pairs of noslips sitting in the zoo if you’re ballsy enough. (I have been informed i was lied to, bamboozled, hoodwinked even. Still going through with it though :godo:)

Media

[X] I have added screenshots/videos to this PR showcasing its changes ingame, or this PR does not require an ingame showcase
Changelog

🆑

tweak: Snake skin boots are no longer no-slips.