### PR TITLE
- Added collision effects to bike horn, applicable plushies.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/bike_horn.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/bike_horn.yml
@@ -26,6 +26,11 @@
       collection: BikeHorn
       params:
         variation: 0.125
+  - type: EmitSoundOnCollide
+    sound:
+      collection: BikeHorn
+      params:
+        variation: 0.125
   - type: Tag
     tags:
     - Payload # yes, you can make re-usable prank grenades

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -164,6 +164,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/mousesqueek.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Items/Toys/mousesqueek.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -237,6 +240,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Voice/Arachnid/arachnid_laugh.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Voice/Arachnid/arachnid_laugh.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -261,6 +267,9 @@
     sound:
       path: /Audio/Items/Toys/weh.ogg
   - type: EmitSoundOnActivate
+    sound:
+      path: /Audio/Items/Toys/weh.ogg
+  - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/weh.ogg
   - type: EmitSoundOnTrigger
@@ -318,6 +327,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/muffled_weh.ogg
+  - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Items/Toys/muffled_weh.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -363,6 +375,9 @@
       sound:
         path: /Audio/Items/Toys/toy_rustle.ogg
     - type: EmitSoundOnTrigger
+      sound:
+        path: /Audio/Items/Toys/toy_rustle.ogg
+    - type: EmitSoundOnCollide
       sound:
         path: /Audio/Items/Toys/toy_rustle.ogg
     - type: MeleeWeapon
@@ -510,6 +525,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Effects/bite.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Effects/bite.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -576,6 +594,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/rattle.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Items/Toys/rattle.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -597,6 +618,9 @@
     sound:
       path: /Audio/Items/Toys/mousesqueek.ogg
   - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Items/Toys/mousesqueek.ogg
+  - type: EmitSoundOnCollide
     sound:
       path: /Audio/Items/Toys/mousesqueek.ogg
   - type: Food
@@ -636,6 +660,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/quack.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Items/Toys/quack.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -659,6 +686,9 @@
     sound:
       path: /Audio/Voice/Vox/shriek1.ogg
   - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Voice/Vox/shriek1.ogg
+  - type: emitSoundOnCollide
     sound:
       path: /Audio/Voice/Vox/shriek1.ogg
   - type: Food
@@ -701,6 +731,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Weapons/Xeno/alien_spitacid.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Weapons/Xeno/alien_spitacid.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -735,6 +768,9 @@
   - type: EmitSoundOnActivate
     sound:
       path: /Audio/Voice/Human/malescream_3.ogg
+  - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Voice/Human/malescream_4.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -764,6 +800,9 @@
     sound:
       path: /Audio/Voice/Moth/moth_chitter.ogg
   - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Voice/Moth/moth_chitter.ogg
+  - type: EmitSoundOnCollide
     sound:
       path: /Audio/Voice/Moth/moth_chitter.ogg
   - type: MeleeWeapon
@@ -853,6 +892,9 @@
       path: /Audio/Items/Toys/ian.ogg
   - type: MeleeWeapon
     soundHit:
+      path: /Audio/Items/Toys/ian.ogg
+  - type: EmitSoundOnCollide
+    sound:
       path: /Audio/Items/Toys/ian.ogg
   - type: Food
     requiresSpecialDigestion: true


### PR DESCRIPTION
## About the PR
- Added collision sounds to the clown's bike horn, as well as plushies with effect noises.

## Why / Balance
` Clown horn just make a thud when hitting walls. ` #27882
No changes to balance.

## Technical details
No code change.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No breaking changes.

**Changelog**
- add: Collision noises to bike horn as well as common plushies.
