### PR TITLE
Head bandana ingestion blocking fix

### DIFF
--- a/Content.Shared/Clothing/Components/MaskComponent.cs
+++ b/Content.Shared/Clothing/Components/MaskComponent.cs
@@ -22,4 +22,16 @@ public sealed partial class MaskComponent : Component
 
     [DataField, AutoNetworkedField]
     public string EquippedPrefix = "toggled";
+
+    /// <summary>
+    /// When <see langword="true"/> will function normally, otherwise will not react to events
+    /// </summary>
+    [DataField("enabled"), AutoNetworkedField]
+    public bool IsEnabled = true;
+
+    /// <summary>
+    /// When <see langword="true"/> will disable <see cref="IsEnabled"/> when folded
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool DisableOnFolded;
 }

--- a/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
@@ -35,7 +35,7 @@ public sealed class MaskSystem : EntitySystem
     private void OnToggleMask(Entity<MaskComponent> ent, ref ToggleMaskEvent args)
     {
         var (uid, mask) = ent;
-        if (mask.ToggleActionEntity == null || !_timing.IsFirstTimePredicted)
+        if (mask.ToggleActionEntity == null || !_timing.IsFirstTimePredicted || !mask.IsEnabled)
             return;
 
         if (!_inventorySystem.TryGetSlotEntity(args.Performer, "mask", out var existing) || !uid.Equals(existing))
@@ -53,7 +53,7 @@ public sealed class MaskSystem : EntitySystem
     // set to untoggled when unequipped, so it isn't left in a 'pulled down' state
     private void OnGotUnequipped(EntityUid uid, MaskComponent mask, GotUnequippedEvent args)
     {
-        if (!mask.IsToggled)
+        if (!mask.IsToggled || !mask.IsEnabled)
             return;
 
         mask.IsToggled = false;
@@ -78,6 +78,8 @@ public sealed class MaskSystem : EntitySystem
 
     private void OnFolded(Entity<MaskComponent> ent, ref FoldedEvent args)
     {
+        if (ent.Comp.DisableOnFolded)
+            ent.Comp.IsEnabled = !args.IsFolded;
         ent.Comp.IsToggled = args.IsFolded;
 
         ToggleMaskComponents(ent.Owner, ent.Comp, ent.Owner);

--- a/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
@@ -7,6 +7,8 @@
     folded: true
   - type: Mask
     isToggled: true
+    enabled: false
+    disableOnFolded: true
   - type: IngestionBlocker
     enabled: false
   - type: IdentityBlocker

--- a/Resources/Prototypes/Entities/Clothing/Masks/bandanas.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/bandanas.yml
@@ -12,6 +12,7 @@
     unfoldedSlots:
     - MASK
   - type: Mask
+    disableOnFolded: true
   - type: IngestionBlocker
   - type: IdentityBlocker
     coverage: MOUTH


### PR DESCRIPTION
## About the PR
Add new flags to MaskComponent for head bandana normal functioning, adjust bandana prototypes accordingly.

## Why / Balance
Fixes https://github.com/space-wizards/space-station-14/issues/27163

## Technical details
Main issue with head bandana and its mask component is that mask even in initially toggled state continues to respond to events, and sets `MaskComponent.IsToggled` to `false`, which further down the chain turns on the `IngestionBlockerComponent`. 
My solution is to add 2 flags to `MaskComponent`, corresponding functionality to `MaskSystem`, and adjust new flags in bandana prototypes:
- `MaskComponent.IsEnabled` - `false` value disables events for component, such as `GotUnequippedEvent`, what prevents toggling off for head bandana
- `MaskComponent.DisableOnFolded` - needed for bandana folding functionality and control `IsEnabled` flag with folded events

No changes are required in other prototypes.

## Media

Video-demo before fix:

[Video-demo before fix](https://github.com/space-wizards/space-station-14/assets/33173619/2d3c79f5-9197-4b98-9dd6-674764d2045a)

Video-demo with fix:

[Video-demo with fix](https://github.com/space-wizards/space-station-14/assets/33173619/716e6f4e-efe6-40ab-894b-5c13c6366be0)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl:
- fix: Head bandana no longer blocks food eating.
