### PR TITLE
fix(uplink): Remove useless gps from death rattle box

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
@@ -54,7 +54,7 @@
   name: deathrattle implant box
   parent: BoxCardboard
   id: BoxDeathRattleImplants
-  description: Six deathrattle implants and handheld GPS devices for the whole squad.
+  description: Six deathrattle implants for the whole squad.
   components:
   - type: Sprite
     layers:
@@ -66,6 +66,4 @@
   - type: StorageFill
     contents:
       - id: DeathRattleImplanter
-        amount: 6
-      - id: HandheldGPSBasic
         amount: 6


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removes the six gps devices from the syndicate death rattle ox

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Is now just bloat and clutter after the death rattle announcement was changed.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
+1 -1

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- remove: Removed the six Handheld GPS devices from the syndicate deathrattle implant box.