### PR TITLE
Remove Rat King from MouseMigration and add it to it's own Event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -234,6 +234,30 @@
       prob: 0.02
     - id: MobMouseCancer
       prob: 0.001
+# Events always spawn a critter regardless of Probability https://github.com/space-wizards/space-station-14/issues/28480 I added the Rat King to their own event with a player cap.
+
+- type: entity
+  id: KingRatMigration
+  parent: BaseStationEventShortDelay
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-vent-creatures-start-announcement
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    earliestStart: 15
+    weight: 6
+    duration: 50
+    minimumPlayers: 15 # Hopefully this is enough for the Rat King's potential Army
+  - type: VentCrittersRule
+    entries:
+    - id: MobMouse
+      prob: 0.02
+    - id: MobMouse1
+      prob: 0.02
+    - id: MobMouse2
+      prob: 0.02
+    - id: MobMouseCancer
+      prob: 0.001
     specialEntries:
     - id: SpawnPointGhostRatKing
       prob: 0.001


### PR DESCRIPTION
Removed Rat King from the MouseMigration event. Something is bugged in the event code causing it to always spawn in an entity regardless of probability, I added KingRatMigration which is the original MouseMigration with the Rat King but requires a minimum of 15 Players

Fixes [#28480](https://github.com/space-wizards/space-station-14/issues/28480)