### PR TITLE
Fix: Suit Sensors Vitals

### DIFF
--- a/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
+++ b/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
@@ -24,7 +24,7 @@ public sealed class SuitSensorStatus
     public bool IsAlive;
     public int? TotalDamage;
     public int? TotalDamageThreshold;
-    public float? DamagePercentage => TotalDamageThreshold == null || TotalDamage == null ? null : TotalDamage / TotalDamageThreshold;
+    public float? DamagePercentage => TotalDamageThreshold == null || TotalDamage == null ? null : TotalDamage / (float) TotalDamageThreshold;
     public NetCoordinates? Coordinates;
 }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
A very simple fix to suit sensors vitals, making them function again.

## Why / Balance
Suit Sensor Vitals have not been working since being de-hardcoded in #26658
Resolves #27146
Resolves #26979 

## Technical details
Makes the DamagePercentage calculation not use integer division as it is unable to output a float, casts the divisor to a float.

## Media
Before (Current Live Behavior, only shows Good or Bad!, Bad! only shows in crit)
![BeforeVitals](https://github.com/space-wizards/space-station-14/assets/57879983/e403a80f-355d-4e3a-887a-a778307198cb)

After
![AfterVitals](https://github.com/space-wizards/space-station-14/assets/57879983/f5e1b101-e662-4c32-b8e6-aebcf6f3a32b)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- fix: Suit sensor vitals now function again.
