### PR TITLE
Fix off-by-one error in LocalizedDatasetPrototype

### DIFF
--- a/Content.Shared/Dataset/LocalizedDatasetPrototype.cs
+++ b/Content.Shared/Dataset/LocalizedDatasetPrototype.cs
@@ -47,9 +47,9 @@ public sealed partial class LocalizedDatasetValues : IReadOnlyList<string>
     {
         get
         {
-            if (index > Count || index < 0)
+            if (index >= Count || index < 0)
                 throw new IndexOutOfRangeException();
-            return Prefix + index;
+            return Prefix + (index + 1);
         }
     }
 

--- a/Content.Tests/Shared/LocalizedDatasetPrototypeTest.cs
+++ b/Content.Tests/Shared/LocalizedDatasetPrototypeTest.cs
@@ -46,14 +46,14 @@ public sealed class LocalizedDatasetPrototypeTest : ContentUnitTest
         Assert.That(values, Has.Count.EqualTo(4));
 
         // Make sure indexing works as expected
-        Assert.That(values[0], Is.EqualTo("test-dataset-1"));
-        Assert.That(values[1], Is.EqualTo("test-dataset-2"));
-        Assert.That(values[2], Is.EqualTo("test-dataset-3"));
-        Assert.That(values[3], Is.EqualTo("test-dataset-4"));
-        Assert.Throws<IndexOutOfRangeException>(() => { var x = values[4]; });
-        Assert.Throws<IndexOutOfRangeException>(() => { var x = values[-1]; });
+        Assert.That(testPrototype.Values[0], Is.EqualTo("test-dataset-1"));
+        Assert.That(testPrototype.Values[1], Is.EqualTo("test-dataset-2"));
+        Assert.That(testPrototype.Values[2], Is.EqualTo("test-dataset-3"));
+        Assert.That(testPrototype.Values[3], Is.EqualTo("test-dataset-4"));
+        Assert.Throws<IndexOutOfRangeException>(() => { var x = testPrototype.Values[4]; });
+        Assert.Throws<IndexOutOfRangeException>(() => { var x = testPrototype.Values[-1]; });
 
         // Make sure that the enumerator gets all of the values
-        Assert.That(testPrototype.Values[testPrototype.Values.Count], Is.EqualTo("test-dataset-4"));
+        Assert.That(testPrototype.Values[^1], Is.EqualTo("test-dataset-4"));
     }
 }


### PR DESCRIPTION
Fixes LocalizedDatasetPrototype indexing returning values starting at 0 instead of 1.

Sigh.