### PR TITLE
Add maximum volume to ChemMaster buffer

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -145,7 +145,7 @@ namespace Content.Server.Chemistry.EntitySystems
             }
             else // Container to buffer
             {
-                amount = FixedPoint2.Min(amount, containerSolution.GetReagentQuantity(id));
+                amount = FixedPoint2.Min(FixedPoint2.Min(amount, containerSolution.GetReagentQuantity(id)), bufferSolution.AvailableVolume);
                 _solutionContainerSystem.RemoveReagent(containerSoln.Value, id, amount);
                 bufferSolution.AddReagent(id, amount);
             }

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -85,7 +85,8 @@
           - PillCanister
   - type: SolutionContainerManager
     solutions:
-      buffer: {}
+      buffer:
+        maxVol: 300
   - type: DumpableSolution
     solution: buffer
     unlimited: true

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -86,7 +86,7 @@
   - type: SolutionContainerManager
     solutions:
       buffer:
-        maxVol: 300
+        maxVol: 1000
   - type: DumpableSolution
     solution: buffer
     unlimited: true


### PR DESCRIPTION
## About the PR
Add a maximum volume to the ChemMaster buffer and make transferring solutions respect the maximum volume. The initial proposed volume limit is 300u.

## Why / Balance
No solution container should have an infinite capacity. That the ChemMaster has an infinite buffer capacity has led to unreasonable meta-strategies that:

- Discourages making pills and bottles, which is the point of the chem master, to be a glorified chemical holding tank
- Discourages using the actual mechanics that are designed to separate chemicals, including electrolysis and centrifuging (https://github.com/space-wizards/space-station-14/pull/22517)
- Having one chemist hoarding all of the round-start base chemicals in their own buffer

The infinite buffer is a [placeholder mechanic](https://discord.com/channels/310555209753690112/675078881425752124/1196275816254930944) that isn't supposed to be there.

300u is an arbitrary limit that is designed to be larger than buckets and the largest obtainable beaker, but small enough to discourage ChemMaster-storing from coming back. Well-justified arguments for a different proposed volume limit welcome.

## Media

https://github.com/space-wizards/space-station-14/assets/3229565/f2426d37-eb35-4fd7-913d-34e2ecb20129

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**

:cl: notafet
- tweak: ChemMasters now have a limited buffer capacity.