### PR TITLE
Upgrade rsi-diff's changed files action | Make it only return rsi and png changes

### DIFF
--- a/.github/workflows/rsi-diff.yml
+++ b/.github/workflows/rsi-diff.yml
@@ -15,9 +15,12 @@ jobs:
 
       - name: Get changed files
         id: files
-        uses: Ana06/get-changed-files@v1.2
+        uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'space-delimited'
+          filter: | 
+            **.rsi
+            **.png
 
       - name: Diff changed RSIs
         id: diff


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Upgrade Ana06/get-changed-files to 2.3.0 and add a filter for only png's and rsi's

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It was brought up to me in https://github.com/space-wizards/space-station-14/pull/29179#issuecomment-2177140740 (and from a dm from them) that space bars can cause issues with the rsi bot.

Upon investigation its case we use "space-delimited" on the "get changes files" check. Which returns ALL changed files. Even if the change has nothing to do with png's or rsi's (example a downstream merging upstream)

I has done da testing and I can confirm it does the workie