### PR TITLE
Fixed bug where ID card computer defaulted to the atmos as the job icon.

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -27,6 +27,9 @@ namespace Content.Client.Access.UI
         private string? _lastJobTitle;
         private string? _lastJobProto;
 
+        // The job that will be picked if the ID doesn't have a job on the station.
+        private static ProtoId<JobPrototype> _defaultJob = "Passenger";
+
         public IdCardConsoleWindow(IdCardConsoleBoundUserInterface owner, IPrototypeManager prototypeManager,
             List<ProtoId<AccessLevelPrototype>> accessLevels)
         {
@@ -65,7 +68,6 @@ namespace Content.Client.Access.UI
             }
 
             JobPresetOptionButton.OnItemSelected += SelectJobPreset;
-
             _accessButtons.Populate(accessLevels, prototypeManager);
             AccessLevelControlContainer.AddChild(_accessButtons);
 
@@ -172,10 +174,14 @@ namespace Content.Client.Access.UI
                                        new List<ProtoId<AccessLevelPrototype>>());
 
             var jobIndex = _jobPrototypeIds.IndexOf(state.TargetIdJobPrototype);
-            if (jobIndex >= 0)
+            // If the job index is < 0 that means they don't have a job registered in the station records.
+            // For example, a new ID from a box would have no job index.
+            if (jobIndex < 0)
             {
-                JobPresetOptionButton.SelectId(jobIndex);
+                jobIndex = _jobPrototypeIds.IndexOf(_defaultJob);
             }
+
+            JobPresetOptionButton.SelectId(jobIndex);
 
             _lastFullName = state.TargetIdFullName;
             _lastJobTitle = state.TargetIdJobTitle;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The ID computer would automatically pick atmos as the default job icon if the ID wasn't registered with the stations records. It now will default to passenger. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/107373427/f2e533da-1ec3-4e4c-bb43-20dc4c6a7269

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl: Beck Thompson
- fix: ID computer will now select passenger as the default id icon instead of atmospheric technician.

