### PR TITLE
Fix flow rate display

### DIFF
--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPassiveGateSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPassiveGateSystem.cs
@@ -39,7 +39,7 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
             var T2 = outlet.Air.Temperature;
             var pressureDelta = P1 - P2;
 
-            float dt = 1/_atmosphereSystem.AtmosTickRate;
+            float dt = args.dt;
             float dV = 0;
             var denom = (T1*V2 + T2*V1);
 
@@ -63,7 +63,9 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
                 var transferMoles = n1 - (n1+n2)*T2*V1 / denom;
 
                 // Get the volume transfered to update our flow meter.
-                dV = n1*Atmospherics.R*T1/P1;
+                // When you remove x from one side and add x to the other the total difference is 2x.
+                // Also account for atmos speedup so that measured flow rate matches the setting on the volume pump.
+                dV = 2*transferMoles*Atmospherics.R*T1/P1 / _atmosphereSystem.Speedup;
 
                 // Actually transfer the gas.
                 _atmosphereSystem.Merge(outlet.Air, inlet.Air.Remove(transferMoles));


### PR DESCRIPTION
## About the PR
Fix the passive gate flow rate display.

## Why / Balance
Make the passive gate flow rate display match what was set on the volume pump.

## Technical details
The flow rate display did not match what was set by the volume pump because:

- The number of moles transferred to be considered for the volume calculation was off by a factor of 2 (see comment)
- The flow rate display did not account for atmos speedup

While here, also fix the code to use the correct `dT` so that the moving average actually has a 1-second window as the comments suggest.

Note that at higher settings the flow rate display will always be lower than the flow rate set on the pump because of other gory technical details. But at least for pipe nets with large volume, the error for lower flow rates will be small.

## Media
![2024-05-28_23-23](https://github.com/space-wizards/space-station-14/assets/3229565/5c99e671-6a6e-4985-997d-05c745f5ff0c)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: notafet
- fix: Fix passive gate flow rate display.
