### PR TITLE
Add collision for beds

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -3,6 +3,8 @@ using System.Numerics;
 using Content.Shared.Alert;
 using Content.Shared.Bed.Sleep;
 using Content.Shared.Buckle.Components;
+using Content.Shared.Climbing.Systems;
+using Content.Shared.Climbing.Components;
 using Content.Shared.Database;
 using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
@@ -26,6 +28,7 @@ namespace Content.Shared.Buckle;
 public abstract partial class SharedBuckleSystem
 {
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly ClimbSystem _climbSystem = default!;
 
     private void InitializeBuckle()
     {
@@ -487,6 +490,9 @@ public abstract partial class SharedBuckleSystem
         var ev = new BuckleChangeEvent(strapUid, buckleUid, false);
         RaiseLocalEvent(buckleUid, ref ev);
         RaiseLocalEvent(strapUid, ref ev);
+
+        if (HasComp<ClimbableComponent>(strapUid))
+            _climbSystem.ForciblySetClimbing(userUid, strapUid);
 
         return true;
     }

--- a/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
@@ -5,6 +5,17 @@
   parent: ReagentDispenserBase
   description: An industrial grade chemical dispenser.
   components:
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,-0.3,0.4,0.3"
+        density: 190
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
   - type: Sprite
     sprite: Structures/dispensers.rsi
     state: industrial-working

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -20,6 +20,8 @@
         density: 190
         mask:
         - TableMask
+        layer:
+        - TableLayer
   - type: Sprite
     sprite: Structures/Furniture/furniture.rsi
     state: bed
@@ -55,7 +57,9 @@
     anchored: true
     noRot: true
   - type: Anchorable
+    flags: 0
   - type: Pullable
+  - type: Climbable
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
@@ -47,15 +47,9 @@
     board: StasisBedMachineCircuitboard
   - type: Physics
     bodyType: Static
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.45,-0.45,0.45,0.05"
-        density: 190
-        mask:
-        - LowImpassable
+  - type: Anchorable
+    flags: 0
+  - type: Climbable
   - type: GuideHelp
     guides:
     - Medical Doctor


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
In this PR we add collision for beds and remove AnchorableComponent from beds. 

## Why / Balance
We remove AnchorableComponent for beds because it is cause of bugs when u want to pull it. We add collision for beds because it remove possibility to anchore many beds and chemdispensers in one tile. We chose this way to fix it because in our opinion we need to add collision to beds because it unrealistic to go right through.
Removing possibility to unanchor the bed isn't the worst because u can disassemble bed and place in other place if u want it. 

## Technical details
We added check if entity has component Climbable and if it have it we remove collision to entity and give player go through it. We added ClimbableComponent to beds to interact with this check. 
We replaced TabletopMachineLayer to MachineLayer and Mask accordingly to chemdispancer because it isnt logic when this big machine is tabletop (it isnt)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**



:cl: Ady4
- add: Added collision to beds.
- remove: Remove possibility to unanchor beds.
- fix: Fixed possibility to stack beds and chemdispensers in one tile.

