### PR TITLE
fix mech energy display for 0

### DIFF
--- a/Content.Client/Mech/Ui/MechMenu.xaml.cs
+++ b/Content.Client/Mech/Ui/MechMenu.xaml.cs
@@ -35,9 +35,17 @@ public sealed partial class MechMenu : FancyWindow
         IntegrityDisplayBar.Value = integrityPercent.Float();
         IntegrityDisplay.Text = Loc.GetString("mech-integrity-display", ("amount", (integrityPercent*100).Int()));
 
-        var energyPercent = mechComp.Energy / mechComp.MaxEnergy;
-        EnergyDisplayBar.Value = energyPercent.Float();
-        EnergyDisplay.Text = Loc.GetString("mech-energy-display", ("amount", (energyPercent*100).Int()));
+        if (mechComp.MaxEnergy != 0f)
+        {
+            var energyPercent = mechComp.Energy / mechComp.MaxEnergy;
+            EnergyDisplayBar.Value = energyPercent.Float();
+            EnergyDisplay.Text = Loc.GetString("mech-energy-display", ("amount", (energyPercent*100).Int()));
+        }
+        else
+        {
+            EnergyDisplayBar.Value = 0f;
+            EnergyDisplay.Text = Loc.GetString("mech-energy-missing");
+        }
 
         SlotDisplay.Text = Loc.GetString("mech-slot-display",
             ("amount", mechComp.MaxEquipmentAmount - mechComp.EquipmentContainer.ContainedEntities.Count));

--- a/Resources/Locale/en-US/mech/mech.ftl
+++ b/Resources/Locale/en-US/mech/mech.ftl
@@ -13,6 +13,7 @@ mech-menu-title = mech control panel
 
 mech-integrity-display = Integrity: {$amount}%
 mech-energy-display = Energy: {$amount}%
+mech-energy-missing = Energy: MISSING
 mech-slot-display = Open Slots: {$amount}
 
 mech-no-enter = You cannot pilot this.


### PR DESCRIPTION
## About the PR
0/0 gaming

## Why / Balance
fixes #27822 

## Technical details
special text if its 0

## Media
![06:32:46](https://github.com/space-wizards/space-station-14/assets/39013340/1de06253-5e1a-4ec6-a12c-2276c7394da6)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun