### PR TITLE
Update component query benchmarks

### DIFF
--- a/Content.Benchmarks/ComponentQueryBenchmark.cs
+++ b/Content.Benchmarks/ComponentQueryBenchmark.cs
@@ -26,7 +26,7 @@ namespace Content.Benchmarks;
 [Virtual]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
 [CategoriesColumn]
-public class EntityQueryBenchmark
+public class ComponentQueryBenchmark
 {
     public const string Map = "Maps/atlas.yml";
 

--- a/Content.Benchmarks/EntityQueryBenchmark.cs
+++ b/Content.Benchmarks/EntityQueryBenchmark.cs
@@ -1,38 +1,55 @@
 ﻿#nullable enable
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
 using Content.IntegrationTests;
 using Content.IntegrationTests.Pair;
 using Content.Shared.Clothing.Components;
+using Content.Shared.Doors.Components;
 using Content.Shared.Item;
 using Robust.Server.GameObjects;
 using Robust.Shared;
 using Robust.Shared.Analyzers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Random;
 
 namespace Content.Benchmarks;
 
+/// <summary>
+/// Benchmarks for comparing the speed of various component fetching/lookup related methods, including directed event
+/// subscriptions
+/// </summary>
 [Virtual]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
 public class EntityQueryBenchmark
 {
     public const string Map = "Maps/atlas.yml";
 
     private TestPair _pair = default!;
     private IEntityManager _entMan = default!;
-    private MapId _mapId = new MapId(10);
+    private MapId _mapId = new(10);
+    private EntityQuery<ItemComponent> _itemQuery;
     private EntityQuery<ClothingComponent> _clothingQuery;
+    private EntityQuery<MapComponent> _mapQuery;
+    private EntityUid[] _items = default!;
 
     [GlobalSetup]
     public void Setup()
     {
         ProgramShared.PathOffset = "../../../../";
-        PoolManager.Startup(null);
+        PoolManager.Startup(typeof(QueryBenchSystem).Assembly);
 
         _pair = PoolManager.GetServerClient().GetAwaiter().GetResult();
         _entMan = _pair.Server.ResolveDependency<IEntityManager>();
+
+        _itemQuery = _entMan.GetEntityQuery<ItemComponent>();
+        _clothingQuery = _entMan.GetEntityQuery<ClothingComponent>();
+        _mapQuery = _entMan.GetEntityQuery<MapComponent>();
 
         _pair.Server.ResolveDependency<IRobustRandom>().SetSeed(42);
         _pair.Server.WaitPost(() =>
@@ -43,17 +60,13 @@ public class EntityQueryBenchmark
             _pair.Server.MapMan.DoMapInitialize(_mapId);
         }).GetAwaiter().GetResult();
 
-        _clothingQuery = _entMan.GetEntityQuery<ClothingComponent>();
-
-        // Apparently ~40% of entities are items, and 1 in 6 of those are clothing.
-        /*
-        var entCount = _entMan.EntityCount;
-        var itemCount = _entMan.Count<ItemComponent>();
-        var clothingCount = _entMan.Count<ClothingComponent>();
-        var itemRatio = (float) itemCount / entCount;
-        var clothingRatio = (float) clothingCount / entCount;
-        Console.WriteLine($"Entities: {entCount}. Items: {itemRatio:P2}. Clothing: {clothingRatio:P2}.");
-        */
+        _items = new EntityUid[_entMan.Count<ItemComponent>()];
+        var i = 0;
+        var enumerator = _entMan.AllEntityQueryEnumerator<ItemComponent>();
+        while (enumerator.MoveNext(out var uid, out _))
+        {
+            _items[i++] = uid;
+        }
     }
 
     [GlobalCleanup]
@@ -63,75 +76,198 @@ public class EntityQueryBenchmark
         PoolManager.Shutdown();
     }
 
-    [Benchmark]
-    public int HasComponent()
+    #region TryComp
+
+    /// <summary>
+    /// Baseline TryComp benchmark. When the benchmark was created, around 40% of the items were clothing.
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("TryComp")]
+    public int TryComp()
     {
         var hashCode = 0;
-        var enumerator = _entMan.AllEntityQueryEnumerator<ItemComponent>();
-        while (enumerator.MoveNext(out var uid, out var _))
-        {
-            if (_entMan.HasComponent<ClothingComponent>(uid))
-                hashCode = HashCode.Combine(hashCode, uid.Id);
-        }
-
-        return hashCode;
-    }
-
-    [Benchmark]
-    public int HasComponentQuery()
-    {
-        var hashCode = 0;
-        var enumerator = _entMan.AllEntityQueryEnumerator<ItemComponent>();
-        while (enumerator.MoveNext(out var uid, out var _))
-        {
-            if (_clothingQuery.HasComponent(uid))
-                hashCode = HashCode.Combine(hashCode, uid.Id);
-        }
-
-        return hashCode;
-    }
-
-    [Benchmark]
-    public int TryGetComponent()
-    {
-        var hashCode = 0;
-        var enumerator = _entMan.AllEntityQueryEnumerator<ItemComponent>();
-        while (enumerator.MoveNext(out var uid, out var _))
-        {
-            if (_entMan.TryGetComponent(uid, out ClothingComponent? clothing))
-                hashCode = HashCode.Combine(hashCode, clothing.GetHashCode());
-        }
-
-        return hashCode;
-    }
-
-    [Benchmark]
-    public int TryGetComponentQuery()
-    {
-        var hashCode = 0;
-        var enumerator = _entMan.AllEntityQueryEnumerator<ItemComponent>();
-        while (enumerator.MoveNext(out var uid, out var _))
+        foreach (var uid in _items)
         {
             if (_clothingQuery.TryGetComponent(uid, out var clothing))
                 hashCode = HashCode.Combine(hashCode, clothing.GetHashCode());
         }
-
         return hashCode;
     }
 
     /// <summary>
-    /// Enumerate all entities with both an item and clothing component.
+    /// Variant of <see cref="TryComp"/> that is meant to always fail to get a component.
     /// </summary>
     [Benchmark]
-    public int Enumerator()
+    [BenchmarkCategory("TryComp")]
+    public int TryCompFail()
     {
         var hashCode = 0;
-        var enumerator = _entMan.AllEntityQueryEnumerator<ItemComponent, ClothingComponent>();
-        while (enumerator.MoveNext(out var _, out var clothing))
+        foreach (var uid in _items)
         {
-            hashCode = HashCode.Combine(hashCode, clothing.GetHashCode());
+            if (_mapQuery.TryGetComponent(uid, out var map))
+                hashCode = HashCode.Combine(hashCode, map.GetHashCode());
+        }
+        return hashCode;
+    }
+
+    /// <summary>
+    /// Variant of <see cref="TryComp"/> that is meant to always succeed getting a component.
+    /// </summary>
+    [Benchmark]
+    [BenchmarkCategory("TryComp")]
+    public int TryCompSucceed()
+    {
+        var hashCode = 0;
+        foreach (var uid in _items)
+        {
+            if (_itemQuery.TryGetComponent(uid, out var item))
+                hashCode = HashCode.Combine(hashCode, item.GetHashCode());
+        }
+        return hashCode;
+    }
+
+    /// <summary>
+    /// Variant of <see cref="TryComp"/> that uses `Resolve()` to try get the component.
+    /// </summary>
+    [Benchmark]
+    [BenchmarkCategory("TryComp")]
+    public int Resolve()
+    {
+        var hashCode = 0;
+        foreach (var uid in _items)
+        {
+            DoResolve(uid, ref hashCode);
+        }
+        return hashCode;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DoResolve(EntityUid uid, ref int hash, ClothingComponent? clothing = null)
+    {
+        if (_clothingQuery.Resolve(uid, ref clothing, false))
+            hash = HashCode.Combine(hash, clothing.GetHashCode());
+    }
+
+    #endregion
+
+    #region Enumeration
+
+    [Benchmark]
+    [BenchmarkCategory("Item Enumerator")]
+    public int SingleItemEnumerator()
+    {
+        var hashCode = 0;
+        var enumerator = _entMan.AllEntityQueryEnumerator<ItemComponent>();
+        while (enumerator.MoveNext(out var item))
+        {
+            hashCode = HashCode.Combine(hashCode, item.GetHashCode());
         }
 
         return hashCode;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Item Enumerator")]
+    public int DoubleItemEnumerator()
+    {
+        var hashCode = 0;
+        var enumerator = _entMan.AllEntityQueryEnumerator<ClothingComponent, ItemComponent>();
+        while (enumerator.MoveNext(out _, out var item))
+        {
+            hashCode = HashCode.Combine(hashCode, item.GetHashCode());
+        }
+
+        return hashCode;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Item Enumerator")]
+    public int TripleItemEnumerator()
+    {
+        var hashCode = 0;
+        var enumerator = _entMan.AllEntityQueryEnumerator<ClothingComponent, ItemComponent, TransformComponent>();
+        while (enumerator.MoveNext(out _, out _, out var xform))
+        {
+            hashCode = HashCode.Combine(hashCode, xform.GetHashCode());
+        }
+
+        return hashCode;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Airlock Enumerator")]
+    public int SingleAirlockEnumerator()
+    {
+        var hashCode = 0;
+        var enumerator = _entMan.AllEntityQueryEnumerator<AirlockComponent>();
+        while (enumerator.MoveNext(out var airlock))
+        {
+            hashCode = HashCode.Combine(hashCode, airlock.GetHashCode());
+        }
+
+        return hashCode;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Airlock Enumerator")]
+    public int DoubleAirlockEnumerator()
+    {
+        var hashCode = 0;
+        var enumerator = _entMan.AllEntityQueryEnumerator<AirlockComponent, DoorComponent>();
+        while (enumerator.MoveNext(out _, out var door))
+        {
+            hashCode = HashCode.Combine(hashCode, door.GetHashCode());
+        }
+
+        return hashCode;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Airlock Enumerator")]
+    public int TripleAirlockEnumerator()
+    {
+        var hashCode = 0;
+        var enumerator = _entMan.AllEntityQueryEnumerator<AirlockComponent, DoorComponent, TransformComponent>();
+        while (enumerator.MoveNext(out _, out _, out var xform))
+        {
+            hashCode = HashCode.Combine(hashCode, xform.GetHashCode());
+        }
+
+        return hashCode;
+    }
+
+    #endregion
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Events")]
+    public int StructEvents()
+    {
+        var ev = new QueryBenchEvent();
+        foreach (var uid in _items)
+        {
+            _entMan.EventBus.RaiseLocalEvent(uid, ref ev);
+        }
+
+        return ev.HashCode;
+    }
+}
+
+[ByRefEvent]
+public struct QueryBenchEvent
+{
+    public int HashCode;
+}
+
+public sealed class QueryBenchSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ClothingComponent, QueryBenchEvent>(OnEvent);
+    }
+
+    private void OnEvent(EntityUid uid, ClothingComponent component, ref QueryBenchEvent args)
+    {
+        args.HashCode = HashCode.Combine(args.HashCode, component.GetHashCode());
     }
 }

--- a/Content.Benchmarks/MapLoadBenchmark.cs
+++ b/Content.Benchmarks/MapLoadBenchmark.cs
@@ -26,7 +26,7 @@ public class MapLoadBenchmark
     public void Setup()
     {
         ProgramShared.PathOffset = "../../../../";
-        PoolManager.Startup(null);
+        PoolManager.Startup();
 
         _pair = PoolManager.GetServerClient().GetAwaiter().GetResult();
         var server = _pair.Server;

--- a/Content.Benchmarks/PvsBenchmark.cs
+++ b/Content.Benchmarks/PvsBenchmark.cs
@@ -49,7 +49,7 @@ public class PvsBenchmark
 #if !DEBUG
         ProgramShared.PathOffset = "../../../../";
 #endif
-        PoolManager.Startup(null);
+        PoolManager.Startup();
 
         _pair = PoolManager.GetServerClient().GetAwaiter().GetResult();
         _entMan = _pair.Server.ResolveDependency<IEntityManager>();

--- a/Content.Benchmarks/SpawnEquipDeleteBenchmark.cs
+++ b/Content.Benchmarks/SpawnEquipDeleteBenchmark.cs
@@ -32,7 +32,7 @@ public class SpawnEquipDeleteBenchmark
     public async Task SetupAsync()
     {
         ProgramShared.PathOffset = "../../../../";
-        PoolManager.Startup(null);
+        PoolManager.Startup();
         _pair = await PoolManager.GetServerClient();
         var server = _pair.Server;
 

--- a/Content.IntegrationTests/PoolManager.Prototypes.cs
+++ b/Content.IntegrationTests/PoolManager.Prototypes.cs
@@ -15,11 +15,8 @@ public static partial class PoolManager
                                        | BindingFlags.Public
                                        | BindingFlags.DeclaredOnly;
 
-    private static void DiscoverTestPrototypes(Assembly? assembly = null)
+    private static void DiscoverTestPrototypes(Assembly assembly)
     {
-        assembly ??= typeof(PoolManager).Assembly;
-        _testPrototypes.Clear();
-
         foreach (var type in assembly.GetTypes())
         {
             foreach (var field in type.GetFields(Flags))

--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -42,6 +42,8 @@ public static partial class PoolManager
     private static bool _dead;
     private static Exception? _poolFailureReason;
 
+    private static HashSet<Assembly> _contentAssemblies = default!;
+
     public static async Task<(RobustIntegrationTest.ServerIntegrationInstance, PoolTestLogHandler)> GenerateServer(
         PoolSettings poolSettings,
         TextWriter testOut)
@@ -54,12 +56,7 @@ public static partial class PoolManager
                 LoadConfigAndUserData = false,
                 LoadContentResources = !poolSettings.NoLoadContent,
             },
-            ContentAssemblies = new[]
-            {
-                typeof(Shared.Entry.EntryPoint).Assembly,
-                typeof(Server.Entry.EntryPoint).Assembly,
-                typeof(PoolManager).Assembly
-            }
+            ContentAssemblies = _contentAssemblies.ToArray()
         };
 
         var logHandler = new PoolTestLogHandler("SERVER");
@@ -140,7 +137,7 @@ public static partial class PoolManager
             {
                 typeof(Shared.Entry.EntryPoint).Assembly,
                 typeof(Client.Entry.EntryPoint).Assembly,
-                typeof(PoolManager).Assembly
+                typeof(PoolManager).Assembly,
             }
         };
 
@@ -422,13 +419,26 @@ we are just going to end this here to save a lot of time. This is the exception 
     /// <summary>
     /// Initialize the pool manager.
     /// </summary>
-    /// <param name="assembly">Assembly to search for to discover extra test prototypes.</param>
-    public static void Startup(Assembly? assembly)
+    /// <param name="extraAssemblies">Assemblies to search for to discover extra prototypes and systems.</param>
+    public static void Startup(params Assembly[] extraAssemblies)
     {
         if (_initialized)
             throw new InvalidOperationException("Already initialized");
 
         _initialized = true;
-        DiscoverTestPrototypes(assembly);
+        _contentAssemblies =
+        [
+            typeof(Shared.Entry.EntryPoint).Assembly,
+            typeof(Server.Entry.EntryPoint).Assembly,
+            typeof(PoolManager).Assembly
+        ];
+        _contentAssemblies.UnionWith(extraAssemblies);
+
+        _testPrototypes.Clear();
+        DiscoverTestPrototypes(typeof(PoolManager).Assembly);
+        foreach (var assembly in extraAssemblies)
+        {
+            DiscoverTestPrototypes(assembly);
+        }
     }
 }

--- a/Content.IntegrationTests/PoolManagerTestEventHandler.cs
+++ b/Content.IntegrationTests/PoolManagerTestEventHandler.cs
@@ -13,7 +13,7 @@ public sealed class PoolManagerTestEventHandler
     [OneTimeSetUp]
     public void Setup()
     {
-        PoolManager.Startup(typeof(PoolManagerTestEventHandler).Assembly);
+        PoolManager.Startup();
         // If the tests seem to be stuck, we try to end it semi-nicely
         _ = Task.Delay(MaximumTotalTestingTimeLimit).ContinueWith(_ =>
         {

--- a/Content.MapRenderer/Program.cs
+++ b/Content.MapRenderer/Program.cs
@@ -29,7 +29,7 @@ namespace Content.MapRenderer
             if (!CommandLineArguments.TryParse(args, out var arguments))
                 return;
 
-            PoolManager.Startup(null);
+            PoolManager.Startup();
             if (arguments.Maps.Count == 0)
             {
                 Console.WriteLine("Didn't specify any maps to paint! Loading the map list...");

--- a/Content.YAMLLinter/Program.cs
+++ b/Content.YAMLLinter/Program.cs
@@ -17,7 +17,7 @@ namespace Content.YAMLLinter
     {
         private static async Task<int> Main(string[] _)
         {
-            PoolManager.Startup(null);
+            PoolManager.Startup();
             var stopwatch = new Stopwatch();
             stopwatch.Start();
 


### PR DESCRIPTION
- Renames the `EntityQueryBenchmark` class to `ComponentQueryBenchmark`
- Adds some multi-component query/enumeration benchmarks
- Changes the `TryGetComponent` benchmarks to use an EntityUid array instead of an `AllEntityQueryEnumerator`
- Adds a directed ref struct event benchmark

<details>
<summary>Results on my machine</summary>

```

BenchmarkDotNet v0.13.12, Windows 10 (10.0.19042.1081/20H2/October2020Update)
AMD Ryzen 7 3800X, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.203
  [Host]     : .NET 8.0.3 (8.0.324.11423), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.3 (8.0.324.11423), X64 RyuJIT AVX2


```
| Method                  | Categories         | Mean       | Error     | StdDev    | Ratio | RatioSD |
|------------------------ |------------------- |-----------:|----------:|----------:|------:|--------:|
| SingleAirlockEnumerator | Airlock Enumerator |   1.294 μs | 0.0005 μs | 0.0005 μs |     ? |       ? |
| DoubleAirlockEnumerator | Airlock Enumerator |   3.385 μs | 0.0014 μs | 0.0012 μs |     ? |       ? |
| TripleAirlockEnumerator | Airlock Enumerator |   4.442 μs | 0.0031 μs | 0.0027 μs |     ? |       ? |
|                         |                    |            |           |           |       |         |
| StructEvents            | Events             | 381.225 μs | 0.1265 μs | 0.1057 μs |  1.00 |    0.00 |
|                         |                    |            |           |           |       |         |
| SingleItemEnumerator    | Item Enumerator    |  51.071 μs | 0.0178 μs | 0.0139 μs |     ? |       ? |
| DoubleItemEnumerator    | Item Enumerator    |  11.358 μs | 0.0258 μs | 0.0241 μs |     ? |       ? |
| TripleItemEnumerator    | Item Enumerator    |  17.037 μs | 0.0393 μs | 0.0367 μs |     ? |       ? |
|                         |                    |            |           |           |       |         |
| TryComp                 | TryComp            |  29.009 μs | 0.1450 μs | 0.1357 μs |  1.00 |    0.00 |
| TryCompFail             | TryComp            |  21.076 μs | 0.0709 μs | 0.0663 μs |  0.73 |    0.00 |
| TryCompSucceed          | TryComp            |  76.457 μs | 0.0614 μs | 0.0544 μs |  2.64 |    0.01 |
| Resolve                 | TryComp            |  30.327 μs | 0.0990 μs | 0.0926 μs |  1.05 |    0.00 |



</details>

I'm not sure about some of the results. In particular, I don't know why `TryCompSucceed` (iterating over all items and trying to get their item component) is so much slower than variants that always or sometimes fail the try-get (map/clothing comps).

The `GetHashCode()` calls are there out of paranoia that it might somehow optimize away actually retrieving the components if they do not get used.
