### PR TITLE
Make projectile & hitscan reflection only try once with the best reflector

### DIFF
--- a/Content.Shared/Weapons/Reflect/ReflectUserComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectUserComponent.cs
@@ -7,7 +7,4 @@ namespace Content.Shared.Weapons.Reflect;
 /// Reflection events will then be relayed.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class ReflectUserComponent : Component
-{
-
-}
+public sealed partial class ReflectUserComponent : Component;


### PR DESCRIPTION
Liltenhead video causes PR: news at 11.

## About the PR
Make reflection pick the best item currently in inventory to deflect with, rather than iterating through all items.

## Why / Balance
Stacking buffs is pretty much always a design nightmare and stuff like "Juggsuit, EMP implants, two e-swords, RIP game design, I am now God and the Hulk combined" is inevitably the result.

Moving to a "best deflector" strategy simplifies the problems space.

## Technical details
This is a one-file edit without much fanciness here.

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/732532/7fc7aa42-6f53-4f3c-a12d-767a02b466e5

## Breaking changes

**Changelog**

:cl:
- tweak: Stacking multiple deflecting items at once has been removed; now only your best item is used.
