### PR TITLE
Make firelock warning light not require power and add a PointLight

### DIFF
--- a/Content.Client/Doors/FirelockSystem.cs
+++ b/Content.Client/Doors/FirelockSystem.cs
@@ -25,15 +25,12 @@ public sealed class FirelockSystem : SharedFirelockSystem
         if (!_appearanceSystem.TryGetData<DoorState>(uid, DoorVisuals.State, out var state, args.Component))
             state = DoorState.Closed;
 
-        if (_appearanceSystem.TryGetData<bool>(uid, DoorVisuals.Powered, out var powered, args.Component) && powered)
-        {
-            boltedVisible = _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.BoltLights, out var lights, args.Component) && lights;
-            unlitVisible =
-                state == DoorState.Closing
-                ||  state == DoorState.Opening
-                ||  state == DoorState.Denying
-                || (_appearanceSystem.TryGetData<bool>(uid, DoorVisuals.ClosedLights, out var closedLights, args.Component) && closedLights);
-        }
+        boltedVisible = _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.BoltLights, out var lights, args.Component) && lights;
+        unlitVisible =
+            state == DoorState.Closing
+            ||  state == DoorState.Opening
+            ||  state == DoorState.Denying
+            || (_appearanceSystem.TryGetData<bool>(uid, DoorVisuals.ClosedLights, out var closedLights, args.Component) && closedLights);
 
         args.Sprite.LayerSetVisible(DoorVisualLayers.BaseUnlit, unlitVisible && !boltedVisible);
         args.Sprite.LayerSetVisible(DoorVisualLayers.BaseBolted, boltedVisible);

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -6,9 +6,9 @@ using Content.Server.Power.EntitySystems;
 using Content.Server.Shuttles.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Monitor;
-using Content.Shared.Doors;
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
+using Robust.Server.GameObjects;
 using Robust.Shared.Map.Components;
 
 namespace Content.Server.Doors.Systems
@@ -20,6 +20,7 @@ namespace Content.Server.Doors.Systems
         [Dependency] private readonly AtmosphereSystem _atmosSystem = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly SharedMapSystem _mapping = default!;
+        [Dependency] private readonly PointLightSystem _pointLight = default!;
 
         private const int UpdateInterval = 30;
         private int _accumulatedTicks;
@@ -53,6 +54,7 @@ namespace Content.Server.Doors.Systems
             var airtightQuery = GetEntityQuery<AirtightComponent>();
             var appearanceQuery = GetEntityQuery<AppearanceComponent>();
             var xformQuery = GetEntityQuery<TransformComponent>();
+            var pointLightQuery = GetEntityQuery<PointLightComponent>();
 
             var query = EntityQueryEnumerator<FirelockComponent, DoorComponent>();
             while (query.MoveNext(out var uid, out var firelock, out var door))
@@ -74,6 +76,11 @@ namespace Content.Server.Doors.Systems
                     firelock.Temperature = fire;
                     firelock.Pressure = pressure;
                     Dirty(uid, firelock);
+
+                    if (pointLightQuery.TryComp(uid, out var pointLight))
+                    {
+                        _pointLight.SetEnabled(uid, fire | pressure, pointLight);
+                    }
                 }
             }
         }

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -109,6 +109,12 @@
       access: [ [ "Engineering" ] ]
     - type: PryUnpowered
       pryModifier: 0.5
+    - type: PointLight
+      energy: 0.5
+      radius: 1.75
+      color: Red
+      enabled: false
+      castShadows: false
 
 - type: entity
   id: Firelock


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Removes the requirement that a firelock be powered to show the warning lights.
Adds a small red PointLight to firelocks when pressure or temperature warnings are active.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Gives more visibility to firelocks in darkness and power out events to warn players of danger.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![Content Client_HG16h4FBxQ](https://github.com/space-wizards/space-station-14/assets/10494922/4e9a2596-76da-40d3-acea-4c5054d9ae07)


https://github.com/space-wizards/space-station-14/assets/10494922/0eb69484-ad28-4c0d-8cb1-c75f1278c7ad


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Added a red light to firelocks when their warning lights are active.
- tweak: Firelocks no longer require power to show warning lights.
