### PR TITLE
Give botanists a roundstart plant clipper

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -119,6 +119,7 @@
     contents:
     - id: HydroponicsToolMiniHoe
     - id: HydroponicsToolSpade
+    - id: HydroponicsToolClippers
     - id: RobustHarvestChemistryBottle
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

There are several circumstances where not having a plant clipper can break the balance. On reach, there is no way to get clippers. If there is no power, then you can't get more seeds. This is, in my opinion, a necessity alongside the mini hoe and spade and I'm not sure why it has been missing all this time.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://github.com/space-wizards/space-station-14/assets/134914314/0fb7f5f0-a28f-4f5b-b259-55bc1420c78a)

**Changelog**

:cl: Ubaser
- tweak: Botanists now spawn with a plant clipper.
