### PR TITLE
Widen power monitoring widget

### DIFF
--- a/Content.Client/Power/PowerMonitoringWindow.xaml.Widgets.cs
+++ b/Content.Client/Power/PowerMonitoringWindow.xaml.Widgets.cs
@@ -482,7 +482,7 @@ public sealed class PowerMonitoringButton : Button
         {
             HorizontalAlignment = HAlignment.Right,
             Align = Label.AlignMode.Right,
-            SetWidth = 72f,
+            SetWidth = 80f,
             Margin = new Thickness(10, 0, 0, 0),
             ClipText = true,
         };


### PR DESCRIPTION
## About the PR
Widen the power monitoring widget so that the label isn't cut off.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/3229565/23eb0a54-3a37-4bbd-8e6e-53ea9d80f4d3)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None