### PR TITLE
Cargo bounty corrections

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
@@ -11,6 +11,7 @@ using Content.Shared.Cargo.Prototypes;
 using Content.Shared.Database;
 using Content.Shared.NameIdentifier;
 using Content.Shared.Stacks;
+using Content.Shared.Whitelist;
 using JetBrains.Annotations;
 using Robust.Server.Containers;
 using Robust.Shared.Containers;
@@ -23,6 +24,7 @@ public sealed partial class CargoSystem
 {
     [Dependency] private readonly ContainerSystem _container = default!;
     [Dependency] private readonly NameIdentifierSystem _nameIdentifier = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelistSys = default!;
 
     [ValidatePrototypeId<NameIdentifierGroupPrototype>]
     private const string BountyNameIdentifierGroup = "Bounty";
@@ -311,7 +313,7 @@ public sealed partial class CargoSystem
             var temp = new HashSet<EntityUid>();
             foreach (var entity in entities)
             {
-                if (!entry.Whitelist.IsValid(entity, EntityManager))
+                if (!_whitelistSys.IsValid(entry.Whitelist, entity) || (entry.Blacklist != null && _whitelistSys.IsValid(entry.Blacklist, entity)))
                     continue;
 
                 count += _stackQuery.CompOrNull(entity)?.Count ?? 1;

--- a/Content.Shared/Cargo/Prototypes/CargoBountyPrototype.cs
+++ b/Content.Shared/Cargo/Prototypes/CargoBountyPrototype.cs
@@ -31,7 +31,7 @@ public sealed partial class CargoBountyPrototype : IPrototype
     /// <summary>
     /// The entries that must be satisfied for the cargo bounty to be complete.
     /// </summary>
-    [DataField( required: true)]
+    [DataField(required: true)]
     public List<CargoBountyItemEntry> Entries = new();
 
     /// <summary>
@@ -49,6 +49,12 @@ public readonly partial record struct CargoBountyItemEntry()
     /// </summary>
     [DataField(required: true)]
     public EntityWhitelist Whitelist { get; init; } = default!;
+
+    /// <summary>
+    /// A blacklist that can be used to exclude items in the whitelist.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Blacklist { get; init; } = null;
 
     // todo: implement some kind of simple generic condition system
 

--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -309,6 +309,9 @@
     whitelist:
       tags:
       - Pie
+    blacklist:
+      tags:
+      - Slice
 
 - type: cargoBounty
   id: BountyPrisonUniform
@@ -541,6 +544,12 @@
     whitelist:
       tags:
       - Fruit
+    blacklist:
+      tags:
+      - Slice
+      - Cake
+      - Pie
+      - Bread
 
 - type: cargoBounty
   id: BountyVegetable
@@ -552,6 +561,12 @@
     whitelist:
       tags:
       - Vegetable
+    blacklist:
+      tags:
+      - Slice
+      - Cake
+      - Pie
+      - Bread
 
 - type: cargoBounty
   id: BountyChili

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -34,7 +34,9 @@
     flavors:
       - bread
   - type: Tag
-    tags: [] #override bread
+    tags:
+    - Bread
+    - Slice
   - type: SolutionContainerManager
     solutions:
       food:
@@ -116,6 +118,8 @@
   - type: Tag
     tags:
     - Fruit
+    - Bread
+    - Slice
 
 - type: entity
   name: cornbread
@@ -274,6 +278,8 @@
   - type: Tag
     tags:
     - Meat
+    - Bread
+    - Slice
 
 - type: entity
   name: mimana bread
@@ -418,6 +424,8 @@
   - type: Tag
     tags:
     - Meat
+    - Bread
+    - Slice
 
 - type: entity
   name: spider meat bread
@@ -476,6 +484,8 @@
   - type: Tag
     tags:
     - Meat
+    - Bread
+    - Slice
 
 - type: entity
   name: tofu bread
@@ -585,6 +595,8 @@
   - type: Tag
     tags:
     - Meat
+    - Bread
+    - Slice
 
 # Other than bread/slices
 
@@ -594,9 +606,6 @@
   id: FoodBreadBaguette
   description: Bon appétit!
   components:
-  - type: Tag
-    tags:
-    - Baguette
   - type: Sprite
     state: baguette
   - type: SliceableFood
@@ -824,6 +833,7 @@
     tags:
     - VimPilot
     - DoorBumpOpener
+    - Bread
   - type: CanEscapeInventory
     baseResistTime: 2
   - type: Puller

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -23,6 +23,9 @@
           Quantity: 5
   - type: Item
     size: Normal
+  - type: Tag
+    tags:
+    - Cake
 
 - type: entity
   parent: FoodCakeBase
@@ -45,6 +48,10 @@
           Quantity: 1
   - type: Item
     size: Tiny
+  - type: Tag
+    tags:
+    - Cake
+    - Slice
 
 # Custom Cake Example
 
@@ -63,6 +70,7 @@
     slice: FoodCakeBlueberrySlice
   - type: Tag
     tags:
+    - Cake
     - Fruit
 
 - type: entity
@@ -78,7 +86,9 @@
       color: blue
   - type: Tag
     tags:
+    - Cake
     - Fruit
+    - Slice
 
 # Cake
 
@@ -203,6 +213,7 @@
     slice: FoodCakeOrangeSlice
   - type: Tag
     tags:
+    - Cake
     - Fruit
 
 - type: entity
@@ -214,7 +225,9 @@
     state: orange-slice
   - type: Tag
     tags:
+    - Cake
     - Fruit
+    - Slice
 # Tastes like sweetness, cake, oranges.
 
 - type: entity
@@ -229,6 +242,7 @@
     slice: FoodCakeLimeSlice
   - type: Tag
     tags:
+    - Cake
     - Fruit
 
 - type: entity
@@ -240,7 +254,9 @@
     state: lime-slice
   - type: Tag
     tags:
+    - Cake
     - Fruit
+    - Slice
 # Tastes like sweetness, cake, limes.
 
 - type: entity
@@ -255,6 +271,7 @@
     slice: FoodCakeLemonSlice
   - type: Tag
     tags:
+    - Cake
     - Fruit
 
 - type: entity
@@ -266,7 +283,9 @@
     state: lemon-slice
   - type: Tag
     tags:
+    - Cake
     - Fruit
+    - Slice
 # Tastes like sweetness, cake, lemons.
 
 - type: entity
@@ -296,6 +315,7 @@
           Quantity: 5
   - type: Tag
     tags:
+    - Cake
     - Fruit
 
 - type: entity
@@ -323,7 +343,9 @@
           Quantity: 1
   - type: Tag
     tags:
+    - Cake
     - Fruit
+    - Slice
 
 - type: entity
   name: chocolate cake
@@ -379,6 +401,7 @@
     slice: FoodCakeAppleSlice
   - type: Tag
     tags:
+    - Cake
     - Fruit
 
 - type: entity
@@ -391,7 +414,9 @@
     state: apple-slice
   - type: Tag
     tags:
+    - Cake
     - Fruit
+    - Slice
 # Tastes like sweetness, cake, slime.
 
 - type: entity
@@ -436,6 +461,7 @@
           Quantity: 11
   - type: Tag
     tags:
+    - Cake
     - Fruit
 
 - type: entity
@@ -457,7 +483,9 @@
           Quantity: 2.2
   - type: Tag
     tags:
+    - Cake
     - Fruit
+    - Slice
 # Tastes like sweetness, cake, pumpkin.
 
 - type: entity
@@ -686,6 +714,7 @@
     tags:
     - VimPilot
     - DoorBumpOpener
+    - Cake
   - type: CanEscapeInventory
     baseResistTime: 2
   - type: Puller
@@ -752,3 +781,6 @@
     color: "#FFFF00"
     radius: 1.4
     energy: 1.4
+  - type: Tag
+    tags:
+    - Slice

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -163,9 +163,6 @@
 
 # Nuggets
 
-- type: Tag
-  id: Nugget
-
 - type: entity
   name: chicken nugget
   parent: FoodBakedBase
@@ -530,6 +527,9 @@
           Quantity: 5
         - ReagentId: Theobromine
           Quantity: 3
+  - type: Tag
+    tags:
+    - Slice
 
 - type: entity
   name: special brownies
@@ -585,6 +585,9 @@
           Quantity: 3
         - ReagentId: THC
           Quantity: 25
+  - type: Tag
+    tags:
+    - Slice
 
 - type: entity
   name: onion rings

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
@@ -52,6 +52,10 @@
           Quantity: 1.2
         - ReagentId: Vitamin
           Quantity: 1
+  - type: Tag
+    tags:
+    - Pie
+    - Slice
 
 # Pie
 
@@ -94,6 +98,7 @@
     tags:
     - Fruit
     - Pie
+    - Slice
 # Tastes like pie, apple.
 
 - type: entity
@@ -182,6 +187,7 @@
     tags:
     - Fruit
     - Pie
+    - Slice
 # Tastes like pie, cream, banana.
 
 - type: entity
@@ -224,6 +230,7 @@
     tags:
     - Fruit
     - Pie
+    - Slice
 # Tastes like pie, blackberries.
 
 - type: entity
@@ -263,6 +270,7 @@
     tags:
     - Fruit
     - Pie
+    - Slice
 # Tastes like pie, cherries.
 
 - type: entity
@@ -302,6 +310,7 @@
     tags:
     - Meat
     - Pie
+    - Slice
 # Tastes like pie, meat.
 
 - type: entity
@@ -342,6 +351,7 @@
     tags:
     - Meat
     - Pie
+    - Slice
 # Tastes like pie, meat, acid.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -59,6 +59,7 @@
     tags:
     - Pizza
     - ReptilianFood
+    - Slice
 
 # Pizza
 
@@ -135,6 +136,7 @@
     tags:
     - Meat
     - Pizza
+    - Slice
 # Tastes like crust, tomato, cheese, meat.
 
 - type: entity
@@ -291,6 +293,7 @@
     tags:
     - Meat
     - Pizza
+    - Slice
 # Tastes like crust, tomato, cheese, meat, laziness.
 
 - type: entity
@@ -391,6 +394,7 @@
     tags:
     - Meat
     - Pizza
+    - Slice
 # Tastes like crust, tomato, cheese, sausage, sass.
 
 - type: entity
@@ -411,9 +415,13 @@
     - state: pineapple
   - type: SliceableFood
     slice: FoodPizzaPineappleSlice
+  - type: Tag
+    tags:
+    - Meat
+    - Pizza
 
 - type: entity
-  name: slice of pineapple pizza
+  name: slice of Hawaiian pizza
   parent: FoodPizzaSliceBase
   id: FoodPizzaPineappleSlice
   description: A slice of joy/sin.
@@ -432,6 +440,7 @@
     tags:
     - Meat
     - Pizza
+    - Slice
 # Tastes like crust, tomato, cheese, pineapple, ham.
 
 #TODO: This is a meme pizza from /tg/. It has specially coded mechanics.
@@ -504,6 +513,7 @@
     tags:
     - Meat
     - Pizza
+    - Slice
 # Tastes like crust, tomato, cheese, pepperoni, 9 millimeter bullets.
 
 #TODO: Make this do poison damage and make cut pizza slices eventually rot into this.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -302,6 +302,9 @@
       - dough
   - type: Sprite
     state: dough-slice
+  - type: Tag
+    tags:
+    - Slice
 
 - type: entity
   name: cornmeal dough
@@ -331,6 +334,9 @@
       - dough
   - type: Sprite
     state: cornmealdough-slice
+  - type: Tag
+    tags:
+    - Slice
 
 - type: entity
   name: tortilla dough
@@ -363,6 +369,9 @@
   - type: Construction
     graph: Tortilla
     node: start
+  - type: Tag
+    tags:
+    - Slice
 
 - type: entity
   name: flattened tortilla dough
@@ -503,6 +512,9 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
+  - type: Tag
+    tags:
+    - Slice
 
 - type: entity
   name: chèvre log
@@ -550,6 +562,9 @@
           Quantity: 1
         - ReagentId: Vitamin
           Quantity: 0.2
+  - type: Tag
+    tags:
+    - Slice
 
 - type: entity
   name: tofu
@@ -595,6 +610,9 @@
           Quantity: 3
         - ReagentId: Nutriment
           Quantity: 2
+  - type: Tag
+    tags:
+    - Slice
 
 - type: entity
   name: burned mess

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1065,6 +1065,9 @@
     state: slice
   - type: Extractable
     grindableSolutionName: food
+  - type: Tag
+    tags:
+    - Slice
 
 - type: entity
   name: pineapple slice
@@ -1085,6 +1088,7 @@
   - type: Tag
     tags:
     - Fruit
+    - Slice
 
 - type: entity
   name: onion slice
@@ -1108,6 +1112,10 @@
           Quantity: 1
         - ReagentId: Vitamin
           Quantity: 1
+  - type: Tag
+    tags:
+    - Vegetable
+    - Slice
 
 - type: entity
   name: red onion slice
@@ -1131,6 +1139,10 @@
           Quantity: 1
         - ReagentId: Vitamin
           Quantity: 1
+  - type: Tag
+    tags:
+    - Vegetable
+    - Slice
 
 - type: entity
   name: chili pepper
@@ -1650,6 +1662,7 @@
   - type: Tag
     tags:
     - Fruit
+    - Slice
 
 - type: entity
   name: grapes

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -28,9 +28,6 @@
   id: ATVKeys
 
 - type: Tag
-  id: Baguette
-
-- type: Tag
   id: Balloon
 
 - type: Tag
@@ -257,6 +254,9 @@
 
 - type: Tag
   id: CableCoil
+
+- type: Tag
+  id: Cake
 
 - type: Tag
   id: CaneBlade
@@ -927,6 +927,9 @@
   id: NozzleBackTank
 
 - type: Tag
+  id: Nugget # for chicken nuggets
+
+- type: Tag
   id: NukeOpsUplink
 
 - type: Tag
@@ -1121,6 +1124,9 @@
 
 - type: Tag
   id: Skewer
+
+- type: Tag
+  id: Slice # sliced fruit, vegetables, pizza etc.
 
 - type: Tag
   id: SmallAIChip


### PR DESCRIPTION
## About the PR
Small follow-up to #28226.
I made a few corrections to cargo bounties.

## Why / Balance
Previously you could cut a watermelon or pineapple into 5 slices, which would each count as a whole fruit towards fulfilling bounties. Same with vegetables and pies. Also fruit pies/cakes were considered fruit.

## Technical details
Added a blacklist to the cargo bounty component and added the neccessary blacklist tags to the bounties.
Added the "Slice" tag to all food prototypes created by SlicableFoodComponent (except meat, which has the equivalent tag "Cutlet")
Baguette is now bread.
Moved the "Nugget" tag to tags.yml

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Removed the "Baguette" tag, which was used nowhere. Maybe in some forks. Sue me, France.

**Changelog**

:cl:
- fix: Corrected some cargo bounties.
