### PR TITLE
Forcemap can be cleared with empty string again

### DIFF
--- a/Content.IntegrationTests/Tests/Commands/ForceMapTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/ForceMapTest.cs
@@ -1,3 +1,4 @@
+using Content.Server.Maps;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
@@ -49,27 +50,34 @@ public sealed class ForceMapTest
         var entMan = server.EntMan;
         var configManager = server.ResolveDependency<IConfigurationManager>();
         var consoleHost = server.ResolveDependency<IConsoleHost>();
+        var gameMapMan = server.ResolveDependency<IGameMapManager>();
 
         await server.WaitAssertion(() =>
         {
             // Make sure we're set to the default map
-            Assert.That(configManager.GetCVar(CCVars.GameMap), Is.EqualTo(DefaultMapName),
+            Assert.That(gameMapMan.GetSelectedMap()?.ID, Is.EqualTo(DefaultMapName),
                 $"Test didn't start on expected map ({DefaultMapName})!");
 
             // Try changing to a map that doesn't exist
             consoleHost.ExecuteCommand($"forcemap {BadMapName}");
-            Assert.That(configManager.GetCVar(CCVars.GameMap), Is.EqualTo(DefaultMapName),
+            Assert.That(gameMapMan.GetSelectedMap()?.ID, Is.EqualTo(DefaultMapName),
                 $"Forcemap succeeded with a map that does not exist ({BadMapName})!");
 
             // Try changing to a valid map
             consoleHost.ExecuteCommand($"forcemap {TestMapEligibleName}");
-            Assert.That(configManager.GetCVar(CCVars.GameMap), Is.EqualTo(TestMapEligibleName),
+            Assert.That(gameMapMan.GetSelectedMap()?.ID, Is.EqualTo(TestMapEligibleName),
                 $"Forcemap failed with a valid map ({TestMapEligibleName})");
 
             // Try changing to a map that exists but is ineligible
             consoleHost.ExecuteCommand($"forcemap {TestMapIneligibleName}");
-            Assert.That(configManager.GetCVar(CCVars.GameMap), Is.EqualTo(TestMapIneligibleName),
+            Assert.That(gameMapMan.GetSelectedMap()?.ID, Is.EqualTo(TestMapIneligibleName),
                 $"Forcemap failed with valid but ineligible map ({TestMapIneligibleName})!");
+
+            // Try clearing the force-selected map
+            consoleHost.ExecuteCommand("forcemap \"\"");
+            Assert.That(gameMapMan.GetSelectedMap(), Is.Null,
+                $"Running 'forcemap \"\"' did not clear the forced map!");
+
         });
 
         // Cleanup

--- a/Content.Server/GameTicking/Commands/ForceMapCommand.cs
+++ b/Content.Server/GameTicking/Commands/ForceMapCommand.cs
@@ -29,14 +29,19 @@ namespace Content.Server.GameTicking.Commands
             var gameMap = IoCManager.Resolve<IGameMapManager>();
             var name = args[0];
 
-            if (!gameMap.CheckMapExists(name))
+            // An empty string clears the forced map
+            if (!string.IsNullOrEmpty(name) && !gameMap.CheckMapExists(name))
             {
                 shell.WriteLine(Loc.GetString("forcemap-command-map-not-found", ("map", name)));
                 return;
             }
 
             _configurationManager.SetCVar(CCVars.GameMap, name);
-            shell.WriteLine(Loc.GetString("forcemap-command-success", ("map", name)));
+
+            if (string.IsNullOrEmpty(name))
+                shell.WriteLine(Loc.GetString("forcemap-command-cleared"));
+            else
+                shell.WriteLine(Loc.GetString("forcemap-command-success", ("map", name)));
         }
 
         public CompletionResult GetCompletion(IConsoleShell shell, string[] args)

--- a/Resources/Locale/en-US/game-ticking/forcemap-command.ftl
+++ b/Resources/Locale/en-US/game-ticking/forcemap-command.ftl
@@ -5,4 +5,5 @@ forcemap-command-help = forcemap <map ID>
 forcemap-command-need-one-argument = forcemap takes one argument, the path to the map file.
 forcemap-command-map-not-found = No eligible map exists with name { $map }.
 forcemap-command-success = Forced the game to start with map { $map } next round.
+forcemap-command-cleared = Cleared the forced map setting.
 forcemap-command-arg-map = <map ID>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Running `forcemap ""` will once again clear the forced map setting and restore normal map selection behavior.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #29470.
I didn't even know this was a thing.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
ForceMapCommand no longer considers an empty string an invalid map name. I also made it actually acknowledge this behavior with a different console response message (`Cleared the forced map setting.`) instead of the awkward `Forced the game to start with map  next round.`

Added another step to ForceMapTest to make sure that this behavior is working.

Also changed the way that ForceMapTest checks the current forced map setting to be a bit more robust.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
