### PR TITLE
Stop admin verb pop-in

### DIFF
--- a/Content.Client/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Client/Administration/Systems/AdminVerbSystem.cs
@@ -1,3 +1,6 @@
+using Content.Shared.Administration;
+using Content.Shared.Administration.Managers;
+using Content.Shared.Mind.Components;
 using Content.Shared.Verbs;
 using Robust.Client.Console;
 using Robust.Shared.Utility;
@@ -11,10 +14,12 @@ namespace Content.Client.Administration.Systems
     {
         [Dependency] private readonly IClientConGroupController _clientConGroupController = default!;
         [Dependency] private readonly IClientConsoleHost _clientConsoleHost = default!;
+        [Dependency] private readonly ISharedAdminManager _admin = default!;
 
         public override void Initialize()
         {
             SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddAdminVerbs);
+
         }
 
         private void AddAdminVerbs(GetVerbsEvent<Verb> args)
@@ -33,6 +38,24 @@ namespace Content.Client.Administration.Systems
                 };
                 args.Verbs.Add(verb);
             }
+
+            if (!_admin.IsAdmin(args.User))
+                return;
+
+            if (_admin.HasAdminFlag(args.User, AdminFlags.Admin))
+                args.ExtraCategories.Add(VerbCategory.Admin);
+
+            if (_admin.HasAdminFlag(args.User, AdminFlags.Fun) && HasComp<MindContainerComponent>(args.Target))
+                args.ExtraCategories.Add(VerbCategory.Antag);
+
+            if (_admin.HasAdminFlag(args.User, AdminFlags.Debug))
+                args.ExtraCategories.Add(VerbCategory.Debug);
+
+            if (_admin.HasAdminFlag(args.User, AdminFlags.Fun))
+                args.ExtraCategories.Add(VerbCategory.Smite);
+
+            if (_admin.HasAdminFlag(args.User, AdminFlags.Admin))
+                args.ExtraCategories.Add(VerbCategory.Tricks);
         }
     }
 }

--- a/Content.Client/Verbs/VerbSystem.cs
+++ b/Content.Client/Verbs/VerbSystem.cs
@@ -166,28 +166,22 @@ namespace Content.Client.Verbs
         }
 
         /// <summary>
-        ///     Asks the server to send back a list of server-side verbs, for the given verb type.
-        /// </summary>
-        public SortedSet<Verb> GetVerbs(EntityUid target, EntityUid user, Type type, bool force = false)
-        {
-            return GetVerbs(GetNetEntity(target), user, new List<Type>() { type }, force);
-        }
-
-        /// <summary>
         ///     Ask the server to send back a list of server-side verbs, and for now return an incomplete list of verbs
         ///     (only those defined locally).
         /// </summary>
-        public SortedSet<Verb> GetVerbs(NetEntity target, EntityUid user, List<Type> verbTypes,
-            bool force = false)
+        public SortedSet<Verb> GetVerbs(NetEntity target, EntityUid user, List<Type> verbTypes, out List<VerbCategory> extraCategories, bool force = false)
         {
             if (!target.IsClientSide())
                 RaiseNetworkEvent(new RequestServerVerbsEvent(target, verbTypes, adminRequest: force));
 
             // Some admin menu interactions will try get verbs for entities that have not yet been sent to the player.
             if (!TryGetEntity(target, out var local))
+            {
+                extraCategories = new();
                 return new();
+            }
 
-            return GetLocalVerbs(local.Value, user, verbTypes, force);
+            return GetLocalVerbs(local.Value, user, verbTypes, out extraCategories, force);
         }
 
 

--- a/Content.Shared/Verbs/SharedVerbSystem.cs
+++ b/Content.Shared/Verbs/SharedVerbSystem.cs
@@ -55,13 +55,21 @@ namespace Content.Shared.Verbs
             return GetLocalVerbs(target, user, new List<Type>() { type }, force);
         }
 
+        /// <inheritdoc cref="GetLocalVerbs(Robust.Shared.GameObjects.EntityUid,Robust.Shared.GameObjects.EntityUid,System.Type,bool)"/>
+        public SortedSet<Verb> GetLocalVerbs(EntityUid target, EntityUid user, List<Type> types, bool force = false)
+        {
+            return GetLocalVerbs(target, user, types, out _, force);
+        }
+
         /// <summary>
         ///     Raises a number of events in order to get all verbs of the given type(s) defined in local systems. This
         ///     does not request verbs from the server.
         /// </summary>
-        public SortedSet<Verb> GetLocalVerbs(EntityUid target, EntityUid user, List<Type> types, bool force = false)
+        public SortedSet<Verb> GetLocalVerbs(EntityUid target, EntityUid user, List<Type> types,
+            out List<VerbCategory> extraCategories, bool force = false)
         {
             SortedSet<Verb> verbs = new();
+            extraCategories = new();
 
             // accessibility checks
             bool canAccess = false;
@@ -108,7 +116,7 @@ namespace Content.Shared.Verbs
             // TODO: fix this garbage and use proper generics or reflection or something else, not this.
             if (types.Contains(typeof(InteractionVerb)))
             {
-                var verbEvent = new GetVerbsEvent<InteractionVerb>(user, target, @using, hands, canInteract, canAccess);
+                var verbEvent = new GetVerbsEvent<InteractionVerb>(user, target, @using, hands, canInteract, canAccess, extraCategories);
                 RaiseLocalEvent(target, verbEvent, true);
                 verbs.UnionWith(verbEvent.Verbs);
             }
@@ -117,35 +125,35 @@ namespace Content.Shared.Verbs
                 && @using != null
                 && @using != target)
             {
-                var verbEvent = new GetVerbsEvent<UtilityVerb>(user, target, @using, hands, canInteract, canAccess);
+                var verbEvent = new GetVerbsEvent<UtilityVerb>(user, target, @using, hands, canInteract, canAccess, extraCategories);
                 RaiseLocalEvent(@using.Value, verbEvent, true); // directed at used, not at target
                 verbs.UnionWith(verbEvent.Verbs);
             }
 
             if (types.Contains(typeof(InnateVerb)))
             {
-                var verbEvent = new GetVerbsEvent<InnateVerb>(user, target, @using, hands, canInteract, canAccess);
+                var verbEvent = new GetVerbsEvent<InnateVerb>(user, target, @using, hands, canInteract, canAccess, extraCategories);
                 RaiseLocalEvent(user, verbEvent, true);
                 verbs.UnionWith(verbEvent.Verbs);
             }
 
             if (types.Contains(typeof(AlternativeVerb)))
             {
-                var verbEvent = new GetVerbsEvent<AlternativeVerb>(user, target, @using, hands, canInteract, canAccess);
+                var verbEvent = new GetVerbsEvent<AlternativeVerb>(user, target, @using, hands, canInteract, canAccess, extraCategories);
                 RaiseLocalEvent(target, verbEvent, true);
                 verbs.UnionWith(verbEvent.Verbs);
             }
 
             if (types.Contains(typeof(ActivationVerb)))
             {
-                var verbEvent = new GetVerbsEvent<ActivationVerb>(user, target, @using, hands, canInteract, canAccess);
+                var verbEvent = new GetVerbsEvent<ActivationVerb>(user, target, @using, hands, canInteract, canAccess, extraCategories);
                 RaiseLocalEvent(target, verbEvent, true);
                 verbs.UnionWith(verbEvent.Verbs);
             }
 
             if (types.Contains(typeof(ExamineVerb)))
             {
-                var verbEvent = new GetVerbsEvent<ExamineVerb>(user, target, @using, hands, canInteract, canAccess);
+                var verbEvent = new GetVerbsEvent<ExamineVerb>(user, target, @using, hands, canInteract, canAccess, extraCategories);
                 RaiseLocalEvent(target, verbEvent, true);
                 verbs.UnionWith(verbEvent.Verbs);
             }
@@ -153,7 +161,7 @@ namespace Content.Shared.Verbs
             // generic verbs
             if (types.Contains(typeof(Verb)))
             {
-                var verbEvent = new GetVerbsEvent<Verb>(user, target, @using, hands, canInteract, canAccess);
+                var verbEvent = new GetVerbsEvent<Verb>(user, target, @using, hands, canInteract, canAccess, extraCategories);
                 RaiseLocalEvent(target, verbEvent, true);
                 verbs.UnionWith(verbEvent.Verbs);
             }
@@ -161,7 +169,7 @@ namespace Content.Shared.Verbs
             if (types.Contains(typeof(EquipmentVerb)))
             {
                 var access = canAccess || _interactionSystem.CanAccessEquipment(user, target);
-                var verbEvent = new GetVerbsEvent<EquipmentVerb>(user, target, @using, hands, canInteract, access);
+                var verbEvent = new GetVerbsEvent<EquipmentVerb>(user, target, @using, hands, canInteract, access, extraCategories);
                 RaiseLocalEvent(target, verbEvent);
                 verbs.UnionWith(verbEvent.Verbs);
             }

--- a/Content.Shared/Verbs/VerbEvents.cs
+++ b/Content.Shared/Verbs/VerbEvents.cs
@@ -78,6 +78,13 @@ namespace Content.Shared.Verbs
         public readonly SortedSet<TVerb> Verbs = new();
 
         /// <summary>
+        /// Additional verb categories to show in the pop-up menu, even if there are no verbs currently associated
+        /// with that category. This is mainly useful to prevent verb menu pop-in. E.g., admins will get admin/debug
+        /// related verbs on entities, even though most of those verbs are all defined server-side.
+        /// </summary>
+        public readonly List<VerbCategory> ExtraCategories;
+
+        /// <summary>
         ///     Can the user physically access the target?
         /// </summary>
         /// <remarks>
@@ -123,7 +130,7 @@ namespace Content.Shared.Verbs
         /// </remarks>
         public readonly EntityUid? Using;
 
-        public GetVerbsEvent(EntityUid user, EntityUid target, EntityUid? @using, HandsComponent? hands, bool canInteract, bool canAccess)
+        public GetVerbsEvent(EntityUid user, EntityUid target, EntityUid? @using, HandsComponent? hands, bool canInteract, bool canAccess, List<VerbCategory> extraCategories)
         {
             User = user;
             Target = target;
@@ -131,6 +138,7 @@ namespace Content.Shared.Verbs
             Hands = hands;
             CanAccess = canAccess;
             CanInteract = canInteract;
+            ExtraCategories = extraCategories;
         }
     }
 }

--- a/Resources/Locale/en-US/verbs/verb-system.ftl
+++ b/Resources/Locale/en-US/verbs/verb-system.ftl
@@ -1,4 +1,3 @@
-verb-system-waiting-on-server-text = Waiting on Server...
 verb-system-null-server-response = Entity not in view. You should not see this.
 
 


### PR DESCRIPTION
Adds support for showing dummy verb categories in the right click context menu, for reducing the pop-in caused by server-side admin verbs.  This PR also removes the "Waiting for server" entry in the context menu, because I don't feel like it provides valuable feedback and causes the verb menu to always pop/jump around even if all of the verbs are predicted.

Before:

https://github.com/space-wizards/space-station-14/assets/60421075/b5af5d41-1288-4bf9-915b-b0d58c26371a

After:

https://github.com/space-wizards/space-station-14/assets/60421075/26d7170e-ee6f-4639-9c59-866ed53993e7


This is somewhat janky, and it'd be better to just move all the verb definitions to shared if possible. E.g., by making all the verbs just be wrappers around console commands. One of the issues with this approach is that the order in which the categories should appear in the menu is dependent on the priority of the verbs in that category, which the client doesn't know about. So the order currently just depends on the order in which the dummy categories are added. 