### PR TITLE
fix antag bugs

### DIFF
--- a/Content.Server/Antag/AntagSelectionPlayerPool.cs
+++ b/Content.Server/Antag/AntagSelectionPlayerPool.cs
@@ -5,15 +5,13 @@ using Robust.Shared.Random;
 
 namespace Content.Server.Antag;
 
-public sealed class AntagSelectionPlayerPool(params List<ICommonSession>[] sessions)
+public sealed class AntagSelectionPlayerPool (List<List<ICommonSession>> orderedPools)
 {
-    private readonly List<List<ICommonSession>> _orderedPools = sessions.ToList();
-
     public bool TryPickAndTake(IRobustRandom random, [NotNullWhen(true)] out ICommonSession? session)
     {
         session = null;
 
-        foreach (var pool in _orderedPools)
+        foreach (var pool in orderedPools)
         {
             if (pool.Count == 0)
                 continue;
@@ -25,5 +23,5 @@ public sealed class AntagSelectionPlayerPool(params List<ICommonSession>[] sessi
         return session != null;
     }
 
-    public int Count => _orderedPools.Sum(p => p.Count);
+    public int Count => orderedPools.Sum(p => p.Count);
 }

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -35,7 +35,6 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly GhostRoleSystem _ghostRole = default!;
     [Dependency] private readonly JobSystem _jobs = default!;
-    [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly RoleSystem _role = default!;
     [Dependency] private readonly StationSpawningSystem _stationSpawning = default!;
@@ -133,7 +132,8 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             if (!TryGetNextAvailableDefinition((uid, antag), out var def))
                 continue;
 
-            MakeAntag((uid, antag), args.Player, def.Value);
+            if (TryMakeAntag((uid, antag), args.Player, def.Value))
+                break;
         }
     }
 
@@ -219,6 +219,21 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     }
 
     /// <summary>
+    /// Tries to makes a given player into the specified antagonist.
+    /// </summary>
+    public bool TryMakeAntag(Entity<AntagSelectionComponent> ent, ICommonSession? session, AntagSelectionDefinition def, bool ignoreSpawner = false)
+    {
+        if (!IsSessionValid(ent, session, def) ||
+            !IsEntityValid(session?.AttachedEntity, def))
+        {
+            return false;
+        }
+
+        MakeAntag(ent, session, def, ignoreSpawner);
+        return true;
+    }
+
+    /// <summary>
     /// Makes a given player into the specified antagonist.
     /// </summary>
     public void MakeAntag(Entity<AntagSelectionComponent> ent, ICommonSession? session, AntagSelectionDefinition def, bool ignoreSpawner = false)
@@ -262,7 +277,6 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         {
             var playerXform = Transform(player);
             var pos = RobustRandom.Pick(getPosEv.Coordinates);
-            var mapEnt = _map.GetMap(pos.MapId);
             _transform.SetMapCoordinates((player, playerXform), pos);
         }
 
@@ -291,8 +305,8 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
                 _mind.SetUserId(curMind.Value, session.UserId);
             }
 
-            EntityManager.AddComponents(curMind.Value, def.MindComponents);
             _mind.TransferTo(curMind.Value, antagEnt, ghostCheckOverride: true);
+            _role.MindAddRoles(curMind.Value, def.MindComponents);
             ent.Comp.SelectedMinds.Add((curMind.Value, Name(player)));
         }
 
@@ -310,42 +324,45 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     /// </summary>
     public AntagSelectionPlayerPool GetPlayerPool(Entity<AntagSelectionComponent> ent, List<ICommonSession> sessions, AntagSelectionDefinition def)
     {
-        var primaryList = new List<ICommonSession>();
-        var secondaryList = new List<ICommonSession>();
-        var fallbackList = new List<ICommonSession>();
-        var rawList = new List<ICommonSession>();
+        var preferredList = new List<ICommonSession>();
+        var secondBestList = new List<ICommonSession>();
+        var unwantedList = new List<ICommonSession>();
+        var invalidList = new List<ICommonSession>();
         foreach (var session in sessions)
         {
             if (!IsSessionValid(ent, session, def) ||
                 !IsEntityValid(session.AttachedEntity, def))
             {
-                rawList.Add(session);
+                invalidList.Add(session);
                 continue;
             }
 
             var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
-            if (def.PrefRoles.Count == 0 || pref.AntagPreferences.Any(p => def.PrefRoles.Contains(p)))
+            if (def.PrefRoles.Count != 0 && pref.AntagPreferences.Any(p => def.PrefRoles.Contains(p)))
             {
-                primaryList.Add(session);
+                preferredList.Add(session);
             }
-            else if (def.PrefRoles.Count == 0 || pref.AntagPreferences.Any(p => def.FallbackRoles.Contains(p)))
+            else if (def.FallbackRoles.Count != 0 && pref.AntagPreferences.Any(p => def.FallbackRoles.Contains(p)))
             {
-                secondaryList.Add(session);
+                secondBestList.Add(session);
             }
             else
             {
-                fallbackList.Add(session);
+                unwantedList.Add(session);
             }
         }
 
-        return new AntagSelectionPlayerPool(primaryList, secondaryList, fallbackList, rawList);
+        return new AntagSelectionPlayerPool(new() { preferredList, secondBestList, unwantedList, invalidList });
     }
 
     /// <summary>
     /// Checks if a given session is valid for an antagonist.
     /// </summary>
-    public bool IsSessionValid(Entity<AntagSelectionComponent> ent, ICommonSession session, AntagSelectionDefinition def, EntityUid? mind = null)
+    public bool IsSessionValid(Entity<AntagSelectionComponent> ent, ICommonSession? session, AntagSelectionDefinition def, EntityUid? mind = null)
     {
+        if (session == null)
+            return true;
+
         mind ??= session.GetMind();
 
         if (session.Status is SessionStatus.Disconnected or SessionStatus.Zombie)

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -75,7 +75,7 @@ public sealed partial class NukeopsRuleComponent : Component
     ///     Minimal operatives count for war declaration
     /// </summary>
     [DataField]
-    public int WarDeclarationMinOps = 4;
+    public int WarDeclarationMinOps = 1;//4;
 
     [DataField]
     public WinType WinType = WinType.Neutral;

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -75,7 +75,7 @@ public sealed partial class NukeopsRuleComponent : Component
     ///     Minimal operatives count for war declaration
     /// </summary>
     [DataField]
-    public int WarDeclarationMinOps = 1;//4;
+    public int WarDeclarationMinOps = 4;
 
     [DataField]
     public WinType WinType = WinType.Neutral;

--- a/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
@@ -71,5 +71,5 @@ public sealed partial class TraitorRuleComponent : Component
     public int StartingBalance = 20;
 
     [DataField]
-    public int MaxDifficulty = 20;
+    public int MaxDifficulty = 5;
 }

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -17,6 +17,14 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
     }
 
     /// <summary>
+    /// Queries all gamerules, regardless of if they're active or not.
+    /// </summary>
+    protected EntityQueryEnumerator<T, GameRuleComponent> QueryAllRules()
+    {
+        return EntityQueryEnumerator<T, GameRuleComponent>();
+    }
+
+    /// <summary>
     ///     Utility function for finding a random event-eligible station entity
     /// </summary>
     protected bool TryGetRandomStation([NotNullWhen(true)] out EntityUid? station, Func<EntityUid, bool>? filter = null)

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -34,8 +34,8 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
         if (args.Forced || args.Cancelled)
             return;
 
-        var query = QueryActiveRules();
-        while (query.MoveNext(out var uid, out _, out _, out var gameRule))
+        var query = QueryAllRules();
+        while (query.MoveNext(out var uid, out _, out var gameRule))
         {
             var minPlayers = gameRule.MinPlayers;
             if (args.Players.Length >= minPlayers)

--- a/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
@@ -34,6 +34,7 @@ public sealed class ThiefRuleSystem : GameRuleSystem<ThiefRuleComponent>
 
         //Generate objectives
         GenerateObjectives(mindId, mind, ent);
+        _antag.SendBriefing(args.EntityUid, MakeBriefing(args.EntityUid), null, null);
     }
 
     private void GenerateObjectives(EntityUid mindId, MindComponent mind, ThiefRuleComponent thiefRule)

--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Mind;
@@ -60,6 +61,38 @@ public abstract class SharedRoleSystem : EntitySystem
 
         SubscribeLocalEvent((EntityUid _, T _, ref MindIsAntagonistEvent args) => { args.IsAntagonist = true; args.IsExclusiveAntagonist |= typeof(T).TryGetCustomAttribute<ExclusiveAntagonistAttribute>(out _); });
         _antagTypes.Add(typeof(T));
+    }
+
+    public void MindAddRoles(EntityUid mindId, ComponentRegistry components, MindComponent? mind = null, bool silent = false)
+    {
+        if (!Resolve(mindId, ref mind))
+            return;
+
+        EntityManager.AddComponents(mindId, components);
+        var antagonist = false;
+        foreach (var compReg in components.Values)
+        {
+            var compType = compReg.Component.GetType();
+
+            var comp = EntityManager.ComponentFactory.GetComponent(compType);
+            if (IsAntagonistRole(comp.GetType()))
+            {
+                antagonist = true;
+                break;
+            }
+        }
+
+        var mindEv = new MindRoleAddedEvent(silent);
+        RaiseLocalEvent(mindId, ref mindEv);
+
+        var message = new RoleAddedEvent(mindId, mind, antagonist, silent);
+        if (mind.OwnedEntity != null)
+        {
+            RaiseLocalEvent(mind.OwnedEntity.Value, message, true);
+        }
+
+        _adminLogger.Add(LogType.Mind, LogImpact.Low,
+            $"Role components {string.Join(components.Keys.ToString(), ", ")} added to mind of {_minds.MindOwnerLoggingString(mind)}");
     }
 
     public void MindAddRole(EntityUid mindId, Component component, MindComponent? mind = null, bool silent = false)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Main Fixes
- fixes issue where latejoins weren't actually checked to see if they were valid to be antags (sec/command antags)
- fixes fucked variable in warops code that lead to TC not getting distributed
- changed how mind components were applied to actually update admin antag panel
- fixed traitors having like 7 morbillion objectives.
- fixed delayed gamerules starting even if they don't have enough players

Fixes #27313 
Fixes #27312 
Fixes #27306 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Traitors now have the correct number of objectives.
- fix: Declaring war now gives TC again.
- fix: Latejoining antagonists will now properly exclude command and security staff.
ADMIN:
- fix: Fixed antag status being broken in overlay and UI.