### PR TITLE
Fix IComponentFactory mock in benchmark

### DIFF
--- a/Content.Benchmarks/EntityManagerGetAllComponents.cs
+++ b/Content.Benchmarks/EntityManagerGetAllComponents.cs
@@ -47,6 +47,7 @@ namespace Content.Benchmarks
 
             var componentFactory = new Mock<IComponentFactory>();
             componentFactory.Setup(p => p.GetComponent<DummyComponent>()).Returns(new DummyComponent());
+            componentFactory.Setup(m => m.GetIndex(typeof(DummyComponent))).Returns(CompIdx.Index<DummyComponent>());
             componentFactory.Setup(p => p.GetRegistration(It.IsAny<DummyComponent>())).Returns(dummyReg);
             componentFactory.Setup(p => p.GetAllRegistrations()).Returns(new[] { dummyReg });
             componentFactory.Setup(p => p.GetAllRefTypes()).Returns(new[] { CompIdx.Index<DummyComponent>() });


### PR DESCRIPTION
Required for an engine update.
Requires space-wizards/RobustToolbox/pull/5231
