### PR TITLE
Add playtime_adddepartment command

### DIFF
--- a/Content.Server/Administration/Commands/PlayTimeCommands.cs
+++ b/Content.Server/Administration/Commands/PlayTimeCommands.cs
@@ -1,8 +1,10 @@
 ﻿using Content.Server.Players.PlayTimeTracking;
 using Content.Shared.Administration;
 using Content.Shared.Players.PlayTimeTracking;
+using Content.Shared.Roles;
 using Robust.Server.Player;
 using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Administration.Commands;
 
@@ -118,6 +120,83 @@ public sealed class PlayTimeAddRoleCommand : IConsoleCommand
 
         if (args.Length == 3)
             return CompletionResult.FromHint(Loc.GetString("cmd-playtime_addrole-arg-minutes"));
+
+        return CompletionResult.Empty;
+    }
+}
+
+[AdminCommand(AdminFlags.Moderator)]
+public sealed class PlayTimeAddDepartmentCommand : IConsoleCommand
+{
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly PlayTimeTrackingManager _playTimeTracking = default!;
+    [Dependency] private readonly IPrototypeManager _protoManager = default!;
+
+    public string Command => "playtime_adddepartment";
+    public string Description => Loc.GetString("cmd-playtime_adddepartment-desc");
+    public string Help => Loc.GetString("cmd-playtime_adddepartment-help", ("command", Command));
+
+    public async void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 3)
+        {
+            shell.WriteError(Loc.GetString("cmd-playtime_adddepartment-error-args"));
+            return;
+        }
+
+        var userName = args[0];
+        if (!_playerManager.TryGetSessionByUsername(userName, out var player))
+        {
+            shell.WriteError(Loc.GetString("parse-session-fail", ("username", userName)));
+            return;
+        }
+
+        var department = args[1];
+
+        var m = args[2];
+        if (!int.TryParse(m, out var minutes))
+        {
+            shell.WriteError(Loc.GetString("parse-minutes-fail", ("minutes", minutes)));
+            return;
+        }
+
+        if (!_protoManager.TryIndex<DepartmentPrototype>(department, out var proto))
+        {
+            shell.WriteError(Loc.GetString("parse-department-fail", ("department", department)));
+            return;
+        }
+
+        foreach (var roleName in proto.Roles)
+        {
+            var role = "Job" + roleName;
+            _playTimeTracking.AddTimeToTracker(player, role, TimeSpan.FromMinutes(minutes));
+            var time = _playTimeTracking.GetPlayTimeForTracker(player, role);
+            shell.WriteLine(Loc.GetString("cmd-playtime_adddepartment-succeed",
+                ("username", userName),
+                ("role", role),
+                ("department", department),
+                ("time", time)));
+        }
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.SessionNames(players: _playerManager),
+                Loc.GetString("cmd-playtime_adddepartment-arg-user"));
+        }
+
+        if (args.Length == 2)
+        {
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.PrototypeIDs<DepartmentPrototype>(),
+                Loc.GetString("cmd-playtime_adddepartment-arg-department"));
+        }
+
+        if (args.Length == 3)
+            return CompletionResult.FromHint(Loc.GetString("cmd-playtime_adddepartment-arg-minutes"));
 
         return CompletionResult.Empty;
     }

--- a/Resources/Locale/en-US/players/play-time/play-time-commands.ftl
+++ b/Resources/Locale/en-US/players/play-time/play-time-commands.ftl
@@ -20,6 +20,15 @@ cmd-playtime_addrole-arg-role = <role>
 cmd-playtime_addrole-arg-minutes = <minutes>
 cmd-playtime_addrole-error-args = Expected exactly three arguments
 
+# - playtime_addrole
+cmd-playtime_adddepartment-desc = Adds the specified minutes to a player's roles in department playtimes
+cmd-playtime_adddepartment-help = Usage: {$command} <user name> <department> <minutes>
+cmd-playtime_adddepartment-succeed = Increased role in department '{$department}' playtime for {$username} / '{$role}' to {TOSTRING($time, "dddd\\:hh\\:mm")}
+cmd-playtime_adddepartment-arg-user = <user name>
+cmd-playtime_adddepartment-arg-role = <department>
+cmd-playtime_adddepartment-arg-minutes = <minutes>
+cmd-playtime_adddepartment-error-args = Expected exactly three arguments
+
 # - playtime_getoverall
 cmd-playtime_getoverall-desc = Gets the specified minutes for a player's overall playtime
 cmd-playtime_getoverall-help = Usage: {$command} <user name>


### PR DESCRIPTION
## About the PR
Add `playtime_adddepartment` command that adds playtime for all jobs in the department prototype.

## Why / Balance
Speeds up the opening of roles for players.

## Media

![image](https://github.com/space-wizards/space-station-14/assets/38111072/5a0e27ba-e383-4762-b42f-8752e4277f6b)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase