### PR TITLE
Adjusts the lethality of meteor explosions

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -41,7 +41,7 @@
     explosionType: Default
     intensitySlope: 2
     maxIntensity: 100
-    maxTileBreak: 0.25
+    maxTileBreak: 1
     tileBreakScale: 2
 
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -39,8 +39,11 @@
     damageContainer: Inorganic
   - type: Explosive
     explosionType: Default
-    intensitySlope: 4
+    intensitySlope: 2
     maxIntensity: 100
+    maxTileBreak: 0.25
+    tileBreakScale: 2
+
 
 - type: entity
   parent: BaseMeteor
@@ -99,7 +102,7 @@
         - Impassable
         - BulletImpassable
   - type: Explosive
-    totalIntensity: 100
+    totalIntensity: 50
   - type: Destructible
     thresholds:
     - trigger:
@@ -134,7 +137,7 @@
         - Impassable
         - BulletImpassable
   - type: Explosive
-    totalIntensity: 200
+    totalIntensity: 100
   - type: Destructible
     thresholds:
     - trigger:
@@ -156,7 +159,7 @@
   - type: Sprite
     state: big
   - type: Explosive
-    totalIntensity: 300
+    totalIntensity: 150
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Anti-personnel damage has been halved and tile breaking normalized. Boom hearing range and explosion radius remains unchanged.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Meteors piercing through stations is good as it raises spacing potential of meteor swarms 👍. Being instantly crit by a meteor explosion through a reinforced wall which you did not see coming is not good.
Previous meteor explosions were designed to do considerable damage to (presumably) have an effect on reinforced walls, but the recent buff to meteors means that this paradigm is no longer necessary. This PR adjusts the damage of meteors such that you can survive the fragments of a singular meteor, before being crit by another or dying to depressurisation.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adjusts meteor YAML prototypes.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
C-4 with edited values detonated 2 tiles away from a Urist, of each meteor size and before/after changes.
https://youtu.be/6MxzLFs5Wqw?si=WvT6djvHUm7vrfT8

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
No

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Adjusted meteors to have less lethal blast fragments.
