### PR TITLE
Changes the RCD to construct empty light fixtures

### DIFF
--- a/Resources/Prototypes/RCD/rcd.yml
+++ b/Resources/Prototypes/RCD/rcd.yml
@@ -201,8 +201,8 @@
   category: Lighting
   sprite: /Textures/Interface/Radial/RCD/tube_light.png
   mode: ConstructObject
-  prototype: Poweredlight
-  cost: 2
+  prototype: PoweredlightEmpty
+  cost: 1
   delay: 1
   collisionMask: TabletopMachineMask
   collisionBounds: "-0.23,-0.49,0.23,-0.36"
@@ -214,8 +214,8 @@
   category: Lighting
   sprite: /Textures/Interface/Radial/RCD/bulb_light.png
   mode: ConstructObject
-  prototype: PoweredSmallLight
-  cost: 2
+  prototype: PoweredSmallLightEmpty
+  cost: 1
   delay: 1
   collisionMask: TabletopMachineMask
   collisionBounds: "-0.23,-0.49,0.23,-0.36"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changes the RCD to construct empty light fixtures, instead of light fixtures pre-inserted with tubes/bulbs
Fixes #28349

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The ability to construct many active light fixtures in parallel allowed players to spam out light sources too quickly. This is of particular concern due to the performance impact of lights. Now light fixtures come constructed empty, with tubes/bulbs having to be inserted afterwards by hand. This significantly raises the barrier to spamming. 

Construction cost has been halved to compensate for the changes.

It's worth noting that perhaps the broader problem with the RCD is the fact that you can preform an large amount of parallel actions at once (limited only by the amount of free space around you). Maybe this should be changed to a one action at a time approach, however that's outside the scope of this PR and would likely require further design disscussion _after_ the feature freeze.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![Screenshot from 2024-05-29 01-04-30](https://github.com/space-wizards/space-station-14/assets/96937466/88a42f3b-bc91-4469-a347-5e8b8861fc6a)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Light fixtures constructed by the RCD are now empty

