### PR TITLE
Internals are kept on as long as any breathing tool is on

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.BreathTool.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.BreathTool.cs
@@ -12,17 +12,17 @@ public sealed partial class AtmosphereSystem
 
     private void OnBreathToolShutdown(EntityUid uid, BreathToolComponent component, ComponentShutdown args)
     {
-        DisconnectInternals(component);
+        DisconnectInternals(uid, component);
     }
 
-    public void DisconnectInternals(BreathToolComponent component)
+    public void DisconnectInternals(EntityUid uid, BreathToolComponent component)
     {
         var old = component.ConnectedInternalsEntity;
         component.ConnectedInternalsEntity = null;
 
         if (TryComp<InternalsComponent>(old, out var internalsComponent))
         {
-            _internals.DisconnectBreathTool((old.Value, internalsComponent));
+            _internals.DisconnectBreathTool((old.Value, internalsComponent), uid);
         }
 
         component.IsFunctional = false;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.BreathTool.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.BreathTool.cs
@@ -10,21 +10,21 @@ public sealed partial class AtmosphereSystem
         SubscribeLocalEvent<BreathToolComponent, ComponentShutdown>(OnBreathToolShutdown);
     }
 
-    private void OnBreathToolShutdown(EntityUid uid, BreathToolComponent component, ComponentShutdown args)
+    private void OnBreathToolShutdown(Entity<BreathToolComponent> entity, ref ComponentShutdown args)
     {
-        DisconnectInternals(uid, component);
+        DisconnectInternals(entity);
     }
 
-    public void DisconnectInternals(EntityUid uid, BreathToolComponent component)
+    public void DisconnectInternals(Entity<BreathToolComponent> entity)
     {
-        var old = component.ConnectedInternalsEntity;
-        component.ConnectedInternalsEntity = null;
+        var old = entity.Comp.ConnectedInternalsEntity;
+        entity.Comp.ConnectedInternalsEntity = null;
 
         if (TryComp<InternalsComponent>(old, out var internalsComponent))
         {
-            _internals.DisconnectBreathTool((old.Value, internalsComponent), uid);
+            _internals.DisconnectBreathTool((old.Value, internalsComponent), entity.Owner);
         }
 
-        component.IsFunctional = false;
+        entity.Comp.IsFunctional = false;
     }
 }

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -17,6 +17,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Random;
+using System.Linq;
 
 namespace Content.Server.Atmos.EntitySystems
 {
@@ -220,7 +221,7 @@ namespace Content.Server.Atmos.EntitySystems
         public bool CanConnectToInternals(GasTankComponent component)
         {
             var internals = GetInternalsComponent(component, component.User);
-            return internals != null && internals.BreathToolEntity != null && !component.IsValveOpen;
+            return internals != null && internals.BreathTools.Any() && !component.IsValveOpen;
         }
 
         public void ConnectToInternals(Entity<GasTankComponent> ent)

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -17,7 +17,6 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Random;
-using System.Linq;
 
 namespace Content.Server.Atmos.EntitySystems
 {
@@ -221,7 +220,7 @@ namespace Content.Server.Atmos.EntitySystems
         public bool CanConnectToInternals(GasTankComponent component)
         {
             var internals = GetInternalsComponent(component, component.User);
-            return internals != null && internals.BreathTools.Any() && !component.IsValveOpen;
+            return internals != null && internals.BreathTools.Count != 0 && !component.IsValveOpen;
         }
 
         public void ConnectToInternals(Entity<GasTankComponent> ent)

--- a/Content.Server/Body/Components/InternalsComponent.cs
+++ b/Content.Server/Body/Components/InternalsComponent.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Body.Components
         public EntityUid? GasTankEntity;
 
         [ViewVariables]
-        public EntityUid? BreathToolEntity;
+        public HashSet<EntityUid> BreathTools { get; set; } = new();
 
         /// <summary>
         /// Toggle Internals delay when the target is not you.

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -183,7 +183,7 @@ public sealed class InternalsSystem : EntitySystem
         ent.Comp.BreathTools.Remove(toolEntity);
 
         if (TryComp(toolEntity, out BreathToolComponent? breathTool))
-            _atmos.DisconnectInternals(toolEntity, breathTool);
+            _atmos.DisconnectInternals((toolEntity, breathTool));
 
         if (ent.Comp.BreathTools.Count == 0)
             DisconnectTank(ent);

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -193,7 +193,9 @@ public sealed class InternalsSystem : EntitySystem
 
     public void ConnectBreathTool(Entity<InternalsComponent> ent, EntityUid toolEntity)
     {
-        ent.Comp.BreathTools.Add(toolEntity);
+        if (!ent.Comp.BreathTools.Add(toolEntity))
+            return;
+
         _alerts.ShowAlert(ent, ent.Comp.InternalsAlert, GetSeverity(ent));
     }
 

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -12,7 +12,6 @@ using Content.Shared.Roles;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.Utility;
-using System.Linq;
 
 namespace Content.Server.Body.Systems;
 
@@ -45,7 +44,7 @@ public sealed class InternalsSystem : EntitySystem
 
     private void OnStartingGear(EntityUid uid, InternalsComponent component, ref StartingGearEquippedEvent args)
     {
-        if (!component.BreathTools.Any())
+        if (component.BreathTools.Count == 0)
             return;
 
         if (component.GasTankEntity != null)
@@ -112,7 +111,7 @@ public sealed class InternalsSystem : EntitySystem
         }
 
         // If they're not on then check if we have a mask to use
-        if (!internals.BreathTools.Any())
+        if (internals.BreathTools.Count == 0)
         {
             _popupSystem.PopupEntity(Loc.GetString("internals-no-breath-tool"), uid, user);
             return;
@@ -186,7 +185,7 @@ public sealed class InternalsSystem : EntitySystem
         if (TryComp(toolEntity, out BreathToolComponent? breathTool))
             _atmos.DisconnectInternals(toolEntity, breathTool);
 
-        if (!ent.Comp.BreathTools.Any())
+        if (ent.Comp.BreathTools.Count == 0)
             DisconnectTank(ent);
 
         _alerts.ShowAlert(ent, ent.Comp.InternalsAlert, GetSeverity(ent));
@@ -212,7 +211,7 @@ public sealed class InternalsSystem : EntitySystem
 
     public bool TryConnectTank(Entity<InternalsComponent> ent, EntityUid tankEntity)
     {
-        if (!ent.Comp.BreathTools.Any())
+        if (ent.Comp.BreathTools.Count == 0)
             return false;
 
         if (TryComp(ent.Comp.GasTankEntity, out GasTankComponent? tank))
@@ -238,7 +237,7 @@ public sealed class InternalsSystem : EntitySystem
 
     private short GetSeverity(InternalsComponent component)
     {
-        if (!component.BreathTools.Any() || !AreInternalsWorking(component))
+        if (component.BreathTools.Count == 0 || !AreInternalsWorking(component))
             return 2;
 
         // If pressure in the tank is below low pressure threshold, flash warning on internals UI

--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -29,7 +29,7 @@ public sealed class LungSystem : EntitySystem
 
     private void OnGotUnequipped(Entity<BreathToolComponent> ent, ref GotUnequippedEvent args)
     {
-        _atmosphereSystem.DisconnectInternals(ent);
+        _atmosphereSystem.DisconnectInternals(ent.Owner, ent.Comp);
     }
 
     private void OnGotEquipped(Entity<BreathToolComponent> ent, ref GotEquippedEvent args)
@@ -59,7 +59,7 @@ public sealed class LungSystem : EntitySystem
     {
         if (args.IsToggled || args.IsEquip)
         {
-            _atmos.DisconnectInternals(ent.Comp);
+            _atmos.DisconnectInternals(ent.Owner, ent.Comp);
         }
         else
         {

--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -29,7 +29,7 @@ public sealed class LungSystem : EntitySystem
 
     private void OnGotUnequipped(Entity<BreathToolComponent> ent, ref GotUnequippedEvent args)
     {
-        _atmosphereSystem.DisconnectInternals(ent.Owner, ent.Comp);
+        _atmosphereSystem.DisconnectInternals(ent);
     }
 
     private void OnGotEquipped(Entity<BreathToolComponent> ent, ref GotEquippedEvent args)
@@ -59,7 +59,7 @@ public sealed class LungSystem : EntitySystem
     {
         if (args.IsToggled || args.IsEquip)
         {
-            _atmos.DisconnectInternals(ent.Owner, ent.Comp);
+            _atmos.DisconnectInternals(ent);
         }
         else
         {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Before the change:
Taking off your helmet or mask would toggle off internals even if you had both on.

After the change:
If you have both a mask and helmet on with internals turned on, and you un-equip either, internals will stay on until you take off both.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #27643 and #28567

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
InternalsComponent now uses a HashSet of breathing tools rather than just tracking a single breathing tool, all other code adjusted to account for the possibility of multiple breathing tools and the removal of the correct tool.

Uh... it... it kind of feels overkill to use a HashSet when the largest it can be at the moment is... two entities...? but yeah

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


https://github.com/space-wizards/space-station-14/assets/58439124/de6c86f3-b8fa-46b6-9b89-2939c7282cad

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
InternalsComponent `public EntityUid? BreathToolEntity;` changed to `HashSet<EntityUid> BreathTools { get; set; } = new();`

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Internals are no longer toggled off if you take your helmet off but still have a gas mask on and vice versa.