### PR TITLE
Artifact portal effect changes

### DIFF
--- a/Resources/Prototypes/Entities/Effects/portal.yml
+++ b/Resources/Prototypes/Entities/Effects/portal.yml
@@ -65,7 +65,7 @@
     energy: 1
     netsync: false
   - type: TimedDespawn
-    lifetime: 120
+    lifetime: 1
   - type: Portal
     canTeleportToOtherMaps: true
 


### PR DESCRIPTION
## About the PR
Artifact portal lifespan reduced from 120 seconds to 1 second

## Why / Balance
right now when an artifact causes a portal effect and position change with a random player, the portal hangs for 2 minutes, so usually the artifact is dragged back in and the person goes outside and gameplay continues as normal.

Now the portal will only work for 1 second: This means that in most cases people will not have time to react, and the artifact will end up in a random place on the station, with the person locked in the artifact chamber. This will add interaction between players: the human needs to get out of the lab, and the scientists need to ask the human where he was to find the artifact.

**Changelog**
:cl:
- tweak: Artifact portal lifespan reduced from 120 seconds to 1 second