### PR TITLE
Revolutionaries can now cuff command instead of killing/exiling them

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -180,7 +180,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
             commandList.Add(id);
         }
 
-        return IsGroupDetainedOrDead(commandList, true);
+        return IsGroupDetainedOrDead(commandList, true, true);
     }
 
     private void OnHeadRevMobStateChanged(EntityUid uid, HeadRevolutionaryComponent comp, MobStateChangedEvent ev)
@@ -204,7 +204,8 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         }
 
         // If no Head Revs are alive all normal Revs will lose their Rev status and rejoin Nanotrasen
-        if (IsGroupDetainedOrDead(headRevList, false))
+        // Cuffing Head Revs is not enough - they must be killed.
+        if (IsGroupDetainedOrDead(headRevList, false, false))
         {
             var rev = AllEntityQuery<RevolutionaryComponent, MindContainerComponent>();
             while (rev.MoveNext(out var uid, out _, out var mc))
@@ -240,13 +241,14 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     /// </summary>
     /// <param name="list">The list of the entities</param>
     /// <param name="checkOffStation">Bool for if you want to check if someone is in space and consider them missing in action. (Won't check when emergency shuttle arrives just in case)</param>
+    /// <param name="countCuffed">Bool for if you don't want to count cuffed entities.</param>
     /// <returns></returns>
-    private bool IsGroupDetainedOrDead(List<EntityUid> list, bool checkOffStation)
+    private bool IsGroupDetainedOrDead(List<EntityUid> list, bool checkOffStation, bool countCuffed)
     {
         var gone = 0;
         foreach (var entity in list)
         {
-            if (TryComp<CuffableComponent>(entity, out var cuffed) && cuffed.CuffedHandCount > 0)
+            if (TryComp<CuffableComponent>(entity, out var cuffed) && cuffed.CuffedHandCount > 0 && countCuffed)
             {
                 gone++;
             }

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -28,6 +28,7 @@ using Content.Shared.Zombies;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Server.GameTicking.Components;
+using Content.Shared.Cuffs.Components;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -179,7 +180,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
             commandList.Add(id);
         }
 
-        return IsGroupDead(commandList, true);
+        return IsGroupDetainedOrDead(commandList, true);
     }
 
     private void OnHeadRevMobStateChanged(EntityUid uid, HeadRevolutionaryComponent comp, MobStateChangedEvent ev)
@@ -203,7 +204,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         }
 
         // If no Head Revs are alive all normal Revs will lose their Rev status and rejoin Nanotrasen
-        if (IsGroupDead(headRevList, false))
+        if (IsGroupDetainedOrDead(headRevList, false))
         {
             var rev = AllEntityQuery<RevolutionaryComponent, MindContainerComponent>();
             while (rev.MoveNext(out var uid, out _, out var mc))
@@ -235,35 +236,42 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     }
 
     /// <summary>
-    /// Will take a group of entities and check if they are all alive or dead
+    /// Will take a group of entities and check if these entities are alive, dead or cuffed.
     /// </summary>
     /// <param name="list">The list of the entities</param>
-    /// <param name="checkOffStation">Bool for if you want to check if someone is in space and consider them dead. (Won't check when emergency shuttle arrives just in case)</param>
+    /// <param name="checkOffStation">Bool for if you want to check if someone is in space and consider them missing in action. (Won't check when emergency shuttle arrives just in case)</param>
     /// <returns></returns>
-    private bool IsGroupDead(List<EntityUid> list, bool checkOffStation)
+    private bool IsGroupDetainedOrDead(List<EntityUid> list, bool checkOffStation)
     {
-        var dead = 0;
+        var gone = 0;
         foreach (var entity in list)
         {
-            if (TryComp<MobStateComponent>(entity, out var state))
+            if (TryComp<CuffableComponent>(entity, out var cuffed) && cuffed.CuffedHandCount > 0)
             {
-                if (state.CurrentState == MobState.Dead || state.CurrentState == MobState.Invalid)
-                {
-                    dead++;
-                }
-                else if (checkOffStation && _stationSystem.GetOwningStation(entity) == null && !_emergencyShuttle.EmergencyShuttleArrived)
-                {
-                    dead++;
-                }
+                gone++;
             }
-            //If they don't have the MobStateComponent they might as well be dead.
             else
             {
-                dead++;
+                if (TryComp<MobStateComponent>(entity, out var state))
+                {
+                    if (state.CurrentState == MobState.Dead || state.CurrentState == MobState.Invalid)
+                    {
+                        gone++;
+                    }
+                    else if (checkOffStation && _stationSystem.GetOwningStation(entity) == null && !_emergencyShuttle.EmergencyShuttleArrived)
+                    {
+                        gone++;
+                    }
+                }
+                //If they don't have the MobStateComponent they might as well be dead.
+                else
+                {
+                    gone++;
+                }
             }
         }
 
-        return dead == list.Count || list.Count == 0;
+        return gone == list.Count || list.Count == 0;
     }
 
     private static readonly string[] Outcomes =

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
@@ -5,31 +5,31 @@ roles-antag-rev-head-objective = Your objective is to take over the station by c
 
 head-rev-role-greeting =
     You are a Head Revolutionary.
-    You are tasked with removing all of Command from station via death or exilement.
+    You are tasked with removing all of Command from station via death, exilement or imprisonment.
     The Syndicate has sponsored you with a flash that converts the crew to your side.
     Beware, this won't work on Security, Command, or those wearing sunglasses.
     Viva la revolución!
 
 head-rev-briefing =
     Use flashes to convert people to your cause.
-    Kill all heads to take over the station.
+    Get rid of all heads to take over the station.
 
 head-rev-break-mindshield = The Mindshield was destroyed!
 
 ## Rev
 
 roles-antag-rev-name = Revolutionary
-roles-antag-rev-objective = Your objective is to ensure the safety and follow the orders of the Head Revolutionaries as well as killing all Command staff on station.
+roles-antag-rev-objective = Your objective is to ensure the safety and follow the orders of the Head Revolutionaries as well as getting rid of all Command staff on station.
 
 rev-break-control = {$name} has remembered their true allegiance!
 
 rev-role-greeting =
     You are a Revolutionary.
     You are tasked with taking over the station and protecting the Head Revolutionaries.
-    Eliminate all of the Command staff.
+    Get rid of all of the Command staff.
     Viva la revolución!
 
-rev-briefing = Help your head revolutionaries kill every head to take over the station.
+rev-briefing = Help your head revolutionaries get rid of every head to take over the station.
 
 ## General
 
@@ -40,9 +40,7 @@ rev-not-enough-ready-players = Not enough players readied up for the game. There
 rev-no-one-ready = No players readied up! Can't start a Revolution.
 rev-no-heads = There were no Head Revolutionaries to be selected. Can't start a Revolution.
 
-rev-all-heads-dead = All the heads are dead, now finish up the rest of the crew!
-
-rev-won = The Head Revs survived and killed all of Command.
+rev-won = The Head Revs survived and successfully seized control of the station.
 
 rev-lost = Command survived and killed all of the Head Revs.
 

--- a/Resources/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml
@@ -4,13 +4,13 @@
   - Revolutionaries are antagonists that are sponsored by the Syndicate to take over the station.
 
   ## Head Revolutionaries
-  
+
 <Box>
   <GuideEntityEmbed Entity="Flash" Caption="Flash"/>
   <GuideEntityEmbed Entity="ClothingEyesGlassesSunglasses" Caption="Sunglasses"/>
 </Box>
 
-  [color=#5e9cff]Head Revolutionaries[/color] are chosen at the start of the shift and are tasked with taking over the station by killing or exiling all of the Command staff. Head Revolutionaries will be given a [color=#a4885c]Flash[/color] and a pair of [color=#a4885c]Sunglasses[/color] to aid them.
+  [color=#5e9cff]Head Revolutionaries[/color] are chosen at the start of the shift and are tasked with taking over the station by killing, exiling or cuffing all of the Command staff. Head Revolutionaries will be given a [color=#a4885c]Flash[/color] and a pair of [color=#a4885c]Sunglasses[/color] to aid them.
 
   ## Conversion
 
@@ -41,7 +41,7 @@
 
   ## Objectives
 
-  You must eliminate or exile all of the following Command staff on station in no particular order.
+  You must eliminate, exile or arrest all of the following Command staff on station in no particular order.
   - Captain
   - Head of Personnel
   - Chief Engineer


### PR DESCRIPTION
## About the PR
Cuffed command no longer counts as a blocking condition for Revolutionaries victory, meaning that you can win as Headrev upon cuffing all of the command members. However, Head Revolutionaries still have to be killed for Crew Victory.

## Why / Balance
More roleplay, less murderbone

## Technical details

## Media
https://youtu.be/k4HHPlTHpj8
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl:
- tweak: Revolutionaries can now cuff command members in order to seize control of the station.