### PR TITLE
ActivatableUI tweaks

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -87,7 +87,6 @@ public abstract partial class SharedHandsSystem
     /// </summary>
     /// <param name="uid"></param>
     /// <param name="handsComp"></param>
-
     public void RemoveHands(EntityUid uid, HandsComponent? handsComp = null)
     {
         if (!Resolve(uid, ref handsComp))
@@ -135,6 +134,43 @@ public abstract partial class SharedHandsSystem
         }
 
         return false;
+    }
+
+    public bool TryGetActiveHand(Entity<HandsComponent?> entity, [NotNullWhen(true)] out Hand? hand)
+    {
+        if (!Resolve(entity, ref entity.Comp, false))
+        {
+            hand = null;
+            return false;
+        }
+
+        hand = entity.Comp.ActiveHand;
+        return hand != null;
+    }
+
+    public bool TryGetActiveItem(Entity<HandsComponent?> entity, [NotNullWhen(true)] out EntityUid? item)
+    {
+        if (!TryGetActiveHand(entity, out var hand))
+        {
+            item = null;
+            return false;
+        }
+
+        item = hand.HeldEntity;
+        return item != null;
+    }
+
+    public Hand? GetActiveHand(Entity<HandsComponent?> entity)
+    {
+        if (!Resolve(entity, ref entity.Comp))
+            return null;
+
+        return entity.Comp.ActiveHand;
+    }
+
+    public EntityUid? GetActiveItem(Entity<HandsComponent?> entity)
+    {
+        return GetActiveHand(entity)?.HeldEntity;
     }
 
     /// <summary>
@@ -227,9 +263,17 @@ public abstract partial class SharedHandsSystem
         return true;
     }
 
-    public bool IsHolding(EntityUid uid, EntityUid? entity, [NotNullWhen(true)] out Hand? inHand, HandsComponent? handsComp = null)
+    public bool IsHolding(Entity<HandsComponent?> entity, [NotNullWhen(true)] EntityUid? item)
+    {
+        return IsHolding(entity, item, out _, entity);
+    }
+
+    public bool IsHolding(EntityUid uid, [NotNullWhen(true)] EntityUid? entity, [NotNullWhen(true)] out Hand? inHand, HandsComponent? handsComp = null)
     {
         inHand = null;
+        if (entity == null)
+            return false;
+
         if (!Resolve(uid, ref handsComp, false))
             return false;
 

--- a/Content.Shared/UserInterface/ActivatableUIComponent.cs
+++ b/Content.Shared/UserInterface/ActivatableUIComponent.cs
@@ -4,22 +4,26 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations;
 
 namespace Content.Shared.UserInterface
 {
-    [RegisterComponent, NetworkedComponent]
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
     public sealed partial class ActivatableUIComponent : Component
     {
         [DataField(required: true, customTypeSerializer: typeof(EnumSerializer))]
-        public Enum? Key { get; set; } = default!;
+        public Enum? Key;
+
+        /// <summary>
+        /// Whether the item must be held in one of the user's hands to work.
+        /// This is ignored unless <see cref="RequireHands"/> is true.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
+        public bool InHandsOnly;
+
+        [DataField]
+        public bool SingleUser;
 
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField]
-        public bool InHandsOnly { get; set; } = false;
-
-        [DataField]
-        public bool SingleUser { get; set; } = false;
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField]
-        public bool AdminOnly { get; set; } = false;
+        public bool AdminOnly;
 
         [DataField]
         public LocId VerbText = "ui-verb-toggle-open";
@@ -38,16 +42,15 @@ namespace Content.Shared.UserInterface
         /// <summary>
         ///     Entities that are required to open this UI.
         /// </summary>
-        [DataField("allowedItems")]
-        [ViewVariables(VVAccess.ReadWrite)]
-        public EntityWhitelist? AllowedItems = null;
+        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        public EntityWhitelist? RequiredItems;
 
         /// <summary>
-        ///     Whether you can activate this ui with activateinhand or not
+        ///     If true, then this UI can only be opened via verbs. I.e., normal interactions/activations will not open
+        ///     the UI.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField]
-        public bool RightClickOnly;
+        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        public bool VerbOnly;
 
         /// <summary>
         ///     Whether spectators (non-admin ghosts) should be allowed to view this UI.
@@ -57,17 +60,18 @@ namespace Content.Shared.UserInterface
         public bool AllowSpectator = true;
 
         /// <summary>
-        ///     Whether the UI should close when the item is deselected due to a hand swap or drop
+        ///     Whether the item must be in the user's currently selected/active hand.
+        ///     This is ignored unless <see cref="InHandsOnly"/> is true.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField]
-        public bool CloseOnHandDeselect = true;
+        public bool RequireActiveHand = true;
 
         /// <summary>
         ///     The client channel currently using the object, or null if there's none/not single user.
         ///     NOTE: DO NOT DIRECTLY SET, USE ActivatableUISystem.SetCurrentSingleUser
         /// </summary>
-        [ViewVariables]
+        [DataField, AutoNetworkedField]
         public EntityUid? CurrentSingleUser;
     }
 }

--- a/Content.Shared/UserInterface/ActivatableUISystem.Power.cs
+++ b/Content.Shared/UserInterface/ActivatableUISystem.Power.cs
@@ -20,12 +20,19 @@ public sealed partial class ActivatableUISystem
     {
         _cell.SetPowerCellDrawEnabled(uid, false);
 
-        if (HasComp<ActivatableUIRequiresPowerCellComponent>(uid) &&
-            TryComp<ActivatableUIComponent>(uid, out var activatable) &&
-            activatable.Key != null)
+        if (!HasComp<ActivatableUIRequiresPowerCellComponent>(uid) ||
+            !TryComp(uid, out ActivatableUIComponent? activatable))
         {
-            _uiSystem.CloseUi(uid, activatable.Key);
+            return;
         }
+
+        if (activatable.Key == null)
+        {
+            Log.Error($"Encountered null key in activatable ui on entity {ToPrettyString(uid)}");
+            return;
+        }
+
+        _uiSystem.CloseUi(uid, activatable.Key);
     }
 
     private void OnBatteryOpened(EntityUid uid, ActivatableUIRequiresPowerCellComponent component, BoundUIOpenedEvent args)
@@ -55,8 +62,14 @@ public sealed partial class ActivatableUISystem
     /// </summary>
     public void CheckUsage(EntityUid uid, ActivatableUIComponent? active = null, ActivatableUIRequiresPowerCellComponent? component = null, PowerCellDrawComponent? draw = null)
     {
-        if (!Resolve(uid, ref component, ref draw, ref active, false) || active.Key == null)
+        if (!Resolve(uid, ref component, ref draw, ref active, false))
             return;
+
+        if (active.Key == null)
+        {
+            Log.Error($"Encountered null key in activatable ui on entity {ToPrettyString(uid)}");
+            return;
+        }
 
         if (_cell.HasActivatableCharge(uid))
             return;

--- a/Content.Shared/UserInterface/ActivatableUISystem.cs
+++ b/Content.Shared/UserInterface/ActivatableUISystem.cs
@@ -3,11 +3,11 @@ using Content.Shared.Administration.Managers;
 using Content.Shared.Ghost;
 using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
-using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
-using Robust.Shared.Player;
+using Robust.Shared.Containers;
 
 namespace Content.Shared.UserInterface;
 
@@ -17,23 +17,27 @@ public sealed partial class ActivatableUISystem : EntitySystem
     [Dependency] private readonly ActionBlockerSystem _blockerSystem = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _uiSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+
+    private readonly List<EntityUid> _toClose = new();
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<ActivatableUIComponent, ActivateInWorldEvent>(OnActivate);
-        SubscribeLocalEvent<ActivatableUIComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<ActivatableUIComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<ActivatableUIComponent, HandDeselectedEvent>(OnHandDeselected);
-        SubscribeLocalEvent<ActivatableUIComponent, GotUnequippedHandEvent>((uid, aui, _) => CloseAll(uid, aui));
-        // *THIS IS A BLATANT WORKAROUND!* RATIONALE: Microwaves need it
-        SubscribeLocalEvent<ActivatableUIComponent, EntParentChangedMessage>(OnParentChanged);
+        SubscribeLocalEvent<ActivatableUIComponent, GotUnequippedHandEvent>(OnHandUnequipped);
         SubscribeLocalEvent<ActivatableUIComponent, BoundUIClosedEvent>(OnUIClose);
+        SubscribeLocalEvent<ActivatableUIComponent, GetVerbsEvent<ActivationVerb>>(GetActivationVerb);
+        SubscribeLocalEvent<ActivatableUIComponent, GetVerbsEvent<Verb>>(GetVerb);
+
+        SubscribeLocalEvent<ActivatableUIComponent, EntGotInsertedIntoContainerMessage>(OnGotInserted);
+
         SubscribeLocalEvent<BoundUserInterfaceMessageAttempt>(OnBoundInterfaceInteractAttempt);
-
-        SubscribeLocalEvent<ActivatableUIComponent, GetVerbsEvent<ActivationVerb>>(AddOpenUiVerb);
-
         SubscribeLocalEvent<UserInterfaceComponent, OpenUiActionEvent>(OnActionPerform);
 
         InitializePower();
@@ -59,25 +63,54 @@ public sealed partial class ActivatableUISystem : EntitySystem
         args.Handled = _uiSystem.TryToggleUi(uid, args.Key, args.Performer);
     }
 
-    private void AddOpenUiVerb(EntityUid uid, ActivatableUIComponent component, GetVerbsEvent<ActivationVerb> args)
+
+    private void GetActivationVerb(EntityUid uid, ActivatableUIComponent component, GetVerbsEvent<ActivationVerb> args)
+    {
+        if (component.VerbOnly || !ShouldAddVerb(uid, component, args))
+            return;
+
+        args.Verbs.Add(new ActivationVerb
+        {
+            // TODO VERBS add "open UI" icon
+            Act = () => InteractUI(args.User, uid, component),
+            Text = Loc.GetString(component.VerbText)
+        });
+    }
+
+    private void GetVerb(EntityUid uid, ActivatableUIComponent component, GetVerbsEvent<Verb> args)
+    {
+        if (!component.VerbOnly || !ShouldAddVerb(uid, component, args))
+            return;
+
+        args.Verbs.Add(new Verb
+        {
+            // TODO VERBS add "open UI" icon
+            Act = () => InteractUI(args.User, uid, component),
+            Text = Loc.GetString(component.VerbText)
+        });
+    }
+
+    private bool ShouldAddVerb<T>(EntityUid uid, ActivatableUIComponent component, GetVerbsEvent<T> args) where T : Verb
     {
         if (!args.CanAccess)
-            return;
+            return false;
 
-        if (component.RequireHands && args.Hands == null)
-            return;
+        if (component.RequireHands)
+        {
+            if (args.Hands == null)
+                return false;
 
-        if (component.InHandsOnly && args.Using != uid)
-            return;
+            if (component.InHandsOnly)
+            {
+                if (!_hands.IsHolding(args.User, uid, out var hand, args.Hands))
+                    return false;
 
-        if (!args.CanInteract && (!component.AllowSpectator || !HasComp<GhostComponent>(args.User)))
-            return;
+                if (component.RequireActiveHand && args.Hands.ActiveHand != hand)
+                    return false;
+            }
+        }
 
-        ActivationVerb verb = new();
-        verb.Act = () => InteractUI(args.User, uid, component);
-        verb.Text = Loc.GetString(component.VerbText);
-        // TODO VERBS add "open UI" icon?
-        args.Verbs.Add(verb);
+        return args.CanInteract || component.AllowSpectator && HasComp<GhostComponent>(args.User);
     }
 
     private void OnActivate(EntityUid uid, ActivatableUIComponent component, ActivateInWorldEvent args)
@@ -85,24 +118,10 @@ public sealed partial class ActivatableUISystem : EntitySystem
         if (args.Handled)
             return;
 
-        if (component.InHandsOnly)
+        if (component.VerbOnly)
             return;
 
-        if (component.AllowedItems != null)
-            return;
-
-        args.Handled = InteractUI(args.User, uid, component);
-    }
-
-    private void OnUseInHand(EntityUid uid, ActivatableUIComponent component, UseInHandEvent args)
-    {
-        if (args.Handled)
-            return;
-
-        if (component.RightClickOnly)
-            return;
-
-        if (component.AllowedItems != null)
+        if (component.RequiredItems != null)
             return;
 
         args.Handled = InteractUI(args.User, uid, component);
@@ -110,15 +129,19 @@ public sealed partial class ActivatableUISystem : EntitySystem
 
     private void OnInteractUsing(EntityUid uid, ActivatableUIComponent component, InteractUsingEvent args)
     {
-        if (args.Handled) return;
-        if (component.AllowedItems == null) return;
-        if (!component.AllowedItems.IsValid(args.Used, EntityManager)) return;
-        args.Handled = InteractUI(args.User, uid, component);
-    }
+        if (args.Handled)
+            return;
 
-    private void OnParentChanged(EntityUid uid, ActivatableUIComponent aui, ref EntParentChangedMessage args)
-    {
-        CloseAll(uid, aui);
+        if (component.VerbOnly)
+            return;
+
+        if (component.RequiredItems == null)
+            return;
+
+        if (!component.RequiredItems.IsValid(args.Used, EntityManager))
+            return;
+
+        args.Handled = InteractUI(args.User, uid, component);
     }
 
     private void OnUIClose(EntityUid uid, ActivatableUIComponent component, BoundUIClosedEvent args)
@@ -148,22 +171,33 @@ public sealed partial class ActivatableUISystem : EntitySystem
         if (!_blockerSystem.CanInteract(user, uiEntity) && (!aui.AllowSpectator || !HasComp<GhostComponent>(user)))
             return false;
 
-        if (aui.RequireHands && !HasComp<HandsComponent>(user))
-            return false;
+        if (aui.RequireHands)
+        {
+            if (!TryComp(user, out HandsComponent? hands))
+                return false;
+
+            if (aui.InHandsOnly)
+            {
+                if (!_hands.IsHolding(user, uiEntity, out var hand, hands))
+                    return false;
+
+                if (aui.RequireActiveHand && hands.ActiveHand != hand)
+                    return false;
+            }
+        }
 
         if (aui.AdminOnly && !_adminManager.IsAdmin(user))
             return false;
 
         if (aui.SingleUser && aui.CurrentSingleUser != null && user != aui.CurrentSingleUser)
         {
-            string message = Loc.GetString("machine-already-in-use", ("machine", uiEntity));
+            var message = Loc.GetString("machine-already-in-use", ("machine", uiEntity));
             _popupSystem.PopupEntity(message, uiEntity, user);
 
-            // If we get here, supposedly, the object is in use.
-            // Check with BUI that it's ACTUALLY in use just in case.
-            // Since this could brick the object if it goes wrong.
             if (_uiSystem.IsUiOpen(uiEntity, aui.Key))
-                return false;
+                return true;
+
+            Log.Error($"Activatable UI has user without being opened? Entity: {ToPrettyString(uiEntity)}. User: {aui.CurrentSingleUser}, Key: {aui.Key}");
         }
 
         // If we've gotten this far, fire a cancellable event that indicates someone is about to activate this.
@@ -199,26 +233,72 @@ public sealed partial class ActivatableUISystem : EntitySystem
             return;
 
         aui.CurrentSingleUser = user;
+        Dirty(uid, aui);
 
         RaiseLocalEvent(uid, new ActivatableUIPlayerChangedEvent());
     }
 
     public void CloseAll(EntityUid uid, ActivatableUIComponent? aui = null)
     {
-        if (!Resolve(uid, ref aui, false) || aui.Key == null)
+        if (!Resolve(uid, ref aui, false))
             return;
+
+        if (aui.Key == null)
+        {
+            Log.Error($"Encountered null key in activatable ui on entity {ToPrettyString(uid)}");
+            return;
+        }
 
         _uiSystem.CloseUi(uid, aui.Key);
     }
 
-    private void OnHandDeselected(EntityUid uid, ActivatableUIComponent? aui, HandDeselectedEvent args)
+    private void OnHandDeselected(Entity<ActivatableUIComponent> ent, ref HandDeselectedEvent args)
     {
-        if (!Resolve(uid, ref aui, false))
+        if (ent.Comp.RequireHands && ent.Comp.InHandsOnly && ent.Comp.RequireActiveHand)
+            CloseAll(ent, ent);
+    }
+
+    private void OnHandUnequipped(Entity<ActivatableUIComponent> ent, ref GotUnequippedHandEvent args)
+    {
+        if (ent.Comp.RequireHands && ent.Comp.InHandsOnly)
+            CloseAll(ent, ent);
+    }
+
+    private void OnGotInserted(Entity<ActivatableUIComponent> ent, ref EntGotInsertedIntoContainerMessage args)
+    {
+        CheckAccess((ent, ent));
+    }
+
+    public void CheckAccess(Entity<ActivatableUIComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp))
             return;
 
-        if (!aui.CloseOnHandDeselect)
+        if (ent.Comp.Key == null)
+        {
+            Log.Error($"Encountered null key in activatable ui on entity {ToPrettyString(ent)}");
             return;
+        }
 
-        CloseAll(uid, aui);
+        foreach (var user in _uiSystem.GetActors(ent.Owner, ent.Comp.Key))
+        {
+            if (!_container.IsInSameOrParentContainer(user, ent)
+                && !_interaction.CanAccessViaStorage(user, ent))
+            {
+                _toClose.Add(user);
+                continue;
+
+            }
+
+            if (!_interaction.InRangeUnobstructed(user, ent))
+                _toClose.Add(user);
+        }
+
+        foreach (var user in _toClose)
+        {
+            _uiSystem.CloseUi(ent.Owner, ent.Comp.Key, user);
+        }
+
+        _toClose.Clear();
     }
 }

--- a/Content.Shared/UserInterface/ActivatableUISystem.cs
+++ b/Content.Shared/UserInterface/ActivatableUISystem.cs
@@ -35,7 +35,11 @@ public sealed partial class ActivatableUISystem : EntitySystem
         SubscribeLocalEvent<ActivatableUIComponent, GetVerbsEvent<ActivationVerb>>(GetActivationVerb);
         SubscribeLocalEvent<ActivatableUIComponent, GetVerbsEvent<Verb>>(GetVerb);
 
+        // TODO ActivatableUI
+        // Add UI-user component, and listen for user container changes.
+        // I.e., should lose a computer UI if a player gets shut into a locker.
         SubscribeLocalEvent<ActivatableUIComponent, EntGotInsertedIntoContainerMessage>(OnGotInserted);
+        SubscribeLocalEvent<ActivatableUIComponent, EntGotRemovedFromContainerMessage>(OnGotRemoved);
 
         SubscribeLocalEvent<BoundUserInterfaceMessageAttempt>(OnBoundInterfaceInteractAttempt);
         SubscribeLocalEvent<UserInterfaceComponent, OpenUiActionEvent>(OnActionPerform);
@@ -265,6 +269,11 @@ public sealed partial class ActivatableUISystem : EntitySystem
     }
 
     private void OnGotInserted(Entity<ActivatableUIComponent> ent, ref EntGotInsertedIntoContainerMessage args)
+    {
+        CheckAccess((ent, ent));
+    }
+
+    private void OnGotRemoved(Entity<ActivatableUIComponent> ent, ref EntGotRemovedFromContainerMessage args)
     {
         CheckAccess((ent, ent));
     }

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -372,8 +372,7 @@
   - type: MeleeSpeech
   - type: ActivatableUI
     key: enum.MeleeSpeechUiKey.Key
-    closeOnHandDeselect: false
-    rightClickOnly: true
+    verbOnly: true
   - type: Actions
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door.yml
@@ -16,7 +16,7 @@
     - type: AccessReader
     - type: ActivatableUI
       key: enum.DoorElectronicsConfigurationUiKey.Key
-      allowedItems:
+      requiredItems:
         tags:
         - DoorElectronicsConfigurator
     - type: UserInterface

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/war_declarator.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/war_declarator.yml
@@ -14,7 +14,7 @@
     - type: ActivatableUI
       inHandsOnly: true
       singleUser: true
-      closeOnHandDeselect: false
+      requireActiveHand: false
       key: enum.WarDeclaratorUiKey.Key
     - type: UserInterface
       interfaces:

--- a/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
@@ -17,7 +17,7 @@
   - type: ActivatableUI
     key: enum.ForensicScannerUiKey.Key
     inHandsOnly: true
-    closeOnHandDeselect: false
+    requireActiveHand: false
   - type: UserInterface
     interfaces:
       enum.ForensicScannerUiKey.Key:

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -86,7 +86,6 @@
   - type: ActivatableUI
     key: enum.PdaUiKey.Key
     singleUser: true
-    closeOnHandDeselect: false
   - type: UserInterface
     interfaces:
       enum.PdaUiKey.Key:

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -22,7 +22,6 @@
     contentSize: 12000
   - type: ActivatableUI
     key: enum.PaperUiKey.Key
-    closeOnHandDeselect: false
   - type: UserInterface
     interfaces:
       enum.PaperUiKey.Key:

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -18,7 +18,6 @@
   - type: PaperLabelType
   - type: ActivatableUI
     key: enum.PaperUiKey.Key
-    closeOnHandDeselect: false
     requireHands: false
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -17,7 +17,6 @@
   - type: ActivatableUIRequiresPowerCell
   - type: ActivatableUI
     key: enum.CrewMonitoringUIKey.Key
-    closeOnHandDeselect: false
   - type: UserInterface
     interfaces:
       enum.CrewMonitoringUIKey.Key:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -17,7 +17,6 @@
     storedRotation: -90
   - type: ActivatableUI
     key: enum.HealthAnalyzerUiKey.Key
-    closeOnHandDeselect: false
   - type: UserInterface
     interfaces:
       enum.HealthAnalyzerUiKey.Key:

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -9,7 +9,7 @@
     state: icon
   - type: ActivatableUI
     key: enum.AnomalyScannerUiKey.Key
-    closeOnHandDeselect: false
+    requireActiveHand: false
     inHandsOnly: true
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/barber.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/barber.yml
@@ -10,7 +10,8 @@
   - type: MagicMirror
   - type: ActivatableUI
     key: enum.MagicMirrorUiKey.Key
-    closeOnHandDeselect: true
+    inHandsOnly: true
+    requireActiveHand: true
   - type: UserInterface
     interfaces:
       enum.MagicMirrorUiKey.Key:

--- a/Resources/Prototypes/Entities/Objects/Specific/atmos.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/atmos.yml
@@ -13,7 +13,7 @@
   - type: ActivatableUI
     inHandsOnly: true
     singleUser: true
-    closeOnHandDeselect: false
+    requireActiveHand: false
     key: enum.GasAnalyzerUiKey.Key
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -67,7 +67,7 @@
     - type: ActivatableUI
       key: enum.AccessOverriderUiKey.Key
       requireHands: true
-      closeOnHandDeselect: false
+      requireActiveHand: false
       singleUser: true
     - type: ItemSlots
     - type: ContainerContainer


### PR DESCRIPTION
This PR makes various changes to how ActivatableUi works, including:
- Null UI keys now log errors instead of being silently ignored.
- Changed how hand requirements work 
  - `InHandsOnly` does nothing unless `RequireHands` is true
  - Replaced the `CloseOnHandDeselect` datafield with `RequireActiveHand`, which determines whether or not the entity needs to be held in the currently active hand to have the UI open.
  - `RequireActiveHand` does nothing unless `InHandsOnly` and `RequireHands` are both true
- UIs no longer close on parent change, now they just perform interaction-access checks on container insertion/removal
- Renames the `AllowedItems` datafield to `RequiredItems`
- Renames the `RightClickOnly` datafield to `VerbOnly`