### PR TITLE
Adds supplybot to crafting menu

### DIFF
--- a/Resources/Prototypes/Recipes/Crafting/bots.yml
+++ b/Resources/Prototypes/Recipes/Crafting/bots.yml
@@ -62,3 +62,16 @@
   icon:
     sprite: Mobs/Silicon/Bots/mimebot.rsi
     state: mimebot
+
+- type: construction
+  name: supplybot
+  id: supplybot
+  graph: SupplyBot
+  startNode: start
+  targetNode: bot
+  category: construction-category-utilities
+  objectType: Item
+  description: This bot can be loaded with cargo to make deliveries.
+  icon:
+    sprite: Mobs/Silicon/Bots/supplybot.rsi
+    state: supplybot


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Apparently I added the construction graph back, but not the actual listing in the crafting menu
S-surely this is my last PR for supplybots

fixes #27818 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
you can't craft them without it...