### PR TITLE
Regulate minimum allowed output pressure for internals

### DIFF
--- a/Content.Server/Atmos/Components/GasTankComponent.cs
+++ b/Content.Server/Atmos/Components/GasTankComponent.cs
@@ -3,119 +3,118 @@ using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
-namespace Content.Server.Atmos.Components
+namespace Content.Server.Atmos.Components;
+
+[RegisterComponent]
+public sealed partial class GasTankComponent : Component, IGasMixtureHolder
 {
-    [RegisterComponent]
-    public sealed partial class GasTankComponent : Component, IGasMixtureHolder
-    {
-        public const float MaxExplosionRange = 26f;
-        private const float DefaultLowPressure = 0f;
-        private const float DefaultOutputPressure = Atmospherics.OneAtmosphere;
+    public const float MaxExplosionRange = 26f;
+    private const float DefaultLowPressure = 0f;
+    private const float DefaultOutputPressure = Atmospherics.OneAtmosphere;
 
-        public int Integrity = 3;
-        public bool IsLowPressure => (Air?.Pressure ?? 0F) <= TankLowPressure;
+    public int Integrity = 3;
+    public bool IsLowPressure => (Air?.Pressure ?? 0F) <= TankLowPressure;
 
-        [ViewVariables(VVAccess.ReadWrite), DataField("ruptureSound")]
-        public SoundSpecifier RuptureSound = new SoundPathSpecifier("/Audio/Effects/spray.ogg");
+    [ViewVariables(VVAccess.ReadWrite), DataField("ruptureSound")]
+    public SoundSpecifier RuptureSound = new SoundPathSpecifier("/Audio/Effects/spray.ogg");
 
-        [ViewVariables(VVAccess.ReadWrite), DataField("connectSound")]
-        public SoundSpecifier? ConnectSound =
-            new SoundPathSpecifier("/Audio/Effects/internals.ogg")
-            {
-                Params = AudioParams.Default.WithVolume(5f),
-            };
+    [ViewVariables(VVAccess.ReadWrite), DataField("connectSound")]
+    public SoundSpecifier? ConnectSound =
+        new SoundPathSpecifier("/Audio/Effects/internals.ogg")
+        {
+            Params = AudioParams.Default.WithVolume(5f),
+        };
 
-        [ViewVariables(VVAccess.ReadWrite), DataField("disconnectSound")]
-        public SoundSpecifier? DisconnectSound;
+    [ViewVariables(VVAccess.ReadWrite), DataField("disconnectSound")]
+    public SoundSpecifier? DisconnectSound;
 
-        // Cancel toggles sounds if we re-toggle again.
+    // Cancel toggles sounds if we re-toggle again.
 
-        public EntityUid? ConnectStream;
-        public EntityUid? DisconnectStream;
+    public EntityUid? ConnectStream;
+    public EntityUid? DisconnectStream;
 
-        [DataField("air"), ViewVariables(VVAccess.ReadWrite)]
-        public GasMixture Air { get; set; } = new();
+    [DataField("air"), ViewVariables(VVAccess.ReadWrite)]
+    public GasMixture Air { get; set; } = new();
 
-        /// <summary>
-        ///     Pressure at which tank should be considered 'low' such as for internals.
-        /// </summary>
-        [DataField("tankLowPressure"), ViewVariables(VVAccess.ReadWrite)]
-        public float TankLowPressure = DefaultLowPressure;
+    /// <summary>
+    ///     Pressure at which tank should be considered 'low' such as for internals.
+    /// </summary>
+    [DataField("tankLowPressure"), ViewVariables(VVAccess.ReadWrite)]
+    public float TankLowPressure = DefaultLowPressure;
 
-        /// <summary>
-        ///     Distributed pressure.
-        /// </summary>
-        [DataField("outputPressure"), ViewVariables(VVAccess.ReadWrite)]
-        public float OutputPressure = DefaultOutputPressure;
+    /// <summary>
+    ///     Distributed pressure.
+    /// </summary>
+    [DataField("outputPressure"), ViewVariables(VVAccess.ReadWrite)]
+    public float OutputPressure = DefaultOutputPressure;
 
-        /// <summary>
-        ///     The maximum allowed output pressure.
-        /// </summary>
-        [DataField("maxOutputPressure"), ViewVariables(VVAccess.ReadWrite)]
-        public float MaxOutputPressure = 3 * DefaultOutputPressure;
+    /// <summary>
+    ///     The maximum allowed output pressure.
+    /// </summary>
+    [DataField("maxOutputPressure"), ViewVariables(VVAccess.ReadWrite)]
+    public float MaxOutputPressure = 3 * DefaultOutputPressure;
 
-        /// <summary>
-        ///     Tank is connected to internals.
-        /// </summary>
-        [ViewVariables]
-        public bool IsConnected => User != null;
+    /// <summary>
+    ///     Tank is connected to internals.
+    /// </summary>
+    [ViewVariables]
+    public bool IsConnected => User != null;
 
-        [ViewVariables]
-        public EntityUid? User;
+    [ViewVariables]
+    public EntityUid? User;
 
-        /// <summary>
-        ///     True if this entity was recently moved out of a container. This might have been a hand -> inventory
-        ///     transfer, or it might have been the user dropping the tank. This indicates the tank needs to be checked.
-        /// </summary>
-        [ViewVariables]
-        public bool CheckUser;
+    /// <summary>
+    ///     True if this entity was recently moved out of a container. This might have been a hand -> inventory
+    ///     transfer, or it might have been the user dropping the tank. This indicates the tank needs to be checked.
+    /// </summary>
+    [ViewVariables]
+    public bool CheckUser;
 
-        /// <summary>
-        ///     Pressure at which tanks start leaking.
-        /// </summary>
-        [DataField("tankLeakPressure"), ViewVariables(VVAccess.ReadWrite)]
-        public float TankLeakPressure = 30 * Atmospherics.OneAtmosphere;
+    /// <summary>
+    ///     Pressure at which tanks start leaking.
+    /// </summary>
+    [DataField("tankLeakPressure"), ViewVariables(VVAccess.ReadWrite)]
+    public float TankLeakPressure = 30 * Atmospherics.OneAtmosphere;
 
-        /// <summary>
-        ///     Pressure at which tank spills all contents into atmosphere.
-        /// </summary>
-        [DataField("tankRupturePressure"), ViewVariables(VVAccess.ReadWrite)]
-        public float TankRupturePressure = 40 * Atmospherics.OneAtmosphere;
+    /// <summary>
+    ///     Pressure at which tank spills all contents into atmosphere.
+    /// </summary>
+    [DataField("tankRupturePressure"), ViewVariables(VVAccess.ReadWrite)]
+    public float TankRupturePressure = 40 * Atmospherics.OneAtmosphere;
 
-        /// <summary>
-        ///     Base 3x3 explosion.
-        /// </summary>
-        [DataField("tankFragmentPressure"), ViewVariables(VVAccess.ReadWrite)]
-        public float TankFragmentPressure = 50 * Atmospherics.OneAtmosphere;
+    /// <summary>
+    ///     Base 3x3 explosion.
+    /// </summary>
+    [DataField("tankFragmentPressure"), ViewVariables(VVAccess.ReadWrite)]
+    public float TankFragmentPressure = 50 * Atmospherics.OneAtmosphere;
 
-        /// <summary>
-        ///     Increases explosion for each scale kPa above threshold.
-        /// </summary>
-        [DataField("tankFragmentScale"), ViewVariables(VVAccess.ReadWrite)]
-        public float TankFragmentScale = 2 * Atmospherics.OneAtmosphere;
+    /// <summary>
+    ///     Increases explosion for each scale kPa above threshold.
+    /// </summary>
+    [DataField("tankFragmentScale"), ViewVariables(VVAccess.ReadWrite)]
+    public float TankFragmentScale = 2 * Atmospherics.OneAtmosphere;
 
-        [DataField("toggleAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-        public string ToggleAction = "ActionToggleInternals";
+    [DataField("toggleAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string ToggleAction = "ActionToggleInternals";
 
-        [DataField("toggleActionEntity")] public EntityUid? ToggleActionEntity;
+    [DataField("toggleActionEntity")] public EntityUid? ToggleActionEntity;
 
-        /// <summary>
-        ///     Valve to release gas from tank
-        /// </summary>
-        [DataField("isValveOpen"), ViewVariables(VVAccess.ReadWrite)]
-        public bool IsValveOpen = false;
+    /// <summary>
+    ///     Valve to release gas from tank
+    /// </summary>
+    [DataField("isValveOpen"), ViewVariables(VVAccess.ReadWrite)]
+    public bool IsValveOpen = false;
 
-        /// <summary>
-        ///     Gas release rate in L/s
-        /// </summary>
-        [DataField("valveOutputRate"), ViewVariables(VVAccess.ReadWrite)]
-        public float ValveOutputRate = 100f;
+    /// <summary>
+    ///     Gas release rate in L/s
+    /// </summary>
+    [DataField("valveOutputRate"), ViewVariables(VVAccess.ReadWrite)]
+    public float ValveOutputRate = 100f;
 
-        [DataField("valveSound"), ViewVariables(VVAccess.ReadWrite)]
-        public SoundSpecifier ValveSound =
-            new SoundCollectionSpecifier("valveSqueak")
-            {
-                Params = AudioParams.Default.WithVolume(-5f),
-            };
-    }
+    [DataField("valveSound"), ViewVariables(VVAccess.ReadWrite)]
+    public SoundSpecifier ValveSound =
+        new SoundCollectionSpecifier("valveSqueak")
+        {
+            Params = AudioParams.Default.WithVolume(-5f),
+        };
 }

--- a/Content.Server/Atmos/Components/GasTankComponent.cs
+++ b/Content.Server/Atmos/Components/GasTankComponent.cs
@@ -47,10 +47,16 @@ public sealed partial class GasTankComponent : Component, IGasMixtureHolder
     public float OutputPressure = Atmospherics.OneAtmosphere;
 
     /// <summary>
-    ///     The maximum allowed output pressure.
+    ///     The lowest allowed output pressure.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float MaxOutputPressure = 3 * Atmospherics.OneAtmosphere;
+    public float MinOutputPressure = 17.5f;
+
+    /// <summary>
+    ///     The highest allowed output pressure.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float MaxOutputPressure = 1.5f * Atmospherics.OneAtmosphere;
 
     /// <summary>
     ///     Tank is connected to internals.

--- a/Content.Server/Atmos/Components/GasTankComponent.cs
+++ b/Content.Server/Atmos/Components/GasTankComponent.cs
@@ -9,23 +9,21 @@ namespace Content.Server.Atmos.Components;
 public sealed partial class GasTankComponent : Component, IGasMixtureHolder
 {
     public const float MaxExplosionRange = 26f;
-    private const float DefaultLowPressure = 0f;
-    private const float DefaultOutputPressure = Atmospherics.OneAtmosphere;
 
     public int Integrity = 3;
     public bool IsLowPressure => (Air?.Pressure ?? 0F) <= TankLowPressure;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("ruptureSound")]
+    [ViewVariables(VVAccess.ReadWrite), DataField]
     public SoundSpecifier RuptureSound = new SoundPathSpecifier("/Audio/Effects/spray.ogg");
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("connectSound")]
+    [ViewVariables(VVAccess.ReadWrite), DataField]
     public SoundSpecifier? ConnectSound =
         new SoundPathSpecifier("/Audio/Effects/internals.ogg")
         {
             Params = AudioParams.Default.WithVolume(5f),
         };
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("disconnectSound")]
+    [ViewVariables(VVAccess.ReadWrite), DataField]
     public SoundSpecifier? DisconnectSound;
 
     // Cancel toggles sounds if we re-toggle again.
@@ -33,26 +31,26 @@ public sealed partial class GasTankComponent : Component, IGasMixtureHolder
     public EntityUid? ConnectStream;
     public EntityUid? DisconnectStream;
 
-    [DataField("air"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public GasMixture Air { get; set; } = new();
 
     /// <summary>
     ///     Pressure at which tank should be considered 'low' such as for internals.
     /// </summary>
-    [DataField("tankLowPressure"), ViewVariables(VVAccess.ReadWrite)]
-    public float TankLowPressure = DefaultLowPressure;
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float TankLowPressure;
 
     /// <summary>
     ///     Distributed pressure.
     /// </summary>
-    [DataField("outputPressure"), ViewVariables(VVAccess.ReadWrite)]
-    public float OutputPressure = DefaultOutputPressure;
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float OutputPressure = Atmospherics.OneAtmosphere;
 
     /// <summary>
     ///     The maximum allowed output pressure.
     /// </summary>
-    [DataField("maxOutputPressure"), ViewVariables(VVAccess.ReadWrite)]
-    public float MaxOutputPressure = 3 * DefaultOutputPressure;
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float MaxOutputPressure = 3 * Atmospherics.OneAtmosphere;
 
     /// <summary>
     ///     Tank is connected to internals.
@@ -73,45 +71,45 @@ public sealed partial class GasTankComponent : Component, IGasMixtureHolder
     /// <summary>
     ///     Pressure at which tanks start leaking.
     /// </summary>
-    [DataField("tankLeakPressure"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float TankLeakPressure = 30 * Atmospherics.OneAtmosphere;
 
     /// <summary>
     ///     Pressure at which tank spills all contents into atmosphere.
     /// </summary>
-    [DataField("tankRupturePressure"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float TankRupturePressure = 40 * Atmospherics.OneAtmosphere;
 
     /// <summary>
     ///     Base 3x3 explosion.
     /// </summary>
-    [DataField("tankFragmentPressure"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float TankFragmentPressure = 50 * Atmospherics.OneAtmosphere;
 
     /// <summary>
     ///     Increases explosion for each scale kPa above threshold.
     /// </summary>
-    [DataField("tankFragmentScale"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float TankFragmentScale = 2 * Atmospherics.OneAtmosphere;
 
-    [DataField("toggleAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string ToggleAction = "ActionToggleInternals";
 
-    [DataField("toggleActionEntity")] public EntityUid? ToggleActionEntity;
+    [DataField] public EntityUid? ToggleActionEntity;
 
     /// <summary>
     ///     Valve to release gas from tank
     /// </summary>
-    [DataField("isValveOpen"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool IsValveOpen = false;
 
     /// <summary>
     ///     Gas release rate in L/s
     /// </summary>
-    [DataField("valveOutputRate"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float ValveOutputRate = 100f;
 
-    [DataField("valveSound"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public SoundSpecifier ValveSound =
         new SoundCollectionSpecifier("valveSqueak")
         {

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -65,7 +65,7 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnGasTankSetPressure(Entity<GasTankComponent> ent, ref GasTankSetPressureMessage args)
         {
-            var pressure = Math.Clamp(args.Pressure, 0f, ent.Comp.MaxOutputPressure);
+            var pressure = Math.Clamp(args.Pressure, ent.Comp.MinOutputPressure, ent.Comp.MaxOutputPressure);
 
             ent.Comp.OutputPressure = pressure;
 

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -142,7 +142,7 @@
         - 0 # water vapor
         - 0 # ammonia
         - 0.014251686 # 5% N2O
-        # 0.285033721       total 
+        # 0.285033721       total
       temperature: 293.15
 
 - type: entity


### PR DESCRIPTION
## About the PR
Limit the lowest allowed release pressure of gas tanks to 17.5 kPa, allowing players to still somewhat cheese the presure/duration but not excessively so
I also standardised the Maximum Output Pressure among different tanks rather than have it be derived from the default pressure of each prototype

## Why / Balance
Players can extend the duration a gas tank will last by reducing the output pressure. This is mostly fine at room temperature (although we might want to consider changing the default release pressure to the ~17.5 kPa "meta value" that powergamers already use for a 20% "capacity bonus"), but by using very low temperature gases (such as the easily available Liquid Oxygen) which are more dense, very low pressures can be used to drastically extend the operational capacity of a tank (~15m out of emergency tanks and 2.5 hours out of a normal tank).  While this is only possible because we don't have cold gas damage implemented, and ultimately introducing that will be a better answer, I think this also has merit on its own and can be added faster/with less game design considerations. 
There is no legitimate reason to use such low pressure apart from this cold gas trick. So why would equipment deemed "safe" let you use a pressure setting that would normally suffocate you? 
This works as an interim solution and does not conflict with introducing cold damage later. Players also still get to cheese their gas tanks at the level possible at room temperature (or that can be taken away too by increasing the minimum release pressure to 21.3 kPa)

Changing max pressure was mostly just a consistency thing since previously there was significant difference between the max output pressure of Air and O2/N2 tanks, which doesn't make much sense. This just makes things more consistent but probably doesn't actually matter regarding gameplay, breathing hot gases is undesirable anyway due to their increased density/reduced moles per volume

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- tweak: Internals gas tanks can no longer be set to dangerously low output pressures.

