### PR TITLE
Fix mobs not being able to pry doors by just left clicking on them

### DIFF
--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -1,15 +1,14 @@
-using Content.Shared.Prying.Components;
-using Content.Shared.Verbs;
-using Content.Shared.DoAfter;
-using Robust.Shared.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
+using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
-using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
-using Robust.Shared.Audio;
+using Content.Shared.Prying.Components;
+using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Serialization;
 using PryUnpoweredComponent = Content.Shared.Prying.Components.PryUnpoweredComponent;
 
 namespace Content.Shared.Prying.Systems;
@@ -99,14 +98,16 @@ public sealed class PryingSystem : EntitySystem
             // to be marked as handled.
             return true;
 
-        return StartPry(target, user, null, 0.1f, out id); // hand-prying is much slower
+        // hand-prying is much slower
+        var modifier = CompOrNull<PryingComponent>(user)?.SpeedModifier ?? 0.1f;
+        return StartPry(target, user, null, modifier, out id);
     }
 
     private bool CanPry(EntityUid target, EntityUid user, out string? message, PryingComponent? comp = null)
     {
         BeforePryEvent canev;
 
-        if (comp != null)
+        if (comp != null || Resolve(user, ref comp))
         {
             canev = new BeforePryEvent(user, comp.PryPowered, comp.Force);
         }


### PR DESCRIPTION
## About the PR
Alt+left clicking remains unchanged.
I commend any zombies and terminators that were forced to alt+left click for so long.

## Media
https://github.com/space-wizards/space-station-14/assets/10968691/dd4a2993-4c26-46ab-af92-6db252fe651b

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed mobs that are able to pry doors not being able to do so by just left clicking on them.