### PR TITLE
Fix Supplybot Ghostrole

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -341,6 +341,8 @@
   - type: GhostRole
     name: ghost-role-information-supplybot-name
     description: ghost-role-information-supplybot-description
+    raffle:
+      settings: default
   - type: Construction
     graph: SupplyBot
     node: bot

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -339,10 +339,12 @@
     layers:
     - state: supplybot
   - type: GhostRole
+    makeSentient: true
     name: ghost-role-information-supplybot-name
     description: ghost-role-information-supplybot-description
     raffle:
       settings: default
+  - type: GhostTakeoverAvailable
   - type: Construction
     graph: SupplyBot
     node: bot


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds GhostTakeoverAvailable to supplybot

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
can't get the role without it