### PR TITLE
Fix camera recoil system overriding all other eye offsets

### DIFF
--- a/Content.Shared/Camera/GetEyeOffsetEvent.cs
+++ b/Content.Shared/Camera/GetEyeOffsetEvent.cs
@@ -1,0 +1,6 @@
+using System.Numerics;
+
+namespace Content.Shared.Camera;
+
+[ByRefEvent]
+public record struct GetEyeOffsetEvent(Vector2 Offset);

--- a/Content.Shared/Camera/GetEyeOffsetEvent.cs
+++ b/Content.Shared/Camera/GetEyeOffsetEvent.cs
@@ -1,6 +1,19 @@
 using System.Numerics;
+using Content.Shared.Movement.Systems;
 
 namespace Content.Shared.Camera;
 
+/// <summary>
+///     Raised directed by-ref when <see cref="SharedContentEyeSystem.UpdateEyeOffset"/> is called.
+///     Should be subscribed to by any systems that want to modify an entity's eye offset,
+///     so that they do not override each other.
+/// </summary>
+/// <param name="Offset">
+///     The total offset to apply.
+/// </param>
+/// <remarks>
+///     Note that in most cases <see cref="Offset"/> should be incremented or decremented by subscribers, not set.
+///     Otherwise, any offsets applied by previous subscribing systems will be overridden.
+/// </remarks>
 [ByRefEvent]
 public record struct GetEyeOffsetEvent(Vector2 Offset);

--- a/Content.Shared/Camera/SharedCameraRecoilSystem.cs
+++ b/Content.Shared/Camera/SharedCameraRecoilSystem.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Shared.Movement.Systems;
 using JetBrains.Annotations;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Camera;
@@ -29,6 +30,7 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
     protected const float KickMagnitudeMax = 1f;
 
     [Dependency] private readonly SharedContentEyeSystem _eye = default!;
+    [Dependency] private readonly INetManager _net = default!;
 
     public override void Initialize()
     {
@@ -82,7 +84,8 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
 
     public override void Update(float frameTime)
     {
-        UpdateEyes(frameTime);
+        if (_net.IsServer)
+            UpdateEyes(frameTime);
     }
 
     public override void FrameUpdate(float frameTime)

--- a/Content.Shared/Camera/SharedCameraRecoilSystem.cs
+++ b/Content.Shared/Camera/SharedCameraRecoilSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared.Movement.Systems;
 using JetBrains.Annotations;
 using Robust.Shared.Serialization;
 
@@ -27,7 +28,7 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
     /// </summary>
     protected const float KickMagnitudeMax = 1f;
 
-    [Dependency] private readonly SharedEyeSystem _eye = default!;
+    [Dependency] private readonly SharedContentEyeSystem _eye = default!;
 
     public override void Initialize()
     {
@@ -58,9 +59,7 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
             if (magnitude <= 0.005f)
             {
                 recoil.CurrentKick = Vector2.Zero;
-                var ev = new GetEyeOffsetEvent();
-                RaiseLocalEvent(uid, ref ev);
-                _eye.SetOffset(uid, ev.Offset, eye);
+                _eye.UpdateEyeOffset((uid, eye));
             }
             else // Continually restore camera to 0.
             {
@@ -76,10 +75,7 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
                     y = 0;
 
                 recoil.CurrentKick = new Vector2(x, y);
-
-                var ev = new GetEyeOffsetEvent();
-                RaiseLocalEvent(uid, ref ev);
-                _eye.SetOffset(uid, ev.Offset, eye);
+                _eye.UpdateEyeOffset((uid, eye));
             }
         }
     }

--- a/Content.Shared/Camera/SharedCameraRecoilSystem.cs
+++ b/Content.Shared/Camera/SharedCameraRecoilSystem.cs
@@ -1,6 +1,5 @@
 using System.Numerics;
 using JetBrains.Annotations;
-using Robust.Shared.Player;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Camera;
@@ -30,6 +29,16 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
 
     [Dependency] private readonly SharedEyeSystem _eye = default!;
 
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<CameraRecoilComponent, GetEyeOffsetEvent>(OnCameraRecoilGetEyeOffset);
+    }
+
+    private void OnCameraRecoilGetEyeOffset(Entity<CameraRecoilComponent> ent, ref GetEyeOffsetEvent args)
+    {
+        args.Offset += ent.Comp.BaseOffset + ent.Comp.CurrentKick;
+    }
+
     /// <summary>
     ///     Applies explosion/recoil/etc kickback to the view of the entity.
     /// </summary>
@@ -39,10 +48,8 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
     /// </remarks>
     public abstract void KickCamera(EntityUid euid, Vector2 kickback, CameraRecoilComponent? component = null);
 
-    public override void FrameUpdate(float frameTime)
+    private void UpdateEyes(float frameTime)
     {
-        base.FrameUpdate(frameTime);
-
         var query = AllEntityQuery<EyeComponent, CameraRecoilComponent>();
 
         while (query.MoveNext(out var uid, out var eye, out var recoil))
@@ -51,7 +58,9 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
             if (magnitude <= 0.005f)
             {
                 recoil.CurrentKick = Vector2.Zero;
-                _eye.SetOffset(uid, recoil.BaseOffset + recoil.CurrentKick, eye);
+                var ev = new GetEyeOffsetEvent();
+                RaiseLocalEvent(uid, ref ev);
+                _eye.SetOffset(uid, ev.Offset, eye);
             }
             else // Continually restore camera to 0.
             {
@@ -60,15 +69,29 @@ public abstract class SharedCameraRecoilSystem : EntitySystem
                 var restoreRate = MathHelper.Lerp(RestoreRateMin, RestoreRateMax, Math.Min(1, recoil.LastKickTime / RestoreRateRamp));
                 var restore = normalized * restoreRate * frameTime;
                 var (x, y) = recoil.CurrentKick - restore;
-                if (Math.Sign(x) != Math.Sign(recoil.CurrentKick.X)) x = 0;
+                if (Math.Sign(x) != Math.Sign(recoil.CurrentKick.X))
+                    x = 0;
 
-                if (Math.Sign(y) != Math.Sign(recoil.CurrentKick.Y)) y = 0;
+                if (Math.Sign(y) != Math.Sign(recoil.CurrentKick.Y))
+                    y = 0;
 
                 recoil.CurrentKick = new Vector2(x, y);
 
-                _eye.SetOffset(uid, recoil.BaseOffset + recoil.CurrentKick, eye);
+                var ev = new GetEyeOffsetEvent();
+                RaiseLocalEvent(uid, ref ev);
+                _eye.SetOffset(uid, ev.Offset, eye);
             }
         }
+    }
+
+    public override void Update(float frameTime)
+    {
+        UpdateEyes(frameTime);
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        UpdateEyes(frameTime);
     }
 }
 

--- a/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedContentEyeSystem.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Shared.Administration;
 using Content.Shared.Administration.Managers;
+using Content.Shared.Camera;
 using Content.Shared.Ghost;
 using Content.Shared.Input;
 using Content.Shared.Movement.Components;
@@ -126,6 +127,13 @@ public abstract class SharedContentEyeSystem : EntitySystem
         component.MaxZoom = value;
         component.TargetZoom = Clamp(component.TargetZoom, component);
         Dirty(uid, component);
+    }
+
+    public void UpdateEyeOffset(Entity<EyeComponent?> eye)
+    {
+        var ev = new GetEyeOffsetEvent();
+        RaiseLocalEvent(eye, ref ev);
+        _eye.SetOffset(eye, ev.Offset, eye);
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
This made it so anything that has camera recoil component could never have any other code applying offsets. If you managed to it still wasn't running on the server, so guns would shoot at the wrong spot for example.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
