### PR TITLE
Move PendingZombieComponent to Shared

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/CauseZombieInfection.cs
+++ b/Content.Server/Chemistry/ReagentEffects/CauseZombieInfection.cs
@@ -2,6 +2,7 @@ using Content.Server.Zombies;
 using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
+using Content.Shared.Zombies;
 
 namespace Content.Server.Chemistry.ReagentEffects;
 

--- a/Content.Server/Chemistry/ReagentEffects/CureZombieInfection.cs
+++ b/Content.Server/Chemistry/ReagentEffects/CureZombieInfection.cs
@@ -2,6 +2,7 @@ using Content.Server.Zombies;
 using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
+using Content.Shared.Zombies;
 
 namespace Content.Server.Chemistry.ReagentEffects;
 

--- a/Content.Shared/Zombies/PendingZombieComponent.cs
+++ b/Content.Shared/Zombies/PendingZombieComponent.cs
@@ -1,7 +1,7 @@
 using Content.Shared.Damage;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
-namespace Content.Server.Zombies;
+namespace Content.Shared.Zombies;
 
 /// <summary>
 /// Temporary because diseases suck.

--- a/Content.Shared/Zombies/PendingZombieComponent.cs
+++ b/Content.Shared/Zombies/PendingZombieComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Damage;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Zombies;
@@ -6,7 +7,7 @@ namespace Content.Shared.Zombies;
 /// <summary>
 /// Temporary because diseases suck.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class PendingZombieComponent : Component
 {
     /// <summary>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Move PendingZombieComponent to Shared to pass registration check in WhitlelsitComponentSystem

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
Add using Content.Shared.Zombie for CureZombieInfection and CauseZombieInfection. In PendingZombieComponent rename codespace to Content.Shared.PendingZombie


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

no cl
