### PR TITLE
Adjust power monitor power display

### DIFF
--- a/Content.Client/Power/PowerMonitoringWindow.xaml.Widgets.cs
+++ b/Content.Client/Power/PowerMonitoringWindow.xaml.Widgets.cs
@@ -102,7 +102,8 @@ public sealed partial class PowerMonitoringWindow
         button.ToolTip = Loc.GetString(name);
 
         // Update power value
-        button.PowerValue.Text = Loc.GetString("power-monitoring-window-value", ("value", entry.PowerValue));
+        // Don't use SI prefixes, just give the number in W, so that it is readily apparent which consumer is using a lot of power.
+        button.PowerValue.Text = Loc.GetString("power-monitoring-window-button-value", ("value", Math.Round(entry.PowerValue).ToString("N0")));
     }
 
     private void UpdateEntrySourcesOrLoads(BoxContainer masterContainer, BoxContainer currentContainer, PowerMonitoringConsoleEntry[]? entries, SpriteSpecifier.Texture icon)
@@ -480,6 +481,7 @@ public sealed class PowerMonitoringButton : Button
         PowerValue = new Label()
         {
             HorizontalAlignment = HAlignment.Right,
+            Align = Label.AlignMode.Right,
             SetWidth = 72f,
             Margin = new Thickness(10, 0, 0, 0),
             ClipText = true,

--- a/Resources/Locale/en-US/components/power-monitoring-component.ftl
+++ b/Resources/Locale/en-US/components/power-monitoring-component.ftl
@@ -14,6 +14,7 @@ power-monitoring-window-total-sources = Total generator output
 power-monitoring-window-total-battery-usage = Total battery usage
 power-monitoring-window-total-loads = Total network loads
 power-monitoring-window-value = { POWERWATTS($value) }
+power-monitoring-window-button-value = {$value} W
 power-monitoring-window-show-inactive-consumers = Show Inactive Consumers
 
 power-monitoring-window-show-cable-networks = Toggle cable networks


### PR DESCRIPTION
## About the PR
Change power monitor display values to be right-justified and without the SI prefix.

## Why / Balance
The current value display poorly conveys the key information you want out of the power monitor, which is to be able to quickly see what is consuming the most power. See the "Before" screenshot below, can you quickly see what substation is using the most power?

In the "After", it is much easier to see which substations are actually consuming the most power.

## Media
**Before**
![image](https://github.com/space-wizards/space-station-14/assets/3229565/89e98c08-deff-4c88-ae38-65e9d0114b79)

**After**
![2024-06-01_12-16](https://github.com/space-wizards/space-station-14/assets/3229565/ab3ef093-8ca3-4856-9b37-7afc81305b27)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
