### PR TITLE
SS14-20845 Chatfactor: Ingress, Validation, Sanitization

### DIFF
--- a/Content.Server/Chat/V2/Commands/DeleteChatMessageCommand.cs
+++ b/Content.Server/Chat/V2/Commands/DeleteChatMessageCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 using Content.Server.Administration;
-using Content.Server.Chat.V2.Repository;
+using Content.Server.Chat.V2.Systems;
 using Content.Shared.Administration;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Errors;

--- a/Content.Server/Chat/V2/Commands/NukeChatMessagesCommand.cs
+++ b/Content.Server/Chat/V2/Commands/NukeChatMessagesCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 using Content.Server.Administration;
-using Content.Server.Chat.V2.Repository;
+using Content.Server.Chat.V2.Systems;
 using Content.Shared.Administration;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Errors;

--- a/Content.Server/Chat/V2/Messages.cs
+++ b/Content.Server/Chat/V2/Messages.cs
@@ -1,6 +1,6 @@
-﻿using Content.Shared.Chat.Prototypes;
-using Content.Shared.Chat.V2;
+﻿using Content.Shared.Chat.V2;
 using Content.Shared.Radio;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Chat.V2;
 
@@ -66,16 +66,12 @@ public sealed class LoocCreatedEvent(EntityUid speaker, string message) : IChatE
 /// <summary>
 /// Raised locally when a character speaks on the radio.
 /// </summary>
-public sealed class RadioCreatedEvent(
-    EntityUid speaker,
-    string message,
-    string channel)
-    : IChatEvent
+public sealed class RadioCreatedEvent(EntityUid speaker, string message, ProtoId<RadioChannelPrototype> channel) : IChatEvent
 {
     public uint Id { get; set; }
     public EntityUid Sender { get; set; } = speaker;
     public string Message { get; set; } = message;
-    public string Channel = channel;
+    public ProtoId<RadioChannelPrototype> Channel = channel;
     public MessageType Type => MessageType.Radio;
 }
 
@@ -121,7 +117,6 @@ public sealed class ChatValidationEvent<T>(T attemptEvent) where T : ChatAttempt
 /// should be used instead of the non-sanitized message.
 /// </summary>
 /// <param name="attemptEvent">The chat message to sanitize.</param>
-[ByRefEvent]
 public sealed class ChatSanitizationEvent<T>(T attemptEvent) where T : ChatAttemptEvent
 {
     public string ChatMessageRaw = attemptEvent.Message;

--- a/Content.Server/Chat/V2/Systems/ChatAttemptHandlerSystem.cs
+++ b/Content.Server/Chat/V2/Systems/ChatAttemptHandlerSystem.cs
@@ -1,0 +1,235 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Content.Server.Administration.Managers;
+using Content.Shared.Chat.V2;
+using Content.Shared.Chat.V2.Components;
+using Content.Shared.Ghost;
+using Content.Shared.Mobs.Systems;
+using Robust.Shared.Player;
+
+namespace Content.Server.Chat.V2.Systems;
+
+/// <summary>
+/// ChatAttemptHandlerSystem defines a set of handlers and processes for managing chat attempts sent by clients.
+/// </summary>
+public sealed class ChatAttemptHandlerSystem : EntitySystem
+{
+    private const string DeadChatFailed = "chat-system-dead-chat-failed";
+    private const string EmoteFailed = "chat-system-emote-failed";
+    private const string LocalChatFailed = "chat-system-local-chat-failed";
+    private const string RadioFailed = "chat-system-radio-failed";
+    private const string WhisperFailed = "chat-system-whisper-failed";
+    private const string EntityNotOwnedBySender = "chat-system-entity-not-owned-by-sender";
+
+    [Dependency] private readonly ChatRepositorySystem _repo = default!;
+    [Dependency] private readonly IAdminManager _admin = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+
+    private string _deadChatFailed = "";
+    private string _emoteFailed = "";
+    private string _localChatFailed = "";
+    private string _radioFailed = "";
+    private string _whisperFailed = "";
+    private string _entityNotOwnedBySender = "";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _deadChatFailed = Loc.GetString(DeadChatFailed);
+        _emoteFailed = Loc.GetString(EmoteFailed);
+        _localChatFailed = Loc.GetString(LocalChatFailed);
+        _radioFailed = Loc.GetString(RadioFailed);
+        _whisperFailed = Loc.GetString(WhisperFailed);
+        _entityNotOwnedBySender = Loc.GetString(EntityNotOwnedBySender);
+
+        SubscribeNetworkEvent<AttemptDeadChatEvent>(HandleAttemptDeadChat);
+        SubscribeNetworkEvent<AttemptEmoteEvent>(HandleAttemptEmote);
+        SubscribeNetworkEvent<AttemptLocalChatEvent>(HandleAttemptLocalChat);
+        SubscribeNetworkEvent<AttemptLoocEvent>(HandleAttemptLooc);
+        SubscribeNetworkEvent<AttemptEquipmentRadioEvent>(HandleAttemptEquipmentRadio);
+        SubscribeNetworkEvent<AttemptInternalRadioEvent>(HandleAttemptInternalRadio);
+        SubscribeNetworkEvent<AttemptWhisperEvent>(HandleAttemptWhisper);
+    }
+
+    private void HandleAttemptDeadChat(AttemptDeadChatEvent ev, EntitySessionEventArgs args)
+    {
+        var entityUid = GetEntity(ev.Sender);
+
+        if (!ValidateMessage(ev, args.SenderSession, out var reason))
+        {
+            RaiseNetworkEvent(new DeadChatFailedEvent(ev.Sender, reason), args.SenderSession);
+
+            return;
+        }
+
+        var isAdmin = _admin.IsAdmin(entityUid);
+
+        // Dead Chat doesn't use a sentinel component to control access. Admins can always talk on Dead Chat.
+        if (!isAdmin)
+        {
+            // Non-admins can only talk on dead chat if they're a ghost or currently dead.
+            if (!HasComp<GhostComponent>(entityUid) && !_mobState.IsDead(entityUid))
+            {
+                RaiseNetworkEvent(new DeadChatFailedEvent(ev.Sender, _deadChatFailed),
+                    args.SenderSession);
+            }
+
+            return;
+        }
+
+        _repo.Add(new DeadChatCreatedEvent(entityUid, SanitizeMessage(ev), isAdmin));
+    }
+
+    private void HandleAttemptEmote(AttemptEmoteEvent ev, EntitySessionEventArgs args)
+    {
+        if (!ValidateMessage(ev, args.SenderSession, out var reason, _emoteFailed, out CanEmoteComponent? comp))
+        {
+            RaiseNetworkEvent(new EmoteFailedEvent(ev.Sender, reason), args.SenderSession);
+
+            return;
+        }
+
+        _repo.Add(new EmoteCreatedEvent(GetEntity(ev.Sender), SanitizeMessage(ev), comp.Range));
+    }
+
+    private void HandleAttemptLocalChat(AttemptLocalChatEvent ev, EntitySessionEventArgs args)
+    {
+        if (!ValidateMessage(ev, args.SenderSession, out var reason, _localChatFailed, out CanLocalChatComponent? comp))
+        {
+            RaiseNetworkEvent(new LocalChatFailedEvent(ev.Sender, reason), args.SenderSession);
+
+            return;
+        }
+
+        _repo.Add(new LocalChatCreatedEvent(GetEntity(ev.Sender), SanitizeMessage(ev), comp.Range));
+    }
+
+    private void HandleAttemptLooc(AttemptLoocEvent ev, EntitySessionEventArgs args)
+    {
+        if (!ValidateMessage(ev, args.SenderSession, out var reason))
+        {
+            RaiseNetworkEvent(new LoocFailedEvent(ev.Sender, reason), args.SenderSession);
+
+            return;
+        }
+
+        _repo.Add(new LoocCreatedEvent(GetEntity(ev.Sender), SanitizeMessage(ev)));
+    }
+
+    private void HandleAttemptEquipmentRadio(AttemptEquipmentRadioEvent ev, EntitySessionEventArgs args)
+    {
+        if (!ValidateMessage(ev, args.SenderSession, out var reason, _radioFailed,
+                out CanRadioUsingEquipmentComponent? comp))
+        {
+            RaiseNetworkEvent(new RadioFailedEvent(ev.Sender, reason), args.SenderSession);
+
+            return;
+        }
+
+        _repo.Add(new RadioCreatedEvent(GetEntity(ev.Sender), SanitizeMessage(ev), ev.Channel));
+    }
+
+    private void HandleAttemptInternalRadio(AttemptInternalRadioEvent ev, EntitySessionEventArgs args)
+    {
+        if (!ValidateMessage(ev, args.SenderSession, out var reason, _radioFailed, out CanRadioComponent? comp))
+        {
+            RaiseNetworkEvent(new RadioFailedEvent(ev.Sender, reason), args.SenderSession);
+
+            return;
+        }
+
+        _repo.Add(new RadioCreatedEvent(GetEntity(ev.Sender), SanitizeMessage(ev), ev.Channel));
+    }
+
+    private void HandleAttemptWhisper(AttemptWhisperEvent ev, EntitySessionEventArgs args)
+    {
+        if (!ValidateMessage(ev, args.SenderSession, out var reason, _whisperFailed, out CanWhisperComponent? comp))
+        {
+            RaiseNetworkEvent(new WhisperFailedEvent(ev.Sender, reason), args.SenderSession);
+
+            return;
+        }
+
+        _repo.Add(new WhisperCreatedEvent(GetEntity(ev.Sender), SanitizeMessage(ev), comp.MinRange, comp.MaxRange));
+    }
+
+    /// <summary>
+    /// Validates messages. Return true means the message is valid.
+    /// </summary>
+    private bool ValidateMessage<T>(T ev, ICommonSession player, out string reason) where T : ChatAttemptEvent
+    {
+        var entityUid = GetEntity(ev.Sender);
+
+        // This check is simple, so we don't need to raise an event for it.
+        if (player.AttachedEntity != null || player.AttachedEntity != entityUid)
+        {
+            reason = _entityNotOwnedBySender;
+
+            return false;
+        }
+
+        // Raise both the general and specific ChatValidationEvents. This allows for general
+        var validate = new ChatValidationEvent<ChatAttemptEvent>(ev);
+        RaiseLocalEvent(entityUid, validate);
+
+        if (validate.IsCancelled)
+        {
+            reason = validate.Reason;
+
+            return false;
+        }
+
+        var validateT = new ChatValidationEvent<T>(ev);
+        RaiseLocalEvent(entityUid, validateT);
+
+        if (validate.IsCancelled)
+        {
+            reason = validate.Reason;
+
+            return false;
+        }
+
+        reason = "";
+
+        return true;
+    }
+
+    /// <summary>
+    /// Validates messages which depend on a sentinel component to be legal.
+    /// </summary>
+    private bool ValidateMessage<T1, T2>(
+        T1 ev,
+        ICommonSession player,
+        out string reason,
+        string invalidCompReason,
+        [NotNullWhen(true)] out T2? comp
+    ) where T1 : ChatAttemptEvent where T2 : IComponent
+    {
+        comp = default;
+
+        var entityUid = GetEntity(ev.Sender);
+
+        if (!ValidateMessage(ev, player, out reason))
+        {
+            return false;
+        }
+
+        if (TryComp(entityUid, out comp))
+            return true;
+
+        reason = Loc.GetString(invalidCompReason);
+
+        return false;
+    }
+
+    /// <summary>
+    /// Sanitizes messages. The return string is sanitized.
+    /// </summary>
+    private string SanitizeMessage<T>(T evt) where T : ChatAttemptEvent
+    {
+        var sanitize = new ChatSanitizationEvent<T>(evt);
+        RaiseLocalEvent(ref sanitize);
+
+        return sanitize.ChatMessageSanitized ?? sanitize.ChatMessageRaw;
+    }
+}

--- a/Content.Server/Chat/V2/Systems/ChatRateLimitSystem.cs
+++ b/Content.Server/Chat/V2/Systems/ChatRateLimitSystem.cs
@@ -1,0 +1,104 @@
+﻿using Content.Server.Administration.Logs;
+using Content.Server.Chat.Managers;
+using Content.Shared.CCVar;
+using Content.Shared.Chat.V2;
+using Content.Shared.Database;
+using Content.Shared.Players;
+using Robust.Shared.Configuration;
+using Robust.Server.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Chat.V2.Systems;
+
+public sealed class ChatRateLimitSystem : EntitySystem
+{
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IConfigurationManager _configuration = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+
+    private int _periodLength;
+    private bool _chatRateLimitAnnounceAdmins;
+    private int _chatRateLimitAnnounceAdminDelay;
+    private int _chatRateLimitCount;
+    private int _maxChatMessageLength;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _configuration.OnValueChanged(CCVars.ChatRateLimitPeriod, periodLength => _periodLength = periodLength, true);
+        _configuration.OnValueChanged(CCVars.ChatRateLimitAnnounceAdmins, announce => _chatRateLimitAnnounceAdmins = announce, true);
+        _configuration.OnValueChanged(CCVars.ChatRateLimitAnnounceAdminsDelay, announce => _chatRateLimitAnnounceAdminDelay = announce, true);
+        _configuration.OnValueChanged(CCVars.ChatRateLimitCount, limitCount => _chatRateLimitCount = limitCount, true);
+        _configuration.OnValueChanged(CCVars.ChatMaxAnnouncementLength, maxLen => _maxChatMessageLength = maxLen, true);
+
+        SubscribeLocalEvent<ChatValidationEvent<ChatAttemptEvent>>((msg, args) => HandleValidationEvent(msg, args));
+    }
+
+    private void HandleValidationEvent(ChatValidationEvent<ChatAttemptEvent> validationEvent, EntitySessionEventArgs args)
+    {
+        if (validationEvent.IsCancelled)
+            return;
+
+        if (IsRateLimited(GetEntity(validationEvent.Event.Sender), validationEvent.Event.Message.Length, out var reason))
+        {
+            validationEvent.Cancel(reason);
+        }
+    }
+
+    private bool IsRateLimited(EntityUid entityUid, int messageLen, out string reason)
+    {
+        reason = "";
+
+        if (!_playerManager.TryGetSessionByEntity(entityUid, out var session))
+            return false;
+
+        var data = session.ContentData();
+
+        if (data == null)
+            return false;
+
+        var time = _gameTiming.RealTime;
+
+        if (data.MessageCountExpiresAt < time)
+        {
+            data.MessageCountExpiresAt = time + TimeSpan.FromSeconds(_periodLength);
+
+            // Backoff from spamming slowly
+            data.MessageCount /= 2;
+            data.TotalMessageLength /= 2;
+
+            data.RateLimitAnnouncedToPlayer = false;
+        }
+
+        data.MessageCount += 1;
+        data.TotalMessageLength += messageLen;
+
+        if (data.MessageCount <= _chatRateLimitCount && data.TotalMessageLength <= _maxChatMessageLength)
+            return false;
+
+        // Breached rate limits, inform admins if configured.
+        if (_chatRateLimitAnnounceAdmins)
+        {
+            if (data.CanAnnounceToAdminsNextAt < time)
+            {
+                _chatManager.SendAdminAlert(Loc.GetString("chat-manager-rate-limit-admin-announcement", ("player", session.Name)));
+
+                data.CanAnnounceToAdminsNextAt = time + TimeSpan.FromSeconds(_chatRateLimitAnnounceAdminDelay);
+            }
+        }
+
+        if (data.RateLimitAnnouncedToPlayer)
+            return true;
+
+        reason = Loc.GetString(Loc.GetString("chat-manager-rate-limited"));
+
+        _adminLogger.Add(LogType.ChatRateLimited, LogImpact.Medium, $"Player {session} breached chat rate limits");
+
+        data.RateLimitAnnouncedToPlayer = true;
+
+        return true;
+    }
+}

--- a/Content.Server/Chat/V2/Systems/ChatRepositorySystem.cs
+++ b/Content.Server/Chat/V2/Systems/ChatRepositorySystem.cs
@@ -1,13 +1,12 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Content.Shared.Chat.V2;
-using Content.Shared.Chat.V2.Repository;
+using Content.Shared.Chat.V2.Systems;
 using Robust.Server.Player;
 using Robust.Shared.Network;
 using Robust.Shared.Replays;
 
-namespace Content.Server.Chat.V2.Repository;
+namespace Content.Server.Chat.V2.Systems;
 
 /// <summary>
 /// Stores <see cref="IChatEvent"/>, gives them UIDs, and issues <see cref="MessageCreatedEvent"/>.

--- a/Content.Server/Chat/V2/Systems/RadioChannelValidationSystem.cs
+++ b/Content.Server/Chat/V2/Systems/RadioChannelValidationSystem.cs
@@ -1,0 +1,66 @@
+﻿using Content.Shared.Chat.V2;
+using Content.Shared.Chat.V2.Components;
+using Content.Shared.Radio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Chat.V2.Systems;
+
+public sealed class RadioChannelValidationSystem : EntitySystem
+{
+    private const string RadioChannelFailed = "chat-system-radio-channel-failed";
+    private const string RadioChannelKey = "channel";
+
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ChatValidationEvent<AttemptEquipmentRadioEvent>>((msg, args) => HandleRadioValidationEvent(msg, args));
+        SubscribeLocalEvent<ChatValidationEvent<AttemptInternalRadioEvent>>((msg, args) => HandleRadioValidationEvent(msg, args));
+    }
+
+    private void HandleRadioValidationEvent(ChatValidationEvent<AttemptEquipmentRadioEvent> msg, EntitySessionEventArgs args)
+    {
+        if (!_proto.TryIndex<RadioChannelPrototype>(msg.Event.Channel, out _))
+        {
+            msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
+
+            return;
+        }
+
+        if (!TryComp<CanRadioUsingEquipmentComponent>(GetEntity(msg.Event.Sender), out var comp))
+        {
+            msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
+
+            return;
+        }
+
+        if (!comp.Channels.Contains(msg.Event.Channel))
+        {
+            msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
+        }
+    }
+
+    private void HandleRadioValidationEvent(ChatValidationEvent<AttemptInternalRadioEvent> msg, EntitySessionEventArgs args)
+    {
+        if (!_proto.TryIndex<RadioChannelPrototype>(msg.Event.Channel, out _))
+        {
+            msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
+
+            return;
+        }
+
+        if (!TryComp<CanRadioComponent>(GetEntity(msg.Event.Sender), out var comp))
+        {
+            msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
+
+            return;
+        }
+
+        if (!comp.SendChannels.Contains(msg.Event.Channel))
+        {
+            msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
+        }
+    }
+}

--- a/Content.Server/Chat/V2/Systems/RadioChannelValidationSystem.cs
+++ b/Content.Server/Chat/V2/Systems/RadioChannelValidationSystem.cs
@@ -16,51 +16,24 @@ public sealed class RadioChannelValidationSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<ChatValidationEvent<AttemptEquipmentRadioEvent>>((msg, args) => HandleRadioValidationEvent(msg, args));
-        SubscribeLocalEvent<ChatValidationEvent<AttemptInternalRadioEvent>>((msg, args) => HandleRadioValidationEvent(msg, args));
+        SubscribeLocalEvent<ChatValidationEvent<AttemptEquipmentRadioEvent>>(OnValidateAttemptEquipmentRadioEvent);
+        SubscribeLocalEvent<ChatValidationEvent<AttemptInternalRadioEvent>>(OnValidateAttemptInternalRadioEvent);
     }
 
-    private void HandleRadioValidationEvent(ChatValidationEvent<AttemptEquipmentRadioEvent> msg, EntitySessionEventArgs args)
+    private void OnValidateAttemptEquipmentRadioEvent(ChatValidationEvent<AttemptEquipmentRadioEvent> msg, EntitySessionEventArgs args)
     {
-        if (!_proto.TryIndex<RadioChannelPrototype>(msg.Event.Channel, out _))
-        {
+        if (!_proto.TryIndex(msg.Event.Channel, out _) ||
+            !TryComp<CanRadioUsingEquipmentComponent>(GetEntity(msg.Event.Sender), out var comp) ||
+            !comp.Channels.Contains(msg.Event.Channel))
             msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
-
-            return;
-        }
-
-        if (!TryComp<CanRadioUsingEquipmentComponent>(GetEntity(msg.Event.Sender), out var comp))
-        {
-            msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
-
-            return;
-        }
-
-        if (!comp.Channels.Contains(msg.Event.Channel))
-        {
-            msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
-        }
     }
 
-    private void HandleRadioValidationEvent(ChatValidationEvent<AttemptInternalRadioEvent> msg, EntitySessionEventArgs args)
+    private void OnValidateAttemptInternalRadioEvent(ChatValidationEvent<AttemptInternalRadioEvent> msg, EntitySessionEventArgs args)
     {
-        if (!_proto.TryIndex<RadioChannelPrototype>(msg.Event.Channel, out _))
-        {
+        if (!_proto.TryIndex(msg.Event.Channel, out _) ||
+            !TryComp<CanRadioComponent>(GetEntity(msg.Event.Sender), out var comp) ||
+            !comp.SendChannels.Contains(msg.Event.Channel)
+        )
             msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
-
-            return;
-        }
-
-        if (!TryComp<CanRadioComponent>(GetEntity(msg.Event.Sender), out var comp))
-        {
-            msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
-
-            return;
-        }
-
-        if (!comp.SendChannels.Contains(msg.Event.Channel))
-        {
-            msg.Cancel(Loc.GetString(RadioChannelFailed, (RadioChannelKey, msg.Event.Channel)));
-        }
     }
 }

--- a/Content.Shared/Chat/V2/Components/CanEmoteComponent.cs
+++ b/Content.Shared/Chat/V2/Components/CanEmoteComponent.cs
@@ -1,0 +1,16 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Chat.V2.Components;
+
+/// <summary>
+/// Declares that this entity can emote.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CanEmoteComponent : Component
+{
+    /// <summary>
+    /// How far can this emote be seen from?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Range = 10.0f;
+}

--- a/Content.Shared/Chat/V2/Components/CanLocalChatComponent.cs
+++ b/Content.Shared/Chat/V2/Components/CanLocalChatComponent.cs
@@ -1,0 +1,18 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Chat.V2.Components;
+
+/// <summary>
+/// Declares that this entity can chat in local chat
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CanLocalChatComponent : Component
+{
+    // TODO: Ensure you can't locally chat in insufficient atmosphere
+
+    /// <summary>
+    /// How far can this entity be heard from?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Range = 10.0f;
+}

--- a/Content.Shared/Chat/V2/Components/CanRadioComponent.cs
+++ b/Content.Shared/Chat/V2/Components/CanRadioComponent.cs
@@ -1,0 +1,28 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Chat.V2.Components;
+
+/// <summary>
+/// Declares that this entity can innately send messages on the radio.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CanRadioComponent : Component
+{
+    /// <summary>
+    /// What channels can this entity talk on?
+    /// </summary>
+    [DataField("sendChannels"), AutoNetworkedField]
+    public HashSet<string> SendChannels = new();
+
+    /// <summary>
+    /// What channels can this entity talk on?
+    /// </summary>
+    [DataField("receiveChannels"), AutoNetworkedField]
+    public HashSet<string> ReceiveChannels = new();
+
+    [DataField("receiveAllChannels"), AutoNetworkedField]
+    public bool CanListenOnAllChannels;
+
+    [DataField("globalReceive"), AutoNetworkedField]
+    public bool IsInfiniteRange;
+}

--- a/Content.Shared/Chat/V2/Components/CanRadioComponent.cs
+++ b/Content.Shared/Chat/V2/Components/CanRadioComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class CanRadioComponent : Component
     public HashSet<string> SendChannels = new();
 
     /// <summary>
-    /// What channels can this entity talk on?
+    /// What channels can this entity receive on?
     /// </summary>
     [DataField("receiveChannels"), AutoNetworkedField]
     public HashSet<string> ReceiveChannels = new();

--- a/Content.Shared/Chat/V2/Components/CanRadioUsingEquipmentComponent.cs
+++ b/Content.Shared/Chat/V2/Components/CanRadioUsingEquipmentComponent.cs
@@ -1,0 +1,16 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Chat.V2.Components;
+
+/// <summary>
+/// Declares that this entity uses a removable piece of equipment (e.g. a headset) to send messages on the radio.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CanRadioUsingEquipmentComponent : Component
+{
+    /// <summary>
+    /// What channels can this entity talk on?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<string> Channels = new();
+}

--- a/Content.Shared/Chat/V2/Components/CanWhisperComponent.cs
+++ b/Content.Shared/Chat/V2/Components/CanWhisperComponent.cs
@@ -1,0 +1,24 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Chat.V2.Components;
+
+/// <summary>
+/// Declares that this entity can whisper.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CanWhisperComponent : Component
+{
+    // TODO: Ensure you can't whisper in insufficient atmosphere
+
+    /// <summary>
+    /// How far can this entity be clearly heard from?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float MinRange = 2.0f;
+
+    /// <summary>
+    /// How far can this entity be heard at all from?
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float MaxRange = 5.0f;
+}

--- a/Content.Shared/Chat/V2/Messages.cs
+++ b/Content.Shared/Chat/V2/Messages.cs
@@ -1,0 +1,299 @@
+﻿using Robust.Shared.Serialization;
+
+namespace Content.Shared.Chat.V2;
+
+#region Attempt Messages
+
+/// <summary>
+/// Defines the abstract concept of a chat attempt.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="message">The message sent.</param>
+[Serializable, NetSerializable]
+public abstract class ChatAttemptEvent(NetEntity sender, string message) : EntityEventArgs
+{
+    public NetEntity Sender = sender;
+    public string Message = message;
+}
+
+/// <summary>
+/// /// Raised when an announcement is attempted by a communications console.
+/// </summary>
+/// <param name="console">The console sending the message</param>
+/// <param name="sender">Who sent the message</param>
+/// <param name="message">The message sent</param>
+[Serializable, NetSerializable]
+public sealed class AttemptCommsAnnouncementEvent(NetEntity sender, string message, NetEntity console) : ChatAttemptEvent(sender, message)
+{
+    public NetEntity Console = console;
+}
+
+/// <summary>
+/// Raised when a mob tries to speak in dead chat.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="message">The message sent</param>
+[Serializable, NetSerializable]
+public sealed class AttemptDeadChatEvent(NetEntity sender, string message) : ChatAttemptEvent(sender, message);
+
+/// <summary>
+/// Raised when a mob tries to emote.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="message">The message sent</param>
+[Serializable, NetSerializable]
+public sealed class AttemptEmoteEvent(NetEntity sender, string message) : ChatAttemptEvent(sender, message);
+
+/// <summary>
+/// Raised when a mob tries to speak in local chat.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="message">The message sent</param>
+[Serializable, NetSerializable]
+public sealed class AttemptLocalChatEvent(NetEntity sender, string message) : ChatAttemptEvent(sender, message);
+
+/// <summary>
+/// Raised when a mob tries to use the radio.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="message">The message sent</param>
+/// <param name="channel">The channel the message is on</param>
+[Serializable, NetSerializable]
+public abstract class RadioAttemptEvent(NetEntity sender, string message, string channel) : ChatAttemptEvent(sender, message)
+{
+    public string Channel = channel;
+}
+
+/// <summary>
+/// Raised when a mob tries to use the radio via a headset or similar device.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="message">The message sent</param>
+/// <param name="channel">The channel the message is on</param>
+[Serializable, NetSerializable]
+public sealed class AttemptEquipmentRadioEvent(NetEntity sender, string message, string channel)
+    : RadioAttemptEvent(sender, message, channel);
+
+/// <summary>
+/// Raised when a mob tries to use the radio via their innate abilities.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="message">The message sent</param>
+/// <param name="channel">The channel the message is on</param>
+[Serializable, NetSerializable]
+public sealed class AttemptInternalRadioEvent(NetEntity sender, string message, string channel) : RadioAttemptEvent(sender, message, channel);
+
+/// <summary>
+/// Raised when a mob tries to speak in LOOC.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="message">The message sent</param>
+[Serializable, NetSerializable]
+public sealed class AttemptLoocEvent(NetEntity sender, string message) : ChatAttemptEvent(sender, message);
+
+/// <summary>
+/// Raised when a mob tries to whisper.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="message">The message sent</param>
+[Serializable, NetSerializable]
+public sealed class AttemptWhisperEvent(NetEntity sender, string message) : ChatAttemptEvent(sender, message);
+
+# endregion
+
+#region Failure messages
+
+/// <summary>
+/// Defines the abstract concept of chat attempts failing.
+/// </summary>
+/// <param name="sender">The speaker</param>
+/// <param name="reason">Why the attempt failed</param>
+[Serializable, NetSerializable]
+public abstract class ChatFailedEvent(NetEntity sender, string reason) : EntityEventArgs
+{
+    public NetEntity Sender = sender;
+    public string Reason = reason;
+}
+
+/// <summary>
+/// Raised when an announcement is attempted by a communications console, and it fails for some reason.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="reason">The failure reason</param>
+[Serializable, NetSerializable]
+public sealed class CommsAnnouncementFailedEvent(NetEntity sender, string reason) : ChatFailedEvent(sender, reason);
+
+/// <summary>
+/// Raised when a character has failed to speak in Dead chat.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="reason">The failure reason</param>
+[Serializable, NetSerializable]
+public sealed class DeadChatFailedEvent(NetEntity sender, string reason) : ChatFailedEvent(sender, reason);
+
+/// <summary>
+/// Raised when a mob has failed to emote.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="reason">The failure reason</param>
+[Serializable, NetSerializable]
+public sealed class EmoteFailedEvent(NetEntity sender, string reason) : ChatFailedEvent(sender, reason);
+
+/// <summary>
+/// Raised when a character has failed to speak in local chat.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="reason">The failure reason</param>
+[Serializable, NetSerializable]
+public sealed class LocalChatFailedEvent(NetEntity sender, string reason) : ChatFailedEvent(sender, reason);
+
+/// <summary>
+/// Raised when a character has failed to speak on the radio.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="reason">The failure reason</param>
+[Serializable, NetSerializable]
+public sealed class RadioFailedEvent(NetEntity sender, string reason) : ChatFailedEvent(sender, reason);
+
+/// <summary>
+/// Raised when a character has failed to speak in LOOC.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="reason">The failure reason</param>
+[Serializable, NetSerializable]
+public sealed class LoocFailedEvent(NetEntity sender, string reason) : ChatFailedEvent(sender, reason);
+
+/// <summary>
+/// Raised when a character has failed to whisper.
+/// </summary>
+/// <param name="sender">Who sent the message</param>
+/// <param name="reason">The failure reason</param>
+[Serializable, NetSerializable]
+public sealed class WhisperFailedEvent(NetEntity sender, string reason) : ChatFailedEvent(sender, reason);
+
+# endregion
+
+#region Success messages
+
+/// <summary>
+/// Defines the abstract concept of succeeding at sending a chat message.
+/// </summary>
+/// <param name="speaker">The speaker of the message</param>
+/// <param name="asName">What name the speaker should present as</param>
+/// <param name="message">The message, possibly altered from when it was sent</param>
+/// <param name="id">The round-unique ID of the message</param>
+[Serializable, NetSerializable]
+public abstract class ChatSuccessEvent(NetEntity speaker, string asName, string message, uint id) : EntityEventArgs
+{
+    public NetEntity Speaker = speaker;
+    public string AsName = asName;
+    public readonly string Message = message;
+    public uint Id = id;
+}
+
+/// <summary>
+/// Raised on the network when a character speaks in dead chat.
+/// </summary>
+/// <param name="speaker">The speaker of the message</param>
+/// <param name="asName">What name the speaker should present as</param>
+/// <param name="message">The message, possibly altered from when it was sent</param>
+/// <param name="id">The round-unique ID of the message</param>
+/// <param name="isAdmin">If the speaker is an admin or not</param>
+[Serializable, NetSerializable]
+public sealed class DeadChatEvent(NetEntity speaker, string asName, string message, uint id, bool isAdmin) : ChatSuccessEvent(speaker, asName, message, id)
+{
+    public bool IsAdmin = isAdmin;
+}
+
+/// <summary>
+/// Raised when a mob emotes.
+/// </summary>
+/// <param name="speaker">The speaker of the message</param>
+/// <param name="asName">What name the speaker should present as</param>
+/// <param name="message">The message, possibly altered from when it was sent</param>
+/// <param name="id">The round-unique ID of the message</param>
+[Serializable, NetSerializable]
+public sealed class EmoteEvent(NetEntity speaker, string asName, string message, uint id) : ChatSuccessEvent(speaker, asName, message, id);
+
+/// <summary>
+/// Raised to inform clients that an entity has spoken in local chat.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class LocalChatEvent(NetEntity speaker, string asName, string message, uint id) : ChatSuccessEvent(speaker, asName, message, id);
+
+/// <summary>
+/// Raised when a character speaks on the radio.
+/// </summary>
+/// <param name="speaker">The speaker of the message</param>
+/// <param name="asName">What name the speaker should present as</param>
+/// <param name="message">The message, possibly altered from when it was sent</param>
+/// <param name="id">The round-unique ID of the message</param>
+/// <param name="channel">The channel the message is on</param>
+[Serializable, NetSerializable]
+public sealed class RadioEvent(NetEntity speaker, string asName, string message, string channel, uint id) : ChatSuccessEvent(speaker, asName, message, id)
+{
+    public readonly string Channel = channel;
+}
+
+/// <summary>
+/// Raised when a character speaks in LOOC.
+/// </summary>
+/// <param name="speaker">The speaker of the message</param>
+/// <param name="asName">What name the speaker should present as</param>
+/// <param name="message">The message, possibly altered from when it was sent</param>
+/// <param name="id">The round-unique ID of the message</param>
+[Serializable, NetSerializable]
+public sealed class LoocEvent(NetEntity speaker, string asName, string message, uint id) : ChatSuccessEvent(speaker, asName, message, id);
+
+/// <summary>
+/// Raised when a character whispers.
+/// </summary>
+/// <param name="speaker">The speaker of the message</param>
+/// <param name="asName">What name the speaker should present as</param>
+/// <param name="message">The message, possibly altered from when it was sent</param>
+/// <param name="id">The round-unique ID of the message</param>
+[Serializable, NetSerializable]
+public sealed class WhisperEmittedEvent(NetEntity speaker, string asName, string message, uint id) : ChatSuccessEvent(speaker, asName, message, id);
+
+#endregion
+
+#region Irregular success messages
+
+/// <summary>
+/// Raised when a mob is given a subtle message in local chat.
+/// </summary>
+/// <param name="target">The target of the message</param>
+/// <param name="message">The message, possibly altered from when it was sent</param>
+[Serializable, NetSerializable]
+public sealed class SubtleChatEvent(NetEntity target, string message) : EntityEventArgs
+{
+    public NetEntity Target = target;
+    public readonly string Message = message;
+}
+
+/// <summary>
+/// Raised when an entity (such as a vending machine) uses local chat. The chat should not appear in the chat log.
+/// </summary>
+/// <param name="speaker">The speaker of the message</param>
+/// <param name="asName">What name the speaker should present as</param>
+/// <param name="message">The message, possibly altered from when it was sent - although for automated messages this is unlikely.</param>
+[Serializable, NetSerializable]
+public sealed class BackgroundChatEvent(NetEntity speaker, string message, string asName) : EntityEventArgs
+{
+    public NetEntity Speaker = speaker;
+    public string AsName = asName;
+    public readonly string Message = message;
+}
+
+/// <summary>
+/// Raised when an announcement is made.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class AnnouncementEvent(string asName, string message, Color? messageColorOverride = null) : EntityEventArgs
+{
+    public string AsName = asName;
+    public readonly string Message = message;
+    public Color? MessageColorOverride = messageColorOverride;
+}
+
+#endregion

--- a/Content.Shared/Chat/V2/Messages.cs
+++ b/Content.Shared/Chat/V2/Messages.cs
@@ -1,4 +1,6 @@
-﻿using Robust.Shared.Serialization;
+﻿using Content.Shared.Radio;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Chat.V2;
 
@@ -59,9 +61,9 @@ public sealed class AttemptLocalChatEvent(NetEntity sender, string message) : Ch
 /// <param name="message">The message sent</param>
 /// <param name="channel">The channel the message is on</param>
 [Serializable, NetSerializable]
-public abstract class RadioAttemptEvent(NetEntity sender, string message, string channel) : ChatAttemptEvent(sender, message)
+public abstract class RadioAttemptEvent(NetEntity sender, string message, ProtoId<RadioChannelPrototype> channel) : ChatAttemptEvent(sender, message)
 {
-    public string Channel = channel;
+    public ProtoId<RadioChannelPrototype> Channel = channel;
 }
 
 /// <summary>

--- a/Content.Shared/Chat/V2/Systems/Types.cs
+++ b/Content.Shared/Chat/V2/Systems/Types.cs
@@ -1,9 +1,8 @@
-﻿using System.Linq;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
-namespace Content.Shared.Chat.V2.Repository;
+namespace Content.Shared.Chat.V2.Systems;
 
 /// <summary>
 /// The record associated with a specific chat event.

--- a/Content.Shared/Players/ContentPlayerData.cs
+++ b/Content.Shared/Players/ContentPlayerData.cs
@@ -1,5 +1,4 @@
-﻿using Content.Shared.Administration;
-using Content.Shared.GameTicking;
+﻿using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Robust.Shared.Network;
 
@@ -42,6 +41,31 @@ public sealed class ContentPlayerData
     /// If true, the admin will not show up in adminwho except to admins with the <see cref="AdminFlags.Stealth"/> flag.
     /// </summary>
     public bool Stealthed { get; set; }
+
+    /// <summary>
+    /// The rate at which this player has been sending messages. Allows for rate-limiting.
+    /// </summary>
+    public int MessageCount;
+
+    /// <summary>
+    /// The total amount of characters someone has been sending. Allows for rate-limiting.
+    /// </summary>
+    public int TotalMessageLength;
+
+    /// <summary>
+    /// When the current count for this session expires.
+    /// </summary>
+    public TimeSpan MessageCountExpiresAt;
+
+    /// <summary>
+    /// Whether rate limiting has been announced to the player
+    /// </summary>
+    public bool RateLimitAnnouncedToPlayer;
+
+    /// <summary>
+    /// When can an announcement to admins next be sent at.
+    /// </summary>
+    public TimeSpan CanAnnounceToAdminsNextAt;
 
     public ContentPlayerData(NetUserId userId, string name)
     {

--- a/Content.Shared/Players/ContentPlayerData.cs
+++ b/Content.Shared/Players/ContentPlayerData.cs
@@ -43,27 +43,40 @@ public sealed class ContentPlayerData
     public bool Stealthed { get; set; }
 
     /// <summary>
-    /// The rate at which this player has been sending messages. Allows for rate-limiting.
+    /// Tracks how many messages in the player's message budget have been used. Goes up when a message is sent, goes
+    /// down each rate-limiting interval. If this number is too high, messages cannot be sent.
     /// </summary>
-    public int MessageCount;
+    /// <example>
+    /// Urist McSpammer says "I like cheese". This counter increases by one. If this counter reaches the
+    /// message limit specified via the chat.rate_limit_count cvar, the player cannot send any more messages until
+    /// enough time has passed that another attempt allows this value to decrement somewhat.
+    /// </example>
+    public int MessageRateOverTime;
 
     /// <summary>
-    /// The total amount of characters someone has been sending. Allows for rate-limiting.
+    /// Tracks how many consumed characters in the player's character budget have been used. Goes up when a message is
+    /// sent, goes down each rate-limiting interval. If this number is too high, messages cannot be sent.
     /// </summary>
-    public int TotalMessageLength;
+    /// <example>
+    /// Urist McSpammer says "I like cheese". This counter increases by the length of the message. If this
+    /// counter reaches the message limit specified via the chat.max_announcement_length cvar, the player cannot send
+    /// any more messages until enough time has passed that another attempt allows this value to decrement somewhat.
+    /// </example>
+    public int NetMessageLengthOverTime;
 
     /// <summary>
-    /// When the current count for this session expires.
+    /// The time that the current frame-of-reference for chat spam detection expires at. This is increased set by
+    /// the value of the cvar chat.rate_limit_period when the first message is sent after the last period expired.
     /// </summary>
     public TimeSpan MessageCountExpiresAt;
 
     /// <summary>
-    /// Whether rate limiting has been announced to the player
+    /// Whether rate limiting has been announced to the player.
     /// </summary>
     public bool RateLimitAnnouncedToPlayer;
 
     /// <summary>
-    /// When can an announcement to admins next be sent at.
+    /// When an announcement to admins can next be sent at.
     /// </summary>
     public TimeSpan CanAnnounceToAdminsNextAt;
 

--- a/Resources/Locale/en-US/chat/chatvalication.ftl
+++ b/Resources/Locale/en-US/chat/chatvalication.ftl
@@ -1,0 +1,10 @@
+﻿chat-system-local-chat-failed = You can't talk!
+chat-system-max-message-length = Your message is too long.
+chat-system-dead-chat-failed = You can't talk to the dead!
+chat-system-emote-failed = You can't emote!
+chat-system-radio-failed = You can't use any radio channel!
+chat-system-radio-channel-failed = You can't talk on the {$channel} radio channel!
+chat-system-whisper-failed = You can't whisper!
+chat-system-communication-console-announcement-failed = This isn't a communications console.
+chat-system-no-radio-key = No radio key specified!
+chat-system-no-such-channel = There is no channel with key '{$key}'!


### PR DESCRIPTION


<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR adds most of, but not all of, the server-side ingest of chat messages. It defines the messages, sentinel components, validation steps and the skeleton of the process for sanitization, although sanitization is missing and will be fulfilled in a future PR.

## Why / Balance
Chatcode smells

## Technical details
Note this PR intoduces a new, more rugged, way of dealing with spam in chat with a more competent rate limiting system. At the moment this should do nothing and should not interfere with the bad current rate-limiting code.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No

**Changelog**
No