### PR TITLE
AME Deconstruction Changes

### DIFF
--- a/Content.Server/Construction/Conditions/AmeShieldIntegrity.cs
+++ b/Content.Server/Construction/Conditions/AmeShieldIntegrity.cs
@@ -5,39 +5,39 @@ using Content.Shared.Examine;
 
 namespace Content.Server.Construction.Conditions;
 
-    [UsedImplicitly]
-    [DataDefinition]
-    public sealed partial class AmeShieldIntegrity : IGraphCondition
+[UsedImplicitly]
+[DataDefinition]
+public sealed partial class AmeShieldIntegrity : IGraphCondition
+{
+    [DataField]
+    public float IntegrityThreshold = 80;
+
+    /// <summary>
+    /// If true, checks for the integrity being above the threshold.
+    /// if false, checks for it being below.
+    /// </summary>
+    [DataField]
+    public bool CheckAbove = true;
+
+    public bool Condition(EntityUid uid, IEntityManager entityManager)
     {
-        [DataField]
-        public float IntegrityThreshold = 80;
+        if (!entityManager.TryGetComponent<AmeShieldComponent>(uid, out var shield))
+            return true;
 
-        /// <summary>
-        /// If true, checks for the integrity being above the threshold.
-        /// if false, checks for it being below.
-        /// </summary>
-        [DataField]
-        public bool CheckAbove = true;
-
-        public bool Condition(EntityUid uid, IEntityManager entityManager)
+        if (CheckAbove)
         {
-            if (!entityManager.TryGetComponent<AmeShieldComponent>(uid, out var shield))
-                return true;
-
-            if (CheckAbove)
-            {
-                return shield.CoreIntegrity >= IntegrityThreshold;
-            }
-            return shield.CoreIntegrity < IntegrityThreshold;
+            return shield.CoreIntegrity >= IntegrityThreshold;
         }
-
-        public bool DoExamine(ExaminedEvent args)
-        {
-            return false;
-        }
-
-        public IEnumerable<ConstructionGuideEntry> GenerateGuideEntry()
-        {
-            yield return new ConstructionGuideEntry();
-        }
+        return shield.CoreIntegrity < IntegrityThreshold;
     }
+
+    public bool DoExamine(ExaminedEvent args)
+    {
+        return false;
+    }
+
+    public IEnumerable<ConstructionGuideEntry> GenerateGuideEntry()
+    {
+        yield return new ConstructionGuideEntry();
+    }
+}

--- a/Content.Server/Construction/Conditions/AmeShieldIntegrity.cs
+++ b/Content.Server/Construction/Conditions/AmeShieldIntegrity.cs
@@ -1,0 +1,43 @@
+using Content.Server.Ame.Components;
+using Content.Shared.Construction;
+using JetBrains.Annotations;
+using Content.Shared.Examine;
+
+namespace Content.Server.Construction.Conditions;
+
+    [UsedImplicitly]
+    [DataDefinition]
+    public sealed partial class AmeShieldIntegrity : IGraphCondition
+    {
+        [DataField]
+        public float IntegrityThreshold = 80;
+
+        /// <summary>
+        /// If true, checks for the integrity being above the threshold.
+        /// if false, checks for it being below.
+        /// </summary>
+        [DataField]
+        public bool CheckAbove = true;
+
+        public bool Condition(EntityUid uid, IEntityManager entityManager)
+        {
+            if (!entityManager.TryGetComponent<AmeShieldComponent>(uid, out var shield))
+                return true;
+
+            if (CheckAbove)
+            {
+                return shield.CoreIntegrity >= IntegrityThreshold;
+            }
+            return shield.CoreIntegrity < IntegrityThreshold;
+        }
+
+        public bool DoExamine(ExaminedEvent args)
+        {
+            return false;
+        }
+
+        public IEnumerable<ConstructionGuideEntry> GenerateGuideEntry()
+        {
+            yield return new ConstructionGuideEntry();
+        }
+    }

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/ame_shielding.yml
@@ -3,17 +3,33 @@
   start: start
   graph:
     - node: start
+    - node: startBroken
 
     - node: ameShielding
       entity: AmeShielding
       edges:
         - to: start
+          conditions:
+            - !type:AmeShieldIntegrity
           completed:
             - !type:AdminLog  # I don't like logging it like this. The log should include the user, AMEShielding EntityID, and AMEPart EntityID, and there should also be a start of attempt log.
               message: "An AME shielding was deconstructed"
             - !type:SpawnPrototype
               prototype: AmePartFlatpack
               amount: 1
+            - !type:DeleteEntity
+          steps:
+            - tool: Welding
+              doAfter: 3
+
+        - to: startBroken
+          conditions:
+            - !type:AmeShieldIntegrity
+              checkAbove: false
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 5
             - !type:DeleteEntity
           steps:
             - tool: Welding


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
deconstructing damaged AME shielding now yields 5 steel instead of a full AME shield flatpack.
if you run a normal ass AME with no overclocking you'll notice no change.
If you overclock an AME, then the cores will yield steel once the controller switches to the warning state.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
being able to reconstruct the AME shielding to reset the integrity is extremely wack. it nullifies the whole point of the damage aspect when you can just reset it in 3 seconds. At the same time, the deconstruction is important because lord knows many an engineer has sealed themselves inside the AME tomb.

this basically just lets normal AME activities continue as normal while limiting the extent to which someone can overclock an AME to extend power infinitely.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
adds a nice lil construction condition that nothing else will ever use.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Deconstructing a damaged AME core now yields steel instead of a full AME flatpack.
