### PR TITLE
fixed "silicones" typo in new rules

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleTypes.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleTypes.xml
@@ -17,5 +17,5 @@
   Familiars are considered non-antagonists, but have instructions to obey someone. They must obey this person even if it causes them to violate roleplay rules or die. You are only a familiar if the game clearly and explicitly tells you that you are a familiar. You are only the familiar of the person the game tells you.
 
   ## Silicon
-  Silicones have a set of laws that they must follow above all else except the core rules. You are only silicon if the game clearly and explicitly tells you that you are a silicon.
+  Silicons have a set of laws that they must follow above all else except the core rules. You are only silicon if the game clearly and explicitly tells you that you are a silicon.
 </Document>

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR0.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR0.xml
@@ -8,7 +8,7 @@
 
   See the list of [textlink="role types" link="RoleTypes"] for more information about the different types of roles.
 
-  - [textlink="1. Silicones must follow Silicon Rules" link="RuleR1"]
+  - [textlink="1. Silicons must follow Silicon Rules" link="RuleR1"]
   - [textlink="2. Familiars must obey their master" link="RuleR2"]
   - [textlink="3. Roleplay a normal person" link="RuleR3"]
   - [textlink="4. Do not metagame, obey the Metashield" link="RuleR4"]

--- a/Resources/ServerInfo/Guidebook/ServerRules/WizDenLRPRules.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/WizDenLRPRules.xml
@@ -33,7 +33,7 @@
 
   See the list of [textlink="role types" link="RoleTypes"] for more information about the different types of roles.
 
-  - [textlink="1. Silicones must follow Silicon Rules" link="RuleR1"]
+  - [textlink="1. Silicons must follow Silicon Rules" link="RuleR1"]
   - [textlink="2. Familiars must obey their master" link="RuleR2"]
   - [textlink="3. Roleplay a normal person" link="RuleR3"]
   - [textlink="4. Do not metagame, obey the Metashield" link="RuleR4"]

--- a/Resources/ServerInfo/Guidebook/ServerRules/WizDenMRPRules.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/WizDenMRPRules.xml
@@ -33,7 +33,7 @@
 
   See the list of [textlink="role types" link="RoleTypes"] for more information about the different types of roles.
 
-  - [textlink="1. Silicones must follow Silicon Rules" link="RuleR1"]
+  - [textlink="1. Silicons must follow Silicon Rules" link="RuleR1"]
   - [textlink="2. Familiars must obey their master" link="RuleR2"]
   - [textlink="3. Roleplay a normal person" link="RuleR3"]
   - [textlink="4. Do not metagame, obey the Metashield" link="RuleR4"]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
![image](https://github.com/space-wizards/space-station-14/assets/62638182/c5aa6a12-ca84-423c-b261-a1beeb67d5a3)
I fixed this. In the 4 places it appears.

## Why / Balance
silicone = rubber, silicon = the element used in the production of semiconductors. Same thing applies to plurals.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Don't think an ingame changelog makes sense for a simple typofix