### PR TITLE
add notification for dependent wearables being dropped

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -424,15 +424,21 @@ public abstract partial class InventorySystem
             return false;
         }
 
+        bool droppedItems = false;
         foreach (var slotDef in inventory.Slots)
         {
             if (slotDef != slotDefinition && slotDef.DependsOn == slotDefinition.Name)
             {
                 //this recursive call might be risky
                 if (TryUnequip(actor, target, slotDef.Name, true, true, predicted, inventory, reparent: reparent))
-                    _popup.PopupPredicted(Loc.GetString("inventory-component-dropped-from-unequip"), target, target);
+                    droppedItems = true;
             }
         }
+
+        // we check if any items were dropped, and make a popup if they were.
+        // this doesn't guarantee that only 1 popup will be shown if multiple items were dropped in recursion.
+        if (droppedItems)
+            _popup.PopupPredicted(Loc.GetString("inventory-component-dropped-from-unequip"), target, target);
 
         if (!_containerSystem.Remove(removedItem.Value, slotContainer, force: force, reparent: reparent))
             return false;

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -447,7 +447,7 @@ public abstract partial class InventorySystem
             return false;
 
         // this is in order to keep track of whether this is the first instance of a recursion call
-        bool firstRun = itemsDropped == 0;
+        var firstRun = itemsDropped == 0;
         ++itemsDropped;
 
         foreach (var slotDef in inventory.Slots)
@@ -462,8 +462,8 @@ public abstract partial class InventorySystem
         // we check if any items were dropped, and make a popup if they were.
         // the reason we check for > 1 is because the first item is always the one we are trying to unequip,
         // whereas we only want to notify for extra dropped items.
-        if (firstRun && itemsDropped > 1)
-            _popup.PopupClient(Loc.GetString("inventory-component-dropped-from-unequip", ("items", itemsDropped)), target, target);
+        if (!silent && _gameTiming.IsFirstTimePredicted && firstRun && itemsDropped > 1)
+            _popup.PopupClient(Loc.GetString("inventory-component-dropped-from-unequip", ("items", itemsDropped - 1)), target, target);
 
         // TODO: Inventory needs a hot cleanup hoo boy
         // Check if something else (AKA toggleable) dumped it into a container.

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -47,7 +47,7 @@ public abstract partial class InventorySystem
 
     private void OnEntRemoved(EntityUid uid, InventoryComponent component, EntRemovedFromContainerMessage args)
     {
-        if(!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
+        if (!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
             return;
 
         var unequippedEvent = new DidUnequipEvent(uid, args.Entity, slotDef);
@@ -59,8 +59,8 @@ public abstract partial class InventorySystem
 
     private void OnEntInserted(EntityUid uid, InventoryComponent component, EntInsertedIntoContainerMessage args)
     {
-        if(!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
-           return;
+        if (!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
+            return;
 
         var equippedEvent = new DidEquipEvent(uid, args.Entity, slotDef);
         RaiseLocalEvent(uid, equippedEvent, true);
@@ -119,7 +119,7 @@ public abstract partial class InventorySystem
 
         RaiseLocalEvent(held.Value, new HandDeselectedEvent(actor));
 
-        TryEquip(actor, actor, held.Value, ev.Slot, predicted: true, inventory: inventory, force: true, checkDoafter:true);
+        TryEquip(actor, actor, held.Value, ev.Slot, predicted: true, inventory: inventory, force: true, checkDoafter: true);
     }
 
     public bool TryEquip(EntityUid uid, EntityUid itemUid, string slot, bool silent = false, bool force = false, bool predicted = false,
@@ -131,7 +131,7 @@ public abstract partial class InventorySystem
     {
         if (!Resolve(target, ref inventory, false))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-equip-cannot"));
             return false;
         }
@@ -142,14 +142,14 @@ public abstract partial class InventorySystem
 
         if (!TryGetSlotContainer(target, slot, out var slotContainer, out var slotDefinition, inventory))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-equip-cannot"));
             return false;
         }
 
         if (!force && !CanEquip(actor, target, itemUid, slot, out var reason, slotDefinition, inventory, clothing))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString(reason));
             return false;
         }
@@ -183,7 +183,7 @@ public abstract partial class InventorySystem
 
         if (!_containerSystem.Insert(itemUid, slotContainer))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
             return false;
         }
@@ -370,14 +370,14 @@ public abstract partial class InventorySystem
 
         if (!Resolve(target, ref inventory, false))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
             return false;
         }
 
         if (!TryGetSlotContainer(target, slot, out var slotContainer, out var slotDefinition, inventory))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
             return false;
         }
@@ -389,7 +389,7 @@ public abstract partial class InventorySystem
 
         if (!force && !CanUnequip(actor, target, slot, out var reason, slotContainer, slotDefinition, inventory))
         {
-            if(!silent && _gameTiming.IsFirstTimePredicted)
+            if (!silent && _gameTiming.IsFirstTimePredicted)
                 _popup.PopupCursor(Loc.GetString(reason));
             return false;
         }
@@ -429,7 +429,8 @@ public abstract partial class InventorySystem
             if (slotDef != slotDefinition && slotDef.DependsOn == slotDefinition.Name)
             {
                 //this recursive call might be risky
-                TryUnequip(actor, target, slotDef.Name, true, true, predicted, inventory, reparent: reparent);
+                if (TryUnequip(actor, target, slotDef.Name, true, true, predicted, inventory, reparent: reparent))
+                    _popup.PopupPredicted(Loc.GetString("inventory-component-dropped-from-unequip"), target, target);
             }
         }
 
@@ -467,7 +468,7 @@ public abstract partial class InventorySystem
         if ((containerSlot == null || slotDefinition == null) && !TryGetSlotContainer(target, slot, out containerSlot, out slotDefinition, inventory))
             return false;
 
-        if (containerSlot.ContainedEntity is not {} itemUid)
+        if (containerSlot.ContainedEntity is not { } itemUid)
             return false;
 
         if (!_containerSystem.CanRemove(itemUid, containerSlot))

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -438,7 +438,7 @@ public abstract partial class InventorySystem
         // we check if any items were dropped, and make a popup if they were.
         // this doesn't guarantee that only 1 popup will be shown if multiple items were dropped in recursion.
         if (droppedItems)
-            _popup.PopupPredicted(Loc.GetString("inventory-component-dropped-from-unequip"), target, target);
+            _popup.PopupClient(Loc.GetString("inventory-component-dropped-from-unequip"), target, target);
 
         if (!_containerSystem.Remove(removedItem.Value, slotContainer, force: force, reparent: reparent))
             return false;

--- a/Resources/Locale/en-US/inventory/components/inventory-component.ftl
+++ b/Resources/Locale/en-US/inventory/components/inventory-component.ftl
@@ -5,6 +5,6 @@ inventory-component-can-unequip-cannot = You can't unequip this!
 
 inventory-component-dropped-from-unequip =
     You dropped {$items ->
-    [2] an item!
+    [1] an item!
     *[other] some items!
 }

--- a/Resources/Locale/en-US/inventory/components/inventory-component.ftl
+++ b/Resources/Locale/en-US/inventory/components/inventory-component.ftl
@@ -2,3 +2,5 @@ inventory-component-can-equip-cannot = You can't equip this!
 inventory-component-can-equip-does-not-fit = This doesn't fit!
 
 inventory-component-can-unequip-cannot = You can't unequip this!
+
+inventory-component-dropped-from-unequip = You dropped an item!

--- a/Resources/Locale/en-US/inventory/components/inventory-component.ftl
+++ b/Resources/Locale/en-US/inventory/components/inventory-component.ftl
@@ -3,4 +3,8 @@ inventory-component-can-equip-does-not-fit = This doesn't fit!
 
 inventory-component-can-unequip-cannot = You can't unequip this!
 
-inventory-component-dropped-from-unequip = You dropped an item!
+inventory-component-dropped-from-unequip =
+    You dropped {$items ->
+    [2] an item!
+    *[other] some items!
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
added a notification for dependent wearables being dropped when the parent clothing is removed (i.e. PDA dropped when jumpsuit removed)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
in relation to issue #28604, this gives a notification when the PDA is dropped. this also doubles purpose in giving a notification if any dependent wearables are dropped as well, 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
this adds a single locale string & an additional check inside the unequip system of the inventory.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/49499807/242afe19-fdde-4e31-bc07-db4241939e66


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: added a popup to notify when extra items are removed from your inventory while unequipping something

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
