### PR TITLE
Simplified and consistent honkbot & jonkbot recipes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -555,7 +555,6 @@
   - type: Tag
     tags:
     - Trash
-    - HappyHonk
     - MimeHappyHonk
   - type: Sprite
     sprite: Objects/Storage/Happyhonk/mime.rsi
@@ -652,6 +651,10 @@
   name: woeful cluwne meal
   description: Nothing good can come of this.
   components:
+  - type: Tag
+    tags:
+    - Trash
+    - CluwneHappyHonk
   - type: Sprite
     sprite: Objects/Storage/Happyhonk/cluwne.rsi
     state: box

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/bots/honkbot.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/bots/honkbot.yml
@@ -6,17 +6,11 @@
     edges:
     - to: bot
       steps:
-      - tag: BoxHug
+      - tag: HappyHonk
         icon:
-          sprite: Objects/Storage/boxes.rsi
-          state: box_hug
-        name: box of hugs
-      - tag: ClownRubberStamp
-        icon:
-          sprite: Objects/Misc/stamps.rsi
-          state: stamp-clown
-        name: clown's rubber stamp
-        doAfter: 2
+          sprite: Objects/Storage/Happyhonk/clown.rsi
+          state: box
+        name: happy honk meal
       - tag: BikeHorn
         icon:
             sprite: Objects/Fun/bikehorn.rsi
@@ -45,21 +39,15 @@
     edges:
     - to: bot
       steps:
-      - tag: HappyHonk
+      - tag: CluwneHappyHonk
         icon:
-          sprite: Objects/Storage/Happyhonk/clown.rsi
+          sprite: Objects/Storage/Happyhonk/cluwne.rsi
           state: box
-        name: happy honk meal
-      - tag: ClownRubberStamp
-        icon:
-          sprite: Objects/Misc/stamps.rsi
-          state: stamp-clown
-        name: clown's rubber stamp
-        doAfter: 2
+        name: woeful cluwne meal
       - tag: CluwneHorn
         icon:
-            sprite: Objects/Fun/cluwnehorn.rsi
-            state: icon
+          sprite: Objects/Fun/cluwnehorn.rsi
+          state: icon
         name: broken bike horn
         doAfter: 2
       - tag: ProximitySensor

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -401,6 +401,9 @@
   id: ClownSuit
 
 - type: Tag
+  id: CluwneHappyHonk
+
+- type: Tag
   id: CluwneHorn
 
 - type: Tag


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- Honkbot recipe now uses `happy honk meal` instead of `box of hugs` and `clown's rubber stamp`
- Jonkbot recipe now uses `woeful cluwne meal` instead of `happy honk meal`
- Recipes with clown `happy honk meal` no longer accept _mime edition_ `happy honk meal`

## Why / Balance
Honkbots are funny little goobers but require clown spawn-exclusive box of hugs and clown's rubber stamp which are difficult to obtain (see #26481). Their recipe is adjusted to make them somewhat obtainable outside of clowns.

Each recipe now follows a theme of appropriate happy honk meal and horn/item (e.g. clown for honkbot, cluwne for jonkbot, mime for mimebot), making the recipes consistent and easier to remember. 

Despite this, they are unlikely to be spammed:
1) Bike horn spawns very rarely in clown happy honk meal
2) Broken bike horn spawns in a woeful cluwne meal, obtainable once from an emagged happyhonk vendor
3) Suspenders spawn very rarely in maints

The mime happy honk meal (already tagged with 'MimeHappyHonk') was erroneously tagged with 'HappyHonk', which has been removed to avoid substitution in honkbot recipe.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
yaml changes only

- honkbot.yml (recipe changes)
- tags.yml (`CluwneHappyHonk`)
- box.yml (added `CluwneHappyHonk` tag to woeful cluwne meal, removed `HappyHonk` tag from mime happy honk meal)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/20566341/79beac4d-1a90-48f1-a6cf-dd37c5a61b85)
![image](https://github.com/space-wizards/space-station-14/assets/20566341/4f740e35-4be1-4b47-8dda-1a24a47297e8)



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Possible conflict for files modifying tags.yml (lines 403 - 405)


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: DamnFeds
- tweak: honkbot now uses a happy honk meal instead of box of hugs and clown's rubber stamp. Honk!