### PR TITLE
Pathological Liar

### DIFF
--- a/Content.Server/Speech/Components/ReplacementAccentComponent.cs
+++ b/Content.Server/Speech/Components/ReplacementAccentComponent.cs
@@ -32,5 +32,11 @@ namespace Content.Server.Speech.Components
     {
         [DataField("accent", customTypeSerializer: typeof(PrototypeIdSerializer<ReplacementAccentPrototype>), required: true)]
         public string Accent = default!;
+
+        /// <summary>
+        /// allows you to substitute words, not always, but with some chance
+        /// </summary>
+        [DataField]
+        public float ReplacementChance = 1f;
     }
 }

--- a/Content.Server/Speech/Components/ReplacementAccentComponent.cs
+++ b/Content.Server/Speech/Components/ReplacementAccentComponent.cs
@@ -34,7 +34,7 @@ namespace Content.Server.Speech.Components
         public string Accent = default!;
 
         /// <summary>
-        /// allows you to substitute words, not always, but with some chance
+        /// Allows you to substitute words, not always, but with some chance
         /// </summary>
         [DataField]
         public float ReplacementChance = 1f;

--- a/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
@@ -49,6 +49,12 @@ namespace Content.Server.Speech.EntitySystems
             if (prototype.WordReplacements == null)
                 return message;
 
+            // Prohibition of repeated word replacements.
+            // All replaced words placed in the final message are placed here as dashes (___) with the same length.
+            // The regex search goes through this buffer message, from which the already replaced words are crossed out,
+            // ensuring that the replaced words cannot be replaced again.
+            var maskMessage = message;
+
             foreach (var (first, replace) in prototype.WordReplacements)
             {
                 var f = _loc.GetString(first);
@@ -56,10 +62,10 @@ namespace Content.Server.Speech.EntitySystems
                 // this is kind of slow but its not that bad
                 // essentially: go over all matches, try to match capitalization where possible, then replace
                 // rather than using regex.replace
-                for (int i = Regex.Count(message, $@"(?<!\w){f}(?!\w)", RegexOptions.IgnoreCase); i > 0; i--)
+                for (int i = Regex.Count(maskMessage, $@"(?<!\w){f}(?!\w)", RegexOptions.IgnoreCase); i > 0; i--)
                 {
                     // fetch the match again as the character indices may have changed
-                    Match match = Regex.Match(message, $@"(?<!\w){f}(?!\w)", RegexOptions.IgnoreCase);
+                    Match match = Regex.Match(maskMessage, $@"(?<!\w){f}(?!\w)", RegexOptions.IgnoreCase);
                     var replacement = r;
 
                     // Intelligently replace capitalization
@@ -83,6 +89,8 @@ namespace Content.Server.Speech.EntitySystems
 
                     // In-place replace the match with the transformed capitalization replacement
                     message = message.Remove(match.Index, match.Length).Insert(match.Index, replacement);
+                    string mask = new string('_', match.Length);
+                    maskMessage = message.Remove(match.Index, match.Length).Insert(match.Index, mask);
                 }
             }
 

--- a/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server.Speech.EntitySystems
         {
             if (!_random.Prob(component.ReplacementChance))
                 return;
-            
+
             args.Message = ApplyReplacements(args.Message, component.Accent);
         }
 

--- a/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
@@ -24,6 +24,9 @@ namespace Content.Server.Speech.EntitySystems
 
         private void OnAccent(EntityUid uid, ReplacementAccentComponent component, AccentGetEvent args)
         {
+            if (!_random.Prob(component.ReplacementChance))
+                return;
+            
             args.Message = ApplyReplacements(args.Message, component.Accent);
         }
 

--- a/Resources/Locale/en-US/speech/speech-liar.ftl
+++ b/Resources/Locale/en-US/speech/speech-liar.ftl
@@ -34,11 +34,11 @@ liar-word-replacement-11 = isnt
 liar-word-12 = will
 liar-word-replacement-12 = wont
 
-liar-word-12 = go
-liar-word-replacement-12 = dont go
+liar-word-12 = not
+liar-word-replacement-12 = ""
 
-liar-word-13 = dont go
-liar-word-replacement-13 = go
+liar-word-13 = dont
+liar-word-replacement-13 = ""
 
 liar-word-14 = can
 liar-word-replacement-14 = cant
@@ -49,11 +49,11 @@ liar-word-replacement-15 = can
 liar-word-16 = should
 liar-word-replacement-16 = shouldnt
 
-liar-word-17 = do
-liar-word-replacement-17 = dont
+liar-word-17 = dead
+liar-word-replacement-17 = alive
 
-liar-word-18 = dont
-liar-word-replacement-18 = do
+liar-word-18 = alive
+liar-word-replacement-18 = dead
 
 liar-word-19 = does
 liar-word-replacement-19 = doesnt
@@ -89,7 +89,7 @@ liar-word-29 = do
 liar-word-replacement-29 = "don't"
 
 liar-word-30 = "don't"
-liar-word-replacement-30 = do
+liar-word-replacement-30 = ""
 
 liar-word-31 = does
 liar-word-replacement-31 = "doesn't"
@@ -112,3 +112,21 @@ liar-word-replacement-36 = nuh
 
 liar-word-37 = nuh
 liar-word-replacement-37 = yuh
+
+liar-word-38 = love
+liar-word-replacement-38 = hate
+
+liar-word-39 = hate
+liar-word-replacement-39 = love
+
+liar-word-40 = like
+liar-word-replacement-40 = don't like
+
+liar-word-41 = good
+liar-word-replacement-41 = bad
+
+liar-word-42 = bad
+liar-word-replacement-42 = good
+
+liar-word-42 = want
+liar-word-replacement-42 = "don't want"

--- a/Resources/Locale/en-US/speech/speech-liar.ftl
+++ b/Resources/Locale/en-US/speech/speech-liar.ftl
@@ -130,34 +130,3 @@ liar-word-replacement-42 = good
 
 liar-word-42 = want
 liar-word-replacement-42 = "don't want"
-
-liar-word-43 = help
-liar-word-replacement-43 = hurt
-
-liar-word-44 = hurt
-liar-word-replacement-44 = help
-
-liar-word-45 = help
-liar-word-replacement-45 = hurting
-
-liar-word-46 = hurt
-liar-word-replacement-46 = helping
-
-liar-word-47 = repair
-liar-word-replacement-47 = break
-
-liar-word-48 = break
-liar-word-replacement-48 = repair
-
-liar-word-49 = repairing
-liar-word-replacement-49 = breaking
-
-liar-word-50 = breaking
-liar-word-replacement-50 = repairing
-
-liar-word-51 = cold
-liar-word-replacement-51 = hot
-
-liar-word-52 = hot
-liar-word-replacement-52 = cold
-

--- a/Resources/Locale/en-US/speech/speech-liar.ftl
+++ b/Resources/Locale/en-US/speech/speech-liar.ftl
@@ -62,7 +62,7 @@ liar-word-20 = did
 liar-word-replacement-20 = didnt
 
 liar-word-21 = didnt
-liar-word-replacement-21 = did
+liar-word-replacement-21 = ""
 
 liar-word-22 = nothing
 liar-word-replacement-22 = something

--- a/Resources/Locale/en-US/speech/speech-liar.ftl
+++ b/Resources/Locale/en-US/speech/speech-liar.ftl
@@ -130,3 +130,34 @@ liar-word-replacement-42 = good
 
 liar-word-42 = want
 liar-word-replacement-42 = "don't want"
+
+liar-word-43 = help
+liar-word-replacement-43 = hurt
+
+liar-word-44 = hurt
+liar-word-replacement-44 = help
+
+liar-word-45 = help
+liar-word-replacement-45 = hurting
+
+liar-word-46 = hurt
+liar-word-replacement-46 = helping
+
+liar-word-47 = repair
+liar-word-replacement-47 = break
+
+liar-word-48 = break
+liar-word-replacement-48 = repair
+
+liar-word-49 = repairing
+liar-word-replacement-49 = breaking
+
+liar-word-50 = breaking
+liar-word-replacement-50 = repairing
+
+liar-word-51 = cold
+liar-word-replacement-51 = hot
+
+liar-word-52 = hot
+liar-word-replacement-52 = cold
+

--- a/Resources/Locale/en-US/speech/speech-liar.ftl
+++ b/Resources/Locale/en-US/speech/speech-liar.ftl
@@ -19,65 +19,59 @@ liar-word-replacement-6 = yep
 liar-word-7 = sure
 liar-word-replacement-7 = nah
 
-liar-word-8 = nah
-liar-word-replacement-8 = sure
+liar-word-8 = was
+liar-word-replacement-8 = wasnt
 
-liar-word-9 = absolutely
-liar-word-replacement-9 = not at all
+liar-word-9 = wasnt
+liar-word-replacement-9 = was
 
-liar-word-10 = not at all
-liar-word-replacement-10 = absolutely
+liar-word-10 = was
+liar-word-replacement-10 = wasnt
 
-liar-word-11 = definitely
-liar-word-replacement-11 = no way
+liar-word-11 = is
+liar-word-replacement-11 = isnt
 
-liar-word-12 = no way
-liar-word-replacement-12 = definitely
+liar-word-12 = will
+liar-word-replacement-12 = wont
 
-liar-word-13 = of course
-liar-word-replacement-13 = nope
+liar-word-12 = go
+liar-word-replacement-12 = dont go
 
-liar-word-14 = nope
-liar-word-replacement-14 = of course
+liar-word-13 = dont go
+liar-word-replacement-13 = go
 
-liar-word-15 = certainly
-liar-word-replacement-15 = nope
+liar-word-14 = can
+liar-word-replacement-14 = cant
 
-liar-word-16 = nope
-liar-word-replacement-16 = certainly
+liar-word-15 = cant
+liar-word-replacement-15 = can
 
-liar-word-17 = undoubtedly
-liar-word-replacement-17 = doubtfully
+liar-word-16 = should
+liar-word-replacement-16 = shouldnt
 
-liar-word-18 = doubtfully
-liar-word-replacement-18 = undoubtedly
+liar-word-17 = do
+liar-word-replacement-17 = dont
 
-liar-word-19 = sure thing
-liar-word-replacement-19 = no way
+liar-word-18 = dont
+liar-word-replacement-18 = do
 
-liar-word-20 = no way
-liar-word-replacement-20 = sure thing
+liar-word-19 = does
+liar-word-replacement-19 = doesnt
 
-liar-word-21 = absolutely
-liar-word-replacement-21 = not a chance
+liar-word-20 = did
+liar-word-replacement-20 = didnt
 
-liar-word-22 = not a chance
-liar-word-replacement-22 = absolutely
+liar-word-21 = didnt
+liar-word-replacement-21 = did
 
-liar-word-23 = for sure
-liar-word-replacement-23 = no chance
+liar-word-22 = nothing
+liar-word-replacement-22 = something
 
-liar-word-24 = no chance
-liar-word-replacement-24 = for sure
+liar-word-23 = something
+liar-word-replacement-23 = nothing
 
-liar-word-25 = yup
-liar-word-replacement-25 = nope
+liar-word-24 = somebody
+liar-word-replacement-24 = nobody
 
-liar-word-26 = nope
-liar-word-replacement-26 = yup
-
-liar-word-27 = affirmative
-liar-word-replacement-27 = negative
-
-liar-word-28 = negative
-liar-word-replacement-28 = affirmative
+liar-word-25 = nobody
+liar-word-replacement-25 = somebody

--- a/Resources/Locale/en-US/speech/speech-liar.ftl
+++ b/Resources/Locale/en-US/speech/speech-liar.ftl
@@ -75,3 +75,27 @@ liar-word-replacement-24 = nobody
 
 liar-word-25 = nobody
 liar-word-replacement-25 = somebody
+
+liar-word-26 = can
+liar-word-replacement-26 = can't
+
+liar-word-27 = can't
+liar-word-replacement-27 = can
+
+liar-word-28 = should
+liar-word-replacement-28 = shouldn't
+
+liar-word-29 = do
+liar-word-replacement-29 = don't
+
+liar-word-30 = don't
+liar-word-replacement-30 = do
+
+liar-word-31 = does
+liar-word-replacement-31 = doesn't
+
+liar-word-32 = did
+liar-word-replacement-32 = didn't
+
+liar-word-33 = didn't
+liar-word-replacement-33 = did

--- a/Resources/Locale/en-US/speech/speech-liar.ftl
+++ b/Resources/Locale/en-US/speech/speech-liar.ftl
@@ -1,0 +1,83 @@
+liar-word-1 = yes
+liar-word-replacement-1 = no
+
+liar-word-2 = no
+liar-word-replacement-2 = yes
+
+liar-word-3 = yeah
+liar-word-replacement-3 = nah
+
+liar-word-4 = nah
+liar-word-replacement-4 = yeah
+
+liar-word-5 = yep
+liar-word-replacement-5 = nope
+
+liar-word-6 = nope
+liar-word-replacement-6 = yep
+
+liar-word-7 = sure
+liar-word-replacement-7 = nah
+
+liar-word-8 = nah
+liar-word-replacement-8 = sure
+
+liar-word-9 = absolutely
+liar-word-replacement-9 = not at all
+
+liar-word-10 = not at all
+liar-word-replacement-10 = absolutely
+
+liar-word-11 = definitely
+liar-word-replacement-11 = no way
+
+liar-word-12 = no way
+liar-word-replacement-12 = definitely
+
+liar-word-13 = of course
+liar-word-replacement-13 = nope
+
+liar-word-14 = nope
+liar-word-replacement-14 = of course
+
+liar-word-15 = certainly
+liar-word-replacement-15 = nope
+
+liar-word-16 = nope
+liar-word-replacement-16 = certainly
+
+liar-word-17 = undoubtedly
+liar-word-replacement-17 = doubtfully
+
+liar-word-18 = doubtfully
+liar-word-replacement-18 = undoubtedly
+
+liar-word-19 = sure thing
+liar-word-replacement-19 = no way
+
+liar-word-20 = no way
+liar-word-replacement-20 = sure thing
+
+liar-word-21 = absolutely
+liar-word-replacement-21 = not a chance
+
+liar-word-22 = not a chance
+liar-word-replacement-22 = absolutely
+
+liar-word-23 = for sure
+liar-word-replacement-23 = no chance
+
+liar-word-24 = no chance
+liar-word-replacement-24 = for sure
+
+liar-word-25 = yup
+liar-word-replacement-25 = nope
+
+liar-word-26 = nope
+liar-word-replacement-26 = yup
+
+liar-word-27 = affirmative
+liar-word-replacement-27 = negative
+
+liar-word-28 = negative
+liar-word-replacement-28 = affirmative

--- a/Resources/Locale/en-US/speech/speech-liar.ftl
+++ b/Resources/Locale/en-US/speech/speech-liar.ftl
@@ -77,27 +77,27 @@ liar-word-25 = nobody
 liar-word-replacement-25 = somebody
 
 liar-word-26 = can
-liar-word-replacement-26 = can't
+liar-word-replacement-26 = "can't"
 
-liar-word-27 = can't
+liar-word-27 = "can't"
 liar-word-replacement-27 = can
 
 liar-word-28 = should
-liar-word-replacement-28 = shouldn't
+liar-word-replacement-28 = "shouldn't"
 
 liar-word-29 = do
-liar-word-replacement-29 = don't
+liar-word-replacement-29 = "don't"
 
-liar-word-30 = don't
+liar-word-30 = "don't"
 liar-word-replacement-30 = do
 
 liar-word-31 = does
-liar-word-replacement-31 = doesn't
+liar-word-replacement-31 = "doesn't"
 
 liar-word-32 = did
-liar-word-replacement-32 = didn't
+liar-word-replacement-32 = "didn't"
 
-liar-word-33 = didn't
+liar-word-33 = "didn't"
 liar-word-replacement-33 = did
 
 liar-word-34 = ye

--- a/Resources/Locale/en-US/speech/speech-liar.ftl
+++ b/Resources/Locale/en-US/speech/speech-liar.ftl
@@ -99,3 +99,16 @@ liar-word-replacement-32 = didn't
 
 liar-word-33 = didn't
 liar-word-replacement-33 = did
+
+liar-word-34 = ye
+liar-word-34-2 = ya
+liar-word-replacement-34 = na
+
+liar-word-35 = na
+liar-word-replacement-35 = ye
+
+liar-word-36 = yuh
+liar-word-replacement-36 = nuh
+
+liar-word-37 = nuh
+liar-word-replacement-37 = yuh

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -38,3 +38,6 @@ trait-southern-desc = You have a different way of speakin'.
 
 trait-snoring-name = Snoring
 trait-snoring-desc = You will snore while sleeping.
+
+trait-liar-name = Pathological liar
+trait-liar-desc = You can hardly bring yourself to tell the truth. Sometimes you lie anyway.

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -472,13 +472,3 @@
     liar-word-40: liar-word-replacement-40
     liar-word-41: liar-word-replacement-41
     liar-word-42: liar-word-replacement-42
-    liar-word-43: liar-word-replacement-43
-    liar-word-44: liar-word-replacement-44
-    liar-word-45: liar-word-replacement-45
-    liar-word-46: liar-word-replacement-46
-    liar-word-47: liar-word-replacement-47
-    liar-word-48: liar-word-replacement-48
-    liar-word-49: liar-word-replacement-49
-    liar-word-50: liar-word-replacement-50
-    liar-word-51: liar-word-replacement-51
-    liar-word-52: liar-word-replacement-52

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -454,6 +454,3 @@
     liar-word-23: liar-word-replacement-23
     liar-word-24: liar-word-replacement-24
     liar-word-25: liar-word-replacement-25
-    liar-word-26: liar-word-replacement-26
-    liar-word-27: liar-word-replacement-27
-    liar-word-28: liar-word-replacement-28

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -425,3 +425,35 @@
     chatsan-word-42: chatsan-replacement-42
     chatsan-word-43: chatsan-replacement-43
     chatsan-word-44: chatsan-replacement-44
+
+- type: accent
+  id: liar
+  wordReplacements:
+    liar-word-1: liar-word-replacement-1
+    liar-word-2: liar-word-replacement-2
+    liar-word-3: liar-word-replacement-3
+    liar-word-4: liar-word-replacement-4
+    liar-word-5: liar-word-replacement-5
+    liar-word-6: liar-word-replacement-6
+    liar-word-7: liar-word-replacement-7
+    liar-word-8: liar-word-replacement-8
+    liar-word-9: liar-word-replacement-9
+    liar-word-10: liar-word-replacement-10
+    liar-word-11: liar-word-replacement-11
+    liar-word-12: liar-word-replacement-12
+    liar-word-13: liar-word-replacement-13
+    liar-word-14: liar-word-replacement-14
+    liar-word-15: liar-word-replacement-15
+    liar-word-16: liar-word-replacement-16
+    liar-word-17: liar-word-replacement-17
+    liar-word-18: liar-word-replacement-18
+    liar-word-19: liar-word-replacement-19
+    liar-word-20: liar-word-replacement-20
+    liar-word-21: liar-word-replacement-21
+    liar-word-22: liar-word-replacement-22
+    liar-word-23: liar-word-replacement-23
+    liar-word-24: liar-word-replacement-24
+    liar-word-25: liar-word-replacement-25
+    liar-word-26: liar-word-replacement-26
+    liar-word-27: liar-word-replacement-27
+    liar-word-28: liar-word-replacement-28

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -472,3 +472,13 @@
     liar-word-40: liar-word-replacement-40
     liar-word-41: liar-word-replacement-41
     liar-word-42: liar-word-replacement-42
+    liar-word-43: liar-word-replacement-43
+    liar-word-44: liar-word-replacement-44
+    liar-word-45: liar-word-replacement-45
+    liar-word-46: liar-word-replacement-46
+    liar-word-47: liar-word-replacement-47
+    liar-word-48: liar-word-replacement-48
+    liar-word-49: liar-word-replacement-49
+    liar-word-50: liar-word-replacement-50
+    liar-word-51: liar-word-replacement-51
+    liar-word-52: liar-word-replacement-52

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -454,3 +454,11 @@
     liar-word-23: liar-word-replacement-23
     liar-word-24: liar-word-replacement-24
     liar-word-25: liar-word-replacement-25
+    liar-word-25: liar-word-replacement-26
+    liar-word-25: liar-word-replacement-27
+    liar-word-25: liar-word-replacement-28
+    liar-word-25: liar-word-replacement-29
+    liar-word-25: liar-word-replacement-30
+    liar-word-25: liar-word-replacement-31
+    liar-word-25: liar-word-replacement-32
+    liar-word-25: liar-word-replacement-33

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -454,11 +454,16 @@
     liar-word-23: liar-word-replacement-23
     liar-word-24: liar-word-replacement-24
     liar-word-25: liar-word-replacement-25
-    liar-word-25: liar-word-replacement-26
-    liar-word-25: liar-word-replacement-27
-    liar-word-25: liar-word-replacement-28
-    liar-word-25: liar-word-replacement-29
-    liar-word-25: liar-word-replacement-30
-    liar-word-25: liar-word-replacement-31
-    liar-word-25: liar-word-replacement-32
-    liar-word-25: liar-word-replacement-33
+    liar-word-26: liar-word-replacement-26
+    liar-word-27: liar-word-replacement-27
+    liar-word-28: liar-word-replacement-28
+    liar-word-29: liar-word-replacement-29
+    liar-word-30: liar-word-replacement-30
+    liar-word-31: liar-word-replacement-31
+    liar-word-32: liar-word-replacement-32
+    liar-word-33: liar-word-replacement-33
+    liar-word-34: liar-word-replacement-34
+    liar-word-34-2: liar-word-replacement-34
+    liar-word-35: liar-word-replacement-35
+    liar-word-36: liar-word-replacement-36
+    liar-word-37: liar-word-replacement-37

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -467,3 +467,8 @@
     liar-word-35: liar-word-replacement-35
     liar-word-36: liar-word-replacement-36
     liar-word-37: liar-word-replacement-37
+    liar-word-38: liar-word-replacement-38
+    liar-word-39: liar-word-replacement-39
+    liar-word-40: liar-word-replacement-40
+    liar-word-41: liar-word-replacement-41
+    liar-word-42: liar-word-replacement-42

--- a/Resources/Prototypes/Traits/neutral.yml
+++ b/Resources/Prototypes/Traits/neutral.yml
@@ -23,3 +23,12 @@
   description: trait-southern-desc
   components:
     - type: SouthernAccent
+
+- type: trait
+  id: Liar
+  name: trait-liar-name
+  description: trait-liar-desc
+  components:
+    - type: ReplacementAccent
+      replacementChance: 0.15
+      accent: liar


### PR DESCRIPTION
## About the PR
Added the trait accent “Pathological Liar.” The accent has a 15% chance of inverting your message to the opposite. Replacing “Yes” with “No”, “Can” with “can't” and so on.

![image](https://github.com/space-wizards/space-station-14/assets/96445749/a79e6631-0d96-4447-a57d-2680ca1ac559)

## Why / Balance
I thought it was really fun when instead of saying “no I didn't kill the clown” your character suddenly says “yes, I kill the clown”

**Changelog**

:cl:
- add: Added Pathological Liar trait accent. The accent has a 15% chance of inverting your message to the opposite. Replacing “Yes” with “No”, “Can” with “can't” and so on.
