### PR TITLE
Possibly fixed air alarms

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AtmosAlarmableSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosAlarmableSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Tag;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Atmos.Monitor.Systems;
@@ -86,7 +87,7 @@ public sealed class AtmosAlarmableSystem : EntitySystem
             return;
 
         if (!args.Data.TryGetValue(DeviceNetworkConstants.Command, out string? cmd)
-            || !args.Data.TryGetValue(AlertSource, out HashSet<string>? sourceTags))
+            || !args.Data.TryGetValue(AlertSource, out HashSet<ProtoId<TagPrototype>>? sourceTags))
         {
             return;
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Made air alarms change their alarm level once again, as in Normal, Warning, and Danger.

## Why / Balance
#28272 apparently broke it. 
https://github.com/space-wizards/space-station-14/pull/28272#issuecomment-2175448288 and the following comment contain some related information.

## Technical details
Just changed a type.

On the line 94 the member `SyncWithTags` is used, I haven't yet figured out if it also needs changing of it's type. 
I'll have to leave that for tomorrow, since running out of time for today, and can't be bothered to figure out how I'd have to change it's serialization..

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Before: 


https://github.com/space-wizards/space-station-14/assets/62134478/28ce6f82-101f-409f-a9d3-32aa08a3a353

After:

https://github.com/space-wizards/space-station-14/assets/62134478/485622f2-60fc-49e1-84ea-0d06ae4761e7



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl:
- fix: Fix air alarms not alarming air.
