### PR TITLE
Header of Gas tank UI screen now fetched from Entity name and locale …

### DIFF
--- a/Content.Client/UserInterface/Systems/Atmos/GasTank/GasTankBoundUserInterface.cs
+++ b/Content.Client/UserInterface/Systems/Atmos/GasTank/GasTankBoundUserInterface.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Atmos.Components;
 using JetBrains.Annotations;
-using Robust.Client.GameObjects;
 
 namespace Content.Client.UserInterface.Systems.Atmos.GasTank
 {
@@ -9,6 +8,8 @@ namespace Content.Client.UserInterface.Systems.Atmos.GasTank
     {
         [ViewVariables]
         private GasTankWindow? _window;
+
+        [Dependency] private readonly IEntityManager _entityManager = default!;
 
         public GasTankBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
         {
@@ -30,7 +31,7 @@ namespace Content.Client.UserInterface.Systems.Atmos.GasTank
         protected override void Open()
         {
             base.Open();
-            _window = new GasTankWindow(this);
+            _window = new GasTankWindow(this, _entityManager);
             _window.OnClose += Close;
             _window.OpenCentered();
         }

--- a/Content.Client/UserInterface/Systems/Atmos/GasTank/GasTankBoundUserInterface.cs
+++ b/Content.Client/UserInterface/Systems/Atmos/GasTank/GasTankBoundUserInterface.cs
@@ -9,8 +9,6 @@ namespace Content.Client.UserInterface.Systems.Atmos.GasTank
         [ViewVariables]
         private GasTankWindow? _window;
 
-        [Dependency] private readonly IEntityManager _entityManager = default!;
-
         public GasTankBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
         {
         }
@@ -31,7 +29,7 @@ namespace Content.Client.UserInterface.Systems.Atmos.GasTank
         protected override void Open()
         {
             base.Open();
-            _window = new GasTankWindow(this, _entityManager);
+            _window = new GasTankWindow(this);
             _window.OnClose += Close;
             _window.OpenCentered();
         }

--- a/Content.Client/UserInterface/Systems/Atmos/GasTank/GasTankWindow.cs
+++ b/Content.Client/UserInterface/Systems/Atmos/GasTank/GasTankWindow.cs
@@ -15,7 +15,9 @@ namespace Content.Client.UserInterface.Systems.Atmos.GasTank
     public sealed class GasTankWindow
         : BaseWindow
     {
+
         private GasTankBoundUserInterface _owner;
+        private readonly IEntityManager _entityManager;
         private readonly Label _lblName;
         private readonly BoxContainer _topContainer;
         private readonly Control _contentContainer;
@@ -27,12 +29,13 @@ namespace Content.Client.UserInterface.Systems.Atmos.GasTank
         private readonly RichTextLabel _lblInternals;
         private readonly Button _btnInternals;
 
-        public GasTankWindow(GasTankBoundUserInterface owner)
+        public GasTankWindow(GasTankBoundUserInterface owner, IEntityManager entityManager)
         {
             TextureButton btnClose;
             _resourceCache = IoCManager.Resolve<IResourceCache>();
             _owner = owner;
-            var rootContainer = new LayoutContainer {Name = "GasTankRoot"};
+            _entityManager = entityManager;
+            var rootContainer = new LayoutContainer { Name = "GasTankRoot" };
             AddChild(rootContainer);
 
             MouseFilter = MouseFilterMode.Stop;
@@ -94,7 +97,8 @@ namespace Content.Client.UserInterface.Systems.Atmos.GasTank
                 {
                     (_lblName = new Label
                     {
-                        Text = Loc.GetString("gas-tank-window-label"),
+                        Text = Loc.GetString(
+                            _entityManager.GetComponent<MetaDataComponent>(owner.Owner).EntityName),
                         FontOverride = font,
                         FontColorOverride = StyleNano.NanoGold,
                         VerticalAlignment = VAlignment.Center,
@@ -112,7 +116,7 @@ namespace Content.Client.UserInterface.Systems.Atmos.GasTank
 
             var middle = new PanelContainer
             {
-                PanelOverride = new StyleBoxFlat {BackgroundColor = Color.FromHex("#202025")},
+                PanelOverride = new StyleBoxFlat { BackgroundColor = Color.FromHex("#202025") },
                 Children =
                 {
                     (_contentContainer = new BoxContainer
@@ -127,13 +131,13 @@ namespace Content.Client.UserInterface.Systems.Atmos.GasTank
             _topContainer.AddChild(new PanelContainer
             {
                 MinSize = new Vector2(0, 2),
-                PanelOverride = new StyleBoxFlat {BackgroundColor = Color.FromHex("#525252ff")}
+                PanelOverride = new StyleBoxFlat { BackgroundColor = Color.FromHex("#525252ff") }
             });
             _topContainer.AddChild(middle);
             _topContainer.AddChild(new PanelContainer
             {
                 MinSize = new Vector2(0, 2),
-                PanelOverride = new StyleBoxFlat {BackgroundColor = Color.FromHex("#525252ff")}
+                PanelOverride = new StyleBoxFlat { BackgroundColor = Color.FromHex("#525252ff") }
             });
 
 
@@ -142,15 +146,15 @@ namespace Content.Client.UserInterface.Systems.Atmos.GasTank
 
             //internals
             _lblInternals = new RichTextLabel
-                {MinSize = new Vector2(200, 0), VerticalAlignment = VAlignment.Center};
-            _btnInternals = new Button {Text = Loc.GetString("gas-tank-window-internals-toggle-button") };
+            { MinSize = new Vector2(200, 0), VerticalAlignment = VAlignment.Center };
+            _btnInternals = new Button { Text = Loc.GetString("gas-tank-window-internals-toggle-button") };
 
             _contentContainer.AddChild(
                 new BoxContainer
                 {
                     Orientation = LayoutOrientation.Horizontal,
                     Margin = new Thickness(0, 7, 0, 0),
-                    Children = {_lblInternals, _btnInternals}
+                    Children = { _lblInternals, _btnInternals }
                 });
 
             // Separator

--- a/Content.Client/UserInterface/Systems/Atmos/GasTank/GasTankWindow.cs
+++ b/Content.Client/UserInterface/Systems/Atmos/GasTank/GasTankWindow.cs
@@ -29,12 +29,12 @@ namespace Content.Client.UserInterface.Systems.Atmos.GasTank
         private readonly RichTextLabel _lblInternals;
         private readonly Button _btnInternals;
 
-        public GasTankWindow(GasTankBoundUserInterface owner, IEntityManager entityManager)
+        public GasTankWindow(GasTankBoundUserInterface owner)
         {
             TextureButton btnClose;
             _resourceCache = IoCManager.Resolve<IResourceCache>();
             _owner = owner;
-            _entityManager = entityManager;
+            _entityManager = IoCManager.Resolve<IEntityManager>();
             var rootContainer = new LayoutContainer { Name = "GasTankRoot" };
             AddChild(rootContainer);
 

--- a/Resources/Locale/en-US/movement/jetpacks.ftl
+++ b/Resources/Locale/en-US/movement/jetpacks.ftl
@@ -1,2 +1,3 @@
 jetpack-no-station = Can't use jetpacks under gravity
 jetpack-to-grid = The jetpack turns off
+jetpack = Jetpack


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changed displayed header name of UI window

## Why / Balance
https://github.com/space-wizards/space-station-14/issues/27242

## Technical details
Changed logic of displayed window header invoked by "Toggle UI" button from hardcoded "Gas Tank" to dependable from entity name

![image](https://github.com/space-wizards/space-station-14/assets/18354118/c58208ea-7cf6-4f9d-9def-1baf6630b442)

**Changelog**
- fix: Jetpack UI window now has correctly displayed header
