### PR TITLE
Stop Toilets crushing you into walls

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -51,6 +51,10 @@
       disposals: !type:Container
   - type: Physics
     bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        hard: false
   - type: Construction
     graph: Toilet
     node: toilet


### PR DESCRIPTION

## About the PR
So many maps have these aligned next to walls/directional windows/anything else. 
Upon unbuckling from the toilet you would be crushed inside a wall if it were not for admin intervention, unanchoring the toilet or someone being nearby to help. 



## Why / Balance
I don't like dying on the shitter

## Technical details
n/a

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
