### PR TITLE
Set ahelp new player icon to use minutes, not seconds

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -75,7 +75,7 @@ namespace Content.Client.Administration.UI.Bwoink
                 if (info.Antag && info.ActiveThisRound)
                     sb.Append(new Rune(0x1F5E1)); // 🗡
 
-                if (info.OverallPlaytime <= TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.NewPlayerThreshold)))
+                if (info.OverallPlaytime <= TimeSpan.FromMinutes(_cfg.GetCVar(CCVars.NewPlayerThreshold)))
                     sb.Append(new Rune(0x23F2)); // ⏲
 
                 sb.AppendFormat("\"{0}\"", text);
@@ -226,7 +226,7 @@ namespace Content.Client.Administration.UI.Bwoink
             if (pl.Antag)
                 sb.Append(new Rune(0x1F5E1)); // 🗡
 
-            if (pl.OverallPlaytime <= TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.NewPlayerThreshold)))
+            if (pl.OverallPlaytime <= TimeSpan.FromMinutes(_cfg.GetCVar(CCVars.NewPlayerThreshold)))
                 sb.Append(new Rune(0x23F2)); // ⏲
 
             sb.AppendFormat("\"{0}\"", pl.CharacterName);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The new player icon is now (correctly) based on minutes and not seconds. #28810 shows it not working on someone with 1 minute of playtime, so it may still be broken, but this is also a bug regardless and should allow more debugging without admins having to look at someone who *just* joined the server. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I (mistakenly) used FromSeconds instead of FromMinutes, making the cvar only show for players with less than.. 10 minutes of playtime. The description says minutes and seconds are far too granular for something like this.

![image](https://github.com/space-wizards/space-station-14/assets/135308300/bf009d50-5837-4b3e-9a3e-bf7c6c89a96c)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
