### PR TITLE
Reduce selection of traitor max from 12 to 8

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -147,7 +147,7 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]
-      max: 12
+      max: 8
       playerRatio: 10
       lateJoinAdditional: true
       mindComponents:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Initial syndicate traitor selection reduced to 8 instead of 12

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
There's too many damn syndicates, every single shift on Lizard there is 12 syndicates or MORE. There is a drain of sec players because syndicates just effortlessly take down the station with sheer numbers rather than any interesting gimmick or skill. There are twice to thrice as many syndicate as there are sec players at this point.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Max amount of traitors dropped from 12 to 8.