### PR TITLE
Hardsuit balance

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -13,17 +13,18 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/basic.rsi
   - type: ExplosionResistance
-    damageCoefficient: 0.9
+    damageCoefficient: 0.7
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Caustic: 0.9
+        Blunt: 0.75
+        Slash: 0.75
+        Heat: 0.75
+        Piercing: 0.75
+        Caustic: 0.75
   - type: ClothingSpeedModifier
     walkModifier: 0.80
-    sprintModifier: 0.80
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBasic
@@ -45,13 +46,13 @@
   - type: TemperatureProtection
     coefficient: 0.001
   - type: ExplosionResistance
-    damageCoefficient: 0.5
+    damageCoefficient: 0.7
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.8
         Heat: 0.2
         Radiation: 0.5
         Caustic: 0.5
@@ -79,15 +80,16 @@
   - type: TemperatureProtection
     coefficient: 0.01
   - type: ExplosionResistance
-    damageCoefficient: 0.5
+    damageCoefficient: 0.7
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Shock: 0.8
-        Caustic: 0.5
+        Blunt: 0.8
+        Slash: 0.8
+        Heat: 0.8
+        Piercing: 0.8
+        Shock: 0.3
+        Caustic: 0.8
         Radiation: 0.2
   - type: ClothingSpeedModifier
     walkModifier: 0.7
@@ -115,12 +117,13 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
+        Heat: 0.9
         Piercing: 0.9
         Radiation: 0.3 #salv is supposed to have radiation hazards in the future
         Caustic: 0.8
   - type: ClothingSpeedModifier
     walkModifier: 0.9
-    sprintModifier: 0.8
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSpatio
@@ -146,12 +149,12 @@
       coefficients:
         Blunt: 0.7
         Slash: 0.7
-        Piercing: 0.5
-        Radiation: 0.3
+        Piercing: 0.7
+        Radiation: 0.5
         Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.85
+    sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSalvage
@@ -175,13 +178,14 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.5
-        Heat: 0.3
-        Radiation: 0.1
+        Blunt: 0.45
+        Slash: 0.45
+        Piercing: 0.45
+        Heat: 0.45
+        Caustic: 0.45
+        Radiation: 0.45
   - type: ExplosionResistance
-    damageCoefficient: 0.2
+    damageCoefficient: 0.45
   - type: TemperatureProtection
     coefficient: 0.001
   - type: ToggleableClothing
@@ -208,11 +212,12 @@
       coefficients:
         Blunt: 0.6
         Slash: 0.6
+        Heat: 0.6
         Piercing: 0.6
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.75
-    sprintModifier: 0.75
+    sprintModifier: 0.70
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
@@ -231,15 +236,19 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.7
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.7
+        Heat: 0.8
+        Piercing: 0.8
+        Caustic: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.65
-    sprintModifier: 0.65
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
@@ -264,12 +273,13 @@
     modifiers:
       coefficients:
         Blunt: 0.5
-        Slash: 0.6
-        Piercing: 0.6
+        Slash: 0.5
+        Heat: 0.6
+        Piercing: 0.4
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.7
-    sprintModifier: 0.7
+    sprintModifier: 0.6
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
@@ -297,7 +307,8 @@
         Slash: 0.8
         Piercing: 0.6
         Heat: 0.5
-        Radiation: 0.5
+        Radiation: 0.2
+        Shock: 0.7
         Caustic: 0.6
   - type: ClothingSpeedModifier
     walkModifier: 0.8
@@ -321,7 +332,7 @@
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.2
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
@@ -330,9 +341,10 @@
         Piercing: 0.8
         Heat: 0.4
         Radiation: 0.0
+        Shock: 0.3
         Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
+    walkModifier: 0.8
     sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
@@ -352,10 +364,13 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.7
   - type: Armor
     modifiers:
       coefficients:
         Caustic: 0.1
+        Heat: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.95
@@ -422,15 +437,15 @@
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.6
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.6
-        Slash: 0.5
+        Slash: 0.6
+        Heat: 0.6
         Piercing: 0.5
-        Radiation: 0.5
-        Caustic: 0.6
+        Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -453,13 +468,14 @@
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.5
+    damageCoefficient: 0.3
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.8
+        Blunt: 0.6
+        Slash: 0.6
+        Heat: 0.6
+        Piercing: 0.6
         Radiation: 0.5
         Caustic: 0.8
   - type: ClothingSpeedModifier
@@ -642,19 +658,19 @@
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.5
+    damageCoefficient: 0.3
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.4
-        Heat: 0.25
+        Blunt: 0.4
+        Slash: 0.4
+        Piercing: 0.2
+        Heat: 0.2
         Radiation: 0.25
         Caustic: 0.75
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 1.0
+    sprintModifier: 1.0
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWizard
@@ -707,14 +723,14 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.9
-        Heat: 0.4
+        Blunt: 0.65
+        Slash: 0.65
+        Piercing: 0.65
+        Heat: 0.5
         Caustic: 0.75
   - type: ClothingSpeedModifier
-    walkModifier: 0.6
-    sprintModifier: 0.6
+    walkModifier: 0.95
+    sprintModifier: 0.95
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateEVA
@@ -736,18 +752,18 @@
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.6
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.8
-        Piercing: 0.85
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.4
         Heat: 0.4
         Caustic: 0.75
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateCap
@@ -928,15 +944,14 @@
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.9
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.9
         Slash: 0.9
+        Heat: 0.9
+        Radiation: 0.3
         Piercing: 0.9
-        Caustic: 0.8
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -24,7 +24,7 @@
         Caustic: 0.75
   - type: ClothingSpeedModifier
     walkModifier: 0.80
-    sprintModifier: 0.85
+    sprintModifier: 0.75
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBasic
@@ -112,17 +112,19 @@
   - type: PressureProtection
     highPressureMultiplier: 0.7
     lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.3
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Heat: 0.9
-        Piercing: 0.9
-        Radiation: 0.3 #salv is supposed to have radiation hazards in the future
-        Caustic: 0.8
+        Blunt: 0.7
+        Slash: 0.7
+        Heat: 0.7
+        Piercing: 0.7
+        Radiation: 0.5 #salv is supposed to have radiation hazards in the future
+        Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
+    walkModifier: 0.85
     sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
@@ -149,12 +151,13 @@
       coefficients:
         Blunt: 0.7
         Slash: 0.7
+        Heat: 0.7
         Piercing: 0.7
         Radiation: 0.5
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.85
-    sprintModifier: 0.8
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSalvage
@@ -217,7 +220,7 @@
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.75
-    sprintModifier: 0.70
+    sprintModifier: 0.75
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
@@ -247,8 +250,8 @@
         Piercing: 0.8
         Caustic: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
@@ -472,15 +475,15 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Heat: 0.6
-        Piercing: 0.6
-        Radiation: 0.5
-        Caustic: 0.8
+        Blunt: 0.65
+        Slash: 0.65
+        Heat: 0.65
+        Piercing: 0.65
+        Radiation: 0.3
+        Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.85
-    sprintModifier: 0.9
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLuxury


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This Pr changes several of the stats for multiple of the hardsuits found in game.

Basic Hardsuit
-Blunt 10% --> 25%
-Slash 10% -->25%
-Heat 0% ----> 25%
-piercing 10% -->25%
-caustic 10% -->25%
-Radiation 0% 
-Shock 0%
-Explosive 10% -->30%

-movement walk 20% slower 
-movement run 20% slower --> 25%

Mime/ Clown Hardsuit (Balancing it as an EVA since it costs an EVA to craft)
-Blunt 10%
-Slash 10%
-Heat 0% --> 10%
-piercing 10%
-caustic 20% --> 0%
-Radiation 0% --> 70%
-Shock 0% --> 20%
-Explosive 10% --> 0%
-movement walk 10% slower
-movement run 10% slower

CE Hardsuit (Balanced around being both good at engineering and atmos)
-Blunt 20%
-Slash 20%
-Heat 60%
-piercing 20%
-caustic 30%
-Radiation 100%
-Shock 0% --> 60%
-Explosive 80% --> 50%
-movement walk 25% slower --> 20%
-movement run 20% slower

Atmos Hardsuit
-Blunt 10% -->20%
-Slash 10% --> 20%
-Heat 80%
-piercing 10% --> 20%
-caustic 50% 
-Radiation 50%
-Shock 0% 
-Explosive 50% -->30%
-movement walk 30% slower
-movement run 30% slower

Engineering Hardsuit (Gave better shock protection since It's an important part of their job)
-Blunt 10% -->20%
-Slash 10% --> 20%
-Heat 0% --> 20%
-piercing 10% --> 20%
-caustic 50% --> 20%
-Radiation 80%
-Shock 20% -->70%
-Explosive 50% --> 30%
-movement walk 30% slower
-movement run 30% slower

Maxim Hardsuit (A very rare suit that you will most likely not find with no slow debuff  Quoted by Lead Devs as "endgame Armor")
-Blunt 40% --> 55%
-Slash 40% --> 55%
-Heat 70% --> 55%
-piercing 50%  -->55%
-Caustic 0% --> 55%
-Radiation 90% --> 55%
-Shock 0% 
-Explosive 80% --> 55%
-movement walk 0% slower
-movement run 0% slower

Luxury Mining Hardsuit (Upgraded Salv suit with more protection and faster movement speed, that is very expensive to purchase)
-Blunt 10% -->35%
-Slash 10% --> 35%
-Heat 0% --> 35%
-piercing 20% --> 35%
-Caustic 20% -->35%
-Radiation 50% 
-Shock 0%
-Explosive 50% -->70%
-movement walk 15% slower
-movement run 15% slower

Salvage Hardsuit (Made the suit faster so they can get more loot from time based expeditions, and nerfed piercing prot)
-Blunt 30%
-Slash 30%
-Heat 30%
-piercing 50% --> 30%
-Caustic 30%
-Radiation 70% --> 50% (They have to deal with rad artifacts and bananium sometimes)
-Shock 0%
-Explosive 70% 
-movement walk 25% slower --> 15%
-movement run 25% slower --> 15%

Spationaut Hardsuit (same stats as the Salvage Hardsuit)
-Blunt 30%
-Slash 30%
-Heat 30%
-piercing 50% --> 30%
-Caustic 30%
-Radiation 70% --> 50% (They have to deal with rad artifacts and bananium sometimes)
-Shock 0%
-Explosive 70% 
-movement walk 25% slower --> 15%
-movement run 25% slower --> 15%

Brigmedic Hardsuit (is designed for being a healer instead of combat so people actually do the role)
-Blunt 20% -->20%
-Slash 20% --> 20%
-Heat 0% -->20%
-piercing 30% --> 20%
-Caustic 0% --> 20%
-Radiation 0%
-Shock 0%
-Explosive 0% --> 30%
-movement walk 35% slower --> 15%
-movement run 35% slower --> 15%

Sec Hardsuit (added much needed heat prot)
-Blunt 40%
-Slash 40%
-Heat 0% --> 30%
-piercing 40%
-Caustic 30%
-Radiation 0%
-Shock 0%
-Explosive 60% 
-movement walk 25% slower 
-movement run 25% slower 

Wardens Hardsuit (Wardens should have a heavily armored slow suit that keeps them in sec where they belong)
-Blunt 50% 
-Slash 40% --> 50%
-Heat 0% --> 40%
-piercing 40% --> 60%
-Caustic 30%
-Radiation 0%
-Shock 0%
-Explosive 60%
-movement walk 30% slower 
-movement run 30% slower --> 40% 

HOS Hardsuit (a better and faster sec hardsuit)
-Blunt 40% 
-Slash 50% --> 40%
-Heat 0% --> 40%
-piercing 50%
-Caustic 40% --> 30%
-Radiation 50% --> 0%
-Shock 0%
-Explosive 40% --> 50%
-movement walk 20% slower
-movement run 20% slower

Captains Hardsuit (gave some shock and rad protection since cap should be able to do all of the heads jobs if they are not in shift)
-Blunt 20%
-Slash 20%
-Heat 50%
-piercing 40%
-Caustic 40%
-Radiation 50% --> 80%
-Shock 0% --> 30%
-Explosive 50%
-movement walk 20% slower
-movement run 20% slower

CMO Hardsuit (Designed to make those chem bombs not as bad)
-Blunt 0%
-Slash 0%
-Heat 0% -->30%
-piercing 0%
-Caustic 90%
-Radiation 0%
-Shock 0%
-Explosive 0% --> 30%
-movement walk 10% slower
-movement run 5% slower

Pirate EVA (Pirates should be designed for quick attacks where they get in and out with loot)
-Blunt 20%  --> 35%
-Slash 20% --> 35%
-Heat 60% --> 50%
-piercing 10% --> 35%
-Caustic 25%
-Radiation 0%
-Shock 0%
-Explosive 30%
-movement walk 40% slower --> 5%
-movement run 40% slower --> 5%

Pirate Captain (there is only one pirate captain and they would be able to afford a good hardsuit)
-Blunt 30% --> 50%
-Slash 20% --> 50%
-Heat 60%
-piercing 15% --> 60%
-Caustic 25% -->30%
-Radiation 0%
-Shock 0%
-Explosive 40% --> 50%
-movement walk 20% slower --> 10%
-movement run 20% slower --> 10%

Wizard Hardsuit (There is only 1 wizard at a time, and they should be extremely powerful so that they actually have a chance)
-Blunt 40% --> 60%
-Slash 40% --> 60%
-piercing 60% --> 80%
-Heat 75% -->80%
-Caustic 25% --> 80%
-Radiation 75% --> 80%
-Explosive 50% --> 70%
-movement walk 20% slower --> 0%
-movement run 20% slower --> 0%

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I believe these changes will improve, and make gameplay feel much better when it comes to hardsuits. Sec having heat protection will help them a lot when they have to deal with emagged borgs, lazer raptors, behonkers, and every other threat on, and off of the station.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
All I changed, and added were stat values.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: All Hardsuits have more armor!
- tweak: Sec Hardsuits now have heat protection.
- tweak: Brigmedic Hardsuit is much quicker with less protection.
- tweak: Warden's Hardsuit is much slower with much more protection!
- tweak: Salvage Hardsuits have exchanged armor for quicker mobility!
- tweak: Wizard Hardsuits have much more protection
- tweak: Pirate Hardsuits have more mobility!
- tweak Captains hardsuit is more resistant to radiation, and shock.
- tweak: CMO's Hardsuit has more protection against Chem explosions!