### PR TITLE
Prevent uncuffing while buckled, reduce anti-spam cuff cooldown

### DIFF
--- a/Resources/Locale/en-US/cuffs/components/cuffable-component.ftl
+++ b/Resources/Locale/en-US/cuffs/components/cuffable-component.ftl
@@ -1,5 +1,6 @@
 cuffable-component-cannot-interact-message = You can't do that!
 cuffable-component-cannot-remove-cuffs-too-far-message = You are too far away to remove the restraints.
+cuffable-component-cannot-remove-cuffs-buckled-message = You can't reach the cuffs!
 
 cuffable-component-start-uncuffing-self = You start to painfully wriggle out of your restraints.
 cuffable-component-start-uncuffing-observer = {$user} starts unrestraining {$target}!

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -27,7 +27,7 @@
     guides:
     - Security
   - type: UseDelay
-    delay: 30
+    delay: 3
 
 - type: entity
   name: makeshift handcuffs


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR seeks to make security handling prisoners significantly easier by enabling them to not have to deal with them spamming uncuff attempts constantly.

This also undoes the previous change of making the cuff cooldown 30 seconds.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
There have been a variety of PRs seeking to fix the issue of prisoner uncuffing. Essentially, prisoners can spam uncuffs out the ass which forces sec to tediously micromanage and cancel them constantly just to be able to handle prisoners. These attempts fail basically 100% of the time because sec is usually right next them and not completely blind.

The previous PR attempted to mitigate this by extending the self uncuff cooldown to 30 seconds which is really excessive and long and just a heavy-handed solution to this issue. It doesn't really stop the problem as sec still needs to deal with people attempting uncuffs in situations where they have literally no chance of succeeding or escaping.

This PR essentially just skips all of this unnecessary tedium by just stopping people from being able to uncuff at all if you buckle them into a chair or on a bed. This lets sec actually do things like searches, interrogations and various prisoner interactions without having to constantly deal with uncuff spam.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a subscription into SharedBuckleSystem which just cancels the uncuff attempt if the user is uncuffing themselves and also buckled.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/8331a2bd-bba0-42b2-8d2e-ffbbe6492e2d)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: You can no longer uncuff yourself if you are currently buckled to a chair or bed.
- tweak: Reduced the self uncuff delay to 3 seconds.
