### PR TITLE
Data field to enable or disable miasma from rotting corpses

### DIFF
--- a/Content.Server/Atmos/Rotting/RottingSystem.cs
+++ b/Content.Server/Atmos/Rotting/RottingSystem.cs
@@ -34,6 +34,9 @@ public sealed class RottingSystem : SharedRottingSystem
         if (!TryComp<PerishableComponent>(uid, out var perishable))
             return;
 
+        if (!perishable.CreateMols)
+            return;
+
         var molsToDump = perishable.MolsPerSecondPerUnitMass * physics.FixturesMass * (float) component.TotalRotTime.TotalSeconds;
         var tileMix = _atmosphere.GetTileMixture(uid, excite: true);
         tileMix?.AdjustMoles(Gas.Ammonia, molsToDump);
@@ -121,6 +124,9 @@ public sealed class RottingSystem : SharedRottingSystem
             }
 
             if (!TryComp<PhysicsComponent>(uid, out var physics))
+                continue;
+
+            if (!perishable.CreateMols)
                 continue;
             // We need a way to get the mass of the mob alone without armor etc in the future
             // or just remove the mass mechanics altogether because they aren't good.

--- a/Content.Shared/Atmos/Rotting/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Rotting/PerishableComponent.cs
@@ -38,6 +38,12 @@ public sealed partial class PerishableComponent : Component
     public TimeSpan PerishUpdateRate = TimeSpan.FromSeconds(5);
 
     /// <summary>
+    /// If rot generates moles of gas
+    /// </summary>
+    [DataField]
+    public bool CreateMols = true;
+
+    /// <summary>
     /// How many moles of gas released per second, per unit of mass.
     /// </summary>
     [DataField]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds option to prevent corpses from generating miasma

## Why / Balance
Used for downstream forks that might not want miasma

("Atmos takes a backseat in CM14, the purple stank is distracting")

## Technical details
Adds boolean CreateMols data field to PerishableComponents.cs
- set to true by default, where true makes rotting corpses generate miasma

Adds checks to RottingSystems.cs to skip ammonia if CreateMols = false

## Media
![image](https://github.com/CM-14/CM-14/assets/20566341/2b10e229-530a-41c7-9a75-6f7fdf64faa1)
When CreateMols = false

- [x] I have added screenshots/videos to this PR showcasing its changes ingame

## Breaking changes
Should be none

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

No cl as backend only