### PR TITLE
Make UseDelay SetLength do EnsureComp

### DIFF
--- a/Content.Server/Fluids/EntitySystems/SpraySystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpraySystem.cs
@@ -144,7 +144,7 @@ public sealed class SpraySystem : EntitySystem
 
         _audio.PlayPvs(entity.Comp.SpraySound, entity, entity.Comp.SpraySound.Params.WithVariation(0.125f));
 
-        _useDelay.SetLength((entity, useDelay), TimeSpan.FromSeconds(cooldownTime));
+        _useDelay.SetLength(entity.Owner, TimeSpan.FromSeconds(cooldownTime));
         _useDelay.TryResetDelay((entity, useDelay));
     }
 }

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -135,11 +135,8 @@ public abstract class SharedStorageSystem : EntitySystem
 
     private void OnMapInit(Entity<StorageComponent> entity, ref MapInitEvent args)
     {
-        if (TryComp<UseDelayComponent>(entity, out var useDelayComp))
-        {
-            UseDelay.SetLength((entity, useDelayComp), entity.Comp.QuickInsertCooldown, QuickInsertUseDelayID);
-            UseDelay.SetLength((entity, useDelayComp), entity.Comp.OpenUiCooldown, OpenUiUseDelayID);
-        }
+        UseDelay.SetLength(entity.Owner, entity.Comp.QuickInsertCooldown, QuickInsertUseDelayID);
+        UseDelay.SetLength(entity.Owner, entity.Comp.OpenUiCooldown, OpenUiUseDelayID);
     }
 
     private void OnStorageGetState(EntityUid uid, StorageComponent component, ref ComponentGetState args)

--- a/Content.Shared/Timing/UseDelaySystem.cs
+++ b/Content.Shared/Timing/UseDelaySystem.cs
@@ -47,7 +47,7 @@ public sealed class UseDelaySystem : EntitySystem
     {
         // Set default delay length from the prototype
         // This makes it easier for simple use cases that only need a single delay
-        SetLength(ent, ent.Comp.Delay, DefaultId);
+        SetLength((ent, ent.Comp), ent.Comp.Delay, DefaultId);
     }
 
     private void OnUnpaused(Entity<UseDelayComponent> ent, ref EntityUnpausedEvent args)
@@ -62,9 +62,14 @@ public sealed class UseDelaySystem : EntitySystem
     /// <summary>
     /// Sets the length of the delay with the specified ID.
     /// </summary>
-    public bool SetLength(Entity<UseDelayComponent> ent, TimeSpan length, string id = DefaultId)
+    /// <remarks>
+    /// This will add a UseDelay component to the entity if it doesn't have one.
+    /// </remarks>
+    public bool SetLength(Entity<UseDelayComponent?> ent, TimeSpan length, string id = DefaultId)
     {
-        if (ent.Comp.Delays.TryGetValue(id, out var entry))
+        EnsureComp<UseDelayComponent>(ent.Owner, out var comp);
+
+        if (comp.Delays.TryGetValue(id, out var entry))
         {
             if (entry.Length == length)
                 return true;
@@ -73,7 +78,7 @@ public sealed class UseDelaySystem : EntitySystem
         }
         else
         {
-            ent.Comp.Delays.Add(id, new UseDelayInfo(length));
+            comp.Delays.Add(id, new UseDelayInfo(length));
         }
 
         Dirty(ent);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Calling `UseDelaySystem.SetLength` on an entity that doesn't have a `UseDelayComponent` will now add one to the entity. 

Fixes #27208 (but for real this time)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This makes it possible for other systems to use UseDelay without having to manually add the component to the YAML for entities that use it.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
SetLength now takes `Entity<UseDelayComponent?>` instead of `Entity<UseDelayComponent>` and uses EnsureComp to add the component if needed.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.