### PR TITLE
Replaces reagent-effect-guidebook-missing with more descriptive guidebook entries

### DIFF
--- a/Content.Server/Chemistry/ReactionEffects/AreaReactionEffect.cs
+++ b/Content.Server/Chemistry/ReactionEffects/AreaReactionEffect.cs
@@ -46,7 +46,9 @@ namespace Content.Server.Chemistry.ReactionEffects
         public override bool ShouldLog => true;
 
         protected override string ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
-            => Loc.GetString("reagent-effect-guidebook-missing");
+            => Loc.GetString("reagent-effect-guidebook-area-reaction",
+                    ("duration", _duration)
+                );
 
         public override LogImpact LogImpact => LogImpact.High;
 

--- a/Content.Server/Chemistry/ReagentEffects/AddToSolutionReaction.cs
+++ b/Content.Server/Chemistry/ReagentEffects/AddToSolutionReaction.cs
@@ -26,6 +26,6 @@ namespace Content.Server.Chemistry.ReagentEffects
         }
 
         protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys) =>
-            Loc.GetString("reagent-effect-guidebook-missing", ("chance", Probability));
+            Loc.GetString("reagent-effect-guidebook-add-to-solution-reaction", ("chance", Probability));
     }
 }

--- a/Content.Shared/Chemistry/Reagent/ReagentEffect.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentEffect.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Text.Json.Serialization;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Database;
@@ -28,7 +28,7 @@ namespace Content.Shared.Chemistry.Reagent
 
         public virtual string ReagentEffectFormat => "guidebook-reagent-effect-description";
 
-        protected abstract string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys); // => Loc.GetString("reagent-effect-guidebook-missing", ("chance", Probability));
+        protected abstract string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys);
 
         /// <summary>
         ///     What's the chance, from 0 to 1, that this effect will occur?

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -1,4 +1,4 @@
-﻿-create-3rd-person =
+-create-3rd-person =
     { $chance ->
         [1] Creates
         *[other] create
@@ -345,11 +345,17 @@ reagent-effect-guidebook-reduce-rotting =
         *[other] regenerate
     } {NATURALFIXED($time, 3)} {MANY("second", $time)} of rotting
 
-reagent-effect-guidebook-missing =
+reagent-effect-guidebook-area-reaction =
     { $chance ->
         [1] Causes
         *[other] cause
-    } an unknown effect as nobody has written this effect yet
+    } a smoke or foam reaction for {NATURALFIXED($duration, 3)} {MANY("second", $duration)}
+
+reagent-effect-guidebook-add-to-solution-reaction =
+    { $chance ->
+        [1] Causes
+        *[other] cause
+    } chemicals applied to an object to be added to its internal solution container
 
 reagent-effect-guidebook-plant-attribute =
     { $chance ->


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Removed `reagent-effect-guidebook-missing` locstring, replacing it where it was used with more descriptive locstrings (`reagent-effect-guidebook-add-to-solution-reaction` and `reagent-effect-guidebook-area-reaction`).

Closes https://github.com/space-wizards/space-station-14/issues/28041

## Why / Balance

To quote Moony in the linked issue,
> The reagent-effect-guidebook-missing localization string, for an effect that nobody has bothered to implement a guidebook description for, defeats the point of the in-game guidebook code ... and shouldn't exist.

For the reasoning above, I've removed the `reagent-effect-guidebook-missing` locstring to prevent further use of it in the future.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

Fairly sure there's nothing user-facing here. I couldn't find these entries in the guidebook, at least.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
