### PR TITLE
fix singulo decay

### DIFF
--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.Emitter.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.Emitter.cs
@@ -49,7 +49,7 @@ public sealed partial class ParticleAcceleratorSystem
                 ParticleAcceleratorPowerState.Level0 => 1,
                 ParticleAcceleratorPowerState.Level1 => 2,
                 ParticleAcceleratorPowerState.Level2 => 3,
-                ParticleAcceleratorPowerState.Level3 => 10,
+                ParticleAcceleratorPowerState.Level3 => 6,
                 _ => 0,
             } * 10;
         }

--- a/Content.Shared/Singularity/Components/SingularityComponent.cs
+++ b/Content.Shared/Singularity/Components/SingularityComponent.cs
@@ -81,26 +81,4 @@ public sealed partial class SingularityComponent : Component
     );
 
     #endregion Audio
-
-    #region Update Timing
-
-    /// <summary>
-    /// The amount of time that should elapse between automated updates to this singularity.
-    /// </summary>
-    [DataField("updatePeriod")]
-    [ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan TargetUpdatePeriod = TimeSpan.FromSeconds(1.0);
-
-    /// <summary>
-    /// </summary>
-    [ViewVariables(VVAccess.ReadOnly)]
-    public TimeSpan NextUpdateTime = default!;
-
-    /// <summary>
-    /// The last time this singularity was updated.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadOnly)]
-    public TimeSpan LastUpdateTime = default!;
-
-    #endregion Update Timing
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes #28733

fixes issues where PA level 2 & 3 would still grow too fast for the singulo and it would inevitably loose.

Now level 2 is stable at stage 3 singulo with a minor downward trend and level 3 hovers between stage 3 and 4 singulo.

i tested both for several minutes and didn't see any trends upwards or unexpected breaches running them.

additionally nerfs the level 4 particles quite a bit since i was able to trivially get to level 6 using it.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Level 2 & 3 being death buttons is lame.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a check so that singulofood entities dont also get the generic consumption energy as well.

Changes the decay to not use timespans and instead just modify based on deltatime.
The timespan issue caused imprecision which led to frequent issues where despite the numbers lining up, the singulo wouldn't decay fast enough to match the PA.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- fix: Fixed singularity decay being underpowered, leading to continuous growth on higher PA strengths.
