### PR TITLE
Implement permissive version of AddMarkup and use it for tips

### DIFF
--- a/Content.Client/MassMedia/Ui/ArticleEditorPanel.xaml.cs
+++ b/Content.Client/MassMedia/Ui/ArticleEditorPanel.xaml.cs
@@ -76,7 +76,7 @@ public sealed partial class ArticleEditorPanel : Control
 
         TextEditPanel.Visible = !_preview;
         PreviewPanel.Visible = _preview;
-        PreviewLabel.SetMarkup(Rope.Collapse(ContentField.TextRope));
+        PreviewLabel.SetMarkupPermissive(Rope.Collapse(ContentField.TextRope));
     }
 
     private void OnCancel(BaseButton.ButtonEventArgs eventArgs)

--- a/Content.Client/Message/RichTextLabelExt.cs
+++ b/Content.Client/Message/RichTextLabelExt.cs
@@ -5,22 +5,24 @@ namespace Content.Client.Message;
 
 public static class RichTextLabelExt
 {
-    /**
-     * Sets the labels markup.
-     * <remarks>
-     * Invalid markup will cause exceptions to be thrown. Don't use this for user input!
-     * </remarks>
-     */
+
+
+     /// <summary>
+     /// Sets the labels markup.
+     /// </summary>
+     /// <remarks>
+     /// Invalid markup will cause exceptions to be thrown. Don't use this for user input!
+     /// </remarks>
     public static RichTextLabel SetMarkup(this RichTextLabel label, string markup)
     {
         label.SetMessage(FormattedMessage.FromMarkup(markup));
         return label;
     }
 
-    /**
-     * Sets the labels markup.<br/>
-     * Uses <c>FormatedMessage.FromMarkupPermissive</c> which treats invalid markup as text.
-     */
+     /// <summary>
+     /// Sets the labels markup.<br/>
+     /// Uses <c>FormatedMessage.FromMarkupPermissive</c> which treats invalid markup as text.
+     /// </summary>
     public static RichTextLabel SetMarkupPermissive(this RichTextLabel label, string markup)
     {
         label.SetMessage(FormattedMessage.FromMarkupPermissive(markup));

--- a/Content.Client/Message/RichTextLabelExt.cs
+++ b/Content.Client/Message/RichTextLabelExt.cs
@@ -5,9 +5,25 @@ namespace Content.Client.Message;
 
 public static class RichTextLabelExt
 {
+    /**
+     * Sets the labels markup.
+     * <remarks>
+     * Invalid markup will cause exceptions to be thrown. Don't use this for user input!
+     * </remarks>
+     */
     public static RichTextLabel SetMarkup(this RichTextLabel label, string markup)
     {
         label.SetMessage(FormattedMessage.FromMarkup(markup));
+        return label;
+    }
+
+    /**
+     * Sets the labels markup.<br/>
+     * Uses <c>FormatedMessage.FromMarkupPermissive</c> which treats invalid markup as text.
+     */
+    public static RichTextLabel SetMarkupPermissive(this RichTextLabel label, string markup)
+    {
+        label.SetMessage(FormattedMessage.FromMarkupPermissive(markup));
         return label;
     }
 }

--- a/Content.Client/Tips/TippyUIController.cs
+++ b/Content.Client/Tips/TippyUIController.cs
@@ -175,7 +175,7 @@ public sealed class TippyUIController : UIController
                     sprite.LayerSetVisible("hiding", false);
                 }
                 sprite.Rotation = 0;
-                tippy.Label.SetMarkup(_currentMessage.Msg);
+                tippy.Label.SetMarkupPermissive(_currentMessage.Msg);
                 tippy.Label.Visible = false;
                 tippy.LabelPanel.Visible = false;
                 tippy.Visible = true;


### PR DESCRIPTION
This PR add a version of the `AddMarkup` extension method for `RichTextLabel` that uses the `FormatedMessage.FromMarkupPermissive` method which treats invalid markup as text instead of throwing errors.

That version should be used instead for user input or in places that contain a lot of unescaped invalid markup.

This PR changes tips and the news article editor to both use the new safe version of the `AddMarkup` method
