### PR TITLE
Make the sentient plant mutation non-copyable to other plantholders

### DIFF
--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -40,7 +40,7 @@ public sealed class MutationSystem : EntitySystem
         }
 
         // Add up everything in the bits column and put the number here.
-        const int totalbits = 275;
+        const int totalbits = 262;
 
         // Tolerances (55)
         MutateFloat(ref seed.NutrientConsumption  , 0.05f, 1.2f, 5, totalbits, severity);
@@ -66,10 +66,10 @@ public sealed class MutationSystem : EntitySystem
         // Kill the plant (30)
         MutateBool(ref seed.Viable        , false, 30, totalbits, severity);
 
-        // Fun (90)
+        // Fun (72)
         MutateBool(ref seed.Seedless      , true , 10, totalbits, severity);
         MutateBool(ref seed.Slip          , true , 10, totalbits, severity);
-        MutateBool(ref seed.Sentient      , true , 10, totalbits, severity);
+        MutateBool(ref seed.Sentient      , true , 2 , totalbits, severity);
         MutateBool(ref seed.Ligneous      , true , 10, totalbits, severity);
         MutateBool(ref seed.Bioluminescent, true , 10, totalbits, severity);
         MutateBool(ref seed.TurnIntoKudzu , true , 10, totalbits, severity);
@@ -115,10 +115,10 @@ public sealed class MutationSystem : EntitySystem
         CrossFloat(ref result.Production, a.Production);
         CrossFloat(ref result.Potency, a.Potency);
 
+        // we do not transfer Sentient to another plant to avoid ghost role spam
         CrossBool(ref result.Seedless, a.Seedless);
         CrossBool(ref result.Viable, a.Viable);
         CrossBool(ref result.Slip, a.Slip);
-        CrossBool(ref result.Sentient, a.Sentient);
         CrossBool(ref result.Ligneous, a.Ligneous);
         CrossBool(ref result.Bioluminescent, a.Bioluminescent);
         CrossBool(ref result.TurnIntoKudzu, a.TurnIntoKudzu);

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -298,8 +298,17 @@ public sealed class PlantHolderSystem : EntitySystem
             {
                 healthOverride = component.Health;
             }
-            component.Seed.Unique = false;
-            var seed = _botany.SpawnSeedPacket(component.Seed, Transform(args.User).Coordinates, args.User, healthOverride);
+            var packetSeed = component.Seed;
+            if (packetSeed.Sentient)
+            {
+                packetSeed = packetSeed.Clone(); // clone before modifying the seed
+                packetSeed.Sentient = false;
+            }
+            else
+            {
+                packetSeed.Unique = false;
+            }
+            var seed = _botany.SpawnSeedPacket(packetSeed, Transform(args.User).Coordinates, args.User, healthOverride);
             _randomHelper.RandomOffset(seed, 0.25f);
             var displayName = Loc.GetString(component.Seed.DisplayName);
             _popup.PopupCursor(Loc.GetString("plant-holder-component-take-sample-message",
@@ -626,8 +635,15 @@ public sealed class PlantHolderSystem : EntitySystem
         }
         else if (component.Age < 0) // Revert back to seed packet!
         {
+            var packetSeed = component.Seed;
+            if (packetSeed.Sentient)
+            {
+                if (!packetSeed.Unique) // clone if necessary before modifying the seed
+                    packetSeed = packetSeed.Clone();
+                packetSeed.Sentient = false; // remove Sentient to avoid ghost role spam
+            }
             // will put it in the trays hands if it has any, please do not try doing this
-            _botany.SpawnSeedPacket(component.Seed, Transform(uid).Coordinates, uid);
+            _botany.SpawnSeedPacket(packetSeed, Transform(uid).Coordinates, uid);
             RemovePlant(uid, component);
             component.ForceUpdate = true;
             Update(uid, component);

--- a/Content.Server/Botany/Systems/SeedExtractorSystem.cs
+++ b/Content.Server/Botany/Systems/SeedExtractorSystem.cs
@@ -29,12 +29,12 @@ public sealed class SeedExtractorSystem : EntitySystem
             return;
         if (!_botanySystem.TryGetSeed(produce, out var seed) || seed.Seedless)
         {
-            _popupSystem.PopupCursor(Loc.GetString("seed-extractor-component-no-seeds",("name", args.Used)),
+            _popupSystem.PopupCursor(Loc.GetString("seed-extractor-component-no-seeds", ("name", args.Used)),
                 args.User, PopupType.MediumCaution);
             return;
         }
 
-        _popupSystem.PopupCursor(Loc.GetString("seed-extractor-component-interact-message",("name", args.Used)),
+        _popupSystem.PopupCursor(Loc.GetString("seed-extractor-component-interact-message", ("name", args.Used)),
             args.User, PopupType.Medium);
 
         QueueDel(args.Used);
@@ -42,12 +42,19 @@ public sealed class SeedExtractorSystem : EntitySystem
         var amount = _random.Next(seedExtractor.BaseMinSeeds, seedExtractor.BaseMaxSeeds + 1);
         var coords = Transform(uid).Coordinates;
 
+        var packetSeed = seed;
+        if (packetSeed.Sentient)
+        {
+            if (!packetSeed.Unique) // clone if necessary before modifying the seed
+                packetSeed = packetSeed.Clone();
+            packetSeed.Sentient = false; // remove Sentient to avoid ghost role spam
+        }
         if (amount > 1)
-            seed.Unique = false;
+            packetSeed.Unique = false;
 
         for (var i = 0; i < amount; i++)
         {
-            _botanySystem.SpawnSeedPacket(seed, coords, args.User);
+            _botanySystem.SpawnSeedPacket(packetSeed, coords, args.User);
         }
     }
 }


### PR DESCRIPTION
## About the PR
This PR changes seed packets to lose the sentient mutation gene if created by clipping, the seed extractor or reverting a plant with cryoxadone. Crossing plants will no longer transfer the gene either.

## Why / Balance
Fixes #20825
The ghost role menu is often spammed by lots of sentient hydroponics trays from the sentient plant mutation. The large number of these is caused by it being possible to transfer sentience by producing seeds from the mutated plant and putting them into other trays.
By removing this propagation we can make this ghost role more rare. If a botanist wants multiple sentient trays he will have to mutate each one of them separately.
The mutation has also been made rarer. While the exact probability depends on the amount of mutagen given at once and whether Left4Zed is used, my calculation says that using 90u of mutagen should give you a 50-60% chance of getting a sentient tray.

## Technical details
Each time we spawn a seed packet we first clone the seed data if necessary and set the Sentient gene to false.
The Unique bool is adjusted accordingly.
The number of bits for Sentient has been reduced.
The total number of bits has been corrected.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**.
:cl:
- tweak: The sentient plant mutation can no longer be propagated to other trays via seeds or swabs. It has also been made more rare.
