### PR TITLE
Fix RoleLoadout equality

### DIFF
--- a/Content.Shared/Preferences/Loadouts/Loadout.cs
+++ b/Content.Shared/Preferences/Loadouts/Loadout.cs
@@ -7,8 +7,25 @@ namespace Content.Shared.Preferences.Loadouts;
 /// Specifies the selected prototype and custom data for a loadout.
 /// </summary>
 [Serializable, NetSerializable, DataDefinition]
-public sealed partial class Loadout
+public sealed partial class Loadout : IEquatable<Loadout>
 {
     [DataField]
     public ProtoId<LoadoutPrototype> Prototype;
+
+    public bool Equals(Loadout? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Prototype.Equals(other.Prototype);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return ReferenceEquals(this, obj) || obj is Loadout other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return Prototype.GetHashCode();
+    }
 }

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -274,7 +274,24 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     {
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
-        return Role.Equals(other.Role) && SelectedLoadouts.SequenceEqual(other.SelectedLoadouts) && Points == other.Points;
+
+        if (!Role.Equals(other.Role) || SelectedLoadouts.Count != other.SelectedLoadouts.Count ||
+            Points != other.Points)
+        {
+            return false;
+        }
+
+        // Tried using SequenceEqual but it stinky so.
+        foreach (var (key, value) in SelectedLoadouts)
+        {
+            if (!other.SelectedLoadouts.TryGetValue(key, out var otherValue) ||
+                !otherValue.SequenceEqual(value))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public override bool Equals(object? obj)

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -275,7 +275,8 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
 
-        if (!Role.Equals(other.Role) || SelectedLoadouts.Count != other.SelectedLoadouts.Count ||
+        if (!Role.Equals(other.Role) ||
+            SelectedLoadouts.Count != other.SelectedLoadouts.Count ||
             Points != other.Points)
         {
             return false;


### PR DESCRIPTION
Knew it was janky but thought SequenceEqual was better than it is so we just do it manually.

:cl:
- fix: Fix the character profile sometimes thinking there's changes to save even if the loadouts haven't changed.