### PR TITLE
fix ninja hacking not affecting sechud

### DIFF
--- a/Content.Client/CriminalRecords/Systems/CriminalRecordsHackerSystem.cs
+++ b/Content.Client/CriminalRecords/Systems/CriminalRecordsHackerSystem.cs
@@ -2,6 +2,4 @@ using Content.Shared.CriminalRecords.Systems;
 
 namespace Content.Client.CriminalRecords.Systems;
 
-public sealed class CriminalRecordsHackerSystem : SharedCriminalRecordsHackerSystem
-{
-}
+public sealed class CriminalRecordsHackerSystem : SharedCriminalRecordsHackerSystem;

--- a/Content.Client/CriminalRecords/Systems/CriminalRecordsSystem.cs
+++ b/Content.Client/CriminalRecords/Systems/CriminalRecordsSystem.cs
@@ -2,4 +2,4 @@ using Content.Shared.CriminalRecords.Systems;
 
 namespace Content.Client.CriminalRecords.Systems;
 
-public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleSystem;
+public sealed class CriminalRecordsSystem : SharedCriminalRecordsSystem;

--- a/Content.Server/CriminalRecords/Systems/CriminalRecordsConsoleSystem.cs
+++ b/Content.Server/CriminalRecords/Systems/CriminalRecordsConsoleSystem.cs
@@ -27,7 +27,7 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly RadioSystem _radio = default!;
     [Dependency] private readonly SharedIdCardSystem _idCard = default!;
-    [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
+    [Dependency] private readonly StationRecordsSystem _records = default!;
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
 
@@ -80,7 +80,7 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
         if (!CheckSelected(ent, msg.Actor, out var mob, out var key))
             return;
 
-        if (!_stationRecords.TryGetRecord<CriminalRecord>(key.Value, out var record) || record.Status == msg.Status)
+        if (!_records.TryGetRecord<CriminalRecord>(key.Value, out var record) || record.Status == msg.Status)
             return;
 
         // validate the reason
@@ -106,7 +106,7 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
         // will probably never fail given the checks above
         _criminalRecords.TryChangeStatus(key.Value, msg.Status, msg.Reason);
 
-        var name = RecordName(key.Value);
+        var name = _records.RecordName(key.Value);
         var officer = Loc.GetString("criminal-records-console-unknown-officer");
         if (_idCard.TryFindIdCard(mob.Value, out var id) && id.Comp.FullName is { } fullName)
             officer = fullName;
@@ -145,7 +145,6 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
             ent.Comp.SecurityChannel, ent);
 
         UpdateUserInterface(ent);
-        UpdateCriminalIdentity(name, msg.Status);
     }
 
     private void OnAddHistory(Entity<CriminalRecordsConsoleComponent> ent, ref CriminalRecordAddHistory msg)
@@ -189,15 +188,15 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
             return;
         }
 
-        var listing = _stationRecords.BuildListing((owningStation.Value, stationRecords), console.Filter);
+        var listing = _records.BuildListing((owningStation.Value, stationRecords), console.Filter);
 
         var state = new CriminalRecordsConsoleState(listing, console.Filter);
         if (console.ActiveKey is { } id)
         {
             // get records to display when a crewmember is selected
             var key = new StationRecordKey(id, owningStation.Value);
-            _stationRecords.TryGetRecord(key, out state.StationRecord, stationRecords);
-            _stationRecords.TryGetRecord(key, out state.CriminalRecord, stationRecords);
+            _records.TryGetRecord(key, out state.StationRecord, stationRecords);
+            _records.TryGetRecord(key, out state.CriminalRecord, stationRecords);
             state.SelectedKey = id;
         }
 
@@ -233,17 +232,6 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
     }
 
     /// <summary>
-    /// Gets the name from a record, or empty string if this somehow fails.
-    /// </summary>
-    private string RecordName(StationRecordKey key)
-    {
-        if (!_stationRecords.TryGetRecord<GeneralStationRecord>(key, out var record))
-            return "";
-
-        return record.Name;
-    }
-
-    /// <summary>
     /// Checks if the new identity's name has a criminal record attached to it, and gives the entity the icon that
     /// belongs to the status if it does.
     /// </summary>
@@ -255,14 +243,14 @@ public sealed class CriminalRecordsConsoleSystem : SharedCriminalRecordsConsoleS
         // TODO use the entity's station? Not the station of the map that it happens to currently be on?
         var station = _station.GetStationInMap(xform.MapID);
 
-        if (station != null && _stationRecords.GetRecordByName(station.Value, name) is { } id)
+        if (station != null && _records.GetRecordByName(station.Value, name) is { } id)
         {
-            if (_stationRecords.TryGetRecord<CriminalRecord>(new StationRecordKey(id, station.Value),
+            if (_records.TryGetRecord<CriminalRecord>(new StationRecordKey(id, station.Value),
                     out var record))
             {
                 if (record.Status != SecurityStatus.None)
                 {
-                    SetCriminalIcon(name, record.Status, uid);
+                    _criminalRecords.SetCriminalIcon(name, record.Status, uid);
                     return;
                 }
             }

--- a/Content.Server/CriminalRecords/Systems/CriminalRecordsHackerSystem.cs
+++ b/Content.Server/CriminalRecords/Systems/CriminalRecordsHackerSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.CriminalRecords.Components;
 using Content.Shared.CriminalRecords.Systems;
 using Content.Shared.Dataset;
 using Content.Shared.Security;
+using Content.Shared.StationRecords;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -14,6 +15,7 @@ namespace Content.Server.CriminalRecords.Systems;
 public sealed class CriminalRecordsHackerSystem : SharedCriminalRecordsHackerSystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly CriminalRecordsSystem _criminalRecords = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly StationSystem _station = default!;
@@ -38,8 +40,7 @@ public sealed class CriminalRecordsHackerSystem : SharedCriminalRecordsHackerSys
         foreach (var (key, record) in _records.GetRecordsOfType<CriminalRecord>(station))
         {
             var reason = _random.Pick(reasons.Values);
-            record.Status = SecurityStatus.Wanted;
-            record.Reason = reason;
+            _criminalRecords.OverwriteStatus(new StationRecordKey(key, station), record, SecurityStatus.Wanted, reason);
             // no radio message since spam
             // no history since lazy and its easy to remove anyway
             // main damage with this is existing arrest warrants are lost and to anger beepsky

--- a/Content.Server/CriminalRecords/Systems/CriminalRecordsSystem.cs
+++ b/Content.Server/CriminalRecords/Systems/CriminalRecordsSystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Server.StationRecords.Systems;
 using Content.Shared.CriminalRecords;
+using Content.Shared.CriminalRecords.Systems;
 using Content.Shared.Security;
 using Content.Shared.StationRecords;
 using Content.Server.GameTicking;
@@ -15,10 +16,10 @@ namespace Content.Server.CriminalRecords.Systems;
 ///         - See security officers' actions in Criminal Records in the radio
 ///         - See reasons for any action with no need to ask the officer personally
 /// </summary>
-public sealed class CriminalRecordsSystem : EntitySystem
+public sealed class CriminalRecordsSystem : SharedCriminalRecordsSystem
 {
     [Dependency] private readonly GameTicker _ticker = default!;
-    [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
+    [Dependency] private readonly StationRecordsSystem _records = default!;
 
     public override void Initialize()
     {
@@ -29,28 +30,40 @@ public sealed class CriminalRecordsSystem : EntitySystem
 
     private void OnGeneralRecordCreated(AfterGeneralRecordCreatedEvent ev)
     {
-        _stationRecords.AddRecordEntry(ev.Key, new CriminalRecord());
-        _stationRecords.Synchronize(ev.Key);
+        _records.AddRecordEntry(ev.Key, new CriminalRecord());
+        _records.Synchronize(ev.Key);
     }
 
     /// <summary>
     /// Tries to change the status of the record found by the StationRecordKey.
-    /// Reason should only be passed if status is Wanted.
+    /// Reason should only be passed if status is Wanted, nullability isn't checked.
     /// </summary>
     /// <returns>True if the status is changed, false if not</returns>
     public bool TryChangeStatus(StationRecordKey key, SecurityStatus status, string? reason)
     {
         // don't do anything if its the same status
-        if (!_stationRecords.TryGetRecord<CriminalRecord>(key, out var record)
+        if (!_records.TryGetRecord<CriminalRecord>(key, out var record)
             || status == record.Status)
             return false;
 
+        OverwriteStatus(key, record, status, reason);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Sets the status without checking previous status or reason nullability.
+    /// </summary>
+    public void OverwriteStatus(StationRecordKey key, CriminalRecord record, SecurityStatus status, string? reason)
+    {
         record.Status = status;
         record.Reason = reason;
 
-        _stationRecords.Synchronize(key);
+        var name = _records.RecordName(key);
+        if (name != string.Empty)
+            UpdateCriminalIdentity(name, status);
 
-        return true;
+        _records.Synchronize(key);
     }
 
     /// <summary>
@@ -59,7 +72,7 @@ public sealed class CriminalRecordsSystem : EntitySystem
     /// <returns>True if adding succeeded, false if not</returns>
     public bool TryAddHistory(StationRecordKey key, CrimeHistory entry)
     {
-        if (!_stationRecords.TryGetRecord<CriminalRecord>(key, out var record))
+        if (!_records.TryGetRecord<CriminalRecord>(key, out var record))
             return false;
 
         record.History.Add(entry);
@@ -81,7 +94,7 @@ public sealed class CriminalRecordsSystem : EntitySystem
     /// <returns>True if the line was removed, false if not</returns>
     public bool TryDeleteHistory(StationRecordKey key, uint index)
     {
-        if (!_stationRecords.TryGetRecord<CriminalRecord>(key, out var record))
+        if (!_records.TryGetRecord<CriminalRecord>(key, out var record))
             return false;
 
         if (index >= record.History.Count)

--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -224,6 +224,17 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
     }
 
     /// <summary>
+    /// Get the name for a record, or an empty string if it has no record.
+    /// </summary>
+    public string RecordName(StationRecordKey key)
+    {
+        if (!TryGetRecord<GeneralStationRecord>(key, out var record))
+           return string.Empty;
+
+        return record.Name;
+    }
+
+    /// <summary>
     ///     Gets all records of a specific type from a station.
     /// </summary>
     /// <param name="station">The station to get the records from.</param>

--- a/Content.Shared/CriminalRecords/Systems/SharedCriminalRecordsConsoleSystem.cs
+++ b/Content.Shared/CriminalRecords/Systems/SharedCriminalRecordsConsoleSystem.cs
@@ -1,52 +1,6 @@
-using Content.Shared.IdentityManagement;
-using Content.Shared.IdentityManagement.Components;
-using Content.Shared.Security;
-using Content.Shared.Security.Components;
-
 namespace Content.Shared.CriminalRecords.Systems;
 
-public abstract class SharedCriminalRecordsConsoleSystem : EntitySystem
-{
-    /// <summary>
-    /// Any entity that has a the name of the record that was just changed as their visible name will get their icon
-    /// updated with the new status, if the record got removed their icon will be removed too.
-    /// </summary>
-    public void UpdateCriminalIdentity(string name, SecurityStatus status)
-    {
-        var query = EntityQueryEnumerator<IdentityComponent>();
-
-        while (query.MoveNext(out var uid, out var identity))
-        {
-            if (!Identity.Name(uid, EntityManager).Equals(name))
-                continue;
-
-            if (status == SecurityStatus.None)
-                RemComp<CriminalRecordComponent>(uid);
-            else
-                SetCriminalIcon(name, status, uid);
-        }
-    }
-
-    /// <summary>
-    /// Decides the icon that should be displayed on the entity based on the security status
-    /// </summary>
-    public void SetCriminalIcon(string name, SecurityStatus status, EntityUid characterUid)
-    {
-        EnsureComp<CriminalRecordComponent>(characterUid, out var record);
-
-        var previousIcon = record.StatusIcon;
-
-        record.StatusIcon = status switch
-        {
-            SecurityStatus.Paroled => "SecurityIconParoled",
-            SecurityStatus.Wanted => "SecurityIconWanted",
-            SecurityStatus.Detained => "SecurityIconIncarcerated",
-            SecurityStatus.Discharged => "SecurityIconDischarged",
-            SecurityStatus.Suspected => "SecurityIconSuspected",
-            _ => record.StatusIcon
-        };
-
-        if(previousIcon != record.StatusIcon)
-            Dirty(characterUid, record);
-    }
-}
+/// <summary>
+/// Station records aren't predicted, just exists for access.
+/// </summary>
+public abstract class SharedCriminalRecordsConsoleSystem : EntitySystem;

--- a/Content.Shared/CriminalRecords/Systems/SharedCriminalRecordsSystem.cs
+++ b/Content.Shared/CriminalRecords/Systems/SharedCriminalRecordsSystem.cs
@@ -1,0 +1,52 @@
+using Content.Shared.IdentityManagement;
+using Content.Shared.IdentityManagement.Components;
+using Content.Shared.Security;
+using Content.Shared.Security.Components;
+
+namespace Content.Shared.CriminalRecords.Systems;
+
+public abstract class SharedCriminalRecordsSystem : EntitySystem
+{
+    /// <summary>
+    /// Any entity that has a the name of the record that was just changed as their visible name will get their icon
+    /// updated with the new status, if the record got removed their icon will be removed too.
+    /// </summary>
+    public void UpdateCriminalIdentity(string name, SecurityStatus status)
+    {
+        var query = EntityQueryEnumerator<IdentityComponent>();
+
+        while (query.MoveNext(out var uid, out var identity))
+        {
+            if (!Identity.Name(uid, EntityManager).Equals(name))
+                continue;
+
+            if (status == SecurityStatus.None)
+                RemComp<CriminalRecordComponent>(uid);
+            else
+                SetCriminalIcon(name, status, uid);
+        }
+    }
+
+    /// <summary>
+    /// Decides the icon that should be displayed on the entity based on the security status
+    /// </summary>
+    public void SetCriminalIcon(string name, SecurityStatus status, EntityUid characterUid)
+    {
+        EnsureComp<CriminalRecordComponent>(characterUid, out var record);
+
+        var previousIcon = record.StatusIcon;
+
+        record.StatusIcon = status switch
+        {
+            SecurityStatus.Paroled => "SecurityIconParoled",
+            SecurityStatus.Wanted => "SecurityIconWanted",
+            SecurityStatus.Detained => "SecurityIconIncarcerated",
+            SecurityStatus.Discharged => "SecurityIconDischarged",
+            SecurityStatus.Suspected => "SecurityIconSuspected",
+            _ => record.StatusIcon
+        };
+
+        if (previousIcon != record.StatusIcon)
+            Dirty(characterUid, record);
+    }
+}


### PR DESCRIPTION
## About the PR
hacking and changing status in the console now use the same code
refactoring too

## Why / Balance
bug bad fixes #28013

## Technical details
- moved RecordName into station records system and made it public
- moved criminal identity stuff from console to criminal records since it has nothing to do with the console
- misc refactoring

## Media
![16:16:36](https://github.com/space-wizards/space-station-14/assets/39013340/0d8d4d8a-be6f-444a-b5c1-397897219ede)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed ninja criminal records hack not changing sechud icons.