### PR TITLE
Do not wake up NPC if there is still a mind attached.

### DIFF
--- a/Content.Server/NPC/Systems/NPCSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSystem.cs
@@ -52,7 +52,7 @@ namespace Content.Server.NPC.Systems
                 return;
 
             // This NPC has an attached mind, so it should not wake up.
-            if (TryComp<MindContainerComponent>(uid, out var mindContainer) && mindContainer.Mind != null)
+            if (TryComp<MindContainerComponent>(uid, out var mindContainer) && mindContainer.HasMind)
                 return;
 
             WakeNPC(uid, component);

--- a/Content.Server/NPC/Systems/NPCSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSystem.cs
@@ -2,6 +2,8 @@ using System.Diagnostics.CodeAnalysis;
 using Content.Server.NPC.Components;
 using Content.Server.NPC.HTN;
 using Content.Shared.CCVar;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.NPC;
@@ -47,6 +49,10 @@ namespace Content.Server.NPC.Systems
         public void OnPlayerNPCDetach(EntityUid uid, HTNComponent component, PlayerDetachedEvent args)
         {
             if (_mobState.IsIncapacitated(uid) || TerminatingOrDeleted(uid))
+                return;
+
+            // This NPC has an attached mind, so it should not wake up.
+            if (TryComp<MindContainerComponent>(uid, out var mindContainer) && mindContainer.Mind != null)
                 return;
 
             WakeNPC(uid, component);

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -79,7 +79,7 @@ namespace Content.Server.Zombies
         /// <param name="target">the entity being zombified</param>
         /// <param name="mobState"></param>
         /// <remarks>
-        ///     ALRIGHT BIG BOY. YOU'VE COME TO THE LAYER OF THE BEAST. THIS IS YOUR WARNING.
+        ///     ALRIGHT BIG BOYS, GIRLS AND ANYONE ELSE. YOU'VE COME TO THE LAYER OF THE BEAST. THIS IS YOUR WARNING.
         ///     This function is the god function for zombie stuff, and it is cursed. I have
         ///     attempted to label everything thouroughly for your sanity. I have attempted to
         ///     rewrite this, but this is how it shall lie eternal. Turn back now.
@@ -226,6 +226,11 @@ namespace Content.Server.Zombies
 
             _identity.QueueIdentityUpdate(target);
 
+            var htn = EnsureComp<HTNComponent>(target);
+            htn.RootTask = new HTNCompoundTask() { Task = "SimpleHostileCompound" };
+            htn.Blackboard.SetValue(NPCBlackboard.Owner, target);
+            _npc.SleepNPC(target, htn);
+
             //He's gotta have a mind
             var hasMind = _mind.TryGetMind(target, out var mindId, out _);
             if (hasMind && _mind.TryGetSession(mindId, out var session))
@@ -241,9 +246,6 @@ namespace Content.Server.Zombies
             }
             else
             {
-                var htn = EnsureComp<HTNComponent>(target);
-                htn.RootTask = new HTNCompoundTask() { Task = "SimpleHostileCompound" };
-                htn.Blackboard.SetValue(NPCBlackboard.Owner, target);
                 _npc.WakeNPC(target, htn);
             }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This pr makes it so that entities with an active mind (player) in them not wake up after the player disconnects.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This became apparent with diona nymphs (?) and slime gyras (?). This caused players that disconnected while a nymph, gyras or other npc to resume their NPC behavior. Which I would call unwanted. This fixes that.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Checks for if the "mind" value in mind component is filled. And returns if it is

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Vasilis
- fix: NPC's activly being controlled by a player wont return to their AI behevior if the player disconnects.