### PR TITLE
Fix climbing and bonking simultaneously

### DIFF
--- a/Content.Shared/Climbing/Systems/BonkSystem.cs
+++ b/Content.Shared/Climbing/Systems/BonkSystem.cs
@@ -107,17 +107,16 @@ public sealed partial class BonkSystem : EntitySystem
         var doAfterArgs = new DoAfterArgs(EntityManager, user, bonkableComponent.BonkDelay, new BonkDoAfterEvent(), uid, target: uid, used: climber)
         {
             BreakOnMove = true,
-            BreakOnDamage = true
+            BreakOnDamage = true,
+            DuplicateCondition = DuplicateConditions.SameTool | DuplicateConditions.SameTarget
         };
 
-        _doAfter.TryStartDoAfter(doAfterArgs);
-
-        return true;
+        return _doAfter.TryStartDoAfter(doAfterArgs);
     }
 
-    private void OnAttemptClimb(EntityUid uid, BonkableComponent component, AttemptClimbEvent args)
+    private void OnAttemptClimb(EntityUid uid, BonkableComponent component, ref AttemptClimbEvent args)
     {
-        if (args.Cancelled || !HasComp<ClumsyComponent>(args.Climber) || !HasComp<HandsComponent>(args.User))
+        if (args.Cancelled)
             return;
 
         if (TryStartBonk(uid, args.User, args.Climber, component))

--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -222,7 +222,8 @@ public sealed partial class ClimbSystem : VirtualController
             used: entityToMove)
         {
             BreakOnMove = true,
-            BreakOnDamage = true
+            BreakOnDamage = true,
+            DuplicateCondition = DuplicateConditions.SameTool | DuplicateConditions.SameTarget
         };
 
         _audio.PlayPredicted(comp.StartClimbSound, climbable, user);

--- a/Content.Shared/Interaction/Components/ClumsyComponent.cs
+++ b/Content.Shared/Interaction/Components/ClumsyComponent.cs
@@ -19,5 +19,6 @@ public sealed partial class ClumsyComponent : Component
     /// <summary>
     /// Sound to play when clumsy interactions fail.
     /// </summary>
+    [DataField]
     public SoundSpecifier ClumsySound = new SoundPathSpecifier("/Audio/Items/bikehorn.ogg");
 }

--- a/Content.Shared/Interaction/Components/ClumsyComponent.cs
+++ b/Content.Shared/Interaction/Components/ClumsyComponent.cs
@@ -1,22 +1,23 @@
 using Content.Shared.Damage;
 using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
 
-namespace Content.Shared.Interaction.Components
+namespace Content.Shared.Interaction.Components;
+
+/// <summary>
+/// A simple clumsy tag-component.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ClumsyComponent : Component
 {
     /// <summary>
-    /// A simple clumsy tag-component.
+    /// Damage dealt to a clumsy character when they try to fire a gun.
     /// </summary>
-    [RegisterComponent]
-    public sealed partial class ClumsyComponent : Component
-    {
-        [DataField("clumsyDamage", required: true)]
-        [ViewVariables(VVAccess.ReadWrite)]
-        public DamageSpecifier ClumsyDamage = default!;
+    [DataField(required: true), AutoNetworkedField]
+    public DamageSpecifier ClumsyDamage = default!;
 
-        /// <summary>
-        ///     Sound to play when clumsy interactions fail
-        /// </summary>
-        [DataField("clumsySound")]
-        public SoundSpecifier ClumsySound = new SoundPathSpecifier("/Audio/Items/bikehorn.ogg");
-    }
+    /// <summary>
+    /// Sound to play when clumsy interactions fail.
+    /// </summary>
+    public SoundSpecifier ClumsySound = new SoundPathSpecifier("/Audio/Items/bikehorn.ogg");
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Due to an oversight, it was possible for clumsy characters to trigger the doAfters for both successfully climbing and bonking at the same time. This made it easy to pass through windoors on tables. This fixes that.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bug fix. 
Fixes #27245.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Modified the DoAfterArgs for climbing and bonking so they now consider any DoAfter with the same user, "tool" (dragged person), and target to be a duplicate DoAfter, even if the DoAfterEvent is a different type. This prevents them running simultaneously. 

Also fixed BonkSystem's subscription to AttemptClimbEvent to be by-ref, so cancellation actually works. Previously this was causing the climb DoAfter to always start, when when a bonk happened.

As a bonus, ClumsyComponent is now networked, so adding it via VV on the server duplicates it on the client for proper prediction (which was annoying while I was testing this fix). I also went ahead and cleaned up the rest of ClumsyComponent to use modern standards.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
