### PR TITLE
Fix queued deletion check (singulo loosing at beyond PA 1 but only on live servers)

### DIFF
--- a/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
@@ -116,10 +116,12 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
     /// </summary>
     public void ConsumeEntity(EntityUid hungry, EntityUid morsel, EventHorizonComponent eventHorizon, BaseContainer? outerContainer = null)
     {
-        if (!EntityManager.IsQueuedForDeletion(morsel) // I saw it log twice a few times for some reason?
-        && (HasComp<MindContainerComponent>(morsel)
+        if (EntityManager.IsQueuedForDeletion(morsel)) // already handled, and we're substepping
+            return;
+
+        if (HasComp<MindContainerComponent>(morsel)
             || _tagSystem.HasTag(morsel, "HighRiskItem")
-            || HasComp<ContainmentFieldGeneratorComponent>(morsel)))
+            || HasComp<ContainmentFieldGeneratorComponent>(morsel))
         {
             _adminLogger.Add(LogType.EntityDelete, LogImpact.Extreme, $"{ToPrettyString(morsel)} entered the event horizon of {ToPrettyString(hungry)} and was deleted");
         }


### PR DESCRIPTION
## About the PR
Fix a queued deletion check. Singulo food performed a check to see if a food item was queued for deletion, but failed to stop running the code and return when a deletion was queued.

Acknowledgement to @EmoGarbage404 for doing the initial investigation on this issue.

## Why / Balance
This broken check caused the same singulo food to contribute multiple times to singularity energy when physics substepping is on. In other words, the PA was doubly as strong on live servers (tickrate 30) than in the development environment (tickrate 60).

This also resulted in anything greater than PA 1 leading to singuloose on live servers, but PA 3 being safe in the development environment.

## Breaking changes
N/A

**Changelog**
:cl: notafet
- fix: The singularity is now safe to operate up to PA level 3.
