### PR TITLE
Katana Dash checks based on vision rather than collision

### DIFF
--- a/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
+++ b/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Ninja.Components;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
+using Content.Shared.Examine;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Timing;
 
@@ -21,6 +22,7 @@ public sealed class DashAbilitySystem : EntitySystem
     [Dependency] private readonly SharedChargesSystem _charges = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
@@ -83,7 +85,7 @@ public sealed class DashAbilitySystem : EntitySystem
         var origin = Transform(user).MapPosition;
         var target = args.Target.ToMap(EntityManager, _transform);
         // prevent collision with the user duh
-        if (!_interaction.InRangeUnobstructed(origin, target, 0f, CollisionGroup.Opaque, uid => uid == user))
+        if (!_examine.InRangeUnOccluded(origin, target, SharedInteractionSystem.MaxRaycastRange, null))
         {
             // can only dash if the destination is visible on screen
             _popup.PopupClient(Loc.GetString("dash-ability-cant-see", ("item", uid)), user, user);

--- a/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
+++ b/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
@@ -79,8 +79,7 @@ public sealed class DashAbilitySystem : EntitySystem
             _popup.PopupClient(Loc.GetString("dash-ability-no-charges", ("item", uid)), user, user);
             return;
         }
-
-        var origin = Transform(user).MapPosition;
+        var origin = _transform.GetMapCoordinates(user);
         var target = args.Target.ToMap(EntityManager, _transform);
         // prevent collision with the user duh
         if (!_examine.InRangeUnOccluded(origin, target, SharedInteractionSystem.MaxRaycastRange, null))

--- a/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
+++ b/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Charges.Systems;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Ninja.Components;
-using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Examine;
 using Robust.Shared.Audio.Systems;
@@ -21,7 +20,6 @@ public sealed class DashAbilitySystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedChargesSystem _charges = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
-    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changed katana dash's check to be based off of vision occlusion rather than collision checks, fixing the problem that katana dash had similar to door remotes getting LOS blocked by random objects like lockers and consoles

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
feels bad to get line of sight blocked despite being able to see your target

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
examine system has a better check for "in vision" things compared to the interact system using collision layers and rays

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The ninja's katana dash is now more reliable.