### PR TITLE
make it so you cant build disposal pipes in impassable objects

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -178,7 +178,7 @@
   targetNode: pipe
   category: construction-category-utilities
   placementMode: SnapgridCenter
-  canBuildInImpassable: true
+  canBuildInImpassable: false
   icon:
     sprite: Structures/Piping/disposal.rsi
     state: conpipe-s


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
You wont be able to build disposal pipes under the walls, like gas pipes and ETC.

## Why / Balance
Constructing pipes under the wall allows you to noclip under any wall/airlock, being able to get you in any place you want (even cap cabin), which makes it really easy for antags to get high risk items.

## Breaking changes
<!--
no
-->

**Changelog**
:cl:
- fix: Disposal pipes are now blocked from constructing underneath impassable objects.