### PR TITLE
Prevent non-inital infected from getting the succumb to zombie action

### DIFF
--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -35,7 +35,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     {
         base.Initialize();
 
-        SubscribeLocalEvent<PendingZombieComponent, ZombifySelfActionEvent>(OnZombifySelf);
+        SubscribeLocalEvent<IncurableZombieComponent, ZombifySelfActionEvent>(OnZombifySelf);
     }
 
     protected override void AppendRoundEndText(EntityUid uid, ZombieRuleComponent component, GameRuleComponent gameRule,

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -128,7 +128,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         component.NextRoundEndCheck = _timing.CurTime + component.EndCheckDelay;
     }
 
-    private void OnZombifySelf(EntityUid uid, PendingZombieComponent component, ZombifySelfActionEvent args)
+    private void OnZombifySelf(EntityUid uid, IncurableZombieComponent component, ZombifySelfActionEvent args)
     {
         _zombie.ZombifyEntity(uid);
         if (component.Action != null)

--- a/Content.Server/Zombies/IncurableZombieComponent.cs
+++ b/Content.Server/Zombies/IncurableZombieComponent.cs
@@ -1,5 +1,6 @@
-﻿namespace Content.Server.Zombies;
-using Robust.Shared.Prototypes;
+﻿using Robust.Shared.Prototypes;
+
+namespace Content.Server.Zombies;
 
 /// <summary>
 /// This is used for a zombie that cannot be cured by any methods. Gives a succumb to zombie infection action.

--- a/Content.Server/Zombies/IncurableZombieComponent.cs
+++ b/Content.Server/Zombies/IncurableZombieComponent.cs
@@ -1,10 +1,15 @@
 ﻿namespace Content.Server.Zombies;
+using Robust.Shared.Prototypes;
 
 /// <summary>
-/// This is used for a zombie that cannot be cured by any methods.
+/// This is used for a zombie that cannot be cured by any methods. Gives a succumb to zombie infection action.
 /// </summary>
 [RegisterComponent]
 public sealed partial class IncurableZombieComponent : Component
 {
+    [DataField]
+    public EntProtoId ZombifySelfActionPrototype = "ActionTurnUndead";
 
+    [DataField]
+    public EntityUid? Action;
 }

--- a/Content.Server/Zombies/PendingZombieComponent.cs
+++ b/Content.Server/Zombies/PendingZombieComponent.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Damage;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Zombies;
@@ -48,9 +47,6 @@ public sealed partial class PendingZombieComponent : Component
     [DataField]
     public TimeSpan MaxInitialInfectedGrace = TimeSpan.FromMinutes(15f);
 
-    [DataField]
-    public EntProtoId ZombifySelfActionPrototype = "ActionTurnUndead";
-
     /// <summary>
     /// The chance each second that a warning will be shown.
     /// </summary>
@@ -66,6 +62,4 @@ public sealed partial class PendingZombieComponent : Component
         "zombie-infection-warning",
         "zombie-infection-underway"
     };
-
-    [DataField] public EntityUid? Action;
 }

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -64,7 +64,14 @@ namespace Content.Server.Zombies
 
             SubscribeLocalEvent<PendingZombieComponent, MapInitEvent>(OnPendingMapInit);
 
+            SubscribeLocalEvent<IncurableZombieComponent, MapInitEvent>(OnPendingMapInit);
+
             SubscribeLocalEvent<ZombifyOnDeathComponent, MobStateChangedEvent>(OnDamageChanged);
+        }
+
+        private void OnPendingMapInit(EntityUid uid, IncurableZombieComponent component, MapInitEvent args)
+        {
+            _actions.AddAction(uid, ref component.Action, component.ZombifySelfActionPrototype);
         }
 
         private void OnPendingMapInit(EntityUid uid, PendingZombieComponent component, MapInitEvent args)
@@ -77,7 +84,6 @@ namespace Content.Server.Zombies
 
             component.NextTick = _timing.CurTime + TimeSpan.FromSeconds(1f);
             component.GracePeriod = _random.Next(component.MinInitialInfectedGrace, component.MaxInitialInfectedGrace);
-            _actions.AddAction(uid, ref component.Action, component.ZombifySelfActionPrototype);
         }
 
         public override void Update(float frameTime)


### PR DESCRIPTION
## Why / Balance
had a hos think he was an inital infected because of the action and gunned down half of sec
makes it harder to tell if you were infected (oh i got the action guess im infected)

## Technical details
makes incurable zombie have the action rather than the pendingzombie component

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- fix: Fixed non-inital infected getting the succumb to zombie action.
