### PR TITLE
Adjusts price of SWAT crate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -34,7 +34,7 @@
     sprite: Clothing/OuterClothing/Armor/riot.rsi
     state: icon
   product: CrateSecurityRiot
-  cost: 5500
+  cost: 7500
   category: cargoproduct-category-name-security
   group: market
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Raises price of SWAT crate to 7500 spesos from 5500 spesos.
<!-- What did you change in this PR? -->

## Why / Balance
The shotgun crate is 7000 spesos and comes with 2 enforcers and 3 boxes of lethal shells. The SWAT crate was 5500 spesos ad comes with 2 enforcers loaded with beanbags, beanbag shells boxes, and a bunch of riot gear. Clearly, the SWAT crate simply has better value since these purchases are most often made during warops, where printing lethal shells is extremely easy and cheap. I am unsure if the extra gear is worth only $500, but this stops it from being a strictly better purchase for arming crew. 
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
Changes one number in cargo_security.yml
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
- tweak: The price of the SWAT crate has been adjusted from 5500 spesos to 7500 spesos.
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->