### PR TITLE
make cargo balance ui updating its own component

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -40,6 +40,7 @@ namespace Content.Server.Cargo.Systems
             SubscribeLocalEvent<CargoOrderConsoleComponent, BoundUIOpenedEvent>(OnOrderUIOpened);
             SubscribeLocalEvent<CargoOrderConsoleComponent, ComponentInit>(OnInit);
             SubscribeLocalEvent<CargoOrderConsoleComponent, InteractUsingEvent>(OnInteractUsing);
+            SubscribeLocalEvent<CargoOrderConsoleComponent, BankBalanceUpdatedEvent>(OnOrderBalanceUpdated);
             Reset();
         }
 
@@ -314,6 +315,15 @@ namespace Content.Server.Cargo.Systems
         }
 
         #endregion
+
+
+        private void OnOrderBalanceUpdated(Entity<CargoOrderConsoleComponent> ent, ref BankBalanceUpdatedEvent args)
+        {
+            if (!_uiSystem.IsUiOpen(ent.Owner, CargoConsoleUiKey.Orders))
+                continue;
+
+            UpdateOrderState(ent, args.Station);
+        }
 
         private void UpdateOrderState(EntityUid consoleUid, EntityUid? station)
         {

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -320,7 +320,7 @@ namespace Content.Server.Cargo.Systems
         private void OnOrderBalanceUpdated(Entity<CargoOrderConsoleComponent> ent, ref BankBalanceUpdatedEvent args)
         {
             if (!_uiSystem.IsUiOpen(ent.Owner, CargoConsoleUiKey.Orders))
-                continue;
+                return;
 
             UpdateOrderState(ent, args.Station);
         }

--- a/Content.Server/Cargo/Systems/CargoSystem.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.cs
@@ -84,12 +84,14 @@ public sealed partial class CargoSystem : SharedCargoSystem
         var query = EntityQueryEnumerator<TransformComponent, BankClientComponent>();
 
         var ev = new BankBalanceUpdatedEvent(uid, component.Balance);
-        while (query.MoveNext(out var client, out var xform, out _))
+        while (query.MoveNext(out var client, out var xform, out var comp))
         {
             var station = _station.GetOwningStation(client, xform);
             if (station != uid)
                 continue;
 
+            comp.Balance = component.Balance;
+            Dirty(client, comp);
             RaiseLocalEvent(client, ref ev);
         }
     }

--- a/Content.Server/Cargo/Systems/CargoSystem.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.cs
@@ -81,7 +81,7 @@ public sealed partial class CargoSystem : SharedCargoSystem
     public void UpdateBankAccount(EntityUid uid, StationBankAccountComponent component, int balanceAdded)
     {
         component.Balance += balanceAdded;
-        var query = EntityQueryEnumerator<TransformComponent, BankClientComponent>();
+        var query = EntityQueryEnumerator<BankClientComponent, TransformComponent>();
 
         var ev = new BankBalanceUpdatedEvent(uid, component.Balance);
         while (query.MoveNext(out var client, out var xform, out var comp))

--- a/Content.Server/Cargo/Systems/CargoSystem.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.cs
@@ -84,7 +84,7 @@ public sealed partial class CargoSystem : SharedCargoSystem
         var query = EntityQueryEnumerator<BankClientComponent, TransformComponent>();
 
         var ev = new BankBalanceUpdatedEvent(uid, component.Balance);
-        while (query.MoveNext(out var client, out var xform, out var comp))
+        while (query.MoveNext(out var client, out var comp, out var xform))
         {
             var station = _station.GetOwningStation(client, xform);
             if (station != uid)

--- a/Content.Server/Cargo/Systems/CargoSystem.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.cs
@@ -81,18 +81,16 @@ public sealed partial class CargoSystem : SharedCargoSystem
     public void UpdateBankAccount(EntityUid uid, StationBankAccountComponent component, int balanceAdded)
     {
         component.Balance += balanceAdded;
-        var query = EntityQueryEnumerator<CargoOrderConsoleComponent>();
+        var query = EntityQueryEnumerator<TransformComponent, BankClientComponent>();
 
-        while (query.MoveNext(out var oUid, out var _))
+        var ev = new BankBalanceUpdatedEvent(uid, component.Balance);
+        while (query.MoveNext(out var client, out var xform, out _))
         {
-            if (!_uiSystem.IsUiOpen(oUid, CargoConsoleUiKey.Orders))
-                continue;
-
-            var station = _station.GetOwningStation(oUid);
+            var station = _station.GetOwningStation(client, xform);
             if (station != uid)
                 continue;
 
-            UpdateOrderState(oUid, station);
+            RaiseLocalEvent(client, ref ev);
         }
     }
 }

--- a/Content.Shared/Cargo/Components/BankClientComponent.cs
+++ b/Content.Shared/Cargo/Components/BankClientComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Cargo;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Cargo.Components;
@@ -7,8 +8,16 @@ namespace Content.Shared.Cargo.Components;
 /// When its balance changes it will have <see cref="BankBalanceUpdatedEvent"/> raised on it.
 /// Other systems can then use this for logic or to update ui states.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
-public sealed partial class BankClientComponent : Component;
+[RegisterComponent, NetworkedComponent, Access(typeof(SharedCargoSystem))]
+[AutoGenerateComponentState]
+public sealed partial class BankClientComponent : Component
+{
+    /// <summary>
+    /// The balance updated for the last station this entity was a part of.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int Balance;
+}
 
 /// <summary>
 /// Raised on an entity with <see cref="BankClientComponent"/> when the bank's balance is updated.

--- a/Content.Shared/Cargo/Components/BankClientComponent.cs
+++ b/Content.Shared/Cargo/Components/BankClientComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Cargo.Components;
+
+/// <summary>
+/// Makes an entity a client of the station's bank account.
+/// When its balance changes it will have <see cref="BankBalanceUpdatedEvent"/> raised on it.
+/// Other systems can then use this for logic or to update ui states.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BankClientComponent : Component;
+
+/// <summary>
+/// Raised on an entity with <see cref="BankClientComponent"/> when the bank's balance is updated.
+/// </summary>
+[ByRefEvent]
+public record struct BankBalanceUpdatedEvent(EntityUid Station, int Balance);

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -68,6 +68,7 @@
   - type: RadarConsole
     followEntity: true
   - type: CargoOrderConsole
+  - type: BankClient
   - type: CrewMonitoringConsole
   - type: GeneralStationRecordConsole
     canDeleteEntries: true

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -577,6 +577,7 @@
           tags:
           - Write
   - type: CargoOrderConsole
+  - type: BankClient
   - type: ActivatableUI
     verbText: qm-clipboard-computer-verb-text
     key: enum.CargoConsoleUiKey.Orders

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -735,6 +735,7 @@
     - map: ["computerLayerKeys"]
       state: tech_key
   - type: CargoOrderConsole
+  - type: BankClient
   - type: ActiveRadio
     channels:
     - Supply


### PR DESCRIPTION
## About the PR
title

## Why / Balance
need this downstream

## Technical details
- added new `BankClientComponent` that gets queried to update ui for any bank related console
- cargo ordering console handles its BankBalanceUpdatedEvent instead of being hardcoded to update ui
- all cargo ordering console entities now have BankClient

## Media
it work
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
`CargoOrderConsoleComponent` now needs `BankClientComponent` for UI to update the same

**Changelog**
no cl no fun