### PR TITLE
Adjust some gas thresholds

### DIFF
--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -36,14 +36,21 @@
 - type: alarmThreshold
   id: stationCO2
   upperBound: !type:AlarmThresholdSetting
-    threshold: 0.0025
+    threshold: 0.006
   upperWarnAround: !type:AlarmThresholdSetting
-    threshold: 0.5
+    threshold: 0.5 # minor gasping and airloss at 0.3%
 
 - type: alarmThreshold
   id: stationPlasma
   upperBound: !type:AlarmThresholdSetting
-    threshold: 0.00125
+    threshold: 0.005 # lightable beyond this concentration
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.5
+
+- type: alarmThreshold
+  id: stationTritium
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 0.004 # lightable beyond this concentration
   upperWarnAround: !type:AlarmThresholdSetting
     threshold: 0.5
 

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -19,8 +19,8 @@
         Oxygen: stationOxygen
         Nitrogen: ignore
         CarbonDioxide: stationCO2
-        Plasma: stationPlasma # everything below is usually bad
-        Tritium: danger
+        Plasma: stationPlasma
+        Tritium: stationTritium
         WaterVapor: stationWaterVapor
         Ammonia: stationAmmonia
         NitrousOxide: stationNO


### PR DESCRIPTION
## About the PR
Increase some dangerous gas thresholds to avoid the situations where air alarms overreact, leading to players disregarding clear air alarm warnings.

## Why / Balance
When air alarms overreact, players disregard their warnings, making air alarms less useful overall. I've adjusted plasma, tritium, and CO2 with in-game testing results shown below.

## Media

Tider with a welder tries to welder light 0.5% plasma. It is not possible and therefore safe.
![2024-06-21_22-32](https://github.com/space-wizards/space-station-14/assets/3229565/58c5a4d1-261c-44cb-b047-e287ffe53555)

Tider with a welder tries to welder light 0.4% tritium. It is not possible and therefore safe.
![2024-06-21_22-44](https://github.com/space-wizards/space-station-14/assets/3229565/d5b76c73-0924-4d41-be60-7197550e7cc0)

The carbon dioxide gasping starts happening around 0.3%, but since the airloss damage at that level is very slow, I've opted to make this the warning threshold and the danger threshold at 0.6% since it isn't lightable and poses a much less significant threat to the station.

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl: notafet
- tweak: Reduce air alarm sensitivity to plasma, tritium, and carbon dioxide.
