### PR TITLE
Prevent ghosts from spawning on terminating maps/grids

### DIFF
--- a/Content.IntegrationTests/Tests/Minds/GhostTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/GhostTests.cs
@@ -156,4 +156,20 @@ public sealed class GhostTests
         await data.Pair.CleanReturnAsync();
     }
 
+    [Test]
+    public async Task TestGhostGridNotTerminating()
+    {
+        var data = await SetupData();
+
+        Assert.DoesNotThrowAsync(async () =>
+        {
+            // Delete the grid
+            await data.Server.WaitPost(() => data.SEntMan.DeleteEntity(data.MapData.Grid.Owner));
+        });
+
+        await data.Pair.RunTicksSync(5);
+
+        await data.Pair.CleanReturnAsync();
+    }
+
 }

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -409,23 +409,41 @@ namespace Content.Server.Ghost
             return SpawnGhost(mind, spawnPosition, canReturn);
         }
 
+        private bool IsValidSpawnPosition(EntityCoordinates? spawnPosition)
+        {
+            if (spawnPosition?.IsValid(EntityManager) != true)
+                return false;
+
+            var mapUid = spawnPosition?.GetMapUid(EntityManager);
+            var gridUid = spawnPosition?.EntityId;
+            // Test if the map is being deleted
+            if (mapUid == null || TerminatingOrDeleted(mapUid.Value))
+                return false;
+            // Test if the grid is being deleted
+            if (gridUid != null && TerminatingOrDeleted(gridUid.Value))
+                return false;
+
+            return true;
+        }
+
         public EntityUid? SpawnGhost(Entity<MindComponent?> mind, EntityCoordinates? spawnPosition = null,
             bool canReturn = false)
         {
             if (!Resolve(mind, ref mind.Comp))
                 return null;
 
-            // Test if the map is being deleted
-            var mapUid = spawnPosition?.GetMapUid(EntityManager);
-            if (mapUid == null || TerminatingOrDeleted(mapUid.Value))
+            // Test if the map or grid is being deleted
+            if (!IsValidSpawnPosition(spawnPosition))
                 spawnPosition = null;
 
+            // If it's bad, look for a valid point to spawn
             spawnPosition ??= _ticker.GetObserverSpawnPoint();
 
-            if (!spawnPosition.Value.IsValid(EntityManager))
+            // Make sure the new point is valid too
+            if (!IsValidSpawnPosition(spawnPosition))
             {
                 Log.Warning($"No spawn valid ghost spawn position found for {mind.Comp.CharacterName}"
-                    + " \"{ToPrettyString(mind)}\"");
+                    + $" \"{ToPrettyString(mind)}\"");
                 _minds.TransferTo(mind.Owner, null, createGhost: false, mind: mind.Comp);
                 return null;
             }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added extra checks and modified logic to make sure that ghosts don't try to spawn on grids or maps that are terminating.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I encountered a [random test failure](https://github.com/space-wizards/space-station-14/actions/runs/9129321107/job/25103598487) on a different PR and got annoyed. While fixing it, I encountered a different, related bug and took care of that too.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Under the right conditions, especially on server shutdown, the ghost spawned by a player's character being deleted would try to attach to a grid on a map that was terminating. TransformSystem doesn't like that and logs an error.

This PR adds some extra validation to the logic for spawning ghosts and for selecting observer spawnpoints to make sure that the selected point and its parent map aren't being terminated.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Code.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.