### PR TITLE
Make female reptilians use female cry sound instead of male

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1346,9 +1346,9 @@
     speechVerb: Reptilian
   - type: Vocal
     sounds:
-      Male: UnisexReptilian
-      Female: UnisexReptilian
-      Unsexed: UnisexReptilian
+      Male: MaleReptilian
+      Female: FemaleReptilian
+      Unsexed: MaleReptilian
   - type: TypingIndicator
     proto: lizard
   - type: InteractionPopup
@@ -2836,7 +2836,7 @@
         Slash: 6
         Piercing: 6
         Structural: 15
-  
+
 - type: entity
   name: space cat
   id: MobCatSpace

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -32,9 +32,9 @@
     proto: lizard
   - type: Vocal
     sounds:
-      Male: UnisexReptilian
-      Female: UnisexReptilian
-      Unsexed: UnisexReptilian
+      Male: MaleReptilian
+      Female: FemaleReptilian
+      Unsexed: MaleReptilian
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Scale

--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -72,7 +72,7 @@
       collection: Weh
 
 - type: emoteSounds
-  id: UnisexReptilian
+  id: MaleReptilian
   params:
     variation: 0.125
   sounds:
@@ -86,6 +86,24 @@
       collection: Whistles
     Crying:
       collection: MaleCry
+    Weh:
+      collection: Weh
+
+- type: emoteSounds
+  id: FemaleReptilian
+  params:
+    variation: 0.125
+  sounds:
+    Scream:
+      path: /Audio/Voice/Reptilian/reptilian_scream.ogg
+    Laugh:
+      path: /Audio/Animals/lizard_happy.ogg
+    Honk:
+      collection: BikeHorn
+    Whistle:
+      collection: Whistles
+    Crying:
+      collection: FemaleCry
     Weh:
       collection: Weh
 


### PR DESCRIPTION
## About the PR
Female reptilians use the female cry now, rather than the male one. Also affects kobolds since they share the same emoteSounds, though I've never heard one cry.

## Why / Balance
Reported by someone on Delta.

## Technical details
UnisexReptilian emoteSounds were removed and split up into male and female variants as with humans. Can't do much else unless someone contributes something "unisex" here like the laugh and scream are for reptilians. (I did not find any sounds to use here in the usual places.)

## Media
Not needed.

## Breaking changes
UnisexReptilian needs to be replaced with MaleReptilian/FemaleReptilian downstream if anything uses it for some reason.

**Changelog**
Not needed.