### PR TITLE
Buffs the particle decelerator

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -379,6 +379,34 @@
       startingCharge: 10000
 
 - type: entity
+  name: portable particle decelerator x2
+  suffix: DEBUG
+  parent: WeaponParticleDecelerator
+  id: WeaponParticleDeceleratorX2
+  description: A particle decelerator that simulates 2 people firing them at once.
+  components:
+    - type: Gun
+      fireRate: 1
+      fireCost: 500
+    - type: Battery
+      maxCharge: 20000
+      startingCharge: 20000
+
+- type: entity
+  name: portable particle decelerator x3
+  suffix: DEBUG
+  parent: BaseWeaponBattery
+  id: WeaponParticleDeceleratorX3
+  description: A particle decelerator that simulates 3 people firing them at once.
+  components:
+    - type: Gun
+      fireRate: 1.5
+      fireCost: 500
+    - type: Battery
+      maxCharge: 30000
+      startingCharge: 30000
+
+- type: entity
   name: x-ray cannon
   parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponXrayCannon

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -77,4 +77,4 @@
   - type: TimedDespawn
     lifetime: 0.6
   - type: SinguloFood
-    energy: -100
+    energy: -65

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -77,4 +77,4 @@
   - type: TimedDespawn
     lifetime: 0.6
   - type: SinguloFood
-    energy: -125
+    energy: -100

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -77,4 +77,4 @@
   - type: TimedDespawn
     lifetime: 0.6
   - type: SinguloFood
-    energy: -10
+    energy: -125


### PR DESCRIPTION
## About the PR
Buffs the particle decelerator to be 6.5x stronger (-10 energy to -65 energy.)
In theory, this is still not good enough to do much with 1 player firing, but makes teams of players actually useful.

Also adds debug prototypes for buffed particle decelerators, to simulate multiple players.

## Why / Balance
-10 singularity energy is ridiculously terrible - you'd need a team of 10+ people to even put a dent in a low level singularity. This should make particle decelerators actually usable for situations outside of admin-spawned ERTs.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- tweak: Particle decelerators are now significantly stronger.
