### PR TITLE
Increase of riot shield durability

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -36,13 +36,13 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 80
+            damage: 140
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
-            damage: 40 #This is probably enough damage before it breaks
+            damage: 100 #This is probably enough damage before it breaks
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
@@ -70,6 +70,18 @@
   components:
     - type: StaticPrice
       price: 90
+          - type: Blocking
+      passiveBlockModifier:
+        coefficients:
+          Blunt: 0.7
+          Slash: 0.7
+      activeBlockModifier:
+        coefficients:
+          Blunt: 0.5
+          Slash: 0.5
+        flatReductions:
+          Blunt: 1
+          Slash: 1
 
 - type: entity
   name: riot laser shield
@@ -84,12 +96,12 @@
     - type: Blocking
       passiveBlockModifier:
         coefficients:
-          Heat: 0.8
+          Heat: 0.7
       activeBlockModifier:
         coefficients:
-          Heat: 0.7
+          Heat: 0.5
         flatReductions:
-          Heat: 2
+          Heat: 1
 
 - type: entity
   name: riot bullet shield
@@ -104,15 +116,12 @@
     - type: Blocking
       passiveBlockModifier:
         coefficients:
-          Blunt: 0.8
-          Piercing: 0.8
+          Piercing: 0.7
       activeBlockModifier:
         coefficients:
-          Blunt: 0.7
-          Piercing: 0.7
+          Piercing: 0.5
         flatReductions:
-          Blunt: 1.5
-          Piercing: 1.5
+          Piercing: 1
 
 #Craftable shields
 

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -70,7 +70,7 @@
   components:
     - type: StaticPrice
       price: 90
-          - type: Blocking
+    - type: Blocking
       passiveBlockModifier:
         coefficients:
           Blunt: 0.7


### PR DESCRIPTION
Increases the total health of riot shields, as well as modifying their damage co-efficient to closer reflect the shield type

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? --> This PR aims to make security use riot shields more often, while making the riot shield + pistol combo more viable in combat than its meager state currently. right now security never really uses them as the tradeoff of a bulky, hard to carry shield for minimal protection is rough!

The recent change to make most guns require wielding to accurately fire is already a fantastic change for gunplay. I believe increasing the usefulness of shields would also aid in making gunplay feel more varied

I also would LOVE to see security use riot shields to block hallways, section off areas, and use the anchoring system more which is why I increased the active block resist on all the riot shields

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. --> I changed this in the hopes of not only increasing the use of riot shields, but it might also decrease the need to arm security from armory if they have access to an easier alternative on blue alert. But as stated above it also increases the variety of viable "loudouts" for combat using already existing items and abilities

I considered possibly making each shield weak to a damage type as well (I.E the standard riot shield would take 150-200% heat damage or something) to try and maintain balance. If that needs to be done it certainly could be

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. --> in Shields.yml i increased the damage threshold's by 60 damage, making sure to keep the higher one that doesnt spawn materials so that weird bugs don't occur upon overkill (nukes)

I also modified the 3 riot shields damage co-efficients, making them uniform across the board for their respective damage types



## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
**I believe this PR does not require media as it is entirely numerical**


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
--> 

<Make sure to take this Changelog template out of the comment block in order for it to show up.>



:cl:
- tweak: Increased Security Riot shields durability significantly and makes actively blocking better

