### PR TITLE
Fix bugs resulting in quantum APC visual states

### DIFF
--- a/Content.Server/Power/Components/ApcComponent.cs
+++ b/Content.Server/Power/Components/ApcComponent.cs
@@ -11,12 +11,9 @@ public sealed partial class ApcComponent : BaseApcNetComponent
     [DataField("onReceiveMessageSound")]
     public SoundSpecifier OnReceiveMessageSound = new SoundPathSpecifier("/Audio/Machines/machine_switch.ogg");
 
-    [DataField("lastChargeState")]
     public ApcChargeState LastChargeState;
-    [DataField("lastChargeStateTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
-    public TimeSpan LastChargeStateTime;
+    public TimeSpan? LastChargeStateTime;
 
-    [DataField("lastExternalState")]
     public ApcExternalPowerState LastExternalState;
 
     /// <summary>
@@ -24,7 +21,6 @@ public sealed partial class ApcComponent : BaseApcNetComponent
     /// Done after every <see cref="VisualsChangeDelay"/> to show the latest load.
     /// If charge state changes it will be instantly updated.
     /// </summary>
-    [DataField("lastUiUpdate", customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan LastUiUpdate;
 
     [DataField("enabled")]
@@ -32,6 +28,11 @@ public sealed partial class ApcComponent : BaseApcNetComponent
     // TODO: remove this since it probably breaks when 2 people use it
     [DataField("hasAccess")]
     public bool HasAccess = false;
+
+    /// <summary>
+    /// APC state needs to always be updated after first processing tick.
+    /// </summary>
+    public bool NeedStateUpdate;
 
     public const float HighPowerThreshold = 0.9f;
     public static TimeSpan VisualsChangeDelay = TimeSpan.FromSeconds(1);


### PR DESCRIPTION
There were TWO bugs here

FIRST, APCs *did* update their visual state on initialization, but at that point the relevant power state hasn't been initialized yet, so it always returns a bogus result. There aren't guaranteed to be subsequent power updates that actually trigger the APC to update so this can get it stuck.

Fixed by just deferring the on-init update to be after the first update tick, which is itself ordered to be after power update.

SECOND: Once I fixed that, I ran into the issue that APCs created at *server startup* also fail to update, because the throttling system (to prevent frequent APC updates) thinks the LastChargeStateTime was at server startup.

Fixed by making that variable nullable so it defaults to null.

Also removed the useless datafields on the "last update" fields. These are all just used to cache and throttle updates, something that should not be persisted to a map file.
