### PR TITLE
Non-uplink PDAs no longer can have TC inserted into them

### DIFF
--- a/Content.Server/PDA/Ringer/RingerSystem.cs
+++ b/Content.Server/PDA/Ringer/RingerSystem.cs
@@ -43,13 +43,19 @@ namespace Content.Server.PDA.Ringer
             SubscribeLocalEvent<RingerComponent, RingerPlayRingtoneMessage>(RingerPlayRingtone);
             SubscribeLocalEvent<RingerComponent, RingerRequestUpdateInterfaceMessage>(UpdateRingerUserInterfaceDriver);
 
-            SubscribeLocalEvent<RingerUplinkComponent, CurrencyInsertAttemptEvent>(OnCurrencyInsert);
+            SubscribeLocalEvent<RingerComponent, CurrencyInsertAttemptEvent>(OnCurrencyInsert);
         }
 
         //Event Functions
 
-        private void OnCurrencyInsert(EntityUid uid, RingerUplinkComponent uplink, CurrencyInsertAttemptEvent args)
+        private void OnCurrencyInsert(EntityUid uid, RingerComponent ringer, CurrencyInsertAttemptEvent args)
         {
+            if (!TryComp<RingerUplinkComponent>(uid, out var uplink))
+            {
+                args.Cancel();
+                return;
+            }
+
             // if the store can be locked, it must be unlocked first before inserting currency. Stops traitor checking.
             if (!uplink.Unlocked)
                 args.Cancel();

--- a/Content.Server/Store/Systems/StoreSystem.cs
+++ b/Content.Server/Store/Systems/StoreSystem.cs
@@ -1,4 +1,3 @@
-using Content.Server.PDA.Ringer;
 using Content.Server.Store.Components;
 using Content.Shared.UserInterface;
 using Content.Shared.FixedPoint;
@@ -86,10 +85,6 @@ public sealed partial class StoreSystem : EntitySystem
             return;
 
         if (!TryComp<StoreComponent>(args.Target, out var store))
-            return;
-
-        // PDAs without uplinks shouldn't be allowed to have currency added
-        if (TryComp<RingerComponent>(args.Target, out var ringer) && !TryComp<RingerUplinkComponent>(args.Target, out var ringerUplink))
             return;
 
         var ev = new CurrencyInsertAttemptEvent(args.User, args.Target.Value, args.Used, store);

--- a/Content.Server/Store/Systems/StoreSystem.cs
+++ b/Content.Server/Store/Systems/StoreSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.PDA.Ringer;
 using Content.Server.Store.Components;
 using Content.Shared.UserInterface;
 using Content.Shared.FixedPoint;
@@ -5,11 +6,11 @@ using Content.Shared.Implants.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Stacks;
+using Content.Shared.Store.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
-using System.Linq;
-using Content.Shared.Store.Components;
 using Robust.Shared.Utility;
+using System.Linq;
 
 namespace Content.Server.Store.Systems;
 
@@ -85,6 +86,10 @@ public sealed partial class StoreSystem : EntitySystem
             return;
 
         if (!TryComp<StoreComponent>(args.Target, out var store))
+            return;
+
+        // PDAs without uplinks shouldn't be allowed to have currency added
+        if (TryComp<RingerComponent>(args.Target, out var ringer) && !TryComp<RingerUplinkComponent>(args.Target, out var ringerUplink))
             return;
 
         var ev = new CurrencyInsertAttemptEvent(args.User, args.Target.Value, args.Used, store);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

PDAs without an uplink no longer can have TC inserted. Fixes https://github.com/space-wizards/space-station-14/issues/28960

## Why / Balance

Two reasons:
- Obviously, non-syndicate PDAs shouldn't take TC
- The ability to insert TC into PDAs only extends to regular PDAs and unlocked syndicate PDAs, allowing players to tell if a PDA is actually a locked uplink as well. This is obviously bad as well.

## Technical details

Listens for a `CurrencyInsertAttemptEvent` event on the `RingerComponent` instead of `RingerUplinkComponent`, and checks for the latter when the event fires. Should there not be a ringerUplink, then the TC insertion is cancelled.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Non-uplink PDAs can no longer have telecrystals inserted into them.
