### PR TITLE
Fix wall vending machines spawning items in walls.

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.Popups;
 using Content.Shared.Throwing;
 using Content.Shared.UserInterface;
 using Content.Shared.VendingMachines;
+using Content.Shared.Wall;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
@@ -384,7 +385,22 @@ namespace Content.Server.VendingMachines
                 return;
             }
 
-            var ent = Spawn(vendComponent.NextItemToEject, Transform(uid).Coordinates);
+            // Default spawn coordinates
+            var spawnCoordinates = Transform(uid).Coordinates;
+
+            //Make sure the wallvends spawn outside of the wall.
+            if (HasComp<WallMountComponent>(uid))
+            {
+                if (TryComp<WallMountComponent>(uid, out var wallMountComponent))
+                {
+                    const float distanceFromWallVend = 0.5f;
+                    var offset = wallMountComponent.Direction.ToWorldVec() * distanceFromWallVend;
+                    spawnCoordinates = Transform(uid).Coordinates.Offset(offset);
+                }
+            }
+
+            var ent = Spawn(vendComponent.NextItemToEject, spawnCoordinates);
+
             if (vendComponent.ThrowNextItem)
             {
                 var range = vendComponent.NonLimitedEjectRange;


### PR DESCRIPTION
## About the PR
Currently the Nano Med vend spawns in to walls, this will fix that.
Fixes #28268, #26613, #26612

## Why / Balance
It made some med items inaccessible as they were in walls or would spawn in another room or maints.

## Technical details
Nanomed vends and other vends have a WallMountComponent comp that has a direction prop that indicates its access side, this is used to spawn it in that direction.

## Media

https://github.com/space-wizards/space-station-14/assets/47093363/473cb5ae-b1f9-4950-88a4-29741bdc94ed

double checked some normal ones and they were all good too:
![image](https://github.com/space-wizards/space-station-14/assets/47093363/500e1f31-fe39-4f1e-afae-87656559467e)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**

:cl: Repo
- fix: NanoMed, wall vends will spawn items the correct direction.
