### PR TITLE
monkeys get a different deathgasp emote

### DIFF
--- a/Resources/Locale/en-US/chat/emotes.ftl
+++ b/Resources/Locale/en-US/chat/emotes.ftl
@@ -44,6 +44,7 @@ chat-emote-msg-clap = claps!
 chat-emote-msg-snap = snaps fingers
 chat-emote-msg-salute = salute
 chat-emote-msg-deathgasp = seizes up and falls limp, {POSS-ADJ($entity)} eyes dead and lifeless...
+chat-emote-msg-deathgasp-monkey = lets out a faint chimper as {SUBJECT($entity)} collapses and stops moving...
 chat-emote-msg-buzz = buzz!
 chat-emote-msg-chirp = chirps!
 chat-emote-msg-beep = beeps.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1155,6 +1155,8 @@
     templateId: monkey
     speciesId: monkey
   - type: InventorySlots
+  - type: Deathgasp
+    prototype: MonkeyDeathgasp
   - type: Cuffable
   - type: RotationVisuals
     defaultRotation: 90

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -349,6 +349,12 @@
   - deathgasp
 
 - type: emote
+  id: MonkeyDeathgasp
+  name: chat-emote-name-deathgasp
+  icon: Interface/Actions/scream.png
+  chatMessages: ["chat-emote-msg-deathgasp-monkey"]
+
+- type: emote
   id: Buzz
   name: chat-emote-name-buzz
   category: Vocal


### PR DESCRIPTION
## Why / Balance
it's cool
the emote is:
``the monkey lets out a faint chimper as it collapses and stops moving...``

## Media

https://github.com/space-wizards/space-station-14/assets/45323883/aff333ad-589c-4c22-9c41-edb66d9199a8



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase