### PR TITLE
Honk mech recipe & stat buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -167,7 +167,7 @@
     attackRate: 1
     damage:
       types:
-        Blunt: 14 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
+        Blunt: 16 # sorta better than industrial mech due to higher tier
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
     baseSprintSpeed: 3.38

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -46,7 +46,7 @@
     attackRate: 0.75
     damage:
       types:
-        Blunt: 25 #thwack
+        Blunt: 20 #thwack
         Structural: 20
     soundHit:
       collection: MetalThud
@@ -162,6 +162,9 @@
     pilotWhitelist:
       components:
       - HumanoidAppearance
+  - type: MovementSpeedModifier
+    baseWalkSpeed: 2.25
+    baseSprintSpeed: 3.38
 
 - type: entity
   parent: MechHonker

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -46,7 +46,7 @@
     attackRate: 0.75
     damage:
       types:
-        Blunt: 20 #thwack
+        Blunt: 25 #thwack
         Structural: 20
     soundHit:
       collection: MetalThud
@@ -162,6 +162,12 @@
     pilotWhitelist:
       components:
       - HumanoidAppearance
+  - type: MeleeWeapon
+    hidden: true
+    attackRate: 1
+    damage:
+      types:
+        Blunt: 14 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
     baseSprintSpeed: 3.38

--- a/Resources/Prototypes/Recipes/Lathes/mech_parts.yml
+++ b/Resources/Prototypes/Recipes/Lathes/mech_parts.yml
@@ -60,9 +60,9 @@
   category: Mech
   completetime: 10
   materials:
-    Steel: 3000
+    Steel: 1800
     Glass: 1200
-    Bananium: 500
+    Bananium: 400
 
 - type: latheRecipe
   id: HonkerLArm
@@ -70,9 +70,9 @@
   category: Mech
   completetime: 10
   materials:
-    Steel: 3000
-    Glass: 1200
-    Bananium: 500
+    Steel: 1200
+    Glass: 1000
+    Bananium: 150
 
 - type: latheRecipe
   id: HonkerLLeg
@@ -80,9 +80,9 @@
   category: Mech
   completetime: 10
   materials:
-    Steel: 3000
-    Glass: 1200
-    Bananium: 500
+    Steel: 1200
+    Glass: 1000
+    Bananium: 150
 
 - type: latheRecipe
   id: HonkerRLeg
@@ -90,9 +90,9 @@
   category: Mech
   completetime: 10
   materials:
-    Steel: 3000
-    Glass: 1200
-    Bananium: 500
+    Steel: 1200
+    Glass: 1000
+    Bananium: 150
 
 - type: latheRecipe
   id: HonkerRArm
@@ -100,9 +100,9 @@
   category: Mech
   completetime: 10
   materials:
-    Steel: 3000
-    Glass: 1200
-    Bananium: 500
+    Steel: 1200
+    Glass: 1000
+    Bananium: 150
 
 - type: latheRecipe
   id: MechEquipmentHorn

--- a/Resources/Prototypes/Recipes/Lathes/mech_parts.yml
+++ b/Resources/Prototypes/Recipes/Lathes/mech_parts.yml
@@ -62,7 +62,7 @@
   materials:
     Steel: 1800
     Glass: 1200
-    Bananium: 400
+    Bananium: 600
 
 - type: latheRecipe
   id: HonkerLArm
@@ -72,7 +72,7 @@
   materials:
     Steel: 1200
     Glass: 1000
-    Bananium: 150
+    Bananium: 300
 
 - type: latheRecipe
   id: HonkerLLeg
@@ -82,7 +82,7 @@
   materials:
     Steel: 1200
     Glass: 1000
-    Bananium: 150
+    Bananium: 300
 
 - type: latheRecipe
   id: HonkerRLeg
@@ -92,7 +92,7 @@
   materials:
     Steel: 1200
     Glass: 1000
-    Bananium: 150
+    Bananium: 300
 
 - type: latheRecipe
   id: HonkerRArm
@@ -102,7 +102,7 @@
   materials:
     Steel: 1200
     Glass: 1000
-    Bananium: 150
+    Bananium: 300
 
 - type: latheRecipe
   id: MechEquipmentHorn
@@ -111,7 +111,7 @@
   completetime: 10
   materials:
     Steel: 500
-    Bananium: 200
+    Bananium: 300
 
 # HAMTR
 - type: latheRecipe


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Honker mech:
- faster movement speed (still slower than Ripley)
- removed structural damage and made dps slightly higher than ripley
- recipe made much cheaper

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

I found the Honker unusually absent from rounds despite being one of two mechs and no longer locked behind T3.

Testing confirmed outdated stats: unusually low speed compared to Ripley, slow yet high damaging melee with structural component, and being extremely expensive to fabricate. This may have to do with mechs in general being undermaintained and the Honker formerly being a T3 tech.

- increased the speed to be approximately 75% of sprint speed (assuming 4.5 base sprint speed, 3.38 is equivalent to 75%). For comparison, the Ripley is faster at 3.6 sprint speed (equivalent to 80%) but much less armoured with 75% damage transfer.

- decreased damage per swing from 25 to 16 and removed structrual damage, increase swing rate from 0.75 to 1 - should feel more consistent in combat

- decreased the recipe cost to what seems more in-line with a T2 tech - many parts no longer require a full stack of steel each, and bananium cost is decreased as it is typically ignored by salvage.

Please keep in mind the Honker mech has a 50% damage transfer to the pilot (ignoring other stats). This may need to be adjusted for balance.

Changes overall are to increase accessibility of Honker mechs and improve interest in mech code.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

yaml changes only:
- mechs.yml
- mech_parts.yml

Weirdly 100 bananium in yaml material seems to be equivalent to 2/3 (0.66) bananium in-game, I haven't been able to explain why

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/20566341/26727587-1edc-473e-a6f4-cdf554ca7f39)

![image](https://github.com/space-wizards/space-station-14/assets/20566341/82a97299-c867-4b49-b9e8-f0412d967145)


- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Damn Feds
- tweak: Honker mech is much cheaper to produce, hits slightly harder and faster overall. Honk!