### PR TITLE
More trinkets for loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -1,3 +1,14 @@
+# Timers
+- type: loadoutEffectGroup
+  id: Privilege
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Command
+      time: 3600 # 1 hour
+
+# Plushies
 - type: loadout
   id: PlushieLizard
   equipment: PlushieLizard
@@ -7,7 +18,98 @@
   storage:
     back:
     - PlushieLizard
+    
+- type: loadout
+  id: PlushieSpaceLizard
+  equipment: PlushieSpaceLizard
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Privilege
 
+- type: startingGear
+  id: PlushieSpaceLizard
+  storage:
+    back:
+    - PlushieSpaceLizard
+
+# Smokeables
+- type: loadout
+  id: Lighter
+  equipment: Lighter
+
+- type: startingGear
+  id: Lighter
+  storage:
+    back:
+    - Lighter
+
+- type: loadout
+  id: CigPackGreen
+  equipment: CigPackGreen
+
+- type: startingGear
+  id: CigPackGreen
+  storage:
+    back:
+    - CigPackGreen
+
+- type: loadout
+  id: CigPackRed
+  equipment: CigPackRed
+
+- type: startingGear
+  id: CigPackRed
+  storage:
+    back:
+    - CigPackRed
+
+- type: loadout
+  id: CigPackBlue
+  equipment: CigPackBlue
+
+- type: startingGear
+  id: CigPackBlue
+  storage:
+    back:
+    - CigPackBlue
+
+- type: loadout
+  id: CigPackBlack
+  equipment: CigPackBlack
+
+- type: startingGear
+  id: CigPackBlack
+  storage:
+    back:
+    - CigPackBlack
+
+- type: loadout
+  id: CigarCase
+  equipment: CigarCase
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Privilege
+
+- type: startingGear
+  id: CigarCase
+  storage:
+    back:
+    - CigarCase
+
+- type: loadout
+  id: CigarGold
+  equipment: CigarGold
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Privilege
+
+- type: startingGear
+  id: CigarGold
+  storage:
+    back:
+    - CigarGold
+
+# Pins
 - type: loadout
   id: ClothingNeckLGBTPin
   equipment: ClothingNeckLGBTPin

--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -1,6 +1,6 @@
 # Timers
 - type: loadoutEffectGroup
-  id: Privilege
+  id: Command
   effects:
   - !type:JobRequirementLoadoutEffect
     requirement:
@@ -22,9 +22,6 @@
 - type: loadout
   id: PlushieSpaceLizard
   equipment: PlushieSpaceLizard
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: Privilege
 
 - type: startingGear
   id: PlushieSpaceLizard
@@ -88,7 +85,7 @@
   equipment: CigarCase
   effects:
   - !type:GroupLoadoutEffect
-    proto: Privilege
+    proto: Command
 
 - type: startingGear
   id: CigarCase
@@ -101,7 +98,7 @@
   equipment: CigarGold
   effects:
   - !type:GroupLoadoutEffect
-    proto: Privilege
+    proto: Command
 
 - type: startingGear
   id: CigarGold

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -6,6 +6,14 @@
   maxLimit: 3
   loadouts:
   - PlushieLizard
+  - PlushieSpaceLizard
+  - Lighter
+  - CigPackGreen
+  - CigPackRed
+  - CigPackBlue
+  - CigPackBlack
+  - CigarCase
+  - CigarGold
   - ClothingNeckLGBTPin
   - ClothingNeckAromanticPin
   - ClothingNeckAsexualPin


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds a lighter and various smokeables to the loadout menu. Adds a space lizard plushie to loadouts.

Players with 1 hour of command playtime can choose between a cigar case or a singular havian cigar.
The same players will also have the privilege of taking a space lizard plushie to work instead of a plebian normal lizard plushie!
(Space lizard plushie is locked behind 1 hour of command playtime as well)
<!-- What did you change in this PR? -->

## Why / Balance
Cigarettes are effectively for roleplay purposes only and readily available in shadycigs machines.
The lighter might raise a powergaming problem (the playerbase is not to be trusted), but they are also readily available in shadycigs machines... so I suppose it doesn't matter.
Cigars only available to people who have played command before as a small sign of prestige.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame,
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
![Screenshot_3](https://github.com/space-wizards/space-station-14/assets/36332236/bb5c9f12-1f61-45f1-9998-41633c0a0852)

:cl: cooldolphin
- add: Cigarettes in the loadout menu.