### PR TITLE
arachnid inventory layout fix

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
@@ -70,7 +70,7 @@
       slotGroup: SecondHotbar
       stripTime: 6
       uiWindowPos: 3,1
-      strippingWindowPos: 2,3
+      strippingWindowPos: 1,5
       displayName: Belt
     - name: back
       slotTexture: back
@@ -79,7 +79,7 @@
       slotGroup: SecondHotbar
       stripTime: 6
       uiWindowPos: 3,0
-      strippingWindowPos: 0,3
+      strippingWindowPos: 0,5
       displayName: Back
 
     - name: pocket4
@@ -89,7 +89,7 @@
       slotGroup: MainHotbar
       stripTime: 3
       uiWindowPos: 2,4
-      strippingWindowPos: 1,5
+      strippingWindowPos: 2,3
       displayName: Pocket 4
     - name: pocket3
       slotTexture: web
@@ -98,7 +98,7 @@
       slotGroup: MainHotbar
       stripTime: 3
       uiWindowPos: 0,4
-      strippingWindowPos: 0,5
+      strippingWindowPos: 0,3
       displayName: Pocket 3
     - name: outerClothing
       slotTexture: suit


### PR DESCRIPTION
## About the PR
The strip interface for arachnid mobs added their extra pockets over already occupied slots, moving their backpack and belt slots into different places. I changed the layout so matching slots are in identical positions across species

## Why / Balance
UI Consistency is good

## Media

![image](https://github.com/space-wizards/space-station-14/assets/35878406/603e4a03-43b4-47b8-b177-6fc986e71879)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl: Errant
- tweak: The strip interface layout of arachnid mobs is now consistent with other species.

