### PR TITLE
Ports the singularity's values from vgstation

### DIFF
--- a/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
+++ b/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
@@ -134,7 +134,7 @@ public sealed class SingularitySystem : SharedSingularitySystem
         {
 			// Normally, a level 6 singularity requires the supermatter + 3000 energy.
 			// The required amount of energy has been bumped up to compensate for the lack of the supermatter.
-            >= 4000 => 6,
+            >= 5000 => 6,
             >= 2000 => 5,
             >= 1000 => 4,
             >= 500 => 3,

--- a/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
+++ b/Content.Server/Singularity/EntitySystems/SingularitySystem.cs
@@ -132,10 +132,12 @@ public sealed class SingularitySystem : SharedSingularitySystem
         singularity.Energy = value;
         SetLevel(uid, value switch
         {
-            >= 2400 => 6,
-            >= 1600 => 5,
-            >= 900 => 4,
-            >= 300 => 3,
+			// Normally, a level 6 singularity requires the supermatter + 3000 energy.
+			// The required amount of energy has been bumped up to compensate for the lack of the supermatter.
+            >= 4000 => 6,
+            >= 2000 => 5,
+            >= 1000 => 4,
+            >= 500 => 3,
             >= 200 => 2,
             > 0 => 1,
             _ => 0
@@ -319,11 +321,11 @@ public sealed class SingularitySystem : SharedSingularitySystem
     {
         comp.EnergyDrain = args.NewValue switch
         {
-            6 => 20,
-            5 => 15,
-            4 => 12,
-            3 => 8,
-            2 => 2,
+            6 => 0,
+            5 => 0,
+            4 => 20,
+            3 => 10,
+            2 => 5,
             1 => 1,
             _ => 0
         };

--- a/Resources/ServerInfo/Guidebook/Engineering/Singularity.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering/Singularity.xml
@@ -88,8 +88,7 @@
 
   [color=red]Do not[/color] turn the PA on unless all the other subsystems are working properly and there is enough power to start the engine.
 
-  Turn power on using the PA control computer. Set the strength to an appropiate level. Currently the only appropriate level is [color=#f0684d]1[/color]; anything above that will ensure that singularity grows too strong to handle.
-  The higher the output stength is set on PA control computer, the bigger the singularity will be.
+  Turn power on using the PA control computer. Set the strength to an appropiate level. The higher the output stength is set on PA control computer, the bigger the singularity will be.
 
   Currently, the output power does not affect the ball lightning, beyond giving the ball lightning extra orbs around it.
 


### PR DESCRIPTION
## About the PR
Ports the singulo values from vgstation, with the exception of the level 6 singularity (which should hopefully be a lot harder to achieve, now.) Overall, the singularity now drains much faster & requires more energy to increase in stage. The most notable gameplay ramifications this has are:

- Particle strength 1 sustains the singularity at level 2, and particle strength 2 & 3 sustain it at 2-3. The hacked particle strength 4 will still set the the singularity loose.
- Singularities above level 5 will not decay.
- Particle Deccelerators are now probably significantly better.

## Why / Balance
The values we have now are completely wrong in comparison to SS13, and make the singularity even more abusable then it is there. Being able to loose the singularity with any level above 1 is extremely stupid, and makes level 2 & 3 basically pointless.

Additionally: the level 6 singularity in SS13 also only occurred while eating a supermatter shard. Obviously, we don't have this, so I felt like raising the energy requirement to be significantly higher was a good way of simulating that rarity & scariness.

## Technical details
Changes the values in SingularitySystem.cs for ``singularity.Energy`` and ``comp.EnergyDrain`` to match their equivalent values from vgstation.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- tweak: The singularity now drains energy much faster, and takes more effort to reach higher stages. This means that you can no longer set the singularity loose with the particle accelerator, unless you hack it.