### PR TITLE
Tweak HoS/Warden hardsuits damage resistances

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -228,8 +228,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
+        Blunt: 0.8
+        Slash: 0.8
         Piercing: 0.9
         Heat: 0.9
 
@@ -325,7 +325,7 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        Piercing: 0.9
+        Piercing: 0.8
         Heat: 0.9
 
 #Luxury Mining Hardsuit

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -260,8 +260,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.6
+        Blunt: 0.4
+        Slash: 0.4
         Piercing: 0.6
         Caustic: 0.7
   - type: ClothingSpeedModifier
@@ -424,8 +424,8 @@
     modifiers:
       coefficients:
         Blunt: 0.6
-        Slash: 0.5
-        Piercing: 0.5
+        Slash: 0.6
+        Piercing: 0.4
         Radiation: 0.5
         Caustic: 0.6
   - type: ClothingSpeedModifier


### PR DESCRIPTION
## About the PR
The HoS suit and the warden suit now use the blunt/slash and pierce of riot suits and bulletproof vests respectively.
This means the HoS suit now has 40% blunt, 40% slash, and 60% pierce.
This means the warden suit now has 60% blunt, 60% slash, and 40% pierce.

## Why / Balance
The warden suit is described as a "Specialized riot suit" but has always been the worst security hardsuit available. It has more slowdown and hardly any extra damage resistance. I think making it significantly more protective than the standard sec suit towards blunt/slash is a fair change since it still retains that 30% slowdown.
As for the HoS suit, I felt it's good for the head of security to have the most effective armor in a large shootout. Considering the only times the HoS even needs their suit is during Nukies or bombings. The HoS would generally be the one leading the defense against the operatives with primarily ballistic weapons and even the only member of security with a real weapon to fight them with if the armory is successfully breached.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/140123969/a3c82688-bde9-4e86-8916-ab26999acf1f)
![image](https://github.com/space-wizards/space-station-14/assets/140123969/b0561be9-4e42-4b82-a2d1-5e87ec5c9c79)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: The HoS hardsuit now has 10% more pierce resist and 10% less slash resist to resemble the bulletproof vest.
- tweak: The warden hardsuit now has 20% more slash resist and 10% more blunt resist to resemble the riot suit.
