### PR TITLE
Removes CLF3

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -752,7 +752,6 @@
     - Thermite
     - Napalm
     - Phlogiston
-    - ChlorineTrifluoride
     - FoamingAgent
     - BuzzochloricBees
     - RobustHarvest

--- a/Resources/Prototypes/Hydroponics/mutations.yml
+++ b/Resources/Prototypes/Hydroponics/mutations.yml
@@ -21,7 +21,6 @@
     - SulfuricAcid
     - Licoxide
     - Napalm
-    - ChlorineTrifluoride
     - Radium
     - Gold
     - Uranium

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -93,45 +93,6 @@
       - !type:Ignite
 
 - type: reagent
-  id: ChlorineTrifluoride
-  name: reagent-name-chlorine-trifluoride
-  parent: BasePyrotechnic
-  desc: reagent-desc-chlorine-trifluoride
-  physicalDesc: reagent-physical-desc-blazing
-  flavor: bitter
-  color: "#FFC8C8"
-  tileReactions:
-  - !type:PryTileReaction
-  metabolisms:
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Heat: 2
-            Poison: 1
-            Caustic: 0.5 # CLF3 is corrosive
-      - !type:FlammableReaction
-        multiplier: 0.2
-      - !type:AdjustTemperature
-        amount: 6000
-  reactiveEffects:
-    Flammable:
-      methods: [ Touch ]
-      effects:
-      - !type:FlammableReaction
-        multiplier: 0.3
-      - !type:Ignite
-      - !type:Emote
-        emote: Scream
-        probability: 0.2
-      - !type:PopupMessage
-        messages: [ "clf3-it-burns", "clf3-get-away" ]
-        visualType: MediumCaution
-        probability: 0.3
-        type: Local
-
-- type: reagent
   id: FoamingAgent
   name: reagent-name-foaming-agent
   parent: BasePyrotechnic

--- a/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
+++ b/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
@@ -30,29 +30,6 @@
     Phlogiston: 3
 
 - type: reaction
-  id: ChlorineTrifluoride
-  minTemp: 370
-  priority: 20
-  reactants:
-    Chlorine:
-      amount: 1
-    Fluorine:
-      amount: 3
-  effects:
-  - !type:ExplosionReactionEffect
-    explosionType: Default # 15 damage per intensity.
-    maxIntensity: 200
-    intensityPerUnit: 5
-    intensitySlope: 5
-    maxTotalIntensity: 200
-  - !type:PopupMessage
-    messages: [ "clf3-explosion" ]
-    type: Pvs
-    visualType: LargeCaution
-  products:
-    ChlorineTrifluoride: 4
-
-- type: reaction
   id: Ash
   minTemp: 520
   reactants:


### PR DESCRIPTION
## About the PR
Removes CLF3 from the game.
Addresses part of #28606.

## Why / Balance
CLF3 in its current state is just better potassium + water that is barely more difficult to synthesize. This is not only boring as hell, but is very abusable (hence the linked issue.) Non-antagonists should probably not be able to semi-trivially synthesize explosives that are actively *good* at breaching the hull with a recipe that only requires two base reagents & a bit of heating up.

Maybe I *could* use the firebomb explosion type to make something more interesting & balanced, but explosions are difficult to tune & the PCTide is soon:tm:. From my limited testing with FireBomb explosions, I'm frankly not even sure you *can* make something that doesn't breach the hull while still doing some amount of fire damage.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Probably none???

**Changelog**
:cl:
- remove: Removed CLF3.
