### PR TITLE
Fix action icons when dragging an active action to another slot

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -289,6 +289,10 @@ public sealed class ActionButton : Control, IEntityControl
         {
             if (_action.IconOn != null)
                 SetActionIcon(_spriteSys.Frame0(_action.IconOn));
+            else if (_action.Icon != null)
+                SetActionIcon(_spriteSys.Frame0(_action.Icon));
+            else
+                SetActionIcon(null);
 
             if (_action.BackgroundOn != null)
                 _buttonBackgroundTexture = _spriteSys.Frame0(_action.BackgroundOn);


### PR DESCRIPTION
## About the PR
Without this, dragging an active action either duplicates the icon of the action that was there before, or leaves an empty space.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
