### PR TITLE
Changing hands unwields item

### DIFF
--- a/Content.Shared/Wieldable/WieldableSystem.cs
+++ b/Content.Shared/Wieldable/WieldableSystem.cs
@@ -41,6 +41,7 @@ public sealed class WieldableSystem : EntitySystem
         SubscribeLocalEvent<WieldableComponent, GotUnequippedHandEvent>(OnItemLeaveHand);
         SubscribeLocalEvent<WieldableComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
         SubscribeLocalEvent<WieldableComponent, GetVerbsEvent<InteractionVerb>>(AddToggleWieldVerb);
+        SubscribeLocalEvent<WieldableComponent, HandDeselectedEvent>(OnDeselectWieldable);
 
         SubscribeLocalEvent<MeleeRequiresWieldComponent, AttemptMeleeEvent>(OnMeleeAttempt);
         SubscribeLocalEvent<GunRequiresWieldComponent, ShotAttemptedEvent>(OnShootAttempt);
@@ -89,6 +90,14 @@ public sealed class WieldableSystem : EntitySystem
     private void OnGunWielded(EntityUid uid, GunWieldBonusComponent component, ref ItemWieldedEvent args)
     {
         _gun.RefreshModifiers(uid);
+    }
+
+    private void OnDeselectWieldable(EntityUid uid, WieldableComponent component, HandDeselectedEvent args)
+    {
+        if (!component.Wielded)
+            return;
+
+        TryUnwield(uid, component, args.User);
     }
 
     private void OnGunRefreshModifiers(Entity<GunWieldBonusComponent> bonus, ref GunRefreshModifiersEvent args)


### PR DESCRIPTION
## About the PR
Guns are being changed to no longer unwield when Use Item In Hand is pressed #28002. The next best way to unwield an item is to switch to the other hand and press Drop. This change just makes it so the item unwields when you change hands, no need to also press Drop. I can't think of a plausible reason anyone would change hands while wielding an item except to use the second hand for something else

## Why / Balance
QOL, saves one pointless keypress, hopefully more intuitive to those who did not already know you can "drop" the second hand to unwield

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- tweak: Changing hands while wielding an item will now immediately unwield it.
