### PR TITLE
Fix Loadout Requirements Only Displaying One Requirement

### DIFF
--- a/Content.Shared/Preferences/Loadouts/Effects/GroupLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/GroupLoadoutEffect.cs
@@ -17,13 +17,16 @@ public sealed partial class GroupLoadoutEffect : LoadoutEffect
     {
         var effectsProto = collection.Resolve<IPrototypeManager>().Index(Proto);
 
+        var reasons = new List<string>();
         foreach (var effect in effectsProto.Effects)
         {
-            if (!effect.Validate(profile, loadout, session, collection, out reason))
-                return false;
+            if (effect.Validate(profile, loadout, session, collection, out reason))
+                continue;
+
+            reasons.Add(reason.ToMarkup());
         }
 
-        reason = null;
-        return true;
+        reason = reasons.Count == 0 ? null : FormattedMessage.FromMarkup(string.Join('\n', reasons));
+        return reason == null;
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This PR aggregates all of the requirement messages into one message and displays that as the tool-tip. 

So, instead of only displaying the first requirement that the player does not meet, this displays all of the requirements that the user does not meet.
 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

The `GroupLoadoutEffect` for loadout requirements previously did not account for multiple requirements for the same loadout.

At the first instance of a failed requirement, it would stop and just display that one.

This is an issue for things like the Senior clothes, which require many things like playing all of the roles in a department and getting x total minutes.

Previously, it would only display one of these requirements, misleading the player into what they think the actual requirements are. When they would check again after completing it, they would be shocked to discover another requirement. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This just uses a list to aggregate all of the reasons and then turns it into a formatted message at the end.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

<details><summary>
Before
</summary>

![image](https://github.com/space-wizards/space-station-14/assets/87614336/316d82db-7b8a-4acf-8833-c6adaf748bee)

</details>

After:

![image](https://github.com/space-wizards/space-station-14/assets/87614336/14f8747d-74c6-43c2-8052-0580f5d3672d)


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Loadouts now display all requirements.