### PR TITLE
Fix cak and breaddog not being able to escape inventories

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -829,6 +829,7 @@
   - type: Puller
     needsHands: false
   - type: Examiner
+  - type: DoAfter
   - type: CombatMode
   - type: MeleeWeapon
     soundHit:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -691,6 +691,7 @@
   - type: Puller
     needsHands: false
   - type: Examiner
+  - type: DoAfter
   - type: CombatMode
   - type: MeleeWeapon
     soundHit:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds the DoAfterComponent to Cak and Bread Dog, allowing them to escape from the inventory.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
🐛 Since they had the component to escape from inventory
Fixes #27792 (Thought it was something much harder but nope!)

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
N/A
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![free the cak](https://github.com/space-wizards/space-station-14/assets/32827189/84b5f7cf-3d43-4d68-a333-f36dc61bda79)


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
no cl smol bug
