### PR TITLE
Give janitors a roundstart light replacer

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -79,6 +79,7 @@
       - id: CleanerGrenade
         amount: 2
       - id: FlashlightLantern
+      - id: LightReplacer
 
 - type: entity
   id: ClothingBeltMedicalFilled


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Turns out only having one light replacer on average per round is actually not intended, and all janitors are supposed to have one? Seems crazy but since it's true i decided to just fix it.

**Changelog**
:cl: Ubaser
- tweak: Janitors now spawn with a light replacer.