### PR TITLE
add ghostnado button to warp menu

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml
@@ -1,5 +1,6 @@
 <DefaultWindow xmlns="https://spacestation14.io" Title="{Loc 'ghost-target-window-title'}" MinSize="450 450" SetSize="450 450">
     <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="0.4">
+        <Button Name="GhostnadoButton" Text="{Loc 'ghost-target-window-ghostnado'}" HorizontalAlignment="Center" Margin="0 4" />
         <LineEdit Name="SearchBar" PlaceHolder="Search" HorizontalExpand="True" Margin="0 4" />
         <ScrollContainer VerticalExpand="True" HorizontalExpand="True" HScrollEnabled="False">
             <BoxContainer Name="ButtonContainer" Orientation="Vertical" VerticalExpand="True" SeparationOverride="5">

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -15,11 +15,14 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
         private string _searchText = string.Empty;
 
         public event Action<NetEntity>? WarpClicked;
+        public event Action? OnGhostnadoClicked;
 
         public GhostTargetWindow()
         {
             RobustXamlLoader.Load(this);
             SearchBar.OnTextChanged += OnSearchTextChanged;
+
+            GhostnadoButton.OnPressed += _ => OnGhostnadoClicked?.Invoke();
         }
 
         public void UpdateWarps(IEnumerable<GhostWarp> warps)

--- a/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
@@ -111,6 +111,12 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
         _net.SendSystemNetworkMessage(msg);
     }
 
+    private void OnGhostnadoClicked()
+    {
+        var msg = new GhostnadoRequestEvent();
+        _net.SendSystemNetworkMessage(msg);
+    }
+
     public void LoadGui()
     {
         if (Gui == null)
@@ -120,6 +126,7 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
         Gui.ReturnToBodyPressed += ReturnToBody;
         Gui.GhostRolesPressed += GhostRolesPressed;
         Gui.TargetWindow.WarpClicked += OnWarpClicked;
+        Gui.TargetWindow.OnGhostnadoClicked += OnGhostnadoClicked;
 
         UpdateGui();
     }

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -43,9 +43,15 @@ namespace Content.Server.Ghost
         [Dependency] private readonly TransformSystem _transformSystem = default!;
         [Dependency] private readonly VisibilitySystem _visibilitySystem = default!;
 
+        private EntityQuery<GhostComponent> _ghostQuery;
+        private EntityQuery<PhysicsComponent> _physicsQuery;
+
         public override void Initialize()
         {
             base.Initialize();
+
+            _ghostQuery = GetEntityQuery<GhostComponent>();
+            _physicsQuery = GetEntityQuery<PhysicsComponent>();
 
             SubscribeLocalEvent<GhostComponent, ComponentStartup>(OnGhostStartup);
             SubscribeLocalEvent<GhostComponent, MapInitEvent>(OnMapInit);
@@ -62,6 +68,7 @@ namespace Content.Server.Ghost
             SubscribeNetworkEvent<GhostWarpsRequestEvent>(OnGhostWarpsRequest);
             SubscribeNetworkEvent<GhostReturnToBodyRequest>(OnGhostReturnToBodyRequest);
             SubscribeNetworkEvent<GhostWarpToTargetRequestEvent>(OnGhostWarpToTargetRequest);
+            SubscribeNetworkEvent<GhostnadoRequestEvent>(OnGhostnadoRequest);
 
             SubscribeLocalEvent<GhostComponent, BooActionEvent>(OnActionPerform);
             SubscribeLocalEvent<GhostComponent, ToggleGhostHearingActionEvent>(OnGhostHearingAction);
@@ -241,7 +248,7 @@ namespace Content.Server.Ghost
         private void OnGhostReturnToBodyRequest(GhostReturnToBodyRequest msg, EntitySessionEventArgs args)
         {
             if (args.SenderSession.AttachedEntity is not {Valid: true} attached
-                || !TryComp(attached, out GhostComponent? ghost)
+                || !_ghostQuery.TryComp(attached, out var ghost)
                 || !ghost.CanReturnToBody
                 || !TryComp(attached, out ActorComponent? actor))
             {
@@ -257,7 +264,7 @@ namespace Content.Server.Ghost
         private void OnGhostWarpsRequest(GhostWarpsRequestEvent msg, EntitySessionEventArgs args)
         {
             if (args.SenderSession.AttachedEntity is not {Valid: true} entity
-                || !HasComp<GhostComponent>(entity))
+                || !_ghostQuery.HasComp(entity))
             {
                 Log.Warning($"User {args.SenderSession.Name} sent a {nameof(GhostWarpsRequestEvent)} without being a ghost.");
                 return;
@@ -270,7 +277,7 @@ namespace Content.Server.Ghost
         private void OnGhostWarpToTargetRequest(GhostWarpToTargetRequestEvent msg, EntitySessionEventArgs args)
         {
             if (args.SenderSession.AttachedEntity is not {Valid: true} attached
-                || !TryComp(attached, out GhostComponent? _))
+                || !_ghostQuery.HasComp(attached))
             {
                 Log.Warning($"User {args.SenderSession.Name} tried to warp to {msg.Target} without being a ghost.");
                 return;
@@ -284,17 +291,37 @@ namespace Content.Server.Ghost
                 return;
             }
 
-            if ((TryComp(target, out WarpPointComponent? warp) && warp.Follow) || HasComp<MobStateComponent>(target))
+            WarpTo(attached, target);
+        }
+
+        private void OnGhostnadoRequest(GhostnadoRequestEvent msg, EntitySessionEventArgs args)
+        {
+            if (args.SenderSession.AttachedEntity is not {} uid
+                || !_ghostQuery.HasComp(uid))
             {
-                _followerSystem.StartFollowingEntity(attached, target);
+                Log.Warning($"User {args.SenderSession.Name} tried to ghostnado without being a ghost.");
                 return;
             }
 
-            var xform = Transform(attached);
-            _transformSystem.SetCoordinates(attached, xform, Transform(target).Coordinates);
-            _transformSystem.AttachToGridOrMap(attached, xform);
-            if (TryComp(attached, out PhysicsComponent? physics))
-                _physics.SetLinearVelocity(attached, Vector2.Zero, body: physics);
+            if (_followerSystem.GetMostFollowed() is not {} target)
+                return;
+
+            WarpTo(uid, target);
+        }
+
+        private void WarpTo(EntityUid uid, EntityUid target)
+        {
+            if ((TryComp(target, out WarpPointComponent? warp) && warp.Follow) || HasComp<MobStateComponent>(target))
+            {
+                _followerSystem.StartFollowingEntity(uid, target);
+                return;
+            }
+
+            var xform = Transform(uid);
+            _transformSystem.SetCoordinates(uid, xform, Transform(target).Coordinates);
+            _transformSystem.AttachToGridOrMap(uid, xform);
+            if (_physicsQuery.TryComp(uid, out var physics))
+                _physics.SetLinearVelocity(uid, Vector2.Zero, body: physics);
         }
 
         private IEnumerable<GhostWarp> GetLocationWarps()

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -247,6 +247,27 @@ public sealed class FollowerSystem : EntitySystem
             StopFollowingEntity(player, uid, followed);
         }
     }
+
+    /// <summary>
+    /// Get the most followed entity.
+    /// </summary>
+    public EntityUid? GetMostFollowed()
+    {
+        EntityUid? picked = null;
+        int most = 0;
+        var query = EntityQueryEnumerator<FollowedComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            var count = comp.Following.Count;
+            if (count > most)
+            {
+                picked = uid;
+                most = count;
+            }
+        }
+
+        return picked;
+    }
 }
 
 public abstract class FollowEvent : EntityEventArgs

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -126,6 +126,12 @@ namespace Content.Shared.Ghost
     }
 
     /// <summary>
+    /// A client to server request for their ghost to be warped to the most followed entity.
+    /// </summary>
+    [Serializable, NetSerializable]
+    public sealed class GhostnadoRequestEvent : EntityEventArgs;
+
+    /// <summary>
     /// A client to server request for their ghost to return to body
     /// </summary>
     [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/ghost/ghost-gui.ftl
+++ b/Resources/Locale/en-US/ghost/ghost-gui.ftl
@@ -10,6 +10,7 @@ ghost-gui-toggle-hearing-popup-off = You can now only hear radio and nearby mess
 
 ghost-target-window-title = Ghost Warp
 ghost-target-window-current-button = Warp: {$name}
+ghost-target-window-ghostnado = I'm feeling lucky
 
 ghost-roles-window-title = Ghost Roles
 ghost-roles-window-request-role-button = Request


### PR DESCRIPTION
## About the PR
ghostnado button that warps you to whoever is followed the most

## Why / Balance
the ghost gang grows

## Technical details
made some things use entity query
added `GetMostFollowed` to FollowerSystem

## Media
![22:56:06](https://github.com/space-wizards/space-station-14/assets/39013340/588d76c8-52f9-4947-a904-96bfdaf57e9d)
![22:56:11](https://github.com/space-wizards/space-station-14/assets/39013340/ef89bb01-9e6f-4260-a3c8-8a622e375628)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no ghost gang no fun