### PR TITLE
Removes RD Hardsuit traitor objective

### DIFF
--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -177,16 +177,6 @@
 
 - type: entity
   parent: BaseRDStealObjective
-  id: RDHardsuitStealObjective
-  components:
-  - type: StealCondition
-    stealGroup: ClothingOuterHardsuitRd
-  - type: Objective
-    # This item must be worn or stored in a slowing duffelbag, very hard to hide.
-    difficulty: 3
-
-- type: entity
-  parent: BaseRDStealObjective
   id: HandTeleporterStealObjective
   components:
   - type: StealCondition


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removed the RD's hardsuit from traitor steal objectives.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Keeping the RD Hardsuit as a traitor objective is poor design ever since it was made a 5x5. Players are required to either A: wear the hardsuit and impersonate the RD whilst praying the RD did not have a tracker implant, or B: happen to have a duffel bag (which is something a good amount of players do not use) on hand when you kill or steal the hardsuit. The hardsuit objective was balanced around having a small size, so while I understand this is "intended," it's simply too difficult to achieve. Stealing it is the first step, you still need to hide it or keep it on you without getting caught. Carrying around a duffelbag in your hand all the time is not only extremely inconvenient, but it is suspicious as well. Hiding it somewhere risks it being found; people finding hidden areas or stumbling upon your stash is far more common than you'd think. Wearing the duffel puts you at just as much of a disadvantage as carrying it by hand, as it removes more than half of your inventory space, leaving only a 2x5 space to hold items. Furthermore, duffel bags slow you down significantly. There is not a single other steal objective in the game that is this unreasonably difficult, with the only thing coming close being the nuke disk (due to the existence of the pinpointer); even still, the pinpointer can be combatted by simply placing a decoy as most people do not check the pinpointer unless they have reason to do so.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- remove: Removed the RD's Experimental Hardsuit as a steal objective.
-->
