### PR TITLE
Nerfs welderbombing

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
@@ -32,7 +32,7 @@
   - type: PacifismDangerousAttack
   - type: Explosive
     explosionType: Default
-    totalIntensity: 120 # ~ 5 tile radius
+    totalIntensity: 60 # Mediocre explosion. Not enough to do any meaningful structural damage to anything other then windows, provided you're only using one tank.
 
 - type: entity
   id: WeldingFuelTankFull
@@ -74,7 +74,7 @@
         maxVol: 5000
   - type: Explosive
     explosionType: Default
-    totalIntensity: 140
+    totalIntensity: 120
 
 # Water
 


### PR DESCRIPTION
## About the PR
Nerfs welderbombing to a (hopefully) much more reasonable level of destruction (half of the value it used to be set at.)
Addresses part of #28606.

To quote the comment I wrote:
``# Mediocre explosion. Not enough to do any meaningful structural damage to anything other then windows, provided you're only using one tank.``

## Why / Balance
Fuel tanks being able to space hull and do real damage is very abusable. This hopefully makes them more reasonable while not making welderbombing completely useless.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- tweak: Nerfed the explosive power of fuel tanks.