### PR TITLE
Firelocks are no longer pryable by hand if they are powered

### DIFF
--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -63,14 +63,10 @@ public abstract class SharedFirelockSystem : EntitySystem
 
     private void OnBeforePry(EntityUid uid, FirelockComponent component, ref BeforePryEvent args)
     {
-        if (args.Cancelled)
-            return;
-
-        if (!component.Powered || args.StrongPry || args.PryPowered)
+        if (args.Cancelled || !component.Powered || args.StrongPry || args.PryPowered)
             return;
 
         args.Cancelled = true;
-
     }
 
     private void OnDoorGetPryTimeModifier(EntityUid uid, FirelockComponent component, ref GetPryTimeModifierEvent args)

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -21,6 +21,7 @@ public abstract class SharedFirelockSystem : EntitySystem
 
         // Access/Prying
         SubscribeLocalEvent<FirelockComponent, BeforeDoorOpenedEvent>(OnBeforeDoorOpened);
+        SubscribeLocalEvent<FirelockComponent, BeforePryEvent>(OnBeforePry);
         SubscribeLocalEvent<FirelockComponent, GetPryTimeModifierEvent>(OnDoorGetPryTimeModifier);
         SubscribeLocalEvent<FirelockComponent, PriedEvent>(OnAfterPried);
 
@@ -58,6 +59,18 @@ public abstract class SharedFirelockSystem : EntitySystem
             args.Cancel();
         else if (args.User != null)
             WarnPlayer((uid, component), args.User.Value);
+    }
+
+    private void OnBeforePry(EntityUid uid, FirelockComponent component, ref BeforePryEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (!component.Powered || args.PryPowered)
+            return;
+
+        args.Cancelled = true;
+
     }
 
     private void OnDoorGetPryTimeModifier(EntityUid uid, FirelockComponent component, ref GetPryTimeModifierEvent args)

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -66,7 +66,7 @@ public abstract class SharedFirelockSystem : EntitySystem
         if (args.Cancelled)
             return;
 
-        if (!component.Powered || args.ToolUsed || args.PryPowered)
+        if (!component.Powered || args.StrongPry || args.PryPowered)
             return;
 
         args.Cancelled = true;

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -66,7 +66,7 @@ public abstract class SharedFirelockSystem : EntitySystem
         if (args.Cancelled)
             return;
 
-        if (!component.Powered || args.PryPowered)
+        if (!component.Powered || args.ToolUsed || args.PryPowered)
             return;
 
         args.Cancelled = true;

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -43,13 +43,25 @@ public sealed partial class PryingComponent : Component
 /// Cancel to stop the entity from being pried open.
 /// </summary>
 [ByRefEvent]
-public record struct BeforePryEvent(EntityUid User, bool PryPowered, bool Force)
+public record struct BeforePryEvent(EntityUid User, bool PryPowered, bool Force, bool ToolUsed)
 {
     public readonly EntityUid User = User;
 
+    /// <summary>
+    /// Whether prying should be allowed even if whatever is being pried is powered.
+    /// </summary>
     public readonly bool PryPowered = PryPowered;
 
+    /// <summary>
+    /// Whether prying should be allowed to go through under most circumstances. (E.g. airlock is bolted).
+    /// Systems may still wish to ignore this occasionally.
+    /// </summary>
     public readonly bool Force = Force;
+
+    /// <summary>
+    /// Whether a tool was used to pry the door or not.
+    /// </summary>
+    public readonly bool ToolUsed = ToolUsed;
 
     public string? Message;
 

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -43,7 +43,7 @@ public sealed partial class PryingComponent : Component
 /// Cancel to stop the entity from being pried open.
 /// </summary>
 [ByRefEvent]
-public record struct BeforePryEvent(EntityUid User, bool PryPowered, bool Force, bool ToolUsed)
+public record struct BeforePryEvent(EntityUid User, bool PryPowered, bool Force, bool StrongPry)
 {
     public readonly EntityUid User = User;
 
@@ -59,9 +59,9 @@ public record struct BeforePryEvent(EntityUid User, bool PryPowered, bool Force,
     public readonly bool Force = Force;
 
     /// <summary>
-    /// Whether a tool was used to pry the door or not.
+    /// Whether anything other than bare hands were used. This should only be false if prying is being performed without a prying comp.
     /// </summary>
-    public readonly bool ToolUsed = ToolUsed;
+    public readonly bool StrongPry = StrongPry;
 
     public string? Message;
 

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -109,7 +109,7 @@ public sealed class PryingSystem : EntitySystem
 
         if (comp != null || Resolve(user, ref comp, false))
         {
-            canev = new BeforePryEvent(user, comp.PryPowered, comp.Force);
+            canev = new BeforePryEvent(user, comp.PryPowered, comp.Force, true);
         }
         else
         {
@@ -119,7 +119,7 @@ public sealed class PryingSystem : EntitySystem
                 return false;
             }
 
-            canev = new BeforePryEvent(user, false, false);
+            canev = new BeforePryEvent(user, false, false, false);
         }
 
         RaiseLocalEvent(target, ref canev);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Firelocks are no longer pryable by hand if they are powered. If the firelock is unlocked(it is not containing a dangerous environment) then it can still be opened and closed freely.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Discussion on this is still ongoing with maintainers but I was asked to make this pr ahead of time. I have no opinion on if this is a good change or not, and in my opinion either is acceptable. I am just waiting on maintainer consensus.

The argument I was provided is the following:
Allowing crew to pry open firelocks with their bare hands allows them to expose the rest of the station to dangerous conditions rendering firelocks ineffective. This is compounded by the lack of other tools to further restrict firelocks.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This is the same handling airlocks use, but no message is provided.
The beforepry event is modified to indicate whether a tool was used so we can still allow prying when the firelock is powered and something like a crowbar is used.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Locked firelocks can no longer be pried by hand when powered.