### PR TITLE
Space worms

### DIFF
--- a/Content.Server/StationEvents/Components/KudzuGrowthRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/KudzuGrowthRuleComponent.cs
@@ -1,9 +1,11 @@
 ﻿using Content.Server.StationEvents.Events;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.StationEvents.Components;
 
 [RegisterComponent, Access(typeof(KudzuGrowthRule))]
 public sealed partial class KudzuGrowthRuleComponent : Component
 {
-
+    [DataField]
+    public EntProtoId Spawn = "Kudzu";
 }

--- a/Content.Server/StationEvents/Events/KudzuGrowthRule.cs
+++ b/Content.Server/StationEvents/Events/KudzuGrowthRule.cs
@@ -13,8 +13,7 @@ public sealed class KudzuGrowthRule : StationEventSystem<KudzuGrowthRuleComponen
         // Pick a place to plant the kudzu.
         if (!TryFindRandomTile(out var targetTile, out _, out var targetGrid, out var targetCoords))
             return;
-        Spawn("Kudzu", targetCoords);
-        Sawmill.Info($"Spawning a Kudzu at {targetTile} on {targetGrid}");
-
+        Spawn(component.Spawn, targetCoords);
+        Sawmill.Info($"Spawning a {component.Spawn} at {targetTile} on {targetGrid}");
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -332,8 +332,8 @@
       params:
         volume: 6
   - type: Kudzu
-    growthTickChance: 0.1
-    spreadChance: 0.35
+    growthTickChance: 0.2
+    spreadChance: 0.45
   - type: Slippery
     launchForwardsMultiplier: 2.5
   - type: StepTrigger

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -304,3 +304,69 @@
   components:
     - type: Kudzu
       spreadChance: 0 #appears during pulsation. It shouldnt spreading.
+
+- type: entity
+  name: space worms
+  description: Disgusting slimy space worms, densely covering the floor. 
+  id: SpaceWormsKudzu
+  parent: BaseKudzu
+  components:
+  - type: Clickable
+  - type: Sprite
+    drawdepth: FloorObjects
+    sprite: Structures/Hydroponics/misc.rsi
+    state: spaceworms
+  - type: Fixtures
+    fixtures:
+      slips:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,-0.3,0.4,0.3"
+        hard: false
+        layer:
+        - SlipLayer
+        - MidImpassable
+  - type: FootstepModifier
+    footstepSoundCollection:
+      collection: FootstepSticky
+      params:
+        volume: 6
+  - type: Kudzu
+    growthTickChance: 0.1
+    spreadChance: 0.35
+  - type: Slippery
+    launchForwardsMultiplier: 2.5
+  - type: StepTrigger
+    intersectRatio: 0.2
+  - type: Damageable
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 15 
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: DamageContacts
+    damage:
+      types:
+        Poison: 0.75
+  - type: Food # Do you eat worms? You're disgusting.
+    delay: 0.75
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        reagents:
+        - ReagentId: Protein
+          Quantity: 2
+        - ReagentId: InsectBlood
+          Quantity: 2
+  - type: Temperature
+    heatDamage:
+      types:
+        Heat: 25
+  - type: Flammable
+    fireSpread: true
+    damage:
+     types:
+       Heat: 3

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -197,6 +197,18 @@
   - type: KudzuGrowthRule
 
 - type: entity
+  id: SpaceWormsGrowth
+  parent: BaseStationEventLongDelay
+  components:
+  - type: StationEvent
+    earliestStart: 15
+    minimumPlayers: 15
+    weight: 7
+    duration: 240
+  - type: KudzuGrowthRule
+    spawn: SpaceWormsKudzu
+
+- type: entity
   id: MouseMigration
   parent: BaseStationEventShortDelay
   components:
@@ -277,7 +289,7 @@
     duration: 60
     maxDuration: 120
   - type: PowerGridCheckRule
-  
+
 - type: entity
   parent: BaseGameRule
   id: SolarFlare


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Simple new kudzu type.
- Slippery
- Easy to remove
- Poison contact damage
- Food?
- can randomly spawned via event
- die easily from high temperatures, but are immune to pressure and space

## Why / Balance
more event variety
accidentally found a texture of these worms in the game files and thought "why not add them?"

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
minor changes in Kudzu rule

## Media

https://github.com/space-wizards/space-station-14/assets/96445749/4fc15b4d-de74-4a51-85de-ef65e620dd2b

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Space worms can could infect the station
