### PR TITLE
Fix Gas Analyzers not opening

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
@@ -95,9 +95,9 @@ namespace Content.Server.Atmos.EntitySystems
             component.Enabled = true;
             Dirty(uid, component);
             UpdateAppearance(uid, component);
-            if (!HasComp<ActiveGasAnalyzerComponent>(uid))
-                AddComp<ActiveGasAnalyzerComponent>(uid);
+            EnsureComp<ActiveGasAnalyzerComponent>(uid);
             UpdateAnalyzer(uid, component);
+            OpenUserInterface(uid, user, component);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #27606

:cl:
- fix: Fix gas analyzers not opening their UI when used in-hand.