### PR TITLE
Replace Chef Ship Helmet

### DIFF
--- a/Resources/Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
@@ -428,7 +428,7 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: ClothingHeadHelmetHardsuitBasic
+- proto: ClothingHeadHelmetEVALarge
   entities:
   - uid: 82
     components:


### PR DESCRIPTION
## About the PR
Does a small replacement of the base hardsuit helmet in the new chef ship with a basic EVA one.

## Why / Balance
You literally couldn't pick up the hardsuit helmet because it's made to be attached to a hardsuit.

**Changelog**
N/A