### PR TITLE
Fix observe selection popup

### DIFF
--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -30,7 +30,6 @@
                                         <cc:UICommandButton Command="observe" Name="ObserveButton" Access="Public"
                                                             Text="{Loc 'ui-lobby-observe-button'}"
                                                             StyleClasses="ButtonBig" />
-                                                            <!-- WindowType="{x:Type lobbyUi:ObserveWarningWindow}" /> -->
                                         <Label Name="StartTime"
                                                Access="Public"
                                                Align="Left"

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -29,8 +29,8 @@
                                     <BoxContainer Orientation="Horizontal" SeparationOverride="6" Margin="3 3 3 3">
                                         <cc:UICommandButton Command="observe" Name="ObserveButton" Access="Public"
                                                             Text="{Loc 'ui-lobby-observe-button'}"
-                                                            StyleClasses="ButtonBig"
-                                                            WindowType="{x:Type lobbyUi:ObserveWarningWindow}" />
+                                                            StyleClasses="ButtonBig" />
+                                                            <!-- WindowType="{x:Type lobbyUi:ObserveWarningWindow}" /> -->
                                         <Label Name="StartTime"
                                                Access="Public"
                                                Align="Left"

--- a/Content.Client/Lobby/UI/LobbyGui.xaml.cs
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml.cs
@@ -23,8 +23,8 @@ namespace Content.Client.Lobby.UI
 
             LeaveButton.OnPressed += _ => _consoleHost.ExecuteCommand("disconnect");
             OptionsButton.OnPressed += _ => UserInterfaceManager.GetUIController<OptionsUIController>().ToggleWindow();
+            ObserveButton.OnPressed += _ => UserInterfaceManager.GetUIController<ObserveWarningWindowUIController>().ToggleWindow();
         }
-
         public void SwitchState(LobbyGuiState state)
         {
             DefaultState.Visible = false;

--- a/Content.Client/Lobby/UI/ObserveWarningWindowUIController.cs
+++ b/Content.Client/Lobby/UI/ObserveWarningWindowUIController.cs
@@ -1,4 +1,3 @@
-using Linguini.Syntax.Ast;
 using Robust.Client.UserInterface.Controllers;
 
 namespace Content.Client.Lobby.UI;

--- a/Content.Client/Lobby/UI/ObserveWarningWindowUIController.cs
+++ b/Content.Client/Lobby/UI/ObserveWarningWindowUIController.cs
@@ -4,31 +4,31 @@ namespace Content.Client.Lobby.UI;
 
 public sealed class ObserveWarningWindowUIController : UIController
 {
-    private ObserveWarningWindow _optionsWindow = default!;
+    private ObserveWarningWindow _observeWarningWindow = default!;
 
     private void EnsureWindow()
     {
-        if (_optionsWindow is { Disposed: false })
+        if (_observeWarningWindow is { Disposed: false })
             return;
 
-        _optionsWindow = UIManager.CreateWindow<ObserveWarningWindow>();
+        _observeWarningWindow = UIManager.CreateWindow<ObserveWarningWindow>();
     }
 
     public void OpenWindow()
     {
         EnsureWindow();
 
-        _optionsWindow.OpenCentered();
-        _optionsWindow.MoveToFront();
+        _observeWarningWindow.OpenCentered();
+        _observeWarningWindow.MoveToFront();
     }
 
     public void ToggleWindow()
     {
         EnsureWindow();
 
-        if (_optionsWindow.IsOpen)
+        if (_observeWarningWindow.IsOpen)
         {
-            _optionsWindow.Close();
+            _observeWarningWindow.Close();
         }
         else
         {

--- a/Content.Client/Lobby/UI/ObserveWarningWindowUIController.cs
+++ b/Content.Client/Lobby/UI/ObserveWarningWindowUIController.cs
@@ -1,0 +1,40 @@
+using Linguini.Syntax.Ast;
+using Robust.Client.UserInterface.Controllers;
+
+namespace Content.Client.Lobby.UI;
+
+public sealed class ObserveWarningWindowUIController : UIController
+{
+    private ObserveWarningWindow _optionsWindow = default!;
+
+    private void EnsureWindow()
+    {
+        if (_optionsWindow is { Disposed: false })
+            return;
+
+        _optionsWindow = UIManager.CreateWindow<ObserveWarningWindow>();
+    }
+
+    public void OpenWindow()
+    {
+        EnsureWindow();
+
+        _optionsWindow.OpenCentered();
+        _optionsWindow.MoveToFront();
+    }
+
+    public void ToggleWindow()
+    {
+        EnsureWindow();
+
+        if (_optionsWindow.IsOpen)
+        {
+            _optionsWindow.Close();
+        }
+        else
+        {
+            OpenWindow();
+        }
+    }
+}
+


### PR DESCRIPTION
## About the PR
Created ObserveWarningWindowUIController that prevents multiple windows from opening.


## Why / Balance
Resolves #28855.

## Technical details
Added a simple ObserveWarningWindowUIController that adds Toggle functionality and prevents multiple windows from opening.

## Media
- [❌] I have added screenshots/videos to this PR showcasing its changes ingame, **or** **this PR does not require an ingame showcase**.

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Now, after clicking the observe button in the lobby, you can open only one pop-up warning window.