### PR TITLE
Fix blood-red magboots and speed boots sprite toggle issues.

### DIFF
--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -1,8 +1,10 @@
 using Content.Shared.Actions;
+using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;
+using Content.Shared.Item;
 using Content.Shared.Movement.Systems;
 using Content.Shared.PowerCell;
 using Content.Shared.Toggleable;
@@ -18,10 +20,12 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly ClothingSpeedModifierSystem _clothingSpeedModifier = default!;
+    [Dependency] private readonly ClothingSystem _clothing = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private readonly SharedPowerCellSystem _powerCell = default!;
+    [Dependency] private readonly SharedItemSystem _item = default!;
 
     public override void Initialize()
     {
@@ -166,6 +170,12 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
             return;
 
         uid.Comp.Enabled = value;
+
+        if (uid.Comp.ToggleableSprite && TryComp<ItemComponent>(uid, out var item))
+        {
+            _item.SetHeldPrefix(uid, uid.Comp.Enabled ? "on" : null, component: item);
+            _clothing.SetEquippedPrefix(uid, uid.Comp.Enabled ? "on" : null);
+        }
 
         _appearance.SetData(uid, ToggleVisuals.Toggled, uid.Comp.Enabled);
         _actions.SetToggled(uid.Comp.ToggleActionEntity, uid.Comp.Enabled);

--- a/Content.Shared/Clothing/Components/ToggleClothingSpeedComponent.cs
+++ b/Content.Shared/Clothing/Components/ToggleClothingSpeedComponent.cs
@@ -17,6 +17,12 @@ public sealed partial class ToggleClothingSpeedComponent : Component
     public EntProtoId ToggleAction = "ActionToggleSpeedBoots";
 
     /// <summary>
+    ///     Does this clothing item have a sprite that should update when it is activated?
+    ///     e.g. speedboots have a red region that changes to green when they are active
+    /// </summary>
+    [DataField] public bool ToggleableSprite = false;
+
+    /// <summary>
     /// The action entity
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -97,6 +97,13 @@
     walkModifier: 0.95
     sprintModifier: 0.9
     enabled: false
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.ToggleVisuals.Toggled:
+        enum.ToggleVisuals.Layer:
+          True: {state: icon-on}
+          False: {state: icon}
   - type: GasTank
     outputPressure: 42.6
     air:

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -102,6 +102,7 @@
     sprite: Clothing/Shoes/Boots/speedboots.rsi
   - type: ToggleClothingSpeed
     toggleAction: ActionToggleSpeedBoots
+    toggleableSprite: true
   - type: ClothingSpeedModifier
     walkModifier: 1.5
     sprintModifier: 1.5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Blood-red magboots would only update their game sprite and toggle action sprite when active, for the other actions they provided and for the item icon in the inventory they would continue to appear off. Fixed this!

Speed Boots would only update their item and action sprite, the clothing/held sprite would still appear off. Fixed this as well! Also left a boolean on the component they use for future boots of the sort (slowboots when).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
- Fixes #28354
- Fixes #28355

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The magboots fix was a simple yml mistake

For the speedboots I added a new bool to ToggleClothingSpeedComponent.cs regarding whether the entity's sprite would need updating after activation, and then implemented a check for this in ClothingSpeedModifierSystem.cs modeled after the way magboots update their sprites in MagbootsSystem.cs.

A future PR might want to look into combining some of these systems, there seems to be some redundancy but I didn't want to fix what isn't broken.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
 - fix: Blood-red Magboots and Speed Boots on/off lights now work as intended.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
