### PR TITLE
fixed missing characters in OwO accent

### DIFF
--- a/Content.Server/Speech/EntitySystems/OwOAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/OwOAccentSystem.cs
@@ -8,7 +8,7 @@ namespace Content.Server.Speech.EntitySystems
         [Dependency] private readonly IRobustRandom _random = default!;
 
         private static readonly IReadOnlyList<string> Faces = new List<string>{
-            " (・`ω´・)", " ;;w;;", " owo", " UwU", " >w<", " ^w^"
+            " (•`ω´•)", " ;;w;;", " owo", " UwU", " >w<", " ^w^"
         }.AsReadOnly();
 
         private static readonly IReadOnlyDictionary<string, string> SpecialWords = new Dictionary<string, string>()


### PR DESCRIPTION
## About the PR
I replaced two unicode characters with *different* unicode characters (ones from wgl4) so that they actually show up ingame.

## Why / Balance
it was broken

## Media
Before:
![image](https://github.com/space-wizards/space-station-14/assets/62638182/614c46de-a9bd-4841-8238-909c2ee99f3d)
After:
![image](https://github.com/space-wizards/space-station-14/assets/62638182/5884382b-3832-44c6-b797-00f44edf4de9)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase