### PR TITLE
Changes light fixture values

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -186,9 +186,9 @@
   description: A light fixture.
   components:
   - type: LightBulb
-    color: "#FFE4CE" # 5000K color temp
-    lightEnergy: 0.8
-    lightRadius: 10
+    color: "#FFF5E0" # Ported from /vg/
+    lightEnergy: 1.5
+    lightRadius: 6
     lightSoftness: 1
     PowerUse: 25
 

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -32,9 +32,9 @@
       shader: unshaded
     state: base
   - type: PointLight
-    color: "#FFE4CE" # 5000K color temp
-    energy: 0.8
-    radius: 10
+    color: "#FFF5E0" # Ported from /vg/
+    energy: 1.5
+    radius: 6
     softness: 1
     offset: "0, -0.5"
   - type: Damageable


### PR DESCRIPTION
## About the PR
Ports the values for standard light fixtures from /vg/station. Overall, they're more white, and have higher energy, but a much lower radius.
I am aware that these probably will not perfectly translate 1:1, but the result on devstation looks promising, and the Pow3r hellbug makes this basically untestable without putting in a ton of effort.

## Why / Balance
Current lighting is kind of pissy and dim. It's difficult to describe but, it's definitely not perfect. The dimness especially can have quite and ugly effect.

This should make lighting moodier while making it less pissy.

## Media
**NEW**
![image](https://github.com/space-wizards/space-station-14/assets/78941145/948852d7-5741-4282-9d48-02ceab894c62)

**CURRENT/OLD**
![image](https://github.com/space-wizards/space-station-14/assets/78941145/315e9a4a-71ef-42a0-aba7-478bcee3cf0f)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Changed the lighting temperature.
