### PR TITLE
remove firefighting remote and bolting firelocks

### DIFF
--- a/Resources/Prototypes/Access/engineering.yml
+++ b/Resources/Prototypes/Access/engineering.yml
@@ -16,9 +16,3 @@
   - ChiefEngineer
   - Engineering
   - Atmospherics
-
-- type: accessGroup
-  id: FireFight
-  tags:
-    - Engineering
-    - Atmospherics

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -94,7 +94,6 @@
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
-      - id: DoorRemoteFirefight
       - id: RCD
       - id: RCDAmmo
 
@@ -111,7 +110,6 @@
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
-      - id: DoorRemoteFirefight
       - id: RCD
       - id: RCDAmmo
 

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -144,24 +144,6 @@
 
 - type: entity
   parent: DoorRemoteDefault
-  id: DoorRemoteFirefight
-  name: fire-fighting door remote
-  description: A gadget which can open and bolt FireDoors remotely.
-  components:
-    - type: Sprite
-      layers:
-        - state: door_remotebase
-        - state: door_remotelightscolour
-          color: "#ff9900"
-        - state: door_remotescreencolour
-          color: "#e02020"
-
-    - type: Access
-      groups:
-        - FireFight
-
-- type: entity
-  parent: DoorRemoteDefault
   id: DoorRemoteAll
   name: super door remote
   suffix: Admeme

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -105,9 +105,6 @@
       arc: 360
     - type: StaticPrice
       price: 150
-    - type: DoorBolt
-    - type: AccessReader
-      access: [ [ "Engineering" ] ]
     - type: PryUnpowered
       pryModifier: 0.5
 

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -342,3 +342,6 @@ chem_master: ChemMaster
 
 # 2024-05-21
 CrateJanitorExplosive: ClosetJanitorBombFilled
+
+# 2024-05-27
+DoorRemoteFirefight: null


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removes the firefighting remote completely as well as firelock bolting

Fixes #28249

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
So first of all the implementation was completely fucked to the point where it literally functioned as a normal door remote that lets you affect both atmos AND engie airlocks. This gives atmos techs a diet CE remote and lets them do lots of dumb bs like bolting out engineers and unbolting things that CE bolts. 

Furthermore, bolting firelocks comes with the absurd fact that you can't unbolt the firelocks without a remote. This makes it extremely difficult for people to mitigate bad actors as you literally just _need_ either CE or another atmos tech to come deal with it short of just busting down the firelock entirely.

ok but these are just bugs and not actual bad elements so why should it be removed entirely?

On the topic of hacking firelocks, this is just a bad way to cope with something that's easily fixable in other ways. Hacking is very cumbersome and requires tools so while its better than just being flat out denied unless you have a remote, it can still royally fuck people en masse if someone grabs a remote and decides to bolt tons of firelocks (of which there are many across the whole station). You can't effectively mitigate the damage because you can trivially perpetrate it across the entire station on a scale that is painful to unfuck without a remote.

Besides the remote opening functionality which is pointless with recent changes to firelock opening and the emergency access which was flat-out broken, the bolting is superfluous and heavy-handed for something that can already be dealt with. It's extremely easy to just weld shut a firelock to prevent someone from entering. This actually creates a use for welders for atmos techs and creates dangerous situations around plasma that can be cool. It's also far easier to reverse and can't be done as quickly or remotely (beneficial to prevent trolling through windows and such).

the firefighting remote is just unnecessary with the slew of firelock changes and reasonable alternatives and only opens up avenues of abuse and annoying to resolve situations through incompetence.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- remove: Removed the fire-fighting remote.
