### PR TITLE
Fix preferences sent to client not being sanitized

### DIFF
--- a/Content.Server/Database/UserDbDataManager.cs
+++ b/Content.Server/Database/UserDbDataManager.cs
@@ -67,7 +67,7 @@ public sealed class UserDbDataManager : IPostInjectInit
                 _playTimeTracking.LoadData(session, cancel));
 
             cancel.ThrowIfCancellationRequested();
-            _prefs.SanitizeData(session);
+            _prefs.FinishLoad(session);
 
             _sawmill.Verbose($"Load complete for user {session}");
         }

--- a/Content.Server/Preferences/Managers/IServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/IServerPreferencesManager.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Preferences.Managers
         void Init();
 
         Task LoadData(ICommonSession session, CancellationToken cancel);
-        void SanitizeData(ICommonSession session);
+        void FinishLoad(ICommonSession session);
         void OnClientDisconnected(ICommonSession session);
 
         bool TryGetCachedPreferences(NetUserId userId, [NotNullWhen(true)] out PlayerPreferences? playerPreferences);

--- a/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
@@ -199,27 +199,28 @@ namespace Content.Server.Preferences.Managers
                 {
                     var prefs = await GetOrCreatePreferencesAsync(session.UserId, cancel);
                     prefsData.Prefs = prefs;
-                    prefsData.PrefsLoaded = true;
-
-                    var msg = new MsgPreferencesAndSettings();
-                    msg.Preferences = prefs;
-                    msg.Settings = new GameSettings
-                    {
-                        MaxCharacterSlots = MaxCharacterSlots
-                    };
-                    _netManager.ServerSendMessage(msg, session.Channel);
                 }
             }
         }
 
-        public void SanitizeData(ICommonSession session)
+        public void FinishLoad(ICommonSession session)
         {
             // This is a separate step from the actual database load.
             // Sanitizing preferences requires play time info due to loadouts.
             // And play time info is loaded concurrently from the DB with preferences.
-            var data = _cachedPlayerPrefs[session.UserId];
-            DebugTools.Assert(data.Prefs != null);
-            data.Prefs = SanitizePreferences(session, data.Prefs, _dependencies);
+            var prefsData = _cachedPlayerPrefs[session.UserId];
+            DebugTools.Assert(prefsData.Prefs != null);
+            prefsData.Prefs = SanitizePreferences(session, prefsData.Prefs, _dependencies);
+
+            prefsData.PrefsLoaded = true;
+
+            var msg = new MsgPreferencesAndSettings();
+            msg.Preferences = prefsData.Prefs;
+            msg.Settings = new GameSettings
+            {
+                MaxCharacterSlots = MaxCharacterSlots
+            };
+            _netManager.ServerSendMessage(msg, session.Channel);
         }
 
         public void OnClientDisconnected(ICommonSession session)


### PR DESCRIPTION
Fucking whoops

In #27742 I made it so sanitization of character profiles was moved to be *after* database load. Except that means I moved it to be after the copy of all character profiles got sent to the client.

Move the sending to *also* be in that second load stage, and rename it. Fixes the issue.
