### PR TITLE
Dock device link port

### DIFF
--- a/Content.Server/Shuttles/Components/DockingSignalControlComponent.cs
+++ b/Content.Server/Shuttles/Components/DockingSignalControlComponent.cs
@@ -1,0 +1,14 @@
+using Content.Shared.DeviceLinking;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Shuttles.Components;
+
+[RegisterComponent]
+public sealed partial class DockingSignalControlComponent : Component
+{
+    /// <summary>
+    /// Output port that is high while docked.
+    /// </summary>
+    [DataField]
+    public ProtoId<SourcePortPrototype> DockStatusSignalPort = "DockStatus";
+}

--- a/Content.Server/Shuttles/Systems/DockingSignalControlSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSignalControlSystem.cs
@@ -1,0 +1,28 @@
+using Content.Server.DeviceLinking.Systems;
+using Content.Server.Shuttles.Components;
+using Content.Server.Shuttles.Events;
+
+namespace Content.Server.Shuttles.Systems;
+
+public sealed class DockingSignalControlSystem : EntitySystem
+{
+    [Dependency] private readonly DeviceLinkSystem _deviceLinkSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DockingSignalControlComponent, DockEvent>(OnDocked);
+        SubscribeLocalEvent<DockingSignalControlComponent, UndockEvent>(OnUndocked);
+    }
+
+    private void OnDocked(Entity<DockingSignalControlComponent> ent, ref DockEvent args)
+    {
+        _deviceLinkSystem.SendSignal(ent, ent.Comp.DockStatusSignalPort, signal: true);
+    }
+
+    private void OnUndocked(Entity<DockingSignalControlComponent> ent, ref UndockEvent args)
+    {
+        _deviceLinkSystem.SendSignal(ent, ent.Comp.DockStatusSignalPort, signal: false);
+    }
+}

--- a/Resources/Locale/en-US/machine-linking/transmitter_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/transmitter_ports.ftl
@@ -19,6 +19,9 @@ signal-port-description-right = This port is invoked whenever the lever is moved
 signal-port-name-doorstatus = Door status
 signal-port-description-doorstatus = This port is invoked with HIGH when the door opens and LOW when the door finishes closing.
 
+signal-port-name-dockstatus = Dock status
+signal-port-description-dockstatus = This port is invoked with HIGH when docked and LOW when undocked.
+
 signal-port-name-middle = Middle
 signal-port-description-middle = This port is invoked whenever the lever is moved to the neutral position.
 

--- a/Resources/Prototypes/DeviceLinking/source_ports.yml
+++ b/Resources/Prototypes/DeviceLinking/source_ports.yml
@@ -46,6 +46,11 @@
   defaultLinks: [ DoorBolt ]
 
 - type: sourcePort
+  id: DockStatus
+  name: signal-port-name-dockstatus
+  description: signal-port-description-dockstatus
+
+- type: sourcePort
   id: OrderSender
   name: signal-port-name-order-sender
   description: signal-port-description-order-sender

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -6,6 +6,11 @@
   description: Necessary for connecting two space craft together.
   components:
   - type: Docking
+  - type: DockingSignalControl
+  - type: DeviceLinkSource
+    ports:
+      - DoorStatus
+      - DockStatus
   - type: Fixtures
     fixtures:
       fix1:
@@ -75,7 +80,6 @@
   suffix: Glass, Docking
   description: Necessary for connecting two space craft together.
   components:
-  - type: Docking
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/shuttle.rsi
     snapCardinals: false
@@ -127,7 +131,6 @@
   suffix: Glass, Docking
   description: Necessary for connecting two space craft together.
   components:
-  - type: Docking
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/shuttle_syndicate.rsi
     snapCardinals: false


### PR DESCRIPTION
## About the PR
Adds a new port "dock status" to the shuttle dock airlocks.
Also very minor yaml cleanup removing redundant Docking comp since it's inherited from the parent. 

## Why / Balance
External airlocks are often linked to bolt each other when opened, to avoid spacing. This doesn't work very well for dock airlocks, since those are always open while docked, so the other airlock would always be bolted.

This new port offers a solution: connect both "door status" and "dock status" to an xor gate, and the xor output to the other airlock's bolt port. Now the other airlock will only bolt if the dock is open but not docked.

This can also be used to keep a dock always closed and bolted while it is not docked, by connecting both door and dock status to a nor gate. Sadly, the dock won't auto open after docking since it doesn't unbolt in time, so you have to open it manually after docking.

Mini fans still have to stay due to docks being buggy with atmos, but when that is fixed, mappers could opt to replace them with logic gates instead.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/48867431/0e2e1f66-78a8-466f-b7e0-70895485b9e4)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Shuttle docks now have a "dock status" device link port