### PR TITLE
Makes bullet casings destructible by explosions

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
@@ -16,6 +16,17 @@
           - ItemMask
         restitution: 0.3  # fite me
         friction: 0.2
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StrongMetallic # We only want explosions breaking them (for the most part)
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
   - type: Tag
     tags:
     - Cartridge


### PR DESCRIPTION
## About the PR
What it says on the tin. Makes bullet casings able to be destroyed, primarily intended via explosions.

They will not drop anything, and have a fairly high structural damage modifier that makes them *mostly* impossible to destroy using direct melee, unless you're a really robust weapon. Ideally, this wouldn't be possible at all, but it uses the rwall damage modifier set, so it's not my problem.

## Why / Balance
Fixes **part** of #22445 (DOES NOT ACTUALLY IMPLEMENT LOWER SPACE FRICTION.)

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun