### PR TITLE
Survival box loadout group cleanup

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -38,8 +38,6 @@
 - type: loadoutGroup
   id: Survival
   name: loadout-group-survival-basic
-  minLimit: 1
-  maxLimit: 1
   hidden: true
   loadouts:
   - EmergencyNitrogen
@@ -410,8 +408,6 @@
 - type: loadoutGroup
   id: SurvivalClown
   name: loadout-group-survival-clown
-  minLimit: 2
-  maxLimit: 2
   hidden: true
   loadouts:
   - EmergencyNitrogenClown
@@ -733,8 +729,6 @@
 - type: loadoutGroup
   id: SurvivalExtended
   name: loadout-group-survival-extended
-  minLimit: 2
-  maxLimit: 2
   hidden: true
   loadouts:
   - EmergencyNitrogenExtended
@@ -1013,8 +1007,6 @@
 - type: loadoutGroup
   id: SurvivalSecurity
   name: loadout-group-survival-security
-  minLimit: 2
-  maxLimit: 2
   hidden: true
   loadouts:
   - EmergencyNitrogenSecurity
@@ -1195,8 +1187,6 @@
 - type: loadoutGroup
   id: SurvivalMedical
   name: loadout-group-survival-medical
-  minLimit: 2
-  maxLimit: 2
   hidden: true
   loadouts:
   - EmergencyNitrogenMedical
@@ -1230,8 +1220,6 @@
 - type: loadoutGroup
   id: SurvivalSyndicate
   name: loadout-group-survival-syndicate
-  minLimit: 2
-  maxLimit: 2
   hidden: true
   loadouts:
   - EmergencyNitrogenSyndicate


### PR DESCRIPTION
MinLimit now ignores unavailable loadout options so a limit of 1 is sufficient, and since that is also the default value it's no longer necessary to specify these
