### PR TITLE
Persist Agent ID Job Icon between UI loads

### DIFF
--- a/Content.Client/Access/UI/AgentIDCardBoundUserInterface.cs
+++ b/Content.Client/Access/UI/AgentIDCardBoundUserInterface.cs
@@ -40,9 +40,9 @@ namespace Content.Client.Access.UI
             SendMessage(new AgentIDCardJobChangedMessage(newJob));
         }
 
-        public void OnJobIconChanged(string newJobIcon)
+        public void OnJobIconChanged(string newJobIconId)
         {
-            SendMessage(new AgentIDCardJobIconChangedMessage(newJobIcon));
+            SendMessage(new AgentIDCardJobIconChangedMessage(newJobIconId));
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Content.Client.Access.UI
 
             _window.SetCurrentName(cast.CurrentName);
             _window.SetCurrentJob(cast.CurrentJob);
-            _window.SetAllowedIcons(cast.Icons);
+            _window.SetAllowedIcons(cast.Icons, cast.CurrentJobIconId);
         }
 
         protected override void Dispose(bool disposing)

--- a/Content.Client/Access/UI/AgentIDCardWindow.xaml.cs
+++ b/Content.Client/Access/UI/AgentIDCardWindow.xaml.cs
@@ -38,7 +38,7 @@ namespace Content.Client.Access.UI
             JobLineEdit.OnFocusExit += e => OnJobChanged?.Invoke(e.Text);
         }
 
-        public void SetAllowedIcons(HashSet<string> icons)
+        public void SetAllowedIcons(HashSet<string> icons, string currentJobIconId)
         {
             IconGrid.DisposeAllChildren();
 
@@ -79,6 +79,10 @@ namespace Content.Client.Access.UI
                 jobIconButton.AddChild(jobIconTexture);
                 jobIconButton.OnPressed += _ => _bui.OnJobIconChanged(jobIcon.ID);
                 IconGrid.AddChild(jobIconButton);
+
+                if (jobIconId.Equals(currentJobIconId))
+                    jobIconButton.Pressed = true;
+
                 i++;
             }
         }

--- a/Content.Server/Access/Systems/AgentIDCardSystem.cs
+++ b/Content.Server/Access/Systems/AgentIDCardSystem.cs
@@ -67,7 +67,7 @@ namespace Content.Server.Access.Systems
             if (!TryComp<IdCardComponent>(uid, out var idCard))
                 return;
 
-            var state = new AgentIDCardBoundUserInterfaceState(idCard.FullName ?? "", idCard.JobTitle ?? "", component.Icons);
+            var state = new AgentIDCardBoundUserInterfaceState(idCard.FullName ?? "", idCard.JobTitle ?? "", idCard.JobIcon ?? "", component.Icons);
             _uiSystem.SetUiState(uid, AgentIDCardUiKey.Key, state);
         }
 
@@ -94,7 +94,7 @@ namespace Content.Server.Access.Systems
                 return;
             }
 
-            if (!_prototypeManager.TryIndex<StatusIconPrototype>(args.JobIcon, out var jobIcon))
+            if (!_prototypeManager.TryIndex<StatusIconPrototype>(args.JobIconId, out var jobIcon))
             {
                 return;
             }

--- a/Content.Shared/Access/SharedAgentIDCardSystem.cs
+++ b/Content.Shared/Access/SharedAgentIDCardSystem.cs
@@ -26,12 +26,14 @@ namespace Content.Shared.Access.Systems
         public readonly HashSet<string> Icons;
         public string CurrentName { get; }
         public string CurrentJob { get; }
+        public string CurrentJobIconId { get; }
 
-        public AgentIDCardBoundUserInterfaceState(string currentName, string currentJob, HashSet<string> icons)
+        public AgentIDCardBoundUserInterfaceState(string currentName, string currentJob, string currentJobIconId, HashSet<string> icons)
         {
             Icons = icons;
             CurrentName = currentName;
             CurrentJob = currentJob;
+            CurrentJobIconId = currentJobIconId;
         }
     }
 
@@ -60,11 +62,11 @@ namespace Content.Shared.Access.Systems
     [Serializable, NetSerializable]
     public sealed class AgentIDCardJobIconChangedMessage : BoundUserInterfaceMessage
     {
-        public string JobIcon { get; }
+        public string JobIconId { get; }
 
-        public AgentIDCardJobIconChangedMessage(string jobIcon)
+        public AgentIDCardJobIconChangedMessage(string jobIconId)
         {
-            JobIcon = jobIcon;
+            JobIconId = jobIconId;
         }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Modified the Agent ID Card to persist the selected Job Icon between UI loads

## Why / Balance
Fixes #27348  

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Modified to include the current job icon when updating the state of the AgentID window (the current name and current job were already being passed in).
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/42426760/f1068368-df0e-48dd-ae53-95a0fedc2f9b)

- [ X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl: AllenTheGreat
- fix: The Agent ID card will no longer reset the selected job icon between UI loads
