### PR TITLE
Prevent stacking pipes

### DIFF
--- a/Content.Server/Atmos/Components/PipeRestrictOverlapComponent.cs
+++ b/Content.Server/Atmos/Components/PipeRestrictOverlapComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Atmos.Components;
+
+/// <summary>
+/// This is used for restricting anchoring pipes so that they do not overlap.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PipeRestrictOverlapComponent : Component;

--- a/Content.Server/Atmos/Components/PipeRestrictOverlapComponent.cs
+++ b/Content.Server/Atmos/Components/PipeRestrictOverlapComponent.cs
@@ -1,7 +1,9 @@
+using Content.Server.Atmos.EntitySystems;
+
 namespace Content.Server.Atmos.Components;
 
 /// <summary>
 /// This is used for restricting anchoring pipes so that they do not overlap.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, Access(typeof(PipeRestrictOverlapSystem))]
 public sealed partial class PipeRestrictOverlapComponent : Component;

--- a/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
@@ -1,0 +1,123 @@
+using System.Linq;
+using Content.Server.Atmos.Components;
+using Content.Server.NodeContainer;
+using Content.Server.NodeContainer.Nodes;
+using Content.Server.Popups;
+using Content.Shared.Atmos;
+using Content.Shared.Construction.Components;
+using JetBrains.Annotations;
+using Robust.Server.GameObjects;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server.Atmos.EntitySystems;
+
+/// <summary>
+/// This handles restricting pipe-based entities from overlapping outlets/inlets with other entities.
+/// </summary>
+public sealed class PipeRestrictOverlapSystem : EntitySystem
+{
+    [Dependency] private readonly MapSystem _map = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly TransformSystem _xform = default!;
+
+    private readonly List<EntityUid> _anchoredEntities = new();
+    private EntityQuery<NodeContainerComponent> _nodeContainerQuery;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<PipeRestrictOverlapComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
+        SubscribeLocalEvent<PipeRestrictOverlapComponent, AnchorAttemptEvent>(OnAnchorAttempt);
+
+        _nodeContainerQuery = GetEntityQuery<NodeContainerComponent>();
+    }
+
+    private void OnAnchorStateChanged(Entity<PipeRestrictOverlapComponent> ent, ref AnchorStateChangedEvent args)
+    {
+        if (!args.Anchored)
+            return;
+
+        if (HasComp<AnchorableComponent>(ent) && CheckOverlap(ent))
+        {
+            _popup.PopupEntity(Loc.GetString("pipe-restrict-overlap-popup-force-unanchor", ("pipe", ent.Owner)), ent);
+            _xform.Unanchor(ent, Transform(ent));
+        }
+    }
+
+    private void OnAnchorAttempt(Entity<PipeRestrictOverlapComponent> ent, ref AnchorAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (!_nodeContainerQuery.TryComp(ent, out var node))
+            return;
+
+        var xform = Transform(ent);
+        if (CheckOverlap((ent, node, xform)))
+        {
+            _popup.PopupEntity(Loc.GetString("pipe-restrict-overlap-popup-blocked", ("pipe", ent.Owner)), ent, args.User);
+            args.Cancel();
+        }
+    }
+
+    [PublicAPI]
+    public bool CheckOverlap(EntityUid uid)
+    {
+        if (!_nodeContainerQuery.TryComp(uid, out var node))
+            return false;
+
+        return CheckOverlap((uid, node, Transform(uid)));
+    }
+
+    public bool CheckOverlap(Entity<NodeContainerComponent, TransformComponent> ent)
+    {
+        if (ent.Comp2.GridUid is not { } grid || !TryComp<MapGridComponent>(grid, out var gridComp))
+            return false;
+
+        var indices = _map.TileIndicesFor(grid, gridComp, ent.Comp2.Coordinates);
+        _anchoredEntities.Clear();
+        _map.GetAnchoredEntities((grid, gridComp), indices, _anchoredEntities);
+
+        foreach (var otherEnt in _anchoredEntities)
+        {
+            // this should never actually happen but just for safety
+            if (otherEnt == ent.Owner)
+                continue;
+
+            if (!_nodeContainerQuery.TryComp(otherEnt, out var otherComp))
+                continue;
+
+            if (PipeNodesOverlap(ent, (otherEnt, otherComp, Transform(otherEnt))))
+                return true;
+        }
+
+        return false;
+    }
+
+    public bool PipeNodesOverlap(Entity<NodeContainerComponent, TransformComponent> ent, Entity<NodeContainerComponent, TransformComponent> other)
+    {
+        var entDirs = GetAllDirections(ent).ToList();
+        var otherDirs = GetAllDirections(other).ToList();
+
+        foreach (var dir in entDirs)
+        {
+            foreach (var otherDir in otherDirs)
+            {
+                if ((dir & otherDir) != 0)
+                    return true;
+            }
+        }
+
+        return false;
+
+        IEnumerable<PipeDirection> GetAllDirections(Entity<NodeContainerComponent, TransformComponent> pipe)
+        {
+            foreach (var node in pipe.Comp1.Nodes.Values)
+            {
+                // we need to rotate the pipe manually like this because the rotation doesn't update for pipes that are unanchored.
+                if (node is PipeNode pipeNode)
+                    yield return pipeNode.OriginalPipeDirection.RotatePipeDirection(pipe.Comp2.LocalRotation);
+            }
+        }
+    }
+}

--- a/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
@@ -39,7 +39,7 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
 
         if (HasComp<AnchorableComponent>(ent) && CheckOverlap(ent))
         {
-            _popup.PopupEntity(Loc.GetString("pipe-restrict-overlap-popup-force-unanchor", ("pipe", ent.Owner)), ent);
+            _popup.PopupEntity(Loc.GetString("pipe-restrict-overlap-popup-blocked", ("pipe", ent.Owner)), ent);
             _xform.Unanchor(ent, Transform(ent));
         }
     }

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -15,6 +15,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Storage;
 using Robust.Shared.Containers;
+using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
@@ -91,7 +92,7 @@ namespace Content.Server.Construction
         }
 
         // LEGACY CODE. See warning at the top of the file!
-        private async Task<EntityUid?> Construct(EntityUid user, string materialContainer, ConstructionGraphPrototype graph, ConstructionGraphEdge edge, ConstructionGraphNode targetNode)
+        private async Task<EntityUid?> Construct(EntityUid user, string materialContainer, ConstructionGraphPrototype graph, ConstructionGraphEdge edge, ConstructionGraphNode targetNode, EntityCoordinates coords)
         {
             // We need a place to hold our construction items!
             var container = _container.EnsureContainer<Container>(user, materialContainer, out var existed);
@@ -261,7 +262,7 @@ namespace Content.Server.Construction
             }
 
             var newEntityProto = graph.Nodes[edge.Target].Entity.GetId(null, user, new(EntityManager));
-            var newEntity = EntityManager.SpawnEntity(newEntityProto, EntityManager.GetComponent<TransformComponent>(user).Coordinates);
+            var newEntity = EntityManager.SpawnEntity(newEntityProto, coords);
 
             if (!TryComp(newEntity, out ConstructionComponent? construction))
             {
@@ -376,7 +377,7 @@ namespace Content.Server.Construction
                 }
             }
 
-            if (await Construct(user, "item_construction", constructionGraph, edge, targetNode) is not { Valid: true } item)
+            if (await Construct(user, "item_construction", constructionGraph, edge, targetNode, Transform(user).Coordinates) is not { Valid: true } item)
                 return false;
 
             // Just in case this is a stack, attempt to merge it. If it isn't a stack, this will just normally pick up
@@ -511,22 +512,16 @@ namespace Content.Server.Construction
                 return;
             }
 
-            if (await Construct(user, (ev.Ack + constructionPrototype.GetHashCode()).ToString(), constructionGraph,
-                    edge, targetNode) is not {Valid: true} structure)
+            if (await Construct(user,
+                    (ev.Ack + constructionPrototype.GetHashCode()).ToString(),
+                    constructionGraph,
+                    edge,
+                    targetNode,
+                    GetCoordinates(ev.Location)) is not {Valid: true} structure)
             {
                 Cleanup();
                 return;
             }
-
-            // We do this to be able to move the construction to its proper position in case it's anchored...
-            // Oh wow transform anchoring is amazing wow I love it!!!!
-            // ikr
-            var xform = Transform(structure);
-            var wasAnchored = xform.Anchored;
-            xform.Anchored = false;
-            xform.Coordinates = GetCoordinates(ev.Location);
-            xform.LocalRotation = constructionPrototype.CanRotate ? ev.Angle : Angle.Zero;
-            xform.Anchored = wasAnchored;
 
             RaiseNetworkEvent(new AckStructureConstructionMessage(ev.Ack, GetNetEntity(structure)));
             _adminLogger.Add(LogType.Construction, LogImpact.Low, $"{ToPrettyString(user):player} has turned a {ev.PrototypeName} construction ghost into {ToPrettyString(structure)} at {Transform(structure).Coordinates}");

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -99,7 +99,7 @@ namespace Content.Server.Construction
             ConstructionGraphEdge edge,
             ConstructionGraphNode targetNode,
             EntityCoordinates coords,
-            Angle angle)
+            Angle angle = default)
         {
             // We need a place to hold our construction items!
             var container = _container.EnsureContainer<Container>(user, materialContainer, out var existed);
@@ -390,8 +390,7 @@ namespace Content.Server.Construction
                     constructionGraph,
                     edge,
                     targetNode,
-                    Transform(user).Coordinates,
-                    Angle.Zero) is not { Valid: true } item)
+                    Transform(user).Coordinates) is not { Valid: true } item)
                 return false;
 
             // Just in case this is a stack, attempt to merge it. If it isn't a stack, this will just normally pick up

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -523,6 +523,9 @@ namespace Content.Server.Construction
                 return;
             }
 
+            var xform = Transform(structure);
+            xform.LocalRotation = constructionPrototype.CanRotate ? ev.Angle : Angle.Zero;
+
             RaiseNetworkEvent(new AckStructureConstructionMessage(ev.Ack, GetNetEntity(structure)));
             _adminLogger.Add(LogType.Construction, LogImpact.Low, $"{ToPrettyString(user):player} has turned a {ev.PrototypeName} construction ghost into {ToPrettyString(structure)} at {Transform(structure).Coordinates}");
             Cleanup();

--- a/Content.Server/NodeContainer/Nodes/PipeNode.cs
+++ b/Content.Server/NodeContainer/Nodes/PipeNode.cs
@@ -20,7 +20,7 @@ namespace Content.Server.NodeContainer.Nodes
         ///     The directions in which this pipe can connect to other pipes around it.
         /// </summary>
         [DataField("pipeDirection")]
-        private PipeDirection _originalPipeDirection;
+        public PipeDirection OriginalPipeDirection;
 
         /// <summary>
         ///     The *current* pipe directions (accounting for rotation)
@@ -110,26 +110,26 @@ namespace Content.Server.NodeContainer.Nodes
                 return;
 
             var xform = entMan.GetComponent<TransformComponent>(owner);
-            CurrentPipeDirection = _originalPipeDirection.RotatePipeDirection(xform.LocalRotation);
+            CurrentPipeDirection = OriginalPipeDirection.RotatePipeDirection(xform.LocalRotation);
         }
 
         bool IRotatableNode.RotateNode(in MoveEvent ev)
         {
-            if (_originalPipeDirection == PipeDirection.Fourway)
+            if (OriginalPipeDirection == PipeDirection.Fourway)
                 return false;
 
             // update valid pipe direction
             if (!RotationsEnabled)
             {
-                if (CurrentPipeDirection == _originalPipeDirection)
+                if (CurrentPipeDirection == OriginalPipeDirection)
                     return false;
 
-                CurrentPipeDirection = _originalPipeDirection;
+                CurrentPipeDirection = OriginalPipeDirection;
                 return true;
             }
 
             var oldDirection = CurrentPipeDirection;
-            CurrentPipeDirection = _originalPipeDirection.RotatePipeDirection(ev.NewRotation);
+            CurrentPipeDirection = OriginalPipeDirection.RotatePipeDirection(ev.NewRotation);
             return oldDirection != CurrentPipeDirection;
         }
 
@@ -142,12 +142,12 @@ namespace Content.Server.NodeContainer.Nodes
 
             if (!RotationsEnabled)
             {
-                CurrentPipeDirection = _originalPipeDirection;
+                CurrentPipeDirection = OriginalPipeDirection;
                 return;
             }
 
             var xform = entityManager.GetComponent<TransformComponent>(Owner);
-            CurrentPipeDirection = _originalPipeDirection.RotatePipeDirection(xform.LocalRotation);
+            CurrentPipeDirection = OriginalPipeDirection.RotatePipeDirection(xform.LocalRotation);
         }
 
         public override IEnumerable<Node> GetReachableNodes(TransformComponent xform,

--- a/Resources/Locale/en-US/construction/conditions/no-unstackable-in-tile.ftl
+++ b/Resources/Locale/en-US/construction/conditions/no-unstackable-in-tile.ftl
@@ -1,1 +1,3 @@
 construction-step-condition-no-unstackable-in-tile = You cannot make a stack of similar devices.
+pipe-restrict-overlap-popup-blocked = { CAPITALIZE(THE($pipe))} { CONJUGATE-BE($pipe) } blocked by other pipes.
+pipe-restrict-overlap-popup-force-unanchor = { CAPITALIZE(THE($pipe))} doesn't fit over the other pipes!

--- a/Resources/Locale/en-US/construction/conditions/no-unstackable-in-tile.ftl
+++ b/Resources/Locale/en-US/construction/conditions/no-unstackable-in-tile.ftl
@@ -1,3 +1,2 @@
 construction-step-condition-no-unstackable-in-tile = You cannot make a stack of similar devices.
-pipe-restrict-overlap-popup-blocked = { CAPITALIZE(THE($pipe))} { CONJUGATE-BE($pipe) } blocked by other pipes.
-pipe-restrict-overlap-popup-force-unanchor = { CAPITALIZE(THE($pipe))} doesn't fit over the other pipes!
+pipe-restrict-overlap-popup-blocked = { CAPITALIZE(THE($pipe))} doesn't fit over the other pipes!

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -358,6 +358,7 @@
   - type: PipeColorVisuals
   - type: Rotatable
   - type: GasRecycler
+  - type: PipeRestrictOverlap
   - type: NodeContainer
     nodes:
       inlet:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -51,6 +51,7 @@
   - type: Appearance
   - type: PipeColorVisuals
   - type: NodeContainer
+  - type: PipeRestrictOverlap
   - type: AtmosUnsafeUnanchor
   - type: AtmosPipeColor
   - type: Tag

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -246,6 +246,7 @@
       key: enum.ThermomachineUiKey.Key
     - type: WiresPanel
     - type: WiresVisuals
+    - type: PipeRestrictOverlap
     - type: NodeContainer
       nodes:
         pipe:
@@ -420,6 +421,7 @@
   - type: GasCondenser
   - type: AtmosPipeColor
   - type: AtmosDevice
+  - type: PipeRestrictOverlap
   - type: ApcPowerReceiver
     powerLoad: 10000
   - type: Machine

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
@@ -176,6 +176,7 @@
           nodeGroupID: Teg
 
     - type: AtmosUnsafeUnanchor
+    - type: PipeRestrictOverlap
     - type: TegCirculator
     - type: StealTarget
       stealGroup: Teg


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds a new system that prevents pipes with overlapping inlets from being placed on top of one another

fixes #21187
fixes #10333

Requires https://github.com/space-wizards/RobustToolbox/pull/5174

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
multiple pipes can currently exist on the same tile while both being connected to the pipenet from the same direction. this can cause huge issues like separate lines overlapping and transferring when they shouldn't or multiple devices being able to draw from a single point. in general, it allows for the creation of extremely obtuse and exploitative setups while also tripping new players who don't expect pipes to just casually break the laws of physics.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
currently has mispredicts because all of nodegroups are server-only but uh that shit aint happening now in this PR.

construction code doesn't actually have a system to allow me to prevent it in a more elegant way so it just immediately unwrenches itself when it spawns.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/98561806/b8b934fb-1f22-4ddf-8bed-405cdf25a640

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Multiple pipes facing the same direction can no longer be placed on the same tile. You can still have overlapping straight pipes or corners going in opposite directions.
