### PR TITLE
Add percentage reading to chargers

### DIFF
--- a/Content.Server/Power/EntitySystems/ChargerSystem.cs
+++ b/Content.Server/Power/EntitySystems/ChargerSystem.cs
@@ -62,7 +62,7 @@ internal sealed class ChargerSystem : EntitySystem
                 foreach (var contained in container.ContainedEntities)
                 {
                     if (!TryComp<BatteryComponent>(contained, out var battery))
-                        return;
+                        continue;
 
                     var chargePercentage = (battery.CurrentCharge / battery.MaxCharge) * 100;
                     args.PushMarkup(Loc.GetString("charger-content", ("chargePercentage", (int) chargePercentage)));

--- a/Content.Server/Power/EntitySystems/ChargerSystem.cs
+++ b/Content.Server/Power/EntitySystems/ChargerSystem.cs
@@ -41,7 +41,32 @@ internal sealed class ChargerSystem : EntitySystem
 
     private void OnChargerExamine(EntityUid uid, ChargerComponent component, ExaminedEvent args)
     {
+        // rate at which the charger charges
         args.PushMarkup(Loc.GetString("charger-examine", ("color", "yellow"), ("chargeRate", (int) component.ChargeRate)));
+
+        // try to get contents of the charger
+        if (!_container.TryGetContainer(uid, component.SlotId, out var container))
+            return;
+
+        // if charger is empty and not a power cell type charger, add empty message
+        // power cells have their own empty message by default, for things like flash lights
+        if (container.ContainedEntities.Count == 0 && !HasComp<PowerCellSlotComponent>(uid))
+        {
+            args.PushMarkup(Loc.GetString("charger-empty"));
+        }
+        else
+        {
+            // add how much each item is charged it 
+            foreach (var contained in container.ContainedEntities)
+            {
+                if (!TryComp<BatteryComponent>(contained, out var battery))
+                    return;
+
+                var chargePercentage = (battery.CurrentCharge / battery.MaxCharge) * 100;
+                args.PushMarkup(Loc.GetString("charger-content", ("color", "yellow"), ("chargePercentage", (int) chargePercentage)));
+            }
+        }
+        
     }
 
     public override void Update(float frameTime)

--- a/Content.Server/Power/EntitySystems/ChargerSystem.cs
+++ b/Content.Server/Power/EntitySystems/ChargerSystem.cs
@@ -65,7 +65,7 @@ internal sealed class ChargerSystem : EntitySystem
                         return;
 
                     var chargePercentage = (battery.CurrentCharge / battery.MaxCharge) * 100;
-                    args.PushMarkup(Loc.GetString("charger-content", ("color", "yellow"), ("chargePercentage", (int) chargePercentage)));
+                    args.PushMarkup(Loc.GetString("charger-content", ("chargePercentage", (int) chargePercentage)));
                 }
             }
         }

--- a/Content.Server/Power/EntitySystems/ChargerSystem.cs
+++ b/Content.Server/Power/EntitySystems/ChargerSystem.cs
@@ -41,32 +41,34 @@ internal sealed class ChargerSystem : EntitySystem
 
     private void OnChargerExamine(EntityUid uid, ChargerComponent component, ExaminedEvent args)
     {
-        // rate at which the charger charges
-        args.PushMarkup(Loc.GetString("charger-examine", ("color", "yellow"), ("chargeRate", (int) component.ChargeRate)));
-
-        // try to get contents of the charger
-        if (!_container.TryGetContainer(uid, component.SlotId, out var container))
-            return;
-
-        // if charger is empty and not a power cell type charger, add empty message
-        // power cells have their own empty message by default, for things like flash lights
-        if (container.ContainedEntities.Count == 0 && !HasComp<PowerCellSlotComponent>(uid))
+        using (args.PushGroup(nameof(ChargerComponent)))
         {
-            args.PushMarkup(Loc.GetString("charger-empty"));
-        }
-        else
-        {
-            // add how much each item is charged it 
-            foreach (var contained in container.ContainedEntities)
+            // rate at which the charger charges
+            args.PushMarkup(Loc.GetString("charger-examine", ("color", "yellow"), ("chargeRate", (int) component.ChargeRate)));
+
+            // try to get contents of the charger
+            if (!_container.TryGetContainer(uid, component.SlotId, out var container))
+                return;
+
+            // if charger is empty and not a power cell type charger, add empty message
+            // power cells have their own empty message by default, for things like flash lights
+            if (container.ContainedEntities.Count == 0 && !HasComp<PowerCellSlotComponent>(uid))
             {
-                if (!TryComp<BatteryComponent>(contained, out var battery))
-                    return;
+                args.PushMarkup(Loc.GetString("charger-empty"));
+            }
+            else
+            {
+                // add how much each item is charged it 
+                foreach (var contained in container.ContainedEntities)
+                {
+                    if (!TryComp<BatteryComponent>(contained, out var battery))
+                        return;
 
-                var chargePercentage = (battery.CurrentCharge / battery.MaxCharge) * 100;
-                args.PushMarkup(Loc.GetString("charger-content", ("color", "yellow"), ("chargePercentage", (int) chargePercentage)));
+                    var chargePercentage = (battery.CurrentCharge / battery.MaxCharge) * 100;
+                    args.PushMarkup(Loc.GetString("charger-content", ("color", "yellow"), ("chargePercentage", (int) chargePercentage)));
+                }
             }
         }
-        
     }
 
     public override void Update(float frameTime)

--- a/Resources/Locale/en-US/power/components/charger.ftl
+++ b/Resources/Locale/en-US/power/components/charger.ftl
@@ -1,2 +1,4 @@
 charger-examine = Charges at [color={$color}]{$chargeRate}W[/color].
 charger-component-charge-rate = Charge rate
+charger-content = Current charge is at [color={$color}]{$chargePercentage}%[/color].
+charger-empty = There is nothing in the charger.

--- a/Resources/Locale/en-US/power/components/charger.ftl
+++ b/Resources/Locale/en-US/power/components/charger.ftl
@@ -1,4 +1,4 @@
 charger-examine = Charges at [color={$color}]{$chargeRate}W[/color].
 charger-component-charge-rate = Charge rate
-charger-content = Current charge is at [color={$color}]{$chargePercentage}%[/color].
+charger-content = Current charge is at [color=#5E7C16]{$chargePercentage}[/color]%.
 charger-empty = There is nothing in the charger.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Shows the percent charged of the item in rechargers

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Power cell rechargers had it, rechargers for weapons didn't

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/58439124/d35399bd-dba4-475d-ba7a-aa91a521dde7


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Rechargers now show the percent charged of the item it is charging.