### PR TITLE
Open slot storage keybind can now also close the UI

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1433,15 +1433,15 @@ public abstract class SharedStorageSystem : EntitySystem
 
     private void HandleOpenBackpack(ICommonSession? session)
     {
-        HandleOpenSlotUI(session, "back");
+        HandleToggleSlotUI(session, "back");
     }
 
     private void HandleOpenBelt(ICommonSession? session)
     {
-        HandleOpenSlotUI(session, "belt");
+        HandleToggleSlotUI(session, "belt");
     }
 
-    private void HandleOpenSlotUI(ICommonSession? session, string slot)
+    private void HandleToggleSlotUI(ICommonSession? session, string slot)
     {
         if (session is not { } playerSession)
             return;
@@ -1455,7 +1455,14 @@ public abstract class SharedStorageSystem : EntitySystem
         if (!ActionBlocker.CanInteract(playerEnt, storageEnt))
             return;
 
-        OpenStorageUI(storageEnt.Value, playerEnt);
+        if (!_ui.IsUiOpen(storageEnt.Value, StorageComponent.StorageUiKey.Key, playerEnt))
+        {
+            OpenStorageUI(storageEnt.Value, playerEnt);
+        }
+        else
+        {
+            _ui.CloseUi(storageEnt.Value, StorageComponent.StorageUiKey.Key, playerEnt);
+        }
     }
 
     protected void ClearCantFillReasons()


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

open slot storage keybind (V for backpack shift+V for belt) will close the storage UI if its already open

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

this just personally bothered me a lot that it didnt work like this

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![Content Client_2024-05-12_18-38-36](https://github.com/space-wizards/space-station-14/assets/19853115/e815cd37-2af1-4d8b-a6d2-297373ee2272)


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: The open slot storage keybinds (V, shift+V) now close the window if it's already opened
