### PR TITLE
Reflow the player tab to show more of the names

### DIFF
--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabEntry.xaml
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabEntry.xaml
@@ -15,16 +15,16 @@
                ClipText="True"/>
         <customControls:VSeparator/>
         <Label Name="JobLabel"
-               SizeFlagsStretchRatio="3"
+               SizeFlagsStretchRatio="2"
                HorizontalExpand="True"
                ClipText="True"/>
         <customControls:VSeparator/>
         <Label Name="AntagonistLabel"
-               SizeFlagsStretchRatio="2"
+               SizeFlagsStretchRatio="1"
                HorizontalExpand="True"
                ClipText="True"/>
         <Label Name="OverallPlaytimeLabel"
-               SizeFlagsStretchRatio="2"
+               SizeFlagsStretchRatio="1"
                HorizontalExpand="True"
                ClipText="True"/>
     </BoxContainer>

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabEntry.xaml
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabEntry.xaml
@@ -23,6 +23,7 @@
                SizeFlagsStretchRatio="1"
                HorizontalExpand="True"
                ClipText="True"/>
+        <customControls:VSeparator/>
         <Label Name="OverallPlaytimeLabel"
                SizeFlagsStretchRatio="1"
                HorizontalExpand="True"

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabHeader.xaml
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabHeader.xaml
@@ -19,20 +19,20 @@
                MouseFilter="Pass"/>
         <cc:VSeparator/>
         <Label Name="JobLabel"
-               SizeFlagsStretchRatio="3"
+               SizeFlagsStretchRatio="2"
                HorizontalExpand="True"
                ClipText="True"
                Text="{Loc player-tab-job}"
                MouseFilter="Pass"/>
         <cc:VSeparator/>
         <Label Name="AntagonistLabel"
-               SizeFlagsStretchRatio="2"
+               SizeFlagsStretchRatio="1"
                HorizontalExpand="True"
                ClipText="True"
                Text="{Loc player-tab-antagonist}"
                MouseFilter="Pass"/>
         <Label Name="PlaytimeLabel"
-               SizeFlagsStretchRatio="2"
+               SizeFlagsStretchRatio="1"
                HorizontalExpand="True"
                ClipText="True"
                Text="{Loc player-tab-playtime}"

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabHeader.xaml
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabHeader.xaml
@@ -31,6 +31,7 @@
                ClipText="True"
                Text="{Loc player-tab-antagonist}"
                MouseFilter="Pass"/>
+        <cc:VSeparator/>
         <Label Name="PlaytimeLabel"
                SizeFlagsStretchRatio="1"
                HorizontalExpand="True"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Changes the weights on the admin menu player tab columns so that the username and character name have more space.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

The other columns had a lot of blank space, while the names were cut off.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Old:
![Content Client_X438Diqg1I](https://github.com/space-wizards/space-station-14/assets/10494922/ff1dc8b0-c102-48f5-9adf-52ed981b73f1)
![Content Client_CSLgW01M4h](https://github.com/space-wizards/space-station-14/assets/10494922/731dc0f4-3feb-42b2-8385-35523d22ab3f)


New:
![Content Client_PUNFrNhDxz](https://github.com/space-wizards/space-station-14/assets/10494922/013ca44c-a624-4abb-bd0c-8e1733171648)
![Content Client_D51HSobhtD](https://github.com/space-wizards/space-station-14/assets/10494922/c5336c92-79f0-471c-af33-149087058003)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
ADMIN
- tweak: Tweaked the player tab column widths so that usernames and character names are more visible.
