### PR TITLE
Fix verb categories shuffling

### DIFF
--- a/Content.Client/Verbs/UI/VerbMenuUIController.cs
+++ b/Content.Client/Verbs/UI/VerbMenuUIController.cs
@@ -8,6 +8,7 @@ using Content.Shared.Verbs;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controllers;
+using Robust.Shared.Collections;
 using Robust.Shared.Input;
 using Robust.Shared.Utility;
 
@@ -115,6 +116,13 @@ namespace Content.Client.Verbs.UI
         private void FillVerbPopup(ContextMenuPopup popup)
         {
             HashSet<string> listedCategories = new();
+            var extras = new ValueList<string>(ExtraCategories.Count);
+
+            foreach (var cat in ExtraCategories)
+            {
+                extras.Add(cat.Text);
+            }
+
             foreach (var verb in CurrentVerbs)
             {
                 if (verb.Category == null)
@@ -122,17 +130,15 @@ namespace Content.Client.Verbs.UI
                     var element = new VerbMenuElement(verb);
                     _context.AddElement(popup, element);
                 }
-                else if (listedCategories.Add(verb.Category.Text))
+                // Add the category if it's not an extra (this is to avoid shuffling if we're filling from server verbs response).
+                else if (!extras.Contains(verb.Category.Text) && listedCategories.Add(verb.Category.Text))
                     AddVerbCategory(verb.Category, popup);
             }
 
-            if (ExtraCategories != null)
+            foreach (var category in ExtraCategories)
             {
-                foreach (var category in ExtraCategories)
-                {
-                    if (listedCategories.Add(category.Text))
-                        AddVerbCategory(category, popup);
-                }
+                if (listedCategories.Add(category.Text))
+                    AddVerbCategory(category, popup);
             }
 
             popup.InvalidateMeasure();


### PR DESCRIPTION
If it's an extra category we leave it in its default spot.

Resolves https://github.com/space-wizards/space-station-14/issues/27865

:cl:
- fix: Fix verb categories shuffling around.