### PR TITLE
Fix Loadout Editor not closing when Character Editor is closed.

### DIFF
--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -742,7 +742,6 @@ namespace Content.Client.Preferences.UI
             CharacterSlot = _preferencesManager.Preferences.SelectedCharacterIndex;
 
             UpdateAntagRequirements();
-            UpdateRoleRequirements();
             UpdateControls();
             ShowClothes.Pressed = true;
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixed a bug causing the loadout editor window to not close properly whenever the character editor was closed.

Fixes #27027

## Technical details
Removed a redundant UpdateRoleRequirements() call in LoadServerData() that was screwing up the updating order established inside UpdateControls(), where UpdateRoleRequirements() call needed to be done after UpdateLoadouts(). I suspect there may be more of these order-of-operation bugs floating around in the update logic but I'm not experienced enough with this codebase yet to really pursue them.

[ X] this PR does not require an ingame showcase
