### PR TITLE
missing nukies can be filled in by ghost roles

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -205,16 +205,24 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         var playerPool = GetPlayerPool(ent, pool, def);
         var count = GetTargetAntagCount(ent, playerPool, def);
 
+        // if there is both a spawner and players getting picked, let it fall back to a spawner.
+        var noSpawner = def.SpawnerPrototype == null;
         for (var i = 0; i < count; i++)
         {
             var session = (ICommonSession?) null;
             if (def.PickPlayer)
             {
-                if (!playerPool.TryPickAndTake(RobustRandom, out session))
+                if (!playerPool.TryPickAndTake(RobustRandom, out session) && noSpawner)
+                {
+                    Log.Warning($"Couldn't pick a player for {ToPrettyString(ent):rule}, no longer choosing antags for this definition");
                     break;
+                }
 
-                if (ent.Comp.SelectedSessions.Contains(session))
+                if (session != null && ent.Comp.SelectedSessions.Contains(session))
+                {
+                    Log.Warning($"Somehow picked {session} for an antag when this rule already selected them previously");
                     continue;
+                }
             }
 
             MakeAntag(ent, session, def);

--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -104,6 +104,7 @@ public partial struct AntagSelectionDefinition()
 
     /// <summary>
     /// Whether or not players should be picked to inhabit this antag or not.
+    /// If no players are left and <see cref="SpawnerPrototype"/> is set, it will make a ghost role.
     /// </summary>
     [DataField]
     public bool PickPlayer = true;

--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -103,6 +103,33 @@
         state: radiation
 
 - type: entity
+  noSpawn: true
+  parent: SpawnPointLoneNukeOperative
+  id: SpawnPointNukeopsCommander
+  components:
+  - type: GhostRole
+    name: roles-antag-nuclear-operative-commander-name
+    description: roles-antag-nuclear-operative-commander-objective
+
+- type: entity
+  noSpawn: true
+  parent: SpawnPointLoneNukeOperative
+  id: SpawnPointNukeopsMedic
+  components:
+  - type: GhostRole
+    name: roles-antag-nuclear-operative-agent-name
+    description: roles-antag-nuclear-operative-agent-objective
+
+- type: entity
+  noSpawn: true
+  parent: SpawnPointLoneNukeOperative
+  id: SpawnPointNukeopsOperative
+  components:
+  - type: GhostRole
+    name: roles-antag-nuclear-operative-name
+    description: roles-antag-nuclear-operative-objective
+
+- type: entity
   parent: MarkerBase
   id: SpawnPointGhostDragon
   noSpawn: true

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -90,8 +90,7 @@
     definitions:
     - prefRoles: [ NukeopsCommander ]
       fallbackRoles: [ Nukeops, NukeopsMedic ]
-      max: 1
-      playerRatio: 10
+      spawnerPrototype: SpawnPointNukeopsCommander
       startingGear: SyndicateCommanderGearFull
       components:
       - type: NukeOperative
@@ -107,8 +106,7 @@
         prototype: NukeopsCommander
     - prefRoles: [ NukeopsMedic ]
       fallbackRoles: [ Nukeops, NukeopsCommander ]
-      max: 1
-      playerRatio: 10
+      spawnerPrototype: SpawnPointNukeopsMedic
       startingGear: SyndicateOperativeMedicFull
       components:
       - type: NukeOperative
@@ -124,7 +122,7 @@
         prototype: NukeopsMedic
     - prefRoles: [ Nukeops ]
       fallbackRoles: [ NukeopsCommander, NukeopsMedic ]
-      min: 0
+      spawnerPrototype: SpawnPointNukeopsOperative
       max: 3
       playerRatio: 10
       startingGear: SyndicateOperativeGearFull


### PR DESCRIPTION
## About the PR
title, and made it minimum 1 operative so you never have just batman and robin vs 80p station

right now the spawners have no requirements since better to have some bozo that at least wants to be a nukie than nobody or someone that doesnt want to be one
this can be changed easily if its unwanted

## Why / Balance
- sometimes there no nukies are picked at all and you just get trolled
- if a lot of people are ghost gang instead of readying up they can pick operative instead of just having a much weaker team because of something out of round

fixes #28312
fixes #28211

## Technical details
if a definition both picks players and has a spawner its allowed to fall back to spawner instead of cancelling the definitions selection

also added some logging if it fails so its easier to know why

## Media
(rule edited to start with just 1 player instead of 20)

the whole gangs here
![14:51:15](https://github.com/space-wizards/space-station-14/assets/39013340/7b30739f-3f16-4700c-be6e-983264bfaaf8)

commander is real
![14:52:23](https://github.com/space-wizards/space-station-14/assets/39013340/0b043e38-4e1a-4d17-9404-71f2984cbca1)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Nukies will have ghost roles opened if not enough people can be picked.
