### PR TITLE
Fix some abnormally high-capacity boxes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -353,28 +353,6 @@
   - type: Storage
 
 - type: entity
-  name: deathrattle implant box
-  parent: BoxCardboard
-  id: BoxDeathRattleImplants
-  description: Six deathrattle implants and handheld GPS devices for the whole squad.
-  components:
-  - type: Item
-    size: Normal
-  - type: StorageFill
-    contents:
-      - id: DeathRattleImplanter
-        amount: 6
-      - id: HandheldGPSBasic
-        amount: 6
-  - type: Storage
-    grid:
-    - 0,0,5,3
-  - type: Sprite
-    layers:
-      - state: box
-      - state: syringe
-
-- type: entity
   name: lead-lined box
   parent: BoxCardboard
   suffix: DEBUG

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -456,21 +456,16 @@
   id: BoxDarts
   description: This box filled with colorful darts.
   components:
-  - type: Item
-    size: Normal
   - type: StorageFill
     contents:
       - id: Dart
-        amount: 3
+        amount: 2
       - id: DartBlue
-        amount: 3
+        amount: 2
       - id: DartPurple
-        amount: 3
+        amount: 2
       - id: DartYellow
-        amount: 3
-  - type: Storage
-    grid:
-    - 0,0,5,3
+        amount: 2
   - type: Sprite
     layers:
       - state: box

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -39,10 +39,6 @@
   id: BoxLightbulb
   description: This box is shaped on the inside so that only light tubes and bulbs fit.
   components:
-  - type: StorageFill
-    contents:
-      - id: LightBulb
-        amount: 12
   - type: Sprite
     layers:
       - state: box
@@ -53,50 +49,40 @@
     whitelist:
       components:
       - LightBulb
+  - type: StorageFill
+    contents:
+      - id: LightBulb
+        amount: 12
 
 - type: entity
   name: lighttube box
-  parent: BoxCardboard
+  parent: BoxLightbulb
   id: BoxLighttube
-  description: This box is shaped on the inside so that only light tubes and bulbs fit.
   components:
-  - type: StorageFill
-    contents:
-      - id: LightTube
-        amount: 12
   - type: Sprite
     layers:
       - state: box
       - state: lighttube
-  - type: Storage
-    grid:
-    - 0,0,5,3
-    whitelist:
-      components:
-      - LightBulb
+  - type: StorageFill
+    contents:
+      - id: LightTube
+        amount: 12
 
 - type: entity
   name: mixed lights box
-  parent: BoxCardboard
+  parent: BoxLightbulb
   id: BoxLightMixed
-  description: This box is shaped on the inside so that only light tubes and bulbs fit.
   components:
+  - type: Sprite
+    layers:
+      - state: box
+      - state: lightmixed
   - type: StorageFill
     contents:
       - id: LightTube
         amount: 6
       - id: LightBulb
         amount: 6
-  - type: Sprite
-    layers:
-      - state: box
-      - state: lightmixed
-  - type: Storage
-    grid:
-    - 0,0,5,3
-    whitelist:
-      components:
-      - LightBulb
 
 - type: entity
   name: PDA box
@@ -451,7 +437,7 @@
   name: darts box
   parent: BoxCardboard
   id: BoxDarts
-  description: This box is filled with colorful darts.
+  description: A box filled with colorful darts.
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -404,6 +404,7 @@
   name: candle box
   parent: BoxCardboard
   id: BoxCandle
+  description: This box is specifically moulded to only carry candles.
   components:
   - type: Sprite
     layers:
@@ -411,51 +412,51 @@
       - state: candle
   - type: Storage
     grid:
-    - 0,0,9,2
+    - 0,0,5,3
+    whitelist:
+      tags:
+      - Candle
   - type: StorageFill
     contents:
       - id: Candle
-        amount: 3
+        amount: 4
       - id: CandleBlue
-        amount: 3
+        amount: 2
       - id: CandleRed
-        amount: 3
+        amount: 2
       - id: CandleGreen
-        amount: 3
+        amount: 2
       - id: CandlePurple
-        amount: 3
+        amount: 2
 
 - type: entity
   name: small candle box
-  parent: BoxCardboard
+  parent: BoxCandle
   id: BoxCandleSmall
   components:
-  - type: Sprite
-    layers:
-      - state: box
-      - state: candle
-  - type: Storage
-    grid:
-    - 0,0,9,2
   - type: StorageFill
     contents:
       - id: CandleSmall
-        amount: 5
+        amount: 8
       - id: CandleBlueSmall
-        amount: 5
+        amount: 4
       - id: CandleRedSmall
-        amount: 5
+        amount: 4
       - id: CandleGreenSmall
-        amount: 5
+        amount: 4
       - id: CandlePurpleSmall
-        amount: 5
+        amount: 4
 
 - type: entity
   name: darts box
   parent: BoxCardboard
   id: BoxDarts
-  description: This box filled with colorful darts.
+  description: This box is filled with colorful darts.
   components:
+  - type: Sprite
+    layers:
+      - state: box
+      - state: darts
   - type: StorageFill
     contents:
       - id: Dart
@@ -466,7 +467,4 @@
         amount: 2
       - id: DartYellow
         amount: 2
-  - type: Sprite
-    layers:
-      - state: box
-      - state: darts
+

--- a/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
@@ -49,3 +49,23 @@
     layers:
       - state: box_of_doom
       - state: throwing_knives
+
+- type: entity
+  name: deathrattle implant box
+  parent: BoxCardboard
+  id: BoxDeathRattleImplants
+  description: Six deathrattle implants and handheld GPS devices for the whole squad.
+  components:
+  - type: Sprite
+    layers:
+      - state: box_of_doom
+      - state: syringe
+  - type: Storage
+    grid:
+    - 0,0,5,3
+  - type: StorageFill
+    contents:
+      - id: DeathRattleImplanter
+        amount: 6
+      - id: HandheldGPSBasic
+        amount: 6

--- a/Resources/Prototypes/Entities/Objects/Misc/candles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/candles.yml
@@ -4,6 +4,9 @@
   id: Candle
   description: A thin wick threaded through fat.
   components:
+    - type: Tag
+      tags:
+      - Candle
     - type: Sprite
       noRot: true
       sprite: Objects/Misc/candles.rsi

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -257,6 +257,9 @@
 
 - type: Tag
   id: CableCoil
+  
+- type: Tag
+  id: Candle
 
 - type: Tag
   id: CaneBlade


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixed some abnormally high-capacity boxes to be more inline with existing expectations around box capacity.
- Dart boxes now have a normal storage capacity and 1 less dart of each colour.
- Candle boxes are now whitelisted to candles only (akin to replacement light boxes), and have a smaller capacity (6x4, the same as light boxes) with slightly less coloured candles.
- Replacement light boxes have had duplicated yaml removed through parenting.
- Deathrattle implant box, a nukeops only item, has been moved to the syndicate.yml box fills and given a new sprite. It retains its abnormally high capacity.

Fixes #28271

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![Screenshot from 2024-05-27 21-25-21](https://github.com/space-wizards/space-station-14/assets/96937466/65042f21-236e-490f-bb39-68c00b62cc23)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Candle boxes can now only hold candles.


