### PR TITLE
Predict ActivatableUIRequiresPower

### DIFF
--- a/Content.Client/Power/ActivatableUIRequiresPowerSystem.cs
+++ b/Content.Client/Power/ActivatableUIRequiresPowerSystem.cs
@@ -1,21 +1,27 @@
+using Content.Client.Power.EntitySystems;
+using Content.Shared.Popups;
 using Content.Shared.Power.Components;
+using Content.Shared.Power.EntitySystems;
 using Content.Shared.UserInterface;
 using Content.Shared.Wires;
 
 namespace Content.Client.Power;
 
-public sealed class ActivatableUIRequiresPowerSystem : EntitySystem
+public sealed class ActivatableUIRequiresPowerSystem : SharedActivatableUIRequiresPowerSystem
 {
-    public override void Initialize()
-    {
-        base.Initialize();
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
-        SubscribeLocalEvent<ActivatableUIRequiresPowerComponent, ActivatableUIOpenAttemptEvent>(OnActivate);
-    }
-
-    private void OnActivate(EntityUid uid, ActivatableUIRequiresPowerComponent component, ActivatableUIOpenAttemptEvent args)
+    protected override void OnActivate(Entity<ActivatableUIRequiresPowerComponent> ent, ref ActivatableUIOpenAttemptEvent args)
     {
-        // Client can't predict the power properly at the moment so rely upon the server to do it.
+        if (args.Cancelled || this.IsPowered(ent.Owner, EntityManager))
+        {
+            return;
+        }
+
+        if (TryComp<WiresPanelComponent>(ent.Owner, out var panel) && panel.Open)
+            return;
+
+        _popup.PopupClient(Loc.GetString("base-computer-ui-component-not-powered", ("machine", ent.Owner)), args.User, args.User);
         args.Cancel();
     }
 }

--- a/Content.Client/Power/EntitySystems/StaticPowerSystem.cs
+++ b/Content.Client/Power/EntitySystems/StaticPowerSystem.cs
@@ -1,0 +1,16 @@
+using Content.Client.Power.Components;
+
+namespace Content.Client.Power.EntitySystems;
+
+public static class StaticPowerSystem
+{
+    // Using this makes the call shorter.
+    // ReSharper disable once UnusedParameter.Global
+    public static bool IsPowered(this EntitySystem system, EntityUid uid, IEntityManager entManager, ApcPowerReceiverComponent? receiver = null)
+    {
+        if (receiver == null && !entManager.TryGetComponent(uid, out receiver))
+            return false;
+
+        return receiver.Powered;
+    }
+}

--- a/Content.Server/Power/EntitySystems/ActivatableUIRequiresPowerSystem.cs
+++ b/Content.Server/Power/EntitySystems/ActivatableUIRequiresPowerSystem.cs
@@ -1,34 +1,33 @@
-using Content.Shared.Popups;
 using Content.Server.Power.Components;
-using Content.Shared.UserInterface;
-using JetBrains.Annotations;
-using Content.Shared.Wires;
-using Content.Server.UserInterface;
 using Content.Shared.Power.Components;
+using Content.Shared.Power.EntitySystems;
+using Content.Shared.UserInterface;
+using Content.Shared.Wires;
 using ActivatableUISystem = Content.Shared.UserInterface.ActivatableUISystem;
 
 namespace Content.Server.Power.EntitySystems;
 
-public sealed class ActivatableUIRequiresPowerSystem : EntitySystem
+public sealed class ActivatableUIRequiresPowerSystem : SharedActivatableUIRequiresPowerSystem
 {
     [Dependency] private readonly ActivatableUISystem _activatableUI = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<ActivatableUIRequiresPowerComponent, ActivatableUIOpenAttemptEvent>(OnActivate);
         SubscribeLocalEvent<ActivatableUIRequiresPowerComponent, PowerChangedEvent>(OnPowerChanged);
     }
 
-    private void OnActivate(EntityUid uid, ActivatableUIRequiresPowerComponent component, ActivatableUIOpenAttemptEvent args)
+    protected override void OnActivate(Entity<ActivatableUIRequiresPowerComponent> ent, ref ActivatableUIOpenAttemptEvent args)
     {
-        if (args.Cancelled) return;
-        if (this.IsPowered(uid, EntityManager)) return;
-        if (TryComp<WiresPanelComponent>(uid, out var panel) && panel.Open)
+        if (args.Cancelled || this.IsPowered(ent.Owner, EntityManager))
+        {
             return;
-        _popup.PopupCursor(Loc.GetString("base-computer-ui-component-not-powered", ("machine", uid)), args.User);
+        }
+
+        if (TryComp<WiresPanelComponent>(ent.Owner, out var panel) && panel.Open)
+            return;
+
         args.Cancel();
     }
 

--- a/Content.Shared/Power/EntitySystems/SharedActivatableUIRequiresPowerSystem.cs
+++ b/Content.Shared/Power/EntitySystems/SharedActivatableUIRequiresPowerSystem.cs
@@ -1,0 +1,15 @@
+using Content.Shared.Power.Components;
+using Content.Shared.UserInterface;
+
+namespace Content.Shared.Power.EntitySystems;
+
+public abstract class SharedActivatableUIRequiresPowerSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ActivatableUIRequiresPowerComponent, ActivatableUIOpenAttemptEvent>(OnActivate);
+    }
+
+    protected abstract void OnActivate(Entity<ActivatableUIRequiresPowerComponent> ent, ref ActivatableUIOpenAttemptEvent args);
+}


### PR DESCRIPTION
Now that SC has networked ApcPowerReceivers client can predict this most of the time. A lot of BUIs aren't going to handle the state coming in cleanly but we can fix em as we find em.

:cl:
- tweak: Predict opening even more interfaces.