### PR TITLE
Fix for four dir rotation error

### DIFF
--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -76,6 +76,8 @@ public abstract class SharedCombatModeSystem : EntitySystem
             return;
 
         component.IsInCombatMode = value;
+        Dirty(entity, component);
+
 
         if (component.CombatToggleActionEntity != null)
             _actionsSystem.SetToggled(component.CombatToggleActionEntity, component.IsInCombatMode);
@@ -85,7 +87,7 @@ public abstract class SharedCombatModeSystem : EntitySystem
             return;
 
         SetMouseRotatorComponents(entity, value);
-        Dirty(entity, component);
+        DirtyEntity(entity);
     }
 
     private void SetMouseRotatorComponents(EntityUid uid, bool value)

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -76,7 +76,6 @@ public abstract class SharedCombatModeSystem : EntitySystem
             return;
 
         component.IsInCombatMode = value;
-        Dirty(entity, component);
 
         if (component.CombatToggleActionEntity != null)
             _actionsSystem.SetToggled(component.CombatToggleActionEntity, component.IsInCombatMode);
@@ -86,6 +85,7 @@ public abstract class SharedCombatModeSystem : EntitySystem
             return;
 
         SetMouseRotatorComponents(entity, value);
+        Dirty(entity, component);
     }
 
     private void SetMouseRotatorComponents(EntityUid uid, bool value)

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -87,15 +87,15 @@ public abstract class SharedCombatModeSystem : EntitySystem
             return;
 
         SetMouseRotatorComponents(entity, value);
-        DirtyEntity(entity);
     }
 
-    private void SetMouseRotatorComponents(EntityUid uid, bool value)
+    private void SetMouseRotatorComponents(EntityUid entity, bool value)
     {
         if (value)
         {
-            EnsureComp<MouseRotatorComponent>(uid);
-            EnsureComp<NoRotateOnMoveComponent>(uid);
+            var mouseRotator = EnsureComp<MouseRotatorComponent>(entity);
+            Dirty(entity, mouseRotator);
+            var noRotate = EnsureComp<NoRotateOnMoveComponent>(entity);
         }
         else
         {

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -94,12 +94,12 @@ public abstract class SharedCombatModeSystem : EntitySystem
         {
             var mouseRotator = EnsureComp<MouseRotatorComponent>(entity);
             Dirty(entity, mouseRotator);
-            var noRotate = EnsureComp<NoRotateOnMoveComponent>(entity);
+            EnsureComp<NoRotateOnMoveComponent>(entity);
         }
         else
         {
-            RemComp<MouseRotatorComponent>(uid);
-            RemComp<NoRotateOnMoveComponent>(uid);
+            RemComp<MouseRotatorComponent>(entity);
+            RemComp<NoRotateOnMoveComponent>(entity);
         }
     }
 

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -78,7 +78,6 @@ public abstract class SharedCombatModeSystem : EntitySystem
         component.IsInCombatMode = value;
         Dirty(entity, component);
 
-
         if (component.CombatToggleActionEntity != null)
             _actionsSystem.SetToggled(component.CombatToggleActionEntity, component.IsInCombatMode);
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I'm working on #27510 and noticed that ``[ERRO] system.mouse_rotator: User localhost@JoeGenero (057c06c0-0b64-499c-95d2-0e84823a6a1a) tried setting 4-dir rotation directly without a valid mouse rotator component attached!`` gets thrown occasionally when I trigger combat mode and attack with insane lag, I fixed it by moving the entity dirtying to the lines after the comp gets added or removed to the entity

This unfortunately does not solve the issues I'm working towards, but it should get rid of the error in Grafana since it no longer shows up locally...

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
not player facing so nuh