### PR TITLE
Make freeze, freeze & mute, and unmute verbs work on disconnected players.

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -131,59 +131,6 @@ namespace Content.Server.Administration.Systems
                     prayerVerb.Impact = LogImpact.Low;
                     args.Verbs.Add(prayerVerb);
 
-                    // Freeze
-                    var frozen = TryComp<AdminFrozenComponent>(args.Target, out var frozenComp);
-                    var frozenAndMuted = frozenComp?.Muted ?? false;
-
-                    if (!frozen)
-                    {
-                        args.Verbs.Add(new Verb
-                        {
-                            Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
-                            Text = Loc.GetString("admin-verbs-freeze"),
-                            Category = VerbCategory.Admin,
-                            Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
-                            Act = () =>
-                            {
-                                EnsureComp<AdminFrozenComponent>(args.Target);
-                            },
-                            Impact = LogImpact.Medium,
-                        });
-                    }
-
-                    if (!frozenAndMuted)
-                    {
-                        // allow you to additionally mute someone when they are already frozen
-                        args.Verbs.Add(new Verb
-                        {
-                            Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
-                            Text = Loc.GetString("admin-verbs-freeze-and-mute"),
-                            Category = VerbCategory.Admin,
-                            Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
-                            Act = () =>
-                            {
-                                _freeze.FreezeAndMute(args.Target);
-                            },
-                            Impact = LogImpact.Medium,
-                        });
-                    }
-
-                    if (frozen)
-                    {
-                        args.Verbs.Add(new Verb
-                        {
-                            Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
-                            Text = Loc.GetString("admin-verbs-unfreeze"),
-                            Category = VerbCategory.Admin,
-                            Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
-                            Act = () =>
-                            {
-                                RemComp<AdminFrozenComponent>(args.Target);
-                            },
-                            Impact = LogImpact.Medium,
-                        });
-                    }
-
                     // Erase
                     args.Verbs.Add(new Verb
                     {
@@ -262,6 +209,60 @@ namespace Content.Server.Administration.Systems
                         Impact = LogImpact.High,
                     });
                 }
+
+                // Freeze
+                var frozen = TryComp<AdminFrozenComponent>(args.Target, out var frozenComp);
+                var frozenAndMuted = frozenComp?.Muted ?? false;
+
+                if (!frozen)
+                {
+                    args.Verbs.Add(new Verb
+                    {
+                        Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
+                        Text = Loc.GetString("admin-verbs-freeze"),
+                        Category = VerbCategory.Admin,
+                        Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
+                        Act = () =>
+                        {
+                            EnsureComp<AdminFrozenComponent>(args.Target);
+                        },
+                        Impact = LogImpact.Medium,
+                    });
+                }
+
+                if (!frozenAndMuted)
+                {
+                    // allow you to additionally mute someone when they are already frozen
+                    args.Verbs.Add(new Verb
+                    {
+                        Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
+                        Text = Loc.GetString("admin-verbs-freeze-and-mute"),
+                        Category = VerbCategory.Admin,
+                        Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
+                        Act = () =>
+                        {
+                            _freeze.FreezeAndMute(args.Target);
+                        },
+                        Impact = LogImpact.Medium,
+                    });
+                }
+
+                if (frozen)
+                {
+                    args.Verbs.Add(new Verb
+                    {
+                        Priority = -1, // This is just so it doesn't change position in the menu between freeze/unfreeze.
+                        Text = Loc.GetString("admin-verbs-unfreeze"),
+                        Category = VerbCategory.Admin,
+                        Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/snow.svg.192dpi.png")),
+                        Act = () =>
+                        {
+                            RemComp<AdminFrozenComponent>(args.Target);
+                        },
+                        Impact = LogImpact.Medium,
+                    });
+                }
+
 
                 // Admin Logs
                 if (_adminManager.HasAdminFlag(player, AdminFlags.Logs))


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This makes the freeze, freeze & mute, and unfreeze verb work on any entity.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The verbs do not require an ICommonSession to function.
Admins often wish to apply these verbs to disconnected players.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

I moved the code out of the if block for the actorcomponent.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
ADMIN:
- tweak: Freeze, freeze & mute, and unfreeze verbs now work on any entity. Not just connected players. 