### PR TITLE
Increased Frezon and Nitrous Oxide price

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -86,7 +86,7 @@
   molarMass: 44
   color: 2887E8
   reagent: NitrousOxide
-  pricePerMole: 1
+  pricePerMole: 3
 
 - type: gas
   id: 8
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 3
+  pricePerMole: 5


### PR DESCRIPTION


## About the PR
Upped prices of Frezon and Nitrous Oxide
Frezon: 3 --> 5
Nitrous Oxide: 1 --> 3

## Why / Balance
Mixing gases mechanic is by far the most difficult one to learn, due to certain Pipestacking nerf the inability to place pipes over other devices lead to expanding of frezon and tritium "cooking" schemes. Most people are demotivated to make them, so upping prices might fix this situation at least.

### Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- tweak: Frezon's and Nitrous Oxide's prices were increased.
