### PR TITLE
Remove imagesharp and StatusEffectAddedEvent from FlashOverlay

### DIFF
--- a/Content.Client/Flash/FlashSystem.cs
+++ b/Content.Client/Flash/FlashSystem.cs
@@ -22,7 +22,6 @@ public sealed class FlashSystem : SharedFlashSystem
         SubscribeLocalEvent<FlashedComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<FlashedComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<FlashedComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
-        SubscribeLocalEvent<FlashedComponent, StatusEffectAddedEvent>(OnStatusAdded);
 
         _overlay = new();
     }
@@ -34,8 +33,8 @@ public sealed class FlashSystem : SharedFlashSystem
 
     private void OnPlayerDetached(EntityUid uid, FlashedComponent component, LocalPlayerDetachedEvent args)
     {
-        _overlay.PercentComplete = 1.0f;
         _overlay.ScreenshotTexture = null;
+        _overlay.RequestScreenTexture = false;
         _overlayMan.RemoveOverlay(_overlay);
     }
 
@@ -43,6 +42,7 @@ public sealed class FlashSystem : SharedFlashSystem
     {
         if (_player.LocalEntity == uid)
         {
+            _overlay.RequestScreenTexture = true;
             _overlayMan.AddOverlay(_overlay);
         }
     }
@@ -51,17 +51,9 @@ public sealed class FlashSystem : SharedFlashSystem
     {
         if (_player.LocalEntity == uid)
         {
-            _overlay.PercentComplete = 1.0f;
             _overlay.ScreenshotTexture = null;
+            _overlay.RequestScreenTexture = false;
             _overlayMan.RemoveOverlay(_overlay);
-        }
-    }
-
-    private void OnStatusAdded(EntityUid uid, FlashedComponent component, StatusEffectAddedEvent args)
-    {
-        if (_player.LocalEntity == uid && args.Key == FlashedKey)
-        {
-            _overlay.ReceiveFlash();
         }
     }
 }


### PR DESCRIPTION
## About the PR
Needed for #28766

## Why / Balance
No longer requires imagesharp for the screenshot and gets rid of an unneccessary event.

## Technical details
It now grabs the screenshot via RequestScreenTexture.
Gets rid of StatusEffectAddedEvent.
Requires https://github.com/space-wizards/RobustToolbox/pull/5234

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none (I hope)

**Changelog**
no fun
