### PR TITLE
Adjust TEG efficiency curve, remove heat transfer limit

### DIFF
--- a/Content.Server/Power/Generation/Teg/TegSystem.cs
+++ b/Content.Server/Power/Generation/Teg/TegSystem.cs
@@ -128,7 +128,6 @@ public sealed class TegSystem : EntitySystem
         // Shift ramp position based on demand and generation from previous tick.
         var curRamp = component.RampPosition;
         var lastDraw = supplier.CurrentSupply;
-        // Limit amount lost/gained based on power factor.
         curRamp = MathHelper.Clamp(lastDraw, curRamp / component.RampFactor, curRamp * component.RampFactor);
         curRamp = MathF.Max(curRamp, component.RampMinimum);
         component.RampPosition = curRamp;
@@ -140,14 +139,9 @@ public sealed class TegSystem : EntitySystem
             var hotA = airA.Temperature > airB.Temperature;
             var cHot = hotA ? cA : cB;
 
-            // Calculate maximum amount of energy to generate this tick based on ramping above.
-            // This clamps the thermal energy transfer as well.
-            var targetEnergy = curRamp / _atmosphere.AtmosTickRate;
-            var transferMax = targetEnergy / (component.ThermalEfficiency * component.PowerFactor);
-
             // Calculate thermal and electrical energy transfer between the two sides.
             var δT = MathF.Abs(airA.Temperature - airB.Temperature);
-            var transfer = Math.Min(δT * cA * cB / (cA + cB - cHot * component.ThermalEfficiency), transferMax);
+            var transfer = δT * cA * cB / (cA + cB - cHot * component.ThermalEfficiency);
             electricalEnergy = transfer * component.ThermalEfficiency * component.PowerFactor;
             var outTransfer = transfer * (1 - component.ThermalEfficiency);
 


### PR DESCRIPTION
## About the PR
The TEG used to limit hot-cold energy transfer based on actual power drawn, and had maximum efficiency at whatever temperature difference. This PR adjusts the hot-cold energy transfer to be uncapped, "venting" the excess heat that is not used to generate power, and adds an efficiency curve that limits efficiency at low thermal temperatures.

## Why / Balance
People have been cheesing the TEG by hooking up the hot end to the CO2 miner (which produces infinite, room-temperature gas) and the cold end to a space radiator.

With this change, you will actually need to set up a burn chamber in order to get appreciable power out of the TEG (see below).

If you build a gas holding chamber, you will have to throttle the gas flowing into the TEG instead of constantly cycling the gas through over and over again.

Blessed conceptually by @PJB3005 

## Technical details
TEG added efficiency as a function of temperature difference:
![image](https://github.com/space-wizards/space-station-14/assets/3229565/e1daadcc-3868-4418-9c9c-df9fdd2f0f60)

## Media
The CO2 trick no longer gives you appreciable power:
![2024-06-15_12-11](https://github.com/space-wizards/space-station-14/assets/3229565/0601c183-9a70-4c77-8ee2-53ffdd2a7d52)

But setting up the burn chamber like you're supposed to still does:
![2024-06-15_12-23](https://github.com/space-wizards/space-station-14/assets/3229565/4b7987aa-3b8e-41cf-8b9e-76df8a29ae62)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: notafet
- tweak: The TEG must now be operated at higher temperatures to generate power.