### PR TITLE
Add LocalizedDatasetPrototype

### DIFF
--- a/Content.Shared/Dataset/LocalizedDatasetPrototype.cs
+++ b/Content.Shared/Dataset/LocalizedDatasetPrototype.cs
@@ -1,0 +1,94 @@
+using System.Collections;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Dataset;
+
+/// <summary>
+/// A variant of <see cref="DatasetPrototype"/> intended to specify a sequence of LocId strings
+/// without having to copy-paste a ton of LocId strings into the YAML.
+/// </summary>
+[Prototype("localizedDataset")]
+public sealed partial class LocalizedDatasetPrototype : IPrototype
+{
+    /// <summary>
+    /// Identifier for this prototype.
+    /// </summary>
+    [ViewVariables]
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// Collection of LocId strings.
+    /// </summary>
+    [DataField]
+    public LocalizedDatasetValues Values { get; private set; } = [];
+}
+
+[Serializable, NetSerializable]
+[DataDefinition]
+public sealed partial class LocalizedDatasetValues : IReadOnlyList<string>
+{
+    /// <summary>
+    /// String prepended to the index number to generate each LocId string.
+    /// For example, a prefix of <c>tips-dataset-</c> will generate <c>tips-dataset-1</c>,
+    /// <c>tips-dataset-2</c>, etc.
+    /// </summary>
+    [DataField(required: true)]
+    public string Prefix { get; private set; } = default!;
+
+    /// <summary>
+    /// How many values are in the dataset.
+    /// </summary>
+    [DataField(required: true)]
+    public int Count { get; private set; }
+
+    public string this[int index]
+    {
+        get
+        {
+            if (index > Count)
+                throw new IndexOutOfRangeException();
+            return Prefix + index;
+        }
+    }
+
+    public IEnumerator<string> GetEnumerator()
+    {
+        return new Enumerator(this);
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public sealed class Enumerator : IEnumerator<string>
+    {
+        private int _index = 0; // Whee, 1-indexing
+
+        private readonly LocalizedDatasetValues _values;
+
+        public Enumerator(LocalizedDatasetValues values)
+        {
+            _values = values;
+        }
+
+        public string Current => _values.Prefix + _index;
+
+        object IEnumerator.Current => Current;
+
+        public void Dispose() { }
+
+        public bool MoveNext()
+        {
+            _index++;
+            return _index <= _values.Count;
+        }
+
+        public void Reset()
+        {
+            _index = 0;
+        }
+    }
+}

--- a/Content.Shared/Dataset/LocalizedDatasetPrototype.cs
+++ b/Content.Shared/Dataset/LocalizedDatasetPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Dataset;
 /// A variant of <see cref="DatasetPrototype"/> intended to specify a sequence of LocId strings
 /// without having to copy-paste a ton of LocId strings into the YAML.
 /// </summary>
-[Prototype("localizedDataset")]
+[Prototype]
 public sealed partial class LocalizedDatasetPrototype : IPrototype
 {
     /// <summary>

--- a/Content.Shared/Dataset/LocalizedDatasetPrototype.cs
+++ b/Content.Shared/Dataset/LocalizedDatasetPrototype.cs
@@ -47,7 +47,7 @@ public sealed partial class LocalizedDatasetValues : IReadOnlyList<string>
     {
         get
         {
-            if (index > Count)
+            if (index > Count || index < 0)
                 throw new IndexOutOfRangeException();
             return Prefix + index;
         }

--- a/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
+++ b/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
@@ -12,6 +12,11 @@ namespace Content.Shared.Random.Helpers
             return random.Pick(prototype.Values);
         }
 
+        public static string Pick(this IRobustRandom random, LocalizedDatasetPrototype prototype)
+        {
+            return random.Pick(prototype.Values);
+        }
+
         public static string Pick(this IWeightedRandomPrototype prototype, System.Random random)
         {
             var picks = prototype.Weights;

--- a/Content.Tests/Shared/LocalizedDatasetPrototypeTest.cs
+++ b/Content.Tests/Shared/LocalizedDatasetPrototypeTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Content.Shared.Dataset;
 using NUnit.Framework;
 using Robust.Shared.Collections;
@@ -49,6 +50,8 @@ public sealed class LocalizedDatasetPrototypeTest : ContentUnitTest
         Assert.That(values[1], Is.EqualTo("test-dataset-2"));
         Assert.That(values[2], Is.EqualTo("test-dataset-3"));
         Assert.That(values[3], Is.EqualTo("test-dataset-4"));
+        Assert.Throws<IndexOutOfRangeException>(() => { var x = values[4]; });
+        Assert.Throws<IndexOutOfRangeException>(() => { var x = values[-1]; });
 
         // Make sure that the enumerator gets all of the values
         Assert.That(testPrototype.Values[testPrototype.Values.Count], Is.EqualTo("test-dataset-4"));

--- a/Content.Tests/Shared/LocalizedDatasetPrototypeTest.cs
+++ b/Content.Tests/Shared/LocalizedDatasetPrototypeTest.cs
@@ -1,0 +1,56 @@
+using Content.Shared.Dataset;
+using NUnit.Framework;
+using Robust.Shared.Collections;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.Manager;
+
+namespace Content.Tests.Shared;
+
+[TestFixture]
+[TestOf(typeof(LocalizedDatasetPrototype))]
+public sealed class LocalizedDatasetPrototypeTest : ContentUnitTest
+{
+    private IPrototypeManager _prototypeManager;
+
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+        IoCManager.Resolve<ISerializationManager>().Initialize();
+        _prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+        _prototypeManager.Initialize();
+        _prototypeManager.LoadString(TestPrototypes);
+        _prototypeManager.ResolveResults();
+    }
+
+    private const string TestPrototypes = @"
+- type: localizedDataset
+  id: Test
+  values:
+    prefix: test-dataset-
+    count: 4
+";
+
+    [Test]
+    public void LocalizedDatasetTest()
+    {
+        var testPrototype = _prototypeManager.Index<LocalizedDatasetPrototype>("Test");
+        var values = new ValueList<string>();
+        foreach (var value in testPrototype.Values)
+        {
+            values.Add(value);
+        }
+
+        // Make sure we get the right number of values
+        Assert.That(values, Has.Count.EqualTo(4));
+
+        // Make sure indexing works as expected
+        Assert.That(values[0], Is.EqualTo("test-dataset-1"));
+        Assert.That(values[1], Is.EqualTo("test-dataset-2"));
+        Assert.That(values[2], Is.EqualTo("test-dataset-3"));
+        Assert.That(values[3], Is.EqualTo("test-dataset-4"));
+
+        // Make sure that the enumerator gets all of the values
+        Assert.That(testPrototype.Values[testPrototype.Values.Count], Is.EqualTo("test-dataset-4"));
+    }
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds a variant of DatasetPrototype specifically for cases where a dataset of sequentially-numbered LocId strings is desired (like tips, word lists, advertisements, etc).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This saves you from having to make a dumb boilerplate YAML file that just lists all the LocIds like:
```yaml
- type: dataset
  id: Test
  values:
  - test-string-1
  - test-string-2
  - test-string-3
  - test-string-4
   ...
  - test-string-128
  - test-string-129
```
and instead lets you just do: 
```yaml
- type: localizedDataset
  id: Test
  values:
    prefix: test-string-
    count: 129
```

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

On the C# side, `LocalizedDatasetPrototype` can be used just like a regular `DatasetPrototype` - `Values` implements `IReadOnlyList`, so you can index it, iterate through it, or (the most likely case) pass it to `RobustRandom.Pick` to get a random entry.

Behind the scenes though, any operations on `Values` will actually just construct the LocId strings from the prefix and index number. This should also cut down on the memory usage of localized datasets, since they won't need to actually store all the LocIds and can just construct them as needed.

Also includes a unit test to demonstrate that it works.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Code.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.