### PR TITLE
Hotfix for crashes from bad item names

### DIFF
--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -239,8 +239,10 @@ namespace Content.Client.Examine
 
             if (knowTarget)
             {
-                var itemName = FormattedMessage.RemoveMarkup(Identity.Name(target, EntityManager, player));
-                var labelMessage = FormattedMessage.FromMarkup($"[bold]{itemName}[/bold]");
+                // TODO: FormattedMessage.RemoveMarkupPermissive
+                // var itemName = FormattedMessage.RemoveMarkupPermissive(Identity.Name(target, EntityManager, player));
+                var itemName = FormattedMessage.FromMarkupPermissive(Identity.Name(target, EntityManager, player)).ToString();
+                var labelMessage = FormattedMessage.FromMarkupPermissive($"[bold]{itemName}[/bold]");
                 var label = new RichTextLabel();
                 label.SetMessage(labelMessage);
                 hBox.AddChild(label);


### PR DESCRIPTION
Crash bad.

This just makes the client not crash when trying to examine an item with bad markup in its name. We should still sanitize labels.

Also, this has a commented-out version that's slightly cleaner but needs an engine update. This is a hotfix though, so the slightly more verbose version is good for now.