### PR TITLE
Fix Slime and Geras speed

### DIFF
--- a/Resources/Prototypes/Body/Parts/slime.yml
+++ b/Resources/Prototypes/Body/Parts/slime.yml
@@ -99,7 +99,7 @@
 #Because it turns out body effects movement speed
 - type: entity
   id: LegsSlime
-  name: "slime legs"
+  name: slime legs
   parent: LegsAnimal
   noSpawn: true
   components:
@@ -109,7 +109,7 @@
 
 - type: entity
   id: LegsGeras
-  name: "slime legs"
+  name: slime legs
   parent: LegsAnimal
   noSpawn: true
   components:

--- a/Resources/Prototypes/Body/Parts/slime.yml
+++ b/Resources/Prototypes/Body/Parts/slime.yml
@@ -94,3 +94,25 @@
     - type: Sprite
       sprite: Mobs/Species/Slime/parts.rsi
       state: "r_foot"
+
+#The following are geras/slime slime parts
+#Because it turns out body effects movement speed
+- type: entity
+  id: LegsSlime
+  name: "slime legs"
+  parent: LegsAnimal
+  noSpawn: true
+  components:
+  - type: MovementBodyPart
+    walkSpeed: 2
+    sprintSpeed: 4
+
+- type: entity
+  id: LegsGeras
+  name: "slime legs"
+  parent: LegsAnimal
+  noSpawn: true
+  components:
+  - type: MovementBodyPart
+    walkSpeed: 3
+    sprintSpeed: 5

--- a/Resources/Prototypes/Body/Parts/slime.yml
+++ b/Resources/Prototypes/Body/Parts/slime.yml
@@ -115,4 +115,4 @@
   components:
   - type: MovementBodyPart
     walkSpeed: 3
-    sprintSpeed: 5
+    sprintSpeed: 5 # +.5 from normal movement speed

--- a/Resources/Prototypes/Body/Prototypes/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Prototypes/Animal/slimes.yml
@@ -19,7 +19,7 @@
 
 - type: body
   id: Geras
-  name: "geras"
+  name: "slimes"
   root: torso
   slots:
     torso:

--- a/Resources/Prototypes/Body/Prototypes/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Prototypes/Animal/slimes.yml
@@ -1,4 +1,4 @@
-﻿- type: body
+- type: body
   id: Slimes
   name: "slimes"
   root: torso
@@ -11,7 +11,26 @@
         core: SentientSlimesCore
         lungs: OrganSlimesLungs
     legs:
-      part: LegsAnimal
+      part: LegsSlime
+      connections:
+      - feet
+    feet:
+      part: FeetAnimal
+
+- type: body
+  id: Geras
+  name: "geras"
+  root: torso
+  slots:
+    torso:
+      part: TorsoSlime
+      connections:
+      - legs
+      organs:
+        core: SentientSlimesCore
+        lungs: OrganSlimesLungs
+    legs:
+      part: LegsGeras
       connections:
       - feet
     feet:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   name: basic slime
   id: BaseMobAdultSlimes
   parent: [ SimpleMobBase, MobCombat ]
@@ -176,6 +176,9 @@
         Base: blue_adult_slime
       Dead:
         Base: blue_adult_slime_dead
+  - type: Body
+    prototype: Geras
+    requiredLegs: 1
 
 - type: entity
   name: blue slime

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -26,9 +26,6 @@
     thresholds:
       0: Alive
       120: Dead
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 2
-    baseSprintSpeed: 4
   - type: FootstepModifier
     footstepSoundCollection:
       path: /Audio/Effects/Footsteps/slime1.ogg
@@ -150,9 +147,6 @@
   noSpawn: true
   components:
   # they portable...
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 3
-    baseSprintSpeed: 5 # +.5 from normal movement speed
   - type: MobThresholds
     thresholds:
       0: Alive


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
So, slimes are supposed to be slower than players and Geras a little faster, but these weren't being applied. Now they are.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
🐛 since unintended. Can't find a specific issue here but it's been mentioned on this discord [thread](https://discord.com/channels/310555209753690112/1231929864433565706).

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
So it turns out the BodyComponent replaces baseSpeeds based on how the legs are defined. So I just, made slimes and gerases their own "legs". I had to copy the slime body proto entirely for geras (only changing the legs) since I don't think I can only change the legs alone (if I can though please tell me!)

I removed the extra speed components in the slime prototypes because of this. Alternatively I can probably remove the legs from slimes and that'll make them only get their base speed from the speed modifier if that's prefered.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/32827189/50bd58fc-75f6-426d-b8a3-633fab55b389



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Slimes and Gerases move at their proper speeds
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
