### PR TITLE
Tune spacing speed to fix under-pressure lockout

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -40,7 +40,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("underPressureLockoutThreshold")]
-        public float UnderPressureLockoutThreshold = 2;
+        public float UnderPressureLockoutThreshold = 60; // this must be tuned in conjunction with atmos.mmos_spacing_speed
 
         /// <summary>
         ///     Pressure locked vents still leak a little (leading to eventual pressurization of sealed sections)

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1047,7 +1047,7 @@ namespace Content.Shared.CCVar
         ///     1.0 for instant spacing, 0.2 means 20% of remaining air lost each time
         /// </summary>
         public static readonly CVarDef<float> AtmosSpacingEscapeRatio =
-            CVarDef.Create("atmos.mmos_spacing_speed", 0.05f, CVar.SERVERONLY);
+            CVarDef.Create("atmos.mmos_spacing_speed", 0.15f, CVar.SERVERONLY);
 
         /// <summary>
         ///     Minimum amount of air allowed on a spaced tile before it is reset to 0 immediately in kPa


### PR DESCRIPTION
## About the PR
Slightly increase spacing speed to fix under pressure lockout.

## Why / Balance
Since super-slow spacing was added, [under-pressure lockout](https://github.com/space-wizards/space-station-14/pull/9824) has been broken.

This means that even if one small room is spaced, the vents leak all of the air out of distro and even if atmos techs repair the breach spacing will be difficult to recover from because all of distro is gone. This causes the whole station to slowly suffocate to death.

Speeding up spacing is part of the [atmos roadmap](https://docs.spacestation14.com/en/space-station-14/departments/atmos/proposals/atmos-rework.html).

According to @AJCM-git atmos fixes are acceptable during the freeze.

## Media

Under-pressure lockout works again:

![2024-05-28_21-40](https://github.com/space-wizards/space-station-14/assets/3229565/9936e07d-4021-4919-9763-9a9548ec1860)

Here's a video of the adjusted spacing speed:

https://github.com/space-wizards/space-station-14/assets/3229565/8e87eb37-1475-4d46-8b9b-b09496a4f4cb

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: notafet
- tweak: Slightly increase spacing speed to fix under-pressure lockout.
- fix: Fix vent under-pressure lockout.
