### PR TITLE
Remove IndigestionBlocker from ClothingHeadBandBase

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
@@ -7,8 +7,6 @@
     folded: true
   - type: Mask
     isToggled: true
-  - type: IngestionBlocker
-    enabled: false
   - type: IdentityBlocker
     enabled: false
     coverage: MOUTH


### PR DESCRIPTION
Removed the IndigestionBlocker tag from the ClothingHeadBandBase to [fix not being able to eat with the bandana on your head](https://github.com/space-wizards/space-station-14/issues/27163)