### PR TITLE
Make immovable rod announce at the end of the event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -476,11 +476,11 @@
   noSpawn: true
   components:
   - type: StationEvent
-    startAnnouncement: station-event-immovable-rod-start-announcement
-    startAudio:
+    endAnnouncement: station-event-immovable-rod-start-announcement
+    endAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 5
-    duration: 1
+    duration: 25
     earliestStart: 45
     minimumPlayers: 20
   - type: ImmovableRodRule


### PR DESCRIPTION
fixes #27544 

https://github.com/space-wizards/space-station-14/assets/124214523/e1911107-adfa-444e-8655-2400355c51f5




:cl:
- tweak: Immovable rod announce now happens at the end of event.