### PR TITLE
Remove Entity<SolutionComponent> from components

### DIFF
--- a/Content.Server/Animals/Components/UdderComponent.cs
+++ b/Content.Server/Animals/Components/UdderComponent.cs
@@ -27,12 +27,6 @@ namespace Content.Server.Animals.Components
         public string SolutionName = "udder";
 
         /// <summary>
-        ///     The solution to add reagent to.
-        /// </summary>
-        [DataField]
-        public Entity<SolutionComponent>? Solution = null;
-
-        /// <summary>
         ///     The amount of reagent to be generated on update.
         /// </summary>
         [DataField, ViewVariables(VVAccess.ReadOnly)]

--- a/Content.Server/Animals/Components/WoolyComponent.cs
+++ b/Content.Server/Animals/Components/WoolyComponent.cs
@@ -27,12 +27,6 @@ public sealed partial class WoolyComponent : Component
     public string SolutionName = "wool";
 
     /// <summary>
-    ///     The solution to add reagent to.
-    /// </summary>
-    [DataField]
-    public Entity<SolutionComponent>? Solution;
-
-    /// <summary>
     ///     The amount of reagent to be generated on update.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly)]

--- a/Content.Server/Animals/Systems/UdderSystem.cs
+++ b/Content.Server/Animals/Systems/UdderSystem.cs
@@ -61,11 +61,11 @@ internal sealed class UdderSystem : EntitySystem
                 _hunger.ModifyHunger(uid, -udder.HungerUsage, hunger);
             }
 
-            if (!_solutionContainerSystem.ResolveSolution(uid, udder.SolutionName, ref udder.Solution))
+            if (!_solutionContainerSystem.TryGetSolution(uid, udder.SolutionName, out var solutionEnt))
                 continue;
 
             //TODO: toxins from bloodstream !?
-            _solutionContainerSystem.TryAddReagent(udder.Solution.Value, udder.ReagentId, udder.QuantityPerUpdate, out _);
+            _solutionContainerSystem.TryAddReagent(solutionEnt.Value, udder.ReagentId, udder.QuantityPerUpdate, out _);
         }
     }
 
@@ -89,7 +89,7 @@ internal sealed class UdderSystem : EntitySystem
         if (args.Cancelled || args.Handled || args.Args.Used == null)
             return;
 
-        if (!_solutionContainerSystem.ResolveSolution(entity.Owner, entity.Comp.SolutionName, ref entity.Comp.Solution, out var solution))
+        if (!_solutionContainerSystem.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out var solutionEnt, out var solution))
             return;
 
         if (!_solutionContainerSystem.TryGetRefillableSolution(args.Args.Used.Value, out var targetSoln, out var targetSolution))
@@ -106,7 +106,7 @@ internal sealed class UdderSystem : EntitySystem
         if (quantity > targetSolution.AvailableVolume)
             quantity = targetSolution.AvailableVolume;
 
-        var split = _solutionContainerSystem.SplitSolution(entity.Comp.Solution.Value, quantity);
+        var split = _solutionContainerSystem.SplitSolution(solutionEnt.Value, quantity);
         _solutionContainerSystem.TryAddSolution(targetSoln.Value, split);
 
         _popupSystem.PopupEntity(Loc.GetString("udder-system-success", ("amount", quantity), ("target", Identity.Entity(args.Args.Used.Value, EntityManager))), entity.Owner,

--- a/Content.Server/Animals/Systems/WoolySystem.cs
+++ b/Content.Server/Animals/Systems/WoolySystem.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Timing;
 namespace Content.Server.Animals.Systems;
 
 /// <summary>
-///     Gives ability to produce fiber reagents, produces endless if the 
+///     Gives ability to produce fiber reagents, produces endless if the
 ///     owner has no HungerComponent
 /// </summary>
 public sealed class WoolySystem : EntitySystem
@@ -52,10 +52,10 @@ public sealed class WoolySystem : EntitySystem
                 _hunger.ModifyHunger(uid, -wooly.HungerUsage, hunger);
             }
 
-            if (!_solutionContainer.ResolveSolution(uid, wooly.SolutionName, ref wooly.Solution))
+            if (!_solutionContainer.TryGetSolution(uid, wooly.SolutionName, out var solutionEnt))
                 continue;
 
-            _solutionContainer.TryAddReagent(wooly.Solution.Value, wooly.ReagentId, wooly.Quantity, out _);
+            _solutionContainer.TryAddReagent(solutionEnt.Value, wooly.ReagentId, wooly.Quantity, out _);
         }
     }
 

--- a/Content.Server/Anomaly/Components/ReagentProducerAnomalyComponent.cs
+++ b/Content.Server/Anomaly/Components/ReagentProducerAnomalyComponent.cs
@@ -93,10 +93,4 @@ public sealed partial class ReagentProducerAnomalyComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("solution")]
     public string SolutionName = "default";
-
-    /// <summary>
-    /// Solution where the substance is generated
-    /// </summary>
-    [DataField("solutionRef")]
-    public Entity<SolutionComponent>? Solution = null;
 }

--- a/Content.Server/Anomaly/Effects/ReagentProducerAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/ReagentProducerAnomalySystem.cs
@@ -68,7 +68,7 @@ public sealed class ReagentProducerAnomalySystem : EntitySystem
             if (component.AccumulatedFrametime < component.UpdateInterval)
                 continue;
 
-            if (!_solutionContainer.ResolveSolution(uid, component.SolutionName, ref component.Solution, out var producerSolution))
+            if (!_solutionContainer.TryGetSolution(uid, component.SolutionName, out var solutionEnt, out var producerSolution))
                 continue;
 
             Solution newSol = new();
@@ -76,7 +76,7 @@ public sealed class ReagentProducerAnomalySystem : EntitySystem
             if (anomaly.Severity >= 0.97) reagentProducingAmount *= component.SupercriticalReagentProducingModifier;
 
             newSol.AddReagent(component.ProducingReagent, reagentProducingAmount);
-            _solutionContainer.TryAddSolution(component.Solution.Value, newSol); //TO DO - the container is not fully filled. 
+            _solutionContainer.TryAddSolution(solutionEnt.Value, newSol); //TO DO - the container is not fully filled.
 
             component.AccumulatedFrametime = 0;
 

--- a/Content.Server/Atmos/Piping/Unary/Components/GasCondenserComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasCondenserComponent.cs
@@ -23,12 +23,6 @@ public sealed partial class GasCondenserComponent : Component
     public string SolutionId = "tank";
 
     /// <summary>
-    /// The solution that gases are condensed into.
-    /// </summary>
-    [DataField]
-    public Entity<SolutionComponent>? Solution = null;
-
-    /// <summary>
     /// For a condenser, how many U of reagents are given per each mole of gas.
     /// </summary>
     /// <remarks>

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCondenserSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCondenserSystem.cs
@@ -32,7 +32,7 @@ public sealed class GasCondenserSystem : EntitySystem
     {
         if (!(TryComp<ApcPowerReceiverComponent>(entity, out var receiver) && _power.IsPowered(entity, receiver))
             || !_nodeContainer.TryGetNode(entity.Owner, entity.Comp.Inlet, out PipeNode? inlet)
-            || !_solution.ResolveSolution(entity.Owner, entity.Comp.SolutionId, ref entity.Comp.Solution, out var solution))
+            || !_solution.TryGetSolution(entity.Owner, entity.Comp.SolutionId, out var solutionEnt, out var solution))
         {
             return;
         }
@@ -62,7 +62,7 @@ public sealed class GasCondenserSystem : EntitySystem
             inlet.Air.AdjustMoles(i, moles - (amount.Float() / moleToReagentMultiplier));
         }
 
-        _solution.UpdateChemicals(entity.Comp.Solution.Value);
+        _solution.UpdateChemicals(solutionEnt.Value);
     }
 
     public float NumberOfMolesToConvert(ApcPowerReceiverComponent comp, GasMixture mix, float dt)

--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -1,7 +1,6 @@
 using Content.Server.Body.Systems;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Shared.Alert;
-using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
@@ -135,37 +134,25 @@ namespace Content.Server.Body.Components
         [DataField]
         public ProtoId<ReagentPrototype> BloodReagent = "Blood";
 
-        /// <summary>Name/Key that <see cref="BloodSolution"/> is indexed by.</summary>
+        /// <summary>
+        /// Internal solution for blood storage
+        /// </summary>
         [DataField]
         public string BloodSolutionName = DefaultBloodSolutionName;
 
-        /// <summary>Name/Key that <see cref="ChemicalSolution"/> is indexed by.</summary>
+        /// <summary>
+        /// Internal solution for reagent storage
+        /// </summary>
         [DataField]
         public string ChemicalSolutionName = DefaultChemicalsSolutionName;
 
-        /// <summary>Name/Key that <see cref="TemporarySolution"/> is indexed by.</summary>
+        /// <summary>
+        /// Temporary blood solution.
+        /// When blood is lost, it goes to this solution, and when this
+        /// solution hits a certain cap, the blood is actually spilled as a puddle.
+        /// </summary>
         [DataField]
         public string BloodTemporarySolutionName = DefaultBloodTemporarySolutionName;
-
-        /// <summary>
-        ///     Internal solution for blood storage
-        /// </summary>
-        [DataField]
-        public Entity<SolutionComponent>? BloodSolution = null;
-
-        /// <summary>
-        ///     Internal solution for reagent storage
-        /// </summary>
-        [DataField]
-        public Entity<SolutionComponent>? ChemicalSolution = null;
-
-        /// <summary>
-        ///     Temporary blood solution.
-        ///     When blood is lost, it goes to this solution, and when this
-        ///     solution hits a certain cap, the blood is actually spilled as a puddle.
-        /// </summary>
-        [DataField]
-        public Entity<SolutionComponent>? TemporarySolution = null;
 
         /// <summary>
         /// Variable that stores the amount of status time added by having a low blood level.

--- a/Content.Server/Body/Components/LungComponent.cs
+++ b/Content.Server/Body/Components/LungComponent.cs
@@ -24,12 +24,6 @@ public sealed partial class LungComponent : Component
     public string SolutionName = LungSystem.LungSolutionName;
 
     /// <summary>
-    /// The solution on this entity that these lungs act on.
-    /// </summary>
-    [DataField]
-    public Entity<SolutionComponent>? Solution = null;
-
-    /// <summary>
     /// The type of gas this lung needs. Used only for the breathing alerts, not actual metabolism.
     /// </summary>
     [DataField]

--- a/Content.Server/Body/Components/StomachComponent.cs
+++ b/Content.Server/Body/Components/StomachComponent.cs
@@ -23,12 +23,6 @@ namespace Content.Server.Body.Components
         public TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
 
         /// <summary>
-        ///     The solution inside of this stomach this transfers reagents to the body.
-        /// </summary>
-        [DataField]
-        public Entity<SolutionComponent>? Solution = null;
-
-        /// <summary>
         ///     What solution should this stomach push reagents into, on the body?
         /// </summary>
         [DataField]

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -115,7 +115,7 @@ public sealed class BloodstreamSystem : EntitySystem
 
             bloodstream.NextUpdate += bloodstream.UpdateInterval;
 
-            if (!_solutionContainerSystem.ResolveSolution(uid, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution))
+            if (!_solutionContainerSystem.TryGetSolution(uid, bloodstream.BloodSolutionName, out var bloodSolutionEnt, out var bloodSolution))
                 continue;
 
             // Adds blood to their blood level if it is below the maximum; Blood regeneration. Must be alive.
@@ -280,11 +280,11 @@ public sealed class BloodstreamSystem : EntitySystem
     {
         TryModifyBleedAmount(entity.Owner, -entity.Comp.BleedAmount, entity.Comp);
 
-        if (_solutionContainerSystem.ResolveSolution(entity.Owner, entity.Comp.BloodSolutionName, ref entity.Comp.BloodSolution, out var bloodSolution))
+        if (_solutionContainerSystem.TryGetSolution(entity.Owner, entity.Comp.BloodSolutionName, out _, out var bloodSolution))
             TryModifyBloodLevel(entity.Owner, bloodSolution.AvailableVolume, entity.Comp);
 
-        if (_solutionContainerSystem.ResolveSolution(entity.Owner, entity.Comp.ChemicalSolutionName, ref entity.Comp.ChemicalSolution))
-            _solutionContainerSystem.RemoveAllSolution(entity.Comp.ChemicalSolution.Value);
+        if (_solutionContainerSystem.TryGetSolution(entity.Owner, entity.Comp.ChemicalSolutionName, out var chemSolutionEnt))
+            _solutionContainerSystem.RemoveAllSolution(chemSolutionEnt.Value);
     }
 
     /// <summary>
@@ -293,14 +293,14 @@ public sealed class BloodstreamSystem : EntitySystem
     public bool TryAddToChemicals(EntityUid uid, Solution solution, BloodstreamComponent? component = null)
     {
         return Resolve(uid, ref component, logMissing: false)
-            && _solutionContainerSystem.ResolveSolution(uid, component.ChemicalSolutionName, ref component.ChemicalSolution)
-            && _solutionContainerSystem.TryAddSolution(component.ChemicalSolution.Value, solution);
+            && _solutionContainerSystem.TryGetSolution(uid, component.ChemicalSolutionName, out var chemSolutionEnt)
+            && _solutionContainerSystem.TryAddSolution(chemSolutionEnt.Value, solution);
     }
 
     public bool FlushChemicals(EntityUid uid, string excludedReagentID, FixedPoint2 quantity, BloodstreamComponent? component = null)
     {
         if (!Resolve(uid, ref component, logMissing: false)
-            || !_solutionContainerSystem.ResolveSolution(uid, component.ChemicalSolutionName, ref component.ChemicalSolution, out var chemSolution))
+            || !_solutionContainerSystem.TryGetSolution(uid, component.ChemicalSolutionName, out var chemSolutionEnt, out var chemSolution))
             return false;
 
         for (var i = chemSolution.Contents.Count - 1; i >= 0; i--)
@@ -308,7 +308,7 @@ public sealed class BloodstreamSystem : EntitySystem
             var (reagentId, _) = chemSolution.Contents[i];
             if (reagentId.Prototype != excludedReagentID)
             {
-                _solutionContainerSystem.RemoveReagent(component.ChemicalSolution.Value, reagentId, quantity);
+                _solutionContainerSystem.RemoveReagent(chemSolutionEnt.Value, reagentId, quantity);
             }
         }
 
@@ -318,7 +318,7 @@ public sealed class BloodstreamSystem : EntitySystem
     public float GetBloodLevelPercentage(EntityUid uid, BloodstreamComponent? component = null)
     {
         if (!Resolve(uid, ref component)
-            || !_solutionContainerSystem.ResolveSolution(uid, component.BloodSolutionName, ref component.BloodSolution, out var bloodSolution))
+            || !_solutionContainerSystem.TryGetSolution(uid, component.BloodSolutionName, out _, out var bloodSolution))
         {
             return 0.0f;
         }
@@ -340,20 +340,20 @@ public sealed class BloodstreamSystem : EntitySystem
     public bool TryModifyBloodLevel(EntityUid uid, FixedPoint2 amount, BloodstreamComponent? component = null)
     {
         if (!Resolve(uid, ref component, logMissing: false)
-            || !_solutionContainerSystem.ResolveSolution(uid, component.BloodSolutionName, ref component.BloodSolution))
+            || !_solutionContainerSystem.TryGetSolution(uid, component.BloodSolutionName, out var bloodSolutionEnt))
         {
             return false;
         }
 
         if (amount >= 0)
-            return _solutionContainerSystem.TryAddReagent(component.BloodSolution.Value, component.BloodReagent, amount, out _);
+            return _solutionContainerSystem.TryAddReagent(bloodSolutionEnt.Value, component.BloodReagent, amount, out _);
 
         // Removal is more involved,
         // since we also wanna handle moving it to the temporary solution
         // and then spilling it if necessary.
-        var newSol = _solutionContainerSystem.SplitSolution(component.BloodSolution.Value, -amount);
+        var newSol = _solutionContainerSystem.SplitSolution(bloodSolutionEnt.Value, -amount);
 
-        if (!_solutionContainerSystem.ResolveSolution(uid, component.BloodTemporarySolutionName, ref component.TemporarySolution, out var tempSolution))
+        if (!_solutionContainerSystem.TryGetSolution(uid, component.BloodTemporarySolutionName, out var tempSolutionEnt, out var tempSolution))
             return true;
 
         tempSolution.AddSolution(newSol, _prototypeManager);
@@ -361,9 +361,9 @@ public sealed class BloodstreamSystem : EntitySystem
         if (tempSolution.Volume > component.BleedPuddleThreshold)
         {
             // Pass some of the chemstream into the spilled blood.
-            if (_solutionContainerSystem.ResolveSolution(uid, component.ChemicalSolutionName, ref component.ChemicalSolution))
+            if (_solutionContainerSystem.TryGetSolution(uid, component.ChemicalSolutionName, out var chemSolutionEnt))
             {
-                var temp = _solutionContainerSystem.SplitSolution(component.ChemicalSolution.Value, tempSolution.Volume / 10);
+                var temp = _solutionContainerSystem.SplitSolution(chemSolutionEnt.Value, tempSolution.Volume / 10);
                 tempSolution.AddSolution(temp, _prototypeManager);
             }
 
@@ -375,7 +375,7 @@ public sealed class BloodstreamSystem : EntitySystem
             tempSolution.RemoveAllSolution();
         }
 
-        _solutionContainerSystem.UpdateChemicals(component.TemporarySolution.Value);
+        _solutionContainerSystem.UpdateChemicals(tempSolutionEnt.Value);
 
         return true;
     }
@@ -412,25 +412,25 @@ public sealed class BloodstreamSystem : EntitySystem
 
         var tempSol = new Solution();
 
-        if (_solutionContainerSystem.ResolveSolution(uid, component.BloodSolutionName, ref component.BloodSolution, out var bloodSolution))
+        if (_solutionContainerSystem.TryGetSolution(uid, component.BloodSolutionName, out var bloodSolutionEnt, out var bloodSolution))
         {
             tempSol.MaxVolume += bloodSolution.MaxVolume;
             tempSol.AddSolution(bloodSolution, _prototypeManager);
-            _solutionContainerSystem.RemoveAllSolution(component.BloodSolution.Value);
+            _solutionContainerSystem.RemoveAllSolution(bloodSolutionEnt.Value);
         }
 
-        if (_solutionContainerSystem.ResolveSolution(uid, component.ChemicalSolutionName, ref component.ChemicalSolution, out var chemSolution))
+        if (_solutionContainerSystem.TryGetSolution(uid, component.ChemicalSolutionName, out var chemSolutionEnt, out var chemSolution))
         {
             tempSol.MaxVolume += chemSolution.MaxVolume;
             tempSol.AddSolution(chemSolution, _prototypeManager);
-            _solutionContainerSystem.RemoveAllSolution(component.ChemicalSolution.Value);
+            _solutionContainerSystem.RemoveAllSolution(chemSolutionEnt.Value);
         }
 
-        if (_solutionContainerSystem.ResolveSolution(uid, component.BloodTemporarySolutionName, ref component.TemporarySolution, out var tempSolution))
+        if (_solutionContainerSystem.TryGetSolution(uid, component.BloodTemporarySolutionName, out var tempSolutionEnt, out var tempSolution))
         {
             tempSol.MaxVolume += tempSolution.MaxVolume;
             tempSol.AddSolution(tempSolution, _prototypeManager);
-            _solutionContainerSystem.RemoveAllSolution(component.TemporarySolution.Value);
+            _solutionContainerSystem.RemoveAllSolution(tempSolutionEnt.Value);
         }
 
         if (_puddleSystem.TrySpillAt(uid, tempSol, out var puddleUid))
@@ -450,7 +450,7 @@ public sealed class BloodstreamSystem : EntitySystem
             return;
         }
 
-        if (!_solutionContainerSystem.ResolveSolution(uid, component.BloodSolutionName, ref component.BloodSolution, out var bloodSolution))
+        if (!_solutionContainerSystem.TryGetSolution(uid, component.BloodSolutionName, out var bloodSolutionEnt, out var bloodSolution))
         {
             component.BloodReagent = reagent;
             return;
@@ -461,6 +461,6 @@ public sealed class BloodstreamSystem : EntitySystem
         component.BloodReagent = reagent;
 
         if (currentVolume > 0)
-            _solutionContainerSystem.TryAddReagent(component.BloodSolution.Value, component.BloodReagent, currentVolume, out _);
+            _solutionContainerSystem.TryAddReagent(bloodSolutionEnt.Value, component.BloodReagent, currentVolume, out _);
     }
 }

--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -75,11 +75,11 @@ public sealed class LungSystem : EntitySystem
 
     public void GasToReagent(EntityUid uid, LungComponent lung)
     {
-        if (!_solutionContainerSystem.ResolveSolution(uid, lung.SolutionName, ref lung.Solution, out var solution))
+        if (!_solutionContainerSystem.TryGetSolution(uid, lung.SolutionName, out var solutionEnt, out var solution))
             return;
 
         GasToReagent(lung.Air, solution);
-        _solutionContainerSystem.UpdateChemicals(lung.Solution.Value);
+        _solutionContainerSystem.UpdateChemicals(solutionEnt.Value);
     }
 
     private void GasToReagent(GasMixture gas, Solution solution)

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -165,8 +165,8 @@ public sealed class RespiratorSystem : EntitySystem
             _atmosSys.Merge(outGas, lung.Air);
             lung.Air.Clear();
 
-            if (_solutionContainerSystem.ResolveSolution(lung.Owner, lung.SolutionName, ref lung.Solution))
-                _solutionContainerSystem.RemoveAllSolution(lung.Solution.Value);
+            if (_solutionContainerSystem.TryGetSolution(lung.Owner, lung.SolutionName, out var solutionEnt))
+                _solutionContainerSystem.RemoveAllSolution(solutionEnt.Value);
         }
 
         _atmosSys.Merge(ev.Gas, outGas);

--- a/Content.Server/Body/Systems/StomachSystem.cs
+++ b/Content.Server/Body/Systems/StomachSystem.cs
@@ -43,7 +43,7 @@ namespace Content.Server.Body.Systems
                 stomach.NextUpdate += stomach.UpdateInterval;
 
                 // Get our solutions
-                if (!_solutionContainerSystem.ResolveSolution((uid, sol), DefaultSolutionName, ref stomach.Solution, out var stomachSolution))
+                if (!_solutionContainerSystem.TryGetSolution((uid, sol), DefaultSolutionName, out var stomachSolutionEnt, out var stomachSolution))
                     continue;
 
                 if (organ.Body is not { } body || !_solutionContainerSystem.TryGetSolution(body, stomach.BodySolutionName, out var bodySolution))
@@ -75,7 +75,7 @@ namespace Content.Server.Body.Systems
                     stomach.ReagentDeltas.Remove(item);
                 }
 
-                _solutionContainerSystem.UpdateChemicals(stomach.Solution.Value);
+                _solutionContainerSystem.UpdateChemicals(stomachSolutionEnt.Value);
 
                 // Transfer everything to the body solution!
                 _solutionContainerSystem.TryAddSolution(bodySolution.Value, transferSolution);
@@ -103,7 +103,7 @@ namespace Content.Server.Body.Systems
             SolutionContainerManagerComponent? solutions = null)
         {
             return Resolve(uid, ref stomach, ref solutions, logMissing: false)
-                && _solutionContainerSystem.ResolveSolution((uid, solutions), DefaultSolutionName, ref stomach.Solution, out var stomachSolution)
+                && _solutionContainerSystem.TryGetSolution((uid, solutions), DefaultSolutionName, out _, out var stomachSolution)
                 // TODO: For now no partial transfers. Potentially change by design
                 && stomachSolution.CanAddSolution(solution);
         }
@@ -115,13 +115,13 @@ namespace Content.Server.Body.Systems
             SolutionContainerManagerComponent? solutions = null)
         {
             if (!Resolve(uid, ref stomach, ref solutions, logMissing: false)
-                || !_solutionContainerSystem.ResolveSolution((uid, solutions), DefaultSolutionName, ref stomach.Solution)
+                || !_solutionContainerSystem.TryGetSolution((uid, solutions), DefaultSolutionName, out var stomachSolutionEnt)
                 || !CanTransferSolution(uid, solution, stomach, solutions))
             {
                 return false;
             }
 
-            _solutionContainerSystem.TryAddSolution(stomach.Solution.Value, solution);
+            _solutionContainerSystem.TryAddSolution(stomachSolutionEnt.Value, solution);
             // Add each reagent to ReagentDeltas. Used to track how long each reagent has been in the stomach
             foreach (var reagent in solution.Contents)
             {

--- a/Content.Server/Botany/Components/PlantHolderComponent.cs
+++ b/Content.Server/Botany/Components/PlantHolderComponent.cs
@@ -91,7 +91,4 @@ public sealed partial class PlantHolderComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField("solution")]
     public string SoilSolutionName = "soil";
-
-    [DataField]
-    public Entity<SolutionComponent>? SoilSolution = null;
 }

--- a/Content.Server/Chemistry/Components/SolutionRegenerationComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionRegenerationComponent.cs
@@ -18,12 +18,6 @@ public sealed partial class SolutionRegenerationComponent : Component
     public string SolutionName = string.Empty;
 
     /// <summary>
-    /// The solution to add reagents to.
-    /// </summary>
-    [DataField("solutionRef")]
-    public Entity<SolutionComponent>? Solution = null;
-
-    /// <summary>
     /// The reagent(s) to be regenerated in the solution.
     /// </summary>
     [DataField("generated", required: true), ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
@@ -52,9 +52,9 @@ public sealed class InjectorSystem : SharedInjectorSystem
         {
             // Draw from a bloodstream, if the target has that
             if (TryComp<BloodstreamComponent>(target, out var stream) &&
-                SolutionContainers.ResolveSolution(target, stream.BloodSolutionName, ref stream.BloodSolution))
+                SolutionContainers.TryGetSolution(target, stream.BloodSolutionName, out var bloodSolutionEnt))
             {
-                return TryDraw(injector, (target, stream), stream.BloodSolution.Value, user);
+                return TryDraw(injector, (target, stream), bloodSolutionEnt.Value, user);
             }
 
             // Draw from an object (food, beaker, etc)
@@ -209,8 +209,8 @@ public sealed class InjectorSystem : SharedInjectorSystem
         EntityUid user)
     {
         // Get transfer amount. May be smaller than _transferAmount if not enough room
-        if (!SolutionContainers.ResolveSolution(target.Owner, target.Comp.ChemicalSolutionName,
-                ref target.Comp.ChemicalSolution, out var chemSolution))
+        if (!SolutionContainers.TryGetSolution(target.Owner, target.Comp.ChemicalSolutionName,
+                out var chemSolutionEnt, out var chemSolution))
         {
             Popup.PopupEntity(
                 Loc.GetString("injector-component-cannot-inject-message",
@@ -228,7 +228,7 @@ public sealed class InjectorSystem : SharedInjectorSystem
         }
 
         // Move units from attackSolution to targetSolution
-        var removedSolution = SolutionContainers.SplitSolution(target.Comp.ChemicalSolution.Value, realTransferAmount);
+        var removedSolution = SolutionContainers.SplitSolution(chemSolutionEnt.Value, realTransferAmount);
 
         _blood.TryAddToChemicals(target, removedSolution, target.Comp);
 
@@ -365,18 +365,18 @@ public sealed class InjectorSystem : SharedInjectorSystem
     {
         var drawAmount = (float) transferAmount;
 
-        if (SolutionContainers.ResolveSolution(target.Owner, target.Comp.ChemicalSolutionName,
-                ref target.Comp.ChemicalSolution))
+        if (SolutionContainers.TryGetSolution(target.Owner, target.Comp.ChemicalSolutionName,
+            out var chemSolutionEnt))
         {
-            var chemTemp = SolutionContainers.SplitSolution(target.Comp.ChemicalSolution.Value, drawAmount * 0.15f);
+            var chemTemp = SolutionContainers.SplitSolution(chemSolutionEnt.Value, drawAmount * 0.15f);
             SolutionContainers.TryAddSolution(injectorSolution, chemTemp);
             drawAmount -= (float) chemTemp.Volume;
         }
 
-        if (SolutionContainers.ResolveSolution(target.Owner, target.Comp.BloodSolutionName,
-                ref target.Comp.BloodSolution))
+        if (SolutionContainers.TryGetSolution(target.Owner, target.Comp.BloodSolutionName,
+            out var bloodSolutionEnt))
         {
-            var bloodTemp = SolutionContainers.SplitSolution(target.Comp.BloodSolution.Value, drawAmount);
+            var bloodTemp = SolutionContainers.SplitSolution(bloodSolutionEnt.Value, drawAmount);
             SolutionContainers.TryAddSolution(injectorSolution, bloodTemp);
         }
 

--- a/Content.Server/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
@@ -24,7 +24,7 @@ public sealed class SolutionRegenerationSystem : EntitySystem
 
             // timer ignores if its full, it's just a fixed cycle
             regen.NextRegenTime = _timing.CurTime + regen.Duration;
-            if (_solutionContainer.ResolveSolution((uid, manager), regen.SolutionName, ref regen.Solution, out var solution))
+            if (_solutionContainer.TryGetSolution((uid, manager), regen.SolutionName, out var solutionEnt, out var solution))
             {
                 var amount = FixedPoint2.Min(solution.AvailableVolume, regen.Generated.Volume);
                 if (amount <= FixedPoint2.Zero)
@@ -41,7 +41,7 @@ public sealed class SolutionRegenerationSystem : EntitySystem
                     generated = regen.Generated.Clone().SplitSolution(amount);
                 }
 
-                _solutionContainer.TryAddSolution(regen.Solution.Value, generated);
+                _solutionContainer.TryAddSolution(solutionEnt.Value, generated);
             }
         }
     }

--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -273,7 +273,7 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
         if (!TryComp(target, out PuddleComponent? puddle))
             return false;
 
-        if (!_solutionContainerSystem.ResolveSolution(target, puddle.SolutionName, ref puddle.Solution, out var puddleSolution) || puddleSolution.Volume <= 0)
+        if (!_solutionContainerSystem.TryGetSolution(target, puddle.SolutionName, out var puddleSolutionEnt, out var puddleSolution) || puddleSolution.Volume <= 0)
             return false;
 
         // Check if the puddle has any non-evaporative reagents
@@ -309,7 +309,7 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
             _puddleSystem.DoTileReactions(tileRef, absorberSplit);
         }
 
-        _solutionContainerSystem.AddSolution(puddle.Solution.Value, absorberSplit);
+        _solutionContainerSystem.AddSolution(puddleSolutionEnt.Value, absorberSplit);
         _solutionContainerSystem.AddSolution(absorberSoln, puddleSplit);
 
         _audio.PlayPvs(absorber.PickupSound, target);

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
@@ -42,7 +42,7 @@ public sealed partial class PuddleSystem
 
             evaporation.NextTick += EvaporationCooldown;
 
-            if (!_solutionContainerSystem.ResolveSolution(uid, puddle.SolutionName, ref puddle.Solution, out var puddleSolution))
+            if (!_solutionContainerSystem.TryGetSolution(uid, puddle.SolutionName, out _, out var puddleSolution))
                 continue;
 
             var reagentTick = evaporation.EvaporationAmount * EvaporationCooldown.TotalSeconds;

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -200,8 +200,8 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
             HealthAnalyzerUiKey.Key,
             new HealthAnalyzerScannedUserMessage(GetNetEntity(entity.Comp.BodyContainer.ContainedEntity),
             temp?.CurrentTemperature ?? 0,
-            (bloodstream != null && _solutionContainerSystem.ResolveSolution(entity.Comp.BodyContainer.ContainedEntity.Value,
-                bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution))
+            (bloodstream != null && _solutionContainerSystem.TryGetSolution(entity.Comp.BodyContainer.ContainedEntity.Value,
+                bloodstream.BloodSolutionName, out _, out var bloodSolution))
                 ? bloodSolution.FillFraction
                 : 0,
             null,

--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -175,7 +175,7 @@ public sealed class HealingSystem : EntitySystem
             HasDamage(targetDamage, component) ||
             component.ModifyBloodLevel > 0 // Special case if healing item can restore lost blood...
                 && TryComp<BloodstreamComponent>(target, out var bloodstream)
-                && _solutionContainerSystem.ResolveSolution(target, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution)
+                && _solutionContainerSystem.TryGetSolution(target, bloodstream.BloodSolutionName, out var _, out var bloodSolution)
                 && bloodSolution.Volume < bloodSolution.MaxVolume; // ...and there is lost blood to restore.
 
         if (!anythingToDo)

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -187,8 +187,8 @@ public sealed class HealthAnalyzerSystem : EntitySystem
         var bleeding = false;
 
         if (TryComp<BloodstreamComponent>(target, out var bloodstream) &&
-            _solutionContainerSystem.ResolveSolution(target, bloodstream.BloodSolutionName,
-                ref bloodstream.BloodSolution, out var bloodSolution))
+            _solutionContainerSystem.TryGetSolution(target, bloodstream.BloodSolutionName,
+                out _, out var bloodSolution))
         {
             bloodAmount = bloodSolution.FillFraction;
             bleeding = bloodstream.BleedAmount > 0;

--- a/Content.Server/Medical/VomitSystem.cs
+++ b/Content.Server/Medical/VomitSystem.cs
@@ -58,11 +58,11 @@ namespace Content.Server.Medical
             // Empty the stomach out into it
             foreach (var stomach in stomachList)
             {
-                if (_solutionContainer.ResolveSolution(stomach.Comp.Owner, StomachSystem.DefaultSolutionName, ref stomach.Comp.Solution, out var sol))
+                if (_solutionContainer.TryGetSolution(stomach.Comp.Owner, StomachSystem.DefaultSolutionName, out var stomachSolutionEnt, out var sol))
                 {
                     solution.AddSolution(sol, _proto);
                     sol.RemoveAllSolution();
-                    _solutionContainer.UpdateChemicals(stomach.Comp.Solution.Value);
+                    _solutionContainer.UpdateChemicals(stomachSolutionEnt.Value);
                 }
             }
             // Adds a tiny amount of the chem stream from earlier along with vomit
@@ -73,9 +73,9 @@ namespace Content.Server.Medical
                 var vomitAmount = solutionSize;
 
                 // Takes 10% of the chemicals removed from the chem stream
-                if (_solutionContainer.ResolveSolution(uid, bloodStream.ChemicalSolutionName, ref bloodStream.ChemicalSolution))
+                if (_solutionContainer.TryGetSolution(uid, bloodStream.ChemicalSolutionName, out var chemSolutionEnt))
                 {
-                    var vomitChemstreamAmount = _solutionContainer.SplitSolution(bloodStream.ChemicalSolution.Value, vomitAmount);
+                    var vomitChemstreamAmount = _solutionContainer.SplitSolution(chemSolutionEnt.Value, vomitAmount);
                     vomitChemstreamAmount.ScaleSolution(chemMultiplier);
                     solution.AddSolution(vomitChemstreamAmount, _proto);
 

--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -240,7 +240,7 @@ public sealed class FoodSystem : EntitySystem
             if (!_stomach.CanTransferSolution(owner, split, stomach))
                 continue;
 
-            if (!_solutionContainer.ResolveSolution(owner, StomachSystem.DefaultSolutionName, ref stomach.Solution, out var stomachSol))
+            if (!_solutionContainer.TryGetSolution(owner, StomachSystem.DefaultSolutionName, out _, out var stomachSol))
                 continue;
 
             if (stomachSol.AvailableVolume <= highestAvailable)

--- a/Content.Server/Power/Generator/ChemicalFuelGeneratorAdapterComponent.cs
+++ b/Content.Server/Power/Generator/ChemicalFuelGeneratorAdapterComponent.cs
@@ -1,9 +1,6 @@
-﻿using Content.Shared.Chemistry.Components;
-using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Power.Generator;
 
@@ -25,12 +22,6 @@ public sealed partial class ChemicalFuelGeneratorAdapterComponent : Component
     [DataField("solution")]
     [ViewVariables(VVAccess.ReadWrite)]
     public string SolutionName = "tank";
-
-    /// <summary>
-    /// The solution on the <see cref="SolutionContainerManagerComponent"/> to use.
-    /// </summary>
-    [DataField("solutionRef")]
-    public Entity<SolutionComponent>? Solution = null;
 
     /// <summary>
     /// How much reagent (can be fractional) is left in the generator.

--- a/Content.Server/Power/Generator/GeneratorSystem.cs
+++ b/Content.Server/Power/Generator/GeneratorSystem.cs
@@ -1,4 +1,3 @@
-﻿using System.Linq;
 using Content.Server.Audio;
 using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Server.Fluids.EntitySystems;
@@ -65,16 +64,16 @@ public sealed class GeneratorSystem : SharedGeneratorSystem
 
     private void ChemicalEmpty(Entity<ChemicalFuelGeneratorAdapterComponent> entity, ref GeneratorEmpty args)
     {
-        if (!_solutionContainer.ResolveSolution(entity.Owner, entity.Comp.SolutionName, ref entity.Comp.Solution, out var solution))
+        if (!_solutionContainer.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out var solutionEnt, out var solution))
             return;
 
-        var spillSolution = _solutionContainer.SplitSolution(entity.Comp.Solution.Value, solution.Volume);
+        var spillSolution = _solutionContainer.SplitSolution(solutionEnt.Value, solution.Volume);
         _puddle.TrySpillAt(entity.Owner, spillSolution, out _);
     }
 
     private void ChemicalGetClogged(Entity<ChemicalFuelGeneratorAdapterComponent> entity, ref GeneratorGetCloggedEvent args)
     {
-        if (!_solutionContainer.ResolveSolution(entity.Owner, entity.Comp.SolutionName, ref entity.Comp.Solution, out var solution))
+        if (!_solutionContainer.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out var solutionEnt, out var solution))
             return;
 
         foreach (var reagentQuantity in solution)
@@ -89,7 +88,7 @@ public sealed class GeneratorSystem : SharedGeneratorSystem
 
     private void ChemicalUseFuel(Entity<ChemicalFuelGeneratorAdapterComponent> entity, ref GeneratorUseFuel args)
     {
-        if (!_solutionContainer.ResolveSolution(entity.Owner, entity.Comp.SolutionName, ref entity.Comp.Solution, out var solution))
+        if (!_solutionContainer.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out var solutionEnt, out var solution))
             return;
 
         var totalReagent = 0f;
@@ -116,13 +115,13 @@ public sealed class GeneratorSystem : SharedGeneratorSystem
                 availableReagent.Value);
 
             entity.Comp.FractionalReagents[reagentId] = fractionalReagent;
-            _solutionContainer.RemoveReagent(entity.Comp.Solution.Value, reagentId, FixedPoint2.FromCents(toRemove));
+            _solutionContainer.RemoveReagent(solutionEnt.Value, reagentId, FixedPoint2.FromCents(toRemove));
         }
     }
 
     private void ChemicalGetFuel(Entity<ChemicalFuelGeneratorAdapterComponent> entity, ref GeneratorGetFuelEvent args)
     {
-        if (!_solutionContainer.ResolveSolution(entity.Owner, entity.Comp.SolutionName, ref entity.Comp.Solution, out var solution))
+        if (!_solutionContainer.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out var solutionEnt, out var solution))
             return;
 
         var fuel = 0f;

--- a/Content.Shared/Chemistry/Components/SmokeComponent.cs
+++ b/Content.Shared/Chemistry/Components/SmokeComponent.cs
@@ -14,12 +14,6 @@ public sealed partial class SmokeComponent : Component
     public const string SolutionName = "solutionArea";
 
     /// <summary>
-    /// The solution on the entity with touch and ingestion reactions.
-    /// </summary>
-    [DataField]
-    public Entity<SolutionComponent>? Solution = null;
-
-    /// <summary>
     /// The max amount of tiles this smoke cloud can spread to.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Fluids/Components/DrainComponent.cs
+++ b/Content.Shared/Fluids/Components/DrainComponent.cs
@@ -20,9 +20,6 @@ public sealed partial class DrainComponent : Component
     [ValidatePrototypeId<TagPrototype>]
     public const string PlungerTag = "Plunger";
 
-    [DataField]
-    public Entity<SolutionComponent>? Solution = null;
-
     [DataField("accumulator")]
     public float Accumulator = 0f;
 

--- a/Content.Shared/Fluids/Components/PuddleComponent.cs
+++ b/Content.Shared/Fluids/Components/PuddleComponent.cs
@@ -17,9 +17,7 @@ namespace Content.Shared.Fluids.Components
         [DataField]
         public FixedPoint2 OverflowVolume = FixedPoint2.New(20);
 
-        [DataField("solution")] public string SolutionName = "puddle";
-
-        [DataField("solutionRef")]
-        public Entity<SolutionComponent>? Solution;
+        [DataField("solution")]
+        public string SolutionName = "puddle";
     }
 }

--- a/Content.Shared/Fluids/SharedPuddleSystem.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.cs
@@ -73,7 +73,7 @@ public abstract partial class SharedPuddleSystem : EntitySystem
 
     private void OnGetFootstepSound(Entity<PuddleComponent> entity, ref GetFootstepSoundEvent args)
     {
-        if (!_solutionContainerSystem.ResolveSolution(entity.Owner, entity.Comp.SolutionName, ref entity.Comp.Solution,
+        if (!_solutionContainerSystem.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out _,
                 out var solution))
             return;
 
@@ -95,8 +95,8 @@ public abstract partial class SharedPuddleSystem : EntitySystem
             }
 
             if (HasComp<EvaporationComponent>(entity) &&
-                _solutionContainerSystem.ResolveSolution(entity.Owner, entity.Comp.SolutionName,
-                    ref entity.Comp.Solution, out var solution))
+                _solutionContainerSystem.TryGetSolution(entity.Owner, entity.Comp.SolutionName,
+                    out _, out var solution))
             {
                 if (CanFullyEvaporate(solution))
                     args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating"));


### PR DESCRIPTION
## About the PR
Gets rid of `Entity<SolutionComponent>` from all components. Storing `Entity` in components breaks serialization, and it was redundant because they all store the solution name anyway which is all that's needed to get the solution.

## Breaking changes
`Entity<SolutionComponent>` has been removed from all components. If your code used `ResolveSolution(uid, comp.SolutionName, ref comp.Solution)` you need to change it to `TryGetSolution(uid, comp.SolutionName, out var solutionEnt)`