### PR TITLE
Prevent fly-by fixture from powering containment field generator

### DIFF
--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -65,7 +65,8 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
     /// </summary>
     private void HandleGeneratorCollide(Entity<ContainmentFieldGeneratorComponent> generator, ref StartCollideEvent args)
     {
-        if (_tags.HasTag(args.OtherEntity, generator.Comp.IDTag))
+        if (_tags.HasTag(args.OtherEntity, generator.Comp.IDTag) &&
+            args.OtherFixtureId == generator.Comp.SourceFixtureId)
         {
             ReceivePower(generator.Comp.PowerReceived, generator);
             generator.Comp.Accumulator = 0f;

--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -65,8 +65,8 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
     /// </summary>
     private void HandleGeneratorCollide(Entity<ContainmentFieldGeneratorComponent> generator, ref StartCollideEvent args)
     {
-        if (_tags.HasTag(args.OtherEntity, generator.Comp.IDTag) &&
-            args.OtherFixtureId == generator.Comp.SourceFixtureId)
+        if (args.OtherFixtureId == generator.Comp.SourceFixtureId &&
+            _tags.HasTag(args.OtherEntity, generator.Comp.IDTag))
         {
             ReceivePower(generator.Comp.PowerReceived, generator);
             generator.Comp.Accumulator = 0f;

--- a/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
+++ b/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
@@ -70,6 +70,14 @@ public sealed partial class ContainmentFieldGeneratorComponent : Component
     public string IDTag = "EmitterBolt";
 
     /// <summary>
+    /// Which fixture ID should test collision with from the entity that powers the generator?
+    /// Prevents the generator from being powered by fly-by fixtures.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
+    public string SourceFixtureId = "projectile";
+
+    /// <summary>
     /// Is the generator toggled on?
     /// </summary>
     [ViewVariables]

--- a/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
+++ b/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
@@ -73,7 +73,6 @@ public sealed partial class ContainmentFieldGeneratorComponent : Component
     /// Which fixture ID should test collision with from the entity that powers the generator?
     /// Prevents the generator from being powered by fly-by fixtures.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
     public string SourceFixtureId = "projectile";
 


### PR DESCRIPTION
## About the PR
Fixes #29222 

TL;DR: the fly-by fixture on the emitter bolt can power the containment field generator.

## Why / Balance
I believe the original behaviour to be unintended, and I personally witnessed it being relied on in a round on Salamander to power a Tesla containment field with only a single emitter.

## Technical details
Adds a field to `ContainmentFieldGeneratorComponent`, `SourceFixtureId`, so we can generate power only when the emitter bolt's `"projectile"` fixture collides with the generator. Otherwise we also catch the `"fly-by"` fixture.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/30327355/7b24d935-cf2b-4099-b562-fc96f1fa9797)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
It might break your tesla meta, but should not have any knock-on effects.

**Changelog**
:cl:
- fix: Containment field generators can no longer be powered by an emitter bolt flying past them. The bolt must hit them directly.