### PR TITLE
uncuffCooldown *= 5

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -27,7 +27,7 @@
     guides:
     - Security
   - type: UseDelay
-    delay: 6
+    delay: 30
 
 - type: entity
   name: makeshift handcuffs


### PR DESCRIPTION
## About the PR
Uncuffing action now has a cooldown of 30sec instead of 6sec

## Why / Balance
https://forum.spacestation14.com/t/uncuff-action-should-have-longer-cooldown-and-duration/
tldr: prisoners attempting 10 uncuffs per minute makes security borderline unbearable

## Technical details


## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl:
- tweak: Time between uncuff attempts is now 30 seconds instead of 6.
