### PR TITLE
Fix firelock prediction issues with periodic pulses of closing lights

### DIFF
--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -28,8 +28,6 @@ namespace Content.Server.Doors.Systems
         {
             base.Initialize();
 
-
-            SubscribeLocalEvent<FirelockComponent, BeforeDoorAutoCloseEvent>(OnBeforeDoorAutoclose);
             SubscribeLocalEvent<FirelockComponent, AtmosAlarmEvent>(OnAtmosAlarm);
 
             SubscribeLocalEvent<FirelockComponent, PowerChangedEvent>(PowerChanged);
@@ -78,19 +76,6 @@ namespace Content.Server.Doors.Systems
                     Dirty(uid, firelock);
                 }
             }
-        }
-
-        private void OnBeforeDoorAutoclose(EntityUid uid, FirelockComponent component, BeforeDoorAutoCloseEvent args)
-        {
-            if (!this.IsPowered(uid, EntityManager))
-                args.Cancel();
-
-            // Make firelocks autoclose, but only if the last alarm type it
-            // remembers was a danger. This is to prevent people from
-            // flooding hallways with endless bad air/fire.
-            if (component.AlarmAutoClose &&
-                (_atmosAlarmable.TryGetHighestAlert(uid, out var alarm) && alarm != AtmosAlarmType.Danger || alarm == null))
-                args.Cancel();
         }
 
         private void OnAtmosAlarm(EntityUid uid, FirelockComponent component, AtmosAlarmEvent args)

--- a/Content.Shared/Doors/Components/FirelockComponent.cs
+++ b/Content.Shared/Doors/Components/FirelockComponent.cs
@@ -19,8 +19,6 @@ namespace Content.Shared.Doors.Components
         [DataField("lockedPryTimeModifier"), ViewVariables(VVAccess.ReadWrite)]
         public float LockedPryTimeModifier = 1.5f;
 
-        [DataField("autocloseDelay")] public TimeSpan AutocloseDelay = TimeSpan.FromSeconds(3f);
-
         /// <summary>
         /// Maximum pressure difference before the firelock will refuse to open, in kPa.
         /// </summary>

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -18,8 +18,6 @@ public abstract class SharedFirelockSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<FirelockComponent, DoorStateChangedEvent>(OnUpdateState);
-
         // Access/Prying
         SubscribeLocalEvent<FirelockComponent, BeforeDoorOpenedEvent>(OnBeforeDoorOpened);
         SubscribeLocalEvent<FirelockComponent, GetPryTimeModifierEvent>(OnDoorGetPryTimeModifier);
@@ -44,19 +42,6 @@ public abstract class SharedFirelockSystem : EntitySystem
             return false;
 
         return _doorSystem.OnPartialClose(uid, door);
-    }
-
-    private void OnUpdateState(EntityUid uid, FirelockComponent component, DoorStateChangedEvent args)
-    {
-        var ev = new BeforeDoorAutoCloseEvent();
-        RaiseLocalEvent(uid, ev);
-        UpdateVisuals(uid, component, args);
-        if (ev.Cancelled)
-        {
-            return;
-        }
-
-        _doorSystem.SetNextStateChange(uid, component.AutocloseDelay);
     }
 
     #region Access/Prying


### PR DESCRIPTION
fixes #28230
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This pr fixes firelocks having random pulses of closing lights which were mispredicts. This would randomly start happening and would happen every 3 seconds due to the set cooldown duration.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

From what I understand the functions existed in order to prevent doors from  closing constantly due to atmos alarms going off making it impossible to cross with crowbars. This is rendered redundant by the check in the EmergencyPressureStop() function in the C.S.FirelockSystem which ensures that a firelock will not auto close for at least 2 seconds after being pried. Due to an oversight in #26582, a part of the handling was transferred to shared while some remained in server due to a power check. This caused mispredicts to happen in some cases which would repeat every 3 seconds.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Firelocks will no longer randomly pulse closing lights. 