### PR TITLE
suit storage whitelist code

### DIFF
--- a/Content.Shared/Armor/AllowSuitStorageComponent.cs
+++ b/Content.Shared/Armor/AllowSuitStorageComponent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Whitelist;
+
 namespace Content.Shared.Armor;
 
 /// <summary>
@@ -6,5 +8,12 @@ namespace Content.Shared.Armor;
 [RegisterComponent]
 public sealed partial class AllowSuitStorageComponent : Component
 {
-
+    /// <summary>
+    /// Whitelist for what entities are allowed in the suit storage slot.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist Whitelist = new()
+    {
+        Components = new[] {"Item"}
+    };
 }

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -248,9 +248,17 @@ public abstract partial class InventorySystem
                 return false;
 
             if (slotDefinition.DependsOnComponents is { } componentRegistry)
+            {
                 foreach (var (_, entry) in componentRegistry)
+                {
                     if (!HasComp(slotEntity, entry.Component.GetType()))
                         return false;
+
+                    if (TryComp<AllowSuitStorageComponent>(slotEntity, out var comp) &&
+                        _whitelistSystem.IsWhitelistFailOrNull(comp.Whitelist, itemUid))
+                        return false;
+                }
+            }
         }
 
         var fittingInPocket = slotDefinition.SlotFlags.HasFlag(SlotFlags.POCKET) &&


### PR DESCRIPTION
## About the PR
AllowSuitStorageComponent now holds Whitelist definitions, allowing each item prototype to use tags to specify what items can be placed in its suit storage slot. No prototype changes included

#27614

## Media
https://github.com/space-wizards/space-station-14/assets/35878406/47000a6b-4f8a-4b22-93b5-0300adfe7892

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
