### PR TITLE
Move air sensor components into abstract base prototype

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -21,7 +21,7 @@
     - type: CollideOnAnchor
 
 - type: entity
-  parent: GasUnaryBase
+  parent: [GasUnaryBase, AirSensorBase]
   id: GasVentPump
   name: air vent
   description: Has a valve and a pump attached to it.
@@ -31,28 +31,7 @@
     - type: ApcPowerReceiver
     - type: ExtensionCableReceiver
     - type: DeviceNetwork
-      deviceNetId: AtmosDevices
-      receiveFrequencyId: AtmosMonitor
-      transmitFrequencyId: AtmosMonitor
       prefix: device-address-prefix-vent
-      sendBroadcastAttemptEvent: true
-      examinableAddress: true
-    - type: WiredNetworkConnection
-    - type: DeviceNetworkRequiresPower
-    - type: AtmosDevice
-    - type: AtmosMonitor
-      temperatureThresholdId: stationTemperature
-      pressureThresholdId: stationPressure
-      gasThresholdPrototypes:
-        Oxygen: stationOxygen
-        Nitrogen: ignore
-        CarbonDioxide: stationCO2
-        Plasma: stationPlasma # everything below is usually bad
-        Tritium: danger
-        WaterVapor: stationWaterVapor
-        Ammonia: stationAmmonia
-        NitrousOxide: stationNO
-        Frezon: danger
     - type: Tag
       tags:
         - GasVent
@@ -115,7 +94,7 @@
       node: passivevent
 
 - type: entity
-  parent: GasUnaryBase
+  parent: [GasUnaryBase, AirSensorBase]
   id: GasVentScrubber
   name: air scrubber
   description: Has a valve and pump attached to it.
@@ -125,25 +104,7 @@
     - type: ApcPowerReceiver
     - type: ExtensionCableReceiver
     - type: DeviceNetwork
-      deviceNetId: AtmosDevices
-      receiveFrequencyId: AtmosMonitor
-      transmitFrequencyId: AtmosMonitor
       prefix: device-address-prefix-scrubber
-      examinableAddress: true
-    - type: DeviceNetworkRequiresPower
-    - type: AtmosMonitor
-      temperatureThresholdId: stationTemperature
-      pressureThresholdId: stationPressure
-      gasThresholdPrototypes:
-        Oxygen: stationOxygen
-        Nitrogen: ignore
-        CarbonDioxide: stationCO2
-        Plasma: stationPlasma # everything below is usually bad
-        Tritium: danger
-        WaterVapor: stationWaterVapor
-        Ammonia: stationAmmonia
-        NitrousOxide: stationNO
-        Frezon: danger
     - type: Tag
       tags:
         - GasScrubber

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -1,7 +1,39 @@
 - type: entity
+  id: AirSensorBase
+  abstract: true
+  components:
+    - type: DeviceNetwork
+      deviceNetId: AtmosDevices
+      receiveFrequencyId: AtmosMonitor
+      transmitFrequencyId: AtmosMonitor
+      prefix: device-address-prefix-sensor
+      sendBroadcastAttemptEvent: true
+      examinableAddress: true
+    - type: WiredNetworkConnection
+    - type: DeviceNetworkRequiresPower
+    - type: AtmosDevice
+    - type: AtmosMonitor
+      temperatureThresholdId: stationTemperature
+      pressureThresholdId: stationPressure
+      gasThresholdPrototypes:
+        Oxygen: stationOxygen
+        Nitrogen: ignore
+        CarbonDioxide: stationCO2
+        Plasma: stationPlasma # everything below is usually bad
+        Tritium: danger
+        WaterVapor: stationWaterVapor
+        Ammonia: stationAmmonia
+        NitrousOxide: stationNO
+        Frezon: danger
+    - type: Tag
+      tags:
+        - AirSensor
+
+- type: entity
   id: AirSensor
   name: air sensor
   description: Air sensor. It senses air.
+  parent: AirSensorBase
   placement:
     mode: SnapgridCenter
   components:
@@ -35,32 +67,6 @@
     - type: InteractionOutline
     - type: ApcPowerReceiver
     - type: ExtensionCableReceiver
-    - type: DeviceNetwork
-      deviceNetId: AtmosDevices
-      receiveFrequencyId: AtmosMonitor
-      transmitFrequencyId: AtmosMonitor
-      prefix: device-address-prefix-sensor
-      sendBroadcastAttemptEvent: true
-      examinableAddress: true
-    - type: WiredNetworkConnection
-    - type: DeviceNetworkRequiresPower
-    - type: AtmosDevice
-    - type: AtmosMonitor
-      temperatureThresholdId: stationTemperature
-      pressureThresholdId: stationPressure
-      gasThresholdPrototypes:
-        Oxygen: stationOxygen
-        Nitrogen: ignore
-        CarbonDioxide: stationCO2
-        Plasma: stationPlasma # everything below is usually bad
-        Tritium: danger
-        WaterVapor: stationWaterVapor
-        Ammonia: stationAmmonia
-        NitrousOxide: stationNO
-        Frezon: danger
-    - type: Tag
-      tags:
-        - AirSensor
     - type: AccessReader
       access: [ [ "Atmospherics" ] ]
     - type: Construction


### PR DESCRIPTION
## About the PR
Move air sensor components into an abstract base prototype.

## Why / Balance
Reduces AtmosMonitor duplication where changing a threshold needs edits in multiple places across different files. Enables us to phase out scrubbers and vents having air sensor functionality but for forks that need it to easily add it back.

## Media
After the change, the affected components still alarm and have the correct prefixes.

![image](https://github.com/space-wizards/space-station-14/assets/3229565/1d59c6b6-9be1-4ab3-81ee-94c1c4b092fa)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
N/A