### PR TITLE
Removes Players Ability to get the QSI from Sci

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -330,7 +330,6 @@
       - FauxTileAstroIce
       - FauxTileAstroSnow
       - OreBagOfHolding
-      - DeviceQuantumSpinInverter
   - type: EmagLatheRecipes
     emagDynamicRecipes:
       - BoxBeanbag

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -140,14 +140,15 @@
     - WeaponForceGun
     - WeaponTetherGun
 
-- type: technology
-  id: QuantumLeaping
-  name: research-technology-quantum-leaping
-  icon:
-    sprite: Objects/Devices/swapper.rsi
-    state: icon
-  discipline: Experimental
-  tier: 3
-  cost: 10000
-  recipeUnlocks:
-  - DeviceQuantumSpinInverter
+# RE-ENABLE WHEN NOT BUGGED AS MUCH!!!
+#- type: technology
+#  id: QuantumLeaping
+#  name: research-technology-quantum-leaping
+#  icon:
+#    sprite: Objects/Devices/swapper.rsi
+#    state: icon
+#  discipline: Experimental
+#  tier: 3
+#  cost: 10000
+#  recipeUnlocks:
+#  - DeviceQuantumSpinInverter


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removes the crews ability to craft the Quantum Spinn Inverter
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Requested by @XxSWAG-MASTER-OVERLORDxX. The Items is just bugged so badly. Let's people send each other to the shadow realm, puts crates in your hand, create a drone out of a person, the other 1000 bugs found with the item never reported.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Comments out the Sci-tech and removes it from the proto-lathe. 

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- remove: Quantum Spin Inverter Sci tech removed till less buggy
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
