### PR TITLE
Fix "no materials loaded" messege in lathes

### DIFF
--- a/Content.Client/Materials/UI/MaterialStorageControl.xaml.cs
+++ b/Content.Client/Materials/UI/MaterialStorageControl.xaml.cs
@@ -87,6 +87,6 @@ public sealed partial class MaterialStorageControl : ScrollContainer
         }
 
         _currentMaterials = mats;
-        NoMatsLabel.Visible = ChildCount == 1;
+        NoMatsLabel.Visible = MaterialList.ChildCount == 1;
     }
 }


### PR DESCRIPTION
## About the PR
fixed broken feature

## Why / Balance
it was broken

## Media
![image](https://github.com/space-wizards/space-station-14/assets/86846189/20a8e1e7-ea6c-424c-aed6-fd479bb2f301)

- [x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: "no materials loaded" messege now appears in lathes!

