### PR TITLE
fix cargo teleporter

### DIFF
--- a/Content.Server/Cargo/Components/StationCargoOrderDatabaseComponent.cs
+++ b/Content.Server/Cargo/Components/StationCargoOrderDatabaseComponent.cs
@@ -1,4 +1,6 @@
+using Content.Server.Station.Components;
 using Content.Shared.Cargo;
+using Content.Shared.Cargo.Components;
 using Content.Shared.Cargo.Prototypes;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
@@ -37,4 +39,18 @@ public sealed partial class StationCargoOrderDatabaseComponent : Component
     /// </summary>
     [DataField]
     public EntProtoId PrinterOutput = "PaperCargoInvoice";
+}
+
+/// <summary>
+/// Event broadcast before a cargo order is fulfilled, allowing alternate systems to fulfill the order.
+/// </summary>
+[ByRefEvent]
+public record struct FulfillCargoOrderEvent(Entity<StationDataComponent> Station, CargoOrderData Order, Entity<CargoOrderConsoleComponent> OrderConsole)
+{
+    public Entity<CargoOrderConsoleComponent> OrderConsole = OrderConsole;
+    public Entity<StationDataComponent> Station = Station;
+    public CargoOrderData Order = Order;
+
+    public EntityUid? FulfillmentEntity;
+    public bool Handled = false;
 }

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -170,13 +170,20 @@ namespace Content.Server.Cargo.Systems
                 return;
             }
 
-            var tradeDestination = TryFulfillOrder(stationData, order, orderDatabase);
+            var ev = new FulfillCargoOrderEvent((station.Value, stationData), order, (uid, component));
+            RaiseLocalEvent(ref ev);
+            ev.FulfillmentEntity ??= station.Value;
 
-            if (tradeDestination == null)
+            if (!ev.Handled)
             {
-                ConsolePopup(args.Session, Loc.GetString("cargo-console-unfulfilled"));
-                PlayDenySound(uid, component);
-                return;
+                ev.FulfillmentEntity = TryFulfillOrder((station.Value, stationData), order, orderDatabase);
+
+                if (ev.FulfillmentEntity == null)
+                {
+                    ConsolePopup(args.Session, Loc.GetString("cargo-console-unfulfilled"));
+                    PlayDenySound(uid, component);
+                    return;
+                }
             }
 
             _idCardSystem.TryFindIdCard(player, out var idCard);
@@ -186,14 +193,14 @@ namespace Content.Server.Cargo.Systems
 
             var approverName = idCard.Comp?.FullName ?? Loc.GetString("access-reader-unknown-id");
             var approverJob = idCard.Comp?.JobTitle ?? Loc.GetString("access-reader-unknown-id");
-            var message = Loc.GetString("cargo-console-unlock-approved-order-broadcast", 
+            var message = Loc.GetString("cargo-console-unlock-approved-order-broadcast",
                 ("productName", Loc.GetString(order.ProductName)),
                 ("orderAmount", order.OrderQuantity),
                 ("approverName", approverName),
                 ("approverJob", approverJob),
                 ("cost", cost));
             _radio.SendRadioMessage(uid, message, component.AnnouncementChannel, uid, escapeMarkup: false);
-            ConsolePopup(args.Session, Loc.GetString("cargo-console-trade-station", ("destination", MetaData(tradeDestination.Value).EntityName)));
+            ConsolePopup(args.Session, Loc.GetString("cargo-console-trade-station", ("destination", MetaData(ev.FulfillmentEntity.Value).EntityName)));
 
             // Log order approval
             _adminLogger.Add(LogType.Action, LogImpact.Low,
@@ -201,10 +208,10 @@ namespace Content.Server.Cargo.Systems
 
             orderDatabase.Orders.Remove(order);
             DeductFunds(bank, cost);
-            UpdateOrders(station.Value, orderDatabase);
+            UpdateOrders(station.Value);
         }
 
-        private EntityUid? TryFulfillOrder(StationDataComponent stationData, CargoOrderData order, StationCargoOrderDatabaseComponent orderDatabase)
+        private EntityUid? TryFulfillOrder(Entity<StationDataComponent> stationData, CargoOrderData order, StationCargoOrderDatabaseComponent orderDatabase)
         {
             // No slots at the trade station
             _listEnts.Clear();
@@ -357,7 +364,7 @@ namespace Content.Server.Cargo.Systems
         /// Updates all of the cargo-related consoles for a particular station.
         /// This should be called whenever orders change.
         /// </summary>
-        private void UpdateOrders(EntityUid dbUid, StationCargoOrderDatabaseComponent _)
+        private void UpdateOrders(EntityUid dbUid)
         {
             // Order added so all consoles need updating.
             var orderQuery = AllEntityQuery<CargoOrderConsoleComponent>();
@@ -392,7 +399,7 @@ namespace Content.Server.Cargo.Systems
             string description,
             string dest,
             StationCargoOrderDatabaseComponent component,
-            StationDataComponent stationData
+            Entity<StationDataComponent> stationData
         )
         {
             DebugTools.Assert(_protoMan.HasIndex<EntityPrototype>(spawnId));
@@ -414,7 +421,7 @@ namespace Content.Server.Cargo.Systems
         private bool TryAddOrder(EntityUid dbUid, CargoOrderData data, StationCargoOrderDatabaseComponent component)
         {
             component.Orders.Add(data);
-            UpdateOrders(dbUid, component);
+            UpdateOrders(dbUid);
             return true;
         }
 
@@ -432,7 +439,7 @@ namespace Content.Server.Cargo.Systems
             {
                 orderDB.Orders.RemoveAt(sequenceIdx);
             }
-            UpdateOrders(dbUid, orderDB);
+            UpdateOrders(dbUid);
         }
 
         public void ClearOrders(StationCargoOrderDatabaseComponent component)

--- a/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
@@ -1,5 +1,6 @@
 using Content.Server.Cargo.Components;
 using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
 using Content.Shared.Cargo;
 using Content.Shared.Cargo.Components;
 using Content.Shared.DeviceLinking;
@@ -16,7 +17,40 @@ public sealed partial class CargoSystem
         SubscribeLocalEvent<CargoTelepadComponent, PowerChangedEvent>(OnTelepadPowerChange);
         // Shouldn't need re-anchored event
         SubscribeLocalEvent<CargoTelepadComponent, AnchorStateChangedEvent>(OnTelepadAnchorChange);
+        SubscribeLocalEvent<FulfillCargoOrderEvent>(OnTelepadFulfillCargoOrder);
     }
+
+    private void OnTelepadFulfillCargoOrder(ref FulfillCargoOrderEvent args)
+    {
+        var query = EntityQueryEnumerator<CargoTelepadComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var tele, out var xform))
+        {
+            if (tele.CurrentState != CargoTelepadState.Idle)
+                continue;
+
+            if (tele.CurrentOrder != null)
+                continue;
+
+            if (!this.IsPowered(uid, EntityManager))
+                continue;
+
+            if (_station.GetOwningStation(uid, xform) != args.Station)
+                continue;
+
+            // todo cannot be fucking asked to figure out device linking rn but this shouldn't just default to the first port.
+            if (!TryComp<DeviceLinkSinkComponent>(uid, out var sinkComponent) ||
+                sinkComponent.LinkedSources.FirstOrNull() is not { } console ||
+                console != args.OrderConsole.Owner)
+                continue;
+
+            tele.CurrentOrder = args.Order;
+            tele.Accumulator = tele.Delay;
+            args.Handled = true;
+            args.FulfillmentEntity = uid;
+            return;
+        }
+    }
+
     private void UpdateTelepad(float frameTime)
     {
         var query = EntityQueryEnumerator<CargoTelepadComponent>();
@@ -33,14 +67,6 @@ public sealed partial class CargoSystem
                 continue;
             }
 
-            if (!TryComp<DeviceLinkSinkComponent>(uid, out var sinkComponent) ||
-                sinkComponent.LinkedSources.FirstOrNull() is not { } console ||
-                !HasComp<CargoOrderConsoleComponent>(console))
-            {
-                comp.Accumulator = comp.Delay;
-                continue;
-            }
-
             comp.Accumulator -= frameTime;
 
             // Uhh listen teleporting takes time and I just want the 1 float.
@@ -51,21 +77,21 @@ public sealed partial class CargoSystem
                 continue;
             }
 
-            var station = _station.GetOwningStation(console);
-
-            if (!TryComp<StationCargoOrderDatabaseComponent>(station, out var orderDatabase) ||
-                orderDatabase.Orders.Count == 0)
+            if (comp.CurrentOrder == null)
             {
                 comp.Accumulator += comp.Delay;
                 continue;
             }
 
             var xform = Transform(uid);
-            if (FulfillNextOrder(orderDatabase, xform.Coordinates, comp.PrinterOutput))
+            if (FulfillOrder(comp.CurrentOrder, xform.Coordinates, comp.PrinterOutput))
             {
                 _audio.PlayPvs(_audio.GetSound(comp.TeleportSound), uid, AudioParams.Default.WithVolume(-8f));
-                UpdateOrders(station.Value, orderDatabase);
 
+                if (_station.GetOwningStation(uid) is { } station)
+                    UpdateOrders(station);
+
+                comp.CurrentOrder = null;
                 comp.CurrentState = CargoTelepadState.Teleporting;
                 _appearance.SetData(uid, CargoTelepadVisuals.State, CargoTelepadState.Teleporting, appearance);
             }

--- a/Content.Server/StationEvents/Events/CargoGiftsRule.cs
+++ b/Content.Server/StationEvents/Events/CargoGiftsRule.cs
@@ -69,7 +69,7 @@ public sealed class CargoGiftsRule : StationEventSystem<CargoGiftsRuleComponent>
                     Loc.GetString(component.Description),
                     Loc.GetString(component.Dest),
                     cargoDb,
-                    stationData!
+                    (station.Value, stationData)
             ))
             {
                 break;

--- a/Content.Shared/Cargo/CargoOrderData.cs
+++ b/Content.Shared/Cargo/CargoOrderData.cs
@@ -1,47 +1,55 @@
 using Robust.Shared.Serialization;
-using Content.Shared.Access.Components;
 using System.Text;
 namespace Content.Shared.Cargo
 {
-    [NetSerializable, Serializable]
-    public sealed class CargoOrderData
+    [DataDefinition, NetSerializable, Serializable]
+    public sealed partial class CargoOrderData
     {
         /// <summary>
         /// Price when the order was added.
         /// </summary>
+        [DataField]
         public int Price;
 
         /// <summary>
         /// A unique (arbitrary) ID which identifies this order.
         /// </summary>
-        public readonly int OrderId;
+        [DataField]
+        public int OrderId { get; private set; }
 
         /// <summary>
         /// Prototype Id for the item to be created
         /// </summary>
-        public readonly string ProductId;
+        [DataField]
+        public string ProductId { get; private set; }
 
         /// <summary>
         /// Prototype Name
         /// </summary>
-        public readonly string ProductName;
+        [DataField]
+        public string ProductName { get; private set; }
 
         /// <summary>
         /// The number of items in the order. Not readonly, as it might change
         /// due to caps on the amount of orders that can be placed.
         /// </summary>
+        [DataField]
         public int OrderQuantity;
 
         /// <summary>
         /// How many instances of this order that we've already dispatched
         /// </summary>
+        [DataField]
         public int NumDispatched = 0;
 
-        public readonly string Requester;
+        [DataField]
+        public string Requester { get; private set; }
         // public String RequesterRank; // TODO Figure out how to get Character ID card data
         // public int RequesterId;
-        public readonly string Reason;
+        [DataField]
+        public string Reason { get; private set; }
         public  bool Approved => Approver is not null;
+        [DataField]
         public string? Approver;
 
         public CargoOrderData(int orderId, string productId, string productName, int price, int amount, string requester, string reason)

--- a/Content.Shared/Cargo/Components/SharedCargoTelepadComponent.cs
+++ b/Content.Shared/Cargo/Components/SharedCargoTelepadComponent.cs
@@ -13,13 +13,13 @@ namespace Content.Shared.Cargo.Components;
 public sealed partial class CargoTelepadComponent : Component
 {
     [DataField]
-    public CargoOrderData? CurrentOrder;
+    public List<CargoOrderData> CurrentOrders = new();
 
     /// <summary>
     /// The actual amount of time it takes to teleport from the telepad
     /// </summary>
     [DataField("delay"), ViewVariables(VVAccess.ReadWrite)]
-    public float Delay = 10f;
+    public float Delay = 5f;
 
     /// <summary>
     /// How much time we've accumulated until next teleport.

--- a/Content.Shared/Cargo/Components/SharedCargoTelepadComponent.cs
+++ b/Content.Shared/Cargo/Components/SharedCargoTelepadComponent.cs
@@ -12,6 +12,9 @@ namespace Content.Shared.Cargo.Components;
 [RegisterComponent, NetworkedComponent, Access(typeof(SharedCargoSystem))]
 public sealed partial class CargoTelepadComponent : Component
 {
+    [DataField]
+    public CargoOrderData? CurrentOrder;
+
     /// <summary>
     /// The actual amount of time it takes to teleport from the telepad
     /// </summary>

--- a/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
+++ b/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
@@ -47,3 +47,5 @@
     board: CargoTelepadMachineCircuitboard
   - type: Appearance
   - type: CollideOnAnchor
+  - type: NameIdentifier
+    group: CargoTelepads

--- a/Resources/Prototypes/name_identifier_groups.yml
+++ b/Resources/Prototypes/name_identifier_groups.yml
@@ -37,3 +37,9 @@
   id: Bounty
   minValue: 0
   maxValue: 999
+
+- type: nameIdentifierGroup
+  id: CargoTelepads
+  prefix: TELE
+  minValue: 0
+  maxValue: 999


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
actually makes it work.

fixes #26181 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
adds an event to order fulfillment so that cargo telepads can actually intercept the order before the ATS grabs it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed cargo telepads not teleporting in orders from linked consoles.
