### PR TITLE
Fix SpawnItemsOnUse not playing sound

### DIFF
--- a/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
+++ b/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
@@ -82,7 +82,9 @@ namespace Content.Server.Storage.EntitySystems
 
             if (component.Sound != null)
             {
-                _audio.PlayPvs(component.Sound, uid);
+                // The entity is often deleted, so play the sound at its position rather than parenting
+                var coordinates = Transform(uid).Coordinates;
+                _audio.PlayPvs(component.Sound, coordinates);
             }
 
             component.Uses--;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
`SpawnItemsOnUse` will now still play its sound on its last use.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #27616.

SpawnItemsOnUse deletes its own entity when its last charge is used, which deletes the attached audio source. This PR moves the audio source off of the entity and into the world so it doesn't get deleted.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Changed `SpawnItemsOnUse`'s call to `AudioSystem.PlayPvs` to use the overload that takes EntityCoordinates instead of an EntityUid. Coordinates are retrieved from the used entity with `Transform(uid).Coordinates`.

This means that the audio source is no longer parented to the used entity, but instead parented to the used entity's parent (typically the grid) at the same location. This allows the sound to play correctly when the used entity is deleted (as is often the case with SpawnItemsOnUse).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.