### PR TITLE
Increase Tesla coil power output

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -60,7 +60,7 @@
     startingCharge: 0
   - type: BatteryDischarger
   - type: TeslaCoil
-    chargeFromLightning: 500000
+    chargeFromLightning: 1000000
   - type: LightningTarget
     priority: 4
     hitProbability: 0.5

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -60,7 +60,7 @@
     startingCharge: 0
   - type: BatteryDischarger
   - type: TeslaCoil
-    chargeFromLightning: 1000000
+    chargeFromLightning: 2000000
   - type: LightningTarget
     priority: 4
     hitProbability: 0.5


### PR DESCRIPTION
## About the PR
Double energy per zap in the Tesla coil.

## Why / Balance
Tesla coils are generating too little power such that on stations like Meta, a round-start (pre-buffed) AME and Tesla are not enough to keep the station powered and the lights from blinking.

See: https://github.com/space-wizards/space-station-14/pull/28419

## Media
1-core (pre-PBJ-buff) AME + Tesla can now power Meta. Tesla still does not provide enough power by itself to power the whole station. Picture shows empty SMES charging with combined AME + Tesla output.

![2024-05-30_14-24](https://github.com/space-wizards/space-station-14/assets/3229565/3f929164-d8bf-4596-81ff-c1708881031d)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: notafet
- tweak: Increase power output from Tesla coils.