### PR TITLE
Chameleon waistbag + chameleon syndicate holster w/ buff

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -107,7 +107,7 @@ uplink-holoclown-kit-desc = A joint venture between Cybersun and Honk.co. Contai
     The holoclown has pockets to store things, a hardlight hand it can manipulate the environment with and is immune to hazardous environments while being resistant to direct trauma, but shares any damage it takes with the user.
 
 uplink-holster-name = Shoulder Holster
-uplink-holster-desc = A deep shoulder holster capable of holding many types of ballistics.
+uplink-holster-desc = A deep shoulder holster capable of holding many types of ballistics. Contains chameleon technology.
 
 uplink-chest-rig-name = Chest Rig
 uplink-chest-rig-desc = Explosion-resistant tactical webbing used for holding traitor goods.

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -247,6 +247,7 @@
         - id: ClothingEyesChameleon
         - id: ClothingHeadsetChameleon
         - id: ClothingShoesChameleon
+        - id: ClothingBeltStorageWaistbagChameleon
         - id: BarberScissors
 
 - type: entity

--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -14,6 +14,7 @@
   - ClothingEyesChameleon
   - ClothingHeadsetChameleon
   - ClothingShoesChameleon
+  - ClothingBeltStorageWaistbagChameleon
   - ChameleonProjector
 
 - type: thiefBackpackSet

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -122,7 +122,7 @@
   name: uplink-sniper-bundle-name
   description: uplink-sniper-bundle-desc
   icon: { sprite: /Textures/Objects/Weapons/Guns/Snipers/heavy_sniper.rsi, state: base }
-  productEntity: BriefcaseSyndieSniperBundleFilled  
+  productEntity: BriefcaseSyndieSniperBundleFilled
   cost:
     Telecrystal: 12
   categories:
@@ -1004,7 +1004,7 @@
     Telecrystal: 6
   categories:
     - UplinkAllies
-  
+
 - type: listing
   id: UplinkSyndicatePersonalAI
   name: uplink-syndicate-pai-name
@@ -1200,7 +1200,7 @@
   description: uplink-holster-desc
   productEntity: ClothingBeltSyndieHolster
   cost:
-    Telecrystal: 1
+    Telecrystal: 2
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -454,7 +454,7 @@
   - type: Appearance
 
 - type: entity
-  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase]
+  parent: ClothingBeltStorageBase
   id: ClothingBeltSecurity
   name: security belt
   description: Can hold security gear like handcuffs and flashes.
@@ -503,8 +503,6 @@
           - SmokeOnTrigger
     sprite: Clothing/Belt/belt_overlay.rsi
   - type: Appearance
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
 
 - type: entity
   parent: [ClothingBeltBase, ClothingSlotBase]

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -613,6 +613,8 @@
     default: ClothingBeltSyndieHolster
   - type: UserInterface
     interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
       enum.ChameleonUiKey.Key:
         type: ChameleonBoundUserInterface
   - type: ExplosionResistance

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -454,7 +454,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltSecurity
   name: security belt
   description: Can hold security gear like handcuffs and flashes.
@@ -503,6 +503,8 @@
           - SmokeOnTrigger
     sprite: Clothing/Belt/belt_overlay.rsi
   - type: Appearance
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
 
 - type: entity
   parent: [ClothingBeltBase, ClothingSlotBase]

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -586,10 +586,10 @@
     - 0,0,3,1
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltSyndieHolster
   name: syndicate shoulder holster
-  description: A deep shoulder holster capable of holding many types of ballistics.
+  description: A deep shoulder holster capable of holding many types of ballistics. Contains chameleon technology.
   components:
   - type: Sprite
     sprite: Clothing/Belt/syndieholster.rsi
@@ -606,6 +606,15 @@
         - Gun
         - BallisticAmmoProvider
         - CartridgeAmmo
+  - type: ChameleonClothing
+    slot: [belt]
+    default: ClothingBeltSyndieHolster
+  - type: UserInterface
+    interfaces:
+      enum.ChameleonUiKey.Key:
+        type: ChameleonBoundUserInterface
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
 
 - type: entity
   parent: ClothingBeltSecurity

--- a/Resources/Prototypes/Entities/Clothing/Belt/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/specific.yml
@@ -1,0 +1,20 @@
+- type: entity
+  parent: ClothingBeltStorageWaistbag
+  id: ClothingBeltStorageWaistbagChameleon
+  name: leather waist bag
+  description: A leather waist bag meant for carrying small items.
+  suffix: Chameleon
+  components:
+  - type: Tag
+    tags: [] # ignore "WhitelistChameleon" tag
+  - type: Sprite
+    sprite: Clothing/Belt/waistbag_leather.rsi
+  - type: ChameleonClothing
+    slot: [belt]
+    default: ClothingBeltStorageWaistbag
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+      enum.ChameleonUiKey.Key:
+        type: ChameleonBoundUserInterface


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- Added chameleon waistbag
- Buffed syndicate holster to be chameleon, 50% explosive resist
  - Cost increased from 1 to 2 tc 

## Why / Balance
- Both chameleon waistbag and syndicate holster complete the chameleon set, arguably missing a belt item (non-matching belts break disguises)

- Syndicate holster made redundant by chest rig and thus never used, took a feature from goonstation to give it chameleon for stealth usage and 50% explosive resist
  - Cost increased to 2 tc due to new features, should be competitive with chest rig (90% explosive resist but non-disguisable)

- I have not yet compared storage of syndicate holster with chest rig, which may need changing

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
yaml and ftl changes only
- uplink-catalog.ftl
- duffelbag.yml
- belts.yml
- specific.yml

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
### Syndicate shoulder holster
![image](https://github.com/space-wizards/space-station-14/assets/20566341/86304ff4-712c-45b8-9478-b9bf715fb482)
![image](https://github.com/space-wizards/space-station-14/assets/20566341/816c28bc-590d-41a6-bece-d517e448dac1)
![image](https://github.com/space-wizards/space-station-14/assets/20566341/9a0d4ae3-5c9d-4a37-a11e-131e8c525095)

### Chameleon Waistbag
![image](https://github.com/space-wizards/space-station-14/assets/20566341/ed8c5b63-29a1-4e14-bb61-b6db834c7f7e)

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->

:cl:
- add: Added chameleon waistbag to the chameleon sets.
- tweak: Syndicate holster now has 50% explosive resist and chameleon ability, and repriced from 1 to 2 tc.
