### PR TITLE
Late join thieves!

### DIFF
--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -41,6 +41,7 @@
         min: 1
         max: 3
       playerRatio: 1
+      lateJoinAdditional: true
       allowNonHumans: true
       multiAntagSetting: All
       startingGear: ThiefGear


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added lateJoinAdditional: true to the thieves game rule

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Thieves are basically on the same level as traitors in terms of their antag status and objectives, might as well as let them late join too.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Latejoin players now have a chance to roll thief.