### PR TITLE
Ninja's pinpointer tracks the research server

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -91,5 +91,5 @@
   - type: Icon
     state: pinpointer-station
   - type: Pinpointer
-    component: BecomesStation
+    component: ResearchServer
     targetName: the station


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This pr has the pinpointer of the ninja track the research server instead of BecomesStation.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I will admit this fix is as much of a hack as what it fixes. Basically, in order to track the station the ninja's pinpointer tries to track a grid with the BecomesStation component. The problem is, apparently every grid gets that when it's saved. This includes randomly spawned wreckage. This leads to the ninja tracking random wreckage in space.

So why ResearchServer? Well we can be sure that any station  which intends to have a playable science department(Hopefully every station) will have an RD server and wrecks do not. Its destruction is unbelievably rare, and it's loosely aligned with the ninja's objective to steal research.

I would have used the CommsConsole component instead since they can be expected to be on the station  and there are multiple of them making it less likely that the ninja's pinpointer will point to nothing. Unfortunately that component is on admin ghosts. As such it would allow ninjas to track admins which while funny, should not happen.

Alternative solutions:
- Have a special case for the pinpointer component where it will try to find the station instead of relying on a component. 
- Rewrite the pinpointer system so that instead of you giving it a component, stuff can have something like "PinpointerTrackableComponent" which would allow the ninja system to just add it to the active station when a ninja spawns.
- Have some marker component added to a grid when the station gets initialized. From what I understand this would go against the design of the current station system where there is no singular grid that is TheStationTM

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Ninjas will no longer be pointed to random wreckage in space.