### PR TITLE
Implement Equals for ApcBoundInterfaceState

### DIFF
--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.APC;
 using Content.Shared.Emag.Components;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Popups;
+using Content.Shared.Rounding;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -147,10 +148,14 @@ public sealed class ApcSystem : EntitySystem
             return;
 
         var battery = netBat.NetworkBattery;
+        const int ChargeAccuracy = 5;
+
+        // TODO: Fix ContentHelpers or make a new one coz this is cooked.
+        var charge = ContentHelpers.RoundToNearestLevels(battery.CurrentStorage / battery.Capacity, 1.0, 100 / ChargeAccuracy) / 100f * ChargeAccuracy;
 
         var state = new ApcBoundInterfaceState(apc.MainBreakerEnabled, apc.HasAccess,
             (int) MathF.Ceiling(battery.CurrentSupply), apc.LastExternalState,
-            battery.CurrentStorage / battery.Capacity);
+            charge);
 
         _ui.SetUiState((uid, ui), ApcUiKey.Key, state);
     }

--- a/Content.Shared/APC/SharedApc.cs
+++ b/Content.Shared/APC/SharedApc.cs
@@ -65,7 +65,7 @@ namespace Content.Shared.APC
         /// Bitmask for the full state for a given APC lock indicator.
         /// </summary>
         All = (Lock),
-        
+
         /// <summary>
         /// The log 2 width in bits of the bitfields indicating the status of an APC lock indicator.
         /// Used for bit shifting operations (Mask for the state for indicator i is (All << (i << LogWidth))).
@@ -175,7 +175,7 @@ namespace Content.Shared.APC
     }
 
     [Serializable, NetSerializable]
-    public sealed class ApcBoundInterfaceState : BoundUserInterfaceState
+    public sealed class ApcBoundInterfaceState : BoundUserInterfaceState, IEquatable<ApcBoundInterfaceState>
     {
         public readonly bool MainBreaker;
         public readonly bool HasAccess;
@@ -190,6 +190,27 @@ namespace Content.Shared.APC
             Power = power;
             ApcExternalPower = apcExternalPower;
             Charge = charge;
+        }
+
+        public bool Equals(ApcBoundInterfaceState? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return MainBreaker == other.MainBreaker &&
+                   HasAccess == other.HasAccess &&
+                   Power == other.Power &&
+                   ApcExternalPower == other.ApcExternalPower &&
+                   MathHelper.CloseTo(Charge, other.Charge);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return ReferenceEquals(this, obj) || obj is ApcBoundInterfaceState other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(MainBreaker, HasAccess, Power, (int)ApcExternalPower, Charge);
         }
     }
 

--- a/Content.Shared/APC/SharedApc.cs
+++ b/Content.Shared/APC/SharedApc.cs
@@ -210,7 +210,7 @@ namespace Content.Shared.APC
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(MainBreaker, HasAccess, Power, (int)ApcExternalPower, Charge);
+            return HashCode.Combine(MainBreaker, HasAccess, Power, (int) ApcExternalPower, Charge);
         }
     }
 
@@ -219,7 +219,7 @@ namespace Content.Shared.APC
     {
     }
 
-    public enum ApcExternalPowerState
+    public enum ApcExternalPowerState : byte
     {
         None,
         Low,
@@ -227,7 +227,7 @@ namespace Content.Shared.APC
     }
 
     [NetSerializable, Serializable]
-    public enum ApcUiKey
+    public enum ApcUiKey : byte
     {
         Key,
     }


### PR DESCRIPTION
Saves a lot on bandwidth. Also made it round to the nearest 5.