### PR TITLE
Made .60 anti-materiel ammo ignore armor resistances

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -9,5 +9,6 @@
       types:
         Piercing: 40
         Structural: 30
+    ignoreResistances: true
   - type: StaminaDamageOnCollide
     damage: 35


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Made it so .60 anti-materiel projectiles ignore all armor resistance. Sorry if this PR is messy!

## Why / Balance
The Hristov is a huge gun with huge bullets. Despite this, it is not very effective against people. Acolyte armor, for example, will make it do less than 25 damage per hit. Thank you @Pumkin69 for the change suggestion.

## Technical details
I just added the ignoreResistances tag(?). 

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

N/A


**Changelog**
:cl:
- tweak: .60 anti-materiel ammo now ignores armor resistances


