### PR TITLE
Add Syndicate SecShades to uplink

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -424,3 +424,6 @@ uplink-barber-scissors-desc = A good tool to give your fellow agent a nice hairc
 
 uplink-backpack-syndicate-name = Syndicate backpack
 uplink-backpack-syndicate-desc = Lightweight explosion-proof а backpack for holding various traitor goods
+
+uplink-sunglasses-sechud-name = Syndicate SecShades
+uplink-sunglasses-sechud-desc = A pair of sunglasses with a sechud discreetly integrated.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1333,6 +1333,16 @@
   categories:
     - UplinkWearables
 
+- type: listing
+  id: UplinkEyesGlassesHiddenSecurity
+  name: uplink-sunglasses-sechud-name
+  description: uplink-sunglasses-sechud-desc
+  productEntity: ClothingEyesGlassesHiddenSecurity
+  cost:
+    Telecrystal: 2
+  categories:
+    - UplinkWearables
+    
  # Pointless
 
 - type: listing


### PR DESCRIPTION
## About the PR
This item has sat unused for a while now from what I see. Lets give it a run.

## Why / Balance
2tc sounds reseasonable to experiment

## Media
![image](https://github.com/space-wizards/space-station-14/assets/130304754/d77030a1-7d9a-46cc-9e45-304eaf287366)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Add hidden security hud shades to syndicate uplink.
