### PR TITLE
Infinate chem dupe fixed (Toilet, drain) + dirty water toilet fix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -104,7 +104,10 @@
   components:
   - type: SolutionContainerManager
     solutions:
-      toilet:
+      drainBuffer:
+        maxVol: 100
+      tank:
+        maxVol: 500
         reagents:
         - ReagentId: Water
           Quantity: 180


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes: #27440

Fixed the duplication glitch and the dirty water toilet.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Beck Thompson, CoffeePoweredPHD
- fix: Fixed infinite reagent duplication glitch with toilets and drains.
- fix: Dirty water toilets now function correctly as toilets.

