### PR TITLE
small SpawnItemsOnUse cleanup

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/figurine_boxes.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/figurine_boxes.yml
@@ -133,3 +133,5 @@
       - id: ToyFigurineHamlet
         prob: 0.20
         orGroup: SpacemenFig
+    sound:
+      path: /Audio/Effects/unwrap.ogg

--- a/Resources/Prototypes/Entities/Objects/Fun/figurine_boxes.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/figurine_boxes.yml
@@ -133,5 +133,3 @@
       - id: ToyFigurineHamlet
         prob: 0.20
         orGroup: SpacemenFig
-    sound:
-      path: /Audio/Effects/unwrap.ogg

--- a/Resources/Prototypes/Entities/Objects/Misc/chopsticks.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/chopsticks.yml
@@ -23,9 +23,8 @@
   - type: SpawnItemsOnUse
     items:
       - id: ChopSticks
+    sound:
+      path: /Audio/Effects/chopstickbreak.ogg
   - type: Sprite
     sprite: Objects/Misc/chopstick.rsi
     state: paired
-  - type: EmitSoundOnUse
-    sound:
-      path: /Audio/Effects/chopstickbreak.ogg


### PR DESCRIPTION
Small follow up to #27621.
See #27616 for more information.

Removes an unnecessary component from chopsticks.
~~Adds missing unwrap sound to the figurine box.~~

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
no fun
