### PR TITLE
Pets toggle internals fix

### DIFF
--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -262,7 +262,7 @@ public sealed class InternalsSystem : EntitySystem
         // 3. in-hand tanks
         // 4. pocket/belt tanks
 
-        if (!Resolve(user, ref user.Comp1, ref user.Comp2, ref user.Comp3))
+        if (!Resolve(user, ref user.Comp2, ref user.Comp3))
             return null;
 
         if (_inventory.TryGetSlotEntity(user, "back", out var backEntity, user.Comp2, user.Comp3) &&


### PR DESCRIPTION
## About the PR
Fix unability for pets to breathe with oxygen tank and mask.

## Why / Balance
Without fix the game says "You are not wearing a gas tank" on attempt to "Toggle Internals" on any pet with both breath mask and oxygen tank, this should be a bug.

## Technical details
The reason for the bug is that the `InternalsSystem` requires `HandsComponent` to toggle internals, which obviously pets don't have. The simplest solution is to disable resolve of `HandsComponent` in `FindBestGasTank()`, and let do this to the `Inventory System.GetHandOrInventoryEntities()` method, which is called next and resolves the `HandsComponent` itself.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Players can now correctly toggle internals on pets.
