### PR TITLE
Fix sandbox check failure when compiling with latest .NET SDK.

### DIFF
--- a/Content.Client/RCD/RCDMenu.xaml.cs
+++ b/Content.Client/RCD/RCDMenu.xaml.cs
@@ -68,7 +68,7 @@ public sealed partial class RCDMenu : RadialMenu
                 tooltip = Loc.GetString(entProto.Name);
             }
 
-            tooltip = char.ToUpper(tooltip[0]) + tooltip.Remove(0, 1);
+            tooltip = OopsConcat(char.ToUpper(tooltip[0]).ToString(), tooltip.Remove(0, 1));
 
             var button = new RCDMenuButton()
             {
@@ -117,6 +117,12 @@ public sealed partial class RCDMenu : RadialMenu
         OnChildAdded += AddRCDMenuButtonOnClickActions;
 
         SendRCDSystemMessageAction += bui.SendRCDSystemMessage;
+    }
+
+    private static string OopsConcat(string a, string b)
+    {
+        // This exists to prevent Roslyn being clever and compiling something that fails sandbox checks.
+        return a + b;
     }
 
     private void AddRCDMenuButtonOnClickActions(Control control)

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -152,8 +152,14 @@ public abstract class SharedChatSystem : EntitySystem
         if (string.IsNullOrEmpty(message))
             return message;
         // Capitalize first letter
-        message = char.ToUpper(message[0]) + message.Remove(0, 1);
+        message = OopsConcat(char.ToUpper(message[0]).ToString(), message.Remove(0, 1));
         return message;
+    }
+
+    private static string OopsConcat(string a, string b)
+    {
+        // This exists to prevent Roslyn being clever and compiling something that fails sandbox checks.
+        return a + b;
     }
 
     public string SanitizeMessageCapitalizeTheWordI(string message, string theWordI = "i")


### PR DESCRIPTION
Roslyn now compiles char + string with string.Concat(ROS<char>). This means doing ref char -> ROS<char> which is not sandbox safe. Actually fixing this in the sandboxer is difficult so I'm gonna just pass on that for now.
