### PR TITLE
Added new HTN operations and preconditions

### DIFF
--- a/Content.Server/NPC/HTN/Preconditions/GunAmmoPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/GunAmmoPrecondition.cs
@@ -35,7 +35,7 @@ public sealed partial class GunAmmoPrecondition : HTNPrecondition
         else
             percent = ammoEv.Count / (float) ammoEv.Capacity;
 
-        percent = Math.Clamp(percent, 0f, 1f);
+        percent = System.Math.Clamp(percent, 0f, 1f);
 
         if (MaxPercent < percent)
             return false;

--- a/Content.Server/NPC/HTN/Preconditions/KeyNotExistsPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/KeyNotExistsPrecondition.cs
@@ -1,0 +1,12 @@
+namespace Content.Server.NPC.HTN.Preconditions;
+
+public sealed partial class KeyNotExistsPrecondition : HTNPrecondition
+{
+    [DataField(required: true)]
+    public string Key = string.Empty;
+
+    public override bool IsMet(NPCBlackboard blackboard)
+    {
+        return !blackboard.ContainsKey(Key);
+    }
+}

--- a/Content.Server/NPC/HTN/Preconditions/Math/KeyBoolEqualsPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/Math/KeyBoolEqualsPrecondition.cs
@@ -15,7 +15,7 @@ public sealed partial class KeyBoolEqualsPrecondition : HTNPrecondition
 
     public override bool IsMet(NPCBlackboard blackboard)
     {
-        if (!blackboard.TryGetValue<bool>(NPCBlackboard.Owner, out var value, _entManager))
+        if (!blackboard.TryGetValue<bool>(Key, out var value, _entManager))
             return false;
 
         return Value == value;

--- a/Content.Server/NPC/HTN/Preconditions/Math/KeyBoolEqualsPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/Math/KeyBoolEqualsPrecondition.cs
@@ -1,0 +1,23 @@
+﻿namespace Content.Server.NPC.HTN.Preconditions.Math;
+
+/// <summary>
+/// Checks for the presence of data in the blackboard and makes a comparison with the specified boolean
+/// </summary>
+public sealed partial class KeyBoolEqualsPrecondition : HTNPrecondition
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    [DataField(required: true)]
+    public string Key = string.Empty;
+
+    [DataField(required: true)]
+    public bool Value;
+
+    public override bool IsMet(NPCBlackboard blackboard)
+    {
+        if (!blackboard.TryGetValue<bool>(NPCBlackboard.Owner, out var value, _entManager))
+            return false;
+
+        return Value == value;
+    }
+}

--- a/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatEqualsPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatEqualsPrecondition.cs
@@ -1,0 +1,18 @@
+﻿namespace Content.Server.NPC.HTN.Preconditions.Math;
+
+public sealed class KeyFloatEqualsPrecondition : HTNPrecondition
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    [DataField(required: true)]
+    public string Key = string.Empty;
+
+    [DataField(required: true)]
+    public float Value;
+
+    public override bool IsMet(NPCBlackboard blackboard)
+    {
+        return blackboard.TryGetValue<float>(NPCBlackboard.Owner, out var value, _entManager) &&
+               MathHelper.CloseTo(value, value);
+    }
+}

--- a/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatEqualsPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatEqualsPrecondition.cs
@@ -12,7 +12,7 @@ public sealed partial class KeyFloatEqualsPrecondition : HTNPrecondition
 
     public override bool IsMet(NPCBlackboard blackboard)
     {
-        return blackboard.TryGetValue<float>(NPCBlackboard.Owner, out var value, _entManager) &&
+        return blackboard.TryGetValue<float>(Key, out var value, _entManager) &&
                MathHelper.CloseTo(value, value);
     }
 }

--- a/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatEqualsPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatEqualsPrecondition.cs
@@ -1,6 +1,6 @@
 ﻿namespace Content.Server.NPC.HTN.Preconditions.Math;
 
-public sealed class KeyFloatEqualsPrecondition : HTNPrecondition
+public sealed partial class KeyFloatEqualsPrecondition : HTNPrecondition
 {
     [Dependency] private readonly IEntityManager _entManager = default!;
 

--- a/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatGreaterPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatGreaterPrecondition.cs
@@ -1,6 +1,6 @@
 ﻿namespace Content.Server.NPC.HTN.Preconditions.Math;
 
-public sealed class KeyFloatGreaterPrecondition : HTNPrecondition
+public sealed partial class KeyFloatGreaterPrecondition : HTNPrecondition
 {
     [Dependency] private readonly IEntityManager _entManager = default!;
 

--- a/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatGreaterPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatGreaterPrecondition.cs
@@ -1,0 +1,17 @@
+﻿namespace Content.Server.NPC.HTN.Preconditions.Math;
+
+public sealed class KeyFloatGreaterPrecondition : HTNPrecondition
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    [DataField(required: true)]
+    public string Key = string.Empty;
+
+    [DataField(required: true)]
+    public float Value;
+
+    public override bool IsMet(NPCBlackboard blackboard)
+    {
+        return blackboard.TryGetValue<float>(NPCBlackboard.Owner, out var value, _entManager) && value > Value;
+    }
+}

--- a/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatGreaterPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatGreaterPrecondition.cs
@@ -12,6 +12,6 @@ public sealed partial class KeyFloatGreaterPrecondition : HTNPrecondition
 
     public override bool IsMet(NPCBlackboard blackboard)
     {
-        return blackboard.TryGetValue<float>(NPCBlackboard.Owner, out var value, _entManager) && value > Value;
+        return blackboard.TryGetValue<float>(Key, out var value, _entManager) && value > Value;
     }
 }

--- a/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatLessPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatLessPrecondition.cs
@@ -1,6 +1,6 @@
 ﻿namespace Content.Server.NPC.HTN.Preconditions.Math;
 
-public sealed class KeyFloatLessPrecondition : HTNPrecondition
+public sealed partial class KeyFloatLessPrecondition : HTNPrecondition
 {
     [Dependency] private readonly IEntityManager _entManager = default!;
 

--- a/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatLessPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatLessPrecondition.cs
@@ -12,6 +12,6 @@ public sealed partial class KeyFloatLessPrecondition : HTNPrecondition
 
     public override bool IsMet(NPCBlackboard blackboard)
     {
-        return blackboard.TryGetValue<float>(NPCBlackboard.Owner, out var value, _entManager) && value < Value;
+        return blackboard.TryGetValue<float>(Key, out var value, _entManager) && value < Value;
     }
 }

--- a/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatLessPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/Math/KeyFloatLessPrecondition.cs
@@ -1,0 +1,17 @@
+﻿namespace Content.Server.NPC.HTN.Preconditions.Math;
+
+public sealed class KeyFloatLessPrecondition : HTNPrecondition
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    [DataField(required: true)]
+    public string Key = string.Empty;
+
+    [DataField(required: true)]
+    public float Value;
+
+    public override bool IsMet(NPCBlackboard blackboard)
+    {
+        return blackboard.TryGetValue<float>(NPCBlackboard.Owner, out var value, _entManager) && value < Value;
+    }
+}

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/AddFloatOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/AddFloatOperator.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Math;
+
+/// <summary>
+/// Gets the key, and adds the value to that float
+/// </summary>
+public sealed partial class AddFloatOperator : HTNOperator
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    [DataField(required: true)]
+    public string TargetKey = string.Empty;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float Amount;
+
+    public override async Task<(bool Valid, Dictionary<string, object>? Effects)> Plan(NPCBlackboard blackboard,
+        CancellationToken cancelToken)
+    {
+        if (!blackboard.TryGetValue<float>(NPCBlackboard.Owner, out var value, _entManager))
+            return (false, null);
+
+        return (
+            true,
+            new Dictionary<string, object>
+            {
+                { TargetKey, value + Amount }
+            }
+        );
+    }
+}

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/AddFloatOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/AddFloatOperator.cs
@@ -19,7 +19,7 @@ public sealed partial class AddFloatOperator : HTNOperator
     public override async Task<(bool Valid, Dictionary<string, object>? Effects)> Plan(NPCBlackboard blackboard,
         CancellationToken cancelToken)
     {
-        if (!blackboard.TryGetValue<float>(NPCBlackboard.Owner, out var value, _entManager))
+        if (!blackboard.TryGetValue<float>(TargetKey, out var value, _entManager))
             return (false, null);
 
         return (

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/SetBoolOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/SetBoolOperator.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Math;
+
+/// <summary>
+/// Just sets a blackboard key to a bool
+/// </summary>
+public sealed partial class SetBoolOperator : HTNOperator
+{
+    [DataField(required: true)]
+    public string TargetKey = string.Empty;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool Value;
+
+    public override async Task<(bool Valid, Dictionary<string, object>? Effects)> Plan(NPCBlackboard blackboard,
+        CancellationToken cancelToken)
+    {
+        return (
+            true,
+            new Dictionary<string, object>
+            {
+                { TargetKey, Value }
+            }
+        );
+    }
+}

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/SetFloatOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/SetFloatOperator.cs
@@ -1,24 +1,28 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators;
+namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Math;
 
 /// <summary>
 /// Just sets a blackboard key to a float
 /// </summary>
 public sealed partial class SetFloatOperator : HTNOperator
 {
-    [DataField("targetKey", required: true)] public string TargetKey = string.Empty;
+    [DataField(required: true)]
+    public string TargetKey = string.Empty;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("amount")]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float Amount;
 
     public override async Task<(bool Valid, Dictionary<string, object>? Effects)> Plan(NPCBlackboard blackboard,
         CancellationToken cancelToken)
     {
-        return (true, new Dictionary<string, object>()
-        {
-            {TargetKey, Amount},
-        });
+        return (
+            true,
+            new Dictionary<string, object>
+            {
+                { TargetKey, Amount }
+            }
+        );
     }
 }

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/SetRandomFloatOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/SetRandomFloatOperator.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Robust.Shared.Random;
+
+namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Math;
+
+/// <summary>
+/// Sets a random float from MinAmount to MaxAmount to blackboard
+/// </summary>
+public sealed class SetRandomFloatOperator : HTNOperator
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    [DataField(required: true)]
+    public string TargetKey = string.Empty;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float MaxAmount = 1f;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float MinAmount = 0f;
+
+    public override async Task<(bool Valid, Dictionary<string, object>? Effects)> Plan(NPCBlackboard blackboard,
+        CancellationToken cancelToken)
+    {
+        return (
+            true,
+            new Dictionary<string, object>
+            {
+                { TargetKey, _random.NextFloat(MinAmount, MaxAmount) }
+            }
+        );
+    }
+}

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/SetRandomFloatOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Math/SetRandomFloatOperator.cs
@@ -7,7 +7,7 @@ namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Math;
 /// <summary>
 /// Sets a random float from MinAmount to MaxAmount to blackboard
 /// </summary>
-public sealed class SetRandomFloatOperator : HTNOperator
+public sealed partial class SetRandomFloatOperator : HTNOperator
 {
     [Dependency] private readonly IRobustRandom _random = default!;
 

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/PlaySoundOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/PlaySoundOperator.cs
@@ -1,0 +1,28 @@
+﻿using Robust.Server.Audio;
+using Robust.Shared.Audio;
+
+namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators;
+
+public sealed partial class PlaySoundOperator : HTNOperator
+{
+    private AudioSystem _audio = default!;
+
+    [DataField(required: true)]
+    public SoundSpecifier? Sound;
+
+    public override void Initialize(IEntitySystemManager sysManager)
+    {
+        base.Initialize(sysManager);
+
+        _audio = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<AudioSystem>();
+    }
+
+    public override HTNOperatorStatus Update(NPCBlackboard blackboard, float frameTime)
+    {
+        var uid = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
+
+        _audio.PlayPvs(Sound, uid);
+
+        return base.Update(blackboard, frameTime);
+    }
+}

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/SayKeyOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/SayKeyOperator.cs
@@ -1,0 +1,36 @@
+﻿using Content.Server.Chat.Systems;
+
+namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators;
+
+public sealed partial class SayKeyOperator : HTNOperator
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    private ChatSystem _chat = default!;
+
+    [DataField(required: true)]
+    public string Key = string.Empty;
+
+    /// <summary>
+    /// Whether to hide message from chat window and logs.
+    /// </summary>
+    [DataField]
+    public bool Hidden;
+
+    public override void Initialize(IEntitySystemManager sysManager)
+    {
+        base.Initialize(sysManager);
+        _chat = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>();
+    }
+
+    public override HTNOperatorStatus Update(NPCBlackboard blackboard, float frameTime)
+    {
+        if (!blackboard.TryGetValue<object>(Key, out var value, _entManager))
+            return HTNOperatorStatus.Failed;
+
+        var speaker = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
+        _chat.TrySendInGameICMessage(speaker, value.ToString() ?? "Oh no...", InGameICChatType.Speak, hideChat: Hidden, hideLog: Hidden);
+
+        return base.Update(blackboard, frameTime);
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Debugging/debug_counter.yml
+++ b/Resources/Prototypes/Entities/Mobs/Debugging/debug_counter.yml
@@ -1,0 +1,53 @@
+- type: entity
+  parent: MobHuman
+  id: MobDebugCounter
+  name: debug counter
+  description: He can count
+  suffix: AI, DEBUG
+  components:
+    - type: HTN
+      rootTask:
+        task: DebugCounterCompound
+      blackboard:
+        MinimumIdleTime: !type:Single
+          0.5
+        MaximumIdleTime: !type:Single
+          0.5
+        Count: !type:Single
+          0
+
+- type: entity
+  parent: MobHuman
+  id: MobDebugRandomCounter
+  name: debug random counter
+  description: He can randomize
+  suffix: AI, DEBUG
+  components:
+    - type: HTN
+      rootTask:
+        task: DebugRandomCounterCompound
+      blackboard:
+        MinimumIdleTime: !type:Single
+          1
+        MaximumIdleTime: !type:Single
+          1
+        Count: !type:Single
+          0
+
+- type: entity
+  parent: MobHuman
+  id: MobDebugRandomLess
+  name: debug random less
+  description: He can lessing
+  suffix: AI, DEBUG
+  components:
+    - type: HTN
+      rootTask:
+        task: DebugRandomLessCompound
+      blackboard:
+        MinimumIdleTime: !type:Single
+          1
+        MaximumIdleTime: !type:Single
+          1
+        Count: !type:Single
+          0

--- a/Resources/Prototypes/NPCs/debug.yml
+++ b/Resources/Prototypes/NPCs/debug.yml
@@ -1,0 +1,90 @@
+- type: htnCompound
+  id: DebugCounterCompound
+  branches:
+    - tasks:
+      - !type:HTNPrimitiveTask
+        operator: !type:AddFloatOperator
+          targetKey: Count
+          amount: 1
+
+      - !type:HTNPrimitiveTask
+        operator: !type:SayKeyOperator
+          key: Count
+
+      - !type:HTNPrimitiveTask
+          operator: !type:RandomOperator
+            targetKey: IdleTime
+            minKey: MinimumIdleTime
+            maxKey: MaximumIdleTime
+
+      - !type:HTNPrimitiveTask
+        operator: !type:WaitOperator
+          key: IdleTime
+        preconditions:
+          - !type:KeyExistsPrecondition
+            key: IdleTime
+
+- type: htnCompound
+  id: DebugRandomCounterCompound
+  branches:
+    - tasks:
+      - !type:HTNPrimitiveTask
+        operator: !type:SetRandomFloatOperator
+          targetKey: Count
+          minAmount: 0
+          maxAmount: 100
+
+      - !type:HTNPrimitiveTask
+        operator: !type:SayKeyOperator
+          key: Count
+
+      - !type:HTNPrimitiveTask
+          operator: !type:RandomOperator
+            targetKey: IdleTime
+            minKey: MinimumIdleTime
+            maxKey: MaximumIdleTime
+
+      - !type:HTNPrimitiveTask
+        operator: !type:WaitOperator
+          key: IdleTime
+        preconditions:
+          - !type:KeyExistsPrecondition
+            key: IdleTime
+
+- type: htnCompound
+  id: DebugRandomLessCompound
+  branches:
+    - tasks:
+      - !type:HTNPrimitiveTask
+        operator: !type:SetRandomFloatOperator
+          targetKey: Count
+          minAmount: 0
+          maxAmount: 100
+
+      - !type:HTNPrimitiveTask
+        operator: !type:SayKeyOperator
+          key: Count
+        preconditions:
+          - !type:KeyFloatLessPrecondition
+            key: Count
+            value: 50
+      
+      - !type:HTNPrimitiveTask
+          operator: !type:RandomOperator
+            targetKey: IdleTime
+            minKey: MinimumIdleTime
+            maxKey: MaximumIdleTime
+
+      - !type:HTNPrimitiveTask
+        operator: !type:WaitOperator
+          key: IdleTime
+        preconditions:
+          - !type:KeyExistsPrecondition
+            key: IdleTime
+
+    - tasks:
+      - !type:HTNPrimitiveTask
+        operator: !type:SpeakOperator
+          speech: "fuck!"
+
+ 


### PR DESCRIPTION
## About the PR
At the code level (These operators are not used in prototypes), new prototypes have been added for various mathematical operations with float and bool, as well as playing music.

## Why / Balance
When designing complex monster behavior, I was faced with the need to create various state falsies, creating random delays that would act as an ability cooldown rather than a wait for the monster. Various distance checks, as well as sound effects.

## Technical details
Just new HTN operators, and moving some old ones to the new namespace "Math"

## Media
https://github.com/space-wizards/space-station-14/assets/54727692/0a6570ad-59f2-4a20-9692-7214980c9047

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Move `SetFloatOperator` from `Content.Server.NPC.HTN.PrimitiveTasks.Operators` -> `Content.Server.NPC.HTN.PrimitiveTasks.Operators.Math`
