### PR TITLE
Make mapping actions slightly more useable

### DIFF
--- a/Resources/mapping_actions.yml
+++ b/Resources/mapping_actions.yml
@@ -1,6 +1,47 @@
 - action: !type:InstantActionComponent
+    icon: /Textures/Tiles/cropped_parallax.png
+    keywords: []
+    checkCanInteract: False
+    checkConsciousness: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: AlignTileAny
+      tileId: Space
+  assignments:
+  - 0: 8
+  name: space
+- action: !type:InstantActionComponent
+    icon: Interface/VerbIcons/delete.svg.192dpi.png
+    keywords: []
+    checkCanInteract: False
+    checkConsciousness: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      eraser: True
+  assignments:
+  - 0: 9
+  name: action-name-mapping-erase
+- action: !type:InstantActionComponent
+    icon: /Textures/Tiles/plating.png
+    keywords: []
+    checkCanInteract: False
+    checkConsciousness: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: AlignTileAny
+      tileId: Plating
+  assignments:
+  - 0: 7
+  name: plating
+- action: !type:InstantActionComponent
     icon:
-      entity: ReinforcedWindow
+      entity: Grille
     keywords: []
     checkCanInteract: False
     checkConsciousness: False
@@ -9,10 +50,10 @@
     temporary: True
     event: !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
-      entityType: ReinforcedWindow
+      entityType: Grille
   assignments:
-  - 0: 3
-  name: ReinforcedWindow
+  - 0: 4
+  name: Grille
 - action: !type:InstantActionComponent
     icon:
       entity: WallSolid
@@ -30,21 +71,6 @@
   name: WallSolid
 - action: !type:InstantActionComponent
     icon:
-      entity: WallReinforced
-    keywords: []
-    checkCanInteract: False
-    checkConsciousness: False
-    clientExclusive: True
-    autoPopulate: False
-    temporary: True
-    event: !type:StartPlacementActionEvent
-      placementOption: SnapgridCenter
-      entityType: WallReinforced
-  assignments:
-  - 0: 1
-  name: WallReinforced
-- action: !type:InstantActionComponent
-    icon:
       entity: Window
     keywords: []
     checkCanInteract: False
@@ -60,6 +86,36 @@
   name: Window
 - action: !type:InstantActionComponent
     icon:
+      entity: WallReinforced
+    keywords: []
+    checkCanInteract: False
+    checkConsciousness: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: WallReinforced
+  assignments:
+  - 0: 1
+  name: WallReinforced
+- action: !type:InstantActionComponent
+    icon:
+      entity: ReinforcedWindow
+    keywords: []
+    checkCanInteract: False
+    checkConsciousness: False
+    clientExclusive: True
+    autoPopulate: False
+    temporary: True
+    event: !type:StartPlacementActionEvent
+      placementOption: SnapgridCenter
+      entityType: ReinforcedWindow
+  assignments:
+  - 0: 3
+  name: ReinforcedWindow
+- action: !type:InstantActionComponent
+    icon:
       entity: Firelock
     keywords: []
     checkCanInteract: False
@@ -73,39 +129,6 @@
   assignments:
   - 0: 5
   name: Firelock
-- action: !type:InstantActionComponent
-    icon:
-      entity: Grille
-    keywords: []
-    checkCanInteract: False
-    checkConsciousness: False
-    clientExclusive: True
-    autoPopulate: False
-    temporary: True
-    event: !type:StartPlacementActionEvent
-      placementOption: SnapgridCenter
-      entityType: Grille
-  assignments:
-  - 0: 4
-  name: Grille
-- action: !type:InstantActionComponent
-    icon: Interface/VerbIcons/delete.svg.192dpi.png
-    keywords: []
-    checkCanInteract: False
-    checkConsciousness: False
-    clientExclusive: True
-    autoPopulate: False
-    temporary: True
-    event: !type:StartPlacementActionEvent
-      eraser: True
-  assignments:
-  - 0: 9
-  - 1: 9
-  - 2: 9
-  - 4: 9
-  - 5: 9
-  - 6: 9
-  name: action-name-mapping-erase
 - action: !type:InstantActionComponent
     icon:
       entity: GasPipeStraight
@@ -1110,34 +1133,4 @@
   assignments:
   - 0: 6
   name: steel floor
-- action: !type:InstantActionComponent
-    icon: /Textures/Tiles/plating.png
-    keywords: []
-    checkCanInteract: False
-    checkConsciousness: False
-    clientExclusive: True
-    autoPopulate: False
-    temporary: True
-    event: !type:StartPlacementActionEvent
-      placementOption: AlignTileAny
-      tileId: Plating
-  assignments:
-  - 0: 7
-  - 1: 8
-  - 2: 8
-  name: plating
-- action: !type:InstantActionComponent
-    icon: /Textures/Tiles/cropped_parallax.png
-    keywords: []
-    checkCanInteract: False
-    checkConsciousness: False
-    clientExclusive: True
-    autoPopulate: False
-    temporary: True
-    event: !type:StartPlacementActionEvent
-      placementOption: AlignTileAny
-      tileId: Space
-  assignments:
-  - 0: 8
-  name: space
 ...


### PR DESCRIPTION
## About the PR
The [minimalist action bar](https://github.com/space-wizards/space-station-14/pull/21352) really [broke mapping actions](https://github.com/space-wizards/space-station-14/issues/21986). This is a stopgap fix to make it slightly more useful.

## Why / Balance
As https://github.com/space-wizards/space-station-14/issues/21986 shows, 6 of the action bar actions are assigned to "Delete Entity" which makes the default map actions bar pretty unusable. This PR makes it slightly less unusable for basic operations.

After the feature freeze we can figure out how we want mapping actions to work.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/3229565/9651c377-94fe-44c6-bab2-d319e92c9d56)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
