### PR TITLE
Make ERT use short raffle timer

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -27,7 +27,7 @@
       name: ghost-role-information-Death-Squad-name
       description: ghost-role-information-Death-Squad-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ DeathSquadGear ]
@@ -65,7 +65,7 @@
       name: ghost-role-information-ert-leader-name
       description: ghost-role-information-ert-leader-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTLeaderGear ]
@@ -97,7 +97,7 @@
       name: ghost-role-information-ert-leader-name
       description: ghost-role-information-ert-leader-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTLeaderGearEVA ]
@@ -121,7 +121,7 @@
       name: ghost-role-information-ert-leader-name
       description: ghost-role-information-ert-leader-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTLeaderGearEVALecter ]
@@ -154,7 +154,7 @@
       name: ghost-role-information-ert-chaplain-name
       description: ghost-role-information-ert-chaplain-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: RandomMetadata
       nameSegments:
@@ -185,7 +185,7 @@
       name: ghost-role-information-ert-chaplain-name
       description: ghost-role-information-ert-chaplain-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTChaplainGearEVA ]
@@ -218,7 +218,7 @@
       name: ghost-role-information-ert-janitor-name
       description: ghost-role-information-ert-janitor-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: RandomMetadata
       nameSegments:
@@ -249,7 +249,7 @@
       name: ghost-role-information-ert-janitor-name
       description: ghost-role-information-ert-janitor-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTJanitorGearEVA ]
@@ -282,7 +282,7 @@
       name: ghost-role-information-ert-engineer-name
       description: ghost-role-information-ert-engineer-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: RandomMetadata
       nameSegments:
@@ -313,7 +313,7 @@
       name: ghost-role-information-ert-engineer-name
       description: ghost-role-information-ert-engineer-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTEngineerGearEVA ]
@@ -346,7 +346,7 @@
       name: ghost-role-information-ert-security-name
       description: ghost-role-information-ert-security-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: RandomMetadata
       nameSegments:
@@ -377,7 +377,7 @@
       name: ghost-role-information-ert-security-name
       description: ghost-role-information-ert-security-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTSecurityGearEVA ]
@@ -400,7 +400,7 @@
       name: ghost-role-information-ert-security-name
       description: ghost-role-information-ert-security-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTSecurityGearEVALecter ]
@@ -433,7 +433,7 @@
       name: ghost-role-information-ert-medical-name
       description: ghost-role-information-ert-medical-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: RandomMetadata
       nameSegments:
@@ -464,7 +464,7 @@
       name: ghost-role-information-ert-medical-name
       description: ghost-role-information-ert-medical-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ERTMedicalGearEVA ]
@@ -494,7 +494,7 @@
       name: ghost-role-information-cburn-agent-name
       description: ghost-role-information-cburn-agent-description
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: RandomMetadata
       nameSegments:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
changed ERT to use the shorter raffle timer, since they're an emergency response team

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
admin request, makes it hard to spawn ERT in time to deal with problems because of the super long default raffles

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
yml change

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no CL