### PR TITLE
Increase the contents of the emergency oxygen and fire lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -20,16 +20,21 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterSuitEmergency
       - id: ClothingMaskBreath
+      - id: ClothingOuterSuitEmergency
       - id: EmergencyOxygenTankFilled
-        prob: 0.80
-        orGroup: EmergencyTankOrRegularTank
+      - id: EmergencyOxygenTankFilled
+        prob: 0.5
+        orGroup: OxygenTank
       - id: OxygenTankFilled
-        prob: 0.20
-        orGroup: EmergencyTankOrRegularTank
+        prob: 0.5
+        orGroup: OxygenTank
       - id: ToolboxEmergencyFilled
-        prob: 0.4
+        prob: 0.5
+        orGroup: Crowbar
+      - id: CrowbarRed
+        prob: 0.5
+        orGroup: Crowbar
       - id: MedkitOxygenFilled
         prob: 0.2
       - id: WeaponFlareGun
@@ -44,16 +49,21 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterSuitEmergency
       - id: ClothingMaskBreath
+      - id: ClothingOuterSuitEmergency
       - id: EmergencyOxygenTankFilled
-        prob: 0.80
-        orGroup: EmergencyTankOrRegularTank
+      - id: EmergencyOxygenTankFilled
+        prob: 0.5
+        orGroup: OxygenTank
       - id: OxygenTankFilled
-        prob: 0.20
-        orGroup: EmergencyTankOrRegularTank
+        prob: 0.5
+        orGroup: OxygenTank
       - id: ToolboxEmergencyFilled
-        prob: 0.4
+        prob: 0.5
+        orGroup: Crowbar
+      - id: CrowbarRed
+        prob: 0.5
+        orGroup: Crowbar
       - id: MedkitOxygenFilled
         prob: 0.2
       - id: WeaponFlareGun
@@ -69,39 +79,63 @@
   - type: StorageFill
     contents:
       - id: ClothingMaskBreath
+      - id: ClothingOuterSuitEmergency
       - id: EmergencyNitrogenTankFilled
-        prob: 0.80
-        orGroup: EmergencyTankOrRegularTank
+      - id: EmergencyNitrogenTankFilled
+        prob: 0.5
+        orGroup: NitrogenTank
       - id: NitrogenTankFilled
-        prob: 0.20
-        orGroup: EmergencyTankOrRegularTank
+        prob: 0.5
+        orGroup: NitrogenTank
 
 - type: entity
   id: ClosetFireFilled
   parent: ClosetFire
   suffix: Filled
   components:
-    - type: StorageFill
-      contents:
-        - id: ClothingOuterSuitFire
-        - id: ClothingHeadHelmetFire
-        - id: ClothingMaskGas
-        - id: OxygenTankFilled
-        - id: FireExtinguisher
-          prob: 0.25
+  - type: StorageFill
+    contents:
+      - id: ClothingOuterSuitFire
+      - id: ClothingHeadHelmetFire
+      - id: ClothingMaskGas
+      - id: EmergencyOxygenTankFilled
+        prob: 0.5
+        orGroup: OxygenTank
+      - id: OxygenTankFilled
+        prob: 0.5
+        orGroup: OxygenTank
+      - id: CrowbarRed
+      - id: FireExtinguisher
+        prob: 0.98
+        orGroup: FireExtinguisher
+      - id: SprayBottleWater #It's just budget cut after budget cut man
+        prob: 0.02
+        orGroup: FireExtinguisher
+
 - type: entity
   id: ClosetWallFireFilledRandom
   parent: ClosetWallFire
   suffix: Filled
   components:
-    - type: StorageFill
-      contents:
-        - id: ClothingOuterSuitFire
-        - id: ClothingHeadHelmetFire
-        - id: ClothingMaskGas
-        - id: OxygenTankFilled
-        - id: FireExtinguisher
-          prob: 0.25
+  - type: StorageFill
+    contents:
+      - id: ClothingOuterSuitFire
+      - id: ClothingHeadHelmetFire
+      - id: ClothingMaskGas
+      - id: EmergencyOxygenTankFilled
+        prob: 0.5
+        orGroup: OxygenTank
+      - id: OxygenTankFilled
+        prob: 0.5
+        orGroup: OxygenTank
+      - id: CrowbarRed
+      - id: FireExtinguisher
+        prob: 0.98
+        orGroup: FireExtinguisher
+      - id: SprayBottleWater #It's just budget cut after budget cut man
+        prob: 0.02
+        orGroup: FireExtinguisher
+
 - type: entity
   id: ClosetMaintenanceFilledRandom
   suffix: Filled, Random

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -23,7 +23,6 @@
       - id: ClothingMaskBreath
       - id: ClothingOuterSuitEmergency
       - id: EmergencyOxygenTankFilled
-      - id: EmergencyOxygenTankFilled
         prob: 0.5
         orGroup: OxygenTank
       - id: OxygenTankFilled
@@ -31,10 +30,6 @@
         orGroup: OxygenTank
       - id: ToolboxEmergencyFilled
         prob: 0.5
-        orGroup: Crowbar
-      - id: CrowbarRed
-        prob: 0.5
-        orGroup: Crowbar
       - id: MedkitOxygenFilled
         prob: 0.2
       - id: WeaponFlareGun
@@ -52,7 +47,6 @@
       - id: ClothingMaskBreath
       - id: ClothingOuterSuitEmergency
       - id: EmergencyOxygenTankFilled
-      - id: EmergencyOxygenTankFilled
         prob: 0.5
         orGroup: OxygenTank
       - id: OxygenTankFilled
@@ -60,10 +54,6 @@
         orGroup: OxygenTank
       - id: ToolboxEmergencyFilled
         prob: 0.5
-        orGroup: Crowbar
-      - id: CrowbarRed
-        prob: 0.5
-        orGroup: Crowbar
       - id: MedkitOxygenFilled
         prob: 0.2
       - id: WeaponFlareGun
@@ -80,7 +70,6 @@
     contents:
       - id: ClothingMaskBreath
       - id: ClothingOuterSuitEmergency
-      - id: EmergencyNitrogenTankFilled
       - id: EmergencyNitrogenTankFilled
         prob: 0.5
         orGroup: NitrogenTank


### PR DESCRIPTION
## About the PR
The emergency oxygen locker is now significantly more likely to contain a large air tank, and always contains a crowbar in or out of a toolbox.
The emergency fire locker is now guaranteed to contain a fire extinguisher in some capacity, but no longer always contains a large oxygen tank.

## Why / Balance
I always felt it was rather irritating how the fire locker contained full sized oxygen tanks, the oxygen locker contained small ones and a crowbar, and the crowbar is never even there when you need it.

## Media
![image](https://github.com/user-attachments/assets/3b7de180-c000-43c6-a571-d242516d907c)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Emergency oxygen and fire lockers now generally contain more supplies
