### PR TITLE
Return medicine recipe solid material costs to 1

### DIFF
--- a/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
@@ -13,7 +13,7 @@
   time: 10
   solids:
     FoodPoppy: 1
-    Brutepack: 10
+    Brutepack: 1
     MaterialCloth1: 1
   reagents:
     TranexamicAcid: 20
@@ -26,7 +26,7 @@
   time: 10
   solids:
     FoodAloe: 1
-    Ointment: 10
+    Ointment: 1
     MaterialCloth1: 1
   reagents:
     Sigynate: 20


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Return medicine recipe solid material costs to 1

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
My previous PR changed the required solid materials from 1->10 and it appears this was not intended behavior.
Fixes #28667

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: blueDev2
- tweak: Rebalanced medicated suture and regen mesh to only require 1 brute pack/ointment respectively
