### PR TITLE
Remove duplicate liar word id

### DIFF
--- a/Resources/Locale/en-US/speech/speech-liar.ftl
+++ b/Resources/Locale/en-US/speech/speech-liar.ftl
@@ -34,9 +34,6 @@ liar-word-replacement-11 = isnt
 liar-word-12 = will
 liar-word-replacement-12 = wont
 
-liar-word-12 = not
-liar-word-replacement-12 = ""
-
 liar-word-13 = dont
 liar-word-replacement-13 = ""
 
@@ -130,3 +127,6 @@ liar-word-replacement-42 = good
 
 liar-word-42 = want
 liar-word-replacement-42 = "don't want"
+
+liar-word-43 = not
+liar-word-replacement-43 = ""


### PR DESCRIPTION
## About the PR
Fix duplicate `.ftl` ID

## Why / Balance
It's a duplicate localization ID. It does nothing, atm. It also breaks https://github.com/space-wizards/RobustToolbox/pull/4885
