### PR TITLE
magnetize ore box

### DIFF
--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -1,11 +1,12 @@
 using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
 
 namespace Content.Server.Storage.Components;
 
 /// <summary>
 /// Applies an ongoing pickup area around the attached entity.
 /// </summary>
-[RegisterComponent, AutoGenerateComponentPause]
+[RegisterComponent, AutoGenerateComponentPause, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class MagnetPickupComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("nextScan")]
@@ -20,4 +21,7 @@ public sealed partial class MagnetPickupComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField("range")]
     public float Range = 1f;
+
+    [ViewVariables(VVAccess.ReadWrite), DataField("enabled"), AutoNetworkedField]
+    public bool Enabled = true;
 }

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -49,11 +49,16 @@ public sealed class MagnetPickupSystem : EntitySystem
 
             comp.NextScan += ScanDelay;
 
-            if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
-                continue;
+            // "slotFlags: NONE" in yaml can be used to bypass inventory slot checking
+            if (comp.SlotFlags != SlotFlags.NONE)
+            {
+                if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
+                    continue;
 
-            if ((slotDef.SlotFlags & comp.SlotFlags) == 0x0)
-                continue;
+                if ((slotDef.SlotFlags & comp.SlotFlags) == 0x0)
+                    continue;
+            }
+
 
             // No space
             if (!_storage.HasSpace((uid, storage)))

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -1,5 +1,9 @@
 using Content.Server.Storage.Components;
+using Content.Shared.Examine;
+using Content.Shared.Hands.Components;
 using Content.Shared.Inventory;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
@@ -18,6 +22,7 @@ public sealed class MagnetPickupSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
 
     private static readonly TimeSpan ScanDelay = TimeSpan.FromSeconds(1);
@@ -29,6 +34,8 @@ public sealed class MagnetPickupSystem : EntitySystem
         base.Initialize();
         _physicsQuery = GetEntityQuery<PhysicsComponent>();
         SubscribeLocalEvent<MagnetPickupComponent, MapInitEvent>(OnMagnetMapInit);
+        SubscribeLocalEvent<MagnetPickupComponent, GetVerbsEvent<AlternativeVerb>>(AddToggleMagnetVerb);
+        SubscribeLocalEvent<MagnetPickupComponent, ExaminedEvent>(OnExamine);
     }
 
     private void OnMagnetMapInit(EntityUid uid, MagnetPickupComponent component, MapInitEvent args)
@@ -36,6 +43,35 @@ public sealed class MagnetPickupSystem : EntitySystem
         component.NextScan = _timing.CurTime;
     }
 
+    private void AddToggleMagnetVerb(EntityUid uid, MagnetPickupComponent component, GetVerbsEvent<AlternativeVerb> args)
+    {
+
+        if (!args.CanAccess || !args.CanInteract || args.Hands == null)
+            return;
+
+        args.Verbs.Add(new AlternativeVerb()
+        {
+            Act = () =>
+                    {
+                        var magnetStateText = ToggleMagnet(uid, component) ? Loc.GetString("comp-magnet-pickup-state-on") : Loc.GetString("comp-magnet-pickup-state-off");
+                        var popupText = Loc.GetString("comp-magnet-pickup-toggle-popup", ("state", magnetStateText));
+                        _popup.PopupClient(popupText, uid, args.User);
+                    },
+            Text = Loc.GetString("comp-magnet-pickup-toggle-verb")
+        });
+    }
+    private bool ToggleMagnet(EntityUid uid, MagnetPickupComponent component)
+    {
+        component.Enabled = !component.Enabled;
+        Dirty(uid, component);
+        return component.Enabled;
+    }
+    private void OnExamine(EntityUid uid, MagnetPickupComponent component, ExaminedEvent args)
+    {
+        var magnetStateText = component.Enabled ? Loc.GetString("comp-magnet-pickup-state-on-colored") : Loc.GetString("comp-magnet-pickup-state-off-colored");
+        var examineText = Loc.GetString("comp-magnet-pickup-examine", ("state", magnetStateText));
+        args.PushMarkup(examineText);
+    }
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -44,6 +80,9 @@ public sealed class MagnetPickupSystem : EntitySystem
 
         while (query.MoveNext(out var uid, out var comp, out var storage, out var xform, out var meta))
         {
+            if (!comp.Enabled)
+                continue;
+
             if (comp.NextScan > currentTime)
                 continue;
 

--- a/Resources/Locale/en-US/components/magnet-pickup-component.ftl
+++ b/Resources/Locale/en-US/components/magnet-pickup-component.ftl
@@ -1,0 +1,7 @@
+comp-magnet-pickup-toggle-verb = Toggle magnet
+comp-magnet-pickup-toggle-popup = The magnet is now {$state}.
+comp-magnet-pickup-state-on = enabled
+comp-magnet-pickup-state-off = disabled
+comp-magnet-pickup-state-on-colored = [color=darkgreen]enabled[/color]
+comp-magnet-pickup-state-off-colored = [color=red]disabled[/color]
+comp-magnet-pickup-examine = The internal magnet appears to be {$state}.

--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -62,6 +62,7 @@
   - type: MagnetPickup
     slotFlags: NONE
     range: 1.5
+    enabled: false
   - type: UserInterface
     interfaces:
       enum.StorageUiKey.Key:

--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -58,6 +58,10 @@
     whitelist:
       tags:
       - Ore
+      - ArtifactFragment
+  - type: MagnetPickup
+    slotFlags: NONE
+    range: 1.5
   - type: UserInterface
     interfaces:
       enum.StorageUiKey.Key:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
the ore box now has a magnet in it, so it can pick up ore while being dragged across the ground. artifact fragments have also been added to its whitelist

a toggle is also now available for anything with magnetized pickup. ore boxes default to magnet disabled, for performance 
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
nobody ever uses the ore box. dumping all your ore on the ground takes the same amount of time, and salvs would rather use ore bags to transport ores from ship to station, since you can hold three at a time. 

now, salvs can bring ore boxes on expeds as a sidegrade to their normal ore bags. its only a sidegrade because even though you get a bit more ore space, you lose a hand (or tail) slot, become slower, and have to deal with the awkwardness of lugging the box through mining tunnels, rocks, and trees. because of this, magnet box does not encroach upon the usefulness of the orebag of holding

(considering slightly increasing ore box space as well)


## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
`MagnetizePickupComponent` has a datafield, `slotFlags` that was used for making sure an entity is in the correct inventory slot before enabling magnetism. i just slightly modified the system to consider `SlotFlags.NONE` as a bypass to the inventory check
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->


https://github.com/space-wizards/space-station-14/assets/57325298/c67406cb-6c01-425a-9cb8-f2431b7df53b

![image](https://github.com/space-wizards/space-station-14/assets/57325298/bb84fb15-e74d-4b46-9488-07b538b5fe87)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->

:cl:
- tweak: Magnetized the ore box. Storage magnets can now be toggled.
