### PR TITLE
Hiding and clearing department prototype code

### DIFF
--- a/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
+++ b/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
@@ -147,7 +147,7 @@ public sealed partial class BanPanel : DefaultWindow
         var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
         foreach (var proto in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
         {
-            CreateRoleGroup(proto.ID, proto.Roles, proto.Color);
+            CreateRoleGroup(proto.ID, proto.Roles.Select(p =>  p.Id), proto.Color);
         }
 
         CreateRoleGroup("Antagonist", prototypeManager.EnumeratePrototypes<AntagPrototype>().Select(p => p.ID), Color.Red);

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -829,16 +829,16 @@ namespace Content.Client.Lobby.UI
                             // Sync other selectors with the same job in case of multiple department jobs
                             if (jobId == job.ID)
                             {
-                                jobSelector.Priority = priority;
+                                other.Select(selectedPrio);
                                 continue;
                             }
 
-                            if (priority != JobPriority.High || jobSelector.Priority != JobPriority.High)
+                            if (selectedJobPrio != JobPriority.High || (JobPriority) other.Selected != JobPriority.High)
                                 continue;
 
                             // Lower any other high priorities to medium.
-                            jobSelector.Priority = JobPriority.Medium;
-                            Profile = Profile?.WithJobPriority(jobSelector.Proto.ID, JobPriority.Medium);
+                            other.Select((int)JobPriority.Medium);
+                            Profile = Profile?.WithJobPriority(jobId, JobPriority.Medium);
                         }
 
                         // TODO: Only reload on high change (either to or from).

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -719,8 +719,17 @@ namespace Content.Client.Lobby.UI
             _jobPriorities.Clear();
             var firstCategory = true;
 
-            var departments = _prototypeManager.EnumeratePrototypes<DepartmentPrototype>().ToArray();
-            Array.Sort(departments, DepartmentUIComparer.Instance);
+            // Get all displayed departments
+            var departments = new List<DepartmentPrototype>();
+            foreach (var department in _prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
+            {
+                if (department.EditorHidden)
+                    continue;
+
+                departments.Add(department);
+            }
+
+            departments.Sort(DepartmentUIComparer.Instance);
 
             var items = new[]
             {
@@ -774,7 +783,7 @@ namespace Content.Client.Lobby.UI
                     JobList.AddChild(category);
                 }
 
-                var jobs = department.Roles.Select(jobId => _prototypeManager.Index<JobPrototype>(jobId))
+                var jobs = department.Roles.Select(jobId => _prototypeManager.Index(jobId))
                     .Where(job => job.SetPreference)
                     .ToArray();
 
@@ -820,14 +829,16 @@ namespace Content.Client.Lobby.UI
                             // Sync other selectors with the same job in case of multiple department jobs
                             if (jobId == job.ID)
                             {
-                                other.Select(selectedPrio);
+                                jobSelector.Priority = priority;
+                                continue;
                             }
-                            else if (selectedJobPrio == JobPriority.High && (JobPriority) other.Selected == JobPriority.High)
-                            {
-                                // Lower any other high priorities to medium.
-                                other.Select((int) JobPriority.Medium);
-                                Profile = Profile?.WithJobPriority(jobId, JobPriority.Medium);
-                            }
+
+                            if (priority != JobPriority.High || jobSelector.Priority != JobPriority.High)
+                                continue;
+
+                            // Lower any other high priorities to medium.
+                            jobSelector.Priority = JobPriority.Medium;
+                            Profile = Profile?.WithJobPriority(jobSelector.Proto.ID, JobPriority.Medium);
                         }
 
                         // TODO: Only reload on high change (either to or from).
@@ -932,6 +943,11 @@ namespace Content.Client.Lobby.UI
                 SetDirty();
                 ReloadPreview();
             };
+
+            if (Profile is null)
+                return;
+
+            UpdateJobPriorities();
         }
 
         private void OnFlavorTextChange(string content)

--- a/Content.Server/Store/Conditions/BuyerDepartmentCondition.cs
+++ b/Content.Server/Store/Conditions/BuyerDepartmentCondition.cs
@@ -43,7 +43,7 @@ public sealed partial class BuyerDepartmentCondition : ListingCondition
         {
             foreach (var department in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
             {
-                if (department.Roles.Contains(job.Prototype) && Blacklist.Contains(department.ID))
+                if (department.Roles.Contains(job.Prototype.Value) && Blacklist.Contains(department.ID))
                     return false;
             }
         }
@@ -56,7 +56,7 @@ public sealed partial class BuyerDepartmentCondition : ListingCondition
             {
                 foreach (var department in prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
                 {
-                    if (department.Roles.Contains(job.Prototype) && Whitelist.Contains(department.ID))
+                    if (department.Roles.Contains(job.Prototype.Value) && Whitelist.Contains(department.ID))
                     {
                         found = true;
                         break;

--- a/Content.Shared/Roles/DepartmentPrototype.cs
+++ b/Content.Shared/Roles/DepartmentPrototype.cs
@@ -1,28 +1,27 @@
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 
 namespace Content.Shared.Roles;
 
 [Prototype("department")]
 public sealed partial class DepartmentPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField]
+    public string ID { get; } = string.Empty;
 
     /// <summary>
-    ///     A description string to display in the character menu as an explanation of the department's function.
+    /// A description string to display in the character menu as an explanation of the department's function.
     /// </summary>
-    [DataField("description", required: true)]
-    public string Description = default!;
+    [DataField(required: true)]
+    public string Description = string.Empty;
 
     /// <summary>
-    ///     A color representing this department to use for text.
+    /// A color representing this department to use for text.
     /// </summary>
-    [DataField("color", required: true)]
-    public Color Color = default!;
+    [DataField(required: true)]
+    public Color Color;
 
-    [ViewVariables(VVAccess.ReadWrite),
-     DataField("roles", customTypeSerializer: typeof(PrototypeIdListSerializer<JobPrototype>))]
-    public List<string> Roles = new();
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public List<ProtoId<JobPrototype>> Roles = new();
 
     /// <summary>
     /// Whether this is a primary department or not.
@@ -34,8 +33,14 @@ public sealed partial class DepartmentPrototype : IPrototype
     /// <summary>
     /// Departments with a higher weight sorted before other departments in UI.
     /// </summary>
-    [DataField("weight")]
-    public int Weight { get; private set; } = 0;
+    [DataField]
+    public int Weight { get; private set; }
+
+    /// <summary>
+    /// Toggles the display of the department in the priority setting menu in the character editor.
+    /// </summary>
+    [DataField]
+    public bool EditorHidden;
 }
 
 /// <summary>
@@ -50,14 +55,14 @@ public sealed class DepartmentUIComparer : IComparer<DepartmentPrototype>
     {
         if (ReferenceEquals(x, y))
             return 0;
+
         if (ReferenceEquals(null, y))
             return 1;
+
         if (ReferenceEquals(null, x))
             return -1;
 
         var cmp = -x.Weight.CompareTo(y.Weight);
-        if (cmp != 0)
-            return cmp;
-        return string.Compare(x.ID, y.ID, StringComparison.Ordinal);
+        return cmp != 0 ? cmp : string.Compare(x.ID, y.ID, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## About the PR
Cleaned up the department prototype and also added the ability to hide them in the role priority selection menu.

## Why / Balance
Departments have too many dependencies to simply remove them, like uplinks, etc. Therefore, now they can simply be hidden.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

