### PR TITLE
shorten short raffle

### DIFF
--- a/Resources/Prototypes/GhostRoleRaffles/settings.yml
+++ b/Resources/Prototypes/GhostRoleRaffles/settings.yml
@@ -11,5 +11,5 @@
   id: short
   settings:
     initialDuration: 10
-    joinExtendsDurationBy: 5
-    maxDuration: 30
+    joinExtendsDurationBy: 2
+    maxDuration: 15


### PR DESCRIPTION
## About the PR
Title says it

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Solves #27751 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
From 30 max seconds to 15 seconds
Increase raffle time by joining a raffle from 5 seconds to 2 seconds.
Initial time left as is, 10 seconds

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Short Raffle is now much shorter.