### PR TITLE
Make held suits slow you only for half

### DIFF
--- a/Content.Shared/Item/HeldSpeedModifierComponent.cs
+++ b/Content.Shared/Item/HeldSpeedModifierComponent.cs
@@ -31,4 +31,10 @@ public sealed partial class HeldSpeedModifierComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public bool MirrorClothingModifier = true;
+
+    /// <summary>
+    /// If true, it will take only half of <see cref="ClothingSpeedModifierComponent"/> speed.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public bool HalfSpeedModifier = true;
 }

--- a/Content.Shared/Item/HeldSpeedModifierSystem.cs
+++ b/Content.Shared/Item/HeldSpeedModifierSystem.cs
@@ -37,6 +37,13 @@ public sealed class HeldSpeedModifierSystem : EntitySystem
         {
             walkMod = clothingSpeedModifier.WalkModifier;
             sprintMod = clothingSpeedModifier.SprintModifier;
+
+            // If ClothingSpeedModifier is 0.6 it will make it 0.8, 0.5 - 0.75 etc.
+            if (component.HalfSpeedModifier)
+            {
+                walkMod = (walkMod + 1) / 2;
+                sprintMod = (sprintMod + 1) / 2;
+            }
         }
 
         args.Args.ModifySpeed(walkMod, sprintMod);

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -14,6 +14,7 @@
     walkModifier: 1
     sprintModifier: 0.9
   - type: HeldSpeedModifier
+    halfSpeedModifier: true
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -242,7 +243,6 @@
     - 0,0,19,9
   - type: ClothingSpeedModifier
     sprintModifier: 1 # makes its stats identical to other variants of bag of holding
-  - type: HeldSpeedModifier
 
 - type: entity
   parent: ClothingBackpackDuffel
@@ -255,4 +255,3 @@
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
-  - type: HeldSpeedModifier

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -14,7 +14,7 @@
     walkModifier: 1
     sprintModifier: 0.9
   - type: HeldSpeedModifier
-    halfSpeedModifier: true
+    halfSpeedModifier: false
 
 - type: entity
   parent: ClothingBackpackDuffel


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
If certain suit has 60% speed modifier,  while held itll be only 80%
Only applied to suits tho, duffels still has all the same

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
current hardsuit slowdown, whether worn or held, feels overly punitive and unrealistic. Wearing a hardsuit should significantly reduce mobility due to its bulk, but merely holding it should result in a less severe encumbrance.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
add new HalfSpeedModifier to HeldSpeedModifierComponent which checks in system and makes all the magic with modifiers

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Holding slowing down clothing now slows you by 50% of the slowdown when wearing them.
