### PR TITLE
unary + sensor yml cleanup

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -1,310 +1,241 @@
 - type: entity
-  parent: GasPipeBase
   abstract: true
+  parent: GasPipeBase
   id: GasUnaryBase
-  placement:
-    mode: SnapgridCenter
   components:
-    - type: AtmosDevice
-    - type: Tag
-      tags:
-        - Unstackable
-    - type: SubFloorHide
-      blockInteractions: false
-      blockAmbience: false
-    - type: NodeContainer
-      nodes:
-        pipe:
-          !type:PipeNode
-          nodeGroupID: Pipe
-          pipeDirection: South
-    - type: CollideOnAnchor
+  - type: Sprite
+    drawdepth: FloorObjects
+  - type: AtmosDevice
+  - type: SubFloorHide
+    blockInteractions: false
+    blockAmbience: false
+  - type: NodeContainer
+    nodes:
+      pipe:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: South
+  - type: CollideOnAnchor
+  - type: Construction
+    graph: GasUnary
+  - type: Tag
+    tags:
+    - Unstackable
 
 - type: entity
-  parent: GasUnaryBase
+  parent: [GasUnaryBase, BaseAtmosMonitor]
   id: GasVentPump
   name: air vent
   description: Has a valve and a pump attached to it.
-  placement:
-    mode: SnapgridCenter
   components:
-    - type: ApcPowerReceiver
-    - type: ExtensionCableReceiver
-    - type: DeviceNetwork
-      deviceNetId: AtmosDevices
-      receiveFrequencyId: AtmosMonitor
-      transmitFrequencyId: AtmosMonitor
-      prefix: device-address-prefix-vent
-      sendBroadcastAttemptEvent: true
-      examinableAddress: true
-    - type: WiredNetworkConnection
-    - type: DeviceNetworkRequiresPower
-    - type: AtmosDevice
-    - type: AtmosMonitor
-      temperatureThresholdId: stationTemperature
-      pressureThresholdId: stationPressure
-      gasThresholdPrototypes:
-        Oxygen: stationOxygen
-        Nitrogen: ignore
-        CarbonDioxide: stationCO2
-        Plasma: stationPlasma # everything below is usually bad
-        Tritium: danger
-        WaterVapor: stationWaterVapor
-        Ammonia: stationAmmonia
-        NitrousOxide: stationNO
-        Frezon: danger
-    - type: Tag
-      tags:
-        - GasVent
-        - Unstackable
-    - type: Sprite
-      drawdepth: FloorObjects
-      sprite: Structures/Piping/Atmospherics/vent.rsi
-      layers:
-        - sprite: Structures/Piping/Atmospherics/pipe.rsi
-          state: pipeHalf
-          map: [ "enum.PipeVisualLayers.Pipe" ]
-        - state: vent_off
-          map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
-    - type: Appearance
-    - type: PipeColorVisuals
-    - type: GenericVisualizer
-      visuals:
-        enum.VentPumpVisuals.State:
-          enabled:
-            Off: { state: vent_off }
-            In: { state: vent_in }
-            Out: { state: vent_out }
-            Welded: { state: vent_welded }
-    - type: GasVentPump
-    - type: Construction
-      graph: GasUnary
-      node: ventpump
-    - type: VentCritterSpawnLocation
-    - type: AmbientSound
-      enabled: true
-      volume: -12
-      range: 5
-      sound:
-        path: /Audio/Ambience/Objects/gas_vent.ogg
-    - type: Weldable
+  - type: DeviceNetwork
+    prefix: device-address-prefix-vent
+  - type: Sprite
+    drawdepth: FloorObjects
+    sprite: Structures/Piping/Atmospherics/vent.rsi
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe.rsi
+      state: pipeHalf
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: vent_off
+      map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
+  - type: GenericVisualizer
+    visuals:
+      enum.VentPumpVisuals.State:
+        enabled:
+          Off: { state: vent_off }
+          In: { state: vent_in }
+          Out: { state: vent_out }
+          Welded: { state: vent_welded }
+  - type: GasVentPump
+  - type: Construction
+    graph: GasUnary
+    node: ventpump
+  - type: VentCritterSpawnLocation
+  - type: AmbientSound
+    enabled: true
+    volume: -12
+    range: 5
+    sound:
+      path: /Audio/Ambience/Objects/gas_vent.ogg
+  - type: Weldable
+  - type: Tag
+    tags:
+    - GasVent
+    - Unstackable
 
 - type: entity
   parent: GasUnaryBase
   id: GasPassiveVent
   name: passive vent
   description: It's an open vent.
-  placement:
-    mode: SnapgridCenter
   components:
-    # TODO ATMOS: Find sprite for this.
-    - type: Sprite
-      drawdepth: FloorObjects
-      sprite: Structures/Piping/Atmospherics/vent.rsi
-      layers:
-        - sprite: Structures/Piping/Atmospherics/pipe.rsi
-          state: pipeHalf
-          map: [ "enum.PipeVisualLayers.Pipe" ]
-        - state: vent_off
-          map: [ "enum.SubfloorLayers.FirstLayer" ]
-    - type: Appearance
-    - type: PipeColorVisuals
-    - type: GasPassiveVent
-    - type: Construction
-      graph: GasUnary
-      node: passivevent
+  # TODO ATMOS: Find sprite for this.
+  - type: Sprite
+    drawdepth: FloorObjects
+    sprite: Structures/Piping/Atmospherics/vent.rsi
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe.rsi
+      state: pipeHalf
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: vent_off
+      map: [ "enum.SubfloorLayers.FirstLayer" ]
+  - type: GasPassiveVent
+  - type: Construction
+    node: passivevent
 
 - type: entity
-  parent: GasUnaryBase
+  parent: [GasUnaryBase, BaseAtmosMonitor]
   id: GasVentScrubber
   name: air scrubber
   description: Has a valve and pump attached to it.
-  placement:
-    mode: SnapgridCenter
   components:
-    - type: ApcPowerReceiver
-    - type: ExtensionCableReceiver
-    - type: DeviceNetwork
-      deviceNetId: AtmosDevices
-      receiveFrequencyId: AtmosMonitor
-      transmitFrequencyId: AtmosMonitor
-      prefix: device-address-prefix-scrubber
-      examinableAddress: true
-    - type: DeviceNetworkRequiresPower
-    - type: AtmosMonitor
-      temperatureThresholdId: stationTemperature
-      pressureThresholdId: stationPressure
-      gasThresholdPrototypes:
-        Oxygen: stationOxygen
-        Nitrogen: ignore
-        CarbonDioxide: stationCO2
-        Plasma: stationPlasma # everything below is usually bad
-        Tritium: danger
-        WaterVapor: stationWaterVapor
-        Ammonia: stationAmmonia
-        NitrousOxide: stationNO
-        Frezon: danger
-    - type: Tag
-      tags:
-        - GasScrubber
-        - Unstackable
-    - type: Sprite
-      drawdepth: FloorObjects
-      sprite: Structures/Piping/Atmospherics/scrubber.rsi
-      layers:
-        - sprite: Structures/Piping/Atmospherics/pipe.rsi
-          state: pipeHalf
-          map: [ "enum.PipeVisualLayers.Pipe" ]
-        - state: scrub_off
-          map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
-    - type: Appearance
-    - type: PipeColorVisuals
-    - type: GenericVisualizer
-      visuals:
-        enum.ScrubberVisuals.State:
-          enabled:
-            Off: { state: scrub_off }
-            Scrub: { state: scrub_on }
-            Siphon: { state: scrub_purge }
-            WideScrub: { state: scrub_wide }
-            Welded: { state: scrub_welded }
-    - type: AtmosDevice
-    - type: GasVentScrubber
-    - type: Construction
-      graph: GasUnary
-      node: ventscrubber
-    - type: AmbientSound
-      enabled: true
-      volume: -12
-      range: 5
-      sound:
-        path: /Audio/Ambience/Objects/gas_vent.ogg
-    - type: Weldable
+  - type: DeviceNetwork
+    prefix: device-address-prefix-scrubber
+    sendBroadcastAttemptEvent: false
+  - type: Sprite
+    sprite: Structures/Piping/Atmospherics/scrubber.rsi
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe.rsi
+      state: pipeHalf
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: scrub_off
+      map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
+  - type: GenericVisualizer
+    visuals:
+      enum.ScrubberVisuals.State:
+        enabled:
+          Off: { state: scrub_off }
+          Scrub: { state: scrub_on }
+          Siphon: { state: scrub_purge }
+          WideScrub: { state: scrub_wide }
+          Welded: { state: scrub_welded }
+  - type: GasVentScrubber
+  - type: Construction
+    graph: GasUnary
+    node: ventscrubber
+  - type: AmbientSound
+    enabled: true
+    volume: -12
+    range: 5
+    sound:
+      path: /Audio/Ambience/Objects/gas_vent.ogg
+  - type: Weldable
+  - type: Tag
+    tags:
+    - GasScrubber
+    - Unstackable
 
 - type: entity
   parent: GasUnaryBase
   id: GasOutletInjector
   name: air injector
   description: Has a valve and pump attached to it.
-  placement:
-    mode: SnapgridCenter
   components:
-    - type: Sprite
-      drawdepth: FloorObjects
-      sprite: Structures/Piping/Atmospherics/outletinjector.rsi
-      layers:
-        - state: pipeHalf
-          sprite: Structures/Piping/Atmospherics/pipe.rsi
-          map: [ "enum.PipeVisualLayers.Pipe" ]
-        - state: injector
-          map: [ "enum.SubfloorLayers.FirstLayer" ]
-        - state: injector-unshaded
-          shader: unshaded
-          map: [ "enum.LightLayers.Unshaded" ]
-          color: "#990000"
-    - type: GenericVisualizer
-      visuals:
-       # toggle color of the unshaded light:
-       enum.OutletInjectorVisuals.Enabled:
-         enum.LightLayers.Unshaded:
-           True: { color: "#5eff5e" }
-           False: { color: "#990000" }
-    - type: Appearance
-    - type: PipeColorVisuals
-    - type: GasOutletInjector
-    - type: Construction
-      graph: GasUnary
-      node: outletinjector
-    - type: SubFloorHide
-      visibleLayers:
-      - enum.SubfloorLayers.FirstLayer
-      - enum.LightLayers.Unshaded
+  - type: Sprite
+    drawdepth: FloorObjects
+    sprite: Structures/Piping/Atmospherics/outletinjector.rsi
+    layers:
+      - state: pipeHalf
+        sprite: Structures/Piping/Atmospherics/pipe.rsi
+        map: [ "enum.PipeVisualLayers.Pipe" ]
+      - state: injector
+        map: [ "enum.SubfloorLayers.FirstLayer" ]
+      - state: injector-unshaded
+        shader: unshaded
+        map: [ "enum.LightLayers.Unshaded" ]
+        color: "#990000"
+  - type: GenericVisualizer
+    visuals:
+     # toggle color of the unshaded light:
+     enum.OutletInjectorVisuals.Enabled:
+       enum.LightLayers.Unshaded:
+         True: { color: "#5eff5e" }
+         False: { color: "#990000" }
+  - type: Appearance
+  - type: PipeColorVisuals
+  - type: GasOutletInjector
+  - type: Construction
+    graph: GasUnary
+    node: outletinjector
+  - type: SubFloorHide
+    visibleLayers:
+    - enum.SubfloorLayers.FirstLayer
+    - enum.LightLayers.Unshaded
 
 - type: entity
+  abstract: true
   parent: [ BaseMachinePowered, ConstructibleMachine ]
   id: BaseGasThermoMachine
   name: thermomachine
-  abstract: true
-  placement:
-    mode: SnapgridCenter
   components:
-    - type: Sprite
-      sprite: Structures/Piping/Atmospherics/thermomachine.rsi
-      snapCardinals: true
-    - type: Appearance
-    - type: PipeColorVisuals
-    - type: Rotatable
-    - type: GasThermoMachine
-    - type: AtmosPipeColor
-    - type: AtmosDevice
-    - type: UserInterface
-      interfaces:
-        enum.ThermomachineUiKey.Key:
-          type: GasThermomachineBoundUserInterface
-    - type: ActivatableUI
-      inHandsOnly: false
-      key: enum.ThermomachineUiKey.Key
-    - type: WiresPanel
-    - type: WiresVisuals
-    - type: PipeRestrictOverlap
-    - type: NodeContainer
-      nodes:
-        pipe:
-          !type:PipeNode
-          nodeGroupID: Pipe
-          pipeDirection: South
-    - type: Transform
-      noRot: false
-    - type: DeviceNetwork
-      deviceNetId: AtmosDevices
-      receiveFrequencyId: AtmosMonitor
-      transmitFrequencyId: AtmosMonitor
-      sendBroadcastAttemptEvent: true
-      examinableAddress: true
-    - type: WiredNetworkConnection
-    - type: PowerSwitch
+  - type: Sprite
+    sprite: Structures/Piping/Atmospherics/thermomachine.rsi
+    snapCardinals: true
+  - type: Appearance
+  - type: PipeColorVisuals
+  - type: Rotatable
+  - type: GasThermoMachine
+  - type: ApcPowerReceiver
+    powerDisabled: true #starts off
+  - type: AtmosPipeColor
+  - type: AtmosDevice
+  - type: UserInterface
+    interfaces:
+      enum.ThermomachineUiKey.Key:
+        type: GasThermomachineBoundUserInterface
+  - type: ActivatableUI
+    inHandsOnly: false
+    key: enum.ThermomachineUiKey.Key
+  - type: WiresPanel
+  - type: WiresVisuals
+  - type: PipeRestrictOverlap
+  - type: NodeContainer
+    nodes:
+      pipe:
+        !type:PipeNode
+        nodeGroupID: Pipe
+        pipeDirection: South
+  - type: Transform
+    noRot: false
+  - type: PowerSwitch
+  - type: StealTarget
+    stealGroup: FreezerHeater
 
 - type: entity
   parent: BaseGasThermoMachine
   id: GasThermoMachineFreezer
   name: freezer
   description: Cools gas in connected pipes.
-  placement:
-    mode: SnapgridCenter
   components:
-    - type: Sprite
-      granularLayersRendering: true
-      layers:
-        - state: freezerOff
-          map: [ "enum.PowerDeviceVisualLayers.Powered" ]
-        - state: freezerPanelOpen
-          map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
-        - state: pipe
-          map: [ "enum.PipeVisualLayers.Pipe" ]
-          renderingStrategy: Default
-    - type: GenericVisualizer
-      visuals:
-        enum.PowerDeviceVisuals.Powered:
-          enum.PowerDeviceVisualLayers.Powered:
-            True: { state: freezerOn }
-            False: { state: freezerOff }
-    - type: GasThermoMachine
-      coefficientOfPerformance: -3.9
-    - type: ApcPowerReceiver
-      powerDisabled: true #starts off
-    - type: Machine
-      board: ThermomachineFreezerMachineCircuitBoard
-    - type: DeviceNetwork
-      prefix: device-address-prefix-freezer
-    - type: StealTarget
-      stealGroup: FreezerHeater
+  - type: Sprite
+    granularLayersRendering: true
+    layers:
+    - state: freezerOff
+      map: [ "enum.PowerDeviceVisualLayers.Powered" ]
+    - state: freezerPanelOpen
+      map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
+    - state: pipe
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+      renderingStrategy: Default
+  - type: GenericVisualizer
+    visuals:
+      enum.PowerDeviceVisuals.Powered:
+        enum.PowerDeviceVisualLayers.Powered:
+          True: { state: freezerOn }
+          False: { state: freezerOff }
+  - type: GasThermoMachine
+    coefficientOfPerformance: -3.9
+  - type: Machine
+    board: ThermomachineFreezerMachineCircuitBoard
+  - type: DeviceNetwork
+    prefix: device-address-prefix-freezer
 
 - type: entity
   parent: GasThermoMachineFreezer
   id: GasThermoMachineFreezerEnabled
   suffix: Enabled
   components:
-  - type: GasThermoMachine
   - type: ApcPowerReceiver
     powerDisabled: false
 
@@ -313,42 +244,35 @@
   id: GasThermoMachineHeater
   name: heater
   description: Heats gas in connected pipes.
-  placement:
-    mode: SnapgridCenter
   components:
-    - type: Sprite
-      granularLayersRendering : true
-      layers:
-        - state: heaterOff
-          map: [ "enum.PowerDeviceVisualLayers.Powered" ]
-        - state: heaterPanelOpen
-          map: ["enum.WiresVisualLayers.MaintenancePanel"]
-        - state: pipe
-          map: [ "enum.PipeVisualLayers.Pipe" ]
-          renderingStrategy: Default
-    - type: GenericVisualizer
-      visuals:
-        enum.PowerDeviceVisuals.Powered:
-          enum.PowerDeviceVisualLayers.Powered:
-            True: { state: heaterOn }
-            False: { state: heaterOff }
-    - type: GasThermoMachine
-      coefficientOfPerformance: 0.95
-    - type: ApcPowerReceiver
-      powerDisabled: true #starts off
-    - type: Machine
-      board: ThermomachineHeaterMachineCircuitBoard
-    - type: DeviceNetwork
-      prefix: device-address-prefix-heater
-    - type: StealTarget
-      stealGroup: FreezerHeater
+  - type: Sprite
+    granularLayersRendering: true
+    layers:
+    - state: heaterOff
+      map: [ "enum.PowerDeviceVisualLayers.Powered" ]
+    - state: heaterPanelOpen
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+    - state: pipe
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+      renderingStrategy: Default
+  - type: GenericVisualizer
+    visuals:
+      enum.PowerDeviceVisuals.Powered:
+        enum.PowerDeviceVisualLayers.Powered:
+          True: { state: heaterOn }
+          False: { state: heaterOff }
+  - type: GasThermoMachine
+    coefficientOfPerformance: 0.95
+  - type: Machine
+    board: ThermomachineHeaterMachineCircuitBoard
+  - type: DeviceNetwork
+    prefix: device-address-prefix-heater
 
 - type: entity
   parent: GasThermoMachineHeater
   id: GasThermoMachineHeaterEnabled
   suffix: Enabled
   components:
-  - type: GasThermoMachine
   - type: ApcPowerReceiver
     powerDisabled: false
 
@@ -387,8 +311,6 @@
   id: BaseGasCondenser
   name: condenser
   description: Condenses gases into liquids. Now we just need some plumbing.
-  placement:
-    mode: SnapgridCenter
   components:
   - type: Sprite
     sprite: Structures/Piping/Atmospherics/condenser.rsi

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -1,84 +1,91 @@
+# an atmos device that can be linked to an air alarm
+# it should have a tag that AirAlarm checks
 - type: entity
+  abstract: true
+  id: BaseAtmosMonitor
+  components:
+  - type: ApcPowerReceiver
+  - type: ExtensionCableReceiver
+  - type: DeviceNetwork
+    deviceNetId: AtmosDevices
+    receiveFrequencyId: AtmosMonitor
+    transmitFrequencyId: AtmosMonitor
+    sendBroadcastAttemptEvent: true
+    examinableAddress: true
+  - type: WiredNetworkConnection
+  - type: DeviceNetworkRequiresPower
+  - type: AtmosDevice
+  - type: AtmosMonitor
+    temperatureThresholdId: stationTemperature
+    pressureThresholdId: stationPressure
+    gasThresholdPrototypes:
+      Oxygen: stationOxygen
+      Nitrogen: ignore
+      CarbonDioxide: stationCO2
+      Plasma: stationPlasma # everything below is usually bad
+      Tritium: danger
+      WaterVapor: stationWaterVapor
+      Ammonia: stationAmmonia
+      NitrousOxide: stationNO
+      Frezon: danger
+
+- type: entity
+  parent: BaseAtmosMonitor
   id: AirSensor
   name: air sensor
   description: Air sensor. It senses air.
   placement:
     mode: SnapgridCenter
   components:
-    - type: Transform
-      anchored: true
-    - type: Damageable
-      damageContainer: Inorganic
-      damageModifierSet: Metallic
-    - type: Destructible
-      thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 100
-        behaviors:
-          - !type:DoActsBehavior
-            acts: ["Destruction"]
-    - type: Physics
-      canCollide: false
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape:
-            !type:PhysShapeAabb
-            bounds: "-0.25,-0.25,0.25,0.25"
-          density: 20
-          mask:
-            - ItemMask
-          restitution: 0.3
-          friction: 0.2
-    - type: Clickable
-    - type: InteractionOutline
-    - type: ApcPowerReceiver
-    - type: ExtensionCableReceiver
-    - type: DeviceNetwork
-      deviceNetId: AtmosDevices
-      receiveFrequencyId: AtmosMonitor
-      transmitFrequencyId: AtmosMonitor
-      prefix: device-address-prefix-sensor
-      sendBroadcastAttemptEvent: true
-      examinableAddress: true
-    - type: WiredNetworkConnection
-    - type: DeviceNetworkRequiresPower
-    - type: AtmosDevice
-    - type: AtmosMonitor
-      temperatureThresholdId: stationTemperature
-      pressureThresholdId: stationPressure
-      gasThresholdPrototypes:
-        Oxygen: stationOxygen
-        Nitrogen: ignore
-        CarbonDioxide: stationCO2
-        Plasma: stationPlasma # everything below is usually bad
-        Tritium: danger
-        WaterVapor: stationWaterVapor
-        Ammonia: stationAmmonia
-        NitrousOxide: stationNO
-        Frezon: danger
-    - type: Tag
-      tags:
-        - AirSensor
-    - type: AccessReader
-      access: [ [ "Atmospherics" ] ]
-    - type: Construction
-      graph: AirSensor
-      node: sensor
-    - type: Appearance
-    - type: Sprite
-      drawdepth: FloorObjects
-      sprite: Structures/Specific/Atmospherics/sensor.rsi
-      layers:
-        - state: gsensor1
-          map: [ "enum.PowerDeviceVisualLayers.Powered" ]
-    - type: GenericVisualizer
-      visuals:
-        enum.PowerDeviceVisuals.Powered:
-          enum.PowerDeviceVisualLayers.Powered:
-            True: { state: gsensor1 }
-            False: { state: gsensor0 }
+  - type: Transform
+    anchored: true
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+  - type: Physics
+    canCollide: false
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+          - ItemMask
+        restitution: 0.3
+        friction: 0.2
+  - type: Clickable
+  - type: InteractionOutline
+  - type: DeviceNetwork
+    prefix: device-address-prefix-sensor
+  - type: Construction
+    graph: AirSensor
+    node: sensor
+  - type: Appearance
+  - type: Sprite
+    drawdepth: FloorObjects
+    sprite: Structures/Specific/Atmospherics/sensor.rsi
+    layers:
+    - state: gsensor1
+      map: [ "enum.PowerDeviceVisualLayers.Powered" ]
+  - type: GenericVisualizer
+    visuals:
+      enum.PowerDeviceVisuals.Powered:
+        enum.PowerDeviceVisualLayers.Powered:
+          True: { state: gsensor1 }
+          False: { state: gsensor0 }
+  - type: Tag
+    tags:
+    - AirSensor
 
 - type: entity
   parent: BaseItem
@@ -86,14 +93,14 @@
   name: air sensor assembly
   description: Air sensor assembly. An assembly of air sensors?
   components:
-    - type: Item
-      size: Small
-    - type: Anchorable
-    - type: Construction
-      graph: AirSensor
-      node: assembly
-    - type: Sprite
-      drawdepth: FloorObjects
-      sprite: Structures/Specific/Atmospherics/sensor.rsi
-      layers:
-        - state: gsensor0
+  - type: Item
+    size: Small
+  - type: Anchorable
+  - type: Construction
+    graph: AirSensor
+    node: assembly
+  - type: Sprite
+    drawdepth: FloorObjects
+    sprite: Structures/Specific/Atmospherics/sensor.rsi
+    layers:
+    - state: gsensor0


### PR DESCRIPTION
## About the PR
- general cleanup of unary piping
- air vent scrubber and sensor now share the AtmosMonitor components in BaseAtmosMonitor
- removed access reader from air sensor because nothing used it, its not an air alarm

## Why / Balance
copy paste "dont want everything below this" 3 times le bad

## Breaking changes
no

**Changelog**
no cl no fun