### PR TITLE
Reduce the amount of burn damage from touching lights

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -91,7 +91,7 @@
     bulb: Tube
     damage:
       types:
-        Heat: 5
+        Heat: 2
   - type: ContainerContainer
     containers:
       light_bulb: !type:ContainerSlot
@@ -132,7 +132,7 @@
     hasLampOnSpawn: LightTube
     damage:
       types:
-        Heat: 5
+        Heat: 2
   - type: AmbientOnPowered
   - type: AmbientSound
     volume: -15
@@ -151,7 +151,7 @@
     hasLampOnSpawn: LedLightTube
     damage:
       types:
-        Heat: 2.5
+        Heat: 1 #LEDs don't get as hot
   - type: PointLight
     radius: 15
     energy: 1
@@ -180,7 +180,7 @@
     hasLampOnSpawn: ExteriorLightTube
     damage:
       types:
-        Heat: 5
+        Heat: 4 #brighter light gets hotter
 
 - type: entity
   parent: AlwaysPoweredWallLight
@@ -204,7 +204,7 @@
     hasLampOnSpawn: SodiumLightTube
     damage:
       types:
-        Heat: 5
+        Heat: 2
   - type: PointLight
     radius: 10
     energy: 2.5
@@ -291,7 +291,7 @@
     bulb: Bulb
     damage:
       types:
-        Heat: 5
+        Heat: 2
   - type: ApcPowerReceiver
   - type: ExtensionCableReceiver
   - type: DeviceNetwork
@@ -330,7 +330,7 @@
     hasLampOnSpawn: LedLightBulb
     damage:
       types:
-        Heat: 2.5
+        Heat: 1
 
 - type: entity
   id: PoweredSmallLight
@@ -345,7 +345,7 @@
     hasLampOnSpawn: LightBulb
     damage:
       types:
-        Heat: 5
+        Heat: 2
 
 #Emergency Lights
 - type: entity
@@ -400,7 +400,7 @@
     hasLampOnSpawn: LightTubeCrystalCyan
     damage:
       types:
-        Heat: 5
+        Heat: 2
   - type: PointLight
     radius: 8
     energy: 3
@@ -427,7 +427,7 @@
     hasLampOnSpawn: LightTubeCrystalBlue
     damage:
       types:
-        Heat: 5
+        Heat: 2
   - type: PointLight
     radius: 8
     energy: 3
@@ -454,7 +454,7 @@
     hasLampOnSpawn: LightTubeCrystalPink
     damage:
       types:
-        Heat: 5
+        Heat: 2
   - type: PointLight
     radius: 8
     energy: 3
@@ -481,7 +481,7 @@
     hasLampOnSpawn: LightTubeCrystalOrange
     damage:
       types:
-        Heat: 5
+        Heat: 2
   - type: PointLight
     radius: 8
     energy: 3
@@ -508,7 +508,7 @@
     hasLampOnSpawn: LightTubeCrystalRed
     damage:
       types:
-        Heat: 5
+        Heat: 2
   - type: PointLight
     radius: 8
     energy: 3
@@ -535,7 +535,7 @@
     hasLampOnSpawn: LightTubeCrystalGreen
     damage:
       types:
-        Heat: 5
+        Heat: 2
   - type: PointLight
     radius: 8
     energy: 3

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -173,7 +173,7 @@
 - type: entity
   id: PoweredlightExterior
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
-  suffix: Blue
+  suffix: Exterior
   parent: Poweredlight
   components:
   - type: PoweredLight
@@ -185,7 +185,7 @@
 - type: entity
   parent: AlwaysPoweredWallLight
   id: AlwaysPoweredLightExterior
-  suffix: Always Powered, Blue
+  suffix: Always Powered, Exterior
   components:
   - type: PointLight
     radius: 12

--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -79,7 +79,7 @@
     bulb: Tube
     damage:
       types:
-        Heat: 20
+        Heat: 2
   - type: ContainerContainer
     containers:
       light_bulb: !type:ContainerSlot
@@ -124,7 +124,7 @@
     hasLampOnSpawn: LightTube
     damage:
       types:
-        Heat: 20
+        Heat: 2
   - type: StaticPrice
     price: 25
   - type: AmbientOnPowered
@@ -153,7 +153,7 @@
     hasLampOnSpawn: LedLightTube
     damage:
       types:
-        Heat: 20
+        Heat: 1
   - type: StaticPrice
     price: 25
   - type: AmbientOnPowered

--- a/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
@@ -89,7 +89,7 @@
     on: false
     damage:
       types:
-        Heat: 5
+        Heat: 2
   - type: ApcPowerReceiver
   - type: ExtensionCableReceiver
   - type: DeviceNetwork


### PR DESCRIPTION
## About the PR
Lights now deal 60% less burn damage than they did previously. Exterior lights have been affected by only 20% because a brighter light is hotter.
- Exterior lights now deal 4 damage (from 5)
- Standard lights now deal 2 damage (from 5)
- LED lights now deal 1 damage (from 2.5)

I also gave exterior lights their own suffix while I was in the file because them sharing a suffix with blue lights was annoying.

## Why / Balance
5 damage seems like a bit much for misclicking or forgetting to wear insuls. I also want to kill lightbulb cauterization even more than I already aimed to with https://github.com/space-wizards/space-station-14/pull/27726. It just makes no sense.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Active lights now deal significantly less burn damage when touched.
