### PR TITLE
Add an option to the admin fax menu to lock papers such that they can't be edited by cybersun pens

### DIFF
--- a/Content.Client/Fax/AdminUI/AdminFaxEui.cs
+++ b/Content.Client/Fax/AdminUI/AdminFaxEui.cs
@@ -16,7 +16,7 @@ public sealed class AdminFaxEui : BaseEui
         _window.OnClose += () => SendMessage(new AdminFaxEuiMsg.Close());
         _window.OnFollowFax += entity => SendMessage(new AdminFaxEuiMsg.Follow(entity));
         _window.OnMessageSend += args => SendMessage(new AdminFaxEuiMsg.Send(args.entity, args.title,
-                    args.stampedBy, args.message, args.stampSprite, args.stampColor));
+                    args.stampedBy, args.message, args.stampSprite, args.stampColor, args.locked));
     }
 
     public override void Opened()

--- a/Content.Client/Fax/AdminUI/AdminFaxWindow.xaml
+++ b/Content.Client/Fax/AdminUI/AdminFaxWindow.xaml
@@ -24,6 +24,7 @@
         <Label Text="{Loc admin-fax-stamp-color}" />
         <ColorSelectorSliders Margin="12 0 0 0" Name="StampColorSelector" Color="#BB3232"/>
         <Control MinHeight="10" />
+        <CheckBox Name="LockPageCheckbox" Text="{Loc admin-fax-lock-page}" ToolTip="{Loc admin-fax-lock-page-tooltip}"/>
         <Button Name="SendButton" Text="{Loc admin-fax-send}"></Button>
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Client/Fax/AdminUI/AdminFaxWindow.xaml
+++ b/Content.Client/Fax/AdminUI/AdminFaxWindow.xaml
@@ -23,8 +23,7 @@
         </BoxContainer>
         <Label Text="{Loc admin-fax-stamp-color}" />
         <ColorSelectorSliders Margin="12 0 0 0" Name="StampColorSelector" Color="#BB3232"/>
-        <Control MinHeight="10" />
         <CheckBox Name="LockPageCheckbox" Text="{Loc admin-fax-lock-page}" ToolTip="{Loc admin-fax-lock-page-tooltip}"/>
-        <Button Name="SendButton" Text="{Loc admin-fax-send}"></Button>
+        <Button Name="SendButton" Text="{Loc admin-fax-send}" Margin="0 10 0 0" />
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Client/Fax/AdminUI/AdminFaxWindow.xaml.cs
+++ b/Content.Client/Fax/AdminUI/AdminFaxWindow.xaml.cs
@@ -14,7 +14,7 @@ public sealed partial class AdminFaxWindow : DefaultWindow
 {
     private const string StampsRsiPath = "/Textures/Objects/Misc/bureaucracy.rsi";
 
-    public Action<(NetEntity entity, string title, string stampedBy, string message, string stampSprite, Color stampColor)>? OnMessageSend;
+    public Action<(NetEntity entity, string title, string stampedBy, string message, string stampSprite, Color stampColor, bool locked)>? OnMessageSend;
     public Action<NetEntity>? OnFollowFax;
 
     [Dependency] private readonly IResourceCache _resCache = default!;
@@ -98,6 +98,7 @@ public sealed partial class AdminFaxWindow : DefaultWindow
 
         var from = FromEdit.Text;
         var stampColor = StampColorSelector.Color;
-        OnMessageSend?.Invoke((faxEntity.Value, title, from, message, stamp, stampColor));
+        var locked = LockPageCheckbox.Pressed;
+        OnMessageSend?.Invoke((faxEntity.Value, title, from, message, stamp, stampColor, locked));
     }
 }

--- a/Content.Server/Fax/AdminUI/AdminFaxEui.cs
+++ b/Content.Server/Fax/AdminUI/AdminFaxEui.cs
@@ -1,3 +1,4 @@
+using Content.Server.Construction.Conditions;
 using Content.Server.DeviceNetwork.Components;
 using Content.Server.EUI;
 using Content.Shared.Eui;
@@ -56,7 +57,8 @@ public sealed class AdminFaxEui : BaseEui
             case AdminFaxEuiMsg.Send sendData:
             {
                 var printout = new FaxPrintout(sendData.Content, sendData.Title, null, null, sendData.StampState,
-                        new() { new StampDisplayInfo { StampedName = sendData.From, StampedColor = sendData.StampColor } });
+                        new() { new StampDisplayInfo { StampedName = sendData.From, StampedColor = sendData.StampColor } },
+                        locked: sendData.Locked);
                 _faxSystem.Receive(_entityManager.GetEntity(sendData.Target), printout);
                 break;
             }

--- a/Content.Server/Fax/FaxConstants.cs
+++ b/Content.Server/Fax/FaxConstants.cs
@@ -29,4 +29,5 @@ public static class FaxConstants
     public const string FaxPaperStampStateData = "fax_data_stamp_state";
     public const string FaxPaperStampedByData = "fax_data_stamped_by";
     public const string FaxSyndicateData = "fax_data_i_am_syndicate";
+    public const string FaxPaperLockedData = "fax_data_locked";
 }

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -299,8 +299,9 @@ public sealed class FaxSystem : EntitySystem
                     args.Data.TryGetValue(FaxConstants.FaxPaperStampStateData, out string? stampState);
                     args.Data.TryGetValue(FaxConstants.FaxPaperStampedByData, out List<StampDisplayInfo>? stampedBy);
                     args.Data.TryGetValue(FaxConstants.FaxPaperPrototypeData, out string? prototypeId);
+                    args.Data.TryGetValue(FaxConstants.FaxPaperLockedData, out bool? locked);
 
-                    var printout = new FaxPrintout(content, name, label, prototypeId, stampState, stampedBy);
+                    var printout = new FaxPrintout(content, name, label, prototypeId, stampState, stampedBy, locked ?? false);
                     Receive(uid, printout, args.SenderAddress);
 
                     break;
@@ -471,7 +472,8 @@ public sealed class FaxSystem : EntitySystem
                                        labelComponent?.CurrentLabel,
                                        metadata.EntityPrototype?.ID ?? DefaultPaperPrototypeId,
                                        paper.StampState,
-                                       paper.StampedBy);
+                                       paper.StampedBy,
+                                       paper.EditingDisabled);
 
         component.PrintingQueue.Enqueue(printout);
         component.SendTimeoutRemaining += component.SendTimeout;
@@ -518,6 +520,7 @@ public sealed class FaxSystem : EntitySystem
             { FaxConstants.FaxPaperNameData, labelComponent?.OriginalName ?? metadata.EntityName },
             { FaxConstants.FaxPaperLabelData, labelComponent?.CurrentLabel },
             { FaxConstants.FaxPaperContentData, paper.Content },
+            { FaxConstants.FaxPaperLockedData, paper.EditingDisabled },
         };
 
         if (metadata.EntityPrototype != null)
@@ -594,6 +597,8 @@ public sealed class FaxSystem : EntitySystem
                     _paperSystem.TryStamp(printed, stamp, printout.StampState);
                 }
             }
+
+            paper.EditingDisabled = printout.Locked;
         }
 
         _metaData.SetEntityName(printed, printout.Name);

--- a/Content.Server/Paper/PaperComponent.cs
+++ b/Content.Server/Paper/PaperComponent.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Paper;
-using Robust.Shared.GameStates;
 
 namespace Content.Server.Paper;
 
@@ -21,4 +20,7 @@ public sealed partial class PaperComponent : SharedPaperComponent
     /// </summary>
     [DataField("stampState")]
     public string? StampState { get; set; }
+
+    [DataField]
+    public bool EditingDisabled = false;
 }

--- a/Content.Server/Paper/PaperSystem.cs
+++ b/Content.Server/Paper/PaperSystem.cs
@@ -102,6 +102,14 @@ namespace Content.Server.Paper
             var editable = paperComp.StampedBy.Count == 0 || _tagSystem.HasTag(args.Used, "WriteIgnoreStamps");
             if (_tagSystem.HasTag(args.Used, "Write") && editable)
             {
+                if (paperComp.EditingDisabled)
+                {
+                    var paperEditingDisabledMessage = Loc.GetString("paper-tamper-proof-modified-message");
+                    _popupSystem.PopupEntity(paperEditingDisabledMessage, uid, args.User);
+
+                    args.Handled = true;
+                    return;
+                }
                 var writeEvent = new PaperWriteEvent(uid, args.User);
                 RaiseLocalEvent(args.Used, ref writeEvent);
 

--- a/Content.Shared/Fax/AdminFaxEui.cs
+++ b/Content.Shared/Fax/AdminFaxEui.cs
@@ -56,8 +56,9 @@ public static class AdminFaxEuiMsg
         public string Content { get; }
         public string StampState { get; }
         public Color StampColor { get; }
+        public bool Locked { get; }
 
-        public Send(NetEntity target, string title, string from, string content, string stamp, Color stampColor)
+        public Send(NetEntity target, string title, string from, string content, string stamp, Color stampColor, bool locked)
         {
             Target = target;
             Title = title;
@@ -65,6 +66,7 @@ public static class AdminFaxEuiMsg
             Content = content;
             StampState = stamp;
             StampColor = stampColor;
+            Locked = locked;
         }
     }
 }

--- a/Content.Shared/Fax/Components/FaxMachineComponent.cs
+++ b/Content.Shared/Fax/Components/FaxMachineComponent.cs
@@ -150,11 +150,14 @@ public sealed partial class FaxPrintout
     [DataField("stampedBy")]
     public List<StampDisplayInfo> StampedBy { get; private set; } = new();
 
+    [DataField]
+    public bool Locked { get; private set; }
+
     private FaxPrintout()
     {
     }
 
-    public FaxPrintout(string content, string name, string? label = null, string? prototypeId = null, string? stampState = null, List<StampDisplayInfo>? stampedBy = null)
+    public FaxPrintout(string content, string name, string? label = null, string? prototypeId = null, string? stampState = null, List<StampDisplayInfo>? stampedBy = null, bool locked = false)
     {
         Content = content;
         Name = name;
@@ -162,5 +165,6 @@ public sealed partial class FaxPrintout
         PrototypeId = prototypeId ?? "";
         StampState = stampState;
         StampedBy = stampedBy ?? new List<StampDisplayInfo>();
+        Locked = locked;
     }
 }

--- a/Resources/Locale/en-US/fax/fax-admin.ftl
+++ b/Resources/Locale/en-US/fax/fax-admin.ftl
@@ -12,3 +12,5 @@ admin-fax-message-placeholder = Your message here...
 admin-fax-stamp = Stamp icon:
 admin-fax-stamp-color = Stamp color:
 admin-fax-send = Send
+admin-fax-lock-page = Lock Page
+admin-fax-lock-page-tooltip = Lock the paper such that it cannot be edited even by things such as cybersun pens.

--- a/Resources/Locale/en-US/paper/paper-component.ftl
+++ b/Resources/Locale/en-US/paper/paper-component.ftl
@@ -12,3 +12,5 @@ paper-component-action-stamp-paper-other = {CAPITALIZE(THE($user))} stamps {THE(
 paper-component-action-stamp-paper-self = You stamp {THE($target)} with {THE($stamp)}.
 
 paper-ui-save-button = Save ({$keybind})
+
+paper-tamper-proof-modified-message = This page was written using tamper-proof ink.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds an option to the admin fax UI to lock papers such that they cannot be
edited by IC means at all.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Faxes with a CC stamp are often interpreted by players to be sanction from the
admins (both from an IC and OOC prospective). This removes the possibility of
people exploiting admin faxes to their own gain. The option was left as a
toggle so that admins can use it as they feel is appropriate because I can think of
quite a few situations where they would not want to lock a fax (eg. sending a
syndicate fax).

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a field to paper component that disables editing the paper. Most of the
code is just ensuring that this field never gets "lost". Let me know if I
missed an edge case.

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![locked-image](https://github.com/space-wizards/space-station-14/assets/57052305/ef774589-bdf3-41ae-b68b-02f221373290)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
- The public action on the admin fax ui got an additional field. This was only used one time in the entire codebase so is probably negligible.
- A few constructors gained a "locked" parameter. This was made optional where appropriate

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

ADMIN:
:cl: Aquif
- add: It is now possible to "lock" admin faxes such that they cannot be edited by cybersun pens or any other IC means.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
