### PR TITLE
Fix slime storage issue

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -14,6 +14,7 @@
     requiredLegs: 2
   # they like eat it idk lol
   - type: Storage
+    clickInsert: false
     grid:
     - 0,0,1,2
     maxItemSize: Large


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Fixes accidental insert of items into slimes

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
disables ClickInsert on slime storage component

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Slimes no longer absorb all items used on them
