### PR TITLE
Fix `TryFindRandomTile` grid weighting

### DIFF
--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -1,7 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Server.GameTicking.Components;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Station.Components;
+using Content.Shared.Random.Helpers;
+using Robust.Server.GameObjects;
 using Robust.Shared.Collections;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -82,17 +85,23 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
         targetCoords = EntityCoordinates.Invalid;
         targetGrid = EntityUid.Invalid;
 
-        var possibleTargets = station.Comp.Grids;
-        if (possibleTargets.Count == 0)
+        // Weight grid choice by tilecount
+        var weights = new Dictionary<Entity<MapGridComponent>, float>();
+        foreach (var possibleTarget in station.Comp.Grids)
+        {
+            if (!TryComp<MapGridComponent>(possibleTarget, out var comp))
+                continue;
+
+            weights.Add((possibleTarget, comp), _map.GetAllTiles(possibleTarget, comp).Count());
+        }
+
+        if (weights.Count == 0)
         {
             targetGrid = EntityUid.Invalid;
             return false;
         }
 
-        targetGrid = RobustRandom.Pick(possibleTargets);
-
-        if (!TryComp<MapGridComponent>(targetGrid, out var gridComp))
-            return false;
+        (targetGrid, var gridComp) = RobustRandom.Pick(weights);
 
         var found = false;
         var aabb = gridComp.LocalAABB;

--- a/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
+++ b/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
@@ -57,7 +57,8 @@ namespace Content.Shared.Random.Helpers
             throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
         }
 
-        public static string Pick(this IRobustRandom random, Dictionary<string, float> weights)
+        public static T Pick<T>(this IRobustRandom random, Dictionary<T, float> weights)
+            where T: notnull
         {
             var sum = weights.Values.Sum();
             var accumulated = 0f;
@@ -74,7 +75,7 @@ namespace Content.Shared.Random.Helpers
                 }
             }
 
-            throw new InvalidOperationException($"Invalid weighted pick");
+            throw new InvalidOperationException("Invalid weighted pick");
         }
 
         public static (string reagent, FixedPoint2 quantity) Pick(this WeightedRandomFillSolutionPrototype prototype, IRobustRandom? random = null)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

absolutely horrid bug in tryfindrandomtile that has existed forever and has always been annoying and sucks

supersedes #26694

fixes #26889 fixes #27509 and idk probably others

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

please

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

weights by grid tilecount

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://github.com/space-wizards/space-station-14/assets/19853115/8518b199-f88b-4ee5-a538-72dac8eead80)

omg kudzu actually spawned on the station

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Tile weighting for many events and variation rules (messes, dragons, revenants, kudzu, gasleak, rods, etc) has been fixed. They will now no longer spawn disproportionately often on smaller grids.
