### PR TITLE
remove IDCARD dependency on jumpsuit

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
@@ -61,7 +61,6 @@
       stripTime: 6
       uiWindowPos: 2,1
       strippingWindowPos: 2,4
-      dependsOn: jumpsuit
       displayName: ID
     - name: belt
       slotTexture: belt

--- a/Resources/Prototypes/InventoryTemplates/diona_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/diona_inventory_template.yml
@@ -95,7 +95,6 @@
       stripTime: 6
       uiWindowPos: 2,1
       strippingWindowPos: 2,4
-      dependsOn: jumpsuit
       displayName: ID
     - name: belt
       slotTexture: belt

--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -101,7 +101,6 @@
       stripTime: 6
       uiWindowPos: 2,1
       strippingWindowPos: 2,4
-      dependsOn: jumpsuit
       displayName: ID
     - name: belt
       slotTexture: belt

--- a/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
@@ -35,7 +35,6 @@
     stripTime: 6
     uiWindowPos: 2,1
     strippingWindowPos: 2,4
-    dependsOn: jumpsuit
     displayName: ID
   - name: suitstorage
     slotTexture: suit_storage


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
In the YAML files for all creatures that can hold a PDA, I removed IDCARD slots' dependency on the jumpsuit slot.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
as mentioned in issue #28604, one potential noob-trap mechanic is losing your PDA when you switch your jumpsuit. this causes the PDA to be unequipped, and might be forgotten & left behind. this aims to resolve the issue by removing the need for a jumpsuit to carry your PDA

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
YAML file changes

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Players no longer drop their PDA upon unequipping their jumpsuit.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
