### PR TITLE
Half the amount of bleed rate cauterized by burn damage

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -242,7 +242,7 @@
     Piercing: 0.2
     Shock: 0.0
     Cold: 0.0
-    Heat: -1 # heat damage cauterizes wounds, but will still hurt obviously.
+    Heat: -0.5 # heat damage cauterizes wounds, but will still hurt obviously.
     Poison: 0.0
     Radiation: 0.0
     Asphyxiation: 0.0


### PR DESCRIPTION
## About the PR
**1** burn damage now removes **.5** bleed rate instead of **1** bleed rate.
 _Maximum bleed rate is **10** for comparison._

## Why / Balance
Rapid bloodloss prevention items like tourniquets or gauze were overshadowed by just touching a light twice without insuls or hitting yourself with a welder, see https://github.com/space-wizards/space-station-14/pull/27719.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Burn damage is now half as effective at cauterizing wounds as it was previously
