### PR TITLE
Tomato killers don't kill the server anymore.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -114,13 +114,18 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
-        damage: 100
+        damage: 40
       behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          FoodMeatTomato:
+            min: 1
+            max: 2
       - !type:GibBehavior { }
   - type: MobThresholds
     thresholds:
       0: Alive
-      24: Dead
+      35: Dead
   - type: Fixtures
     fixtures:
       fix1:
@@ -136,7 +141,7 @@
     hidden: true
     damage:
       groups:
-        Brute: 4
+        Brute: 6
     animation: WeaponArcBite
   - type: Climbing
   - type: NameIdentifier
@@ -156,3 +161,7 @@
   - type: Appearance
   - type: Produce
     seedId: killerTomato
+  - type: PassiveDamage # Slight passive damage. 35 hp \ 5 min \ 60 sec = 0.08
+    damage:
+      types:
+        Blunt: 0.11

--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -121,7 +121,11 @@
           FoodMeatTomato:
             min: 1
             max: 2
-      - !type:GibBehavior { }
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: gib
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -162,6 +166,12 @@
   - type: Produce
     seedId: killerTomato
   - type: PassiveDamage # Slight passive damage. 35 hp \ 5 min \ 60 sec = 0.08
+    allowedStates:
+    - Alive
+    - Dead
+    damageCap: 50
     damage:
       types:
         Blunt: 0.11
+  - type: StaticPrice
+    price: 400

--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -145,7 +145,7 @@
     hidden: true
     damage:
       groups:
-        Brute: 6
+        Brute: 9
     animation: WeaponArcBite
   - type: Climbing
   - type: NameIdentifier

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -599,6 +599,8 @@
   - type: SliceableFood
     count: 3
     slice: FoodMeatTomatoCutlet
+  - type: StaticPrice
+    price: 150
 
 - type: entity
   name: salami
@@ -1270,6 +1272,8 @@
   - type: Sprite
     state: salami-slice
     color: red
+  - type: StaticPrice
+    price: 60
 
 - type: entity
   name: salami slice

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -600,7 +600,7 @@
     count: 3
     slice: FoodMeatTomatoCutlet
   - type: StaticPrice
-    price: 150
+    price: 100
 
 - type: entity
   name: salami
@@ -1273,7 +1273,7 @@
     state: salami-slice
     color: red
   - type: StaticPrice
-    price: 60
+    price: 30
 
 - type: entity
   name: salami slice


### PR DESCRIPTION
## About the PR
Killer tomatoes got a small health and damage buff:
24 -> 35 hp
4 -> 9 brute damage

but now they gradually take blunt damage, which kills them after 5 minutes, and gib them after another minute. It won't allow you to make hordes of 100000 tomatoes that eat up the entire server (and its performance)
also, to add motivation and benefit to tomatoes, they are now worth 400 credits alive, and 100 credits per piece of meat.

## Why / Balance
poorly server...
it's a sloth's order.

**Changelog**
:cl:
- tweak: Killer tomatoes got a small health and damage buff: 24 -> 35 hp and 4->9 brute damage
- tweak: Killer tomatoes now die after 5 minutes of their existence
- add: Killer tomatoes can now be profitably sold.
