### PR TITLE
Add air alarm hysteresis

### DIFF
--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -93,7 +93,7 @@ namespace Content.Server.Doors.Systems
             if (!TryComp<DoorComponent>(uid, out var doorComponent))
                 return;
 
-            if (args.AlarmType == AtmosAlarmType.Normal || args.AlarmType == AtmosAlarmType.Warning)
+            if (args.AlarmType == AtmosAlarmType.Normal)
             {
                 if (doorComponent.State == DoorState.Closed)
                     _doorSystem.TryOpen(uid);


### PR DESCRIPTION
## About the PR
After firelocks have been closed, only re-open them automatically when the air alarm state is "Good" instead of "Warning".

## Why / Balance
In some cases, particularly when the concentration of plasma/hot gas is at or near the danger threshold, the air alarm state would rapidly alternate between "Warning" and "Danger" and also rapidly open and close firelocks. This behavior is unintuitive and can be perceived as buggy.

## Technical details
Since an intermediate warning state already exists, only open airlocks at "Good" instead of "Warning". This behaves like built-in hysteresis.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A
