### PR TITLE
Cryostasis syringe buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -420,7 +420,7 @@
   id: SyringeCryostasis
   parent: BaseSyringe
   name: cryostasis syringe
-  description: A syringe used to contain chemicals or solutions without reactions.
+  description: An improved syringe used to contain chemicals or solutions without reactions.
   components:
   - type: Sprite
     layers:
@@ -438,10 +438,11 @@
         maxVol: 10
         canReact: false
   - type: Injector
+    delay: 1.5
     injectOnly: false
     minTransferAmount: 5
-    maxTransferAmount: 10
-    transferAmount: 10
+    maxTransferAmount: 25
+    transferAmount: 25
   - type: Tag
     tags:
     - Syringe


### PR DESCRIPTION
## About the PR
buff to cryostasis syringes

## Why / Balance
have you ever seen a cryo syringe used ever? they are literally pointless right now, this buff makes it so they are a bit better than regular syringes for capacity and gives them a faster injection speed. they are now a complete upgrade to normal syringes, considering they are behind a T2 civ tech i think this is a justified buff.
improved syringes will help a lot when med is overwhelmed and it still requires science to do their job, research civ and make the syringes for med. 

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## **Changelog**
:cl: 
- tweak: cryo syringe now have 25u capacity
- tweak: cryo syringe now inject faster