### PR TITLE
fix initial infected icons and add a briefing to the character menu

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
@@ -22,6 +22,9 @@ public sealed partial class AdminVerbSystem
     private const string DefaultTraitorRule = "Traitor";
 
     [ValidatePrototypeId<EntityPrototype>]
+    private const string DefaultInitialInfectedRule = "Zombie";
+
+    [ValidatePrototypeId<EntityPrototype>]
     private const string DefaultNukeOpRule = "LoneOpsSpawn";
 
     [ValidatePrototypeId<EntityPrototype>]
@@ -62,6 +65,20 @@ public sealed partial class AdminVerbSystem
             Message = Loc.GetString("admin-verb-make-traitor"),
         };
         args.Verbs.Add(traitor);
+
+        Verb initialInfected = new()
+        {
+            Text = Loc.GetString("admin-verb-text-make-initial-infected"),
+            Category = VerbCategory.Antag,
+            Icon = new SpriteSpecifier.Rsi(new("/Textures/Interface/Misc/job_icons.rsi"), "InitialInfected"),
+            Act = () =>
+            {
+                _antag.ForceMakeAntag<ZombieRuleComponent>(targetPlayer, DefaultInitialInfectedRule);
+            },
+            Impact = LogImpact.High,
+            Message = Loc.GetString("admin-verb-make-initial-infected"),
+        };
+        args.Verbs.Add(initialInfected);
 
         Verb zombie = new()
         {

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Antag;
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Popups;
+using Content.Server.Roles;
 using Content.Server.RoundEnd;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
@@ -35,7 +36,25 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     {
         base.Initialize();
 
+        SubscribeLocalEvent<InitialInfectedRoleComponent, GetBriefingEvent>(OnGetBriefing);
+        SubscribeLocalEvent<ZombieRoleComponent, GetBriefingEvent>(OnGetBriefing);
         SubscribeLocalEvent<IncurableZombieComponent, ZombifySelfActionEvent>(OnZombifySelf);
+    }
+
+    private void OnGetBriefing(EntityUid uid, InitialInfectedRoleComponent component, ref GetBriefingEvent args)
+    {
+        if (!TryComp<MindComponent>(uid, out var mind) || mind.OwnedEntity == null)
+            return;
+        if (HasComp<ZombieRoleComponent>(uid)) // don't show both briefings
+            return;
+        args.Append(Loc.GetString("zombie-patientzero-role-greeting"));
+    }
+
+    private void OnGetBriefing(EntityUid uid, ZombieRoleComponent component, ref GetBriefingEvent args)
+    {
+        if (!TryComp<MindComponent>(uid, out var mind) || mind.OwnedEntity == null)
+            return;
+        args.Append(Loc.GetString("zombie-infection-greeting"));
     }
 
     protected override void AppendRoundEndText(EntityUid uid, ZombieRuleComponent component, GameRuleComponent gameRule,

--- a/Resources/Locale/en-US/administration/antag.ftl
+++ b/Resources/Locale/en-US/administration/antag.ftl
@@ -1,5 +1,6 @@
 verb-categories-antag = Antag ctrl
 admin-verb-make-traitor = Make the target into a traitor.
+admin-verb-make-initial-infected = Make the target into an Initial Infected.
 admin-verb-make-zombie = Zombifies the target immediately.
 admin-verb-make-nuclear-operative = Make target into a lone Nuclear Operative.
 admin-verb-make-pirate = Make the target into a pirate. Note this doesn't configure the game rule.
@@ -7,6 +8,7 @@ admin-verb-make-head-rev = Make the target into a Head Revolutionary.
 admin-verb-make-thief = Make the target into a thief.
 
 admin-verb-text-make-traitor = Make Traitor
+admin-verb-text-make-initial-infected = Make Initial Infected
 admin-verb-text-make-zombie = Make Zombie
 admin-verb-text-make-nuclear-operative = Make Nuclear Operative
 admin-verb-text-make-pirate = Make Pirate

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -277,7 +277,7 @@
     duration: 60
     maxDuration: 120
   - type: PowerGridCheckRule
-  
+
 - type: entity
   parent: BaseGameRule
   id: SolarFlare
@@ -404,6 +404,7 @@
         maxInitialInfectedGrace: 450
       - type: ZombifyOnDeath
       - type: IncurableZombie
+      - type: InitialInfected
       mindComponents:
       - type: InitialInfectedRole
         prototype: InitialInfected

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -244,6 +244,7 @@
       - type: PendingZombie
       - type: ZombifyOnDeath
       - type: IncurableZombie
+      - type: InitialInfected
       mindComponents:
       - type: InitialInfectedRole
         prototype: InitialInfected


### PR DESCRIPTION
## About the PR
Fixes initial infected icons not showing up.
Adds the missing antag briefing for initials infected and zombies to the character menu.
Adds the "make initial infected" verb to the antag ctrl for admins (needed this for debugging).

Fixes #29254
## Why / Balance
Bugfix
The character menu should show you if you're an antagonist.

## Technical details
Adds the missing InitialInfectedComponent to the Zombies gamerule and midround event.
Subscribes GetBriefingEvent to add the briefing to the character menu.

## Media
![1](https://github.com/space-wizards/space-station-14/assets/161409025/bbcfd04f-4b8b-41cb-96ac-f7034058c19a)
![4](https://github.com/space-wizards/space-station-14/assets/161409025/2c786efa-7add-4eec-8511-545d428cfe57)
![2](https://github.com/space-wizards/space-station-14/assets/161409025/2c2e3017-dd0e-4f15-801e-ca03720e1bc4)
![3](https://github.com/space-wizards/space-station-14/assets/161409025/c45ce154-81f0-43d6-bb09-216ab211147a)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed initial infected status icons not showing up.
- add: Added an antagonist message to the character menu for initial infected and zombies.

ADMIN:
- add: Added the "Make Inititial Infected" verb to the antag control.
