### PR TITLE
Prevent Quantum Spin Inverter from Teleporting Things into Microwaves

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -79,6 +79,7 @@ namespace Content.Server.Kitchen.EntitySystems
             SubscribeLocalEvent<MicrowaveComponent, EntInsertedIntoContainerMessage>(OnContentUpdate);
             SubscribeLocalEvent<MicrowaveComponent, EntRemovedFromContainerMessage>(OnContentUpdate);
             SubscribeLocalEvent<MicrowaveComponent, InteractUsingEvent>(OnInteractUsing, after: new[] { typeof(AnchorableSystem) });
+            SubscribeLocalEvent<MicrowaveComponent, ContainerIsInsertingAttemptEvent>(OnInsertAttempt);
             SubscribeLocalEvent<MicrowaveComponent, BreakageEventArgs>(OnBreak);
             SubscribeLocalEvent<MicrowaveComponent, PowerChangedEvent>(OnPowerChanged);
             SubscribeLocalEvent<MicrowaveComponent, AnchorStateChangedEvent>(OnAnchorChanged);
@@ -307,6 +308,32 @@ namespace Content.Server.Kitchen.EntitySystems
                 return;
 
             UpdateUserInterfaceState(uid, component);
+        }
+
+        private void OnInsertAttempt(Entity<MicrowaveComponent> ent, ref ContainerIsInsertingAttemptEvent args)
+        {
+            if (ent.Comp.Broken)
+            {
+                args.Cancel();
+                return;
+            }
+
+            if (TryComp<ItemComponent>(args.EntityUid, out var item))
+            {
+                if (_item.GetSizePrototype(item.Size) > _item.GetSizePrototype(ent.Comp.MaxItemSize))
+                {
+                    args.Cancel();
+                    return;
+                }
+            }
+            else
+            {
+                args.Cancel();
+                return;
+            }
+
+            if (ent.Comp.Storage.Count >= ent.Comp.Capacity)
+                args.Cancel();
         }
 
         private void OnInteractUsing(Entity<MicrowaveComponent> ent, ref InteractUsingEvent args)

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -312,12 +312,6 @@ namespace Content.Server.Kitchen.EntitySystems
 
         private void OnInsertAttempt(Entity<MicrowaveComponent> ent, ref ContainerIsInsertingAttemptEvent args)
         {
-            if (!(TryComp<ApcPowerReceiverComponent>(ent, out var apc) && apc.Powered))
-            {
-                args.Cancel();
-                return;
-            }
-
             if (ent.Comp.Broken)
             {
                 args.Cancel();

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -312,6 +312,12 @@ namespace Content.Server.Kitchen.EntitySystems
 
         private void OnInsertAttempt(Entity<MicrowaveComponent> ent, ref ContainerIsInsertingAttemptEvent args)
         {
+            if (!(TryComp<ApcPowerReceiverComponent>(ent, out var apc) && apc.Powered))
+            {
+                args.Cancel();
+                return;
+            }
+
             if (ent.Comp.Broken)
             {
                 args.Cancel();

--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -151,9 +151,9 @@ public sealed class SwapTeleporterSystem : EntitySystem
         }
 
         var (teleEnt, cont) = GetTeleportingEntity((uid, xform));
-        var (otherTeleEnt, othercont) = GetTeleportingEntity((linkedEnt, Transform(linkedEnt)));
+        var (otherTeleEnt, otherCont) = GetTeleportingEntity((linkedEnt, Transform(linkedEnt)));
 
-        if (othercont != null || cont != null)
+        if (otherCont != null || cont != null)
         {
             _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-fail", ("entity", Identity.Entity(linkedEnt, EntityManager))),
                 teleEnt,

--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -153,6 +153,14 @@ public sealed class SwapTeleporterSystem : EntitySystem
         var teleEnt = GetTeleportingEntity((uid, xform));
         var otherTeleEnt = GetTeleportingEntity((linkedEnt, Transform(linkedEnt)));
 
+        if (_container.TryGetOuterContainer(teleEnt, Transform(teleEnt), out var othercontainer) &&
+            !_container.CanInsert(teleEnt, othercontainer))
+            return;
+
+        if (_container.TryGetOuterContainer(otherTeleEnt, Transform(otherTeleEnt), out var container) &&
+            !_container.CanInsert(otherTeleEnt, container))
+            return;
+
         _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-other",
             ("entity", Identity.Entity(linkedEnt, EntityManager))),
             otherTeleEnt,

--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Popups;
 using Content.Shared.Teleportation.Components;
 using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
-using Linguini.Syntax.Ast;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map.Components;

--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -153,9 +153,11 @@ public sealed class SwapTeleporterSystem : EntitySystem
         var (teleEnt, cont) = GetTeleportingEntity((uid, xform));
         var (otherTeleEnt, otherCont) = GetTeleportingEntity((linkedEnt, Transform(linkedEnt)));
 
-        if (otherCont != null || cont != null)
+        if (otherCont != null && !_container.CanInsert(teleEnt, otherCont) ||
+            cont != null && !_container.CanInsert(otherTeleEnt, cont))
         {
-            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-fail", ("entity", Identity.Entity(linkedEnt, EntityManager))),
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-fail",
+                ("entity", Identity.Entity(linkedEnt, EntityManager))),
                 teleEnt,
                 teleEnt,
                 PopupType.MediumCaution);

--- a/Resources/Locale/en-US/portal/swap-teleporter.ftl
+++ b/Resources/Locale/en-US/portal/swap-teleporter.ftl
@@ -5,6 +5,7 @@ swap-teleporter-popup-link-destroyed = Quantum link destroyed!
 swap-teleporter-popup-teleport-cancel-time = It's still recharging!
 swap-teleporter-popup-teleport-cancel-link = It's not linked with another device!
 swap-teleporter-popup-teleport-other = {CAPITALIZE(THE($entity))} activates, and you find yourself somewhere else.
+swap-teleporter-popup-teleport-fail = {CAPITALIZE(THE($entity))} activates and fails to transport you anywhere.
 
 swap-teleporter-verb-destroy-link = Destroy Quantum Link
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Puts a check on the QSI teleport if the thing that can be teleported would fit into the inventory it would be teleported into.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #29157 and #27397 (as far as I can tell from my testing)
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Uses CanInsert to check if both objects being teleported would be able to fit into the inventory of the other object. If not then the teleport is canceled.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/83733158/4f5b05d0-0d78-49fd-9ed5-88eb55915cc1

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: You can no longer teleport objects that should not be in other objects into other objects with the Quantum Spin Inverter
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
