### PR TITLE
Vending Machines repairing fix

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -155,7 +155,7 @@ namespace Content.Server.VendingMachines
             if (comp == null)
                 return;
 
-            if (comp.TotalDamage == 0)
+            if (component.Broken && comp.TotalDamage == 0)
             {
                 component.Broken = false;
                 TryUpdateVisualState(uid, component);

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -151,6 +151,16 @@ namespace Content.Server.VendingMachines
 
         private void OnDamage(EntityUid uid, VendingMachineComponent component, DamageChangedEvent args)
         {
+            TryComp<DamageableComponent>(uid, out var comp);
+            if (comp == null)
+                return;
+
+            if (comp.TotalDamage == 0)
+            {
+                component.Broken = false;
+                TryUpdateVisualState(uid, component);
+            }
+
             if (component.Broken || component.DispenseOnHitCoolingDown ||
                 component.DispenseOnHitChance == null || args.DamageDelta == null)
                 return;


### PR DESCRIPTION
## About the PR
Allows welders to repair vending machines

## Why / Balance
Fixes #28912 

## Technical details
Adds a check for if the damage change on a vending machine is equals to 0 (I.E, is repairing) and the machine is broken. If pass, the vending machine is unbroken. 

## Breaking changes
**Changelog**

- fix: Using a welder on vending machines now correctly repairs the vending machine.