### PR TITLE
show sleeper agents in round end summary

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -455,6 +455,7 @@
     startAnnouncement: station-event-communication-interception
     startAudio:
       path: /Audio/Announcements/intercept.ogg
+    duration: null # the rule has to last the whole round not 1 second
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     definitions:


### PR DESCRIPTION
## About the PR

fixes #27648

## Why / Balance
redtext bad greentext good

## Technical details
no

## Media
you have been greentextful!
![08:14:26](https://github.com/space-wizards/space-station-14/assets/39013340/1f9ab168-3068-4edc-aa19-88000060de01)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed sleeper agents not showing up in the round end summary.