### PR TITLE
Fix and enable TestEmptyLoadout

### DIFF
--- a/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
+++ b/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
@@ -1,15 +1,52 @@
+using System.Collections.Generic;
 using Content.Server.Station.Systems;
+using Content.Shared.Inventory;
 using Content.Shared.Preferences;
 using Content.Shared.Preferences.Loadouts;
 using Content.Shared.Roles.Jobs;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.Preferences;
 
 [TestFixture]
-[Ignore("HumanoidAppearance crashes upon loading default profiles.")]
 public sealed class LoadoutTests
 {
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: playTimeTracker
+  id: PlayTimeLoadoutTester
+
+- type: loadout
+  id: TestJumpsuit
+  equipment: TestJumpsuit
+
+- type: startingGear
+  id: TestJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorGrey
+
+- type: loadoutGroup
+  id: LoadoutTesterJumpsuit
+  name: test
+  loadouts:
+  - TestJumpsuit
+
+- type: roleLoadout
+  id: JobLoadoutTester
+  groups:
+  - LoadoutTesterJumpsuit
+
+- type: job
+  id: LoadoutTester
+  playTimeTracker: PlayTimeLoadoutTester
+";
+
+    private readonly Dictionary<string, EntProtoId> _expectedEquipment = new()
+    {
+        ["jumpsuit"] = "ClothingUniformJumpsuitColorGrey"
+    };
+
     /// <summary>
     /// Checks that an empty loadout still spawns with default gear and not naked.
     /// </summary>
@@ -26,18 +63,38 @@ public sealed class LoadoutTests
 
         // Check that an empty role loadout spawns gear
         var stationSystem = entManager.System<StationSpawningSystem>();
+        var inventorySystem = entManager.System<InventorySystem>();
         var testMap = await pair.CreateTestMap();
 
-        // That's right I can't even spawn a dummy profile without station spawning / humanoidappearance code crashing.
-        var profile = new HumanoidCharacterProfile();
-
-        profile.SetLoadout(new RoleLoadout("TestRoleLoadout"));
-
-        stationSystem.SpawnPlayerMob(testMap.GridCoords, job: new JobComponent()
+        await server.WaitAssertion(() =>
         {
-            // Sue me, there's so much involved in setting up jobs
-            Prototype = "CargoTechnician"
-        }, profile, station: null);
+            var profile = new HumanoidCharacterProfile();
+
+            profile.SetLoadout(new RoleLoadout("LoadoutTester"));
+
+            var tester = stationSystem.SpawnPlayerMob(testMap.GridCoords, job: new JobComponent()
+            {
+                Prototype = "LoadoutTester"
+            }, profile, station: null);
+
+            var slotQuery = inventorySystem.GetSlotEnumerator(tester);
+            var checkedCount = 0;
+            while (slotQuery.NextItem(out var item, out var slot))
+            {
+                // Make sure the slot is valid
+                Assert.That(_expectedEquipment.TryGetValue(slot.Name, out var expectedItem), $"Spawned item in unexpected slot: {slot.Name}");
+
+                // Make sure that the item is the right one
+                var meta = entManager.GetComponent<MetaDataComponent>(item);
+                Assert.That(meta.EntityPrototype.ID, Is.EqualTo(expectedItem.Id), $"Spawned wrong item in slot {slot.Name}!");
+
+                checkedCount++;
+            }
+            // Make sure the number of items is the same
+            Assert.That(checkedCount, Is.EqualTo(_expectedEquipment.Count), "Number of items does not match expected!");
+
+            entManager.DeleteEntity(tester);
+        });
 
         await pair.CleanReturnAsync();
     }

--- a/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
+++ b/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
@@ -28,7 +28,7 @@ public sealed class LoadoutTests
 
 - type: loadoutGroup
   id: LoadoutTesterJumpsuit
-  name: test
+  name: generic-unknown
   loadouts:
   - TestJumpsuit
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes the issue that was preventing the TestEmptyLoadout CI test from working, and makes it actually do something.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This sad, abandoned test needed love. And I'm tired of seeing that 1 test was skipped when I run tests.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Moved stuff that needs to run in the game thread into an await block so it can actually run.
Added some functionality that I _think_ does what the test was intended to do: it spawns a player with no set loadout for a role and verifies that they receive the default gear.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
