### PR TITLE
Add collision sound effects to clown horn and some plushies (#27882)

### DIFF
--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -365,9 +365,9 @@ reagent-effect-guidebook-plant-cryoxadone =
 
 reagent-effect-guidebook-plant-phalanximine =
     { $chance ->
-        [1] Makes
-        *[other] make
-    } a plant not viable due to mutation viable again
+        [1] Restores
+        *[other] restore
+    } viability to a plant rendered nonviable by a mutation.
 
 reagent-effect-guidebook-plant-diethylamine =
     { $chance ->

--- a/Resources/Locale/en-US/reagents/meta/botany.ftl
+++ b/Resources/Locale/en-US/reagents/meta/botany.ftl
@@ -11,7 +11,7 @@ reagent-name-plant-b-gone = plant-B-gone
 reagent-desc-plant-b-gone = A harmful toxic mixture to kill plantlife. Very effective against kudzu.
 
 reagent-name-robust-harvest = robust harvest
-reagent-desc-robust-harvest = A highly effective fertilizer, with a limited potency-boosting effect on plants. Be careful with it's usage since using too much has a chance to reduce the plant yield. It has a positive effect on dionas.
+reagent-desc-robust-harvest = A highly effective fertilizer with a limited potency-boosting effect on plants. Use it cautiously, as excessive application can reduce plant yield. It has a particularly beneficial effect on dionas.
 
 reagent-name-weed-killer = weed killer
 reagent-desc-weed-killer = A mixture that targets weeds. Very effective against kudzu. While useful it slowly poisons plants with toxins, be careful when using it.
@@ -20,4 +20,4 @@ reagent-name-ammonia = ammonia
 reagent-desc-ammonia = An effective fertilizer, it gives your plants some nutrients.
 
 reagent-name-diethylamine = diethylamine
-reagent-desc-diethylamine = A very potent fertilizer, treats plants with nutrients, eliminates pests, and sometimes it can even speed up growth.
+reagent-desc-diethylamine = A highly potent fertilizer that provides essential nutrients to plants, eliminates pests, and sometimes even accelerates growth.

--- a/Resources/Prototypes/Entities/Objects/Fun/bike_horn.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/bike_horn.yml
@@ -26,6 +26,11 @@
       collection: BikeHorn
       params:
         variation: 0.125
+  - type: EmitSoundOnCollide
+    sound:
+      collection: BikeHorn
+      params:
+        variation: 0.125
   - type: Tag
     tags:
     - Payload # yes, you can make re-usable prank grenades

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -272,7 +272,7 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/weh.ogg
-  - type: EmitSoundOnTrigger
+  - type: EmitSoundOnCollide
     sound:
       path: /Audio/Items/Toys/weh.ogg
   - type: Food
@@ -327,7 +327,7 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/muffled_weh.ogg
-  - type: EmitSoundOnTrigger
+  - type: EmitSoundOnCollide
     sound:
       path: /Audio/Items/Toys/muffled_weh.ogg
   - type: Food
@@ -688,7 +688,7 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Voice/Vox/shriek1.ogg
-  - type: emitSoundOnCollide
+  - type: EmitSoundOnCollide
     sound:
       path: /Audio/Voice/Vox/shriek1.ogg
   - type: Food
@@ -778,7 +778,7 @@
   - type: MeleeWeapon
     soundHit:
       path: /Audio/Voice/Human/malescream_4.ogg
-  - type: EmitSoundOnTrigger
+  - type: EmitSoundOnCollide
     sound:
       path: /Audio/Voice/Human/malescream_5.ogg
 

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -164,6 +164,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/mousesqueek.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Items/Toys/mousesqueek.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -237,6 +240,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Voice/Arachnid/arachnid_laugh.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Voice/Arachnid/arachnid_laugh.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -261,6 +267,9 @@
     sound:
       path: /Audio/Items/Toys/weh.ogg
   - type: EmitSoundOnActivate
+    sound:
+      path: /Audio/Items/Toys/weh.ogg
+  - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/weh.ogg
   - type: EmitSoundOnTrigger
@@ -318,6 +327,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/muffled_weh.ogg
+  - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Items/Toys/muffled_weh.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -363,6 +375,9 @@
       sound:
         path: /Audio/Items/Toys/toy_rustle.ogg
     - type: EmitSoundOnTrigger
+      sound:
+        path: /Audio/Items/Toys/toy_rustle.ogg
+    - type: EmitSoundOnCollide
       sound:
         path: /Audio/Items/Toys/toy_rustle.ogg
     - type: MeleeWeapon
@@ -510,6 +525,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Effects/bite.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Effects/bite.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -576,6 +594,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/rattle.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Items/Toys/rattle.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -597,6 +618,9 @@
     sound:
       path: /Audio/Items/Toys/mousesqueek.ogg
   - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Items/Toys/mousesqueek.ogg
+  - type: EmitSoundOnCollide
     sound:
       path: /Audio/Items/Toys/mousesqueek.ogg
   - type: Food
@@ -636,6 +660,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Items/Toys/quack.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Items/Toys/quack.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -659,6 +686,9 @@
     sound:
       path: /Audio/Voice/Vox/shriek1.ogg
   - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Voice/Vox/shriek1.ogg
+  - type: emitSoundOnCollide
     sound:
       path: /Audio/Voice/Vox/shriek1.ogg
   - type: Food
@@ -701,6 +731,9 @@
   - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Weapons/Xeno/alien_spitacid.ogg
+  - type: EmitSoundOnCollide
+    sound:
+      path: /Audio/Weapons/Xeno/alien_spitacid.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -735,6 +768,9 @@
   - type: EmitSoundOnActivate
     sound:
       path: /Audio/Voice/Human/malescream_3.ogg
+  - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Voice/Human/malescream_4.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
@@ -764,6 +800,9 @@
     sound:
       path: /Audio/Voice/Moth/moth_chitter.ogg
   - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Voice/Moth/moth_chitter.ogg
+  - type: EmitSoundOnCollide
     sound:
       path: /Audio/Voice/Moth/moth_chitter.ogg
   - type: MeleeWeapon
@@ -853,6 +892,9 @@
       path: /Audio/Items/Toys/ian.ogg
   - type: MeleeWeapon
     soundHit:
+      path: /Audio/Items/Toys/ian.ogg
+  - type: EmitSoundOnCollide
+    sound:
       path: /Audio/Items/Toys/ian.ogg
   - type: Food
     requiresSpecialDigestion: true


### PR DESCRIPTION
## About the PR
- Added EmitSoundOnCollide type to clown's bike horn as well as plushies with existing sound effects.

## Why / Balance
Fixes #27882

## Technical details
No code.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No breaking changes.

**Changelog**

- add: Sound effects to bike horn, plushies when they collide with an object (example: thrown) 

