### PR TITLE
remove ingestion / identity blockers from bandanas

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
@@ -7,6 +7,11 @@
     folded: true
   - type: Mask
     isToggled: true
+  - type: IngestionBlocker
+    enabled: false
+  - type: IdentityBlocker
+    enabled: false
+    coverage: MOUTH
   - type: Sprite # needed for vendor inventory icons
     layers:
     - state: icon
@@ -20,51 +25,51 @@
     - Bandana
 
 - type: entity
-  parent: [ClothingHeadBandBase, ClothingMaskBandBlack]
+  parent: [ClothingMaskBandBlack, ClothingHeadBandBase]
   id: ClothingHeadBandBlack
   name: black bandana
 
 - type: entity
-  parent: [ClothingHeadBandBase, ClothingMaskBandBlue]
+  parent: [ClothingMaskBandBlue, ClothingHeadBandBase]
   id: ClothingHeadBandBlue
   name: blue bandana
 
 - type: entity
-  parent: [ClothingHeadBandBase, ClothingMaskBandBotany]
+  parent: [ClothingMaskBandBotany, ClothingHeadBandBase]
   id: ClothingHeadBandBotany
   name: botany bandana
 
 - type: entity
-  parent: [ClothingHeadBandBase, ClothingMaskBandGold]
+  parent: [ClothingMaskBandGold, ClothingHeadBandBase]
   id: ClothingHeadBandGold
   name: gold bandana
 
 - type: entity
-  parent: [ClothingHeadBandBase, ClothingMaskBandGreen]
+  parent: [ClothingMaskBandGreen, ClothingHeadBandBase]
   id: ClothingHeadBandGreen
   name: green bandana
 
 - type: entity
-  parent: [ClothingHeadBandBase, ClothingMaskBandGrey]
+  parent: [ClothingMaskBandGrey, ClothingHeadBandBase]
   id: ClothingHeadBandGrey
   name: grey bandana
 
 - type: entity
-  parent: [ClothingHeadBandBase, ClothingMaskBandRed]
+  parent: [ClothingMaskBandRed, ClothingHeadBandBase]
   id: ClothingHeadBandRed
   name: red bandana
 
 - type: entity
-  parent: [ClothingHeadBandBase, ClothingMaskBandSkull]
+  parent: [ClothingMaskBandSkull, ClothingHeadBandBase]
   id: ClothingHeadBandSkull
   name: skull bandana
 
 - type: entity
-  parent: [ClothingHeadBandBase, ClothingMaskBandMerc]
+  parent: [ClothingMaskBandMerc, ClothingHeadBandBase]
   id: ClothingHeadBandMerc
   name: mercenary bandana
 
 - type: entity
-  parent: [ClothingHeadBandBase, ClothingMaskBandBrown]
+  parent: [ClothingMaskBandBrown, ClothingHeadBandBase]
   id: ClothingHeadBandBrown
   name: brown bandana

--- a/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
@@ -7,7 +7,6 @@
     folded: true
   - type: Mask
     isToggled: true
-    coverage: MOUTH
   - type: Sprite # needed for vendor inventory icons
     layers:
     - state: icon

--- a/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
@@ -7,10 +7,6 @@
     folded: true
   - type: Mask
     isToggled: true
-  - type: IngestionBlocker
-    enabled: false
-  - type: IdentityBlocker
-    enabled: false
     coverage: MOUTH
   - type: Sprite # needed for vendor inventory icons
     layers:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->


Bandanas cover your head, not your face, so they should not block ingestion / identity. This is the intended behavior as `enabled: false` was present on `IngestionBlocker` and `IndentityBlocker` but it does not actually do anything. I don't think it's really necessary to add the disabled marker, since I'm not aware of this being a problem anywhere else, it's just whoever first wrote the yaml made a mistake. 

Fixes #27163.

There are bandanas that cover your mouth too, these block ingestion like normal.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Bandanas no longer prevent you from eating or being identified.