### PR TITLE
fix: deconstruct verb on undeconstructables

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Guided.cs
+++ b/Content.Server/Construction/ConstructionSystem.Guided.cs
@@ -41,6 +41,18 @@ namespace Content.Server.Construction
                 component.Node == component.DeconstructionNode)
                 return;
 
+            if (!_prototypeManager.TryIndex(component.Graph, out ConstructionGraphPrototype? graph))
+                return;
+
+            if (component.DeconstructionNode == null)
+                return;
+
+            if (GetCurrentNode(uid, component) is not {} currentNode)
+                return;
+
+            if (graph.Path(currentNode.Name, component.DeconstructionNode) is not {} path || path.Length == 0)
+                return;
+
             Verb verb = new();
             //verb.Category = VerbCategories.Construction;
             //TODO VERBS add more construction verbs? Until then, removing construction category


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This patch makes attempt to check if is it even possible from current construction node to reach specified deconstructTarget.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Instead of adding `deconstructionTarget: null` (I seen in in some prototypes for gun recipes) for all undeconstructable objects, I added this check to make prototypes less redundant and prone to errors when construction node has no outgoing edges. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Some of prototypes don't specify their deconstructTarget node, which made them show the deconstruct verb as deconstructTarget is set to "start" node by default. Now before verb is added, checked is existence of path between current construction node and defined deconstruction node.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl:
- fix: Fixed undeconstructable objects showing deconstruct verb.

