### PR TITLE
Fix internals not auto-activating for entities spawned in space

### DIFF
--- a/Content.IntegrationTests/Tests/Internals/AutoInternalsTests.cs
+++ b/Content.IntegrationTests/Tests/Internals/AutoInternalsTests.cs
@@ -3,8 +3,6 @@ using Content.Server.Body.Systems;
 using Content.Server.Station.Systems;
 using Content.Shared.Preferences;
 using Content.Shared.Roles.Jobs;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Map;
 
 namespace Content.IntegrationTests.Tests.Internals;
 
@@ -20,8 +18,6 @@ public sealed class AutoInternalsTests
 
         var testMap = await pair.CreateTestMap();
 
-        var mapMan = server.ResolveDependency<IMapManager>();
-        var entMan = server.ResolveDependency<IEntityManager>();
         var stationSpawning = server.System<StationSpawningSystem>();
         var atmos = server.System<AtmosphereSystem>();
         var internals = server.System<InternalsSystem>();
@@ -37,7 +33,7 @@ public sealed class AutoInternalsTests
             Assert.That(atmos.HasAtmosphere(testMap.Grid), Is.False, "Test map has atmosphere - test needs adjustment!");
             Assert.That(internals.AreInternalsWorking(dummy), "Internals did not automatically connect!");
 
-            entMan.DeleteEntity(dummy);
+            server.EntMan.DeleteEntity(dummy);
         });
 
         await pair.CleanReturnAsync();
@@ -51,19 +47,17 @@ public sealed class AutoInternalsTests
 
         var testMap = await pair.CreateTestMap();
 
-        var mapMan = server.ResolveDependency<IMapManager>();
-        var entMan = server.ResolveDependency<IEntityManager>();
         var atmos = server.System<AtmosphereSystem>();
         var internals = server.System<InternalsSystem>();
 
         await server.WaitAssertion(() =>
         {
-            var dummy = entMan.Spawn("TestInternalsDummyEntity", testMap.MapCoords);
+            var dummy = server.EntMan.Spawn("TestInternalsDummyEntity", testMap.MapCoords);
 
             Assert.That(atmos.HasAtmosphere(testMap.Grid), Is.False, "Test map has atmosphere - test needs adjustment!");
             Assert.That(internals.AreInternalsWorking(dummy), "Internals did not automatically connect!");
 
-            entMan.DeleteEntity(dummy);
+            server.EntMan.DeleteEntity(dummy);
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/Internals/AutoInternalsTests.cs
+++ b/Content.IntegrationTests/Tests/Internals/AutoInternalsTests.cs
@@ -1,0 +1,95 @@
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Body.Systems;
+using Content.Server.Station.Systems;
+using Content.Shared.Preferences;
+using Content.Shared.Roles.Jobs;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.Internals;
+
+[TestFixture]
+[TestOf(typeof(InternalsSystem))]
+public sealed class AutoInternalsTests
+{
+    [Test]
+    public async Task TestInternalsAutoActivateInSpaceForStationSpawn()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var testMap = await pair.CreateTestMap();
+
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var stationSpawning = server.System<StationSpawningSystem>();
+        var atmos = server.System<AtmosphereSystem>();
+        var internals = server.System<InternalsSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var profile = new HumanoidCharacterProfile();
+            var dummy = stationSpawning.SpawnPlayerMob(testMap.GridCoords, new JobComponent()
+            {
+                Prototype = "TestInternalsDummy"
+            }, profile, station: null);
+
+            Assert.That(atmos.HasAtmosphere(testMap.Grid), Is.False, "Test map has atmosphere - test needs adjustment!");
+            Assert.That(internals.AreInternalsWorking(dummy), "Internals did not automatically connect!");
+
+            entMan.DeleteEntity(dummy);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task TestInternalsAutoActivateInSpaceForEntitySpawn()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var testMap = await pair.CreateTestMap();
+
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var atmos = server.System<AtmosphereSystem>();
+        var internals = server.System<InternalsSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var dummy = entMan.Spawn("TestInternalsDummyEntity", testMap.MapCoords);
+
+            Assert.That(atmos.HasAtmosphere(testMap.Grid), Is.False, "Test map has atmosphere - test needs adjustment!");
+            Assert.That(internals.AreInternalsWorking(dummy), "Internals did not automatically connect!");
+
+            entMan.DeleteEntity(dummy);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: playTimeTracker
+  id: PlayTimeInternalsDummy
+
+- type: startingGear
+  id: InternalsDummyGear
+  equipment:
+    mask: ClothingMaskBreath
+    suitstorage: OxygenTankFilled
+
+- type: job
+  id: TestInternalsDummy
+  playTimeTracker: PlayTimeInternalsDummy
+  startingGear: InternalsDummyGear
+
+- type: entity
+  id: TestInternalsDummyEntity
+  parent: MobHuman
+  components:
+    - type: Loadout
+      prototypes: [InternalsDummyGear]
+";
+}

--- a/Content.Shared/Clothing/LoadoutSystem.cs
+++ b/Content.Shared/Clothing/LoadoutSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared.Body.Systems;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.Preferences;
@@ -27,7 +28,8 @@ public sealed class LoadoutSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<LoadoutComponent, MapInitEvent>(OnMapInit);
+        // Wait until the character has all their organs before we give them their loadout
+        SubscribeLocalEvent<LoadoutComponent, MapInitEvent>(OnMapInit, after: [typeof(SharedBodySystem)]);
     }
 
     public static string GetJobPrototype(string? loadout)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Space ninjas will start with their internals activated automatically again.

Adds tests to verify that humans spawned on a grid with no atmosphere get their internals connected automatically. This is tested for both station spawns (role assignments) and entity spawns (debug spawn menu, antag spawners, etc.).

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This has been fixed and broken again a few times recently. This fixes it and the tests should help catch it if it happens again in the future.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Due to the way that BodySystem works, organs aren't spawned until MapInit. Loadouts are also given during MapInit, which means, due to the ordering of subscriptions, the presence of organs in a body is not guaranteed while applying a loadout to a mob. Mobs spawned by EntityManager get their loadout applied before BodySystem can run, while mobs spawned by station spawner get it applied after.

So LoadoutSystem's MapInit subscription was given an explicit `after` to make sure that it runs after BodySystem.

The first test (station spawn) passes on the current master and with this PR.
The second test (entity manager spawn) fails on the current master and passes with this PR.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Code
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed space ninja's starting with their internals disabled.