### PR TITLE
feat: allow developers to customize vscode settings, closes #29285

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "omnisharp.analyzeOpenDocumentsOnly": true,
-    "dotnet.defaultSolution": "SpaceStation14.sln"
-}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Removed `.vscode/settings.json` from VCS.

## Why / Balance
Apparently, it's [already ignored](https://github.com/space-wizards/space-station-14/blob/master/.gitignore#L266) in `.gitignore`, but somehow still ended up in VCS.

That file being in version control prevents developers from customizing their workspace VSCode settings which should not be the case. It's important to have that capability because workspace settings override user settings and there is no easy way to edit workspace settings without affecting other devs if `settings.json` is in VCS.

## Technical details
No code changes.

## Media
N/A.

## Breaking changes
None.
