### PR TITLE
Dropping Corpses Devoured by Space Dragons on Gib/Butcher. 

### DIFF
--- a/Content.Server/Devour/DevourSystem.cs
+++ b/Content.Server/Devour/DevourSystem.cs
@@ -48,7 +48,7 @@ public sealed class DevourSystem : SharedDevourSystem
         _audioSystem.PlayPvs(component.SoundDevour, uid);
     }
     
-        private void OnGibContents(EntityUid uid, DevourerComponent component, ref BeingGibbedEvent args)
+    private void OnGibContents(EntityUid uid, DevourerComponent component, ref BeingGibbedEvent args)
     {
         if (!component.ShouldStoreDevoured)
             return;

--- a/Content.Server/Devour/DevourSystem.cs
+++ b/Content.Server/Devour/DevourSystem.cs
@@ -47,6 +47,7 @@ public sealed class DevourSystem : SharedDevourSystem
 
         _audioSystem.PlayPvs(component.SoundDevour, uid);
     }
+    
         private void OnGibContents(EntityUid uid, DevourerComponent component, ref BeingGibbedEvent args)
     {
         if (!component.ShouldStoreDevoured)

--- a/Content.Server/Devour/DevourSystem.cs
+++ b/Content.Server/Devour/DevourSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Devour;
@@ -15,6 +16,7 @@ public sealed class DevourSystem : SharedDevourSystem
         base.Initialize();
 
         SubscribeLocalEvent<DevourerComponent, DevourDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<DevourerComponent, BeingGibbedEvent>(OnGibContents);
     }
 
     private void OnDoAfter(EntityUid uid, DevourerComponent component, DevourDoAfterEvent args)
@@ -44,6 +46,15 @@ public sealed class DevourSystem : SharedDevourSystem
         }
 
         _audioSystem.PlayPvs(component.SoundDevour, uid);
+    }
+        private void OnGibContents(EntityUid uid, DevourerComponent component, ref BeingGibbedEvent args)
+    {
+        if (!component.ShouldStoreDevoured)
+            return;
+
+        // For some reason we have two different systems that should handle gibbing,
+        // and for some another reason GibbingSystem, which should empty all containers, doesn't get involved in this process
+        ContainerSystem.EmptyContainer(component.Stomach);
     }
 }
 


### PR DESCRIPTION
## About the PR
Space Dragon upon being gibbed/butchered now drops the bodies of those they have consumed. This PR is credited to user Mnemotechnician, who originally submitted it downstream to DV. https://github.com/DeltaV-Station/Delta-v/pull/1308

They have given their permission to PR this upstream under your MIT license.

## Why / Balance
Bug fix to issue https://github.com/space-wizards/space-station-14/issues/20405

## Technical details
Made DevourSystem empty the stomach container of the Devourer when it's being gibbed (butchering includes gibbing).

## Media

https://github.com/space-wizards/space-station-14/assets/49795619/a5f44c84-aa2b-43b7-90db-ae3b3f84d911

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl:
- fix: Space Dragons will drop bodies upon being gibbed/butchered
