### PR TITLE
Feat/pai map show position

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -17,7 +17,7 @@
         type: InstrumentBoundUserInterface
         requireInputValidation: false
       enum.StationMapUiKey.Key:
-        type: UntrackedStationMapBoundUserInterface
+        type: StationMapBoundUserInterface
         requireInputValidation: false
   - type: Sprite
     sprite: Objects/Fun/pai.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
pAI maps now show current position.

## Why / Balance
https://github.com/space-wizards/space-station-14/issues/29295. It makes sense for pAI to know it's location to effectively help their owner navigate.

## Technical details
No code changes.

PR is based on the branch from https://github.com/space-wizards/space-station-14/pull/29294 because I need my vscode settings. Once that one is merged diff will look clean. Let me know if you want a rebase on top of master instead.

## Media
![image](https://github.com/space-wizards/space-station-14/assets/108279/7aa9895a-ee67-44d0-9419-c23f734ca72a)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None.

**Changelog**
- tweak: pAI maps now show current position
