### PR TITLE
Fix some buckle interactions

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
@@ -13,10 +13,11 @@ public abstract partial class SharedBuckleSystem
     private void InitializeInteraction()
     {
         SubscribeLocalEvent<StrapComponent, GetVerbsEvent<InteractionVerb>>(AddStrapVerbs);
-        SubscribeLocalEvent<StrapComponent, InteractHandEvent>(OnStrapInteractHand);
+        SubscribeLocalEvent<StrapComponent, InteractHandEvent>(OnStrapInteractHand, after: [typeof(InteractionPopupSystem)]);
         SubscribeLocalEvent<StrapComponent, DragDropTargetEvent>(OnStrapDragDropTarget);
         SubscribeLocalEvent<StrapComponent, CanDropTargetEvent>(OnCanDropTarget);
 
+        SubscribeLocalEvent<BuckleComponent, InteractHandEvent>(OnBuckleInteractHand, after: [typeof(InteractionPopupSystem)]);
         SubscribeLocalEvent<BuckleComponent, GetVerbsEvent<InteractionVerb>>(AddUnbuckleVerb);
     }
 
@@ -58,6 +59,9 @@ public abstract partial class SharedBuckleSystem
         if (args.Handled)
             return;
 
+        if (!component.Enabled)
+            return;
+
         if (!TryComp(args.User, out BuckleComponent? buckle))
             return;
 
@@ -68,7 +72,20 @@ public abstract partial class SharedBuckleSystem
         else
             return;
 
-        args.Handled = true; // This generate popups on failure.
+        // TODO BUCKLE add out bool for whether a pop-up was generated or not.
+        args.Handled = true;
+    }
+
+    private void OnBuckleInteractHand(Entity<BuckleComponent> ent, ref InteractHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (ent.Comp.BuckledTo != null)
+            TryUnbuckle(ent!, args.User, popup: true);
+
+        // TODO BUCKLE add out bool for whether a pop-up was generated or not.
+        args.Handled = true;
     }
 
     private void AddStrapVerbs(EntityUid uid, StrapComponent component, GetVerbsEvent<InteractionVerb> args)


### PR DESCRIPTION
Fixes two of the issues mentioned in #29282
There's still something wrong with appearance data but the player rotation code is very cursed and will probably take a bit more to fix.

https://github.com/space-wizards/space-station-14/assets/60421075/4b2d18df-cfea-4a14-b40b-58f6b57ccbe7

:cl:
- fix: Fixed not being able to pick up folded rollerbeds.
- fix: Fixed not being able to unbuckle entities by clicking on them.
