### PR TITLE
Added Train station into map rotation

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -15,4 +15,4 @@
   - Saltern
   - Packed
   - Reach
-  #- Train <- return after station anchoring PR is finished and merged
+  - Train


### PR DESCRIPTION
## About the PR
Added Train station
#24927

there were two reasons why this card wasn't in the rotation yet.
the first is a random turn of the station at the beginning of the round. I fixed it in #26175
the second is waiting for the station anchor #26098 But, this pr has been delayed for a very long time, and as I see it, the station is quite playable without it. 

So I propose to include this station in the rotation, without the anchor for now.

**Changelog**

:cl:
- add: Added Train station!
