### PR TITLE
Fix Shuttle Roles spawning without PDAs and Headsets

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -629,7 +629,7 @@
         settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
-      roleLoadout: [ JobCargoTechnician ]
+      prototypes: [ LostCargoTechGearSuit, LostCargoTechGearCoat ]
     - type: RandomMetadata
       nameSegments:
       - names_first
@@ -684,7 +684,7 @@
         settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
-      roleLoadout: [ JobClown ]
+      prototypes: [ ClownTroupe ]
     - type: RandomMetadata
       nameSegments:
       - names_clown
@@ -742,7 +742,7 @@
         settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
-      roleLoadout: [ JobChef ]
+      prototypes: [ TravelingChef ]
     - type: RandomMetadata
       nameSegments:
       - names_first
@@ -805,7 +805,7 @@
         settings: default
     - type: GhostTakeoverAvailable
     - type: Loadout
-      roleLoadout: [ JobResearchDirector ]
+      prototypes: [ DisasterVictimRD, DisasterVictimRDAlt ]
     - type: RandomMetadata
       nameSegments:
       - names_first
@@ -823,7 +823,7 @@
         settings: default
     - type: GhostTakeoverAvailable
     - type: Loadout
-      roleLoadout: [ JobChiefMedicalOfficer ]
+      prototypes: [ DisasterVictimCMO, DisasterVictimCMOAlt ]
     - type: RandomMetadata
       nameSegments:
       - names_first
@@ -841,7 +841,7 @@
         settings: default
     - type: GhostTakeoverAvailable
     - type: Loadout
-      roleLoadout: [ JobCaptain ]
+      prototypes: [ DisasterVictimCaptain, DisasterVictimCaptainAlt ]
     - type: RandomMetadata
       nameSegments:
       - names_first
@@ -888,7 +888,7 @@
         settings: short
     - type: GhostTakeoverAvailable
     - type: Loadout
-      prototypes: [ SyndicateOperativeGearCivilian ]
+      prototypes: [ SyndicateOperativeGearDisasterVictim ]
     - type: RandomMetadata
       nameSegments:
       - names_first

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -413,6 +413,7 @@
     ears: ClothingHeadsetCMO
     belt: ClothingBeltMedical
     outerClothing: ClothingOuterCoatLabCmo
+
 #Captain Disaster Victim
 - type: startingGear
   id: DisasterVictimCaptain
@@ -441,6 +442,7 @@
     back: ClothingBackpackSatchelCaptain
     ears: ClothingHeadsetAltCommand
     outerClothing: ClothingOuterArmorCaptainCarapace
+
 #RD Disaster Victim
 - type: startingGear
   id: DisasterVictimRD

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -80,6 +80,18 @@
     shoes: ClothingShoesBootsCombat
     gloves: ClothingHandsGlovesColorBlack
 
+# Syndicate Operative Outfit - Disaster Victim
+- type: startingGear
+  id: SyndicateOperativeGearDisasterVictim
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSyndieFormal
+    back: ClothingBackpackDuffelSyndicate
+    shoes: ClothingShoesBootsCombat
+    gloves: ClothingHandsGlovesColorBlack
+    id: SyndiPDA
+    ears: ClothingHeadsetAltSyndicate
+
+
 #Syndicate Operative Outfit - Basic
 - type: startingGear
   id: SyndicateOperativeGearBasic
@@ -318,6 +330,138 @@
 - type: startingGear
   id: BananaClown
   equipment:
+    id: ClownPDA
+    back: ClothingBackpackClown
     shoes: ClothingShoesClownBanana
     jumpsuit: ClothingUniformJumpsuitClownBanana
     mask: ClothingMaskClownBanana
+    ears: ClothingHeadsetService
+    pocket1: BikeHorn
+    pocket2: ClownRecorder
+
+#Clown Troupe
+- type: startingGear
+  id: ClownTroupe
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitClown
+    shoes: ClothingShoesClown
+    id: ClownPDA
+    back: ClothingBackpackClown
+    ears: ClothingHeadsetService
+    mask: ClothingMaskClown
+    pocket1: BikeHorn
+    pocket2: ClownRecorder
+
+#Lost Cargo Tech
+- type: startingGear
+  id: LostCargoTechGearSuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCargo
+    shoes: ClothingShoesColorBlack
+    head: ClothingHeadHatCargosoft
+    id: CargoPDA
+    back: ClothingBackpackCargo
+    ears: ClothingHeadsetCargo
+    pocket1: AppraisalTool
+
+- type: startingGear
+  id: LostCargoTechGearCoat
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCargo
+    shoes: ClothingShoesBootsWinterCargo
+    head: ClothingHeadHatCargosoft
+    id: CargoPDA
+    back: ClothingBackpackDuffelCargo
+    ears: ClothingHeadsetCargo
+    pocket1: AppraisalTool
+    outerClothing: ClothingOuterWinterCargo
+
+#Traveling Chef
+- type: startingGear
+  id: TravelingChef
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitChef
+    shoes: ClothingShoesColorWhite
+    id: ChefPDA
+    back: ClothingBackpackSatchel
+    ears: ClothingHeadsetService
+    belt: ClothingBeltChef
+
+#CMO Disaster Victim
+- type: startingGear
+  id: DisasterVictimCMO
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCMO
+    shoes: ClothingShoesColorBrown
+    head: ClothingHeadMirror
+    neck: ClothingCloakCmo
+    id: CMOPDA
+    back: ClothingBackpackMedical
+    ears: ClothingHeadsetCMO
+    belt: ClothingBeltMedical
+    outerClothing: ClothingOuterCoatLabCmo
+
+- type: startingGear
+  id: DisasterVictimCMOAlt
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCMOTurtle
+    shoes: ClothingShoesColorBrown
+    head: ClothingHeadHatBeretCmo
+    neck: ClothingNeckMantleCMO
+    id: CMOPDA
+    back: ClothingBackpackSatchelMedical
+    ears: ClothingHeadsetCMO
+    belt: ClothingBeltMedical
+    outerClothing: ClothingOuterCoatLabCmo
+#Captain Disaster Victim
+- type: startingGear
+  id: DisasterVictimCaptain
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCaptain
+    shoes: ClothingShoesBootsLaceup
+    eyes: ClothingEyesGlassesSunglasses
+    gloves: ClothingHandsGlovesCaptain
+    head: ClothingHeadHatCaptain
+    neck: ClothingNeckCloakCap
+    id: CaptainPDA
+    back: ClothingBackpackCaptain
+    ears: ClothingHeadsetAltCommand
+    outerClothing: ClothingOuterArmorCaptainCarapace
+
+- type: startingGear
+  id: DisasterVictimCaptainAlt
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCapFormal
+    shoes: ClothingShoesBootsLaceup
+    eyes: ClothingEyesGlassesSunglasses
+    gloves: ClothingHandsGlovesCaptain
+    head: ClothingHeadHatCapcap
+    neck: ClothingNeckMantleCap
+    id: CaptainPDA
+    back: ClothingBackpackSatchelCaptain
+    ears: ClothingHeadsetAltCommand
+    outerClothing: ClothingOuterArmorCaptainCarapace
+#RD Disaster Victim
+- type: startingGear
+  id: DisasterVictimRD
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitResearchDirector
+    shoes: ClothingShoesColorBrown
+    head: ClothingHeadHatBeretRND
+    neck: ClothingNeckCloakRd
+    id: RnDPDA
+    back: ClothingBackpackScience
+    ears: ClothingHeadsetRD
+    outerClothing: ClothingOuterCoatRD
+
+- type: startingGear
+  id: DisasterVictimRDAlt
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitResearchDirector
+    shoes: ClothingShoesColorBrown
+    head: ClothingHeadHatBeretRND
+    neck: ClothingNeckMantleRD
+    id: RnDPDA
+    back: ClothingBackpackSatchelScience
+    ears: ClothingHeadsetRD
+    outerClothing: ClothingOuterCoatRD


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changes the shuttle roles to use dedicated startingGear prototypes, instead of roleLoadout ones (while it did give them the minimum loadout gear, ids and such were defined in startingGear still for the jobs). Each role gets their general starting gear for their job (minus fills) with a few outfit changes. Additionally gives the Syndicate Disaster victim a syndi PDA and headset (headset may be a little weird since they're still supposed to be non-antag, it'd be easy to change it to a simple passenger one though). Also adds a few alts for some of the outfits for a bit more variation.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #27932
Some doors in the shuttles are locked and you can't really get through without breaking the door down. Alts + extra bits are for the aesthetic mostly (if that's too feature-y I can remove it and PR that after the freeze).

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Just YAML

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![Full Outfits](https://github.com/space-wizards/space-station-14/assets/32827189/72b3fc3a-54eb-4e38-99c1-37494a63bc4f)
![Syndie](https://github.com/space-wizards/space-station-14/assets/32827189/fa8d0483-da04-45b2-8411-782040d9fac1)



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Shuttle roles get PDAs and headsets now
