### PR TITLE
Don't switch-unwield if mob has more than 2 hands

### DIFF
--- a/Content.Shared/Wieldable/WieldableSystem.cs
+++ b/Content.Shared/Wieldable/WieldableSystem.cs
@@ -97,7 +97,8 @@ public sealed class WieldableSystem : EntitySystem
         if (!component.Wielded)
             return;
 
-        TryUnwield(uid, component, args.User);
+        if(TryComp(args.User, out HandsComponent? hands) && hands.Hands.Count == 2)
+            TryUnwield(uid, component, args.User);
     }
 
     private void OnGunRefreshModifiers(Entity<GunWieldBonusComponent> bonus, ref GunRefreshModifiersEvent args)


### PR DESCRIPTION
## About the PR
Mobs  with more than 2 hands will no longer automatically unwield when switching hands. They could be trying to use their extra hands instead of using the occupied one, so it can't be determined if they want to let go of the readied weapon or not - better to assume they do not, imo. They can still unwield by pressing Drop Item on the second hand, as was the case before auto-unwield

I don't think any such mobs currently exist in our codebase, but admins could modify/upload, or one might be added in the future
Suggested/Implied by Smug on #27975

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase