### PR TITLE
Syringes no longer work on chemistry jugs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -26,10 +26,6 @@
       solution: beaker
     - type: ExaminableSolution
       solution: beaker
-    - type: DrawableSolution
-      solution: beaker
-    - type: InjectableSolution
-      solution: beaker
     - type: SolutionTransfer
       canChangeTransferAmount: true
     - type: SolutionItemStatus


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Chemistry jugs are no longer drawable or injectable. Syringes will no longer work on them.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

The standard procedure for chemistry right now is to create medicine in a jug and then deliver to the main medbay area for use by medical doctors. Often the jugs will be placed in to a locker to prevent sabotage or patients drinking directly from the jug.

I decided to try and change this with this PR as I feel the expectation to deliver just jugs diminishes the fun of chemistry. By making jugs no longer drawable/injectable they will no longer be as desireable a medium for medicine - hopefully allowing pills and bottles to make a return.

It also doesn't seem all too realistic - a syringe isn't going to reach the bottom of a jug and I doubt a doctor is going to tip a jug to get the last few drops out.

Game balance-wise it will likely affect the pace at which medicine is distributed, as well as how. I cannot predict how players will handle it, but hopefully the result will be that chemists are working throughout the shift to meet demand and deliver medicine in lower quantities. The result may render chemical-based healing as slightly less dependable, but also slightly less prone to mass sabotage.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Very simple change. I removed the DrawableSolution and InjectableSolution from the Jug entity in chemical-containers.yml.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98577947/4e3c4678-4d3e-486c-8ff4-70bde80cbfee)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Syringes no longer work on chemistry jugs!
