### PR TITLE
SS-28662 Add cvars to support forcing people to departures and making those at departures invincible

### DIFF
--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -101,8 +101,7 @@ public sealed class ArrivalsSystem : EntitySystem
         Enabled = _cfgManager.GetCVar(CCVars.ArrivalsShuttles);
         Subs.CVar(_cfgManager, CCVars.ArrivalsShuttles, SetArrivals);
 
-        Forced = _cfgManager.GetCVar(CCVars.ForceArrivals);
-        Subs.CVar(_cfgManager, CCVars.ForceArrivals, ForceArrivals);
+        _cfgManager.OnValueChanged(CCVars.ForceArrivals, b => Forced = b);
 
         // TODO: This command has been superseded by setting the cvar shuttle.force_arrivals
         // Command so admins can set these for funsies
@@ -538,20 +537,6 @@ public sealed class ArrivalsSystem : EntitySystem
             {
                 QueueDel(uid);
             }
-        }
-    }
-
-    private void ForceArrivals(bool obj)
-    {
-        Forced = obj;
-
-        if (Forced)
-        {
-
-        }
-        else
-        {
-
         }
     }
 

--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -102,8 +102,7 @@ public sealed class ArrivalsSystem : EntitySystem
         Subs.CVar(_cfgManager, CCVars.ArrivalsShuttles, SetArrivals);
 
         _cfgManager.OnValueChanged(CCVars.ForceArrivals, b => Forced = b);
-
-        // TODO: This command has been superseded by setting the cvar shuttle.force_arrivals
+        
         // Command so admins can set these for funsies
         _console.RegisterCommand("arrivals", ArrivalsCommand, ArrivalsCompletion);
     }

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -65,7 +65,15 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
         _spawnerCallbacks = new Dictionary<SpawnPriorityPreference, Action<PlayerSpawningEvent>>()
         {
             { SpawnPriorityPreference.Arrivals, _arrivalsSystem.HandlePlayerSpawning },
-            { SpawnPriorityPreference.Cryosleep, _containerSpawnPointSystem.HandlePlayerSpawning }
+            {
+                SpawnPriorityPreference.Cryosleep, ev =>
+                {
+                    if (_arrivalsSystem.Forced)
+                        _arrivalsSystem.HandlePlayerSpawning(ev);
+                    else
+                        _containerSpawnPointSystem.HandlePlayerSpawning(ev);
+                }
+            }
         };
     }
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1384,6 +1384,12 @@ namespace Content.Shared.CCVar
             CVarDef.Create("shuttle.force_arrivals", false, CVar.SERVERONLY);
 
         /// <summary>
+        /// Should all players who spawn at arrivals have godmode until they leave the map?
+        /// </summary>
+        public static readonly CVarDef<bool> GodmodeArrivals =
+            CVarDef.Create("shuttle.godmode_arrivals", false, CVar.SERVERONLY);
+
+        /// <summary>
         /// Whether to automatically spawn escape shuttles.
         /// </summary>
         public static readonly CVarDef<bool> GridFill =

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1378,6 +1378,12 @@ namespace Content.Shared.CCVar
             CVarDef.Create("shuttle.arrivals_returns", false, CVar.SERVERONLY);
 
         /// <summary>
+        /// Should all players be forced to spawn at departures, even on roundstart, even if their loadout says they spawn in cryo?
+        /// </summary>
+        public static readonly CVarDef<bool> ForceArrivals =
+            CVarDef.Create("shuttle.force_arrivals", false, CVar.SERVERONLY);
+
+        /// <summary>
         /// Whether to automatically spawn escape shuttles.
         /// </summary>
         public static readonly CVarDef<bool> GridFill =


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
A cvar that means everyone must spawn at departures. This could be handy for an admin event? But mostly it's so the tutorial departures terminal can be seen by all newbies on gateway servers.

A cvar that grants everyone who spawns at departures godmode. This is handy for admin events and tutorials.

## Why / Balance
For gateway servers.

## Technical details
Thankfully turned out to be quite simple.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
you get no cl, you are cringe, nay-nay and should take a shower