### PR TITLE
Fix latejoin antag preferences not being respected

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -162,8 +162,11 @@ public sealed partial class AntagSelectionSystem
     /// </summary>
     public bool HasPrimaryAntagPreference(ICommonSession? session, AntagSelectionDefinition def)
     {
-        if (session == null || def.PrefRoles.Count == 0)
+        if (session == null)
             return true;
+
+        if (def.PrefRoles.Count == 0)
+            return false;
 
         var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
         return pref.AntagPreferences.Any(p => def.PrefRoles.Contains(p));
@@ -174,8 +177,11 @@ public sealed partial class AntagSelectionSystem
     /// </summary>
     public bool HasFallbackAntagPreference(ICommonSession? session, AntagSelectionDefinition def)
     {
-        if (session == null || def.FallbackRoles.Count == 0)
+        if (session == null)
             return true;
+
+        if (def.FallbackRoles.Count == 0)
+            return false;
 
         var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
         return pref.AntagPreferences.Any(p => def.FallbackRoles.Contains(p));

--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -5,6 +5,7 @@ using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Objectives;
 using Content.Shared.Chat;
 using Content.Shared.Mind;
+using Content.Shared.Preferences;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
 using Robust.Shared.Enums;
@@ -154,6 +155,30 @@ public sealed partial class AntagSelectionSystem
             return new();
 
         return ent.Comp.SelectedMinds.Select(p => p.Item1).ToList();
+    }
+
+    /// <summary>
+    /// Checks if a given session has the primary antag preferences for a given definition
+    /// </summary>
+    public bool HasPrimaryAntagPreference(ICommonSession? session, AntagSelectionDefinition def)
+    {
+        if (session == null || def.PrefRoles.Count == 0)
+            return true;
+
+        var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
+        return pref.AntagPreferences.Any(p => def.PrefRoles.Contains(p));
+    }
+
+    /// <summary>
+    /// Checks if a given session has the fallback antag preferences for a given definition
+    /// </summary>
+    public bool HasFallbackAntagPreference(ICommonSession? session, AntagSelectionDefinition def)
+    {
+        if (session == null || def.FallbackRoles.Count == 0)
+            return true;
+
+        var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
+        return pref.AntagPreferences.Any(p => def.FallbackRoles.Contains(p));
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes #28406

changes latejoin antags to _actually_ check prefs. ig they just never did LMAO.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed latejoin antagonists not respecting antag preferences (for real this time)
