### PR TITLE
Fix wielding prediction

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -424,10 +424,10 @@ namespace Content.Shared.Cuffs
                     break;
             }
 
-            if (_virtualItem.TrySpawnVirtualItemInHand(handcuff, uid, out var virtItem1))
+            if (_virtualItem.TrySpawnVirtualItemInHand(handcuff, uid, out var virtItem1) && virtItem1 != null)
                 EnsureComp<UnremoveableComponent>(virtItem1.Value);
 
-            if (_virtualItem.TrySpawnVirtualItemInHand(handcuff, uid, out var virtItem2))
+            if (_virtualItem.TrySpawnVirtualItemInHand(handcuff, uid, out var virtItem2) && virtItem2 != null)
                 EnsureComp<UnremoveableComponent>(virtItem2.Value);
         }
 

--- a/Content.Shared/Wieldable/WieldableSystem.cs
+++ b/Content.Shared/Wieldable/WieldableSystem.cs
@@ -218,7 +218,8 @@ public sealed class WieldableSystem : EntitySystem
         {
             if (_virtualItemSystem.TrySpawnVirtualItemInHand(used, user, out var virtualItem, true))
             {
-                virtuals.Add(virtualItem.Value);
+                if (virtualItem != null)
+                    virtuals.Add(virtualItem.Value);
                 continue;
             }
 


### PR DESCRIPTION
The client can't predict entity spawning so instead the old code just always failed on client which means gun wielding is now omegafucked on master.

This just changes it so the client can still return true it just doesn't get the entity out of it.

:cl:
- fix: Fix wielding prediction.