### PR TITLE
Add speed threshold for weightless movement in DoAfter

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/SmokingSystem.Vape.cs
+++ b/Content.Server/Nutrition/EntitySystems/SmokingSystem.Vape.cs
@@ -114,8 +114,7 @@ namespace Content.Server.Nutrition.EntitySystems
                 var vapeDoAfterEvent = new VapeDoAfterEvent(solution, forced);
                 _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, delay, vapeDoAfterEvent, entity.Owner, target: args.Target, used: entity.Owner)
                 {
-                    BreakOnMove = false,
-                    BreakOnDamage = true
+                    BreakOnDamage = true,
                 });
             }
             args.Handled = true;

--- a/Content.Shared/DoAfter/DoAfterArgs.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.cs
@@ -105,33 +105,40 @@ public sealed partial class DoAfterArgs
     public bool BreakOnWeightlessMove = true;
 
     /// <summary>
+    ///     Threshold for user speed when the user is weightless.
+    ///     This does nothing if <see cref="BreakOnWeightlessMove"/> is true.
+    /// </summary>
+    [DataField]
+    public float WeightlessSpeedThreshold = 2.0f;
+
+    /// <summary>
     ///     Threshold for user and target movement
     /// </summary>
-    [DataField("movementThreshold")]
+    [DataField]
     public float MovementThreshold = 0.3f;
 
     /// <summary>
     ///     Threshold for distance user from the used OR target entities.
     /// </summary>
-    [DataField("distanceThreshold")]
+    [DataField]
     public float? DistanceThreshold;
 
     /// <summary>
     ///     Whether damage will cancel the DoAfter. See also <see cref="DamageThreshold"/>.
     /// </summary>
-    [DataField("breakOnDamage")]
+    [DataField]
     public bool BreakOnDamage;
 
     /// <summary>
     ///     Threshold for user damage. This damage has to be dealt in a single event, not over time.
     /// </summary>
-    [DataField("damageThreshold")]
+    [DataField]
     public FixedPoint2 DamageThreshold = 1;
 
     /// <summary>
     ///     If true, this DoAfter will be canceled if the user can no longer interact with the target.
     /// </summary>
-    [DataField("requireCanInteract")]
+    [DataField]
     public bool RequireCanInteract = true;
     #endregion
 
@@ -143,7 +150,7 @@ public sealed partial class DoAfterArgs
     ///     Note that this will block even if the duplicate is cancelled because either DoAfter had
     ///     <see cref="CancelDuplicate"/> enabled.
     /// </remarks>
-    [DataField("blockDuplicate")]
+    [DataField]
     public bool BlockDuplicate = true;
 
     //TODO: User pref to not cancel on second use on specific doafters
@@ -151,7 +158,7 @@ public sealed partial class DoAfterArgs
     ///     If true, this will cancel any duplicate DoAfters when attempting to add a new DoAfter. See also
     ///     <see cref="DuplicateConditions"/>.
     /// </summary>
-    [DataField("cancelDuplicate")]
+    [DataField]
     public bool CancelDuplicate = true;
 
     /// <summary>
@@ -162,7 +169,7 @@ public sealed partial class DoAfterArgs
     ///     Note that both DoAfters may have their own conditions, and they will be considered duplicated if either set
     ///     of conditions is satisfied.
     /// </remarks>
-    [DataField("duplicateCondition")]
+    [DataField]
     public DuplicateConditions DuplicateCondition = DuplicateConditions.All;
     #endregion
 
@@ -246,6 +253,7 @@ public sealed partial class DoAfterArgs
         BreakOnHandChange = other.BreakOnHandChange;
         BreakOnMove = other.BreakOnMove;
         BreakOnWeightlessMove = other.BreakOnWeightlessMove;
+        WeightlessSpeedThreshold = other.WeightlessSpeedThreshold;
         MovementThreshold = other.MovementThreshold;
         DistanceThreshold = other.DistanceThreshold;
         BreakOnDamage = other.BreakOnDamage;


### PR DESCRIPTION
## About the PR
Adds a check for the speed of an weightless entity in DoAfter.

Fixes #21109

Besides, uncuffing doafter is now cancellable in zero gravity, you just need to move a person a little.

If the solution seems whacky, I am open to any suggestion to fix the issue properly.

## Technical details
`WeightlessSpeedThreshold` was added in `DoAfterArgs` and is used for comparing entity velocity value. So if you want to heal/inject or force feed somebody while there's no gravity, you should slow down. It applies only if `BreakOnWeightlessMove` bool is false.

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: While in zero gravity, actions such as healing, uncuffing and injecting now require low movement speed to complete.
