### PR TITLE
Add CVar to disable pow3r parallel processing

### DIFF
--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -3,9 +3,11 @@ using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.Power.Components;
 using Content.Server.Power.NodeGroups;
 using Content.Server.Power.Pow3r;
+using Content.Shared.CCVar;
 using Content.Shared.Power;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
+using Robust.Shared.Configuration;
 using Robust.Shared.Threading;
 
 namespace Content.Server.Power.EntitySystems
@@ -18,6 +20,7 @@ namespace Content.Server.Power.EntitySystems
     {
         [Dependency] private readonly AppearanceSystem _appearance = default!;
         [Dependency] private readonly PowerNetConnectorSystem _powerNetConnector = default!;
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly IParallelManager _parMan = default!;
         [Dependency] private readonly PowerReceiverSystem _powerReceiver = default!;
 
@@ -25,7 +28,7 @@ namespace Content.Server.Power.EntitySystems
         private readonly HashSet<PowerNet> _powerNetReconnectQueue = new();
         private readonly HashSet<ApcNet> _apcNetReconnectQueue = new();
 
-        private readonly BatteryRampPegSolver _solver = new();
+        private BatteryRampPegSolver _solver = new();
 
         public override void Initialize()
         {

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -53,6 +53,13 @@ namespace Content.Server.Power.EntitySystems
             SubscribeLocalEvent<PowerSupplierComponent, ComponentShutdown>(PowerSupplierShutdown);
             SubscribeLocalEvent<PowerSupplierComponent, EntityPausedEvent>(PowerSupplierPaused);
             SubscribeLocalEvent<PowerSupplierComponent, EntityUnpausedEvent>(PowerSupplierUnpaused);
+
+            Subs.CVar(_cfg, CCVars.DebugPow3rDisableParallel, DebugPow3rDisableParallelChanged);
+        }
+
+        private void DebugPow3rDisableParallelChanged(bool val)
+        {
+            _solver = new();
         }
 
         private void ApcPowerReceiverInit(EntityUid uid, ApcPowerReceiverComponent component, ComponentInit args)

--- a/Content.Server/Power/EntitySystems/PowerNetSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerNetSystem.cs
@@ -35,6 +35,7 @@ namespace Content.Server.Power.EntitySystems
             base.Initialize();
 
             UpdatesAfter.Add(typeof(NodeGroupSystem));
+            _solver = new(_cfg.GetCVar(CCVars.DebugPow3rDisableParallel));
 
             SubscribeLocalEvent<ApcPowerReceiverComponent, ComponentInit>(ApcPowerReceiverInit);
             SubscribeLocalEvent<ApcPowerReceiverComponent, ComponentShutdown>(ApcPowerReceiverShutdown);
@@ -62,7 +63,7 @@ namespace Content.Server.Power.EntitySystems
 
         private void DebugPow3rDisableParallelChanged(bool val)
         {
-            _solver = new();
+            _solver = new(val);
         }
 
         private void ApcPowerReceiverInit(EntityUid uid, ApcPowerReceiverComponent component, ComponentInit args)

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -1,6 +1,4 @@
 using System.Diagnostics;
-using Content.Shared.CCVar;
-using Robust.Shared.Configuration;
 using Robust.Shared.Utility;
 using System.Linq;
 using Robust.Shared.Threading;
@@ -13,10 +11,9 @@ namespace Content.Server.Power.Pow3r
         private UpdateNetworkJob _networkJob;
         private bool _disableParallel;
 
-        public BatteryRampPegSolver()
+        public BatteryRampPegSolver(bool disableParallel = false)
         {
-            IConfigurationManager _cfg = IoCManager.Resolve<IConfigurationManager>();
-            _disableParallel = _cfg.GetCVar(CCVars.DebugPow3rDisableParallel);
+            _disableParallel = disableParallel;
             _networkJob = new()
             {
                 Solver = this,

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -11,9 +11,12 @@ namespace Content.Server.Power.Pow3r
     public sealed class BatteryRampPegSolver : IPowerSolver
     {
         private UpdateNetworkJob _networkJob;
+        private bool _disableParallel;
 
         public BatteryRampPegSolver()
         {
+            IConfigurationManager _cfg = IoCManager.Resolve<IConfigurationManager>();
+            _disableParallel = _cfg.GetCVar(CCVars.DebugPow3rDisableParallel);
             _networkJob = new()
             {
                 Solver = this,
@@ -58,8 +61,7 @@ namespace Content.Server.Power.Pow3r
                 // suppliers + discharger) Then decide based on total layer size whether its worth parallelizing that
                 // layer?
                 _networkJob.Networks = group;
-                IConfigurationManager _cfg = IoCManager.Resolve<IConfigurationManager>();
-                if (_cfg.GetCVar(CCVars.DebugPow3rDisableParallel))
+                if (_disableParallel)
                     parallel.ProcessSerialNow(_networkJob, group.Count);
                 else
                     parallel.ProcessNow(_networkJob, group.Count);

--- a/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
+++ b/Content.Server/Power/Pow3r/BatteryRampPegSolver.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
 using Robust.Shared.Utility;
 using System.Linq;
 using Robust.Shared.Threading;
@@ -56,7 +58,11 @@ namespace Content.Server.Power.Pow3r
                 // suppliers + discharger) Then decide based on total layer size whether its worth parallelizing that
                 // layer?
                 _networkJob.Networks = group;
-                parallel.ProcessNow(_networkJob, group.Count);
+                IConfigurationManager _cfg = IoCManager.Resolve<IConfigurationManager>();
+                if (_cfg.GetCVar(CCVars.DebugPow3rDisableParallel))
+                    parallel.ProcessSerialNow(_networkJob, group.Count);
+                else
+                    parallel.ProcessNow(_networkJob, group.Count);
             }
 
             ClearBatteries(state);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2067,6 +2067,6 @@ namespace Content.Shared.CCVar
         /// Set to true to disable parallel processing in the pow3r solver.
         /// </summary>
         public static readonly CVarDef<bool> DebugPow3rDisableParallel =
-            CVarDef.Create("debug.pow3r_disable_parallel", false, CVar.SERVERONLY);
+            CVarDef.Create("debug.pow3r_disable_parallel", true, CVar.SERVERONLY);
     }
 }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2062,5 +2062,11 @@ namespace Content.Shared.CCVar
         /// </summary>
         public static readonly CVarDef<bool> DebugOptionVisualizerTest =
             CVarDef.Create("debug.option_visualizer_test", false, CVar.CLIENTONLY);
+
+        /// <summary>
+        /// Set to true to disable parallel processing in the pow3r solver.
+        /// </summary>
+        public static readonly CVarDef<bool> DebugPow3rDisableParallel =
+            CVarDef.Create("debug.pow3r_disable_parallel", false, CVar.SERVERONLY);
     }
 }


### PR DESCRIPTION
## About the PR
Add CVar to disable pow3r parallel processing.

## Why / Balance
[@PJB3005 wanted it](https://discord.com/channels/310555209753690112/770682801607278632/1246553140053016778). Initial tests seem to suggest that this is responsible for the power blinking (see https://github.com/space-wizards/space-station-14/pull/28419).

On localhost with the CVar disabled, I would get power blinks with a debug generator. This stopped when the CVar was set to true.