### PR TITLE
add: styles for OptionButton

### DIFF
--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -113,6 +113,10 @@ namespace Content.Client.Stylesheets
         public static readonly Color PointGreen = Color.FromHex("#38b026");
         public static readonly Color PointMagenta = Color.FromHex("#FF00FF");
 
+        //OptionButton
+        public static readonly Color OptionButtonBorder = Color.FromHex("#35384C");
+        public static readonly Color OptionButtonBackground = Color.FromHex("#24242B");
+
         // Context menu button colors
         public static readonly Color ButtonColorContext = Color.FromHex("#1119");
         public static readonly Color ButtonColorContextHover = Color.DarkSlateGray;
@@ -1339,6 +1343,11 @@ namespace Content.Client.Stylesheets
                 new StyleRule(new SelectorElement(typeof(Label), new[] { OptionButton.StyleClassOptionButton }, null, null), new[]
                 {
                     new StyleProperty(Label.StylePropertyAlignMode, Label.AlignMode.Center),
+                }),
+
+                new StyleRule(new SelectorElement(typeof(PanelContainer), new[] { OptionButton.StyleClassBackPanel }, null, null), new[]
+                {
+                    new StyleProperty(PanelContainer.StylePropertyPanel, new StyleBoxFlat { BorderColor = OptionButtonBorder, BackgroundColor = OptionButtonBackground, BorderThickness = new Thickness(2, 2, 2, 2) }),
                 }),
 
                 new StyleRule(new SelectorElement(typeof(PanelContainer), new []{ ClassHighDivider}, null, null), new []

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -1345,11 +1345,6 @@ namespace Content.Client.Stylesheets
                     new StyleProperty(Label.StylePropertyAlignMode, Label.AlignMode.Center),
                 }),
 
-                new StyleRule(new SelectorElement(typeof(PanelContainer), new[] { OptionButton.StyleClassBackPanel }, null, null), new[]
-                {
-                    new StyleProperty(PanelContainer.StylePropertyPanel, new StyleBoxFlat { BorderColor = OptionButtonBorder, BackgroundColor = OptionButtonBackground, BorderThickness = new Thickness(2, 2, 2, 2) }),
-                }),
-
                 new StyleRule(new SelectorElement(typeof(PanelContainer), new []{ ClassHighDivider}, null, null), new []
                 {
                     new StyleProperty(PanelContainer.StylePropertyPanel, new StyleBoxFlat { BackgroundColor = NanoGold, ContentMarginBottomOverride = 2, ContentMarginLeftOverride = 2}),
@@ -1608,6 +1603,14 @@ namespace Content.Client.Stylesheets
                     {
                         BackgroundColor = FancyTreeSelectedRowColor,
                     }),
+
+                Element<PanelContainer>().Class(OptionButton.StyleClassBackPanel)
+                    .Prop(PanelContainer.StylePropertyPanel, new StyleBoxFlat
+                    {
+                        BorderColor = OptionButtonBorder,
+                        BackgroundColor = OptionButtonBackground,
+                        BorderThickness = new Thickness(2, 2, 2, 2)
+                    })
             }).ToList());
         }
     }


### PR DESCRIPTION
## About the PR
OptionButton has an opaque background.  
OptionButton is no longer ugly! :tada: 

**BLOCKED PR:**
- https://github.com/space-wizards/RobustToolbox/pull/5201

## Media
![sample](https://github.com/space-wizards/RobustToolbox/assets/1839812/558aa726-d759-4475-9a73-40b652c1f094)

## Changelog

:cl:
- tweak: visual improvement of OptionButton


