### PR TITLE
Move ApcPowerReceiverComponent Powered state to shared

### DIFF
--- a/Content.Client/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Client/Power/Components/ApcPowerReceiverComponent.cs
@@ -1,0 +1,8 @@
+﻿using Content.Shared.Power.Components;
+
+namespace Content.Client.Power.Components;
+
+[RegisterComponent]
+public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverComponent
+{
+}

--- a/Content.Client/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Client/Power/EntitySystems/PowerReceiverSystem.cs
@@ -1,0 +1,22 @@
+﻿using Content.Client.Power.Components;
+using Content.Shared.Power.Components;
+using Content.Shared.Power.EntitySystems;
+using Robust.Shared.GameStates;
+
+namespace Content.Client.Power.EntitySystems;
+
+public abstract class PowerReceiverSystem : SharedPowerReceiverSystem
+{
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ApcPowerReceiverComponent, ComponentHandleState>(OnHandleState);
+    }
+
+    private void OnHandleState(EntityUid uid, ApcPowerReceiverComponent component, ref ComponentHandleState args)
+    {
+        if (args.Current is not ApcPowerReceiverComponentState state)
+            return;
+
+        component.Powered = state.Powered;
+    }
+}

--- a/Content.Client/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Client/Power/EntitySystems/PowerReceiverSystem.cs
@@ -5,10 +5,11 @@ using Robust.Shared.GameStates;
 
 namespace Content.Client.Power.EntitySystems;
 
-public abstract class PowerReceiverSystem : SharedPowerReceiverSystem
+public sealed class PowerReceiverSystem : SharedPowerReceiverSystem
 {
     public override void Initialize()
     {
+        base.Initialize();
         SubscribeLocalEvent<ApcPowerReceiverComponent, ComponentHandleState>(OnHandleState);
     }
 

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -31,7 +31,7 @@ namespace Content.Server.Power.Components
             {
                 _needsPower = value;
                 // Reset this so next tick will do a power update.
-                PoweredLastUpdate = null;
+                Recalculate = true;
             }
         }
 
@@ -48,7 +48,7 @@ namespace Content.Server.Power.Components
             set => NetworkLoad.Enabled = !value;
         }
 
-        public bool? PoweredLastUpdate;
+        public bool Recalculate;
 
         [ViewVariables]
         public PowerState.Load NetworkLoad { get; } = new PowerState.Load

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -1,5 +1,6 @@
 using Content.Server.Power.NodeGroups;
 using Content.Server.Power.Pow3r;
+using Content.Shared.Power.Components;
 
 namespace Content.Server.Power.Components
 {
@@ -8,11 +9,8 @@ namespace Content.Server.Power.Components
     ///     so that it can receive power from a <see cref="IApcNet"/>.
     /// </summary>
     [RegisterComponent]
-    public sealed partial class ApcPowerReceiverComponent : Component
+    public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverComponent
     {
-        [ViewVariables]
-        public bool Powered => (MathHelper.CloseToPercent(NetworkLoad.ReceivingPower, Load) || !NeedsPower) && !PowerDisabled;
-
         /// <summary>
         ///     Amount of charge this needs from an APC per second to function.
         /// </summary>

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -48,6 +48,7 @@ namespace Content.Server.Power.Components
             set => NetworkLoad.Enabled = !value;
         }
 
+        // TODO Is this needed? It forces a PowerChangedEvent when NeedsPower is toggled even if it changes to the same state.
         public bool Recalculate;
 
         [ViewVariables]
@@ -64,10 +65,5 @@ namespace Content.Server.Power.Components
     /// Does nothing on the client.
     /// </summary>
     [ByRefEvent]
-    public readonly record struct PowerChangedEvent(bool Powered, float ReceivingPower)
-    {
-        public readonly bool Powered = Powered;
-        public readonly float ReceivingPower = ReceivingPower;
-    }
-
+    public readonly record struct PowerChangedEvent(bool Powered, float ReceivingPower);
 }

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -305,11 +305,10 @@ namespace Content.Server.Power.EntitySystems
 
         private void UpdateApcPowerReceiver()
         {
-            var metaQuery = GetEntityQuery<MetaDataComponent>();
-            var enumerator = AllEntityQuery<ApcPowerReceiverComponent>();
-            while (enumerator.MoveNext(out var uid, out var apcReceiver))
+            var enumerator = AllEntityQuery<ApcPowerReceiverComponent, MetaDataComponent>();
+            while (enumerator.MoveNext(out var uid, out var apcReceiver, out var metaDataComponent))
             {
-                if (metaQuery.TryComp(uid, out var metaDataComponent) && metaDataComponent.EntityPaused)
+                if (metaDataComponent.EntityPaused)
                     continue;
 
                 _powerReceiver.UpdateIsPowered((uid, apcReceiver));

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -39,6 +39,8 @@ namespace Content.Server.Power.EntitySystems
             SubscribeLocalEvent<ApcPowerReceiverComponent, EntityPausedEvent>(ApcPowerReceiverPaused);
             SubscribeLocalEvent<ApcPowerReceiverComponent, EntityUnpausedEvent>(ApcPowerReceiverUnpaused);
 
+            SubscribeLocalEvent<AppearanceComponent, PowerChangedEvent>(ApcPowerReceiverPowerChanged);
+
             SubscribeLocalEvent<PowerNetworkBatteryComponent, ComponentInit>(BatteryInit);
             SubscribeLocalEvent<PowerNetworkBatteryComponent, ComponentShutdown>(BatteryShutdown);
             SubscribeLocalEvent<PowerNetworkBatteryComponent, EntityPausedEvent>(BatteryPaused);
@@ -85,6 +87,11 @@ namespace Content.Server.Power.EntitySystems
             ref EntityUnpausedEvent args)
         {
             component.NetworkLoad.Paused = false;
+        }
+
+        private void ApcPowerReceiverPowerChanged(Entity<AppearanceComponent> ent, ref PowerChangedEvent args)
+        {
+            _appearance.SetData(ent.Owner, PowerDeviceVisuals.Powered, args.Powered, ent.Comp);
         }
 
         private void BatteryInit(EntityUid uid, PowerNetworkBatteryComponent component, ComponentInit args)
@@ -298,7 +305,6 @@ namespace Content.Server.Power.EntitySystems
 
         private void UpdateApcPowerReceiver()
         {
-            var appearanceQuery = GetEntityQuery<AppearanceComponent>();
             var metaQuery = GetEntityQuery<MetaDataComponent>();
             var enumerator = AllEntityQuery<ApcPowerReceiverComponent>();
             while (enumerator.MoveNext(out var uid, out var apcReceiver))
@@ -307,9 +313,6 @@ namespace Content.Server.Power.EntitySystems
                     continue;
 
                 _powerReceiver.UpdateIsPowered((uid, apcReceiver));
-
-                if (appearanceQuery.TryGetComponent(uid, out var appearance))
-                    _appearance.SetData(uid, PowerDeviceVisuals.Powered, apcReceiver.Powered, appearance);
             }
         }
 

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -303,7 +303,7 @@ namespace Content.Server.Power.EntitySystems
             var enumerator = AllEntityQuery<ApcPowerReceiverComponent>();
             while (enumerator.MoveNext(out var uid, out var apcReceiver))
             {
-                var powered = _powerReceiver.IsPowered(uid, apcReceiver);
+                var powered = _powerReceiver.CalculatePoweredState(uid, apcReceiver);
 
                 // If new value is the same as the old, then exit
                 if (!apcReceiver.Recalculate && apcReceiver.Powered == powered)

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -303,22 +303,13 @@ namespace Content.Server.Power.EntitySystems
             var enumerator = AllEntityQuery<ApcPowerReceiverComponent>();
             while (enumerator.MoveNext(out var uid, out var apcReceiver))
             {
-                var powered = _powerReceiver.IsPowered(uid, apcReceiver);
-                if (powered == apcReceiver.PoweredLastUpdate)
-                    continue;
-
                 if (metaQuery.TryComp(uid, out var metaDataComponent) && metaDataComponent.EntityPaused)
                     continue;
 
-                apcReceiver.PoweredLastUpdate = powered;
-                apcReceiver.Powered = _powerReceiver.IsPowered(uid, apcReceiver);
-                Dirty(uid, apcReceiver, metaDataComponent);
-                var ev = new PowerChangedEvent(apcReceiver.Powered, apcReceiver.NetworkLoad.ReceivingPower);
-
-                RaiseLocalEvent(uid, ref ev);
+                _powerReceiver.UpdateIsPowered((uid, apcReceiver));
 
                 if (appearanceQuery.TryGetComponent(uid, out var appearance))
-                    _appearance.SetData(uid, PowerDeviceVisuals.Powered, powered, appearance);
+                    _appearance.SetData(uid, PowerDeviceVisuals.Powered, apcReceiver.Powered, appearance);
             }
         }
 

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -303,7 +303,10 @@ namespace Content.Server.Power.EntitySystems
             var enumerator = AllEntityQuery<ApcPowerReceiverComponent>();
             while (enumerator.MoveNext(out var uid, out var apcReceiver))
             {
-                var powered = _powerReceiver.CalculatePoweredState(uid, apcReceiver);
+                var powered = !apcReceiver.PowerDisabled
+                              && (!apcReceiver.NeedsPower
+                                  || MathHelper.CloseToPercent(apcReceiver.NetworkLoad.ReceivingPower,
+                                      apcReceiver.Load));
 
                 // If new value is the same as the old, then exit
                 if (!apcReceiver.Recalculate && apcReceiver.Powered == powered)

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -173,9 +173,9 @@ namespace Content.Server.Power.EntitySystems
             if (!_recQuery.Resolve(uid, ref receiver, false))
                 return true;
 
-            return (MathHelper.CloseToPercent(receiver.NetworkLoad.ReceivingPower, receiver.Load)
-                    || !receiver.NeedsPower)
-                   && !receiver.PowerDisabled;
+            return !receiver.PowerDisabled
+                   && (!receiver.NeedsPower
+                       || MathHelper.CloseToPercent(receiver.NetworkLoad.ReceivingPower, receiver.Load));
         }
 
         /// <summary>

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -178,6 +178,30 @@ namespace Content.Server.Power.EntitySystems
                        || MathHelper.CloseToPercent(receiver.NetworkLoad.ReceivingPower, receiver.Load));
         }
 
+        public void UpdateIsPowered(Entity<ApcPowerReceiverComponent?, MetaDataComponent?> entity)
+        {
+            SetIsPowered(entity, IsPowered(entity.Owner, entity.Comp1));
+        }
+
+        private void SetIsPowered(Entity<ApcPowerReceiverComponent?, MetaDataComponent?> entity, bool powered)
+        {
+            if (!_recQuery.Resolve(entity.Owner, ref entity.Comp1, false)
+                || !Resolve(entity.Owner, ref entity.Comp2, false))
+                return;
+
+            // If new value is the same as the old, then exit
+            if (!entity.Comp1.Recalculate && entity.Comp1.Powered == powered)
+                return;
+
+            entity.Comp1.Recalculate = false;
+
+            entity.Comp1.Powered = powered;
+            Dirty(entity.Owner, entity.Comp1, entity.Comp2);
+
+            var ev = new PowerChangedEvent(entity.Comp1.Powered, entity.Comp1.NetworkLoad.ReceivingPower);
+            RaiseLocalEvent(entity.Owner, ref ev);
+        }
+
         /// <summary>
         /// Turn this machine on or off.
         /// Returns true if we turned it on, false if we turned it off.

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -168,11 +168,9 @@ namespace Content.Server.Power.EntitySystems
         /// Otherwise, it returns 'true' because if something doesn't take power
         /// it's effectively always powered.
         /// </summary>
-        public bool IsPowered(EntityUid uid, ApcPowerReceiverComponent? receiver = null)
+        /// <returns>Whether the entity is powered.</returns>
+        public bool CalculatePoweredState(EntityUid uid, ApcPowerReceiverComponent receiver)
         {
-            if (!_recQuery.Resolve(uid, ref receiver, false))
-                return true;
-
             return !receiver.PowerDisabled
                    && (!receiver.NeedsPower
                        || MathHelper.CloseToPercent(receiver.NetworkLoad.ReceivingPower, receiver.Load));

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -168,12 +168,10 @@ namespace Content.Server.Power.EntitySystems
         /// Otherwise, it returns 'true' because if something doesn't take power
         /// it's effectively always powered.
         /// </summary>
-        /// <returns>Whether the entity is powered.</returns>
-        public bool CalculatePoweredState(EntityUid uid, ApcPowerReceiverComponent receiver)
+        /// <returns>True when entity has no ApcPowerReceiverComponent or is Powered. False when not.</returns>
+        public bool IsPowered(EntityUid uid, ApcPowerReceiverComponent? receiver = null)
         {
-            return !receiver.PowerDisabled
-                   && (!receiver.NeedsPower
-                       || MathHelper.CloseToPercent(receiver.NetworkLoad.ReceivingPower, receiver.Load));
+            return !_recQuery.Resolve(uid, ref receiver, false) || receiver.Powered;
         }
 
         /// <summary>

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -178,30 +178,6 @@ namespace Content.Server.Power.EntitySystems
                        || MathHelper.CloseToPercent(receiver.NetworkLoad.ReceivingPower, receiver.Load));
         }
 
-        public void UpdateIsPowered(Entity<ApcPowerReceiverComponent?, MetaDataComponent?> entity)
-        {
-            SetIsPowered(entity, IsPowered(entity.Owner, entity.Comp1));
-        }
-
-        private void SetIsPowered(Entity<ApcPowerReceiverComponent?, MetaDataComponent?> entity, bool powered)
-        {
-            if (!_recQuery.Resolve(entity.Owner, ref entity.Comp1, false)
-                || !Resolve(entity.Owner, ref entity.Comp2, false))
-                return;
-
-            // If new value is the same as the old, then exit
-            if (!entity.Comp1.Recalculate && entity.Comp1.Powered == powered)
-                return;
-
-            entity.Comp1.Recalculate = false;
-
-            entity.Comp1.Powered = powered;
-            Dirty(entity.Owner, entity.Comp1, entity.Comp2);
-
-            var ev = new PowerChangedEvent(entity.Comp1.Powered, entity.Comp1.NetworkLoad.ReceivingPower);
-            RaiseLocalEvent(entity.Owner, ref ev);
-        }
-
         /// <summary>
         /// Turn this machine on or off.
         /// Returns true if we turned it on, false if we turned it off.

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -157,10 +157,6 @@ namespace Content.Server.Power.EntitySystems
         {
             var comp = receiver.Comp;
             comp.NetworkLoad.LinkedNetwork = default;
-            var ev = new PowerChangedEvent(comp.Powered, comp.NetworkLoad.ReceivingPower);
-
-            RaiseLocalEvent(receiver, ref ev);
-            _appearance.SetData(receiver, PowerDeviceVisuals.Powered, comp.Powered);
         }
 
         /// <summary>

--- a/Content.Shared/Power/Components/ApcPowerReceiverComponentState.cs
+++ b/Content.Shared/Power/Components/ApcPowerReceiverComponentState.cs
@@ -1,0 +1,9 @@
+﻿using Robust.Shared.Serialization;
+
+namespace Content.Shared.Power.Components;
+
+[Serializable, NetSerializable]
+public sealed class ApcPowerReceiverComponentState : ComponentState
+{
+    public bool Powered;
+}

--- a/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
+++ b/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
@@ -5,6 +5,6 @@ namespace Content.Shared.Power.Components;
 [NetworkedComponent]
 public abstract partial class SharedApcPowerReceiverComponent : Component
 {
-    [DataField]
+    [ViewVariables]
     public bool Powered;
 }

--- a/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
+++ b/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Power.Components;
+
+[NetworkedComponent]
+public abstract partial class SharedApcPowerReceiverComponent : Component
+{
+    [DataField]
+    public bool Powered;
+}

--- a/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
+++ b/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
@@ -1,0 +1,6 @@
+﻿namespace Content.Shared.Power.EntitySystems;
+
+public abstract class SharedPowerReceiverSystem : EntitySystem
+{
+
+}

--- a/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
+++ b/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
@@ -1,6 +1,4 @@
-﻿using Content.Shared.Power.Components;
-
-namespace Content.Shared.Power.EntitySystems;
+﻿namespace Content.Shared.Power.EntitySystems;
 
 public abstract class SharedPowerReceiverSystem : EntitySystem
 {

--- a/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
+++ b/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
@@ -4,23 +4,5 @@ namespace Content.Shared.Power.EntitySystems;
 
 public abstract class SharedPowerReceiverSystem : EntitySystem
 {
-    private EntityQuery<SharedApcPowerReceiverComponent> _poweredQuery;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        _poweredQuery = GetEntityQuery<SharedApcPowerReceiverComponent>();
-    }
-
-    /// <summary>
-    /// If this takes power, it returns whether it has power.
-    /// Otherwise, it returns 'true' because if something doesn't take power
-    /// it's effectively always powered.
-    /// </summary>
-    /// <returns>True when entity has no ApcPowerReceiverComponent or is Powered. False when not.</returns>
-    public bool IsPowered(EntityUid uid, SharedApcPowerReceiverComponent? receiver = null)
-    {
-        return !_poweredQuery.Resolve(uid, ref receiver, false) || receiver.Powered;
-    }
 }

--- a/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
+++ b/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
@@ -1,6 +1,26 @@
-﻿namespace Content.Shared.Power.EntitySystems;
+﻿using Content.Shared.Power.Components;
+
+namespace Content.Shared.Power.EntitySystems;
 
 public abstract class SharedPowerReceiverSystem : EntitySystem
 {
+    private EntityQuery<SharedApcPowerReceiverComponent> _poweredQuery;
 
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _poweredQuery = GetEntityQuery<SharedApcPowerReceiverComponent>();
+    }
+
+    /// <summary>
+    /// If this takes power, it returns whether it has power.
+    /// Otherwise, it returns 'true' because if something doesn't take power
+    /// it's effectively always powered.
+    /// </summary>
+    /// <returns>True when entity has no ApcPowerReceiverComponent or is Powered. False when not.</returns>
+    public bool IsPowered(EntityUid uid, SharedApcPowerReceiverComponent? receiver = null)
+    {
+        return !_poweredQuery.Resolve(uid, ref receiver, false) || receiver.Powered;
+    }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Moves the Powered state to shared so that the client can use it to predict without having duplicated data in every component.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Multiple components add a Powered bool that just subscribes to PowerChangedEvent, duplicating the data, so this change lowers the amount of data duplication across components.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Put powered state of power receiver in shared for client prediction.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

No cl