### PR TITLE
improve meteor spawning

### DIFF
--- a/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
@@ -66,7 +66,14 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
                 : new Random(uid.Id).NextAngle();
 
             var offset = angle.RotateVec(new Vector2((maximumDistance - minimumDistance) * RobustRandom.NextFloat() + minimumDistance, 0));
-            var subOffset = RobustRandom.NextAngle().RotateVec(new Vector2( (playableArea.TopRight - playableArea.Center).Length() / 2 * RobustRandom.NextFloat(), 0));
+
+            // the line at which spawns occur is perpendicular to the offset.
+            // This means the meteors are less likely to bunch up and hit the same thing.
+            var subOffsetAngle = RobustRandom.Prob(0.5f)
+                ? angle + Math.PI / 2
+                : angle - Math.PI / 2;
+            var subOffset = subOffsetAngle.RotateVec(new Vector2( (playableArea.TopRight - playableArea.Center).Length() / 3 * RobustRandom.NextFloat(), 0));
+
             var spawnPosition = new MapCoordinates(center + offset + subOffset, mapId);
             var meteor = Spawn(spawnProto, spawnPosition);
             var physics = Comp<PhysicsComponent>(meteor);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changes the way meteor spawn position is determined slightly in order to improve the distribution.
Primarily, spreads the meteors out a bit more.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Meteor swarms being more likely to hit different parts of the station versus clumping up makes the threat more engaging as delegation and splitting up becomes required to deal with it.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
![image](https://github.com/space-wizards/space-station-14/assets/98561806/ffc9bc2f-cc16-440c-978d-66dc81f97c6e)

meteor spawning generates a vector with a random angle from the station origin and marks this as the offset point.

in the previous version, a second entirely random vector was chose. This essentially creates a circle, with more spawning area in the center and less towards the edges. This clumps up meteors a bit more and makes them more likely to spawn together (as the distance from the station does not matter).

The new version changes the spawning circle to instead be a kind of line that runs perpendicular to the origin. This means that all spots along it are equally likely and thus the meteors will hit all parts of the station equally instead of just hitting the same small area multiple times.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Changed meteor swarm spawning to be less clumped up and favor hitting multiple areas more.