### PR TITLE
Add CanAttack check if target is in a container

### DIFF
--- a/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
+++ b/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
@@ -169,8 +169,16 @@ namespace Content.Shared.ActionBlocker
 
         public bool CanAttack(EntityUid uid, EntityUid? target = null, Entity<MeleeWeaponComponent>? weapon = null, bool disarm = false)
         {
+            // If target is in a container can we attack
+            if (target != null && _container.IsEntityInContainer(target.Value))
+            {
+                return false;
+            }
+
             _container.TryGetOuterContainer(uid, Transform(uid), out var outerContainer);
-            if (target != null &&  target != outerContainer?.Owner && _container.IsEntityInContainer(uid))
+
+            // If we're in a container can we attack the target.
+            if (target != null && target != outerContainer?.Owner && _container.IsEntityInContainer(uid))
             {
                 var containerEv = new CanAttackFromContainerEvent(uid, target);
                 RaiseLocalEvent(uid, containerEv);


### PR DESCRIPTION
Properly fixes https://github.com/space-wizards/space-station-14/issues/21053 instead of leaving it exploitable.

I don't really like how the checks are done but it's not going to be relevant until someone writes vehicle code that's not terrible.