### PR TITLE
biome flexibility changes

### DIFF
--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -39,6 +39,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
     [Dependency] private readonly IConsoleHost _console = default!;
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IParallelManager _parallel = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly AtmosphereSystem _atmos = default!;
@@ -119,6 +120,9 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
             SetSeed(uid, component, _random.Next());
         }
 
+        if (_proto.TryIndex(component.Template, out var biome))
+            SetTemplate(uid, component, biome);
+
         var xform = Transform(uid);
         var mapId = xform.MapID;
 
@@ -149,6 +153,15 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
                 }
             }
         }
+    }
+
+    public void SetEnabled(Entity<BiomeComponent?> ent, bool enabled = true)
+    {
+        if (!Resolve(ent, ref ent.Comp) || ent.Comp.Enabled == enabled)
+            return;
+
+        ent.Comp.Enabled = enabled;
+        Dirty(ent, ent.Comp);
     }
 
     public void SetSeed(EntityUid uid, BiomeComponent component, int seed, bool dirty = true)

--- a/Content.Shared/Parallax/Biomes/BiomeComponent.cs
+++ b/Content.Shared/Parallax/Biomes/BiomeComponent.cs
@@ -30,14 +30,13 @@ public sealed partial class BiomeComponent : Component
     public List<IBiomeLayer> Layers = new();
 
     /// <summary>
-    /// Templates to use for <see cref="Layers"/>. Optional as this can be set elsewhere.
+    /// Templates to use for <see cref="Layers"/>.
+    /// If this is set on mapinit, it will fill out layers automatically.
+    /// If not set, use <c>BiomeSystem</c> to do it.
+    /// Prototype reloading will also use this.
     /// </summary>
-    /// <remarks>
-    /// This is really just here for prototype reload support.
-    /// </remarks>
-    [ViewVariables(VVAccess.ReadWrite),
-     DataField("template", customTypeSerializer: typeof(PrototypeIdSerializer<BiomeTemplatePrototype>))]
-    public string? Template;
+    [DataField]
+    public ProtoId<BiomeTemplatePrototype>? Template;
 
     /// <summary>
     /// If we've already generated a tile and couldn't deload it then we won't ever reload it in future.


### PR DESCRIPTION
## About the PR
- if BiomeComponent has a template set on mapinit it will get applied to layers automatically
  so you can have it in a map or whatever without needing to use api
- add `SetEnabled` to biome system api so you can actually control when it generates or not

## Why / Balance
need this downstream

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun