### PR TITLE
remove Injector SolutionName constant

### DIFF
--- a/Content.Client/Chemistry/UI/InjectorStatusControl.cs
+++ b/Content.Client/Chemistry/UI/InjectorStatusControl.cs
@@ -32,7 +32,7 @@ public sealed class InjectorStatusControl : Control
     {
         base.FrameUpdate(args);
 
-        if (!_solutionContainers.TryGetSolution(_parent.Owner, InjectorComponent.SolutionName, out _, out var solution))
+        if (!_solutionContainers.TryGetSolution(_parent.Owner, _parent.Comp.SolutionName, out _, out var solution))
             return;
 
         // only updates the UI if any of the details are different than they previously were

--- a/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
@@ -124,7 +124,7 @@ public sealed class InjectorSystem : SharedInjectorSystem
             Popup.PopupEntity(Loc.GetString("injector-component-injecting-user"), target, user);
         }
 
-        if (!SolutionContainers.TryGetSolution(injector.Owner, InjectorComponent.SolutionName, out _, out var solution))
+        if (!SolutionContainers.TryGetSolution(injector.Owner, injector.Comp.SolutionName, out _, out var solution))
             return;
 
         var actualDelay = MathHelper.Max(injector.Comp.Delay, TimeSpan.FromSeconds(1));
@@ -254,7 +254,7 @@ public sealed class InjectorSystem : SharedInjectorSystem
     private void TryInject(Entity<InjectorComponent> injector, EntityUid targetEntity,
         Entity<SolutionComponent> targetSolution, EntityUid user, bool asRefill)
     {
-        if (!SolutionContainers.TryGetSolution(injector.Owner, InjectorComponent.SolutionName, out var soln,
+        if (!SolutionContainers.TryGetSolution(injector.Owner, injector.Comp.SolutionName, out var soln,
                 out var solution) || solution.Volume == 0)
             return;
 
@@ -296,7 +296,7 @@ public sealed class InjectorSystem : SharedInjectorSystem
     private void AfterInject(Entity<InjectorComponent> injector, EntityUid target)
     {
         // Automatically set syringe to draw after completely draining it.
-        if (SolutionContainers.TryGetSolution(injector.Owner, InjectorComponent.SolutionName, out _,
+        if (SolutionContainers.TryGetSolution(injector.Owner, injector.Comp.SolutionName, out _,
                 out var solution) && solution.Volume == 0)
         {
             SetMode(injector, InjectorToggleMode.Draw);
@@ -310,7 +310,7 @@ public sealed class InjectorSystem : SharedInjectorSystem
     private void AfterDraw(Entity<InjectorComponent> injector, EntityUid target)
     {
         // Automatically set syringe to inject after completely filling it.
-        if (SolutionContainers.TryGetSolution(injector.Owner, InjectorComponent.SolutionName, out _,
+        if (SolutionContainers.TryGetSolution(injector.Owner, injector.Comp.SolutionName, out _,
                 out var solution) && solution.AvailableVolume == 0)
         {
             SetMode(injector, InjectorToggleMode.Inject);
@@ -324,7 +324,7 @@ public sealed class InjectorSystem : SharedInjectorSystem
     private void TryDraw(Entity<InjectorComponent> injector, Entity<BloodstreamComponent?> target,
         Entity<SolutionComponent> targetSolution, EntityUid user)
     {
-        if (!SolutionContainers.TryGetSolution(injector.Owner, InjectorComponent.SolutionName, out var soln,
+        if (!SolutionContainers.TryGetSolution(injector.Owner, injector.Comp.SolutionName, out var soln,
                 out var solution) || solution.AvailableVolume == 0)
         {
             return;

--- a/Content.Shared/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Shared/Chemistry/Components/InjectorComponent.cs
@@ -24,7 +24,8 @@ public sealed partial class InjectorDoAfterEvent : SimpleDoAfterEvent
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class InjectorComponent : Component
 {
-    public const string SolutionName = "injector";
+    [DataField]
+    public string SolutionName = "injector";
 
     /// <summary>
     /// Whether or not the injector is able to draw from containers or if it's a single use

--- a/Content.Shared/Chemistry/EntitySystems/SharedInjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedInjectorSystem.cs
@@ -113,7 +113,7 @@ public abstract class SharedInjectorSystem : EntitySystem
         if (injector.Comp.InjectOnly)
             return;
 
-        if (!SolutionContainers.TryGetSolution(injector.Owner, InjectorComponent.SolutionName, out var solEnt, out var solution))
+        if (!SolutionContainers.TryGetSolution(injector.Owner, injector.Comp.SolutionName, out var solEnt, out var solution))
             return;
 
         string msg;


### PR DESCRIPTION
## About the PR
Replaced the constant with a normal variable. 

## Why / Balance
It doesn't make sense. Wherever this constant is used, there is direct access to injector parameters
This also blocks the ability to use InjectorComponent that use other solutions.

no fun, no cl, no game changes, cry