### PR TITLE
Fix double label on chem jugs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -85,7 +85,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (carbon)
+  name: jug
+  suffix: carbon
   id: JugCarbon
   noSpawn: true
   components:
@@ -100,7 +101,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (iodine)
+  name: jug
+  suffix: iodine
   id: JugIodine
   noSpawn: true
   components:
@@ -115,7 +117,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (fluorine)
+  name: jug
+  suffix: fluorine
   id: JugFluorine
   noSpawn: true
   components:
@@ -130,7 +133,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (chlorine)
+  name: jug
+  suffix: chlorine
   id: JugChlorine
   noSpawn: true
   components:
@@ -145,7 +149,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (aluminium)
+  name: jug
+  suffix: aluminium
   id: JugAluminium
   noSpawn: true
   components:
@@ -160,7 +165,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (phosphorus)
+  name: jug
+  suffix: phosphorus
   id: JugPhosphorus
   noSpawn: true
   components:
@@ -175,7 +181,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (sulfur)
+  name: jug
+  suffix: sulfur
   id: JugSulfur
   noSpawn: true
   components:
@@ -190,7 +197,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (silicon)
+  name: jug
+  suffix: silicon
   id: JugSilicon
   noSpawn: true
   components:
@@ -205,7 +213,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (hydrogen)
+  name: jug
+  suffix: hydrogen
   id: JugHydrogen
   noSpawn: true
   components:
@@ -220,7 +229,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (lithium)
+  name: jug
+  suffix: lithium
   id: JugLithium
   noSpawn: true
   components:
@@ -235,7 +245,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (sodium)
+  name: jug
+  suffix: sodium
   id: JugSodium
   noSpawn: true
   components:
@@ -250,7 +261,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (potassium)
+  name: jug
+  suffix: potassium
   id: JugPotassium
   noSpawn: true
   components:
@@ -265,7 +277,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (radium)
+  name: jug
+  suffix: radium
   id: JugRadium
   noSpawn: true
   components:
@@ -280,7 +293,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (iron)
+  name: jug
+  suffix: iron
   id: JugIron
   noSpawn: true
   components:
@@ -295,7 +309,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (copper)
+  name: jug
+  suffix: copper
   id: JugCopper
   noSpawn: true
   components:
@@ -310,7 +325,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (gold)
+  name: jug
+  suffix: gold
   id: JugGold
   noSpawn: true
   components:
@@ -325,7 +341,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (mercury)
+  name: jug
+  suffix: mercury
   id: JugMercury
   noSpawn: true
   components:
@@ -340,7 +357,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (silver)
+  name: jug
+  suffix: silver
   id: JugSilver
   noSpawn: true
   components:
@@ -355,7 +373,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (ethanol)
+  name: jug
+  suffix: ethanol
   id: JugEthanol
   noSpawn: true
   components:
@@ -370,7 +389,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (sugar)
+  name: jug
+  suffix: sugar
   id: JugSugar
   noSpawn: true
   components:
@@ -385,7 +405,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (nitrogen)
+  name: jug
+  suffix: nitrogen
   id: JugNitrogen
   noSpawn: true
   components:
@@ -400,7 +421,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (oxygen)
+  name: jug
+  suffix: oxygen
   id: JugOxygen
   noSpawn: true
   components:
@@ -415,7 +437,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (Plant-B-Gone)
+  name: jug
+  suffix: Plant-B-Gone
   id: JugPlantBGone
   noSpawn: true
   components:
@@ -430,7 +453,8 @@
 
 - type: entity
   parent: Jug
-  name: jug (welding fuel)
+  name: jug
+  suffix: welding fuel
   id: JugWeldingFuel
   noSpawn: true
   components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Reagent jugs in the chem dispenser no longer have double labels (like) (this).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #29126

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Chem jugs previously had their label baked into their name as well as having a label component. With #27863, labels are applied to their entities on MapInit, which means that these jugs wind up with the label added after their pre-baked name, giving them two labels, the second of which can be changed, but not the first.

This PR just removes the prebaked labels from the entity names. Even though the jugs are set to noSpawn, I gave them suffixes identifying the contents so they don't all show up as "jug" in the spawn menu if noSpawn is ever disabled for them.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Chemical jugs no longer spawn with two labels.