### PR TITLE
add access reader log wire

### DIFF
--- a/Content.Server/Access/LogWireAction.cs
+++ b/Content.Server/Access/LogWireAction.cs
@@ -1,0 +1,60 @@
+using Content.Server.Wires;
+using Content.Shared.Access;
+using Content.Shared.Access.Components;
+using Content.Shared.Emag.Components;
+using Content.Shared.Wires;
+
+namespace Content.Server.Access;
+
+public sealed partial class LogWireAction : ComponentWireAction<AccessReaderComponent>
+{
+    public override Color Color { get; set; } = Color.Blue;
+    public override string Name { get; set; } = "wire-name-log";
+
+    [DataField]
+    public int PulseTimeout = 30;
+
+    public override StatusLightState? GetLightState(Wire wire, AccessReaderComponent comp)
+    {
+        return comp.LoggingDisabled ? StatusLightState.Off : StatusLightState.On;
+    }
+
+    public override object StatusKey => AccessWireActionKey.Status;
+
+    public override bool Cut(EntityUid user, Wire wire, AccessReaderComponent comp)
+    {
+        WiresSystem.TryCancelWireAction(wire.Owner, PulseTimeoutKey.Key);
+        comp.LoggingDisabled = true;
+        EntityManager.Dirty(wire.Owner, comp);
+        return true;
+    }
+
+    public override bool Mend(EntityUid user, Wire wire, AccessReaderComponent comp)
+    {
+        comp.LoggingDisabled = false;
+        return true;
+    }
+
+    public override void Pulse(EntityUid user, Wire wire, AccessReaderComponent comp)
+    {
+        comp.LoggingDisabled = true;
+        WiresSystem.StartWireAction(wire.Owner, PulseTimeout, PulseTimeoutKey.Key, new TimedWireEvent(AwaitPulseCancel, wire));
+    }
+
+    public override void Update(Wire wire)
+    {
+        if (!IsPowered(wire.Owner))
+            WiresSystem.TryCancelWireAction(wire.Owner, PulseTimeoutKey.Key);
+    }
+
+    private void AwaitPulseCancel(Wire wire)
+    {
+        if (!wire.IsCut && EntityManager.TryGetComponent<AccessReaderComponent>(wire.Owner, out var comp))
+            comp.LoggingDisabled = false;
+    }
+
+    private enum PulseTimeoutKey : byte
+    {
+        Key
+    }
+}

--- a/Content.Server/Access/LogWireAction.cs
+++ b/Content.Server/Access/LogWireAction.cs
@@ -31,7 +31,7 @@ public sealed partial class LogWireAction : ComponentWireAction<AccessReaderComp
     {
         base.Initialize();
 
-        _acces = EntityManager.System<AccessReaderSystem>();
+        _access = EntityManager.System<AccessReaderSystem>();
     }
 
     public override bool Cut(EntityUid user, Wire wire, AccessReaderComponent comp)

--- a/Content.Server/Access/LogWireAction.cs
+++ b/Content.Server/Access/LogWireAction.cs
@@ -1,6 +1,7 @@
 using Content.Server.Wires;
 using Content.Shared.Access;
 using Content.Shared.Access.Components;
+using Content.Shared.Access.Systems;
 using Content.Shared.Emag.Components;
 using Content.Shared.Wires;
 
@@ -14,12 +15,24 @@ public sealed partial class LogWireAction : ComponentWireAction<AccessReaderComp
     [DataField]
     public int PulseTimeout = 30;
 
+    [DataField]
+    public LocId PulseLog = "log-wire-pulse-log";
+
+    private AccessReaderSystem _access = default!;
+
     public override StatusLightState? GetLightState(Wire wire, AccessReaderComponent comp)
     {
         return comp.LoggingDisabled ? StatusLightState.Off : StatusLightState.On;
     }
 
     public override object StatusKey => AccessWireActionKey.Status;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _acces = EntityManager.System<AccessReaderSystem>();
+    }
 
     public override bool Cut(EntityUid user, Wire wire, AccessReaderComponent comp)
     {
@@ -37,6 +50,7 @@ public sealed partial class LogWireAction : ComponentWireAction<AccessReaderComp
 
     public override void Pulse(EntityUid user, Wire wire, AccessReaderComponent comp)
     {
+        _access.LogAccess((wire.Owner, comp), Loc.GetString(PulseLog));
         comp.LoggingDisabled = true;
         WiresSystem.StartWireAction(wire.Owner, PulseTimeout, PulseTimeoutKey.Key, new TimedWireEvent(AwaitPulseCancel, wire));
     }

--- a/Content.Server/Access/LogWireAction.cs
+++ b/Content.Server/Access/LogWireAction.cs
@@ -16,7 +16,7 @@ public sealed partial class LogWireAction : ComponentWireAction<AccessReaderComp
     public int PulseTimeout = 30;
 
     [DataField]
-    public LocId PulseLog = "log-wire-pulse-log";
+    public LocId PulseLog = "log-wire-pulse-access-log";
 
     private AccessReaderSystem _access = default!;
 

--- a/Content.Shared/Access/Components/AccessReaderComponent.cs
+++ b/Content.Shared/Access/Components/AccessReaderComponent.cs
@@ -66,6 +66,13 @@ public sealed partial class AccessReaderComponent : Component
     public int AccessLogLimit = 20;
 
     /// <summary>
+    /// If true logging on successful access uses will be disabled.
+    /// Can be set by LOG wire.
+    /// </summary>
+    [DataField]
+    public bool LoggingDisabled;
+
+    /// <summary>
     /// Whether or not emag interactions have an effect on this.
     /// </summary>
     [DataField]

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -388,7 +388,7 @@ public sealed class AccessReaderSystem : EntitySystem
     /// <param name="accessor">The accessor to log</param>
     private void LogAccess(Entity<AccessReaderComponent> ent, EntityUid accessor)
     {
-        if (IsPaused(ent))
+        if (IsPaused(ent) || ent.Comp.LoggingDisabled)
             return;
 
         if (ent.Comp.AccessLog.Count >= ent.Comp.AccessLogLimit)

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -382,17 +382,14 @@ public sealed class AccessReaderSystem : EntitySystem
     }
 
     /// <summary>
-    /// Logs an access
+    /// Logs an access for a specific entity.
     /// </summary>
     /// <param name="ent">The reader to log the access on</param>
     /// <param name="accessor">The accessor to log</param>
-    private void LogAccess(Entity<AccessReaderComponent> ent, EntityUid accessor)
+    public void LogAccess(Entity<AccessReaderComponent> ent, EntityUid accessor)
     {
         if (IsPaused(ent) || ent.Comp.LoggingDisabled)
             return;
-
-        if (ent.Comp.AccessLog.Count >= ent.Comp.AccessLogLimit)
-            ent.Comp.AccessLog.Dequeue();
 
         string? name = null;
         if (TryComp<NameIdentifierComponent>(accessor, out var nameIdentifier))
@@ -404,7 +401,21 @@ public sealed class AccessReaderSystem : EntitySystem
             && idCard.Comp is { BypassLogging: false, FullName: not null })
             name = idCard.Comp.FullName;
 
-        name ??= Loc.GetString("access-reader-unknown-id");
+        LogAccess(ent, name ?? Loc.GetString("access-reader-unknown-id"));
+    }
+
+    /// <summary>
+    /// Logs an access with a predetermined name
+    /// </summary>
+    /// <param name="ent">The reader to log the access on</param>
+    /// <param name="name">The name to log as</param>
+    public void LogAccess(Entity<AccessReaderComponent> ent, string name)
+    {
+        if (IsPaused(ent) || ent.Comp.LoggingDisabled)
+            return;
+
+        if (ent.Comp.AccessLog.Count >= ent.Comp.AccessLogLimit)
+            ent.Comp.AccessLog.Dequeue();
 
         var stationTime = _gameTiming.CurTime.Subtract(_gameTicker.RoundStartTimeSpan);
         ent.Comp.AccessLog.Enqueue(new AccessRecord(stationTime, name));

--- a/Resources/Locale/en-US/wires/log-wire.ftl
+++ b/Resources/Locale/en-US/wires/log-wire.ftl
@@ -1,0 +1,1 @@
+log-wire-pulse-access-log = ERROR: Electromagnetic spike detected

--- a/Resources/Locale/en-US/wires/wire-names.ftl
+++ b/Resources/Locale/en-US/wires/wire-names.ftl
@@ -66,3 +66,4 @@ wire-name-bomb-boom = BOOM
 wire-name-bomb-bolt = BOLT
 wire-name-speech = SPKR
 wire-name-listen = MIC
+wire-name-log = LOG

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -4,6 +4,7 @@
   - !type:PowerWireAction
   - !type:PowerWireAction
     pulseTimeout: 15
+  - !type:LogWireAction
   - !type:DoorBoltWireAction
   - !type:DoorBoltLightWireAction
   - !type:DoorTimingWireAction
@@ -57,6 +58,7 @@
   wires:
   - !type:PowerWireAction
   - !type:AccessWireAction
+  - !type:LogWireAction
   - !type:VendingMachineContrabandWireAction
   - !type:VendingMachineEjectItemWireAction
   - !type:SpeechWireAction
@@ -66,6 +68,7 @@
   wires:
   - !type:PowerWireAction
   - !type:AccessWireAction
+  - !type:LogWireAction
   - !type:AirAlarmPanicWire
   - !type:AtmosMonitorDeviceNetWire
 
@@ -121,6 +124,7 @@
   - !type:PowerWireAction
   - !type:PowerWireAction
     pulseTimeout: 15
+  - !type:LogWireAction
   - !type:DoorBoltWireAction
   - !type:DoorBoltLightWireAction
   - !type:DoorTimingWireAction


### PR DESCRIPTION
## About the PR
adds a LOG wire to most access readers that disables logging when cut or pulsed (temporarily)

## Why / Balance
door logging right now is really strong for detectives since few people hack maints doors you can basically trace an antags path through the station and easily find a suspect for a crime every time.
the previous counter was either emagging it which is bad because emag isnt wanted to be a required purchase for syndies, hacking it open or deconstructing it after to wipe the access. the latter require insuls and arent something you can do preemptively.

if you are planning on killing cmo you might disable logging on all the maints doors near med then make your epic getaway, and there is deeper counterplay to this. if an engineer sees that all the doors in an area have logging disabled he can tell the detective to help piece together a story without being so "heres the bad guys name go kill em"

## Technical details
added LoggingDisabled bool to AccessReader which the wire action changes

## Media
blue light for log
![01:47:06](https://github.com/space-wizards/space-station-14/assets/39013340/44c0614d-fb27-49d1-81f8-d87306e67aee)

with log disabled, opening it doesnt create any logs
![01:47:54](https://github.com/space-wizards/space-station-14/assets/39013340/a62a8857-678b-4daa-8703-4ff8c697e7eb)

and its enabled again, look at the valid
![01:48:02](https://github.com/space-wizards/space-station-14/assets/39013340/2d90a47c-f4d4-41a8-9f46-7b8e60edd5eb)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Doors access logging can now be disabled by snipping or pulsing a LOG wire.