### PR TITLE
tweak(revolutionaries): Make it so there is only one head revolutionary. Give the head revolutionary the ability to convert up to 2 other mobs into heads.

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -142,6 +142,12 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
         _npcFaction.AddFaction(ev.Target, RevolutionaryNpcFaction);
         var revComp = EnsureComp<RevolutionaryComponent>(ev.Target);
+        var head = false;
+        if(HasComp<HeadRevolutionaryFlashComponent>(ev.Used))
+        {
+          EnsureComp<HeadRevolutionaryComponent>(ev.Target);
+          head = true;
+        }
 
         if (ev.User != null)
         {
@@ -157,7 +163,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         }
 
         if (mind?.Session != null)
-            _antag.SendBriefing(mind.Session, Loc.GetString("rev-role-greeting"), Color.Red, revComp.RevStartSound);
+            _antag.SendBriefing(mind.Session, Loc.GetString(head ? "head-rev-role-greeting"  :"rev-role-greeting"), Color.Red, revComp.RevStartSound);
     }
 
     //TODO: Enemies of the revolution

--- a/Content.Shared/Revolutionary/Components/HeadRevolutionaryFlashComponent.cs
+++ b/Content.Shared/Revolutionary/Components/HeadRevolutionaryFlashComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared.Revolutionary.Components;
+
+/// <summary>
+/// Component used for marking a Flash as being able to create other Headrevs.
+/// </summary>
+[RegisterComponent]
+public sealed partial class HeadRevolutionaryFlashComponent : Component;

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -171,6 +171,17 @@
 - type: entity
   name: flash
   parent: Flash
+  suffix: Head Revolutionary
+  id: HeadRevFlash
+  components:
+    - type: LimitedCharges
+      maxCharges: 2
+      charges: 2
+    - type: HeadRevolutionaryFlash
+
+- type: entity
+  name: flash
+  parent: Flash
   suffix: 2 charges
   id: SciFlash
   components:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -188,7 +188,7 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ HeadRev ]
-      max: 3
+      max: 1
       playerRatio: 15
       briefing:
         text: head-rev-role-greeting

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -19,4 +19,5 @@
   storage:
     back:
     - Flash
+    - HeadRevFlash
     - ClothingEyesGlassesSunglasses


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added a special flash that has the ability to convert other mobs into Head/lieutenant revolutionaries.
Made it so there is always only one round start head revolutionary.
Gave the round start head revolutionary the special flash.

**Todo:**

- [ ] Give the special flash a blue bulb.
- [ ] Decrease the amount of charges in the special flash based on the players at round start.
- [ ] Do not give the special flash if there are not enough players to justify two head revs.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Currently on high-pop servers a head revolutionary player is pressured into converting people into baby revs as soon as possible. This is because there are multiple other head revolutionaries in the game and those revolutionaries can not be trusted to not expose the revs at the very beginning of the round.

This change would allow head revolutionaries to play the round out slower and give them more time to choose the people they want to convert to the revolution.

An intended effect of this change would be reduced NRP behavior and murder boning due to head revs and players feelings as if they must complete stuff NOW before they are exposed.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
will do when I have the blue flash

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
