### PR TITLE
Ghosts can now always see examine details

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.Group.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.Group.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Ghost;
 using Content.Shared.Verbs;
 using Robust.Shared.Utility;
 
@@ -14,6 +15,8 @@ namespace Content.Shared.Examine
             base.Initialize();
 
             SubscribeLocalEvent<GroupExamineComponent, GetVerbsEvent<ExamineVerb>>(OnGroupExamineVerb);
+
+            _ghostQuery = GetEntityQuery<GhostComponent>();
         }
 
         /// <summary>

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Ghost;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -52,6 +53,10 @@ namespace Content.Shared.Examine
         public bool IsInDetailsRange(EntityUid examiner, EntityUid entity)
         {
             if (IsClientSide(entity))
+                return true;
+
+            // Ghosts can see everything.
+            if (HasComp<GhostComponent>(examiner))
                 return true;
 
             // check if the mob is in critical or dead

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -45,6 +45,8 @@ namespace Content.Shared.Examine
 
         protected const float ExamineBlurrinessMult = 2.5f;
 
+        private EntityQuery<GhostComponent> _ghostQuery;
+
         /// <summary>
         ///     Creates a new examine tooltip with arbitrary info.
         /// </summary>
@@ -56,7 +58,7 @@ namespace Content.Shared.Examine
                 return true;
 
             // Ghosts can see everything.
-            if (HasComp<GhostComponent>(examiner))
+            if (_ghostQuery.HasComp(examiner))
                 return true;
 
             // check if the mob is in critical or dead


### PR DESCRIPTION
This means they bypass range and occlusion checks for getting extra detail, like the charge on an SMES.

:cl:
- tweak: Ghosts can now examine details on objects from any range.