### PR TITLE
Fix some gamerules' round summary not working

### DIFF
--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -26,7 +26,7 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
         SubscribeLocalEvent<T, GameRuleAddedEvent>(OnGameRuleAdded);
         SubscribeLocalEvent<T, GameRuleStartedEvent>(OnGameRuleStarted);
         SubscribeLocalEvent<T, GameRuleEndedEvent>(OnGameRuleEnded);
-        SubscribeLocalEvent<T, RoundEndTextAppendEvent>(OnRoundEndTextAppend);
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndTextAppend);
     }
 
     private void OnStartAttempt(RoundStartAttemptEvent args)
@@ -70,11 +70,16 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
         Ended(uid, component, ruleData, args);
     }
 
-    private void OnRoundEndTextAppend(Entity<T> ent, ref RoundEndTextAppendEvent args)
+    private void OnRoundEndTextAppend(RoundEndTextAppendEvent ev)
     {
-        if (!TryComp<GameRuleComponent>(ent, out var ruleData))
-            return;
-        AppendRoundEndText(ent, ent, ruleData, ref args);
+        var query = AllEntityQuery<T>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (!TryComp<GameRuleComponent>(uid, out var ruleData))
+                return;
+
+            AppendRoundEndText(uid, comp, ruleData, ref ev);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
fixed nukeops, zombies revs and deathmatch round summary not appearing

## Why / Balance
it has been broken for a while and been pissing me off
resolves #27403

## Technical details
makes it entity query instead

## Media
![image](https://github.com/space-wizards/space-station-14/assets/45323883/54a2619c-4336-4e4b-a369-4d8abf29b294)

![image](https://github.com/space-wizards/space-station-14/assets/45323883/4a031a44-4f3c-4ff6-8481-18132ce84787)

![image](https://github.com/space-wizards/space-station-14/assets/45323883/1bbfb845-8d38-44cb-81c3-055fe0f70bd1)

![image](https://github.com/space-wizards/space-station-14/assets/45323883/237b94ba-e15f-40de-b599-3d8338052655)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- fix: Fixed nuclear operatives, zombies, and head revolutionary round end summaries not showing.
