### PR TITLE
Four dir error fix

### DIFF
--- a/Content.Client/MouseRotator/MouseRotatorSystem.cs
+++ b/Content.Client/MouseRotator/MouseRotatorSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.MouseRotator;
+using Content.Shared.MouseRotator;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
@@ -14,7 +14,7 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IEyeManager _eye = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
 
     public override void Update(float frameTime)
     {
@@ -28,8 +28,6 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
         if (player == null || !TryComp<MouseRotatorComponent>(player, out var rotator))
             return;
 
-        var xform = Transform(player.Value);
-
         // Get mouse loc and convert to angle based on player location
         var coords = _input.MouseScreenPosition;
         var mapPos = _eye.PixelToMap(coords);
@@ -37,9 +35,8 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
         if (mapPos.MapId == MapId.Nullspace)
             return;
 
-        var angle = (mapPos.Position - xform.MapPosition.Position).ToWorldAngle();
-
-        var curRot = _transform.GetWorldRotation(xform);
+        var angle = (mapPos.Position - _transformSystem.GetMapCoordinates(player.Value).Position).ToWorldAngle();
+        var curRot = _transformSystem.GetWorldRotation(player.Value);
 
         // 4-dir handling is separate --
         // only raise event if the cardinal direction has changed

--- a/Content.Client/MouseRotator/MouseRotatorSystem.cs
+++ b/Content.Client/MouseRotator/MouseRotatorSystem.cs
@@ -35,8 +35,8 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
         if (mapPos.MapId == MapId.Nullspace)
             return;
 
-        var angle = (mapPos.Position - _transformSystem.GetMapCoordinates(player.Value).Position).ToWorldAngle();
-        var curRot = _transformSystem.GetWorldRotation(player.Value);
+        (var curPos, var curRot) = _transformSystem.GetWorldPositionRotation(player.Value);
+        var angle = (mapPos.Position - curPos).ToWorldAngle();
 
         // 4-dir handling is separate --
         // only raise event if the cardinal direction has changed

--- a/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
+++ b/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Interaction;
+using Content.Shared.Interaction;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.MouseRotator;
@@ -49,10 +49,14 @@ public abstract class SharedMouseRotatorSystem : EntitySystem
 
     private void OnRequestRotation(RequestMouseRotatorRotationEvent msg, EntitySessionEventArgs args)
     {
-        if (args.SenderSession.AttachedEntity is not { } ent
-            || !TryComp<MouseRotatorComponent>(ent, out var rotator) || rotator.Simple4DirMode)
+        if (args.SenderSession.AttachedEntity is not { } ent)
+            return;
+
+        var rotator = EnsureComp<MouseRotatorComponent>(ent);
+
+        if (rotator.Simple4DirMode)
         {
-            Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting local rotation directly without a valid mouse rotator component attached!");
+            Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting local rotation when in 4-dir rotation mode!");
             return;
         }
 
@@ -62,10 +66,14 @@ public abstract class SharedMouseRotatorSystem : EntitySystem
 
     private void OnRequestSimpleRotation(RequestMouseRotatorRotationSimpleEvent ev, EntitySessionEventArgs args)
     {
-        if (args.SenderSession.AttachedEntity is not { } ent
-            || !TryComp<MouseRotatorComponent>(ent, out var rotator) || !rotator.Simple4DirMode)
+        if (args.SenderSession.AttachedEntity is not { } ent)
+            return;
+
+        var rotator = EnsureComp<MouseRotatorComponent>(ent);
+
+        if (!rotator.Simple4DirMode)
         {
-            Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting 4-dir rotation directly without a valid mouse rotator component attached!");
+            Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting 4-dir rotation when not in 4-dir rotation mode!");
             return;
         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
#27510 aims to solve an error that was being thrown on the server when people lag and try to do things at the very start of activating harm mode

When the client-side MouseRotatorSystem throws a predicted event requesting mouse angle, ensured the MouseRotatorComponent exists in SharedMouseRotatorSystem so that it wouldn't throw an error on the server terminal regarding the server-side entity not yet having the MouseRotatorComponent

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
apparently it was spamming grafana

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Before:

https://github.com/space-wizards/space-station-14/assets/58439124/4d6a03b0-9224-403c-87ed-e9a5a0884b43

After:

https://github.com/space-wizards/space-station-14/assets/58439124/01684765-518c-4052-b697-4709af5f89b0

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
not player facing