### PR TITLE
Add pressure and temperature warning text to firelocks

### DIFF
--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -69,7 +69,7 @@ namespace Content.Server.Doors.Systems
                     && xformQuery.TryGetComponent(uid, out var xform)
                     && appearanceQuery.TryGetComponent(uid, out var appearance))
                 {
-                    var (fire, pressure) = CheckPressureAndFire(uid, firelock, xform, airtight, airtightQuery);
+                    var (pressure, fire) = CheckPressureAndFire(uid, firelock, xform, airtight, airtightQuery);
                     _appearance.SetData(uid, DoorVisuals.ClosedLights, fire || pressure, appearance);
                     firelock.Temperature = fire;
                     firelock.Pressure = pressure;

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Access.Systems;
 using Content.Shared.Doors.Components;
+using Content.Shared.Examine;
 using Content.Shared.Popups;
 using Content.Shared.Prying.Components;
 using Robust.Shared.Timing;
@@ -26,6 +27,8 @@ public abstract class SharedFirelockSystem : EntitySystem
         // Visuals
         SubscribeLocalEvent<FirelockComponent, MapInitEvent>(UpdateVisuals);
         SubscribeLocalEvent<FirelockComponent, ComponentStartup>(UpdateVisuals);
+
+        SubscribeLocalEvent<FirelockComponent, ExaminedEvent>(OnExamined);
     }
 
     public bool EmergencyPressureStop(EntityUid uid, FirelockComponent? firelock = null, DoorComponent? door = null)
@@ -107,4 +110,15 @@ public abstract class SharedFirelockSystem : EntitySystem
     }
 
     #endregion
+
+    private void OnExamined(Entity<FirelockComponent> ent, ref ExaminedEvent args)
+    {
+        using (args.PushGroup(nameof(FirelockComponent)))
+        {
+            if (ent.Comp.Pressure)
+                args.PushMarkup(Loc.GetString("firelock-component-examine-pressure-warning"));
+            if (ent.Comp.Temperature)
+                args.PushMarkup(Loc.GetString("firelock-component-examine-temperature-warning"));
+        }
+    }
 }

--- a/Resources/Locale/en-US/atmos/firelock-component.ftl
+++ b/Resources/Locale/en-US/atmos/firelock-component.ftl
@@ -1,2 +1,4 @@
 firelock-component-is-holding-pressure-message = A gush of air blows in your face... Maybe you should reconsider.
 firelock-component-is-holding-fire-message = A gush of warm air blows in your face... Maybe you should reconsider.
+firelock-component-examine-pressure-warning = The [color=red]extreme pressure[/color] differential warning is active.
+firelock-component-examine-temperature-warning = The [color=red]extreme temperature[/color] warning is active.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds examine text for the type of danger that a firelock is holding back.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![Content Client_rWWdLOKk7Q](https://github.com/space-wizards/space-station-14/assets/10494922/a772939d-f2c9-4af2-9125-b0b7ea8ce9fa)
![Content Client_VwHOZqHk87](https://github.com/space-wizards/space-station-14/assets/10494922/3933b17c-c953-4991-bab4-737475bdfb3f)

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Added pressure and temperature warnings to firelock examine text.
