### PR TITLE
Security belts can now hold more items commonly carried by secoffs/HoS

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -482,6 +482,10 @@
         - Handcuff
         - BallisticAmmoProvider
         - CartridgeAmmo
+        - DoorRemote
+        - Whistle
+        - HolosignProjector
+        - BalloonPopper
   - type: ItemMapper
     mapLayers:
       flashbang:


### PR DESCRIPTION
## About the PR
Security belts can now hold the needle, holobarrier projector, door remotes, and whistles.

## Why / Balance
It always made me mad when I couldn't fit holobarriers in secbelts and had to use a rig.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/140123969/60757889-6882-4fff-bbfc-e7cb2a667398)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Security belts can now hold more items that security commonly uses.
