### PR TITLE
add health icons to the secmed hud

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -162,6 +162,9 @@
   - type: ShowHealthBars
     damageContainers:
     - Biological
+  - type: ShowHealthIcons
+    damageContainers: 
+    - Biological
 
 - type: entity
   parent: [ClothingEyesBase, ShowSecurityIcons]

--- a/Resources/Prototypes/StatusEffects/health.yml
+++ b/Resources/Prototypes/StatusEffects/health.yml
@@ -2,7 +2,7 @@
   id: HealthIcon
   abstract: true
   priority: 3
-  locationPreference: Right
+  locationPreference: Left
   isShaded: true
 
 - type: statusIcon


### PR DESCRIPTION
## About the PR
Added health icons to the sec hud

## Why / Balance
https://discord.com/channels/310555209753690112/1221690653990326273/1221690653990326273

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
![image](https://github.com/space-wizards/space-station-14/assets/7510010/5a1330da-1ed6-4535-9e8c-ec713aaef674)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame

## Breaking changes
Nope

**Changelog**
:cl:
- tweak: The crafted medsec hud now displays health icons too.
- tweak: The health status icon now goes on the left for all types of med HUD.
