### PR TITLE
Substation visualisation

### DIFF
--- a/Content.Client/Power/Substation/SubstationVisualizerComponent.cs
+++ b/Content.Client/Power/Substation/SubstationVisualizerComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Client.Power.Substation;
+
+[RegisterComponent]
+public sealed partial class SubstationVisualizerComponent : Component
+{
+
+}

--- a/Content.Client/Power/Substation/SubstationVisualizerSystem.cs
+++ b/Content.Client/Power/Substation/SubstationVisualizerSystem.cs
@@ -1,0 +1,42 @@
+using Content.Shared.Power;
+using Content.Shared.Substation;
+using Robust.Client.GameObjects;
+
+namespace Content.Client.Power.Substation;
+public sealed class SubstationVisualizerSystem : VisualizerSystem<SubstationVisualizerComponent>
+{
+    protected override void OnAppearanceChange(EntityUid uid, SubstationVisualizerComponent comp, ref AppearanceChangeEvent args)
+    {
+        if (args.Sprite == null)
+            return;
+
+        if (!AppearanceSystem.TryGetData<SubstationChargeState>(uid, SubstationVisuals.LastChargeState, out var state, args.Component))
+            state = SubstationChargeState.Full;
+
+        switch (state)
+        {
+            case SubstationChargeState.Dead:
+                args.Sprite.LayerSetState(SubstationVisualLayers.Charge, $"dead");
+                args.Sprite.LayerSetVisible(SubstationVisualLayers.Screen, false);
+                break;
+            case SubstationChargeState.Discharging:
+                args.Sprite.LayerSetState(SubstationVisualLayers.Charge, $"dead");
+                args.Sprite.LayerSetVisible(SubstationVisualLayers.Screen, true);
+                break;
+            case SubstationChargeState.Charging:
+                args.Sprite.LayerSetState(SubstationVisualLayers.Charge, $"charging");
+                args.Sprite.LayerSetVisible(SubstationVisualLayers.Screen, true);
+                break;
+            case SubstationChargeState.Full:
+                args.Sprite.LayerSetState(SubstationVisualLayers.Charge, $"full");
+                args.Sprite.LayerSetVisible(SubstationVisualLayers.Screen, true);
+                break;
+        }
+    }
+}
+
+enum SubstationVisualLayers : byte
+{
+    Charge,
+    Screen,
+}

--- a/Content.Client/Power/Substation/SubstationVisualizerSystem.cs
+++ b/Content.Client/Power/Substation/SubstationVisualizerSystem.cs
@@ -5,6 +5,7 @@ using Robust.Client.GameObjects;
 namespace Content.Client.Power.Substation;
 public sealed class SubstationVisualizerSystem : VisualizerSystem<SubstationVisualizerComponent>
 {
+    [Dependency] private readonly SharedPointLightSystem _lights = default!;
     protected override void OnAppearanceChange(EntityUid uid, SubstationVisualizerComponent comp, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null)
@@ -18,18 +19,22 @@ public sealed class SubstationVisualizerSystem : VisualizerSystem<SubstationVisu
             case SubstationChargeState.Dead:
                 args.Sprite.LayerSetState(SubstationVisualLayers.Charge, $"dead");
                 args.Sprite.LayerSetVisible(SubstationVisualLayers.Screen, false);
+                _lights.SetEnabled(uid, false);
                 break;
             case SubstationChargeState.Discharging:
                 args.Sprite.LayerSetState(SubstationVisualLayers.Charge, $"dead");
                 args.Sprite.LayerSetVisible(SubstationVisualLayers.Screen, true);
+                _lights.SetEnabled(uid, true);
                 break;
             case SubstationChargeState.Charging:
                 args.Sprite.LayerSetState(SubstationVisualLayers.Charge, $"charging");
                 args.Sprite.LayerSetVisible(SubstationVisualLayers.Screen, true);
+                _lights.SetEnabled(uid, true);
                 break;
             case SubstationChargeState.Full:
                 args.Sprite.LayerSetState(SubstationVisualLayers.Charge, $"full");
                 args.Sprite.LayerSetVisible(SubstationVisualLayers.Screen, true);
+                _lights.SetEnabled(uid, true);
                 break;
         }
     }

--- a/Content.Server/Power/Substation/SubstationVisualizerComponent.cs
+++ b/Content.Server/Power/Substation/SubstationVisualizerComponent.cs
@@ -1,0 +1,14 @@
+using Content.Shared.Substation;
+
+namespace Content.Server.Power.Substation;
+
+[RegisterComponent, Access(typeof(SubstationVisualizerSystem))]
+public sealed partial class SubstationVisualizerComponent : Component
+{
+    [ViewVariables]
+    public SubstationChargeState LastChargeState;
+    [ViewVariables]
+    public TimeSpan LastChargeStateTime;
+    [ViewVariables]
+    public TimeSpan VisualsChangeDelay = TimeSpan.FromSeconds(1);
+}

--- a/Content.Server/Power/Substation/SubstationVisualizerSystem.cs
+++ b/Content.Server/Power/Substation/SubstationVisualizerSystem.cs
@@ -52,9 +52,10 @@ internal sealed class SubstationVisualizerSystem : EntitySystem
         PowerState.Battery battery = netBattery.NetworkBattery;
 
         if (battery.CurrentReceiving == 0 && MathHelper.CloseTo(battery.CurrentStorage / battery.Capacity, 0))
-        {
             return SubstationChargeState.Dead;
-        }
+        else
+        if (MathHelper.CloseTo(battery.CurrentStorage / battery.Capacity, 1))
+            return SubstationChargeState.Full;
 
         return (battery.CurrentSupply - battery.CurrentReceiving) switch
         {

--- a/Content.Server/Power/Substation/SubstationVisualizerSystem.cs
+++ b/Content.Server/Power/Substation/SubstationVisualizerSystem.cs
@@ -1,0 +1,66 @@
+using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
+using Content.Server.Power.Pow3r;
+using Content.Shared.Power;
+using Content.Shared.Substation;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Power.Substation;
+internal sealed class SubstationVisualizerSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        UpdatesAfter.Add(typeof(PowerNetSystem));
+
+        SubscribeLocalEvent<SubstationVisualizerComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<SubstationVisualizerComponent, ChargeChangedEvent>(OnBatteryChargeChanged);
+    }
+
+    private void OnMapInit(EntityUid uid, SubstationVisualizerComponent component, MapInitEvent args)
+    {
+        UpdateSubstationState(uid, component);
+    }
+
+    private void OnBatteryChargeChanged(EntityUid uid, SubstationVisualizerComponent component, ref ChargeChangedEvent args)
+    {
+        UpdateSubstationState(uid, component);
+    }
+
+    private void UpdateSubstationState(EntityUid uid, SubstationVisualizerComponent substation)
+    {
+        // copy paste = sad day
+        var newChargeState = CalcChargeState(uid);
+        if (newChargeState != substation.LastChargeState && substation.LastChargeStateTime + substation.VisualsChangeDelay < _gameTiming.CurTime)
+        {
+            substation.LastChargeState = newChargeState;
+            substation.LastChargeStateTime = _gameTiming.CurTime;
+
+            _appearance.SetData(uid, SubstationVisuals.LastChargeState, newChargeState);
+        }
+    }
+
+    private SubstationChargeState CalcChargeState(EntityUid uid, PowerNetworkBatteryComponent? netBattery = null)
+    {
+        if (!Resolve(uid, ref netBattery, false))
+            return SubstationChargeState.Full;
+
+        PowerState.Battery battery = netBattery.NetworkBattery;
+
+        if (battery.CurrentReceiving == 0 && MathHelper.CloseTo(battery.CurrentStorage / battery.Capacity, 0))
+        {
+            return SubstationChargeState.Dead;
+        }
+
+        return (battery.CurrentSupply - battery.CurrentReceiving) switch
+        {
+            > 0 => SubstationChargeState.Discharging,
+            < 0 => SubstationChargeState.Charging,
+            _ => SubstationChargeState.Full
+        };
+    }
+}

--- a/Content.Shared/Substation/SharedSubstationVisualizerComponent.cs
+++ b/Content.Shared/Substation/SharedSubstationVisualizerComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Substation;
+
+[Serializable, NetSerializable]
+public enum SubstationVisuals
+{
+    LastChargeState,
+}
+
+// enum use copied from Apc code to use same state names as substation sprites
+[Serializable, NetSerializable]
+public enum SubstationChargeState : sbyte
+{
+    Dead = 0,
+    Discharging = 1,
+    Charging = 2,
+    Full = 3
+}

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -156,8 +156,11 @@
     sprite: Structures/Power/substation.rsi
     layers:
     - state: substation_wall
-    - state: screen_wall
+    - map: ["enum.SubstationVisualLayers.Screen"]
+      state: screen_wall
       shader: unshaded
+  - type: SubstationVisualizer
+  - type: Appearance
   - type: Battery
     maxCharge: 2000000
     startingCharge: 0

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -13,10 +13,14 @@
     snapCardinals: true
     layers:
     - state: substation
-    - state: screen
+    - map: ["enum.SubstationVisualLayers.Screen"]
+      state: screen
       shader: unshaded
-    - state: full
+    - map: ["enum.SubstationVisualLayers.Charge"]
+      state: full
       shader: unshaded
+  - type: SubstationVisualizer
+  - type: Appearance
   - type: Battery
     maxCharge: 2500000
     startingCharge: 0


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Substations now visualise when it is dis/charging, full or out of power.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes https://github.com/space-wizards/space-station-14/issues/28987
Also if my EMP changes go through then power sabotage will become more common, this change will help inform engineers that a substation is disabled by EMP and not receiving power.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Creates a new SubstationVisualizer component for the server and client, copying and pasting snippets from code use for the Apc or Smes.
This is really just a stopgap solution. Ideally there would be some PowerNetBatteryVisualizer (name too long) that could accept various indicators for charge types, but I'm still learning the codebase. To-do in a separate PR, ideally after EMP changes are merged/closed.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
https://youtu.be/ozq1AjEGn-A
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- tweak: Substations now display their status.

