### PR TITLE
Fix AlertControl throwing an error if the sprite view entity is deleted multiple times

### DIFF
--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -117,11 +117,8 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
         {
             base.Dispose(disposing);
 
-            if (_spriteViewEntity != default)
-            {
+            if (!_entityManager.Deleted(_spriteViewEntity))
                 _entityManager.QueueDeleteEntity(_spriteViewEntity);
-                _spriteViewEntity = default;
-            }
         }
     }
 

--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -3,7 +3,6 @@ using Content.Client.Actions.UI;
 using Content.Client.Cooldown;
 using Content.Shared.Alert;
 using Robust.Client.GameObjects;
-using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Timing;
@@ -117,7 +116,12 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-            _entityManager.QueueDeleteEntity(_spriteViewEntity);
+
+            if (_spriteViewEntity != default)
+            {
+                _entityManager.QueueDeleteEntity(_spriteViewEntity);
+                _spriteViewEntity = default;
+            }
         }
     }
 


### PR DESCRIPTION
## About the PR
Started happening reliably in CM tests as of a week ago.
```
CLIENT: 0.289s [ERRO] root: Predicting the queued deletion of a networked entity: 2475/n0D. Trace:    at System.Environment.get_StackTrace()
    at Robust.Client.GameObjects.ClientEntityManager.QueueDeleteEntity(Nullable`1 uid) in /home/runner/work/CM-14/CM-14/RobustToolbox/Robust.Client/GameObjects/ClientEntityManager.cs:line 85
    at Content.Client.UserInterface.Systems.Alerts.Controls.AlertControl.Dispose(Boolean disposing) in /home/runner/work/CM-14/CM-14/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs:line 120
    at Robust.Client.UserInterface.Control.Dispose() in /home/runner/work/CM-14/CM-14/RobustToolbox/Robust.Client/UserInterface/Control.cs:line 603
    at Content.Client.UserInterface.Systems.Alerts.Widgets.AlertsUI.ClearAllControls() in /home/runner/work/CM-14/CM-14/Content.Client/UserInterface/Systems/Alerts/Widgets/AlertsUI.xaml.cs:line 43
    at Content.Client.UserInterface.Systems.Alerts.AlertsUIController.SystemOnClearAlerts(Object sender, EventArgs e) in /home/runner/work/CM-14/CM-14/Content.Client/UserInterface/Systems/Alerts/AlertsUIController.cs:line 54
    at Content.Client.Alerts.ClientAlertsSystem.OnPlayerDetached(EntityUid uid, AlertsComponent component, LocalPlayerDetachedEvent args) in /home/runner/work/CM-14/CM-14/Content.Client/Alerts/ClientAlertsSystem.cs:line 92
```

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
