### PR TITLE
make RefillableSolution optional for SolutionTransfer

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
@@ -193,7 +193,7 @@ public sealed class SolutionTransferSystem : EntitySystem
         var actualAmount = FixedPoint2.Min(amount, FixedPoint2.Min(sourceSolution.Volume, targetSolution.AvailableVolume));
 
         var solution = _solution.SplitSolution(source, actualAmount);
-        _solution.Refill(targetEntity, target, solution);
+        _solution.AddSolution(target, solution);
 
         _adminLogger.Add(LogType.Action, LogImpact.Medium,
             $"{ToPrettyString(user):player} transferred {SharedSolutionContainerSystem.ToPrettyString(solution)} to {ToPrettyString(targetEntity):target}, which now contains {SharedSolutionContainerSystem.ToPrettyString(targetSolution)}");


### PR DESCRIPTION
## About the PR
`SolutionTransferSystem.Transfer` no longer requires that the destination is refillable.

## Why / Balance
previously it would just silently delete the transferred solution if you were missing it, now its optional.
i dont know of anything that would need the behaviour above, but i need a non-refillable transferrable container downstream and trying to patch syringe and other shitcode to not bypass checks would be annoying

also with finite chems deleting them is bad

## Technical details
title

## Breaking changes
SolutionTransferSystem being used on a destination without RefillableSolutionComponent no longer deletes the transferred solution

**Changelog**
no cl no fun