### PR TITLE
Fix salvage magnet UI opening again when activating the console twice

### DIFF
--- a/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
+++ b/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
@@ -20,10 +20,14 @@ public sealed class SalvageMagnetBoundUserInterface : BoundUserInterface
     protected override void Open()
     {
         base.Open();
-        _window = new OfferingWindow();
-        _window.Title = Loc.GetString("salvage-magnet-window-title");
-        _window.OnClose += Close;
-        _window.OpenCenteredLeft();
+
+        if (_window is null)
+        {
+            _window = new OfferingWindow();
+            _window.Title = Loc.GetString("salvage-magnet-window-title");
+            _window.OnClose += Close;
+            _window.OpenCenteredLeft();
+        }
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)
@@ -106,6 +110,17 @@ public sealed class SalvageMagnetBoundUserInterface : BoundUserInterface
             }
 
             _window.AddOption(option);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing)
+        {
+            _window?.Close();
+            _window?.Dispose();
         }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

When you activate the console again while the first UI is still open, it creates as many windows as there are state updates.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

It was missing a close and dispose on dispose.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Before these changes:

https://github.com/space-wizards/space-station-14/assets/10494922/6e75c25a-bae6-48d9-ab54-a781b62c834b



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed salvage magnet UI opening multiple times when activated.