### PR TITLE
Bump TA requirements up to prevent griefing.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 14400 #4 hrs
+      time: 18000 #5 hrs
   startingGear: StationEngineerGear
   icon: "JobIconStationEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobTechnicalAssistant
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 3600 #1 hr
+      time: 10800 #3 hrs
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 54000 #15 hrs


### PR DESCRIPTION
## About the PR
Bumped the Technical assistant to 3hrs req. and station engineer 5hrs req. to help prevent mass sabotage griefing and raiding. Could be higher, when polling admins this was the most common time.

## Why / Balance
A griefer be any role but when they are in a TA/engineering role the round impact is significantly higher and is much easier to grief with. Eg. Power sabotage, mass sabotage with singulo, ame, atmosflood. Hard to fix things like snipping wires all over the station as they get the tools or RCD, axing lots of holes to space.

## Technical details
NA just a yaml change.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
NA

**Changelog**
Don't think this needs one.

