### PR TITLE
changes in security loadouts

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -146,6 +146,7 @@ loadout-group-detective-neck = Detective neck
 loadout-group-detective-jumpsuit = Detective jumpsuit
 loadout-group-detective-outerclothing = Detective outer clothing
 
+loadout-group-security-cadet-head = Security cadet head
 loadout-group-security-cadet-jumpsuit = Security cadet jumpsuit
 
 # Medical

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -36,15 +36,6 @@
     jumpsuit: ClothingUniformJumpskirtHoSAlt
 
 - type: loadout
-  id: HeadofSecurityJumpsuitBlue
-  equipment: HeadofSecurityJumpsuitBlue
-
-- type: startingGear
-  id: HeadofSecurityJumpsuitBlue
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitHoSBlue
-
-- type: loadout
   id: HeadofSecurityJumpsuitGrey
   equipment: HeadofSecurityJumpsuitGrey
 

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -36,6 +36,42 @@
     jumpsuit: ClothingUniformJumpskirtHoSAlt
 
 - type: loadout
+  id: HeadofSecurityJumpsuitBlue
+  equipment: HeadofSecurityJumpsuitBlue
+
+- type: startingGear
+  id: HeadofSecurityJumpsuitBlue
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHoSBlue
+
+- type: loadout
+  id: HeadofSecurityJumpsuitGrey
+  equipment: HeadofSecurityJumpsuitGrey
+
+- type: startingGear
+  id: HeadofSecurityJumpsuitGrey
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHoSGrey
+
+- type: loadout
+  id: HeadofSecurityJumpsuitParade
+  equipment: HeadofSecurityJumpsuitParade
+
+- type: startingGear
+  id: HeadofSecurityJumpsuitParade
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitHoSParadeMale
+
+- type: loadout
+  id: HeadofSecurityJumpskirtParade
+  equipment: HeadofSecurityJumpskirtParade
+
+- type: startingGear
+  id: HeadofSecurityJumpskirtParade
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtHoSParadeMale
+
+- type: loadout
   id: HeadofSecurityFormalSuit
   equipment: HeadofSecurityFormalSuit
 

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
@@ -1,18 +1,18 @@
 # Jumpsuit
 - type: loadout
-  id: RedJumpsuit
-  equipment: RedJumpsuit
+  id: SecurityJumpsuitGrey
+  equipment: SecurityJumpsuitGrey
 
 - type: startingGear
-  id: RedJumpsuit
+  id: SecurityJumpsuitGrey
   equipment:
-    jumpsuit: ClothingUniformJumpsuitColorRed
+    jumpsuit: ClothingUniformJumpsuitSecGrey
 
 - type: loadout
-  id: RedJumpskirt
-  equipment: RedJumpskirt
+  id: SecurityJumpskirtGrey
+  equipment: SecurityJumpskirtGrey
 
 - type: startingGear
-  id: RedJumpskirt
+  id: SecurityJumpskirtGrey
   equipment:
-    jumpsuit: ClothingUniformJumpskirtColorRed
+    jumpsuit: ClothingUniformJumpskirtSecGrey

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -61,24 +61,6 @@
     jumpsuit: ClothingUniformJumpskirtSec
 
 - type: loadout
-  id: SecurityJumpsuitGrey
-  equipment: SecurityJumpsuitGrey
-
-- type: startingGear
-  id: SecurityJumpsuitGrey
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitSecGrey
-
-- type: loadout
-  id: SecurityJumpskirtGrey
-  equipment: SecurityJumpskirtGrey
-
-- type: startingGear
-  id: SecurityJumpskirtGrey
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtSecGrey
-
-- type: loadout
   id: SeniorOfficerJumpsuit
   equipment: SeniorOfficerJumpsuit
   effects:

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -59,6 +59,24 @@
   id: SecurityJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtSec
+    
+- type: loadout
+  id: SecurityJumpsuitGrey
+  equipment: SecurityJumpsuitGrey
+
+- type: startingGear
+  id: SecurityJumpsuitGrey
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSecGrey
+
+- type: loadout
+  id: SecurityJumpskirtGrey
+  equipment: SecurityJumpskirtGrey
+
+- type: startingGear
+  id: SecurityJumpskirtGrey
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtSecGrey
 
 - type: loadout
   id: SeniorOfficerJumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -59,7 +59,7 @@
   id: SecurityJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtSec
-    
+
 - type: loadout
   id: SecurityJumpsuitGrey
   equipment: SecurityJumpsuitGrey

--- a/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
@@ -45,6 +45,15 @@
   id: WardenCoat
   equipment:
     outerClothing: ClothingOuterCoatWarden
+    
+- type: loadout
+  id: WardenWinterUnarmoredCoat
+  equipment: WardenWinterUnarmoredCoat
+
+- type: startingGear
+  id: WardenWinterUnarmoredCoat
+  equipment:
+    outerClothing: ClothingOuterWinterWardenUnarmored
 
 - type: loadout
   id: WardenArmoredWinterCoat

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -795,8 +795,12 @@
   - HeadofSecurityJumpskirt
   - HeadofSecurityTurtleneck
   - HeadofSecurityTurtleneckSkirt
+  - HeadofSecurityJumpsuitParade
+  - HeadofSecurityJumpskirtParade
   - HeadofSecurityFormalSuit
   - HeadofSecurityFormalSkirt
+  - HeadofSecurityJumpsuitBlue
+  - HeadofSecurityJumpsuitGrey
 
 - type: loadoutGroup
   id: HeadofSecurityNeck
@@ -808,6 +812,7 @@
 
 - type: loadoutGroup
   id: HeadofSecurityOuterClothing
+  minLimit: 0
   name: loadout-group-head-of-security-outerclothing
   loadouts:
   - HeadofSecurityCoat
@@ -830,9 +835,11 @@
 
 - type: loadoutGroup
   id: WardenOuterClothing
+  minLimit: 0
   name: loadout-group-warden-outerclothing
   loadouts:
   - WardenCoat
+  - WardenWinterUnarmoredCoat
   - WardenArmoredWinterCoat
 
 - type: loadoutGroup
@@ -850,8 +857,6 @@
   loadouts:
   - SecurityJumpsuit
   - SecurityJumpskirt
-  - SecurityJumpsuitGrey
-  - SecurityJumpskirtGrey
   - SeniorOfficerJumpsuit
   - SeniorOfficerJumpskirt
 
@@ -873,6 +878,7 @@
 - type: loadoutGroup
   id: SecurityOuterClothing
   name: loadout-group-security-outerclothing
+  minLimit: 0
   loadouts:
   - ArmorVest
   - ArmorVestSlim
@@ -925,11 +931,19 @@
   - DetectiveCoat
 
 - type: loadoutGroup
+  id: SecurityCadetHead
+  name: loadout-group-security-cadet-head
+  minLimit: 0
+  loadouts:
+  - SecurityHelmet
+  - SecurityHat
+
+- type: loadoutGroup
   id: SecurityCadetJumpsuit
   name: loadout-group-security-cadet-jumpsuit
   loadouts:
-  - RedJumpsuit
-  - RedJumpskirt
+  - SecurityJumpsuitGrey
+  - SecurityJumpskirtGrey
 
 # Medical
 - type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -857,6 +857,8 @@
   loadouts:
   - SecurityJumpsuit
   - SecurityJumpskirt
+  - SecurityJumpsuitGrey
+  - SecurityJumpskirtGrey
   - SeniorOfficerJumpsuit
   - SeniorOfficerJumpskirt
 

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -799,7 +799,6 @@
   - HeadofSecurityJumpskirtParade
   - HeadofSecurityFormalSuit
   - HeadofSecurityFormalSkirt
-  - HeadofSecurityJumpsuitBlue
   - HeadofSecurityJumpsuitGrey
 
 - type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -300,6 +300,7 @@
 - type: roleLoadout
   id: JobSecurityCadet
   groups:
+  - SecurityCadetHead
   - SecurityCadetJumpsuit
   - SecurityBackpack
   - Trinkets

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -32,6 +32,7 @@
     outerClothing: ClothingOuterArmorBasic
     id: SecurityCadetPDA
     ears: ClothingHeadsetSecurity
+    gloves: ClothingHandsGlovesColorBlack
     belt: ClothingBeltSecurityFilled
     pocket1: WeaponPistolMk58
     pocket2: BookSecurity

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -27,6 +27,7 @@
   equipment:
     eyes: ClothingEyesGlassesSecurity
     ears: ClothingHeadsetSecurity
+    gloves: ClothingHandsGlovesColorBlack
     pocket1: WeaponPistolMk58
   storage:
     back:


### PR DESCRIPTION
## About the PR
This PR extend loadouts of security and reworks some aspects of them

## Why / Balance
- Why grey jumpsuits for cadets?
- Because red jumpsuits are not unique and there are many of them at the station, but only the security have grey ones

- Why do cadets need hats?
- Why not?

- Why does the HoS need so many jumpsuits in loadout?
- Because they are in the game

- Why do they need gloves?
- Because it looks stricter and more logical. They don't want to leave their fingerprints on the evidence

## Media
![image](https://github.com/space-wizards/space-station-14/assets/91343598/cb9243e9-8093-4d5c-b9cd-f9ee5fca184b)
![image](https://github.com/space-wizards/space-station-14/assets/91343598/9d44ffeb-cc2c-436e-a3be-5f8fe2a3b3af)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: More suits for HoS and others
- add: Officers and cadets now have black gloves
- add: Hats for cadets
- tweak: Cadets now use grey security suit
- tweak: Some loadout groups are optional