### PR TITLE
Scattershot antag fixes

### DIFF
--- a/Content.Server/Access/Systems/PresetIdCardSystem.cs
+++ b/Content.Server/Access/Systems/PresetIdCardSystem.cs
@@ -33,8 +33,8 @@ public sealed class PresetIdCardSystem : EntitySystem
             var station = _stationSystem.GetOwningStation(uid);
 
             // If we're not on an extended access station, the ID is already configured correctly from MapInit.
-            if (station == null || !Comp<StationJobsComponent>(station.Value).ExtendedAccess)
-                return;
+            if (station == null || !TryComp<StationJobsComponent>(station.Value, out var jobsComp) || !jobsComp.ExtendedAccess)
+                continue;
 
             SetupIdAccess(uid, card, true);
             SetupIdName(uid, card);

--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -71,7 +71,7 @@ public sealed partial class AntagSelectionSystem
         var countOffset = 0;
         foreach (var otherDef in ent.Comp.Definitions)
         {
-            countOffset += Math.Clamp(poolSize / otherDef.PlayerRatio, otherDef.Min, otherDef.Max) * otherDef.PlayerRatio;
+            countOffset += Math.Clamp((poolSize - countOffset) / otherDef.PlayerRatio, otherDef.Min, otherDef.Max) * otherDef.PlayerRatio;
         }
         // make sure we don't double-count the current selection
         countOffset -= Math.Clamp(poolSize / def.PlayerRatio, def.Min, def.Max) * def.PlayerRatio;

--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -7,6 +7,7 @@ using Content.Shared.Chat;
 using Content.Shared.Mind;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
+using Robust.Shared.Enums;
 using Robust.Shared.Player;
 
 namespace Content.Server.Antag;
@@ -63,7 +64,9 @@ public sealed partial class AntagSelectionSystem
     /// </summary>
     public int GetTargetAntagCount(Entity<AntagSelectionComponent> ent, AntagSelectionPlayerPool? pool, AntagSelectionDefinition def)
     {
-        var poolSize = pool?.Count ?? _playerManager.Sessions.Length;
+        var poolSize = pool?.Count ?? _playerManager.Sessions
+            .Count(s => s.State.Status is not SessionStatus.Disconnected and not SessionStatus.Zombie);
+
         // factor in other definitions' affect on the count.
         var countOffset = 0;
         foreach (var otherDef in ent.Comp.Definitions)
@@ -71,7 +74,7 @@ public sealed partial class AntagSelectionSystem
             countOffset += Math.Clamp(poolSize / otherDef.PlayerRatio, otherDef.Min, otherDef.Max) * otherDef.PlayerRatio;
         }
         // make sure we don't double-count the current selection
-        countOffset -= Math.Clamp((poolSize + countOffset) / def.PlayerRatio, def.Min, def.Max) * def.PlayerRatio;
+        countOffset -= Math.Clamp(poolSize / def.PlayerRatio, def.Min, def.Max) * def.PlayerRatio;
 
         return Math.Clamp((poolSize - countOffset) / def.PlayerRatio, def.Min, def.Max);
     }

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -324,13 +324,15 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     public AntagSelectionPlayerPool GetPlayerPool(Entity<AntagSelectionComponent> ent, List<ICommonSession> sessions, AntagSelectionDefinition def)
     {
         var preferredList = new List<ICommonSession>();
-        var secondBestList = new List<ICommonSession>();
+        var fallbackList = new List<ICommonSession>();
         var unwantedList = new List<ICommonSession>();
+        var invalidList = new List<ICommonSession>();
         foreach (var session in sessions)
         {
             if (!IsSessionValid(ent, session, def) ||
                 !IsEntityValid(session.AttachedEntity, def))
             {
+                invalidList.Add(session);
                 continue;
             }
 
@@ -341,7 +343,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             }
             else if (def.FallbackRoles.Count != 0 && pref.AntagPreferences.Any(p => def.FallbackRoles.Contains(p)))
             {
-                secondBestList.Add(session);
+                fallbackList.Add(session);
             }
             else
             {
@@ -349,7 +351,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             }
         }
 
-        return new AntagSelectionPlayerPool(new() { preferredList, secondBestList, unwantedList });
+        return new AntagSelectionPlayerPool(new() { preferredList, fallbackList, unwantedList, invalidList });
     }
 
     /// <summary>

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -42,7 +42,7 @@
         max: 3
       playerRatio: 1
       allowNonHumans: true
-      multiAntagSetting: All
+      multiAntagSetting: NotExclusive
       startingGear: ThiefGear
       components:
       - type: Pacified


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
fix some incorrect calculations that resulted in overestimating the amount of antags there should be for latejoin. I don't know if this entirely fixes it but it was broken anyways.

also thieves now check for mutually exclusive antags, so nukeops can't be thieves anymore.

adds some comments and shit.

fixes #27402 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun