### PR TITLE
Fix forcemap not bypassing requirements

### DIFF
--- a/Content.IntegrationTests/Tests/Commands/ForceMapTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/ForceMapTest.cs
@@ -1,0 +1,80 @@
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Console;
+
+namespace Content.IntegrationTests.Tests.Commands;
+
+[TestFixture]
+public sealed class ForceMapTest
+{
+    private const string DefaultMapName = "Empty";
+    private const string BadMapName = "asdf_asd-fa__sdfAsd_f"; // Hopefully no one ever names a map this...
+    private const string TestMapEligibleName = "ForceMapTestEligible";
+    private const string TestMapIneligibleName = "ForceMapTestIneligible";
+
+    [TestPrototypes]
+    private static readonly string TestMaps = @$"
+- type: gameMap
+  id: {TestMapIneligibleName}
+  mapName: {TestMapIneligibleName}
+  mapPath: /Maps/Test/empty.yml
+  minPlayers: 20
+  maxPlayers: 80
+  stations:
+    Empty:
+      stationProto: StandardNanotrasenStation
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: ""Empty""
+
+- type: gameMap
+  id: {TestMapEligibleName}
+  mapName: {TestMapEligibleName}
+  mapPath: /Maps/Test/empty.yml
+  minPlayers: 0
+  stations:
+    Empty:
+      stationProto: StandardNanotrasenStation
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: ""Empty""
+";
+
+    [Test]
+    public async Task TestForceMapCommand()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.EntMan;
+        var configManager = server.ResolveDependency<IConfigurationManager>();
+        var consoleHost = server.ResolveDependency<IConsoleHost>();
+
+        await server.WaitAssertion(() =>
+        {
+            // Make sure we're set to the default map
+            Assert.That(configManager.GetCVar(CCVars.GameMap), Is.EqualTo(DefaultMapName),
+                $"Test didn't start on expected map ({DefaultMapName})!");
+
+            // Try changing to a map that doesn't exist
+            consoleHost.ExecuteCommand($"forcemap {BadMapName}");
+            Assert.That(configManager.GetCVar(CCVars.GameMap), Is.EqualTo(DefaultMapName),
+                $"Forcemap succeeded with a map that does not exist ({BadMapName})!");
+
+            // Try changing to a valid map
+            consoleHost.ExecuteCommand($"forcemap {TestMapEligibleName}");
+            Assert.That(configManager.GetCVar(CCVars.GameMap), Is.EqualTo(TestMapEligibleName),
+                $"Forcemap failed with a valid map ({TestMapEligibleName})");
+
+            // Try changing to a map that exists but is ineligible
+            consoleHost.ExecuteCommand($"forcemap {TestMapIneligibleName}");
+            Assert.That(configManager.GetCVar(CCVars.GameMap), Is.EqualTo(TestMapIneligibleName),
+                $"Forcemap failed with valid but ineligible map ({TestMapIneligibleName})!");
+        });
+
+        // Cleanup
+        configManager.SetCVar(CCVars.GameMap, DefaultMapName);
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/GameTicking/Commands/ForceMapCommand.cs
+++ b/Content.Server/GameTicking/Commands/ForceMapCommand.cs
@@ -29,9 +29,9 @@ namespace Content.Server.GameTicking.Commands
             var gameMap = IoCManager.Resolve<IGameMapManager>();
             var name = args[0];
 
-            if (!gameMap.TrySelectMapIfEligible(name))
+            if (!gameMap.CheckMapExists(name))
             {
-                shell.WriteLine($"No eligible map exists with name {name}.");
+                shell.WriteLine(Loc.GetString("forcemap-command-map-not-found", ("map", name)));
                 return;
             }
 

--- a/Resources/Locale/en-US/game-ticking/forcemap-command.ftl
+++ b/Resources/Locale/en-US/game-ticking/forcemap-command.ftl
@@ -3,5 +3,6 @@
 forcemap-command-description = Forces the game to start with a given map next round.
 forcemap-command-help = forcemap <map ID>
 forcemap-command-need-one-argument = forcemap takes one argument, the path to the map file.
+forcemap-command-map-not-found = No eligible map exists with name { $map }.
 forcemap-command-success = Forced the game to start with map { $map } next round.
 forcemap-command-arg-map = <map ID>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The `forcemap` command once again _forces_ the chosen map to be active, ignoring eligibility requirements.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Broken by #29391.
Fixes #29420.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Swapped out `TrySelectMapIfEligible` for `CheckMapExists`. We don't want to check if it's eligible, and we don't actually need to select it here, since the next line is going to set the CVar anyway.

Also added localization to the "No eligible map exists" message.

Added a simple integration test to help keep forcemap working as intended.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Code.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.