### PR TITLE
Hidden loadout groups

### DIFF
--- a/Content.Client/Lobby/UI/Loadouts/LoadoutWindow.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutWindow.xaml.cs
@@ -29,7 +29,7 @@ public sealed partial class LoadoutWindow : FancyWindow
             if (!protoManager.TryIndex(group, out var groupProto))
                 continue;
 
-            if (groupProto.Hidden == true)
+            if (groupProto.Hidden)
                 continue;
 
             var container = new LoadoutGroupContainer(profile, loadout, protoManager.Index(group), session, collection);

--- a/Content.Client/Lobby/UI/Loadouts/LoadoutWindow.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutWindow.xaml.cs
@@ -29,6 +29,9 @@ public sealed partial class LoadoutWindow : FancyWindow
             if (!protoManager.TryIndex(group, out var groupProto))
                 continue;
 
+            if (groupProto.Hidden == true)
+                continue;
+
             var container = new LoadoutGroupContainer(profile, loadout, protoManager.Index(group), session, collection);
             LoadoutGroupsContainer.AddTab(container, Loc.GetString(groupProto.Name));
             _groups.Add(container);

--- a/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
@@ -33,7 +33,7 @@ public sealed partial class LoadoutGroupPrototype : IPrototype
     /// Hides the loadout group from the player.
     /// </summary>
     [DataField]
-    public bool Hidden = false;
+    public bool Hidden;
 
     [DataField(required: true)]
     public List<ProtoId<LoadoutPrototype>> Loadouts = new();

--- a/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
@@ -29,6 +29,12 @@ public sealed partial class LoadoutGroupPrototype : IPrototype
     [DataField]
     public int MaxLimit = 1;
 
+    /// <summary>
+    /// Hides the loadout group from the player.
+    /// </summary>
+    [DataField]
+    public bool Hidden = false;
+
     [DataField(required: true)]
     public List<ProtoId<LoadoutPrototype>> Loadouts = new();
 }


### PR DESCRIPTION
## About the PR
Makes it possible to hide a loadout group. This is useful for groups where all choices are decided by the game automatically, and adding optional choices into the group is not feasible/desirable for whatever reason. There is then no reason to display this loadout group to the player at all. (Such as survival boxes)

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


