### PR TITLE
Cut low pressure damage to 1/4

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -286,7 +286,7 @@ namespace Content.Shared.Atmos
         ///     (The pressure threshold is so low that it doesn't make sense to do any calculations,
         ///     so it just applies this flat value).
         /// </summary>
-        public const int LowPressureDamage = 4;
+        public const int LowPressureDamage = 1;
 
         public const float WindowHeatTransferCoefficient = 0.1f;
 

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -286,6 +286,7 @@ namespace Content.Shared.Atmos
         ///     (The pressure threshold is so low that it doesn't make sense to do any calculations,
         ///     so it just applies this flat value).
         /// </summary>
+        // Original value is 4, buff back when we have proper ways for players to deal with breaches.
         public const int LowPressureDamage = 1;
 
         public const float WindowHeatTransferCoefficient = 0.1f;


### PR DESCRIPTION
If the Marathon emergency shuttle gets breached, everybody without a suit dies in 60 seconds.

This is not an exaggeration. The entire shuttle reaches dangerously low pressure in 20 seconds, and at 2.4 pressure damage per second, spessmen is in crit in another 40.

If engineers want to respond, they would need to seal the breach in seconds. The canister on Marathon's shuttle can only fill the main shuttle area by like 6 kPa. This is a joke.

Yes, space should be deadly. But the current set of mechanics in SS14 give players 0 counter play, and most cases where "deadly space" actually matters is... nukies being poorly balanced. That's it.

Low pressure damage currently hurts the game *far* more than it adds. In the interest of not letting the game languish for another 6 months in this state, this is a bandaid fix.

When we get proper mechanics to allow players to DEAL with breaches, such as better ways to repressurize areas, this change can be reverted.

:cl:
- remove: Low pressure damage now does only 1/4th as much damage. This is a band-aid until better mechanics exists for the crew to deal with breaches of various kinds.