### PR TITLE
Hotfix examine

### DIFF
--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -46,6 +46,8 @@ namespace Content.Client.Examine
 
         public override void Initialize()
         {
+            base.Initialize();
+
             UpdatesOutsidePrediction = true;
 
             SubscribeLocalEvent<GetVerbsEvent<ExamineVerb>>(AddExamineVerb);


### PR DESCRIPTION
#55328 was failing tests and shouldn't have been merged, it broke examine.

The problem is that for some reason, client-side examine system doesn't call base Initialize. So my entity query change (that I did not test) broke.

By the way, this same "not calling base" meant that group examine system wasn't predicting properly when it totally could've. Incredible.
