### PR TITLE
Renamed old snake_case IDs to PascalCase IDs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -553,7 +553,7 @@
     - type: Sprite
       state: medical
     - type: MachineBoard
-      prototype: chem_master
+      prototype: ChemMaster
       requirements:
         Capacitor: 1
       materialRequirements:

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -1,9 +1,9 @@
 - type: entity
+  parent: ReagentDispenserBase
   id: SodaDispenser
   name: soda dispenser
-  suffix: Filled
-  parent: ReagentDispenserBase
   description: A beverage dispenser with a selection of soda and several other common beverages. Has a single fill slot for containers.
+  suffix: Filled
   components:
   - type: Rotatable
   - type: Sprite
@@ -24,9 +24,9 @@
     - Bartender
 
 - type: entity
+  parent: SodaDispenser
   id: SodaDispenserEmpty
   suffix: Empty
-  parent: soda_dispenser
   components:
   - type: ReagentDispenser
     storageWhitelist:

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -1,5 +1,5 @@
 - type: entity
-  id: soda_dispenser
+  id: SodaDispenser
   name: soda dispenser
   suffix: Filled
   parent: ReagentDispenserBase

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -1,5 +1,5 @@
 - type: entity
-  id: chem_master
+  id: ChemMaster
   parent: [ BaseMachinePowered, ConstructibleMachine ]
   name: ChemMaster 4000
   description: An industrial grade chemical manipulator with pill and bottle production included.

--- a/Resources/ServerInfo/Guidebook/Medical/Chemist.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Chemist.xml
@@ -10,7 +10,7 @@ While chemists primarily make medications, there's a very wide variety of chemic
 <GuideEntityEmbed Entity="ChemDispenser"/>
 <GuideEntityEmbed Entity="ChemBag"/>
 <GuideEntityEmbed Entity="KitchenReagentGrinder"/>
-<GuideEntityEmbed Entity="chem_master"/>
+<GuideEntityEmbed Entity="ChemMaster"/>
 </Box>
 <Box>
 <GuideEntityEmbed Entity="LargeBeaker"/>

--- a/Resources/ServerInfo/Guidebook/Medical/Medical.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Medical.xml
@@ -17,6 +17,6 @@ Right now, medbay is divided into two different sets of care:
 <GuideEntityEmbed Entity="ChemDispenser"/>
 <GuideEntityEmbed Entity="LargeBeaker"/>
 <GuideEntityEmbed Entity="PillCanister"/>
-<GuideEntityEmbed Entity="chem_master"/>
+<GuideEntityEmbed Entity="ChemMaster"/>
 </Box>
 </Document>

--- a/Resources/ServerInfo/Guidebook/Service/Bartender.xml
+++ b/Resources/ServerInfo/Guidebook/Service/Bartender.xml
@@ -7,7 +7,7 @@ The materials for these drinks can be found in various places:
 </Box>
 <Box>
 <GuideEntityEmbed Entity="BoozeDispenser"/>
-<GuideEntityEmbed Entity="soda_dispenser"/>
+<GuideEntityEmbed Entity="SodaDispenser"/>
 <GuideEntityEmbed Entity="VendingMachineBooze"/>
 </Box>
 

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -335,3 +335,6 @@ ReinforcementRadioSyndicateMonkeyNukeops: ReinforcementRadioSyndicateAncestorNuk
 
 # 2024-05-01
 DrinkBottleGoldschlager: DrinkBottleGildlager
+
+# 2024-03-14
+soda_dispenser: SodaDispenser

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -336,5 +336,5 @@ ReinforcementRadioSyndicateMonkeyNukeops: ReinforcementRadioSyndicateAncestorNuk
 # 2024-05-01
 DrinkBottleGoldschlager: DrinkBottleGildlager
 
-# 2024-03-14
+# 2024-05-14
 soda_dispenser: SodaDispenser

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -338,3 +338,4 @@ DrinkBottleGoldschlager: DrinkBottleGildlager
 
 # 2024-05-14
 soda_dispenser: SodaDispenser
+chem_master: ChemMaster


### PR DESCRIPTION
## About the PR
- Renamed soda dispenser ID from old snake_case to new PascalCase used in all other IDs. (no one touched it since soda dispenser creation)
- Renamed chem master ID from old snake_case to new PascalCase used in all other IDs. 
- Added migration file

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

no :cl: no fun
