### PR TITLE
Fix non-ghosts and admins counting toward most followed

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -306,7 +306,7 @@ namespace Content.Server.Ghost
                 return;
             }
 
-            if (_followerSystem.GetMostFollowed() is not {} target)
+            if (_followerSystem.GetMostGhostFollowed() is not {} target)
                 return;
 
             WarpTo(uid, target);

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -267,7 +267,7 @@ public sealed class FollowerSystem : EntitySystem
         while (query.MoveNext(out var uid, out var follower, out var _, out var _))
         {
             // Exclude admins
-            if (_adminManager.IsAdmin(uid))
+            if (_adminManager.IsAdmin(actor.PlayerSession))
                 continue;
 
             var followed = follower.Following;

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -6,7 +6,6 @@ using Content.Shared.Ghost;
 using Content.Shared.Hands;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Events;
-using Content.Shared.Movement.Systems;
 using Content.Shared.Tag;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
@@ -264,7 +263,7 @@ public sealed class FollowerSystem : EntitySystem
 
         // Look for followers that are ghosts and are player controlled
         var query = EntityQueryEnumerator<FollowerComponent, GhostComponent, ActorComponent>();
-        while (query.MoveNext(out var uid, out var follower, out var _, out var actor))
+        while (query.MoveNext(out _, out var follower, out _, out var actor))
         {
             // Exclude admins
             if (_adminManager.IsAdmin(actor.PlayerSession))

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -277,7 +277,7 @@ public sealed class FollowerSystem : EntitySystem
 
             if (followedEnts[followed] > most)
             {
-                picked = uid;
+                picked = followed;
                 most = followedEnts[followed];
             }
         }

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -264,7 +264,7 @@ public sealed class FollowerSystem : EntitySystem
 
         // Look for followers that are ghosts and are player controlled
         var query = EntityQueryEnumerator<FollowerComponent, GhostComponent, ActorComponent>();
-        while (query.MoveNext(out var uid, out var follower, out var _, out var _))
+        while (query.MoveNext(out var uid, out var follower, out var _, out var actor))
         {
             // Exclude admins
             if (_adminManager.IsAdmin(actor.PlayerSession))

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-using Content.Shared.Administration.Managers;
 using Content.Shared.Database;
 using Content.Shared.Follower.Components;
 using Content.Shared.Ghost;
@@ -27,7 +26,6 @@ public sealed class FollowerSystem : EntitySystem
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
     [Dependency] private readonly SharedJointSystem _jointSystem = default!;
     [Dependency] private readonly SharedPhysicsSystem _physicsSystem = default!;
-    [Dependency] private readonly ISharedAdminManager _adminManager = default!;
     [Dependency] private readonly INetManager _netMan = default!;
 
     public override void Initialize()
@@ -261,14 +259,15 @@ public sealed class FollowerSystem : EntitySystem
 
         // Look for followers that are ghosts and are player controlled
         var query = EntityQueryEnumerator<FollowerComponent, GhostComponent, ActorComponent>();
-        while (query.MoveNext(out var uid, out var _, out var _, out var _))
+        while (query.MoveNext(out var _, out var follower, out var ghost, out var _))
         {
             // Exclude admin ghosts
-            if (!_adminManager.IsAdmin(uid))
+            if (!ghost.CanGhostInteract)
             {
+                var followed = follower.Following;
                 // Add new entry or increment existing
-                if (!followedEnts.TryAdd(uid, 0))
-                    followedEnts[uid]++;
+                if (!followedEnts.TryAdd(followed, 1))
+                    followedEnts[followed]++;
             }
         }
 

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -254,11 +254,17 @@ public sealed class FollowerSystem : EntitySystem
     public EntityUid? GetMostFollowed()
     {
         EntityUid? picked = null;
-        int most = 0;
+        var most = 0;
         var query = EntityQueryEnumerator<FollowedComponent>();
         while (query.MoveNext(out var uid, out var comp))
         {
-            var count = comp.Following.Count;
+            var count = 0;
+            foreach (var follower in comp.Following)
+            {
+                // Only count non-admin, ghost followers
+                if (TryComp<GhostComponent>(follower, out var ghost) && !ghost.CanGhostInteract)
+                    count++;
+            }
             if (count > most)
             {
                 picked = uid;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Anomaly cores and admin ghosts no longer count as followers for the purposes of the "Warp to most followed" button.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Counting cores is silly. Counting admins is bad.

Fixes #28106
Fixes #27957

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Instead of using Followers.Count, the code now loops through the followers and checks for GhostComponent. To prevent counting admins, only ghosts with CanGhostInteract true are included.

Slightly less efficient since we now iterate through the followers on each followed object, but this isn't exactly a hot code path.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Warping to the character with one ghost follower, ignoring the other character with more anomaly core followers:

https://github.com/space-wizards/space-station-14/assets/85356/a29ebaae-7e79-44ea-8966-cead995dfb8c

The same thing, but now the one ghost is an aghost, so there is no "most followed" and no warp happens:

https://github.com/space-wizards/space-station-14/assets/85356/d190b0cd-6f44-481b-9fa0-7f772b98888d


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: "Warp to most followed" ghost option no longer includes admins and non-ghost followers.