### PR TITLE
Fix Melee swing effect rotation

### DIFF
--- a/Content.Client/Weapons/Melee/Components/WeaponArcVisualsComponent.cs
+++ b/Content.Client/Weapons/Melee/Components/WeaponArcVisualsComponent.cs
@@ -6,6 +6,8 @@ namespace Content.Client.Weapons.Melee.Components;
 [RegisterComponent]
 public sealed partial class WeaponArcVisualsComponent : Component
 {
+    public EntityUid? User;
+
     [DataField("animation")]
     public WeaponArcAnimation Animation = WeaponArcAnimation.None;
 

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
@@ -55,7 +55,6 @@ public sealed partial class MeleeWeaponSystem
             if (meleeWeaponComponent.SwingLeft)
                 angle *= -1;
         }
-        sprite.NoRotation = true;
         sprite.Rotation = localPos.ToWorldAngle();
         var distance = Math.Clamp(localPos.Length() / 2f, 0.2f, 1f);
 
@@ -65,22 +64,19 @@ public sealed partial class MeleeWeaponSystem
         {
             case WeaponArcAnimation.Slash:
                 _animation.Play(animationUid, GetSlashAnimation(sprite, angle, spriteRotation), SlashAnimationKey);
-                TransformSystem.SetParent(animationUid, xform, user, userXform);
                 if (arcComponent.Fadeout)
                     _animation.Play(animationUid, GetFadeAnimation(sprite, 0.065f, 0.065f + 0.05f), FadeAnimationKey);
                 break;
             case WeaponArcAnimation.Thrust:
                 _animation.Play(animationUid, GetThrustAnimation(sprite, distance, spriteRotation), ThrustAnimationKey);
-                TransformSystem.SetParent(animationUid, xform, user, userXform);
                 if (arcComponent.Fadeout)
                     _animation.Play(animationUid, GetFadeAnimation(sprite, 0.05f, 0.15f), FadeAnimationKey);
                 break;
             case WeaponArcAnimation.None:
                 var (mapPos, mapRot) = TransformSystem.GetWorldPositionRotation(userXform);
-                TransformSystem.AttachToGridOrMap(animationUid, xform);
                 var worldPos = mapPos + (mapRot - userXform.LocalRotation).RotateVec(localPos);
                 var newLocalPos = TransformSystem.GetInvWorldMatrix(xform.ParentUid).Transform(worldPos);
-                TransformSystem.SetLocalPositionNoLerp(xform, newLocalPos);
+                TransformSystem.SetLocalPositionNoLerp(animationUid, newLocalPos, xform);
                 if (arcComponent.Fadeout)
                     _animation.Play(animationUid, GetFadeAnimation(sprite, 0f, 0.15f), FadeAnimationKey);
                 break;
@@ -98,7 +94,6 @@ public sealed partial class MeleeWeaponSystem
         var endRotationOffset = endRotation.RotateVec(new Vector2(0f, -1f));
         startRotation += spriteRotation;
         endRotation += spriteRotation;
-        sprite.NoRotation = true;
 
         return new Animation()
         {

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
@@ -63,11 +63,13 @@ public sealed partial class MeleeWeaponSystem
         switch (arcComponent.Animation)
         {
             case WeaponArcAnimation.Slash:
+                arcComponent.User = user;
                 _animation.Play(animationUid, GetSlashAnimation(sprite, angle, spriteRotation), SlashAnimationKey);
                 if (arcComponent.Fadeout)
                     _animation.Play(animationUid, GetFadeAnimation(sprite, 0.065f, 0.065f + 0.05f), FadeAnimationKey);
                 break;
             case WeaponArcAnimation.Thrust:
+                arcComponent.User = user;
                 _animation.Play(animationUid, GetThrustAnimation(sprite, distance, spriteRotation), ThrustAnimationKey);
                 if (arcComponent.Fadeout)
                     _animation.Play(animationUid, GetFadeAnimation(sprite, 0.05f, 0.15f), FadeAnimationKey);
@@ -199,5 +201,20 @@ public sealed partial class MeleeWeaponSystem
                 }
             }
         };
+    }
+
+    /// <summary>
+    /// Updates the effect positions to follow the user
+    /// </summary>
+    void UpdateEffects(float frameTime)
+    {
+        var arcQuery = EntityQueryEnumerator<TransformComponent, WeaponArcVisualsComponent>();
+        while(arcQuery.MoveNext(out var uid, out var xform, out var arcComponent))
+        {
+            if (arcComponent.User == null)
+                continue;
+            var userPos = TransformSystem.GetWorldPosition(arcComponent.User.Value);
+            TransformSystem.SetWorldPosition(xform, userPos);
+        }
     }
 }

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -46,6 +46,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
+        UpdateEffects(frameTime);
 
         if (!Timing.IsFirstTimePredicted)
             return;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Succeeds https://github.com/space-wizards/space-station-14/pull/21748
Fixes https://github.com/space-wizards/space-station-14/issues/17056
May or may not fix https://github.com/space-wizards/space-station-14/issues/20995, not reviving vehicles to test.

### Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bugfix.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Use the rotation
Thrust & slash effects are no longer `noRotate`, and thus behave as expected when the camera is rotated.
Melee swing effects are now parented to the mapgrid, rather than the user.
Melee swing effects (slash & thrust) are continously teleported to their user.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->


https://github.com/space-wizards/space-station-14/assets/4543739/20029512-0a22-480b-b755-1fb50ec5348e



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

### Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
not fun
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
