### PR TITLE
Active gravity generator can no longer be unanchored

### DIFF
--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -36,7 +36,7 @@ namespace Content.Server.Gravity
 
         private void OnUnanchorAttempt(Entity<GravityGeneratorComponent> ent, ref UnanchorAttemptEvent args)
         {
-            if (TryComp<ApcPowerReceiverComponent>(ent, out var apc) && apc.Powered)
+            if (ent.Comp.GravityActive)
             {
                 _popup.PopupEntity(Loc.GetString("gravity-generator-interact-failed"), ent);
                 args.Cancel();

--- a/Content.Server/Gravity/GravityGeneratorSystem.cs
+++ b/Content.Server/Gravity/GravityGeneratorSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Audio;
 using Content.Server.Power.Components;
+using Content.Shared.Construction.Components;
 using Content.Shared.Construction.EntitySystems;
 using Content.Shared.Database;
 using Content.Shared.Gravity;
@@ -30,18 +31,16 @@ namespace Content.Server.Gravity
             SubscribeLocalEvent<GravityGeneratorComponent, InteractHandEvent>(OnInteractHand);
             SubscribeLocalEvent<GravityGeneratorComponent, SharedGravityGeneratorComponent.SwitchGeneratorMessage>(
                 OnSwitchGenerator);
-            SubscribeLocalEvent<GravityGeneratorComponent, InteractUsingEvent>(OnInteractUsing, before: new []{typeof(AnchorableSystem)});
+            SubscribeLocalEvent<GravityGeneratorComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
         }
 
-        private void OnInteractUsing(Entity<GravityGeneratorComponent> gravity, ref InteractUsingEvent args)
+        private void OnUnanchorAttempt(Entity<GravityGeneratorComponent> ent, ref UnanchorAttemptEvent args)
         {
-            if (!TryComp<ApcPowerReceiverComponent>(args.Target, out var apc))
-                return;
-            if (!apc.Powered)
-                return;
-
-            _popup.PopupEntity(Loc.GetString("gravity-generator-interact-failed"), args.Target);
-            args.Handled = true;
+            if (TryComp<ApcPowerReceiverComponent>(ent, out var apc) && apc.Powered)
+            {
+                _popup.PopupEntity(Loc.GetString("gravity-generator-interact-failed"), ent);
+                args.Cancel();
+            }
         }
 
         private void OnParentChanged(EntityUid uid, GravityGeneratorComponent component, ref EntParentChangedMessage args)

--- a/Content.Server/Gravity/GravitySystem.cs
+++ b/Content.Server/Gravity/GravitySystem.cs
@@ -29,7 +29,7 @@ namespace Content.Server.Gravity
 
             foreach (var (comp, xform) in EntityQuery<GravityGeneratorComponent, TransformComponent>(true))
             {
-                if (!comp.GravityActive || xform.ParentUid != uid)
+                if (!comp.GravityActive || xform.ParentUid != uid || !xform.Anchored)
                     continue;
 
                 enabled = true;

--- a/Resources/Locale/en-US/gravity/gravity-generator-component.ftl
+++ b/Resources/Locale/en-US/gravity/gravity-generator-component.ftl
@@ -29,4 +29,4 @@ gravity-generator-window-eta-value = { TOSTRING($left, "m\\:ss") }
 
 # Interact
 
-gravity-generator-interact-failed = The gravitational field is pushing you away.
+gravity-generator-interact-failed = The active gravitational field is pushing you away.

--- a/Resources/Locale/en-US/gravity/gravity-generator-component.ftl
+++ b/Resources/Locale/en-US/gravity/gravity-generator-component.ftl
@@ -26,3 +26,7 @@ gravity-generator-window-power-label = { $draw } / { $max } W
 
 gravity-generator-window-eta-none = N/A
 gravity-generator-window-eta-value = { TOSTRING($left, "m\\:ss") }
+
+# Interact
+
+gravity-generator-interact-failed = The gravitational field is pushing you away.

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -6,6 +6,9 @@
   placement:
     mode: AlignTileAny
   components:
+  - type: Anchorable
+    flags:
+    - Unanchorable
   - type: AmbientSound
     enabled: false
     volume: -6

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -6,9 +6,6 @@
   placement:
     mode: AlignTileAny
   components:
-  - type: Anchorable
-    flags:
-    - Unanchorable
   - type: AmbientSound
     enabled: false
     volume: -6


### PR DESCRIPTION
## About the PR
title

## Why / Balance
![image](https://github.com/space-wizards/space-station-14/assets/96445749/5c1b3732-8f1c-49df-b4bd-f42efab98088)

**Changelog**
:cl:
- fix: Gravity generator can no longer be unscrewed
