### PR TITLE
Fix ActivatableUIRequiresAccessSystem not showing a popup

### DIFF
--- a/Content.Shared/Access/Systems/ActivatableUIRequiresAccessSystem.cs
+++ b/Content.Shared/Access/Systems/ActivatableUIRequiresAccessSystem.cs
@@ -1,6 +1,6 @@
+using Content.Shared.Access.Components;
 using Content.Shared.Popups;
 using Content.Shared.UserInterface;
-using Content.Shared.Access.Components;
 
 namespace Content.Shared.Access.Systems;
 public sealed class ActivatableUIRequiresAccessSystem : EntitySystem
@@ -24,7 +24,7 @@ public sealed class ActivatableUIRequiresAccessSystem : EntitySystem
         {
             args.Cancel();
             if (activatableUI.Comp.PopupMessage != null)
-                _popup.PopupClient(Loc.GetString(activatableUI.Comp.PopupMessage), activatableUI, args.User);
+                _popup.PopupEntity(Loc.GetString(activatableUI.Comp.PopupMessage), activatableUI, args.User);
         }
     }
 }


### PR DESCRIPTION
## About the PR
The only path that calls this is in Content.Server, so this would never be shown to the player.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed not showing a popup when trying to open an UI that requires some access level.
