### PR TITLE
Microwave recipes now uses stacktype id instead of entity prototype id for stacked entities

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -60,6 +60,7 @@ namespace Content.Server.Kitchen.EntitySystems
         [Dependency] private readonly HandsSystem _handsSystem = default!;
         [Dependency] private readonly SharedItemSystem _item = default!;
         [Dependency] private readonly SharedStackSystem _stack = default!;
+        [Dependency] private readonly IPrototypeManager _prototype = default!;
 
         [ValidatePrototypeId<EntityPrototype>]
         private const string MalfunctionSpark = "Spark";
@@ -206,7 +207,7 @@ namespace Content.Server.Kitchen.EntitySystems
                         // If an entity has a stack component, use the stacktype instead of prototype id
                         if (TryComp<StackComponent>(item, out var stackComp))
                         {
-                            itemID = stackComp.StackTypeId;
+                            itemID = _prototype.Index<StackPrototype>(stackComp.StackTypeId).Spawn;
                         }
                         else
                         {
@@ -478,10 +479,10 @@ namespace Content.Server.Kitchen.EntitySystems
                 string? solidID = null;
                 int amountToAdd = 1;
 
-                // If a microwave recipe uses a stacked item, use the stacktype instead of prototype id
+                // If a microwave recipe uses a stacked item, use the default stack prototype id instead of prototype id
                 if (TryComp<StackComponent>(item, out var stackComp))
                 {
-                    solidID = stackComp.StackTypeId;
+                    solidID = _prototype.Index<StackPrototype>(stackComp.StackTypeId).Spawn;
                     amountToAdd = stackComp.Count;
                 }
                 else

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -203,6 +203,7 @@ namespace Content.Server.Kitchen.EntitySystems
                     {
                         string? itemID = null;
 
+                        // If an entity has a stack component, use the stacktype instead of prototype id
                         if (TryComp<StackComponent>(item, out var stackComp))
                         {
                             itemID = stackComp.StackTypeId;
@@ -227,18 +228,14 @@ namespace Content.Server.Kitchen.EntitySystems
                             if (stackComp.Count == 1)
                             {
                                 _container.Remove(item, component.Storage);
-                                EntityManager.DeleteEntity(item);
-                                break;
                             }
-                            else
-                            {
-                                _stack.Use(item, 1, stackComp);
-                            }
+                            _stack.Use(item, 1, stackComp);
+                            break;
                         }
                         else
                         {
                             _container.Remove(item, component.Storage);
-                            EntityManager.DeleteEntity(item);
+                            Del(item);
                             break;
                         }
                     }

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -157,7 +157,7 @@
   time: 10
   solids:
     FoodBreadBun: 1
-    SheetPlasma1: 2
+    Plasma: 2
 
 - type: microwaveMealRecipe
   id: RecipeCarpBurger

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -157,7 +157,7 @@
   time: 10
   solids:
     FoodBreadBun: 1
-    Plasma: 2
+    SheetPlasma1: 2
 
 - type: microwaveMealRecipe
   id: RecipeCarpBurger

--- a/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
@@ -13,8 +13,8 @@
   time: 10
   solids:
     FoodPoppy: 1
-    Brutepack: 1
-    MaterialCloth1: 1
+    Brutepack: 10
+    Cloth: 1
   reagents:
     TranexamicAcid: 20
     Cryptobiolin: 20
@@ -26,8 +26,8 @@
   time: 10
   solids:
     FoodAloe: 1
-    Ointment: 1
-    MaterialCloth1: 1
+    Ointment: 10
+    Cloth: 1
   reagents:
     Sigynate: 20
     Dermaline: 20

--- a/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
@@ -14,7 +14,7 @@
   solids:
     FoodPoppy: 1
     Brutepack: 10
-    Cloth: 1
+    MaterialCloth1: 1
   reagents:
     TranexamicAcid: 20
     Cryptobiolin: 20
@@ -27,7 +27,7 @@
   solids:
     FoodAloe: 1
     Ointment: 10
-    Cloth: 1
+    MaterialCloth1: 1
   reagents:
     Sigynate: 20
     Dermaline: 20


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Microwave recipes now treat stacked entities by their stacktype id instead of entity prototype id.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This fixes an issue with making medicated sutures and regenerative mesh using brutepacks and ointments from a medical techfab.
Medical techfabs make "Brutepack1" and "Ointment1" entities and stacking them makes them retain their entityid, but the recipe used "Brutepack" and "Ointment" entities, so it was impossible to use brute packs and ointments from techfabs to create advanced medicine.


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Microwave recipes now uses stacktype id instead of entity prototype id for stacked entities

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/89804215/e1624fe0-5593-44c9-940b-8aa42e6a4f6d


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
Any microwave recipe that uses a stacked entity must now instead use the entity of the base stack entity, usually the base stack entity name does not have a number appended to the end of it.
Also when a stacked entity is used, each 
Stackable entity prototypes can be found at Resources\Prototypes\Entities\Objects\Materials or whatever equivalent for the specific fork

As an example, here is the changes to the recipe for Regen Mesh
- type: microwaveMealRecipe
  id: RecipeRegenerativeMesh
  name: regenerative mesh recipe
  result: RegenerativeMesh
  time: 10
  solids:
    FoodAloe: 1
    Ointment: 1 -> Ointment: 10
    MaterialCloth1: 1
  reagents:
    Sigynate: 20
    Dermaline: 20

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: blueDev2
- fix: Fixed microwave recipes that use stacked materials
