### PR TITLE
Floodlights now have medium powercells instead of small

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -212,6 +212,11 @@
     enabled: false
     radius: 8
     energy: 5
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellMedium
   - type: Anchorable
   - type: Damageable
     damageContainer: Inorganic


### PR DESCRIPTION
## About the PR
floodlights now have medium power cells by default instead of small ones

## Why / Balance
Why do industrial floodlights use small cells but tiny flashlights use medium? It makes no sense.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Floodlights now use medium power cells instead of small ones.
