### PR TITLE
Remove THC oil

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/reagents/meta/narcotics.ftl
@@ -13,9 +13,6 @@ reagent-desc-experimental-stimulants = A prototype version of the stimulant chem
 reagent-name-thc = THC
 reagent-desc-thc = The main psychoactive compound in cannabis.
 
-reagent-name-thc-oil = THC oil
-reagent-desc-thc-oil = Pure THC oil, extracted from the leaves of the cannabis plant. Much stronger than its natural form and can be used to numb chronic pain in patients.
-
 reagent-name-bananadine = bananadine
 reagent-desc-bananadine = A mild psychedelic that is found in small traces in banana peels.
 

--- a/Resources/Locale/en-US/reagents/meta/physical-desc.ftl
+++ b/Resources/Locale/en-US/reagents/meta/physical-desc.ftl
@@ -1,4 +1,3 @@
-reagent-physical-desc-skunky = skunky
 reagent-physical-desc-soapy = soapy
 reagent-physical-desc-ferrous = ferrous
 reagent-physical-desc-nothing = nothing

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -775,7 +775,6 @@
     - Desoxyephedrine
     - Ephedrine
     - THC
-    - THCOil
     - SpaceDrugs
     - Nocturine
     - MuteToxin

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -183,25 +183,6 @@
         refresh: false
 
 - type: reagent
-  id: THCOil # deprecated in favor of THC, preserved here for forks
-  name: reagent-name-thc-oil
-  group: Narcotics
-  desc: reagent-desc-thc-oil
-  physicalDesc: reagent-physical-desc-skunky
-  flavor: bitter
-  flavorMinimum: 0.05
-  color: "#DAA520"
-  metabolisms:
-    Narcotic:
-      effects:
-      - !type:GenericStatusEffect
-        key: SeeingRainbows
-        component: SeeingRainbows
-        type: Add
-        time: 16
-        refresh: false
-
-- type: reagent
   id: Nicotine
   name: reagent-name-nicotine
   group: Narcotics


### PR DESCRIPTION
## About the PR
Completely removes THC oil from the game.

## Why / Balance
Minor YAML cleanup. The reagent has been deprecated for 9 months now and only preserved for downstream compability (see #18617). The feature freeze is probably the best time to remove it.
Not to be confused with THC, which remains unchanged. No gameplay changes other than the reagent being removed from the guidebook.

## Technical details
Removed THC oil from the YAML files and corresponding translation strings from .ftl files.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Forks that still use THC oil should not merge this PR.

**Changelog**
Not needed since there is no gameplay impact.
