### PR TITLE
Don't use invalid defaults for loadouts

### DIFF
--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -120,7 +120,10 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
                     if (loadouts.Contains(defaultLoadout))
                         continue;
 
-                    // Still need to apply the effects even if validation is ignored.
+                    // Not valid so don't default to it anyway.
+                    if (!IsValid(profile, session, defaultLoadout.Prototype, collection, out _))
+                        continue;
+
                     loadouts.Add(defaultLoadout);
                     Apply(loadoutProto);
                 }


### PR DESCRIPTION
At the time it made more sense trying to fill anything but now with species specific stuff it's better to have nothing.

Mostly not player-facing.