### PR TITLE
Change PlantAdjustAttribute to use Probability

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantAdjustAttribute.cs
+++ b/Content.Server/Chemistry/ReagentEffects/PlantMetabolism/PlantAdjustAttribute.cs
@@ -12,9 +12,6 @@ namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
         [DataField]
         public float Amount { get; protected set; } = 1;
 
-        [DataField]
-        public float Prob { get; protected set; } = 1; // = (80);
-
         /// <summary>
         /// Localisation key for the name of the adjusted attribute. Used for guidebook descriptions.
         /// </summary>
@@ -45,11 +42,7 @@ namespace Content.Server.Chemistry.ReagentEffects.PlantMetabolism
                                     || mustHaveAlivePlant && (plantHolderComponent.Seed == null || plantHolderComponent.Dead))
                 return false;
 
-            if (Prob >= 1f)
-                return true;
-
-            // Dependencies are never injected for reagents if you intend to do that for this.
-            return !(Prob <= 0f) && IoCManager.Resolve<IRobustRandom>().Prob(Prob);
+            return true;
         }
 
         protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -373,10 +373,10 @@ reagent-effect-guidebook-plant-diethylamine =
     { $chance ->
         [1] Increases
         *[other] increase
-    } the plant's lifespan and/or base health with 10% chance for each.
+    } the plant's lifespan and/or base health with 10% chance for each
 
 reagent-effect-guidebook-plant-robust-harvest =
     { $chance ->
         [1] Increases
         *[other] increase
-    } the plant's potency by {$increase} up to a maximum of {$limit}. Causes the plant to lose its seeds once the potency reaches {$seedlesstreshold}. Trying to add potency over {$limit} may cause decrease in yield at a 10% chance.
+    } the plant's potency by {$increase} up to a maximum of {$limit}. Causes the plant to lose its seeds once the potency reaches {$seedlesstreshold}. Trying to add potency over {$limit} may cause decrease in yield at a 10% chance

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -373,10 +373,10 @@ reagent-effect-guidebook-plant-diethylamine =
     { $chance ->
         [1] Increases
         *[other] increase
-    } the plant's lifespan and/or base health with 10% chance for each
+    } the plant's lifespan and/or base health with 10% chance for each.
 
 reagent-effect-guidebook-plant-robust-harvest =
     { $chance ->
         [1] Increases
         *[other] increase
-    } the plant's potency by {$increase} up to a maximum of {$limit}. Causes the plant to lose its seeds once the potency reaches {$seedlesstreshold}. Trying to add potency over {$limit} may cause decrease in yield at a 10% chance
+    } the plant's potency by {$increase} up to a maximum of {$limit}. Causes the plant to lose its seeds once the potency reaches {$seedlesstreshold}. Trying to add potency over {$limit} may cause decrease in yield at a 10% chance.

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -31,7 +31,7 @@
     - !type:PlantAdjustHealth
       amount: -0.5
     - !type:PlantAdjustMutationMod
-      prob: 0.3
+      probability 0.3
       amount: 0.4
   metabolisms:
     Medicine:
@@ -115,10 +115,10 @@
     - !type:PlantAdjustNutrition
       amount: 0.05
     - !type:PlantAdjustWeeds
-      prob: 0.025
+      probability 0.025
       amount: 1
     - !type:PlantAdjustPests
-      prob: 0.025
+      probability 0.025
       amount: 1
     - !type:RobustHarvest {}
   metabolisms:
@@ -273,12 +273,12 @@
   - !type:PlantAdjustNutrition
     amount: 0.1
   - !type:PlantAdjustPests
-    prob: 0.1
+    probability 0.1
     amount: -1
   - !type:PlantAdjustHealth
     amount: 0.1
   - !type:PlantAffectGrowth
-    prob: 0.2
+    probability 0.2
     amount: 1
   - !type:PlantDiethylamine {}
   metabolisms:

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -31,7 +31,7 @@
     - !type:PlantAdjustHealth
       amount: -0.5
     - !type:PlantAdjustMutationMod
-      probability 0.3
+      probability: 0.3
       amount: 0.4
   metabolisms:
     Medicine:

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -115,10 +115,10 @@
     - !type:PlantAdjustNutrition
       amount: 0.05
     - !type:PlantAdjustWeeds
-      probability 0.025
+      probability: 0.025
       amount: 1
     - !type:PlantAdjustPests
-      probability 0.025
+      probability: 0.025
       amount: 1
     - !type:RobustHarvest {}
   metabolisms:
@@ -273,12 +273,12 @@
   - !type:PlantAdjustNutrition
     amount: 0.1
   - !type:PlantAdjustPests
-    probability 0.1
+    probability: 0.1
     amount: -1
   - !type:PlantAdjustHealth
     amount: 0.1
   - !type:PlantAffectGrowth
-    probability 0.2
+    probability: 0.2
     amount: 1
   - !type:PlantDiethylamine {}
   metabolisms:

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -334,7 +334,7 @@
   - !type:PlantAdjustHealth
     amount: -1.5
   - !type:PlantAdjustMutationMod
-    prob: 0.2
+    probability: 0.2
     amount: 0.1
   metabolisms:
     Poison:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removes the Prob variable from PlantAdjustAttribute and makes it use Probability instead, like effects reagent effects.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

The Prob variable in the PlantAdjustAttribute prototype has been removed. Probability should be used instead.