### PR TITLE
Geras bug fixes

### DIFF
--- a/Content.Server/Geras/GerasSystem.cs
+++ b/Content.Server/Geras/GerasSystem.cs
@@ -38,11 +38,6 @@ public sealed class GerasSystem : SharedGerasSystem
         if (!ent.HasValue)
             return;
 
-        var originalFormMeta = MetaData(uid);
-
-        // Set the name of the Geras to it's form
-        _metaDataSystem.SetEntityName(ent.Value, originalFormMeta.EntityName);
-
         _popupSystem.PopupEntity(Loc.GetString("geras-popup-morph-message-others", ("entity", ent.Value)), ent.Value, Filter.PvsExcept(ent.Value), true);
         _popupSystem.PopupEntity(Loc.GetString("geras-popup-morph-message-user"), ent.Value, ent.Value);
 

--- a/Content.Server/Geras/GerasSystem.cs
+++ b/Content.Server/Geras/GerasSystem.cs
@@ -20,6 +20,12 @@ public sealed class GerasSystem : SharedGerasSystem
     {
         SubscribeLocalEvent<GerasComponent, MorphIntoGeras>(OnMorphIntoGeras);
         SubscribeLocalEvent<GerasComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<GerasComponent, EntityZombifiedEvent>(OnZombification);
+    }
+
+    private void OnZombification(EntityUid uid, GerasComponent component, EntityZombifiedEvent args)
+    {
+        _actionsSystem.RemoveAction(uid, component.GerasActionEntity);
     }
 
     private void OnMapInit(EntityUid uid, GerasComponent component, MapInitEvent args)

--- a/Content.Server/Geras/GerasSystem.cs
+++ b/Content.Server/Geras/GerasSystem.cs
@@ -1,7 +1,7 @@
-using Content.Server.Actions;
 using Content.Server.Polymorph.Systems;
+using Content.Shared.Zombies;
+using Content.Server.Actions;
 using Content.Server.Popups;
-using Content.Shared.Actions;
 using Content.Shared.Geras;
 using Robust.Shared.Player;
 
@@ -10,8 +10,9 @@ namespace Content.Server.Geras;
 /// <inheritdoc/>
 public sealed class GerasSystem : SharedGerasSystem
 {
-    [Dependency] private readonly ActionsSystem _actionsSystem = default!;
     [Dependency] private readonly PolymorphSystem _polymorphSystem = default!;
+    [Dependency] private readonly MetaDataSystem _metaDataSystem = default!;
+    [Dependency] private readonly ActionsSystem _actionsSystem = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
 
     /// <inheritdoc/>
@@ -34,8 +35,17 @@ public sealed class GerasSystem : SharedGerasSystem
         if (!ent.HasValue)
             return;
 
+        if (HasComp<ZombieComponent>(uid))
+            return; // i hate zomber.
+
+        var originalFormMeta = MetaData(uid);
+
+        // Set the name of the Geras to it's form
+        _metaDataSystem.SetEntityName(ent.Value, originalFormMeta.EntityName);
+
         _popupSystem.PopupEntity(Loc.GetString("geras-popup-morph-message-others", ("entity", ent.Value)), ent.Value, Filter.PvsExcept(ent.Value), true);
         _popupSystem.PopupEntity(Loc.GetString("geras-popup-morph-message-user"), ent.Value, ent.Value);
+
         args.Handled = true;
     }
 }

--- a/Content.Server/Geras/GerasSystem.cs
+++ b/Content.Server/Geras/GerasSystem.cs
@@ -30,13 +30,13 @@ public sealed class GerasSystem : SharedGerasSystem
 
     private void OnMorphIntoGeras(EntityUid uid, GerasComponent component, MorphIntoGeras args)
     {
+        if (HasComp<ZombieComponent>(uid))
+            return; // i hate zomber.
+
         var ent = _polymorphSystem.PolymorphEntity(uid, component.GerasPolymorphId);
 
         if (!ent.HasValue)
             return;
-
-        if (HasComp<ZombieComponent>(uid))
-            return; // i hate zomber.
 
         var originalFormMeta = MetaData(uid);
 

--- a/Content.Shared/Geras/SharedGerasSystem.cs
+++ b/Content.Shared/Geras/SharedGerasSystem.cs
@@ -3,7 +3,7 @@ using Content.Shared.Actions;
 namespace Content.Shared.Geras;
 
 /// <summary>
-/// A Geras is the small morph of a slime. This system handles exactly that.
+/// Geras is the god of old age, and A geras is the small morph of a slime. This system allows the slimes to have the morphing action.
 /// </summary>
 public abstract class SharedGerasSystem : EntitySystem
 {

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -140,6 +140,18 @@
   noSpawn: true
   components:
   # they portable...
+  - type: MovementSpeedModifier
+    baseWalkSpeed: 3
+    baseSprintSpeed: 5 # +.5 from normal movement speed
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      80: Dead # weak af tho
+  - type: NameIdentifier
+    group: ""
+  - type: NpcFactionMember
+    factions:
+    - NanoTrasen
   - type: MultiHandedItem
   - type: Item
     size: Huge

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -147,8 +147,6 @@
     thresholds:
       0: Alive
       80: Dead # weak af tho
-  - type: NameIdentifier
-    group: ""
   - type: NpcFactionMember
     factions:
     - NanoTrasen

--- a/Resources/Prototypes/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/Polymorphs/polymorph.yml
@@ -79,7 +79,7 @@
   id: SlimeMorphGeras
   configuration:
     entity: MobSlimesGeras
-    transferName: false
+    transferName: true
     transferHumanoidAppearance: false
     inventory: Drop
     transferDamage: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes the following bugs in relation to slimes:
- Zombie origforms can turn into Geras and be unzombified
- Geras do not retain their origform's name
- All AI mobs do not attack Geras
- Geras not having their speed buff

Also nerfs the health of Geras' a bit (120->80)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- fix: Fixed Geras not having their speed buff.
- fix: Geras are no longer immune to other AI mobs.
- fix: Slimes can no longer morph into a Geras when zombified.
- tweak: Lowered the Geras death threshold.