### PR TITLE
Increase Blast Grenade Recipe Cost and Add Research Requirement

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -165,7 +165,6 @@
     emagStaticRecipes:
       - BoxLethalshot
       - BoxShotgunFlare
-      - GrenadeBlast
       - MagazineBoxLightRifle
       - MagazineBoxMagnum
       - MagazineBoxPistol
@@ -187,6 +186,7 @@
       - BoxBeanbag
       - BoxShotgunIncendiary
       - BoxShotgunUranium
+      - GrenadeBlast
       - GrenadeEMP
       - GrenadeFlash
       - MagazineBoxLightRifleIncendiary
@@ -711,6 +711,7 @@
       - BoxShotgunUranium
       - ExplosivePayload
       - FlashPayload
+      - GrenadeBlast
       - GrenadeEMP
       - GrenadeFlash
       - HoloprojectorSecurity
@@ -731,6 +732,7 @@
       - MagazineRifleUranium
       - MagazineShotgunBeanbag
       - MagazineShotgunIncendiary
+      - PortableRecharger
       - PowerCageHigh
       - PowerCageMedium
       - PowerCageSmall
@@ -753,14 +755,6 @@
       - WeaponLaserCannon
       - WeaponLaserCarbine
       - WeaponXrayCannon
-      - PowerCageSmall
-      - PowerCageMedium
-      - PowerCageHigh
-      - ShuttleGunSvalinnMachineGunCircuitboard
-      - ShuttleGunPerforatorCircuitboard
-      - ShuttleGunFriendshipCircuitboard
-      - ShuttleGunDusterCircuitboard
-      - PortableRecharger
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -678,9 +678,9 @@
   result: GrenadeBlast
   completetime: 3
   materials:
-     Steel: 150
-     Plastic: 100
-     Gold: 50
+     Steel: 450
+     Plastic: 300
+     Gold: 150
      
 - type: latheRecipe
   id: GrenadeFlash

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -156,6 +156,7 @@
   - PowerCageMedium
   - MagazineGrenadeEmpty
   - GrenadeFlash
+  - GrenadeBlast
   - ShuttleGunSvalinnMachineGunCircuitboard
   - ShuttleGunPerforatorCircuitboard
   - ShuttleGunFriendshipCircuitboard


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Blast grenades have been added to the Tier 2 Basic Shuttle Armament research and turned into dynamic recipes at the autolathe and secfab.

Blast grenades have also had their current recipe cost tripled.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Blast grenades, otherwise known as china lake ammo, are rarely printed. But when they are, they are often printed in such large quantities that the person with the china lake or friendship is capable of bombarding the station nonstop for 20+ minutes or killing everyone on the station thrice over. This excessive amount of ammo does nothing but promote murderboning rather than any strategic usage of the ammo to achieve their goals. The price has been adjusted to reflect the amount of damage each grenade is capable of.

Besides that, it's been research gated to go along with the proper ship armaments that it is intended for in terms of NanoTrasen usage. Not sure why the secfab didn't have the blast grenade recipe before, but it does now. Maybe this will allow security to build their own combat shittle to fight nukies or something...

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
just yml stuff
I also deleted some recipes in the secfab that were duplicated for some reason and moved PortableRechargers up to where they should be alphabetically

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Blast grenades have had their manufacturing cost tripled.
- tweak: Blast grenades are now part of the Basic Shuttle Armament research and can be printed at the secfab.