### PR TITLE
Printable Special and Empty Mags for Autolathes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -163,55 +163,55 @@
       - ClothingHeadHatWelding
   - type: EmagLatheRecipes
     emagStaticRecipes:
+      - BoxLethalshot
+      - BoxShotgunFlare
+      - GrenadeBlast
+      - MagazineBoxLightRifle
+      - MagazineBoxMagnum
+      - MagazineBoxPistol
+      - MagazineBoxRifle
+      - MagazineLightRifle
+      - MagazineLightRifleEmpty
       - MagazinePistol 
       - MagazinePistolEmpty
       - MagazinePistolSubMachineGun
       - MagazinePistolSubMachineGunEmpty
-      - SpeedLoaderMagnum
-      - SpeedLoaderMagnumEmpty
-      - MagazineShotgunEmpty
-      - MagazineShotgun
-      - MagazineLightRifle
-      - MagazineLightRifleEmpty
       - MagazineRifle
       - MagazineRifleEmpty
+      - MagazineShotgun
+      - MagazineShotgunEmpty
       - ShellTranquilizer
-      - BoxLethalshot
-      - BoxShotgunFlare
-      - MagazineBoxPistol
-      - MagazineBoxMagnum
-      - MagazineBoxRifle
-      - MagazineBoxLightRifle
-      - GrenadeBlast
+      - SpeedLoaderMagnum
+      - SpeedLoaderMagnumEmpty
     emagDynamicRecipes:
-      - MagazineShotgunBeanbag
-      - MagazineShotgunIncendiary
-      - MagazineLightRifleIncendiary
-      - SpeedLoaderMagnumIncendiary
-      - MagazinePistolIncendiary
-      - MagazineRifleIncendiary
-      - MagazineShotgunIncendiary
-      - MagazineLightRifleUranium
-      - SpeedLoaderMagnumUranium
-      - MagazinePistolUranium
-      - MagazineRifleUranium
-      - MagazineBoxLightRifleIncendiary
-      - MagazineBoxMagnumIncendiary
-      - MagazineBoxPistolIncendiary
-      - MagazineBoxRifleIncendiary
-      - BoxShotgunIncendiary
-      - MagazineBoxLightRifleUranium
-      - MagazineBoxMagnumUranium
-      - MagazineBoxPistolUranium
-      - MagazineBoxRifleUranium
-      - BoxShotgunUranium
       - BoxBeanbag
-      - PowerCageSmall
-      - PowerCageMedium
-      - PowerCageHigh
-      - MagazineGrenadeEmpty
+      - BoxShotgunIncendiary
+      - BoxShotgunUranium
       - GrenadeEMP
       - GrenadeFlash
+      - MagazineBoxLightRifleIncendiary
+      - MagazineBoxLightRifleUranium
+      - MagazineBoxMagnumIncendiary
+      - MagazineBoxMagnumUranium
+      - MagazineBoxPistolIncendiary
+      - MagazineBoxPistolUranium
+      - MagazineBoxRifleIncendiary
+      - MagazineBoxRifleUranium
+      - MagazineGrenadeEmpty
+      - MagazineLightRifleIncendiary
+      - MagazineLightRifleUranium
+      - MagazinePistolIncendiary
+      - MagazinePistolUranium
+      - MagazineRifleIncendiary
+      - MagazineRifleUranium
+      - MagazineShotgunBeanbag
+      - MagazineShotgunIncendiary
+      - MagazineShotgunIncendiary
+      - PowerCageHigh
+      - PowerCageMedium
+      - PowerCageSmall
+      - SpeedLoaderMagnumIncendiary
+      - SpeedLoaderMagnumUranium
 
 - type: entity
   id: AutolatheHyperConvection
@@ -650,16 +650,24 @@
     idleState: icon
     runningState: icon
     staticRecipes:
-      - ClothingEyesHudSecurity
-      - Flash
-      - Handcuffs
-      - Zipties
-      - Stunbaton
-      - ForensicPad
-      - RiotShield
-      - BoxShotgunSlug
       - BoxLethalshot
       - BoxShotgunFlare
+      - BoxShotgunPractice 
+      - BoxShotgunSlug
+      - ClothingEyesHudSecurity
+      - Flash
+      - ForensicPad
+      - Handcuffs
+      - MagazineBoxLightRifle
+      - MagazineBoxLightRiflePractice
+      - MagazineBoxMagnum
+      - MagazineBoxMagnumPractice
+      - MagazineBoxPistol
+      - MagazineBoxPistolPractice
+      - MagazineBoxRifle
+      - MagazineBoxRiflePractice
+      - MagazineLightRifle
+      - MagazineLightRifleEmpty
       - MagazinePistol 
       - MagazinePistolEmpty
       - MagazinePistolSubMachineGun
@@ -668,58 +676,57 @@
       - MagazinePistolSubMachineGunTopMountedEmpty
       - MagazineRifle
       - MagazineRifleEmpty
-      - MagazineLightRifle
-      - MagazineLightRifleEmpty
-      - MagazineShotgunEmpty
       - MagazineShotgun
+      - MagazineShotgunEmpty
       - MagazineShotgunSlug
-      - MagazineBoxPistol
-      - MagazineBoxMagnum
-      - MagazineBoxRifle
-      - MagazineBoxLightRifle
+      - RiotShield
       - SpeedLoaderMagnum
       - SpeedLoaderMagnumEmpty
+      - Stunbaton
+      - TargetClown
       - TargetHuman
       - TargetSyndicate
-      - TargetClown
-      - MagazineBoxLightRiflePractice
-      - MagazineBoxMagnumPractice
-      - MagazineBoxPistolPractice
-      - MagazineBoxRiflePractice
-      - WeaponLaserCarbinePractice
       - WeaponDisablerPractice
-      - BoxShotgunPractice 
+      - WeaponLaserCarbinePractice
+      - Zipties
     dynamicRecipes:
-      - MagazineLightRifleIncendiary
-      - SpeedLoaderMagnumIncendiary
-      - MagazinePistolIncendiary
-      - MagazineRifleIncendiary
-      - MagazineShotgunIncendiary
-      - MagazineLightRifleUranium
-      - SpeedLoaderMagnumUranium
-      - MagazinePistolUranium
-      - MagazineRifleUranium
-      - MagazineShotgunBeanbag
-      - ShellTranquilizer
+      - BoxBeanbag
+      - BoxShotgunIncendiary
+      - BoxShotgunUranium
       - ExplosivePayload
       - FlashPayload
-      - HoloprojectorSecurity
-      - MagazineBoxLightRifleIncendiary
-      - MagazineBoxMagnumIncendiary
-      - MagazineBoxPistolIncendiary
-      - MagazineBoxRifleIncendiary
-      - BoxShotgunIncendiary
-      - MagazineBoxLightRifleUranium
-      - MagazineBoxMagnumUranium
-      - MagazineBoxPistolUranium
-      - MagazineBoxRifleUranium
-      - BoxShotgunUranium
-      - BoxBeanbag
-      - MagazineGrenadeEmpty
       - GrenadeEMP
       - GrenadeFlash
+      - HoloprojectorSecurity
+      - MagazineBoxLightRifleIncendiary
+      - MagazineBoxLightRifleUranium
+      - MagazineBoxMagnumIncendiary
+      - MagazineBoxMagnumUranium
+      - MagazineBoxPistolIncendiary
+      - MagazineBoxPistolUranium
+      - MagazineBoxRifleIncendiary
+      - MagazineBoxRifleUranium
+      - MagazineGrenadeEmpty
+      - MagazineLightRifleIncendiary
+      - MagazineLightRifleUranium
+      - MagazinePistolIncendiary
+      - MagazinePistolUranium
+      - MagazineRifleIncendiary
+      - MagazineRifleUranium
+      - MagazineShotgunBeanbag
+      - MagazineShotgunIncendiary
+      - PowerCageHigh
+      - PowerCageMedium
+      - PowerCageSmall
+      - ShellTranquilizer
+      - ShuttleGunDusterCircuitboard
+      - ShuttleGunFriendshipCircuitboard
+      - ShuttleGunPerforatorCircuitboard
+      - ShuttleGunSvalinnMachineGunCircuitboard
       - Signaller
       - SignalTrigger
+      - SpeedLoaderMagnumIncendiary
+      - SpeedLoaderMagnumUranium
       - TelescopicShield
       - TimerTrigger
       - Truncheon
@@ -730,13 +737,6 @@
       - WeaponLaserCannon
       - WeaponLaserCarbine
       - WeaponXrayCannon
-      - PowerCageSmall
-      - PowerCageMedium
-      - PowerCageHigh
-      - ShuttleGunSvalinnMachineGunCircuitboard
-      - ShuttleGunPerforatorCircuitboard
-      - ShuttleGunFriendshipCircuitboard
-      - ShuttleGunDusterCircuitboard
   - type: MaterialStorage
     whitelist:
       tags:
@@ -769,25 +769,25 @@
       idleState: icon
       runningState: icon
       staticRecipes:
-        - MagazinePistol 
-        - MagazinePistolEmpty 
-        - SpeedLoaderMagnum
-        - SpeedLoaderMagnumEmpty
-        - MagazineShotgunEmpty
-        - MagazineShotgun
-        - MagazineShotgunSlug
-        - ShellTranquilizer
-        - MagazineLightRifle
-        - MagazineLightRifleEmpty
-        - MagazineRifle
-        - MagazineRifleEmpty
-        - BoxShotgunSlug
         - BoxLethalshot
         - BoxShotgunFlare
-        - MagazineBoxPistol
-        - MagazineBoxMagnum
-        - MagazineBoxRifle
+        - BoxShotgunSlug
         - MagazineBoxLightRifle
+        - MagazineBoxMagnum
+        - MagazineBoxPistol
+        - MagazineBoxRifle
+        - MagazineLightRifle
+        - MagazineLightRifleEmpty
+        - MagazinePistol 
+        - MagazinePistolEmpty 
+        - MagazineRifle
+        - MagazineRifleEmpty
+        - MagazineShotgun
+        - MagazineShotgunEmpty
+        - MagazineShotgunSlug
+        - ShellTranquilizer
+        - SpeedLoaderMagnum
+        - SpeedLoaderMagnumEmpty
     - type: MaterialStorage
       whitelist:
         tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -165,6 +165,8 @@
     emagStaticRecipes:
       - MagazinePistol 
       - MagazinePistolEmpty
+      - MagazinePistolSubMachineGun
+      - MagazinePistolSubMachineGunEmpty
       - SpeedLoaderMagnum
       - SpeedLoaderMagnumEmpty
       - MagazineShotgunEmpty

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -163,38 +163,47 @@
       - ClothingHeadHatWelding
   - type: EmagLatheRecipes
     emagStaticRecipes:
-       - CartridgePistol
-       - CartridgeMagnum
-       - ShellShotgun
-       - ShellShotgunFlare
-       - ShellTranquilizer
-       - CartridgeLightRifle
-       - CartridgeRifle
-       - MagazineBoxPistol
-       - MagazineBoxMagnum
-       - MagazineBoxRifle
-       - MagazineBoxLightRifle
-       - GrenadeBlast
+      - MagazinePistol 
+      - MagazinePistolEmpty
+      - SpeedLoaderMagnum
+      - SpeedLoaderMagnumEmpty
+      - MagazineShotgunEmpty
+      - MagazineShotgun
+      - MagazineLightRifle
+      - MagazineLightRifleEmpty
+      - MagazineRifle
+      - MagazineRifleEmpty
+      - ShellTranquilizer
+      - BoxLethalshot
+      - BoxShotgunFlare
+      - MagazineBoxPistol
+      - MagazineBoxMagnum
+      - MagazineBoxRifle
+      - MagazineBoxLightRifle
+      - GrenadeBlast
     emagDynamicRecipes:
-      - ShellShotgunBeanbag
-      - ShellShotgunIncendiary
-      - CartridgePistolIncendiary
-      - CartridgeMagnumIncendiary
-      - CartridgeLightRifleIncendiary
-      - CartridgeRifleIncendiary
-      - MagazineBoxPistolIncendiary
-      - MagazineBoxMagnumIncendiary
+      - MagazineShotgunBeanbag
+      - MagazineShotgunIncendiary
+      - MagazineLightRifleIncendiary
+      - SpeedLoaderMagnumIncendiary
+      - MagazinePistolIncendiary
+      - MagazineRifleIncendiary
+      - MagazineShotgunIncendiary
+      - MagazineLightRifleUranium
+      - SpeedLoaderMagnumUranium
+      - MagazinePistolUranium
+      - MagazineRifleUranium
       - MagazineBoxLightRifleIncendiary
+      - MagazineBoxMagnumIncendiary
+      - MagazineBoxPistolIncendiary
       - MagazineBoxRifleIncendiary
-      - ShellShotgunUranium
-      - CartridgePistolUranium
-      - CartridgeMagnumUranium
-      - CartridgeLightRifleUranium
-      - CartridgeRifleUranium
-      - MagazineBoxPistolUranium
-      - MagazineBoxMagnumUranium
+      - BoxShotgunIncendiary
       - MagazineBoxLightRifleUranium
+      - MagazineBoxMagnumUranium
+      - MagazineBoxPistolUranium
       - MagazineBoxRifleUranium
+      - BoxShotgunUranium
+      - BoxBeanbag
       - PowerCageSmall
       - PowerCageMedium
       - PowerCageHigh
@@ -758,14 +767,21 @@
       idleState: icon
       runningState: icon
       staticRecipes:
-        - CartridgePistol
-        - CartridgeMagnum
-        - ShellShotgun
-        - ShellShotgunSlug
-        - ShellShotgunFlare
+        - MagazinePistol 
+        - MagazinePistolEmpty 
+        - SpeedLoaderMagnum
+        - SpeedLoaderMagnumEmpty
+        - MagazineShotgunEmpty
+        - MagazineShotgun
+        - MagazineShotgunSlug
         - ShellTranquilizer
-        - CartridgeLightRifle
-        - CartridgeRifle
+        - MagazineLightRifle
+        - MagazineLightRifleEmpty
+        - MagazineRifle
+        - MagazineRifleEmpty
+        - BoxShotgunSlug
+        - BoxLethalshot
+        - BoxShotgunFlare
         - MagazineBoxPistol
         - MagazineBoxMagnum
         - MagazineBoxRifle

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -139,71 +139,6 @@
     Steel: 100
 
 - type: latheRecipe
-  id: ShellShotgunBeanbag
-  result: ShellShotgunBeanbag
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 15
-    Steel: 10
-
-- type: latheRecipe
-  id: CartridgeRifle
-  result: CartridgeRifle
-  category: Ammo
-  completetime: 2
-  materials:
-    Steel: 15
-
-- type: latheRecipe
-  id: CartridgePistol
-  result: CartridgePistol
-  category: Ammo
-  completetime: 2
-  materials:
-    Steel: 10
-
-- type: latheRecipe
-  id: ShellShotgun
-  result: ShellShotgun
-  category: Ammo
-  completetime: 2
-  materials:
-    Steel: 20
-
-- type: latheRecipe
-  id: ShellShotgunSlug
-  result: ShellShotgunSlug
-  completetime: 2
-  materials:
-    Steel: 25
-
-- type: latheRecipe
-  id: CartridgeMagnum
-  result: CartridgeMagnum
-  category: Ammo
-  completetime: 2
-  materials:
-    Steel: 20
-
-- type: latheRecipe
-  id: CartridgeLightRifle
-  result: CartridgeLightRifle
-  category: Ammo
-  completetime: 2
-  materials:
-    Steel: 30
-
-- type: latheRecipe
-  id: ShellShotgunFlare
-  result: ShellShotgunFlare
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 20
-    Steel: 5
-
-- type: latheRecipe
   id: ShellTranquilizer
   result: ShellTranquilizer
   category: Ammo
@@ -547,46 +482,6 @@
     Plastic: 190
 
 - type: latheRecipe
-  id: ShellShotgunIncendiary
-  result: ShellShotgunIncendiary
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 20
-
-- type: latheRecipe
-  id: CartridgePistolIncendiary
-  result: CartridgePistolIncendiary
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 10
-
-- type: latheRecipe
-  id: CartridgeMagnumIncendiary
-  result: CartridgeMagnumIncendiary
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 20
-
-- type: latheRecipe
-  id: CartridgeLightRifleIncendiary
-  result: CartridgeLightRifleIncendiary
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 15
-
-- type: latheRecipe
-  id: CartridgeRifleIncendiary
-  result: CartridgeRifleIncendiary
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 15
-
-- type: latheRecipe
   id: MagazineBoxPistolIncendiary
   result: MagazineBoxPistolIncendiary
   category: Ammo
@@ -635,14 +530,6 @@
   materials:
     Steel: 80
     Plastic: 320
-
-- type: latheRecipe
-  id: ShellShotgunPractice
-  result: ShellShotgunPractice
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 20
 
 - type: latheRecipe
   id: MagazineBoxPistolPractice
@@ -703,51 +590,6 @@
   completetime: 5
   materials:
     Steel: 80
-
-- type: latheRecipe
-  id: ShellShotgunUranium
-  result: ShellShotgunUranium
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 20
-    Uranium: 15
-
-- type: latheRecipe
-  id: CartridgePistolUranium
-  result: CartridgePistolUranium
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 5
-    Uranium: 10
-
-- type: latheRecipe
-  id: CartridgeMagnumUranium
-  result: CartridgeMagnumUranium
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 20
-    Uranium: 15
-
-- type: latheRecipe
-  id: CartridgeLightRifleUranium
-  result: CartridgeLightRifleUranium
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 10
-    Uranium: 10
-
-- type: latheRecipe
-  id: CartridgeRifleUranium
-  result: CartridgeRifleUranium
-  category: Ammo
-  completetime: 2
-  materials:
-    Plastic: 10
-    Uranium: 10
 
 - type: latheRecipe
   id: MagazineBoxPistolUranium

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -57,6 +57,7 @@
   tier: 1
   cost: 5000
   recipeUnlocks:
+  - MagazineShotgunBeanbag
   - ShellTranquilizer 
   - BoxBeanbag 
   - WeaponDisabler


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
follow up to #26178 that covers the autolathe emag interaction, replaces printing single ammo with full mags or empty mags + ammo boxes

I removed all the now unused recipes for printing bullets one by one

I also updated the ammo fab to do the same, honestly have no idea what the ammo fab is even used for. But now every lathe/fab is caught up to speed now.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
printing single bits of ammo sucks, people just dump the default magazine and fill it with the ammo of their preference

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
just yml changes

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


https://github.com/space-wizards/space-station-14/assets/58439124/d2f8b95d-6aea-4873-8063-be9a0c5802fa

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: The emagged autolathe now has recipes for ammunition boxes and pre-filled magazines of every type of ammo.
- add: You can now print empty magazines at the emagged autolathe.