### PR TITLE
Maybe fix invalid loadout prototypes

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -467,10 +467,10 @@ namespace Content.Shared.Preferences
             var configManager = collection.Resolve<IConfigurationManager>();
             var prototypeManager = collection.Resolve<IPrototypeManager>();
 
-            if (!prototypeManager.TryIndex<SpeciesPrototype>(Species, out var speciesPrototype) || speciesPrototype.RoundStart == false)
+            if (!prototypeManager.TryIndex(Species, out var speciesPrototype) || speciesPrototype.RoundStart == false)
             {
                 Species = SharedHumanoidAppearanceSystem.DefaultSpecies;
-                speciesPrototype = prototypeManager.Index<SpeciesPrototype>(Species);
+                speciesPrototype = prototypeManager.Index(Species);
             }
 
             var sex = Sex switch

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -59,6 +59,10 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
             return;
         }
 
+        // In some instances SetDefault is not called, e.g. if we're loading data from the server
+        // in those cases we want to fallback group changes to defaults
+        SetDefault(protoManager);
+
         // Reset points to recalculate.
         Points = roleProto.Points;
 
@@ -146,6 +150,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     /// <summary>
     /// Resets the selected loadouts to default if no data is present.
     /// </summary>
+    /// <param name="force">Clear existing data first</param>
     public void SetDefault(IPrototypeManager protoManager, bool force = false)
     {
         if (force)

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -59,9 +59,15 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
             return;
         }
 
-        // In some instances SetDefault is not called, e.g. if we're loading data from the server
-        // in those cases we want to fallback group changes to defaults
-        SetDefault(protoManager);
+        // In some instances we might not have picked up a new group for existing data.
+        foreach (var groupProto in roleProto.Groups)
+        {
+            if (SelectedLoadouts.ContainsKey(groupProto))
+                continue;
+
+            // Data will get set below.
+            SelectedLoadouts[groupProto] = new List<Loadout>();
+        }
 
         // Reset points to recalculate.
         Points = roleProto.Points;


### PR DESCRIPTION
So if we have existing data SetDefault is not normally called iirc. So what I think is happening is that if we have old loadout groups that get saved to DB and loaded these get dropped entirely and nothing is used to replace the group unless the person specifically looks at their loadout.

Need someone affected to send me their loadout to confirm it's fixed.

:cl:
- fix: Fix sometimes spawning without bags.