### PR TITLE
rename admin cloak to lizard cloak

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -8,7 +8,7 @@
     sprite: Clothing/Neck/Cloaks/centcomcloakformal.rsi
   - type: StealTarget
     stealGroup: HeadCloak # leaving this here because I suppose it might be interesting?
-    
+
 - type: entity
   parent: ClothingNeckBase
   id: ClothingNeckCloakCap
@@ -118,7 +118,7 @@
 - type: entity
   parent: ClothingNeckBase
   id: ClothingNeckCloakAdmin
-  name: admin cloak
+  name: lizard cloak
   description: Weh!
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -118,7 +118,7 @@
 - type: entity
   parent: ClothingNeckBase
   id: ClothingNeckCloakAdmin
-  name: lizard cloak
+  name: weh cloak
   description: Weh!
   components:
   - type: Sprite


### PR DESCRIPTION
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

- Admins should probably not "exist" in character
- New players seeing an "admin cloak" may think the player is an admin
- Instead of removing all instances of the cloak from obtainable places, rename it to lizard cloak
    - unless any admins particularly like the "admin cloak" in character, this is probably fine to give to the players / leave in the game with a name change

**Changelog**

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl: Whisper

- tweak: Renamed the player-obtainable "admin cloak" to "weh cloak".
