### PR TITLE
prevent borgs from using locks

### DIFF
--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -224,6 +224,7 @@ public sealed class LockSystem : EntitySystem
 
         var ev = new LockToggleAttemptEvent(user, quiet);
         RaiseLocalEvent(uid, ref ev, true);
+        RaiseLocalEvent(user, ref ev, true);
         return !ev.Cancelled;
     }
 

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Access.Components;
 using Content.Shared.Containers.ItemSlots;
+﻿using Content.Shared.Lock;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
@@ -101,7 +102,7 @@ public abstract partial class SharedBorgSystem : EntitySystem
     private void OnLockToggleAttempt(Entity<BorgChassisComponent> ent, ref LockToggleAttemptEvent args)
     {
         // prevent cyborgs unlocking things, even though they have HandsComponent
-        if (args.User == ent)
+        if (args.User == ent.Owner)
             args.Cancelled = true;
     }
 }

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -30,6 +30,7 @@ public abstract partial class SharedBorgSystem : EntitySystem
         SubscribeLocalEvent<BorgChassisComponent, EntInsertedIntoContainerMessage>(OnInserted);
         SubscribeLocalEvent<BorgChassisComponent, EntRemovedFromContainerMessage>(OnRemoved);
         SubscribeLocalEvent<BorgChassisComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeedModifiers);
+        SubscribeLocalEvent<BorgChassisComponent, LockToggleAttempt>(OnLockToggleAttempt);
 
         InitializeRelay();
     }
@@ -95,5 +96,12 @@ public abstract partial class SharedBorgSystem : EntitySystem
 
         var sprintDif = movement.BaseWalkSpeed / movement.BaseSprintSpeed;
         args.ModifySpeed(1f, sprintDif);
+    }
+
+    private void OnLockToggleAttempt(Entity<BorgChassisComponent> ent, ref LockToggleAttempt args)
+    {
+        // prevent cyborgs unlocking things, even though they have HandsComponent
+        if (args.User == ent)
+            args.Cancelled = true;
     }
 }

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -98,7 +98,7 @@ public abstract partial class SharedBorgSystem : EntitySystem
         args.ModifySpeed(1f, sprintDif);
     }
 
-    private void OnLockToggleAttempt(Entity<BorgChassisComponent> ent, ref LockToggleAttempt args)
+    private void OnLockToggleAttempt(Entity<BorgChassisComponent> ent, ref LockToggleAttemptEvent args)
     {
         // prevent cyborgs unlocking things, even though they have HandsComponent
         if (args.User == ent)

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -30,7 +30,7 @@ public abstract partial class SharedBorgSystem : EntitySystem
         SubscribeLocalEvent<BorgChassisComponent, EntInsertedIntoContainerMessage>(OnInserted);
         SubscribeLocalEvent<BorgChassisComponent, EntRemovedFromContainerMessage>(OnRemoved);
         SubscribeLocalEvent<BorgChassisComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeedModifiers);
-        SubscribeLocalEvent<BorgChassisComponent, LockToggleAttempt>(OnLockToggleAttempt);
+        SubscribeLocalEvent<BorgChassisComponent, LockToggleAttemptEvent>(OnLockToggleAttempt);
 
         InitializeRelay();
     }


### PR DESCRIPTION
## About the PR
borgs arent able to unlock anything, fixes #27844

## Why / Balance
borgs shouldnt be able to unlock:
- caps locker
- robotics console
- other borgs, thats sus as hell
- themselves, it completely bypasses the access requirement if johnny the tider can "law 2 unlock yourself". the point of having access is that only trusted personnel can maintain cyborgs. it also puts more pressure on roboticists to be good at their jobs since if they let a new borg run free unlocked the borg cant just lock itself immediately

## Technical details
made LockToggleAttemptEvent get raised on the user too so it can be cancelled by borg

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Borgs can no longer unlock things.
