### PR TITLE
Fixed not stopping waddling animation

### DIFF
--- a/Content.Client/Movement/Systems/WaddleAnimationSystem.cs
+++ b/Content.Client/Movement/Systems/WaddleAnimationSystem.cs
@@ -87,6 +87,9 @@ public sealed class WaddleAnimationSystem : SharedWaddleAnimationSystem
         if (!TryComp<InputMoverComponent>(entity.Owner, out var mover))
             return;
 
+        if (!entity.Comp.IsCurrentlyWaddling)
+            return;
+
         PlayWaddleAnimationUsing(
             (entity.Owner, entity.Comp),
             CalculateAnimationLength(entity.Comp, mover),


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Finally fix waddling. I think this is the last fix that would be needed for it (at least I hope).
This PR's fixes not-stopping waddling animation with just 2 lines of code.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The only problem is that the animation starts again after it is stopped, which made all the StopWaddling calls meaningless. The solution is simple - just add a condition so that the animation does not start again.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed not-stopping clown waddling
