### PR TITLE
Use non-generic `TryComp()` for metadata & transform

### DIFF
--- a/Content.Client/Gravity/GravitySystem.Shake.cs
+++ b/Content.Client/Gravity/GravitySystem.Shake.cs
@@ -25,7 +25,7 @@ public sealed partial class GravitySystem
     {
         var localPlayer = _playerManager.LocalEntity;
 
-        if (!TryComp<TransformComponent>(localPlayer, out var xform) ||
+        if (!TryComp(localPlayer, out TransformComponent? xform) ||
             xform.GridUid != uid && xform.MapUid != uid)
         {
             return;
@@ -46,7 +46,7 @@ public sealed partial class GravitySystem
 
         var localPlayer = _playerManager.LocalEntity;
 
-        if (!TryComp<TransformComponent>(localPlayer, out var xform))
+        if (!TryComp(localPlayer, out TransformComponent? xform))
             return;
 
         if (xform.GridUid != uid ||

--- a/Content.Client/Maps/GridDraggingSystem.cs
+++ b/Content.Client/Maps/GridDraggingSystem.cs
@@ -61,7 +61,7 @@ public sealed class GridDraggingSystem : SharedGridDraggingSystem
     {
         if (_dragging == null) return;
 
-        if (_lastMousePosition != null && TryComp<TransformComponent>(_dragging.Value, out var xform) &&
+        if (_lastMousePosition != null && TryComp(_dragging.Value, out TransformComponent? xform) &&
             TryComp<PhysicsComponent>(_dragging.Value, out var body) &&
             xform.MapID == _lastMousePosition.Value.MapId)
         {
@@ -104,7 +104,7 @@ public sealed class GridDraggingSystem : SharedGridDraggingSystem
             StartDragging(gridUid, Transform(gridUid).InvWorldMatrix.Transform(mousePos.Position));
         }
 
-        if (!TryComp<TransformComponent>(_dragging, out var xform))
+        if (!TryComp(_dragging, out TransformComponent? xform))
         {
             StopDragging();
             return;

--- a/Content.Client/Salvage/SalvageSystem.cs
+++ b/Content.Client/Salvage/SalvageSystem.cs
@@ -38,7 +38,7 @@ public sealed class SalvageSystem : SharedSalvageSystem
 
         var player = _playerManager.LocalEntity;
 
-        if (!TryComp<TransformComponent>(player, out var xform) ||
+        if (!TryComp(player, out TransformComponent? xform) ||
             !TryComp<SalvageExpeditionComponent>(xform.MapUid, out var expedition) ||
             expedition.Stage < ExpeditionStage.MusicCountdown)
         {

--- a/Content.Client/Sprite/SpriteFadeSystem.cs
+++ b/Content.Client/Sprite/SpriteFadeSystem.cs
@@ -45,7 +45,7 @@ public sealed class SpriteFadeSystem : EntitySystem
         var spriteQuery = GetEntityQuery<SpriteComponent>();
         var change = ChangeRate * frameTime;
 
-        if (TryComp<TransformComponent>(player, out var playerXform) &&
+        if (TryComp(player, out TransformComponent? playerXform) &&
             _stateManager.CurrentState is GameplayState state &&
             spriteQuery.TryGetComponent(player, out var playerSprite))
         {

--- a/Content.Client/Weapons/Misc/TetherGunSystem.cs
+++ b/Content.Client/Weapons/Misc/TetherGunSystem.cs
@@ -82,7 +82,7 @@ public sealed class TetherGunSystem : SharedTetherGunSystem
 
         const float BufferDistance = 0.1f;
 
-        if (TryComp<TransformComponent>(gun.TetherEntity, out var tetherXform) &&
+        if (TryComp(gun.TetherEntity, out TransformComponent? tetherXform) &&
             tetherXform.Coordinates.TryDistance(EntityManager, TransformSystem, coords, out var distance) &&
             distance < BufferDistance)
         {

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
@@ -165,7 +165,7 @@ public sealed partial class AtmosphereSystem
         foreach (var grid in _mapManager.GetAllGrids(playerMap.Value).OrderBy(o => o.Owner))
         {
             var uid = grid.Owner;
-            if (!TryComp<TransformComponent>(uid, out var gridXform))
+            if (!TryComp(uid, out TransformComponent? gridXform))
                 continue;
 
             options.Add(new CompletionOption(uid.ToString(), $"{MetaData(uid).EntityName} - Map {gridXform.MapID}"));

--- a/Content.Server/Bible/BibleSystem.cs
+++ b/Content.Server/Bible/BibleSystem.cs
@@ -167,7 +167,7 @@ namespace Content.Server.Bible
             {
                 Act = () =>
                 {
-                    if (!TryComp<TransformComponent>(args.User, out var userXform))
+                    if (!TryComp(args.User, out TransformComponent? userXform))
                         return;
 
                     AttemptSummon((uid, component), args.User, userXform);

--- a/Content.Server/Engineering/EntitySystems/DisassembleOnAltVerbSystem.cs
+++ b/Content.Server/Engineering/EntitySystems/DisassembleOnAltVerbSystem.cs
@@ -56,7 +56,7 @@ namespace Content.Server.Engineering.EntitySystems
             if (component.Deleted || Deleted(uid))
                 return;
 
-            if (!TryComp<TransformComponent>(uid, out var transformComp))
+            if (!TryComp(uid, out TransformComponent? transformComp))
                 return;
 
             var entity = EntityManager.SpawnEntity(component.Prototype, transformComp.Coordinates);

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -166,7 +166,7 @@ namespace Content.Server.Explosion.EntitySystems
 
         private void HandleGibTrigger(EntityUid uid, GibOnTriggerComponent component, TriggerEvent args)
         {
-            if (!TryComp<TransformComponent>(uid, out var xform))
+            if (!TryComp(uid, out TransformComponent? xform))
                 return;
             if (component.DeleteItems)
             {

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -459,7 +459,7 @@ public sealed class FaxSystem : EntitySystem
         if (sendEntity == null)
             return;
 
-        if (!TryComp<MetaDataComponent>(sendEntity, out var metadata) ||
+        if (!TryComp(sendEntity, out MetaDataComponent? metadata) ||
             !TryComp<PaperComponent>(sendEntity, out var paper))
             return;
 
@@ -506,7 +506,7 @@ public sealed class FaxSystem : EntitySystem
         if (!component.KnownFaxes.TryGetValue(component.DestinationFaxAddress, out var faxName))
             return;
 
-        if (!TryComp<MetaDataComponent>(sendEntity, out var metadata) ||
+        if (!TryComp(sendEntity, out MetaDataComponent? metadata) ||
            !TryComp<PaperComponent>(sendEntity, out var paper))
             return;
 

--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -41,7 +41,7 @@ namespace Content.Server.Gravity
         private void OnComponentShutdown(EntityUid uid, GravityGeneratorComponent component, ComponentShutdown args)
         {
             if (component.GravityActive &&
-                TryComp<TransformComponent>(uid, out var xform) &&
+                TryComp(uid, out TransformComponent? xform) &&
                 TryComp(xform.ParentUid, out GravityComponent? gravity))
             {
                 component.GravityActive = false;
@@ -114,7 +114,7 @@ namespace Content.Server.Gravity
                     UpdateUI(ent, chargeRate);
 
                 if (active != gravGen.GravityActive &&
-                    TryComp<TransformComponent>(uid, out var xform) &&
+                    TryComp(uid, out TransformComponent? xform) &&
                     TryComp<GravityComponent>(xform.ParentUid, out var gravity))
                 {
                     // Force it on in the faster path.

--- a/Content.Server/Medical/MedicalScannerSystem.cs
+++ b/Content.Server/Medical/MedicalScannerSystem.cs
@@ -86,7 +86,7 @@ namespace Content.Server.Medical
                 return;
 
             var name = "Unknown";
-            if (TryComp<MetaDataComponent>(args.Using.Value, out var metadata))
+            if (TryComp(args.Using.Value, out MetaDataComponent? metadata))
                 name = metadata.EntityName;
 
             InteractionVerb verb = new()

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Distance.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Distance.cs
@@ -30,8 +30,8 @@ public sealed partial class PathfindingSystem
 
         if (end.GraphUid != start.GraphUid)
         {
-            if (!TryComp<TransformComponent>(start.GraphUid, out var startXform) ||
-                !TryComp<TransformComponent>(end.GraphUid, out var endXform))
+            if (!TryComp(start.GraphUid, out TransformComponent? startXform) ||
+                !TryComp(end.GraphUid, out TransformComponent? endXform))
             {
                 return Vector2.Zero;
             }

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -261,7 +261,7 @@ public sealed partial class PathfindingSystem
 
     private void OnBodyTypeChange(ref PhysicsBodyTypeChangedEvent ev)
     {
-        if (TryComp<TransformComponent>(ev.Entity, out var xform) &&
+        if (TryComp(ev.Entity, out TransformComponent? xform) &&
             xform.GridUid != null)
         {
             var aabb = _lookup.GetAABBNoContainer(ev.Entity, xform.Coordinates.Position, xform.LocalRotation);

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
@@ -264,7 +264,7 @@ namespace Content.Server.NPC.Pathfinding
             int limit = 40,
             PathFlags flags = PathFlags.None)
         {
-            if (!TryComp<TransformComponent>(entity, out var start))
+            if (!TryComp(entity, out TransformComponent? start))
                 return new PathResultEvent(PathResult.NoPath, new List<PathPoly>());
 
             var layer = 0;
@@ -294,7 +294,7 @@ namespace Content.Server.NPC.Pathfinding
             CancellationToken cancelToken,
             PathFlags flags = PathFlags.None)
         {
-            if (!TryComp<TransformComponent>(entity, out var start))
+            if (!TryComp(entity, out TransformComponent? start))
                 return null;
 
             var request = GetRequest(entity, start.Coordinates, end, range, cancelToken, flags);
@@ -325,8 +325,8 @@ namespace Content.Server.NPC.Pathfinding
             CancellationToken cancelToken,
             PathFlags flags = PathFlags.None)
         {
-            if (!TryComp<TransformComponent>(entity, out var xform) ||
-                !TryComp<TransformComponent>(target, out var targetXform))
+            if (!TryComp(entity, out TransformComponent? xform) ||
+                !TryComp(target, out TransformComponent? targetXform))
                 return new PathResultEvent(PathResult.NoPath, new List<PathPoly>());
 
             var request = GetRequest(entity, xform.Coordinates, targetXform.Coordinates, range, cancelToken, flags);
@@ -400,7 +400,7 @@ namespace Content.Server.NPC.Pathfinding
             var gridUid = coordinates.GetGridUid(EntityManager);
 
             if (!TryComp<GridPathfindingComponent>(gridUid, out var comp) ||
-                !TryComp<TransformComponent>(gridUid, out var xform))
+                !TryComp(gridUid, out TransformComponent? xform))
             {
                 return null;
             }

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -260,8 +260,8 @@ public sealed class NPCUtilitySystem : EntitySystem
             {
                 var radius = blackboard.GetValueOrDefault<float>(NPCBlackboard.VisionRadius, EntityManager);
 
-                if (!TryComp<TransformComponent>(targetUid, out var targetXform) ||
-                    !TryComp<TransformComponent>(owner, out var xform))
+                if (!TryComp(targetUid, out TransformComponent? targetXform) ||
+                    !TryComp(owner, out TransformComponent? xform))
                 {
                     return 0f;
                 }
@@ -308,8 +308,8 @@ public sealed class NPCUtilitySystem : EntitySystem
 
                 if (blackboard.TryGetValue<EntityUid>("Target", out var currentTarget, EntityManager) &&
                     currentTarget == targetUid &&
-                    TryComp<TransformComponent>(owner, out var xform) &&
-                    TryComp<TransformComponent>(targetUid, out var targetXform) &&
+                    TryComp(owner, out TransformComponent? xform) &&
+                    TryComp(targetUid, out TransformComponent? targetXform) &&
                     xform.Coordinates.TryDistance(EntityManager, _transform, targetXform.Coordinates, out var distance) &&
                     distance <= radius + bufferRange)
                 {

--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -111,7 +111,7 @@ public sealed class PAISystem : SharedPAISystem
         if (TryComp<InstrumentComponent>(uid, out var instrument))
             _instrumentSystem.Clean(uid, instrument);
 
-        if (TryComp<MetaDataComponent>(uid, out var metadata))
+        if (TryComp(uid, out MetaDataComponent? metadata))
         {
             var proto = metadata.EntityPrototype;
             if (proto != null)

--- a/Content.Server/Paper/PaperSystem.cs
+++ b/Content.Server/Paper/PaperSystem.cs
@@ -148,7 +148,7 @@ namespace Content.Server.Paper
                 if (TryComp<AppearanceComponent>(uid, out var appearance))
                     _appearance.SetData(uid, PaperVisuals.Status, PaperStatus.Written, appearance);
 
-                if (TryComp<MetaDataComponent>(uid, out var meta))
+                if (TryComp(uid, out MetaDataComponent? meta))
                     _metaSystem.SetEntityDescription(uid, "", meta);
 
                 _adminLogger.Add(LogType.Chat, LogImpact.Low,

--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -271,7 +271,7 @@ namespace Content.Server.Physics.Controllers
                     consoleEnt = cargoConsole.Entity;
                 }
 
-                if (!TryComp<TransformComponent>(consoleEnt, out var xform)) continue;
+                if (!TryComp(consoleEnt, out TransformComponent? xform)) continue;
 
                 var gridId = xform.GridUid;
                 // This tries to see if the grid is a shuttle and if the console should work.

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -248,7 +248,7 @@ public sealed partial class PolymorphSystem : EntitySystem
             }
         }
 
-        if (configuration.TransferName && TryComp<MetaDataComponent>(uid, out var targetMeta))
+        if (configuration.TransferName && TryComp(uid, out MetaDataComponent? targetMeta))
             _metaData.SetEntityName(child, targetMeta.EntityName);
 
         if (configuration.TransferHumanoidAppearance)

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -72,7 +72,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
         if (component.DeleteOnCollide)
             QueueDel(uid);
 
-        if (component.ImpactEffect != null && TryComp<TransformComponent>(uid, out var xform))
+        if (component.ImpactEffect != null && TryComp(uid, out TransformComponent? xform))
         {
             RaiseNetworkEvent(new ImpactEffectEvent(component.ImpactEffect, GetNetCoordinates(xform.Coordinates)), Filter.Pvs(xform.Coordinates, entityMan: EntityManager));
         }

--- a/Content.Server/Salvage/FultonSystem.cs
+++ b/Content.Server/Salvage/FultonSystem.cs
@@ -53,7 +53,7 @@ public sealed class FultonSystem : SharedFultonSystem
     private void Fulton(EntityUid uid, FultonedComponent component)
     {
         if (!Deleted(component.Beacon) &&
-            TryComp<TransformComponent>(component.Beacon, out var beaconXform) &&
+            TryComp(component.Beacon, out TransformComponent? beaconXform) &&
             !Container.IsEntityOrParentInContainer(component.Beacon.Value, xform: beaconXform) &&
             CanFulton(uid))
         {

--- a/Content.Server/Salvage/SalvageSystem.Runner.cs
+++ b/Content.Server/Salvage/SalvageSystem.Runner.cs
@@ -32,7 +32,7 @@ public sealed partial class SalvageSystem
 
     private void OnConsoleFTLAttempt(ref ConsoleFTLAttemptEvent ev)
     {
-        if (!TryComp<TransformComponent>(ev.Uid, out var xform) ||
+        if (!TryComp(ev.Uid, out TransformComponent? xform) ||
             !TryComp<SalvageExpeditionComponent>(xform.MapUid, out var salvage))
         {
             return;

--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -316,7 +316,7 @@ public sealed class ArrivalsSystem : EntitySystem
 
         TryGetArrivals(out var arrivals);
 
-        if (TryComp<TransformComponent>(arrivals, out var arrivalsXform))
+        if (TryComp(arrivals, out TransformComponent? arrivalsXform))
         {
             var mapId = arrivalsXform.MapID;
 
@@ -413,7 +413,7 @@ public sealed class ArrivalsSystem : EntitySystem
         var curTime = _timing.CurTime;
         TryGetArrivals(out var arrivals);
 
-        if (TryComp<TransformComponent>(arrivals, out var arrivalsXform))
+        if (TryComp(arrivals, out TransformComponent? arrivalsXform))
         {
             while (query.MoveNext(out var uid, out var comp, out var shuttle, out var xform))
             {

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -261,7 +261,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         if (!Resolve(stationUid, ref stationShuttle))
             return;
 
-        if (!TryComp<TransformComponent>(stationShuttle.EmergencyShuttle, out var xform) ||
+        if (!TryComp(stationShuttle.EmergencyShuttle, out TransformComponent? xform) ||
             !TryComp<ShuttleComponent>(stationShuttle.EmergencyShuttle, out var shuttle))
         {
             Log.Error($"Attempted to call an emergency shuttle for an uninitialized station? Station: {ToPrettyString(stationUid)}. Shuttle: {ToPrettyString(stationShuttle.EmergencyShuttle)}");
@@ -284,7 +284,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
 
         if (_shuttle.TryFTLDock(stationShuttle.EmergencyShuttle.Value, shuttle, targetGrid.Value, DockTag))
         {
-            if (TryComp<TransformComponent>(targetGrid.Value, out var targetXform))
+            if (TryComp(targetGrid.Value, out TransformComponent? targetXform))
             {
                 var angle = _dock.GetAngle(stationShuttle.EmergencyShuttle.Value, xform, targetGrid.Value, targetXform, xformQuery);
                 _chatSystem.DispatchStationAnnouncement(stationUid, Loc.GetString("emergency-shuttle-docked", ("time", $"{_consoleAccumulator:0}"), ("direction", angle.GetDir())), playDefaultSound: false);
@@ -330,7 +330,7 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
             return;
 
         // Post mapinit? fancy
-        if (TryComp<TransformComponent>(component.Entity, out var xform))
+        if (TryComp(component.Entity, out TransformComponent? xform))
         {
             component.MapEntity = xform.MapUid;
             return;

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -242,7 +242,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         RaiseLocalEvent(entity.Value, ref getShuttleEv);
         entity = getShuttleEv.Console;
 
-        TryComp<TransformComponent>(entity, out var consoleXform);
+        TryComp(entity, out TransformComponent? consoleXform);
         var shuttleGridUid = consoleXform?.GridUid;
 
         NavInterfaceState navState;

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -184,7 +184,7 @@ public sealed partial class ShuttleSystem
             return;
 
         if (!TryComp<DockingComponent>(uid, out var dock) ||
-            !TryComp<TransformComponent>(uid, out var xform) ||
+            !TryComp(uid, out TransformComponent? xform) ||
             xform.GridUid == null)
         {
             return;
@@ -196,7 +196,7 @@ public sealed partial class ShuttleSystem
 
         if (_loader.TryLoad(mapId, component.Path.ToString(), out var ent) &&
             ent.Count == 1 &&
-            TryComp<TransformComponent>(ent[0], out var shuttleXform))
+            TryComp(ent[0], out TransformComponent? shuttleXform))
         {
             var escape = GetSingleDock(ent[0]);
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
@@ -16,7 +16,7 @@ public sealed partial class ShuttleSystem
 
     private void OnIFFShow(EntityUid uid, IFFConsoleComponent component, IFFShowIFFMessage args)
     {
-        if (!TryComp<TransformComponent>(uid, out var xform) || xform.GridUid == null ||
+        if (!TryComp(uid, out TransformComponent? xform) || xform.GridUid == null ||
             (component.AllowedFlags & IFFFlags.HideLabel) == 0x0)
         {
             return;
@@ -34,7 +34,7 @@ public sealed partial class ShuttleSystem
 
     private void OnIFFShowVessel(EntityUid uid, IFFConsoleComponent component, IFFShowVesselMessage args)
     {
-        if (!TryComp<TransformComponent>(uid, out var xform) || xform.GridUid == null ||
+        if (!TryComp(uid, out TransformComponent? xform) || xform.GridUid == null ||
             (component.AllowedFlags & IFFFlags.Hide) == 0x0)
         {
             return;
@@ -54,7 +54,7 @@ public sealed partial class ShuttleSystem
     {
         // If we anchor / re-anchor then make sure flags up to date.
         if (!args.Anchored ||
-            !TryComp<TransformComponent>(uid, out var xform) ||
+            !TryComp(uid, out TransformComponent? xform) ||
             !TryComp<IFFComponent>(xform.GridUid, out var iff))
         {
             _uiSystem.SetUiState(uid, IFFConsoleUiKey.Key, new IFFConsoleBoundUserInterfaceState()

--- a/Content.Server/Spawners/EntitySystems/SpawnOnDespawnSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/SpawnOnDespawnSystem.cs
@@ -14,7 +14,7 @@ public sealed class SpawnOnDespawnSystem : EntitySystem
 
     private void OnDespawn(EntityUid uid, SpawnOnDespawnComponent comp, ref TimedDespawnEvent args)
     {
-        if (!TryComp<TransformComponent>(uid, out var xform))
+        if (!TryComp(uid, out TransformComponent? xform))
             return;
 
         Spawn(comp.Prototype, xform.Coordinates);

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -570,7 +570,7 @@ namespace Content.Shared.Interaction
             Ignored? predicate = null,
             bool popup = false)
         {
-            if (!TryComp<TransformComponent>(other, out var otherXform))
+            if (!TryComp(other, out TransformComponent? otherXform))
                 return false;
 
             return InRangeUnobstructed(origin, other, otherXform.Coordinates, otherXform.LocalRotation, range, collisionMask, predicate,
@@ -633,7 +633,7 @@ namespace Content.Shared.Interaction
                 fixtureA.FixtureCount > 0 &&
                 TryComp<FixturesComponent>(other, out var fixtureB) &&
                 fixtureB.FixtureCount > 0 &&
-                TryComp<TransformComponent>(origin, out var xformA))
+                TryComp(origin, out TransformComponent? xformA))
             {
                 var (worldPosA, worldRotA) = xformA.GetWorldPositionRotation();
                 var xfA = new Transform(worldPosA, worldRotA);

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -113,7 +113,7 @@ public abstract class SharedJetpackSystem : EntitySystem
         if (args.Handled)
             return;
 
-        if (TryComp<TransformComponent>(uid, out var xform) && !CanEnableOnGrid(xform.GridUid))
+        if (TryComp(uid, out TransformComponent? xform) && !CanEnableOnGrid(xform.GridUid))
         {
             _popup.PopupClient(Loc.GetString("jetpack-no-station"), uid, args.Performer);
 

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -313,7 +313,7 @@ namespace Content.Shared.Movement.Systems
             // For stuff like "Moving out of locker" or the likes
             // We'll relay a movement input to the parent.
             if (_container.IsEntityInContainer(entity) &&
-                TryComp<TransformComponent>(entity, out var xform) &&
+                TryComp(entity, out TransformComponent? xform) &&
                 xform.ParentUid.IsValid() &&
                 _mobState.IsAlive(entity))
             {

--- a/Content.Shared/Nutrition/EntitySystems/PressurizedSolutionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/PressurizedSolutionSystem.cs
@@ -179,7 +179,7 @@ public sealed partial class PressurizedSolutionSystem : EntitySystem
         var solution = _solutionContainer.SplitSolution(soln.Value, interactions.Volume);
 
         // Spray the solution onto the ground and anyone nearby
-        if (TryComp<TransformComponent>(entity, out var transform))
+        if (TryComp(entity, out TransformComponent? transform))
             _puddle.TrySplashSpillAt(entity, transform.Coordinates, solution, out _, sound: false);
 
         var drinkName = Identity.Entity(entity, EntityManager);

--- a/Content.Shared/Nutrition/EntitySystems/SharedDrinkSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SharedDrinkSystem.cs
@@ -81,7 +81,7 @@ public abstract partial class SharedDrinkSystem : EntitySystem
     {
         string remainingString = "drink-component-on-examine-is-half-full";
 
-        if (TryComp<MetaDataComponent>(args.Examiner, out var examiner) && examiner.EntityName.Length > 0
+        if (TryComp(args.Examiner, out MetaDataComponent? examiner) && examiner.EntityName.Length > 0
             && string.Compare(examiner.EntityName.Substring(0, 1), "m", StringComparison.InvariantCultureIgnoreCase) > 0)
             remainingString = "drink-component-on-examine-is-half-empty";
 

--- a/Content.Shared/Random/RulesSystem.cs
+++ b/Content.Shared/Random/RulesSystem.cs
@@ -26,7 +26,7 @@ public sealed class RulesSystem : EntitySystem
                     break;
                 case GridInRangeRule griddy:
                 {
-                    if (!TryComp<TransformComponent>(uid, out var xform))
+                    if (!TryComp(uid, out TransformComponent? xform))
                     {
                         return false;
                     }
@@ -50,7 +50,7 @@ public sealed class RulesSystem : EntitySystem
                 }
                 case InSpaceRule:
                 {
-                    if (!TryComp<TransformComponent>(uid, out var xform) ||
+                    if (!TryComp(uid, out TransformComponent? xform) ||
                         xform.GridUid != null)
                     {
                         return false;
@@ -146,7 +146,7 @@ public sealed class RulesSystem : EntitySystem
                 }
                 case NearbyEntitiesRule entity:
                 {
-                    if (!TryComp<TransformComponent>(uid, out var xform) ||
+                    if (!TryComp(uid, out TransformComponent? xform) ||
                         xform.MapUid == null)
                     {
                         return false;
@@ -177,7 +177,7 @@ public sealed class RulesSystem : EntitySystem
                 }
                 case NearbyTilesPercentRule tiles:
                 {
-                    if (!TryComp<TransformComponent>(uid, out var xform) ||
+                    if (!TryComp(uid, out TransformComponent? xform) ||
                         !TryComp<MapGridComponent>(xform.GridUid, out var grid))
                     {
                         return false;
@@ -227,7 +227,7 @@ public sealed class RulesSystem : EntitySystem
                 }
                 case OnMapGridRule:
                 {
-                    if (!TryComp<TransformComponent>(uid, out var xform) ||
+                    if (!TryComp(uid, out TransformComponent? xform) ||
                         xform.GridUid != xform.MapUid ||
                         xform.MapUid == null)
                     {

--- a/Content.Shared/Sound/SharedEmitSoundSystem.cs
+++ b/Content.Shared/Sound/SharedEmitSoundSystem.cs
@@ -72,7 +72,7 @@ public abstract class SharedEmitSoundSystem : EntitySystem
     private void OnEmitSoundOnLand(EntityUid uid, BaseEmitSoundComponent component, ref LandEvent args)
     {
         if (!args.PlaySound ||
-            !TryComp<TransformComponent>(uid, out var xform) ||
+            !TryComp(uid, out TransformComponent? xform) ||
             !TryComp<MapGridComponent>(xform.GridUid, out var grid))
         {
             return;

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -463,7 +463,7 @@ public abstract class SharedStorageSystem : EntitySystem
                 return;
             }
 
-            if (_xformQuery.TryGetComponent(uid, out var transformOwner) && TryComp<TransformComponent>(target, out var transformEnt))
+            if (TryComp(uid, out TransformComponent? transformOwner) && TryComp(target, out TransformComponent? transformEnt))
             {
                 var parent = transformOwner.ParentUid;
 

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -315,7 +315,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
     public bool AttemptLightAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityUid target)
     {
-        if (!TryComp<TransformComponent>(target, out var targetXform))
+        if (!TryComp(target, out TransformComponent? targetXform))
             return false;
 
         return AttemptAttack(user, weaponUid, weapon, new LightAttackEvent(GetNetEntity(target), GetNetEntity(weaponUid), GetNetCoordinates(targetXform.Coordinates)), null);
@@ -323,7 +323,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
     public bool AttemptDisarmAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityUid target)
     {
-        if (!TryComp<TransformComponent>(target, out var targetXform))
+        if (!TryComp(target, out TransformComponent? targetXform))
             return false;
 
         return AttemptAttack(user, weaponUid, weapon, new DisarmAttackEvent(GetNetEntity(target), GetNetCoordinates(targetXform.Coordinates)), null);
@@ -446,7 +446,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         // For consistency with wide attacks stuff needs damageable.
         if (Deleted(target) ||
             !HasComp<DamageableComponent>(target) ||
-            !TryComp<TransformComponent>(target, out var targetXform) ||
+            !TryComp(target, out TransformComponent? targetXform) ||
             // Not in LOS.
             !InRange(user, target.Value, component.Range, session))
         {
@@ -534,7 +534,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     private bool DoHeavyAttack(EntityUid user, HeavyAttackEvent ev, EntityUid meleeUid, MeleeWeaponComponent component, ICommonSession? session)
     {
         // TODO: This is copy-paste as fuck with DoPreciseAttack
-        if (!TryComp<TransformComponent>(user, out var userXform))
+        if (!TryComp(user, out TransformComponent? userXform))
             return false;
 
         var targetMap = GetCoordinates(ev.Coordinates).ToMap(EntityManager, TransformSystem);
@@ -748,7 +748,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     private void DoLungeAnimation(EntityUid user, EntityUid weapon, Angle angle, MapCoordinates coordinates, float length, string? animation)
     {
         // TODO: Assert that offset eyes are still okay.
-        if (!TryComp<TransformComponent>(user, out var userXform))
+        if (!TryComp(user, out TransformComponent? userXform))
             return;
 
         var invMatrix = TransformSystem.GetInvWorldMatrix(userXform);


### PR DESCRIPTION
Allows entity systems to use the cached xform & metadata queries 