### PR TITLE
antag objective issuing refactor

### DIFF
--- a/Content.Server/Antag/AntagObjectivesSystem.cs
+++ b/Content.Server/Antag/AntagObjectivesSystem.cs
@@ -1,0 +1,35 @@
+using Content.Server.Antag.Components;
+using Content.Server.Objectives;
+using Content.Shared.Mind;
+using Content.Shared.Objectives.Systems;
+
+namespace Content.Server.Antag;
+
+/// <summary>
+/// Adds fixed objectives to an antag made with <c>AntagObjectivesComponent</c>.
+/// </summary>
+public sealed class AntagObjectivesSystem : EntitySystem
+{
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AntagObjectivesComponent, AfterAntagEntitySelectedEvent>(OnAntagSelected);
+    }
+
+    private void OnAntagSelected(Entity<AntagObjectivesComponent> ent, ref AfterAntagEntitySelectedEvent args)
+    {
+        if (!_mind.TryGetMind(args.Session, out var mindId, out var mind))
+        {
+            Log.Error($"Antag {ToPrettyString(args.EntityUid):player} was selected by {ToPrettyString(ent):rule} but had no mind attached!");
+            return;
+        }
+
+        foreach (var id in ent.Comp.Objectives)
+        {
+            _mind.TryAddObjective(mindId, mind, id);
+        }
+    }
+}

--- a/Content.Server/Antag/AntagRandomObjectivesSystem.cs
+++ b/Content.Server/Antag/AntagRandomObjectivesSystem.cs
@@ -1,0 +1,52 @@
+using Content.Server.Antag.Components;
+using Content.Server.Objectives;
+using Content.Shared.Mind;
+using Content.Shared.Objectives.Components;
+using Content.Shared.Objectives.Systems;
+using Robust.Shared.Random;
+
+namespace Content.Server.Antag;
+
+/// <summary>
+/// Adds fixed objectives to an antag made with <c>AntagRandomObjectivesComponent</c>.
+/// </summary>
+public sealed class AntagRandomObjectivesSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly ObjectivesSystem _objectives = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AntagRandomObjectivesComponent, AfterAntagEntitySelectedEvent>(OnAntagSelected);
+    }
+
+    private void OnAntagSelected(Entity<AntagRandomObjectivesComponent> ent, ref AfterAntagEntitySelectedEvent args)
+    {
+        if (!_mind.TryGetMind(args.Session, out var mindId, out var mind))
+        {
+            Log.Error($"Antag {ToPrettyString(args.EntityUid):player} was selected by {ToPrettyString(ent):rule} but had no mind attached!");
+            return;
+        }
+
+        var difficulty = 0f;
+        foreach (var set in ent.Comp.Sets)
+        {
+            if (!_random.Prob(set.Prob))
+                continue;
+
+            for (var pick = 0; pick < set.MaxPicks && ent.Comp.MaxDifficulty > difficulty; pick++)
+            {
+                if (_objectives.GetRandomObjective(mindId, mind, set.Groups) is not {} objective)
+                    continue;
+
+                _mind.AddObjective(mindId, mind, objective);
+                var adding = Comp<ObjectiveComponent>(objective).Difficulty;
+                difficulty += adding;
+                Log.Debug($"Added objective {ToPrettyString(objective):objective} to {ToPrettyString(args.EntityUid):player} with {adding} difficulty");
+            }
+        }
+    }
+}

--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -124,7 +124,7 @@ public sealed partial class AntagSelectionSystem
     }
 
     /// <remarks>
-    /// Helper specifically for <see cref="ObjectivesTextGetInfoEvent"/>
+    /// Helper to get just the mind entities and not names.
     /// </remarks>
     public List<EntityUid> GetAntagMindEntityUids(Entity<AntagSelectionComponent?> ent)
     {

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.GameTicking.Rules;
 using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Mind;
+using Content.Server.Objectives;
 using Content.Server.Preferences.Managers;
 using Content.Server.Roles;
 using Content.Server.Roles.Jobs;
@@ -49,6 +50,8 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         base.Initialize();
 
         SubscribeLocalEvent<GhostRoleAntagSpawnerComponent, TakeGhostRoleEvent>(OnTakeGhostRole);
+
+        SubscribeLocalEvent<AntagSelectionComponent, ObjectivesTextGetInfoEvent>(OnObjectivesTextGetInfo);
 
         SubscribeLocalEvent<RulePlayerSpawningEvent>(OnPlayerSpawning);
         SubscribeLocalEvent<RulePlayerJobsAssignedEvent>(OnJobsAssigned);
@@ -422,6 +425,15 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         }
 
         return true;
+    }
+
+    private void OnObjectivesTextGetInfo(Entity<AntagSelectionComponent> ent, ref ObjectivesTextGetInfoEvent args)
+    {
+        if (ent.Comp.AgentName is not {} name)
+            return;
+
+        args.Minds = ent.Comp.SelectedMinds;
+        args.AgentName = Loc.GetString(name);
     }
 }
 

--- a/Content.Server/Antag/Components/AntagObjectivesComponent.cs
+++ b/Content.Server/Antag/Components/AntagObjectivesComponent.cs
@@ -1,0 +1,18 @@
+using Content.Server.Antag;
+using Content.Shared.Objectives.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Antag.Components;
+
+/// <summary>
+/// Gives antags selected by this rule a fixed list of objectives.
+/// </summary>
+[RegisterComponent, Access(typeof(AntagObjectivesSystem))]
+public sealed partial class AntagObjectivesComponent : Component
+{
+    /// <summary>
+    /// List of static objectives to give.
+    /// </summary>
+    [DataField(required: true)]
+    public List<EntProtoId<ObjectiveComponent>> Objectives = new();
+}

--- a/Content.Server/Antag/Components/AntagRandomObjectivesComponent.cs
+++ b/Content.Server/Antag/Components/AntagRandomObjectivesComponent.cs
@@ -1,0 +1,52 @@
+using Content.Server.Antag;
+using Content.Shared.Random;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Antag.Components;
+
+/// <summary>
+/// Gives antags selected by this rule a random list of objectives.
+/// </summary>
+[RegisterComponent, Access(typeof(AntagRandomObjectivesSystem))]
+public sealed partial class AntagRandomObjectivesComponent : Component
+{
+    /// <summary>
+    /// Each set of objectives to add.
+    /// </summary>
+    [DataField(required: true)]
+    public List<AntagObjectiveSet> Sets = new();
+
+    /// <summary>
+    /// If the total difficulty of the currently given objectives exceeds, no more will be given.
+    /// </summary>
+    [DataField(required: true)]
+    public float MaxDifficulty;
+}
+
+/// <summary>
+/// A set of objectives to try picking.
+/// Difficulty is checked over all sets, but each set has its own probability and pick count.
+/// </summary>
+[DataRecord]
+public record struct AntagObjectiveSet()
+{
+    /// <summary>
+    /// The grouping used by the objective system to pick random objectives.
+    /// First a group is picked from these, then an objective from that group.
+    /// </summary>
+    [DataField(required: true)]
+    public ProtoId<WeightedRandomPrototype> Groups = string.Empty;
+
+    /// <summary>
+    /// Probability of this set being used.
+    /// </summary>
+    [DataField]
+    public float Prob = 1f;
+
+    /// <summary>
+    /// Number of times to try picking objectives from this set.
+    /// Even if there is enough difficulty remaining, no more will be given after this.
+    /// </summary>
+    [DataField]
+    public int MaxPicks = 20;
+}

--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -42,6 +42,13 @@ public sealed partial class AntagSelectionComponent : Component
     /// Is not serialized.
     /// </summary>
     public HashSet<ICommonSession> SelectedSessions = new();
+
+    /// <summary>
+    /// Locale id for the name of the antag.
+    /// If this is set then the antag is listed in the round-end summary.
+    /// </summary>
+    [DataField]
+    public LocId? AgentName;
 }
 
 [DataDefinition]

--- a/Content.Server/GameTicking/Rules/Components/ThiefRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/ThiefRuleComponent.cs
@@ -8,23 +8,4 @@ namespace Content.Server.GameTicking.Rules.Components;
 /// Stores data for <see cref="ThiefRuleSystem"/>.
 /// </summary>
 [RegisterComponent, Access(typeof(ThiefRuleSystem))]
-public sealed partial class ThiefRuleComponent : Component
-{
-    [DataField]
-    public ProtoId<WeightedRandomPrototype> BigObjectiveGroup = "ThiefBigObjectiveGroups";
-
-    [DataField]
-    public ProtoId<WeightedRandomPrototype> SmallObjectiveGroup = "ThiefObjectiveGroups";
-
-    [DataField]
-    public ProtoId<WeightedRandomPrototype> EscapeObjectiveGroup = "ThiefEscapeObjectiveGroups";
-
-    [DataField]
-    public float BigObjectiveChance = 0.7f;
-
-    [DataField]
-    public float MaxObjectiveDifficulty = 2.5f;
-
-    [DataField]
-    public int MaxStealObjectives = 10;
-}
+public sealed partial class ThiefRuleComponent : Component;

--- a/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
@@ -23,9 +23,6 @@ public sealed partial class TraitorRuleComponent : Component
     public ProtoId<NpcFactionPrototype> SyndicateFaction = "Syndicate";
 
     [DataField]
-    public ProtoId<WeightedRandomPrototype> ObjectiveGroup = "TraitorObjectiveGroups";
-
-    [DataField]
     public ProtoId<DatasetPrototype> CodewordAdjectives = "adjectives";
 
     [DataField]
@@ -72,7 +69,4 @@ public sealed partial class TraitorRuleComponent : Component
     /// </summary>
     [DataField]
     public int StartingBalance = 20;
-
-    [DataField]
-    public int MaxDifficulty = 5;
 }

--- a/Content.Server/GameTicking/Rules/GenericAntagRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GenericAntagRuleSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Objectives;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -47,7 +48,8 @@ public sealed class GenericAntagRuleSystem : GameRuleSystem<GenericAntagRuleComp
 
     private void OnObjectivesTextGetInfo(EntityUid uid, GenericAntagRuleComponent comp, ref ObjectivesTextGetInfoEvent args)
     {
-        args.Minds = comp.Minds;
+        // just temporary until this is deleted
+        args.Minds = comp.Minds.Select(mindId => (mindId, Comp<MindComponent>(mind).CharacterName ?? "?")).ToList();
         args.AgentName = Loc.GetString(comp.AgentName);
     }
 }

--- a/Content.Server/GameTicking/Rules/GenericAntagRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GenericAntagRuleSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Objectives;
+using Content.Shared.Mind;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -49,7 +50,7 @@ public sealed class GenericAntagRuleSystem : GameRuleSystem<GenericAntagRuleComp
     private void OnObjectivesTextGetInfo(EntityUid uid, GenericAntagRuleComponent comp, ref ObjectivesTextGetInfoEvent args)
     {
         // just temporary until this is deleted
-        args.Minds = comp.Minds.Select(mindId => (mindId, Comp<MindComponent>(mind).CharacterName ?? "?")).ToList();
+        args.Minds = comp.Minds.Select(mindId => (mindId, Comp<MindComponent>(mindId).CharacterName ?? "?")).ToList();
         args.AgentName = Loc.GetString(comp.AgentName);
     }
 }

--- a/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
@@ -24,7 +24,6 @@ public sealed class ThiefRuleSystem : GameRuleSystem<ThiefRuleComponent>
         SubscribeLocalEvent<ThiefRuleComponent, AfterAntagEntitySelectedEvent>(AfterAntagSelected);
 
         SubscribeLocalEvent<ThiefRoleComponent, GetBriefingEvent>(OnGetBriefing);
-        SubscribeLocalEvent<ThiefRuleComponent, ObjectivesTextGetInfoEvent>(OnObjectivesTextGetInfo);
     }
 
     private void AfterAntagSelected(Entity<ThiefRuleComponent> ent, ref AfterAntagEntitySelectedEvent args)
@@ -33,39 +32,7 @@ public sealed class ThiefRuleSystem : GameRuleSystem<ThiefRuleComponent>
             return;
 
         //Generate objectives
-        GenerateObjectives(mindId, mind, ent);
         _antag.SendBriefing(args.EntityUid, MakeBriefing(args.EntityUid), null, null);
-    }
-
-    private void GenerateObjectives(EntityUid mindId, MindComponent mind, ThiefRuleComponent thiefRule)
-    {
-        // Give thieves their objectives
-        var difficulty = 0f;
-
-        if (_random.Prob(thiefRule.BigObjectiveChance)) // 70% chance to 1 big objective (structure or animal)
-        {
-            var objective = _objectives.GetRandomObjective(mindId, mind, thiefRule.BigObjectiveGroup);
-            if (objective != null)
-            {
-                _mindSystem.AddObjective(mindId, mind, objective.Value);
-                difficulty += Comp<ObjectiveComponent>(objective.Value).Difficulty;
-            }
-        }
-
-        for (var i = 0; i < thiefRule.MaxStealObjectives && thiefRule.MaxObjectiveDifficulty > difficulty; i++)  // Many small objectives
-        {
-            var objective = _objectives.GetRandomObjective(mindId, mind, thiefRule.SmallObjectiveGroup);
-            if (objective == null)
-                continue;
-
-            _mindSystem.AddObjective(mindId, mind, objective.Value);
-            difficulty += Comp<ObjectiveComponent>(objective.Value).Difficulty;
-        }
-
-        //Escape target
-        var escapeObjective = _objectives.GetRandomObjective(mindId, mind, thiefRule.EscapeObjectiveGroup);
-        if (escapeObjective != null)
-            _mindSystem.AddObjective(mindId, mind, escapeObjective.Value);
     }
 
     //Add mind briefing
@@ -86,11 +53,5 @@ public sealed class ThiefRuleSystem : GameRuleSystem<ThiefRuleComponent>
 
         briefing += "\n \n" + Loc.GetString("thief-role-greeting-equipment") + "\n";
         return briefing;
-    }
-
-    private void OnObjectivesTextGetInfo(Entity<ThiefRuleComponent> ent, ref ObjectivesTextGetInfoEvent args)
-    {
-        args.Minds = _antag.GetAntagMindEntityUids(ent.Owner);
-        args.AgentName = Loc.GetString("thief-round-end-agent-name");
     }
 }

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -36,14 +36,14 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
     private void OnRoundEndText(RoundEndTextAppendEvent ev)
     {
         // go through each gamerule getting data for the roundend summary.
-        var summaries = new Dictionary<string, Dictionary<string, List<EntityUid>>>();
+        var summaries = new Dictionary<string, Dictionary<string, List<(EntityUid, string)>>>();
         var query = EntityQueryEnumerator<GameRuleComponent>();
         while (query.MoveNext(out var uid, out var gameRule))
         {
             if (!_gameTicker.IsGameRuleAdded(uid, gameRule))
                 continue;
 
-            var info = new ObjectivesTextGetInfoEvent(new List<EntityUid>(), string.Empty);
+            var info = new ObjectivesTextGetInfoEvent(new List<(EntityUid, string)>(), string.Empty);
             RaiseLocalEvent(uid, ref info);
             if (info.Minds.Count == 0)
                 continue;
@@ -51,7 +51,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
             // first group the gamerules by their agents, for example 2 different dragons
             var agent = info.AgentName;
             if (!summaries.ContainsKey(agent))
-                summaries[agent] = new Dictionary<string, List<EntityUid>>();
+                summaries[agent] = new Dictionary<string, List<(EntityUid, string)>>();
 
             var prepend = new ObjectivesTextPrependEvent("");
             RaiseLocalEvent(uid, ref prepend);
@@ -79,7 +79,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
             foreach (var (_, minds) in summary)
             {
                 total += minds.Count;
-                totalInCustody += minds.Where(m => IsInCustody(m)).Count();
+                totalInCustody += minds.Where(pair => IsInCustody(pair.Item1)).Count();
             }
 
             var result = new StringBuilder();
@@ -104,19 +104,16 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
         }
     }
 
-    private void AddSummary(StringBuilder result, string agent, List<EntityUid> minds)
+    private void AddSummary(StringBuilder result, string agent, List<(EntityUid, string)> minds)
     {
         var agentSummaries = new List<(string summary, float successRate, int completedObjectives)>();
 
-        foreach (var mindId in minds)
+        foreach (var (mindId, name) in minds)
         {
-            if (!TryComp(mindId, out MindComponent? mind))
+            if (!TryComp<MindComponent>(mindId, out var mind))
                 continue;
 
-            var title = GetTitle(mindId, mind);
-            if (title == null)
-                continue;
-
+            var title = GetTitle((mindId, mind), name);
             var custody = IsInCustody(mindId, mind) ? Loc.GetString("objectives-in-custody") : string.Empty;
 
             var objectives = mind.Objectives;
@@ -238,33 +235,17 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
 
     /// <summary>
     /// Get the title for a player's mind used in round end.
+    /// Pass in the original entity name which is shown alongside username.
     /// </summary>
-    public string? GetTitle(EntityUid mindId, MindComponent? mind = null)
+    public string GetTitle(Entity<MindComponent?> mind, string name)
     {
-        if (!Resolve(mindId, ref mind))
-            return null;
-
-        var name = mind.CharacterName;
-        var username = (string?) null;
-
-        if (mind.OriginalOwnerUserId != null &&
-            _player.TryGetPlayerData(mind.OriginalOwnerUserId.Value, out var sessionData))
+        if (Resolve(mind, ref mind.Comp) &&
+            mind.Comp.OriginalOwnerUserId != null &&
+            _player.TryGetPlayerData(mind.Comp.OriginalOwnerUserId.Value, out var sessionData))
         {
-            username = sessionData.UserName;
+            var username = sessionData.UserName;
+            return Loc.GetString("objectives-player-user-named", ("user", username), ("name", name));
         }
-
-
-        if (username != null)
-        {
-            if (name != null)
-                return Loc.GetString("objectives-player-user-named", ("user", username), ("name", name));
-
-            return Loc.GetString("objectives-player-user", ("user", username));
-        }
-
-        // nothing to identify the player by, just give up
-        if (name == null)
-            return null;
 
         return Loc.GetString("objectives-player-named", ("name", name));
     }
@@ -279,7 +260,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
 /// The objectives system already checks if the game rule is added so you don't need to check that in this event's handler.
 /// </remarks>
 [ByRefEvent]
-public record struct ObjectivesTextGetInfoEvent(List<EntityUid> Minds, string AgentName);
+public record struct ObjectivesTextGetInfoEvent(List<(EntityUid, string)> Minds, string AgentName);
 
 /// <summary>
 /// Raised on the game rule before text for each agent's objectives is added, letting you prepend something.

--- a/Resources/Locale/en-US/objectives/round-end.ftl
+++ b/Resources/Locale/en-US/objectives/round-end.ftl
@@ -6,7 +6,6 @@ objectives-round-end-result = {$count ->
 objectives-round-end-result-in-custody = {$custody} out of {$count} {MAKEPLURAL($agent)} were in custody.
 
 objectives-player-user-named = [color=White]{$name}[/color] ([color=gray]{$user}[/color])
-objectives-player-user = [color=gray]{$user}[/color]
 objectives-player-named = [color=White]{$name}[/color]
 
 objectives-no-objectives = {$custody}{$title} was a {$agent}.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -428,9 +428,9 @@
         prototype: Nukeops
 
 - type: entity
-  id: SleeperAgentsRule
-  parent: BaseGameRule
   noSpawn: true
+  parent: BaseTraitorRule
+  id: SleeperAgentsRule
   components:
   - type: StationEvent
     earliestStart: 30
@@ -441,7 +441,6 @@
     startAudio:
       path: /Audio/Announcements/intercept.ogg
   - type: AlertLevelInterceptionRule
-  - type: TraitorRule
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -17,25 +17,25 @@
   - type: NinjaRule
     threats: NinjaThreats
 
-# stores configuration for dragon
-- type: entity
-  noSpawn: true
-  parent: BaseGameRule
-  id: Dragon
-  components:
-  - type: GenericAntagRule
-    agentName: dragon-round-end-agent-name
-    objectives:
-    - CarpRiftsObjective
-    - DragonSurviveObjective
-
 - type: entity
   noSpawn: true
   parent: BaseGameRule
   id: Thief
   components:
   - type: ThiefRule
+  - type: AntagObjectives
+    objectives:
+    - EscapeThiefShuttleObjective
+  - type: AntagRandomObjectives
+    sets:
+    - groups: ThiefBigObjectiveGroups
+      prob: 0.7
+      maxPicks: 1
+    - groups: ThiefObjectiveGroups
+      maxPicks: 10
+    maxDifficulty: 2.5
   - type: AntagSelection
+    agentName: thief-round-end-agent-name
     definitions:
     - prefRoles: [ Thief ]
       maxRange:
@@ -53,14 +53,3 @@
         prototype: Thief
       briefing:
         sound: "/Audio/Misc/thief_greeting.ogg"
-
-#- type: entity
-#  noSpawn: true
-#  parent: BaseGameRule
-#  id: Exterminator
-#  components:
-#  - type: GenericAntagRule
-#    agentName: terminator-round-end-agent-name
-#    objectives:
-#    - TerminateObjective
-#    - ShutDownObjective

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -17,6 +17,18 @@
   - type: NinjaRule
     threats: NinjaThreats
 
+# stores configuration for dragon
+- type: entity
+  noSpawn: true
+  parent: BaseGameRule
+  id: Dragon
+  components:
+  - type: GenericAntagRule
+    agentName: dragon-round-end-agent-name
+    objectives:
+    - CarpRiftsObjective
+    - DragonSurviveObjective
+
 - type: entity
   noSpawn: true
   parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -143,7 +143,7 @@
   # TODO: uplink in yml
   - type: AntagRandomObjectives
     sets:
-    - groups: TraitorObjectivesGroups
+    - groups: TraitorObjectiveGroups
     maxDifficulty: 5
   - type: AntagSelection
     agentName: traitor-round-end-agent-name

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -134,16 +134,30 @@
         prototype: Nukeops
 
 - type: entity
-  id: Traitor
+  abstract: true
   parent: BaseGameRule
+  id: BaseTraitorRule
+  components:
+  - type: TraitorRule
+  # TODO: codewords in yml
+  # TODO: uplink in yml
+  - type: AntagRandomObjectives
+    sets:
+    - groups: TraitorObjectivesGroups
+    maxDifficulty: 5
+  - type: AntagSelection
+    agentName: traitor-round-end-agent-name
+
+- type: entity
   noSpawn: true
+  parent: BaseTraitorRule
+  id: Traitor
   components:
   - type: GameRule
     minPlayers: 5
     delay:
       min: 240
       max: 420
-  - type: TraitorRule
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -56,13 +56,6 @@
     ThiefObjectiveGroupAnimal: 2
 
 - type: weightedRandom
-  id: ThiefEscapeObjectiveGroups
-  weights:
-    ThiefObjectiveGroupEscape: 1
-
-
-
-- type: weightedRandom
   id: ThiefObjectiveGroupCollection
   weights:
     HeadCloakStealCollectionObjective: 1           #command


### PR DESCRIPTION
## About the PR
instead of every system that has random objectives copy pasting shit, add `AntagRandomObjectives` to the gamerule yml

also moved fixed objectives part of genericantag into its own component AntagObjectivesComponent, which currently thief uses but will make everything that used genericantag use it too before nuking it entirely

## Why / Balance
negative diff (with genericantag deleted) good

## Technical details
an `AntagObjectiveSet` defines the objective groups prototype, probability of the set being used, the max tries it can have
`AntagRandomObjectives` can have multiple sets, like thief which has 70% chance of adding 1 animal objective and guaranteed chance of trying to add up to 10 normal objectives, difficulty permitting

traitor just has 1 set of `groups: TraitorObjectiveGroups` since it doesnt do anything funny

## Media
it work
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
`TraitorRule` and `ThiefRule` no longer add objectives, they need `AntagRandomObjectives` in the gamerule now

**Changelog**
no cl no fun