### PR TITLE
Revert "remove firefighting remote and bolting firelocks"

### DIFF
--- a/Resources/Prototypes/Access/engineering.yml
+++ b/Resources/Prototypes/Access/engineering.yml
@@ -16,3 +16,9 @@
   - ChiefEngineer
   - Engineering
   - Atmospherics
+
+- type: accessGroup
+  id: FireFight
+  tags:
+    - Engineering
+    - Atmospherics

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -94,6 +94,7 @@
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
+      - id: DoorRemoteFirefight
       - id: RCD
       - id: RCDAmmo
 
@@ -110,6 +111,7 @@
       - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
+      - id: DoorRemoteFirefight
       - id: RCD
       - id: RCDAmmo
 

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -144,6 +144,24 @@
 
 - type: entity
   parent: DoorRemoteDefault
+  id: DoorRemoteFirefight
+  name: fire-fighting door remote
+  description: A gadget which can open and bolt FireDoors remotely.
+  components:
+    - type: Sprite
+      layers:
+        - state: door_remotebase
+        - state: door_remotelightscolour
+          color: "#ff9900"
+        - state: door_remotescreencolour
+          color: "#e02020"
+
+    - type: Access
+      groups:
+        - FireFight
+
+- type: entity
+  parent: DoorRemoteDefault
   id: DoorRemoteAll
   name: super door remote
   suffix: Admeme

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -105,6 +105,7 @@
       arc: 360
     - type: StaticPrice
       price: 150
+    - type: DoorBolt
     - type: AccessReader
       access: [ [ "Engineering" ] ]
     - type: PryUnpowered

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -342,6 +342,3 @@ chem_master: ChemMaster
 
 # 2024-05-21
 CrateJanitorExplosive: ClosetJanitorBombFilled
-
-# 2024-05-27
-DoorRemoteFirefight: null


### PR DESCRIPTION
## About the PR
Re-adds the fire-fighting door remote.

## Why / Balance

Recently, the #28249 issue and the following #28330 PR removed the fire-fighting door remote from Atmospheric Technicians.

There were several stated reasons:
- "It's too similar to the Engineering door remote";
- "Bolted firedoors cannot be unbolted without a remote";
- "Real-life firedoors can also not be bolted";
- "One person can bolt the entire station!".

And so the remote was removed **in its entirety.**

However:

## Atmospheric technicians are now useless in face of any leak that spans more than one or two rooms.

This was said by multiple people in the comments, and was mostly ignored, after which the PR got merged.

### "Just use a holofan"!
Those have 6 charges, and holofans expire after a short amount of time. You cannot contain a leak that spreads more than 6 doors (for example, one that spread to two or three rooms). They also don't provide nearly enough time to solve a problem other than just spacing everything, and you might not even have enough time for that either.

### "Just weld the firelocks shut!"
Good luck doing that in a plasma or tritium leak. Plus, those also have *very* limited fuel.

### "It has too much access/is too similar to the Engineering door remote!"
If this is a concern as stated, open a PR to remove Engineering access. (Not to mention I haven't heard any CE complain about this, and that's with over 200hrs in Engineering.)

### "You can't bolt them in real life either!"
They are literally fire**locks**. You shouldn't be able to _open_ them to begin with. Not to mention holofans are *so* much further away in terms of realism.

### "One person can bolt the entire station!"
And one person can unbolt it also, such as another Atmos Tech or CE. For AA doors, any department head can unbolt them even. If despite that this is STILL a problem on your server, just make a rule against it, or PR adding a bolt wire to firelocks so anyone can unbolt them.

---

Many of the stated reasons are easily fixable without removing the fire-fighting door remote. The previous PR has basically neutered the Atmos Tech to the point you might as well not be one, lest the entire station hounds your ass for "not doing your job" when all you have is _one_ six-use tool to do so.

## Technical details
Reverted the commit from #28330.

## Media
![Content Client_37CsIBy3Xw](https://github.com/space-wizards/space-station-14/assets/82113471/95f9ba35-2a2d-47bb-99ed-290637520281)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**

:cl:
- fix: Re-added fire-fighting door remote
