### PR TITLE
Fix storages bugging out if an open storage has its component removed

### DIFF
--- a/Content.Client/Storage/Systems/StorageSystem.cs
+++ b/Content.Client/Storage/Systems/StorageSystem.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Numerics;
 using Content.Client.Animations;
 using Content.Shared.Hands;
@@ -69,7 +69,7 @@ public sealed class StorageSystem : SharedStorageSystem
 
     public void CloseStorageWindow(Entity<StorageComponent?> entity)
     {
-        if (!Resolve(entity, ref entity.Comp))
+        if (!Resolve(entity, ref entity.Comp, false))
             return;
 
         if (!_openStorages.Contains((entity, entity.Comp)))

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -96,6 +96,7 @@ public abstract class SharedStorageSystem : EntitySystem
             subs.Event<BoundUIClosedEvent>(OnBoundUIClosed);
         });
 
+        SubscribeLocalEvent<StorageComponent, ComponentRemove>(OnRemove);
         SubscribeLocalEvent<StorageComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<StorageComponent, GetVerbsEvent<ActivationVerb>>(AddUiVerb);
         SubscribeLocalEvent<StorageComponent, ComponentGetState>(OnStorageGetState);
@@ -131,6 +132,11 @@ public abstract class SharedStorageSystem : EntitySystem
             .Register<SharedStorageSystem>();
 
         UpdatePrototypeCache();
+    }
+
+    private void OnRemove(Entity<StorageComponent> entity, ref ComponentRemove args)
+    {
+        _ui.CloseUi(entity.Owner, StorageComponent.StorageUiKey.Key);
     }
 
     private void OnMapInit(Entity<StorageComponent> entity, ref MapInitEvent args)


### PR DESCRIPTION
## About the PR
See [Discord](https://discord.com/channels/310555209753690112/900426319433728030/1255450855256231997) for an explanation but tl;dr only the client processed this originally which made it so only the client try to close the bui, which calls close ui with predicted set to true, while being processed outside first time predicted, which makes no close event actually get sent out.

This made the storage button not work because that always checks if the UI is open first and doesn't close on consecutive clicks while pressing E would need you to press E exactly THREE times to fix the UI and get it to open again, the first to close, the second to make you a sandwich I guess, and the third to actually open the UI again.

Ask me how I know from all the AHelps I got downstream in RMC14 from people saying webbing bugged out and me having spent hours debugging this shit.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
