### PR TITLE
Pills are now created from beaker, not buffer

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -138,11 +138,13 @@ namespace Content.Client.Chemistry.UI
         /// <param name="state">State data sent by the server.</param>
         private string GenerateLabel(ChemMasterBoundUserInterfaceState state)
         {
-            if (state.BufferCurrentVolume == 0)
+            if (state.InputContainerInfo == null ||
+                    state.InputContainerInfo.CurrentVolume == 0 ||
+                    state.InputContainerInfo.Reagents == null)
                 return "";
 
-            var reagent = state.BufferReagents.OrderBy(r => r.Quantity).First().Reagent;
-            _prototypeManager.TryIndex(reagent.Prototype, out ReagentPrototype? proto);
+            var reagent = state.InputContainerInfo.Reagents.MaxBy(r=>r.Quantity);
+            _prototypeManager.TryIndex(reagent.Reagent.Prototype, out ReagentPrototype? proto);
             return proto?.LocalizedName ?? "";
         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Title

## Why / Balance
Now making pills is a lot less annoying, since you don't have to do it with a empty chemmaster anymore. 
I think that this will encourage chemists to make pills more often.
Also if I recall correctly, this is how it worked in SS13, but I might be wrong. 

## Technical details
On the chemmaster UI, now the generated label is created using the chems in the beaker instead of chems in the buffer.
On the server side, the solution is fetched from the chemmaster's input slot, and passed to withdrawfrombuffer which now accepts an optional Solution argument, which can be used as a new source of the chems. 
Also the input beaker is manually synced using UpdateChemicals, to make sure the client is aware of the new state of the beaker. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


https://github.com/space-wizards/space-station-14/assets/62134478/81d78632-9ba2-43e0-b962-3224f4855847



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.

- add: Added fun!
- remove: Removed fun!

- fix: Fixed fun!
-->
:cl:
- tweak: Chemmaster now creates pills using the input beaker, instead of drawing from the buffer.