### PR TITLE
Make pressure and volume pumps require power

### DIFF
--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
@@ -9,6 +9,7 @@ using Content.Server.DeviceNetwork.Systems;
 using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NodeContainer.Nodes;
+using Content.Server.Power.Components;
 using Content.Shared.Atmos.Piping.Binary.Components;
 using Content.Shared.Atmos.Visuals;
 using Content.Shared.Audio;
@@ -45,6 +46,7 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
             SubscribeLocalEvent<GasVolumePumpComponent, AtmosDeviceDisabledEvent>(OnVolumePumpLeaveAtmosphere);
             SubscribeLocalEvent<GasVolumePumpComponent, ExaminedEvent>(OnExamined);
             SubscribeLocalEvent<GasVolumePumpComponent, ActivateInWorldEvent>(OnPumpActivate);
+            SubscribeLocalEvent<GasVolumePumpComponent, PowerChangedEvent>(OnPowerChanged);
             // Bound UI subscriptions
             SubscribeLocalEvent<GasVolumePumpComponent, GasVolumePumpChangeTransferRateMessage>(OnTransferRateChangeMessage);
             SubscribeLocalEvent<GasVolumePumpComponent, GasVolumePumpToggleStatusMessage>(OnToggleStatusMessage);
@@ -69,9 +71,15 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
                 args.PushMarkup(str);
         }
 
+        private void OnPowerChanged(EntityUid uid, GasVolumePumpComponent component, ref PowerChangedEvent args)
+        {
+            UpdateAppearance(uid, component);
+        }
+
         private void OnVolumePumpUpdated(EntityUid uid, GasVolumePumpComponent pump, ref AtmosDeviceUpdateEvent args)
         {
             if (!pump.Enabled ||
+                (TryComp<ApcPowerReceiverComponent>(uid, out var power) && !power.Powered) ||
                 !_nodeContainer.TryGetNodes(uid, pump.InletName, pump.OutletName, out PipeNode? inlet, out PipeNode? outlet))
             {
                 _ambientSoundSystem.SetAmbience(uid, false);
@@ -183,7 +191,8 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
             if (!Resolve(uid, ref pump, ref appearance, false))
                 return;
 
-            if (!pump.Enabled)
+            bool pumpOn = pump.Enabled && (TryComp<ApcPowerReceiverComponent>(uid, out var power) && power.Powered);
+            if (!pumpOn)
                 _appearance.SetData(uid, GasVolumePumpVisuals.State, GasVolumePumpState.Off, appearance);
             else if (pump.Blocked)
                 _appearance.SetData(uid, GasVolumePumpVisuals.State, GasVolumePumpState.Blocked, appearance);

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -24,13 +24,18 @@
         pipeDirection: South
 
 - type: entity
-  parent: GasBinaryBase
+  parent: [BaseMachinePowered, GasBinaryBase]
   id: GasPressurePump
   name: gas pump
   description: A pump that moves gas by pressure.
   placement:
     mode: SnapgridCenter
   components:
+  - type: ApcPowerReceiver
+    powerLoad: 200
+  - type: Rotatable
+  - type: Transform
+    noRot: false
   - type: Sprite
     sprite: Structures/Piping/Atmospherics/pump.rsi
     layers:
@@ -64,13 +69,18 @@
       path: /Audio/Ambience/Objects/gas_pump.ogg
 
 - type: entity
-  parent: GasBinaryBase
+  parent: [BaseMachinePowered, GasBinaryBase]
   id: GasVolumePump
   name: volumetric gas pump
   description: A pump that moves gas by volume.
   placement:
     mode: SnapgridCenter
   components:
+    - type: ApcPowerReceiver
+      powerLoad: 200
+    - type: Rotatable
+    - type: Transform
+      noRot: false
     - type: Sprite
       sprite: Structures/Piping/Atmospherics/pump.rsi
       layers:


### PR DESCRIPTION
## About the PR
Make pressure and volume pumps require power.

## Why / Balance
Pumps do work and as a result should require power to operate. This is needed for eventual [soft clogging which is part of the approved atmos roadmap](https://docs.spacestation14.com/en/space-station-14/departments/atmos/proposals/atmos-rework.html). Furthermore, it incentivizes players to use passive gates and manual valves that work in case of a power outage.

The power consumption is currently very small and will unlikely have any major impact besides requiring atmos techs to route LV cables to pumps.

## Media
A powered pressure pump:
![image](https://github.com/space-wizards/space-station-14/assets/3229565/8c60a975-fa49-4da9-8104-29e5150de355)

When the APC is off, it no longer runs:
![image](https://github.com/space-wizards/space-station-14/assets/3229565/cd97ef96-ce70-4510-9cd6-cf994d0d57e6)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: notafet
- tweak: Pressure and volume pumps now require power to operate.