### PR TITLE
Add firelock warnings popup when opening on access allowed

### DIFF
--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -56,23 +56,34 @@ public abstract class SharedFirelockSystem : EntitySystem
 
         if (!component.Powered || (!overrideAccess && component.IsLocked))
             args.Cancel();
+        else if (args.User != null)
+            WarnPlayer((uid, component), args.User.Value);
     }
 
     private void OnDoorGetPryTimeModifier(EntityUid uid, FirelockComponent component, ref GetPryTimeModifierEvent args)
     {
-        if (component.Temperature)
-        {
-            _popupSystem.PopupClient(Loc.GetString("firelock-component-is-holding-fire-message"),
-                uid, args.User, PopupType.MediumCaution);
-        }
-        else if (component.Pressure)
-        {
-            _popupSystem.PopupClient(Loc.GetString("firelock-component-is-holding-pressure-message"),
-                uid, args.User, PopupType.MediumCaution);
-        }
+        WarnPlayer((uid, component), args.User);
 
         if (component.IsLocked)
             args.PryTimeModifier *= component.LockedPryTimeModifier;
+    }
+
+    private void WarnPlayer(Entity<FirelockComponent> ent, EntityUid user)
+    {
+        if (ent.Comp.Temperature)
+        {
+            _popupSystem.PopupClient(Loc.GetString("firelock-component-is-holding-fire-message"),
+                ent.Owner,
+                user,
+                PopupType.MediumCaution);
+        }
+        else if (ent.Comp.Pressure)
+        {
+            _popupSystem.PopupClient(Loc.GetString("firelock-component-is-holding-pressure-message"),
+                ent.Owner,
+                user,
+                PopupType.MediumCaution);
+        }
     }
 
     private void OnAfterPried(EntityUid uid, FirelockComponent component, ref PriedEvent args)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Firelock popups only popped up when prying. This PR makes it also pop up when opening the airlock normally when there are warnings active.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This gives more information to the engineers that they're entering a dangerous area.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/10494922/0be268fb-deb9-4931-9138-d7f87733b5ea

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Opening a firelock when temperature or pressure warnings are active, now always shows the warning popup.