### PR TITLE
feat: allow pAIs to access common radio channel

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -46,6 +46,7 @@
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     channels:
+    - Common
     - Binary
   - type: ActiveRadio
     channels:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added ability for pAI to transmit into the common channel.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

* pAI already [has read access](https://github.com/diraven/space-station-14/blob/164ae2af92a5c8d3f5da4381a1d0f3090635992b/Resources/Prototypes/Entities/Objects/Fun/pai.yml#L52) to common channel.
* Common radio channel is well... common. Which means there is no department-specific information going on there most of the time and it does not introduce any balancing issues.
* Syncidate pAIs [have full access to their respective syndicate radio channel](https://github.com/diraven/space-station-14/blob/164ae2af92a5c8d3f5da4381a1d0f3090635992b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml#L285).

## Breaking changes
None.

**Changelog**
:cl:
- add: Ability for NT pAIs to talk over the Common radio channel.
