### PR TITLE
Make storage UI close upon being locked

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1403,7 +1403,7 @@ public abstract class SharedStorageSystem : EntitySystem
     }
 
     /// <summary>
-    /// Checks if a storage's UI is open  by anyone when locked, and closes it unless they're an admin.
+    /// Checks if a storage's UI is open by anyone when locked, and closes it unless they're an admin.
     /// </summary>
     private void OnLockToggled(EntityUid uid, StorageComponent component, ref LockToggledEvent args)
     {

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -109,6 +109,7 @@ public abstract class SharedStorageSystem : EntitySystem
         SubscribeLocalEvent<StorageComponent, AfterInteractEvent>(AfterInteract);
         SubscribeLocalEvent<StorageComponent, DestructionEventArgs>(OnDestroy);
         SubscribeLocalEvent<StorageComponent, BoundUIOpenedEvent>(OnBoundUIOpen);
+        SubscribeLocalEvent<StorageComponent, LockToggledEvent>(OnLockToggled);
         SubscribeLocalEvent<MetaDataComponent, StackCountChangedEvent>(OnStackCountChanged);
 
         SubscribeLocalEvent<StorageComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
@@ -131,6 +132,21 @@ public abstract class SharedStorageSystem : EntitySystem
             .Register<SharedStorageSystem>();
 
         UpdatePrototypeCache();
+    }
+
+    private void OnLockToggled(EntityUid uid, StorageComponent component, ref LockToggledEvent args)
+    {
+        if (!args.Locked)
+            return;
+
+        var actors = _ui.GetActors(uid, StorageComponent.StorageUiKey.Key).ToList();
+        for (var i = actors.Count - 1; i >= 0; i--)
+        {
+            var actor = actors[i];
+            if (_admin.HasAdminFlag(actor, AdminFlags.Admin))
+                continue;
+            _ui.CloseUi(uid, StorageComponent.StorageUiKey.Key, actor);
+        }
     }
 
     private void OnMapInit(Entity<StorageComponent> entity, ref MapInitEvent args)

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1411,12 +1411,11 @@ public abstract class SharedStorageSystem : EntitySystem
             return;
 
         // Gets everyone looking at the UI
-        var actors = _ui.GetActors(uid, StorageComponent.StorageUiKey.Key).ToList();
-        for (var i = actors.Count - 1; i >= 0; i--)
+        foreach (var actor in _ui.GetActors(uid, StorageComponent.StorageUiKey.Key))
         {
-            var actor = actors[i];
             if (_admin.HasAdminFlag(actor, AdminFlags.Admin))
                 continue;
+                
             // And closes it unless they're an admin
             _ui.CloseUi(uid, StorageComponent.StorageUiKey.Key, actor);
         }

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -134,21 +134,6 @@ public abstract class SharedStorageSystem : EntitySystem
         UpdatePrototypeCache();
     }
 
-    private void OnLockToggled(EntityUid uid, StorageComponent component, ref LockToggledEvent args)
-    {
-        if (!args.Locked)
-            return;
-
-        var actors = _ui.GetActors(uid, StorageComponent.StorageUiKey.Key).ToList();
-        for (var i = actors.Count - 1; i >= 0; i--)
-        {
-            var actor = actors[i];
-            if (_admin.HasAdminFlag(actor, AdminFlags.Admin))
-                continue;
-            _ui.CloseUi(uid, StorageComponent.StorageUiKey.Key, actor);
-        }
-    }
-
     private void OnMapInit(Entity<StorageComponent> entity, ref MapInitEvent args)
     {
         UseDelay.SetLength(entity.Owner, entity.Comp.QuickInsertCooldown, QuickInsertUseDelayID);
@@ -1415,6 +1400,26 @@ public abstract class SharedStorageSystem : EntitySystem
         // if there is no max item size specified, the value used
         // is one below the item size of the storage entity.
         return _nextSmallest[item.Size];
+    }
+
+    /// <summary>
+    /// Checks if a storage's UI is open  by anyone when locked, and closes it unless they're an admin.
+    /// </summary>
+    private void OnLockToggled(EntityUid uid, StorageComponent component, ref LockToggledEvent args)
+    {
+        if (!args.Locked)
+            return;
+
+        //gets everyone looking at the UI
+        var actors = _ui.GetActors(uid, StorageComponent.StorageUiKey.Key).ToList();
+        for (var i = actors.Count - 1; i >= 0; i--)
+        {
+            var actor = actors[i];
+            if (_admin.HasAdminFlag(actor, AdminFlags.Admin))
+                continue;
+            //and closes it unless they're an admin
+            _ui.CloseUi(uid, StorageComponent.StorageUiKey.Key, actor);
+        }
     }
 
     private void OnStackCountChanged(EntityUid uid, MetaDataComponent component, StackCountChangedEvent args)

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1410,14 +1410,14 @@ public abstract class SharedStorageSystem : EntitySystem
         if (!args.Locked)
             return;
 
-        //gets everyone looking at the UI
+        // Gets everyone looking at the UI
         var actors = _ui.GetActors(uid, StorageComponent.StorageUiKey.Key).ToList();
         for (var i = actors.Count - 1; i >= 0; i--)
         {
             var actor = actors[i];
             if (_admin.HasAdminFlag(actor, AdminFlags.Admin))
                 continue;
-            //and closes it unless they're an admin
+            // And closes it unless they're an admin
             _ui.CloseUi(uid, StorageComponent.StorageUiKey.Key, actor);
         }
     }


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Made UI's close for people looking at them if the item gets locked.
*Thanks to ShadowCommander for help*

## Why / Balance
Somethin just ain't right about being able to peek into a storage that is actively locked (aka, it's a bug.)
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
- subscribed `SharedStorageSystem` to `LockToggledEvent` and made a method to close the UI for everyone but admins

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
