### PR TITLE
npc can no longer attack you through a locker

### DIFF
--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -224,7 +224,7 @@ public sealed class NPCUtilitySystem : EntitySystem
                 {
                     if (TryComp<EntityStorageComponent>(container.Owner, out var storageComponent))
                     {
-                        if (storageComponent is { Open: false } && _weldable.IsWelded(container.Owner))
+                        if (storageComponent is { Open: false })
                         {
                             return 0.0f;
                         }


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
NPC  can no longer magically see you hiding in a locker from a mile away and magically attack you through the same closed locker

closes #21053
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed NPCs being able to see and attack you hiding in closed lockers and crates
