### PR TITLE
revamp meteors

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -128,13 +128,13 @@ namespace Content.Shared.CCVar
         ///     Minimum time between meteor swarms in minutes.
         /// </summary>
         public static readonly CVarDef<float>
-            MeteorSwarmMinTime = CVarDef.Create("events.meteor_swarm_min_time", 7.5f, CVar.ARCHIVE | CVar.SERVERONLY);
+            MeteorSwarmMinTime = CVarDef.Create("events.meteor_swarm_min_time", 22.5f, CVar.ARCHIVE | CVar.SERVERONLY);
 
         /// <summary>
         ///     Maximum time between meteor swarms in minutes.
         /// </summary>
         public static readonly CVarDef<float>
-            MeteorSwarmMaxTime = CVarDef.Create("events.meteor_swarm_max_time", 12.5f, CVar.ARCHIVE | CVar.SERVERONLY);
+            MeteorSwarmMaxTime = CVarDef.Create("events.meteor_swarm_max_time", 40f, CVar.ARCHIVE | CVar.SERVERONLY);
 
         /*
          * Game

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -65,8 +65,8 @@
   components:
   - type: MeteorSwarm
     meteors:
-      MeteorSmall: 7
-      MeteorMedium: 3
+      MeteorSmall: 3
+      MeteorMedium: 2
 
 - type: entity
   parent: GameRuleMeteorSwarm
@@ -74,8 +74,8 @@
   components:
   - type: MeteorSwarm
     meteors:
-      MeteorSmall: 3
-      MeteorMedium: 6
+      MeteorSmall: 2
+      MeteorMedium: 2
       MeteorLarge: 1
 
 - type: entity
@@ -85,8 +85,8 @@
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 2
-      MeteorMedium: 4
-      MeteorLarge: 4
+      MeteorMedium: 1
+      MeteorLarge: 3
 
 - type: entity
   parent: GameRuleMeteorSwarm

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -65,8 +65,8 @@
   components:
   - type: MeteorSwarm
     meteors:
-      MeteorSmall: 3
-      MeteorMedium: 1
+      MeteorSmall: 7
+      MeteorMedium: 3
 
 - type: entity
   parent: GameRuleMeteorSwarm
@@ -74,8 +74,8 @@
   components:
   - type: MeteorSwarm
     meteors:
-      MeteorSmall: 2
-      MeteorMedium: 2
+      MeteorSmall: 3
+      MeteorMedium: 6
       MeteorLarge: 1
 
 - type: entity
@@ -84,8 +84,9 @@
   components:
   - type: MeteorSwarm
     meteors:
-      MeteorMedium: 2
-      MeteorLarge: 2
+      MeteorSmall: 2
+      MeteorMedium: 4
+      MeteorLarge: 4
 
 - type: entity
   parent: GameRuleMeteorSwarm

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -66,7 +66,7 @@
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 3
-      MeteorMedium: 2
+      MeteorMedium: 1
 
 - type: entity
   parent: GameRuleMeteorSwarm
@@ -84,9 +84,8 @@
   components:
   - type: MeteorSwarm
     meteors:
-      MeteorSmall: 2
-      MeteorMedium: 1
-      MeteorLarge: 3
+      MeteorMedium: 2
+      MeteorLarge: 2
 
 - type: entity
   parent: GameRuleMeteorSwarm

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -65,8 +65,8 @@
   components:
   - type: MeteorSwarm
     meteors:
-      MeteorSmall: 7
-      MeteorMedium: 3
+      MeteorSmall: 8.5
+      MeteorMedium: 1.5
 
 - type: entity
   parent: GameRuleMeteorSwarm
@@ -74,9 +74,9 @@
   components:
   - type: MeteorSwarm
     meteors:
-      MeteorSmall: 3
+      MeteorSmall: 3.5
       MeteorMedium: 6
-      MeteorLarge: 1
+      MeteorLarge: 0.5
 
 - type: entity
   parent: GameRuleMeteorSwarm
@@ -84,9 +84,9 @@
   components:
   - type: MeteorSwarm
     meteors:
-      MeteorSmall: 2
+      MeteorSmall: 3
       MeteorMedium: 4
-      MeteorLarge: 4
+      MeteorLarge: 3
 
 - type: entity
   parent: GameRuleMeteorSwarm


### PR DESCRIPTION
## About the PR
Less meteors. I s'pose I'll go on space dusty road..

## Why / Balance
The impact of each meteor swarm is powerful, let's go easier on engis.
I can change the frequency of meteors as well, but I don't know how the weights exactly work right now.

## Technical details
This changes the chance of each meteor spawn in each meteor category spawn.
This also changes the frequency of each meteor swarm.

TO BE:
Small: 85% Small, 15% Medium
Medium: 35% Small, 60% Medium, 5% Large
Large: 30% Small, 40% Medium, 30% Large
Frequency: 22.5 minutes to 40 minutes

AS IS:
Small: 70%, 30% Medium
Medium: 30% Small, 60% Medium, 10% Large
Large: 20% Small, 40% Medium, 40% Large
Frequency: 7.5 minutes to 12.5 minutes

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Each meteor swarm got less meteors now.
- tweak: The meteor swarms appear rarer.
