### PR TITLE
add WhiteCane recipe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -910,6 +910,7 @@
       - Saw
       - Hemostat
       - ClothingEyesGlassesChemical
+      - WhiteCane
     dynamicRecipes:
       - ChemicalPayload
       - CryostasisBeaker

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -234,3 +234,10 @@
     Steel: 600
     Plastic: 300
 
+- type: latheRecipe
+  id: WhiteCane
+  result: WhiteCane
+  completetime: 2
+  materials:
+    Steel: 100
+    Plastic: 100


### PR DESCRIPTION
## About the PR
Add White Cane recipe to medical fab

## Why / Balance
Only way to get White Cane was to spawn with it while being blind.
Losing the cane or gaining blindness during the round was detrimental since gaining cane would have been impossible.

## Technical details
add recipe to medical.yml and add recipe to be available at the MedicalTechFab staticRecipes section

## Media
https://imgur.com/a/kTlJLhv



**Changelog**

:cl:
- add: White cane recipe for MedFab
