### PR TITLE
Make Hamlet a valid chef's hat pilot

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -593,6 +593,7 @@
     - CannotSuicide
     - Hamster
     - VimPilot
+    - ChefPilot
 
 - type: entity
   name: Shiva


### PR DESCRIPTION
Foiled again by TagComponent inheritance!

Generic hamsters are able to pilot the chef's hat. Hamlet was supposed to be able to also, but I missed the fact that his tags overwrite the tags from his parent entity. This fixes that little oversight and lets everyone's favorite hamster get up to more mischief.