### PR TITLE
allow ' in character names

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -25,7 +25,7 @@ namespace Content.Shared.Preferences
     [Serializable, NetSerializable]
     public sealed partial class HumanoidCharacterProfile : ICharacterProfile
     {
-        private static readonly Regex RestrictedNameRegex = new("[^A-Z,a-z,0-9, -]");
+        private static readonly Regex RestrictedNameRegex = new("[^A-Z,a-z,0-9, ,\\-,']");
         private static readonly Regex ICNameCaseRegex = new(@"^(?<word>\w)|\b(?<word>\w)(?=\w*$)");
 
         public const int MaxNameLength = 32;


### PR DESCRIPTION
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Allows players to add ' to their character names
use case examples:
- Reptilians, Sar'eni
- Human style nicknames (in servers that allow this), Moren 'Jitters' Rathens

**Changelog**

:cl: Whisper, DrSmugleaf
- add: Players can now add ' to their character names. Please ensure your character names still follow server naming conventions.