### PR TITLE
Revert "Buff the AME until somebody fixes engineering"

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -182,7 +182,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // Fuel is squared so more fuel vastly increases power and efficiency
         // We divide by the number of cores so a larger AME is less efficient at the same fuel settings
         // this results in all AMEs having the same efficiency at the same fuel-per-core setting
-        return 2000000f * fuel * fuel / cores;
+        return 20000f * fuel * fuel / cores;
     }
 
     public int GetTotalStability()


### PR DESCRIPTION
Reverts space-wizards/space-station-14#24806

# Why?
After a quick discussion with @EmoGarbage404, apparently the original issue(s) leading to this have been patched.
Power supply issues from rad collection was patched in https://github.com/space-wizards/space-station-14/pull/24978, though I don't think this behavior was changed for Tesla?


**Changelog**

:cl:
- tweak: AME power output is no longer super-buffed. Larger stations will now require multiple engines to stay powered.