### PR TITLE
fix mapping door access

### DIFF
--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -153,7 +153,7 @@ public sealed class AccessReaderSystem : EntitySystem
             return IsAllowedInternal(access, stationKeys, reader);
 
         if (!_containerSystem.TryGetContainer(target, reader.ContainerAccessProvider, out var container))
-            return false;
+            return Paused(target); // when mapping, containers with electronics arent spawned
 
         foreach (var entity in container.ContainedEntities)
         {


### PR DESCRIPTION
## About the PR
door electronics arent spawned when mapping so it always returned false, preventing you linking doors

fixes #26802
