### PR TITLE
Handheld teleporter portals now must start on the same grid.

### DIFF
--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -1,7 +1,9 @@
 using Content.Server.Administration.Logs;
+using Content.Server.Popups;
 using Content.Shared.DoAfter;
 using Content.Shared.Database;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Popups;
 using Content.Shared.Teleportation.Components;
 using Content.Shared.Teleportation.Systems;
 using Robust.Server.Audio;
@@ -18,6 +20,7 @@ public sealed class HandTeleporterSystem : EntitySystem
     [Dependency] private readonly LinkedEntitySystem _link = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly SharedDoAfterSystem _doafter = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -92,6 +95,16 @@ public sealed class HandTeleporterSystem : EntitySystem
         }
         else if (Deleted(component.SecondPortal))
         {
+            if (xform.ParentUid != xform.GridUid) // Still, don't portal.
+                return;
+
+            if (xform.ParentUid != Transform(component.FirstPortal!.Value).ParentUid)
+            {
+                // Whoops. Fizzle time. Crime time too because yippee I'm not refactoring this logic right now (I started to, I'm not going to.)
+                FizzlePortals(uid, component, user, true);
+                return;
+            }
+
             var timeout = EnsureComp<PortalTimeoutComponent>(user);
             timeout.EnteredPortal = null;
             component.SecondPortal = Spawn(component.SecondPortalPrototype, Transform(user).Coordinates);
@@ -101,22 +114,32 @@ public sealed class HandTeleporterSystem : EntitySystem
         }
         else
         {
-            // Logging
-            var portalStrings = "";
-            portalStrings += ToPrettyString(component.FirstPortal!.Value);
-            if (portalStrings != "")
-                portalStrings += " and ";
-            portalStrings += ToPrettyString(component.SecondPortal!.Value);
-            if (portalStrings != "")
-                _adminLogger.Add(LogType.EntityDelete, LogImpact.Low, $"{ToPrettyString(user):player} closed {portalStrings} with {ToPrettyString(uid)}");
-
-            // Clear both portals
-            QueueDel(component.FirstPortal!.Value);
-            QueueDel(component.SecondPortal!.Value);
-
-            component.FirstPortal = null;
-            component.SecondPortal = null;
-            _audio.PlayPvs(component.ClearPortalsSound, uid);
+            FizzlePortals(uid, component, user, false);
         }
+    }
+
+    private void FizzlePortals(EntityUid uid, HandTeleporterComponent component, EntityUid user, bool instability)
+    {
+        // Logging
+        var portalStrings = "";
+        portalStrings += ToPrettyString(component.FirstPortal);
+        if (portalStrings != "")
+            portalStrings += " and ";
+        portalStrings += ToPrettyString(component.SecondPortal);
+        if (portalStrings != "")
+            _adminLogger.Add(LogType.EntityDelete, LogImpact.Low, $"{ToPrettyString(user):player} closed {portalStrings} with {ToPrettyString(uid)}");
+
+        // Clear both portals
+        if (!Deleted(component.FirstPortal))
+            QueueDel(component.FirstPortal.Value);
+        if (!Deleted(component.SecondPortal))
+            QueueDel(component.SecondPortal.Value);
+
+        component.FirstPortal = null;
+        component.SecondPortal = null;
+        _audio.PlayPvs(component.ClearPortalsSound, uid);
+
+        if (instability)
+            _popup.PopupEntity(Loc.GetString("handheld-teleporter-instability-fizzle"), uid, user, PopupType.MediumCaution);
     }
 }

--- a/Resources/Locale/en-US/teleportation/handheld-teleporter.ftl
+++ b/Resources/Locale/en-US/teleportation/handheld-teleporter.ftl
@@ -1,0 +1,1 @@
+﻿handheld-teleporter-instability-fizzle = The portal fizzles as you try to place it, destroying both ends!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
![image](https://github.com/space-wizards/space-station-14/assets/7806367/ddecfd40-c66f-4c86-8fae-0ce808b3852a)
You can no longer use portals to adjoin grids. (Also fixes a seemingly unreported bug that allowed placing *only* the second portal within containers, and another that causes an exception on trying to fizzle portals when one or the other is already deleted.)

## Why / Balance
Fixes #24291
This is really lame and unfun, let me fly the goddamn shuttle. --cargo player (me)



**Changelog**

:cl:
- remove: The hand teleporter can no longer create portal links between grids.

