### PR TITLE
Remove bogus C# finalizers

### DIFF
--- a/Content.Client/Interaction/DragDropHelper.cs
+++ b/Content.Client/Interaction/DragDropHelper.cs
@@ -73,11 +73,6 @@ public sealed class DragDropHelper<T>
         _cfg.OnValueChanged(CCVars.DragDropDeadZone, SetDeadZone, true);
     }
 
-    ~DragDropHelper()
-    {
-        _cfg.UnsubValueChanged(CCVars.DragDropDeadZone, SetDeadZone);
-    }
-
     /// <summary>
     /// Tell the helper that the mouse button was pressed down on
     /// a target, thus a drag has the possibility to begin for this target.

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButtonContainer.cs
@@ -119,9 +119,4 @@ public class ActionButtonContainer : GridContainer
                 yield return button;
         }
     }
-
-    ~ActionButtonContainer()
-    {
-        UserInterfaceManager.GetUIController<ActionUIController>().RemoveActionContainer();
-    }
 }

--- a/Content.Client/UserInterface/Systems/Inventory/Controls/ItemSlotButtonContainer.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/Controls/ItemSlotButtonContainer.cs
@@ -22,9 +22,4 @@ public sealed class ItemSlotButtonContainer : ItemSlotUIContainer<SlotControl>
     {
         _inventoryController = UserInterfaceManager.GetUIController<InventoryUIController>();
     }
-
-    ~ItemSlotButtonContainer()
-    {
-        _inventoryController.RemoveSlotGroup(SlotGroup);
-    }
 }


### PR DESCRIPTION
Begging people to learn how this programming language works before throwing random syntax into a file.

None of these finalizers ever worked. I also checked whether they were memory leaks and needed *proper* shutdown logic, but they're all instantiated-once UI controls that last for the entire lifetime of the program so it's probably fine.
