### PR TITLE
Add ActionPerformedEvent, ActionsSystem.SetIfBiggerCooldown, action id to action events and BackgroundOn field

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -247,7 +247,10 @@ namespace Content.Client.Actions
             if (action.ClientExclusive)
             {
                 if (instantAction.Event != null)
+                {
                     instantAction.Event.Performer = user;
+                    instantAction.Event.Action = actionId;
+                }
 
                 PerformAction(user, actions, actionId, instantAction, instantAction.Event, GameTiming.CurTime);
             }

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -217,6 +217,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             {
                 action.Event.Target = coords;
                 action.Event.Performer = user;
+                action.Event.Action = actionId;
             }
 
             _actionsSystem.PerformAction(user, actionComp, actionId, action, action.Event, _timing.CurTime);
@@ -251,6 +252,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             {
                 action.Event.Target = entity;
                 action.Event.Performer = user;
+                action.Event.Action = actionId;
             }
 
             _actionsSystem.PerformAction(user, actionComp, actionId, action, action.Event, _timing.CurTime);

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -285,10 +285,19 @@ public sealed class ActionButton : Control, IEntityControl
 
         _controller ??= UserInterfaceManager.GetUIController<ActionUIController>();
         _spriteSys ??= _entities.System<SpriteSystem>();
-        if ((_controller.SelectingTargetFor == ActionId || _action.Toggled) && _action.IconOn != null)
-            SetActionIcon(_spriteSys.Frame0(_action.IconOn));
+        if ((_controller.SelectingTargetFor == ActionId || _action.Toggled))
+        {
+            if (_action.IconOn != null)
+                SetActionIcon(_spriteSys.Frame0(_action.IconOn));
+
+            if (_action.BackgroundOn != null)
+                _buttonBackgroundTexture = _spriteSys.Frame0(_action.BackgroundOn);
+        }
         else
+        {
             SetActionIcon(_action.Icon != null ? _spriteSys.Frame0(_action.Icon) : null);
+            _buttonBackgroundTexture = Theme.ResolveTexture("SlotBackground");
+        }
     }
 
     public void UpdateBackground()

--- a/Content.Server/Actions/ActionOnInteractSystem.cs
+++ b/Content.Server/Actions/ActionOnInteractSystem.cs
@@ -47,7 +47,10 @@ public sealed class ActionOnInteractSystem : EntitySystem
 
         var (actId, act) = _random.Pick(options);
         if (act.Event != null)
+        {
             act.Event.Performer = args.User;
+            act.Event.Action = actId;
+        }
 
         _actions.PerformAction(args.User, null, actId, act, act.Event, _timing.CurTime, false);
         args.Handled = true;
@@ -75,6 +78,7 @@ public sealed class ActionOnInteractSystem : EntitySystem
                 if (entAct.Event != null)
                 {
                     entAct.Event.Performer = args.User;
+                    entAct.Event.Action = entActId;
                     entAct.Event.Target = args.Target.Value;
                 }
 
@@ -100,6 +104,7 @@ public sealed class ActionOnInteractSystem : EntitySystem
         if (act.Event != null)
         {
             act.Event.Performer = args.User;
+            act.Event.Action = actId;
             act.Event.Target = args.ClickLocation;
         }
 

--- a/Content.Shared/Actions/ActionEvents.cs
+++ b/Content.Shared/Actions/ActionEvents.cs
@@ -155,4 +155,9 @@ public abstract partial class BaseActionEvent : HandledEntityEventArgs
     ///     The user performing the action.
     /// </summary>
     public EntityUid Performer;
+
+    /// <summary>
+    ///     The action that was performed.
+    /// </summary>
+    public EntityUid Action;
 }

--- a/Content.Shared/Actions/BaseActionComponent.cs
+++ b/Content.Shared/Actions/BaseActionComponent.cs
@@ -1,5 +1,4 @@
-﻿using Content.Shared.Mobs;
-using Robust.Shared.Audio;
+﻿using Robust.Shared.Audio;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -24,6 +23,11 @@ public abstract partial class BaseActionComponent : Component
     ///     when turned on.
     /// </summary>
     [DataField("iconOn")] public SpriteSpecifier? IconOn;
+
+    /// <summary>
+    ///     For toggle actions only, background to show when toggled on.
+    /// </summary>
+    [DataField] public SpriteSpecifier? BackgroundOn;
 
     /// <summary>
     ///     If not null, this color will modulate the action icon color.

--- a/Content.Shared/Actions/Events/ActionPerformedEvent.cs
+++ b/Content.Shared/Actions/Events/ActionPerformedEvent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.Actions.Events;
+
+/// <summary>
+///     Raised on the action entity when it is used and <see cref="BaseActionEvent.Handled"/>.
+/// </summary>
+/// <param name="Performer">The entity that performed this action.</param>
+[ByRefEvent]
+public readonly record struct ActionPerformedEvent(EntityUid Performer);

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -453,7 +453,10 @@ public abstract class SharedActionsSystem : EntitySystem
         }
 
         if (performEvent != null)
+        {
             performEvent.Performer = user;
+            performEvent.Action = actionEnt;
+        }
 
         // All checks passed. Perform the action!
         PerformAction(user, component, actionEnt, action, performEvent, curTime);


### PR DESCRIPTION
## About the PR
Includes action id in action events from https://github.com/space-wizards/space-station-14/pull/22568
There's no general event for "an action was performed".
Needed for CM, asked Electro and he wants it upstreamed

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

