### PR TITLE
Fix incorrect use of atmos dt

### DIFF
--- a/Content.Server/Power/Generation/Teg/TegSystem.cs
+++ b/Content.Server/Power/Generation/Teg/TegSystem.cs
@@ -179,7 +179,7 @@ public sealed class TegSystem : EntitySystem
         component.LastGeneration = electricalEnergy;
 
         // Turn energy (at atmos tick rate) into wattage.
-        var power = electricalEnergy * _atmosphere.AtmosTickRate;
+        var power = electricalEnergy / args.dt;
         // Add ramp factor. This magics slight power into existence, but allows us to ramp up.
         supplier.MaxSupply = power * component.RampFactor;
 


### PR DESCRIPTION
## About the PR
The original TEG code uses `_atmosphere.AtmosTickRate` which is the atmos sub-ticking rate, and not the actual effective time between atmos tick updates. See https://github.com/space-wizards/space-station-14/pull/18781

## Why / Balance
TEG generates ~7.5× more power than it's supposed to based on conservation of energy.


## Media
Despite the reduction a good burn chamber can still provide enough energy for any station.
![2024-06-16_17-04](https://github.com/space-wizards/space-station-14/assets/3229565/856147fc-0563-4b6e-97c3-95fcfb4b5430)

This screenshot doesn't show this, but this is still limited by pow3r ramping. The actual thermal energy output is in the MW range.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: notafet
- tweak: Adjust TEG power generation levels.