### PR TITLE
Fixes the grammar for the captain's supervisor

### DIFF
--- a/Resources/Locale/en-US/job/job-supervisors.ftl
+++ b/Resources/Locale/en-US/job/job-supervisors.ftl
@@ -1,4 +1,4 @@
-job-supervisors-centcom = CentCom official
+job-supervisors-centcom = Central Command
 job-supervisors-captain = the captain
 job-supervisors-hop = the head of personnel
 job-supervisors-hos = the head of security


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Currently the captain's chain of command introduction on role start is grammatically incorrect, it states "As the Captain you answer directly to _CentCom official_" [emphasis added]. It should either be, 'the CentCom offical', 'CentCom officals' or as I've gone, simply 'Central Command' to match the CentCom announcements.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
before
![Screenshot from 2024-05-03 11-54-30](https://github.com/space-wizards/space-station-14/assets/96937466/3fdb66f5-1fbd-4edd-9be9-936714f60867)

after
![Screenshot from 2024-05-03 11-56-29](https://github.com/space-wizards/space-station-14/assets/96937466/29a27c4e-ecde-4bfe-8694-3b95e15cdf64)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

