### PR TITLE
fix fire spread round removal

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -204,47 +204,30 @@ namespace Content.Server.Atmos.EntitySystems
             if (!flammable.OnFire && !otherFlammable.OnFire)
                 return; // Neither are on fire
 
-            if (flammable.OnFire && otherFlammable.OnFire)
+            // Both are on fire -> equalize fire stacks.
+            // Weight each thing's firestacks by its mass
+            var mass1 = 1f;
+            var mass2 = 1f;
+            if (_physicsQuery.TryComp(uid, out var physics) && _physicsQuery.TryComp(otherUid, out var otherPhys))
             {
-                // Both are on fire -> equalize fire stacks.
-                // Weight each thing's firestacks by its mass
-                var mass1 = 1f;
-                var mass2 = 1f;
-                if (_physicsQuery.TryComp(uid, out var physics) && _physicsQuery.TryComp(otherUid, out var otherPhys))
-                {
-                    mass1 = physics.Mass;
-                    mass2 = otherPhys.Mass;
-                }
-
-                var total = mass1 + mass2;
-                var avg = (flammable.FireStacks * mass1 + otherFlammable.FireStacks * mass2) / total;
-                flammable.FireStacks = flammable.CanExtinguish ? avg : Math.Max(flammable.FireStacks, avg);
-                otherFlammable.FireStacks = otherFlammable.CanExtinguish ? avg : Math.Max(otherFlammable.FireStacks, avg);
-                UpdateAppearance(uid, flammable);
-                UpdateAppearance(otherUid, otherFlammable);
-                return;
+                mass1 = physics.Mass;
+                mass2 = otherPhys.Mass;
             }
 
-            // Only one is on fire -> attempt to spread the fire.
-            var (srcUid, srcFlammable, destUid, destFlammable) = flammable.OnFire
-                ? (uid, flammable, otherUid, otherFlammable)
-                : (otherUid, otherFlammable, uid, flammable);
+            // when the thing on fire is more massive than the other, the following happens:
+            // - the thing on fire loses a small number of firestacks
+            // - the other thing gains a large number of firestacks
+            // so a person on fire engulfs a mouse, but an engulfed mouse barely does anything to a person
+            var total = mass1 + mass2;
+            var avg = (flammable.FireStacks + otherFlammable.FireStacks) / total;
 
-            // if the thing on fire has less mass, spread less firestacks and vice versa
-            var ratio = 0.5f;
-            if (_physicsQuery.TryComp(srcUid, out var srcPhysics) && _physicsQuery.TryComp(destUid, out var destPhys))
-            {
-                ratio *= srcPhysics.Mass / destPhys.Mass;
-            }
-
-            var lost = srcFlammable.FireStacks * ratio;
-            destFlammable.FireStacks += lost;
-            Ignite(destUid, srcUid, destFlammable);
-            if (srcFlammable.CanExtinguish)
-            {
-                srcFlammable.FireStacks -= lost;
-                UpdateAppearance(srcUid, srcFlammable);
-            }
+            // swap the entity losing stacks depending on whichever has the most firestack kilos
+            var (src, dest) = flammable.FireStacks * mass1 > otherFlammable.FireStacks * mass2
+                ? (-1f, 1f)
+                : (1f, -1f);
+            // bring each entity to the same firestack mass, firestacks being scaled by the other's mass
+            AdjustFireStacks(uid, src * avg * mass2, flammable);
+            AdjustFireStacks(otherUid, dest * avg * mass1, otherFlammable);
         }
 
         private void OnIsHot(EntityUid uid, FlammableComponent flammable, IsHotEvent args)
@@ -287,12 +270,25 @@ namespace Content.Server.Atmos.EntitySystems
             if (!Resolve(uid, ref flammable))
                 return;
 
-            flammable.FireStacks = MathF.Min(MathF.Max(flammable.MinimumFireStacks, flammable.FireStacks + relativeFireStacks), flammable.MaximumFireStacks);
+            SetFireStacks(uid, flammable.FireStacks + relativeFireStacks, flammable);
+        }
 
-            if (flammable.OnFire && flammable.FireStacks <= 0)
+        public void SetFireStacks(EntityUid uid, float stacks, FlammableComponent? flammable = null)
+        {
+            if (!Resolve(uid, ref flammable))
+                return;
+
+            flammable.FireStacks = MathF.Min(MathF.Max(flammable.MinimumFireStacks, stacks), flammable.MaximumFireStacks);
+
+            if (flammable.FireStacks <= 0)
+            {
                 Extinguish(uid, flammable);
+            }
             else
+            {
+                flammable.OnFire = true;
                 UpdateAppearance(uid, flammable);
+            }
         }
 
         public void Extinguish(EntityUid uid, FlammableComponent? flammable = null)

--- a/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
+++ b/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
@@ -36,7 +36,7 @@ public sealed class IgnitionSourceSystem : EntitySystem
     /// </summary>
     public void SetIgnited(Entity<IgnitionSourceComponent?> ent, bool ignited = true)
     {
-        if (!Resolve(ent, ref ent.Comp))
+        if (!Resolve(ent, ref ent.Comp, false))
             return;
 
         ent.Comp.Ignited = ignited;


### PR DESCRIPTION
## About the PR
fixes #27983

## Why / Balance
instantly gaining 1m firestacks is bad

## Technical details
- removed copy paste shitcode that used 2 different methods of calculating spread
- comment is better
- the spreading code now uses bounds checking so its not possible to get trolled ever again

## Media

https://github.com/space-wizards/space-station-14/assets/39013340/27dc547b-94f7-4f03-8cd9-0bd23950e60c

forced 10 firestack mouse doesnt crit a urist when in contact for a few seconds

~4 firestack urist instantly puts mice to 10 firestacks because of mass difference

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed fire spreading being insane.