### PR TITLE
Attempt to fix random test fail by undeleted AlertControl._spriteViewEntity

### DIFF
--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -52,20 +52,12 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
             TooltipSupplier = SupplyTooltip;
             Alert = alert;
             _severity = severity;
-
-            _spriteViewEntity = _entityManager.Spawn(Alert.AlertViewEntity);
-            if (_entityManager.TryGetComponent<SpriteComponent>(_spriteViewEntity, out var sprite))
-            {
-                var icon = Alert.GetIcon(_severity);
-                if (sprite.LayerMapTryGet(AlertVisualLayers.Base, out var layer))
-                    sprite.LayerSetSprite(layer, icon);
-            }
-
             _icon = new SpriteView
             {
                 Scale = new Vector2(2, 2)
             };
-            _icon.SetEntity(_spriteViewEntity);
+
+            SetupIcon();
 
             Children.Add(_icon);
             _cooldownGraphic = new CooldownGraphic
@@ -111,6 +103,36 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
             }
 
             _cooldownGraphic.FromTime(Cooldown.Value.Start, Cooldown.Value.End);
+        }
+
+        private void SetupIcon()
+        {
+            if (!_entityManager.Deleted(_spriteViewEntity))
+                _entityManager.QueueDeleteEntity(_spriteViewEntity);
+
+            _spriteViewEntity = _entityManager.Spawn(Alert.AlertViewEntity);
+            if (_entityManager.TryGetComponent<SpriteComponent>(_spriteViewEntity, out var sprite))
+            {
+                var icon = Alert.GetIcon(_severity);
+                if (sprite.LayerMapTryGet(AlertVisualLayers.Base, out var layer))
+                    sprite.LayerSetSprite(layer, icon);
+            }
+
+            _icon.SetEntity(_spriteViewEntity);
+        }
+
+        protected override void EnteredTree()
+        {
+            base.EnteredTree();
+            SetupIcon();
+        }
+
+        protected override void ExitedTree()
+        {
+            base.ExitedTree();
+
+            if (!_entityManager.Deleted(_spriteViewEntity))
+                _entityManager.QueueDeleteEntity(_spriteViewEntity);
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
## About the PR
I vaguely remember PJB saying we should handle stuff like this on Entered/Exited tree instead of Dispose but I kept both in case I'm wrong or it needs both

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

