### PR TITLE
Fix for missing survival boxes

### DIFF
--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -7,8 +7,9 @@
   - CaptainJumpsuit
   - CaptainBackpack
   - CaptainOuterClothing
-  - Trinkets
   - Survival
+  - Trinkets
+
 
 - type: roleLoadout
   id: JobHeadOfPersonnel
@@ -19,8 +20,8 @@
   - HoPBackpack
   - HoPOuterClothing
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 # Civilian
 - type: roleLoadout
@@ -33,8 +34,8 @@
   - PassengerOuterClothing
   - PassengerShoes
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobBartender
@@ -44,8 +45,8 @@
   - CommonBackpack
   - BartenderOuterClothing
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobServiceWorker
@@ -53,8 +54,8 @@
   - BartenderJumpsuit
   - CommonBackpack
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobChef
@@ -65,8 +66,8 @@
   - CommonBackpack
   - ChefOuterClothing
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobLibrarian
@@ -74,8 +75,8 @@
   - LibrarianJumpsuit
   - CommonBackpack
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobLawyer
@@ -84,8 +85,8 @@
   - LawyerJumpsuit
   - CommonBackpack
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobChaplain
@@ -97,8 +98,8 @@
   - CommonBackpack
   - ChaplainOuterClothing
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobJanitor
@@ -109,9 +110,9 @@
   - CommonBackpack
   - JanitorOuterClothing
   - Glasses
+  - Survival
   - Trinkets
   - JanitorPlunger
-  - Survival
 
 - type: roleLoadout
   id: JobBotanist
@@ -121,8 +122,8 @@
   - BotanistBackpack
   - BotanistOuterClothing
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobClown
@@ -133,8 +134,8 @@
   - ClownOuterClothing
   - ClownShoes
   - Glasses
-  - Trinkets
   - SurvivalClown
+  - Trinkets
 
 - type: roleLoadout
   id: JobMime
@@ -145,8 +146,8 @@
   - MimeBackpack
   - MimeOuterClothing
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobMusician
@@ -155,9 +156,9 @@
   - CommonBackpack
   - MusicianOuterClothing
   - Glasses
+  - Survival
   - Trinkets
   - Instruments
-  - Survival
 
 # Cargo
 - type: roleLoadout
@@ -170,8 +171,8 @@
   - QuartermasterOuterClothing
   - QuartermasterShoes
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobCargoTechnician
@@ -182,8 +183,8 @@
   - CargoTechnicianOuterClothing
   - CargoTechnicianShoes
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobSalvageSpecialist
@@ -192,8 +193,8 @@
   - SalvageSpecialistOuterClothing
   - SalvageSpecialistShoes
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 # Engineering
 - type: roleLoadout
@@ -205,16 +206,16 @@
   - ChiefEngineerNeck
   - ChiefEngineerOuterClothing
   - ChiefEngineerShoes
-  - Trinkets
   - SurvivalExtended
+  - Trinkets
 
 - type: roleLoadout
   id: JobTechnicalAssistant
   groups:
   - TechnicalAssistantJumpsuit
   - StationEngineerBackpack
-  - Trinkets
   - SurvivalExtended
+  - Trinkets
 
 - type: roleLoadout
   id: JobStationEngineer
@@ -225,8 +226,8 @@
   - StationEngineerOuterClothing
   - StationEngineerShoes
   - StationEngineerID
-  - Trinkets
   - SurvivalExtended
+  - Trinkets
 
 - type: roleLoadout
   id: JobAtmosphericTechnician
@@ -235,8 +236,8 @@
   - AtmosphericTechnicianBackpack
   - AtmosphericTechnicianOuterClothing
   - AtmosphericTechnicianShoes
-  - Trinkets
   - SurvivalExtended
+  - Trinkets
 
 # Science
 - type: roleLoadout
@@ -250,8 +251,8 @@
   - ScientistGloves
   - ResearchDirectorShoes
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobScientist
@@ -265,8 +266,8 @@
   - ScientistShoes
   - ScientistPDA
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobResearchAssistant
@@ -274,8 +275,8 @@
   - ResearchAssistantJumpsuit
   - ScientistBackpack
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 # Security
 - type: roleLoadout
@@ -288,8 +289,8 @@
   - SecurityBelt
   - HeadofSecurityOuterClothing
   - SecurityShoes
-  - Trinkets
   - SurvivalSecurity
+  - Trinkets
 
 - type: roleLoadout
   id: JobWarden
@@ -300,8 +301,8 @@
   - SecurityBelt
   - WardenOuterClothing
   - SecurityShoes
-  - Trinkets
   - SurvivalSecurity
+  - Trinkets
 
 - type: roleLoadout
   id: JobSecurityOfficer
@@ -313,8 +314,8 @@
   - SecurityShoes
   - SecurityPDA
   - SecurityBelt
-  - Trinkets
   - SurvivalSecurity
+  - Trinkets
 
 - type: roleLoadout
   id: JobDetective
@@ -325,16 +326,16 @@
   - SecurityBackpack
   - DetectiveOuterClothing
   - SecurityShoes
-  - Trinkets
   - SurvivalSecurity
+  - Trinkets
 
 - type: roleLoadout
   id: JobSecurityCadet
   groups:
   - SecurityCadetJumpsuit
   - SecurityBackpack
-  - Trinkets
   - SurvivalSecurity
+  - Trinkets
 
 # Medical
 - type: roleLoadout
@@ -349,8 +350,8 @@
   - ChiefMedicalOfficerNeck
   - ChiefMedicalOfficerShoes
   - Glasses
-  - Trinkets
   - SurvivalMedical
+  - Trinkets
 
 - type: roleLoadout
   id: JobMedicalDoctor
@@ -364,8 +365,8 @@
   - MedicalShoes
   - MedicalDoctorPDA
   - Glasses
-  - Trinkets
   - SurvivalMedical
+  - Trinkets
 
 - type: roleLoadout
   id: JobMedicalIntern
@@ -373,8 +374,8 @@
   - MedicalInternJumpsuit
   - MedicalBackpack
   - Glasses
-  - Trinkets
   - SurvivalMedical
+  - Trinkets
 
 - type: roleLoadout
   id: JobChemist
@@ -385,8 +386,8 @@
   - ChemistBackpack
   - ChemistOuterClothing
   - MedicalShoes
-  - Trinkets
   - SurvivalMedical
+  - Trinkets
 
 - type: roleLoadout
   id: JobParamedic
@@ -399,8 +400,8 @@
   - ParamedicOuterClothing
   - ParamedicShoes
   - Glasses
-  - Trinkets
   - SurvivalMedical
+  - Trinkets
 
 # Wildcards
 - type: roleLoadout
@@ -408,8 +409,8 @@
   groups:
   - CommonBackpack
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobReporter
@@ -417,16 +418,16 @@
   - ReporterJumpsuit
   - CommonBackpack
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobPsychologist
   groups:
   - MedicalBackpack
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 - type: roleLoadout
   id: JobBoxer
@@ -435,8 +436,8 @@
   - BoxerGloves
   - CommonBackpack
   - Glasses
-  - Trinkets
   - Survival
+  - Trinkets
 
 # These loadouts will be used without player configuration, thus they must be designed to work without manual selection
 


### PR DESCRIPTION
## About the PR
Changed the order in which backpacks (etc) get filled, hopefully resolving the missing survival boxes (I could never actually repro that on Dev so I can't be sure, but this DOES fix what symptoms I _could_ produce regarding ordering, so no reason not to do it)

Possible fix for #29300

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- fix: Items should no longer be missing from backpacks at spawn.
