### PR TITLE
Add solution temperature to chemical analysis goggles

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -733,7 +733,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
             return;
         }
 
-        if (!CanSeeHiddenSolution(entity,args.Examiner))
+        if (!CanSeeHiddenSolution(entity, args.Examiner))
             return;
 
         var primaryReagent = solution.GetPrimaryReagentId();
@@ -832,7 +832,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
             return;
         }
 
-        if (!CanSeeHiddenSolution(entity,args.User))
+        if (!CanSeeHiddenSolution(entity, args.User))
             return;
 
         var target = args.Target;
@@ -880,6 +880,9 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
                 , ("color", proto.SubstanceColor.ToHexNoAlpha())
                 , ("amount", quantity)));
         }
+
+        msg.PushNewline();
+        msg.AddMarkup(Loc.GetString("scannable-solution-temperature", ("temperature", Math.Round(solution.Temperature))));
 
         return msg;
     }

--- a/Resources/Locale/en-US/chemistry/components/solution-scanner-component.ftl
+++ b/Resources/Locale/en-US/chemistry/components/solution-scanner-component.ftl
@@ -3,3 +3,4 @@ scannable-solution-verb-message = Examine the chemical composition.
 scannable-solution-main-text = It contains the following chemicals:
 scannable-solution-empty-container = It contains no chemicals.
 scannable-solution-chemical = - {$amount}u [color={$color}]{$type}[/color]
+scannable-solution-temperature = Solution temperature: {$temperature}K


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
title

## Why / Balance
annoying to accidentally make another chemical because the temperature is too high (e.g. oil burning into ash)
atmos techs can see the temperature of gases, so why can't chemists see the temperatures of liquids?

## Media
![image](https://github.com/space-wizards/space-station-14/assets/45323883/53db00a5-a5be-4bd8-8a87-4626a0661d10)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- tweak: Chemical analysis goggles now show the scanned solution's temperature.
