### PR TITLE
Wine and beer bottles can be inserted into booze dispenser

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -362,6 +362,7 @@
   - type: Tag
     tags:
     - Wine
+    - DrinkBottle
 
 - type: entity
   parent: [DrinkBottleVisualsAll, DrinkBottleGlassBaseFull]
@@ -511,6 +512,7 @@
   - type: Tag
     tags:
     - Wine
+    - DrinkBottle
 
 # Small Bottles
 
@@ -536,6 +538,7 @@
   - type: Tag
     tags:
     - Beer
+    - DrinkBottle
 
 - type: entity
   parent: [DrinkBottleVisualsAll, DrinkBottleGlassBaseFull]
@@ -559,7 +562,7 @@
   - type: Tag
     tags:
     - Beer
-
+    - DrinkBottle
 
 - type: entity
   parent: [DrinkBottleVisualsAll, DrinkBottlePlasticBaseFull]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes #27445 by allowing wine DrinkWineBottleFull, DrinkPoisonWinebottleFull DrinkBeerBottleFull, DrinkBeerGrowler to be inserted into booze dispenser.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The aforementioned entities use their own Wine and Beer tags respectively, overriding the DrinkBottle tag inherited from their parent entities (eventually DrinkBottlePlasticBaseFull). This PR adds the DrinkBottle tag in addition to the Wine and Beer tags in the respective entities.

Ultimately tags should probably be additive on inheirtance, so parent DrinkBottle would become DrinkBottle and Wine/Beer on the child, but that is outside the scope of this PR.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Wine and beer bottles can now be inserted into the booze dispenser.

