### PR TITLE
Beacons no longer glitch off on grid split

### DIFF
--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -237,6 +237,16 @@ public sealed partial class NavMapSystem : SharedNavMapSystem
         component.Chunks.Clear();
         component.Beacons.Clear();
 
+        // Refresh beacons
+        var query = EntityQueryEnumerator<NavMapBeaconComponent, TransformComponent>();
+        while (query.MoveNext(out var qUid, out var qNavComp, out var qTransComp))
+        {
+            if (qTransComp.ParentUid != uid)
+                continue;
+
+            UpdateNavMapBeaconData(qUid, qNavComp);
+        }
+
         // Loop over all tiles
         var tileRefs = _mapSystem.GetAllTiles(uid, mapGrid);
 


### PR DESCRIPTION
## About the PR

The station's multi-million spesos beacon system can no longer be defeated by a single wirecutter

Whenever a grid is split, all beacon (and tile) data is dropped from it's NavMapComponent as part of the cleanup. But unlike tile data, beacons did not get refreshed until now. Presumably since grid splitting is off in Debug mode, no one would notice this while working on grid stuff even if they were looking at a Map screen

Something as little as cutting off a single piece of lattice counts as "splitting" the station grid. I suspect larger explosions could also sometimes rip off a tile or two and cause a "station split".

Fixes #27204

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Map labels no longer suddenly disappear for the rest of the round.