### PR TITLE
aHelp fixes and improvements

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
@@ -30,7 +30,11 @@ namespace Content.Client.Administration.UI.Bwoink
                 }
             };
 
-            OnOpen += () => Bwoink.PopulateList();
+            OnOpen += () =>
+            {
+                Bwoink.ChannelSelector.StopFiltering();
+                Bwoink.PopulateList();
+            };
         }
     }
 }

--- a/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml.cs
+++ b/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml.cs
@@ -153,7 +153,7 @@ namespace Content.Client.Administration.UI.CustomControls
 
             var pinButton = new Button
             {
-                Text = info.IsPinned ? "Unpin" : "Pin",
+                Text = info.IsPinned ? Loc.GetString("bwoink-system-unpinned-button-text") : Loc.GetString("bwoink-system-pinned-button-text"),
                 HorizontalAlignment = HAlignment.Right
             };
             pinButton.AddStyleClass("OpenRight");

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -112,7 +112,7 @@ namespace Content.Server.Administration.Systems
                 if (_activeConversations.TryGetValue(e.Session.UserId, out var lastMessageTime))
                 {
                     var timeSinceLastMessage = DateTime.Now - lastMessageTime;
-                    if (timeSinceLastMessage > TimeSpan.FromMinutes(10))
+                    if (timeSinceLastMessage > TimeSpan.FromMinutes(5))
                     {
                         _activeConversations.Remove(e.Session.UserId);
                         return; // Do not send disconnect message if timeout exceeded

--- a/Content.Shared/Administration/PlayerInfo.cs
+++ b/Content.Shared/Administration/PlayerInfo.cs
@@ -18,6 +18,8 @@ namespace Content.Shared.Administration
     {
         private string? _playtimeString;
 
+        public bool IsPinned { get; set; }
+
         public string PlaytimeString => _playtimeString ??=
             OverallPlaytime?.ToString("%d':'hh':'mm") ?? Loc.GetString("generic-unknown-title");
 

--- a/Resources/Locale/en-US/administration/bwoink.ftl
+++ b/Resources/Locale/en-US/administration/bwoink.ftl
@@ -14,3 +14,10 @@ bwoink-system-typing-indicator = {$players} {$count ->
 admin-bwoink-play-sound = Bwoink?
 
 bwoink-title-none-selected = None selected
+
+bwoink-system-player-disconnecting = has disconnected.
+bwoink-system-player-reconnecting = has reconnected.
+bwoink-system-player-banned = has been banned for: {$banReason}
+
+bwoink-system-unpinned-button-text = Unpin
+bwoink-system-pinned-button-text = Pin


### PR DESCRIPTION
## About the PR

Some fixes and upgrades for aHelp window.
Fixes #13604 No longer keeps text in search after closing aHelp
Fixes #23716 When a user from an active ahelp, Active being a message was sent in the last 5min a message in the ahelp will shot and also be sent to the discord relay.
Fixes #12583 Player list can now be pinned. @Chief-Engineer Maybe we can move that last point to its own issue.

## Why / Balance
Admin efficiency, better visibility if the player you are even talking to is there.

## Technical details
- Modified playerlistcontrol to allow pinning of the players and set to top.
- Updated bwoinksystem to report out to aHelp and discord relay when the aHelped player connects, disconnects or gets serverbanned.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/47093363/5bdd6170-1508-4a59-8854-6da4187f12e6)
![image](https://github.com/space-wizards/space-station-14/assets/47093363/592b2cd9-9882-4929-ba39-e476d5134573)
![image](https://github.com/space-wizards/space-station-14/assets/47093363/63853c77-19b5-4257-92dd-077d7c35e342)
![image](https://github.com/space-wizards/space-station-14/assets/47093363/b05c26d1-3a62-4832-a701-5e1a88c2e07c)
![image](https://github.com/space-wizards/space-station-14/assets/47093363/ffdb2a02-178e-460b-9d56-5bf25a793efc)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**

:cl: Repo
ADMIN:
- add: aHelp Player pinning
- add: Disconnection, reconnection, banning notice on relay and ahelp.
- fix: Clears search on aHelp Close

