### PR TITLE
Buff cube boxes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/monkeycube.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/monkeycube.yml
@@ -7,10 +7,7 @@
   - type: StorageFill
     contents:
       - id: MonkeyCubeWrapped
-        amount: 6
-  - type: Storage
-    grid:
-    - 0,0,2,1
+        amount: 8
   - type: Sprite
     sprite: Objects/Misc/monkeycube.rsi
     state: box
@@ -45,7 +42,7 @@
   - type: StorageFill
     contents:
       - id: KoboldCubeWrapped
-        amount: 6
+        amount: 8
   - type: Sprite
     sprite: Objects/Misc/monkeycube.rsi
     state: box_kobold
@@ -59,9 +56,9 @@
   - type: StorageFill
     contents:
       - id: KoboldCubeWrapped
-        amount: 3
+        amount: 4
       - id: MonkeyCubeWrapped
-        amount: 3
+        amount: 4
   - type: Sprite
     sprite: Objects/Misc/monkeycube.rsi
     state: box_variant
@@ -89,10 +86,6 @@
   id: SyndicateSpongeBox
   description: Drymate brand monkey cubes. Just add water!
   components:
-  - type: Storage
-    whitelist:
-      tags:
-      - MonkeyCube
   - type: StorageFill
     contents:
       - id: SyndicateSpongeWrapped


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Make cube boxes inventory 3x3, also remove whitelist
Buff cube boxes to have 8 cubes

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Box itself takes 3x3 in backpack but its 3x2 inside

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Cube boxes buffed 6 -> 8 cubes.
