### PR TITLE
fix pda ui troll

### DIFF
--- a/Content.Client/PDA/PdaBoundUserInterface.cs
+++ b/Content.Client/PDA/PdaBoundUserInterface.cs
@@ -21,8 +21,16 @@ namespace Content.Client.PDA
         protected override void Open()
         {
             base.Open();
-            _menu = new PdaMenu();
+
+            if (_menu == null)
+                CreateMenu();
+
             _menu.OpenCenteredLeft();
+        }
+
+        private void CreateMenu()
+        {
+            _menu = new PdaMenu();
             _menu.OnClose += Close;
             _menu.FlashLightToggleButton.OnToggled += _ =>
             {

--- a/Content.Client/PDA/PdaBoundUserInterface.cs
+++ b/Content.Client/PDA/PdaBoundUserInterface.cs
@@ -25,7 +25,7 @@ namespace Content.Client.PDA
             if (_menu == null)
                 CreateMenu();
 
-            _menu.OpenCenteredLeft();
+            _menu?.OpenCenteredLeft();
         }
 
         private void CreateMenu()


### PR DESCRIPTION
## About the PR
opening pda an even number of times no longer fucks it, you can just always use it

## Why / Balance
bug bad

## Technical details
how it made the menu was so big its in own functions

## Media
imagine a video of me spamming E on pda and it not breaking
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed opening the PDA UI sometimes breaking.
