### PR TITLE
Pizza Parties no longer flood the station with more than it could ever eat.

### DIFF
--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -13,7 +13,7 @@
     sender: cargo-gift-default-sender
     dest: cargo-gift-dest-bar
     gifts:
-      FoodPizzaLarge: 1              # 16 pizzas
+      FoodPizza: 1              # 4 pizzas
       FoodBarSupply: 1
       FoodSoftdrinks: 1
       CrateVendingMachineRestockRobustSoftdrinks: 1
@@ -28,12 +28,13 @@
       startDelay: 10
       duration: 240
       earliestStart: 20
+      minimumPlayers: 40
     - type: CargoGiftsRule
       description: cargo-gift-pizza-large
       sender: cargo-gift-default-sender
       dest: cargo-gift-dest-bar
       gifts:
-        FoodPizzaLarge: 4              # 64 pizzas
+        FoodPizzaLarge: 1              # 16 pizzas
         FoodBarSupply: 1
         FoodSoftdrinksLarge: 1
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Massively decreases the amount of pizza the station gets in both pizza party events, fixing issue #28395. Additionally, the large pizza party event now has a minimum player count to occur.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The small and large pizza party events give you 16 and **64** pizzas respectively. This is far, far more than the station can actually use and is essentially a chance each round for the chef to be put out of a job.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Changes like two numbers, this is very much baby's first howdoicode PR.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- tweak: Pizza party events now give less pizza, and large parties can only occur on 40+ player rounds.
-->
