### PR TITLE
Make failing to fire a gun that requires wielding not delay the next shot

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/GunRequiresWieldComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunRequiresWieldComponent.cs
@@ -6,8 +6,13 @@ namespace Content.Shared.Weapons.Ranged.Components;
 /// <summary>
 /// Indicates that this gun requires wielding to be useable.
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(WieldableSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(WieldableSystem))]
 public sealed partial class GunRequiresWieldComponent : Component
 {
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastPopup;
 
+    [DataField, AutoNetworkedField]
+    public TimeSpan PopupCooldown = TimeSpan.FromSeconds(1);
 }

--- a/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Weapons.Ranged.Components;
+
 namespace Content.Shared.Weapons.Ranged.Events;
 
 /// <summary>
@@ -15,7 +17,7 @@ public record struct ShotAttemptedEvent
     /// <summary>
     /// The gun being shot.
     /// </summary>
-    public EntityUid Used;
+    public Entity<GunComponent> Used;
 
     public bool Cancelled { get; private set; }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -239,7 +239,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         var prevention = new ShotAttemptedEvent
         {
             User = user,
-            Used = gunUid
+            Used = (gunUid, gun)
         };
         RaiseLocalEvent(gunUid, ref prevention);
         if (prevention.Cancelled)


### PR DESCRIPTION
## About the PR
Specially noticeable with very low firerate guns.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Failing to fire a gun that requires wielding will no longer delay the next shot.