### PR TITLE
Small tomato killer tweak

### DIFF
--- a/Resources/Prototypes/Entities/Effects/mobspawn.yml
+++ b/Resources/Prototypes/Entities/Effects/mobspawn.yml
@@ -107,6 +107,7 @@
     - FoodOnionRed
     - FoodWatermelon
     - FoodGatfruit
+    - MobTomatoKiller
     rarePrototypes:
     - MobLuminousEntity
     - MobLuminousObject

--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -135,9 +135,8 @@
   - type: MeleeWeapon
     hidden: true
     damage:
-      types:
-        Blunt: 2
-        Piercing: 2
+      groups:
+        Brute: 4
     animation: WeaponArcBite
   - type: Climbing
   - type: NameIdentifier

--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -135,8 +135,8 @@
   - type: MeleeWeapon
     hidden: true
     damage:
-      groups:
-        Brute: 2
+      types:
+        Blunt: 2
         Piercing: 2
     animation: WeaponArcBite
   - type: Climbing

--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -79,7 +79,6 @@
   description: it seems today it's not you eating tomatoes, it's the tomatoes eating you.
   components:
   - type: Item
-    size: Huge
   - type: NpcFactionMember
     factions:
       - SimpleHostile
@@ -137,15 +136,12 @@
     hidden: true
     damage:
       groups:
-        Brute: 4
+        Brute: 2
+        Piercing: 2
     animation: WeaponArcBite
   - type: Climbing
   - type: NameIdentifier
     group: GenericNumber
-  - type: SlowOnDamage
-    speedModifierThresholds:
-      60: 0.7
-      80: 0.5
   - type: FootstepModifier
     footstepSoundCollection:
       path: /Audio/Effects/Footsteps/slime1.ogg


### PR DESCRIPTION
## About the PR
add tomato killers in flora anomaly bulb spawns
damage from 4 brute -> 2 blunt + 2 piercing
Huge size -> Normal size

**Changelog**
:cl:
- add: Added tomato killers in floral anomaly berries
- tweak: tweak size and damage of killer tomatoes
