### PR TITLE
fixed vents pumping air into space

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
@@ -26,6 +26,7 @@ namespace Content.Server.Atmos.EntitySystems
         public float AtmosTickRate { get; private set; }
         public float Speedup { get; private set; }
         public float HeatScale { get; private set; }
+        public bool VentPressurizationLockout { get; private set; }
 
         /// <summary>
         /// Time between each atmos sub-update.  If you are writing an atmos device, use AtmosDeviceUpdateEvent.dt
@@ -55,6 +56,7 @@ namespace Content.Server.Atmos.EntitySystems
             Subs.CVar(_cfg, CCVars.AtmosHeatScale, value => { HeatScale = value; InitializeGases(); }, true);
             Subs.CVar(_cfg, CCVars.ExcitedGroups, value => ExcitedGroups = value, true);
             Subs.CVar(_cfg, CCVars.ExcitedGroupsSpaceIsAllConsuming, value => ExcitedGroupsSpaceIsAllConsuming = value, true);
+            Subs.CVar(_cfg, CCVars.VentPressurizationLockout, value => VentPressurizationLockout = value, true);
         }
     }
 }

--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -95,13 +95,40 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         ///     I'm not 100% sure if I implemented correctly, so I advise leaving it at 1.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float AveragingTime = 1.0f;
+        public float AveragingTime { get; set; } = 1.0f;
 
         [ViewVariables(VVAccess.ReadWrite)]
-        public float PressureDelta = 0f;
+        public float PressureDelta { get; set; } = 0f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public float LastPressure { get; set; } = 101.325f;
+
+        /// <summary>
+        ///     Timer based check for spacing
+        /// </summary>
+        /// <remarks>
+        ///     This check is intended to catch the failures not handled by UnderPressureLockout or
+        ///     PressurizationLockout.
+        /// </remarks>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool OverheatTimerEnabled { get; set; } = true;
+
+        /// <summary>
+        ///     Defines for how many seconds the vent can move air uninterrupted.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float OverheatMaxTime { get; set; } = 5f;
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float OverheatCounter { get; set; } = 0f;
+
+        /// <summary>
+        ///     Defines how many seconds the vent will stay closed after moving air for <see cref=OverheatMaxTime>
+        ///     seconds.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float OverheatCooldownMaxTime { get; set; } = 1f;
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float OverheatCooldownCounter { get; set; } = 0f;
 
         #endregion
 
@@ -185,7 +212,6 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         // When true, ignore under-pressure lockout. Used to re-fill rooms in air alarm "Fill" mode.
         [DataField]
         public bool PressureLockoutOverride = false;
-
         #endregion
 
         public GasVentPumpData ToAirAlarmData()

--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -130,8 +130,23 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         public float OverheatCooldownMaxTime { get; set; } = 1f;
+
+        /// <summary>
+        ///     Setting this property tells the vent to stop pumping air for X seconds.
+        /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         public float OverheatCooldownCounter { get; set; } = 0f;
+
+        /// <summary>
+        ///     The vent will stay locked up for X seconds after exiting <see cref=UnderPressureLockout>
+        ///     <seealso cref=UnderPressureLockoutThreshold>
+        /// </summary>
+        /// <remarks>
+        ///     This is supposed to stop the vent from trying to repressurize a spaced room just because someone opened
+        ///     a door and increased the room pressure above UPLO threshold for a tick.
+        /// </remarks>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float underPressureLockoutCooldown { get; set; } = 5f;
 
         #endregion
 

--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -59,6 +59,48 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [DataField("underPressureLockoutLeaking")]
         public float UnderPressureLockoutLeaking = 0.0001f;
 
+        #region some averaging stuff
+        [ViewVariables(VVAccess.ReadOnly)]
+        public int samples { get; set; } = 0;
+
+        /// <summary>
+        ///     Calculate average pressure over X atmos updates.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadOnly)]
+        public int maxSamples { get; set; } = 5;
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public float[] measurements { get; set; } = new float[5];
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public float[] pressurizationRate { get; set; } = new float[5];
+
+        /// <summary>
+        ///     The vent will be shut down if the average pressure drop is less than this value.
+        /// </summary>
+        /// <remarks>
+        ///     In my testing, in a underPressureLockout failure the average pressure
+        ///     drop over 5 ticks may drop to -0.04, triggering this check and causing a lockout, solving the
+        ///     underPressureLockout failure.
+        ///
+        ///     This could be set to 0, but then the vents will stay locked for annoyingly long time whenever air flows
+        ///     from this vent to the surroundings. This may cause pressure drops in the order of E-5, causing lockouts
+        ///     while refilling rooms.
+        /// </remarks>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float pressurizationLockout { get; set; } = -0.02f;
+
+        /// <summary>
+        ///     Used to hold pressure from last tick. doesn't really matter what
+        ///     it's initialized to.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float averagePressure { get; set; } = 101.325f;
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public int windowidx { get; set; } = 0;
+        #endregion
+
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("externalPressureBound")]
         public float ExternalPressureBound

--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -75,7 +75,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         ///     I'm not entirely sure if I got the math right, so the value -1 may not be exactly -1 kPa/s
         /// </remarks>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float PressurizationLockout { get; set; } = -0.05f;
+        public float PressurizationLockout { get; set; } = -0.1f;
 
         /// <summary>
         ///     There's some atmos equalization mechanic that equalizes the pressure of the entire room in one tick, and
@@ -92,10 +92,9 @@ namespace Content.Server.Atmos.Piping.Unary.Components
 
         /// <summary>
         ///     Calculate the pressure change over X seconds.
-        ///     I'm not 100% sure if I implemented correctly, so I advise leaving it at 1.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float AveragingTime { get; set; } = 1.0f;
+        public float AveragingTime { get; set; } = 2.0f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public float PressureDelta { get; set; } = 0f;
@@ -116,8 +115,12 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         /// <summary>
         ///     Defines for how many seconds the vent can move air uninterrupted.
         /// </summary>
+        /// <remarks>
+        ///     If I made my testing correctly, a vent on a space tile wastes ~100 moles a second, so a total of 1000
+        ///     moles may be lost, and if I understood correctly, that's 2.5 seconds of miner output.
+        /// </remarks>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float OverheatMaxTime { get; set; } = 5f;
+        public float OverheatMaxTime { get; set; } = 10f;
         [ViewVariables(VVAccess.ReadWrite)]
         public float OverheatCounter { get; set; } = 0f;
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -182,6 +182,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (vent.UnderPressureLockout)
             {
                 vent.LastPressure = environment.Pressure;
+                vent.PressureDelta = 0f;
                 return false;
             }
 
@@ -189,13 +190,14 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             {
                 vent.OverheatCooldownCounter -= dt;
                 vent.LastPressure = environment.Pressure;
+                vent.PressureDelta = 0f;
                 return false;
             }
 
             var difference = environment.Pressure - vent.LastPressure;
             vent.LastPressure = environment.Pressure;
 
-            // Sudden increase in pressure is most likely caused by atmos equalization,
+            // Sudden change in pressure is most likely caused by atmos equalization,
             // If this happens, reset average calculation and don't move air this frame.
             // This may be triggered by the vents themselves, but they'll continue moving air, but just a tiny bit
             // slower than usual.

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -170,7 +170,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         /// <summary>
         ///     Keeps track of the average rate of change in pressure, and returns `false` if
-        ///     the rate is less than <see cref=GasVentPumpComponent.pressurizationLockout>.
+        ///     the rate is less than <see cref=GasVentPumpComponent.PressurizationLockout>.
         ///
         ///     Because this was written by someone lazy, multiple calls in an atmos tick aren't properly supported.
         /// </summary>
@@ -181,31 +181,31 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
         {
             if (vent.UnderPressureLockout)
             {
-                vent.windowidx = -1;
-                vent.samples = 0;
+                vent.WindowIdx = -1;
+                vent.Samples = 0;
                 return false;
             }
-            vent.windowidx = (vent.windowidx + 1) % vent.maxSamples;
+            vent.WindowIdx = (vent.WindowIdx + 1) % vent.MaxSamples;
 
-            var oldAverage = vent.averagePressure;
-            if (vent.samples < vent.maxSamples)
-                vent.samples += 1;
+            var oldAverage = vent.AveragePressure;
+            if (vent.Samples < vent.MaxSamples)
+                vent.Samples += 1;
 
             // Calculate average pressure
             float pressure = 0;
-            vent.measurements[vent.windowidx] = environment.Pressure;
-            for (int i = 0; i < vent.samples; i++)
-                pressure += vent.measurements[i];
-            vent.averagePressure = pressure / vent.samples;
+            vent.Measurements[vent.WindowIdx] = environment.Pressure;
+            for (int i = 0; i < vent.Samples; i++)
+                pressure += vent.Measurements[i];
+            vent.AveragePressure = pressure / vent.Samples;
 
             // Calculate average rate of pressurization
             float refill = 0;
-            vent.pressurizationRate[vent.windowidx] = vent.averagePressure - oldAverage;
-            for (int i = 0; i < vent.samples; i++)
-                refill += vent.pressurizationRate[i];
-            var averagePressurizationRate = refill / vent.samples;
+            vent.PressurizationRate[vent.WindowIdx] = vent.AveragePressure - oldAverage;
+            for (int i = 0; i < vent.Samples; i++)
+                refill += vent.PressurizationRate[i];
+            var averagePressurizationRate = refill / vent.Samples;
 
-            if (averagePressurizationRate < vent.pressurizationLockout)
+            if (averagePressurizationRate < vent.PressurizationLockout)
                 return false;
             return true;
         }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -109,7 +109,9 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 var transferMoles = pressureDelta * environment.Volume / (pipe.Air.Temperature * Atmospherics.R);
 
                 // Don't transfer air if pressure is actively dropping
-                var pressurizing = pressurizationLockout(vent, environment, args.dt);
+                var pressurizing = !vent.UnderPressureLockout;
+                if (_atmosphereSystem.VentPressurizationLockout && _atmosphereSystem.MonstermosEqualization)
+                    pressurizing = pressurizationLockout(vent, environment, args.dt);
                 if (!pressurizing)
                     transferMoles = 0;
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -185,9 +185,9 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 return false;
             }
 
-            if (vent.OverheatCooldownTimer > 0f && vent.OverheatTimerEnabled)
+            if (vent.OverheatCooldownCounter > 0f && vent.OverheatTimerEnabled)
             {
-                vent.OverheatCooldownTimer -= dt;
+                vent.OverheatCooldownCounter -= dt;
                 vent.LastPressure = environment.Pressure;
                 return false;
             }
@@ -211,15 +211,15 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
             if (vent.PressureDelta < vent.PressurizationLockout * dt)
             {
-                vent.OverheatTimer = 0;
+                vent.OverheatCounter = 0;
                 return false;
             }
 
-            vent.OverheatTimer += dt;
-            if (vent.OverheatTimer > vent.OverheatMaxTime)
+            vent.OverheatCounter += dt;
+            if (vent.OverheatCounter > vent.OverheatMaxTime)
             {
-                vent.OverheatTimer -= vent.OverheatMaxTime;
-                vent.OverheatCooldownTimer += vent.OverheatCooldownMaxTime;
+                vent.OverheatCounter -= vent.OverheatMaxTime;
+                vent.OverheatCooldownCounter += vent.OverheatCooldownMaxTime;
             }
             return true;
         }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -214,6 +214,10 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 return false;
             }
 
+            /// Don't start repressurizing instantly after exiting UPLO.
+            /// <see cref=GasVentPumpComponent.underPressureLockoutCooldown>
+            if (vent.LastPressure < vent.UnderPressureLockoutThreshold)
+                vent.OverheatCooldownCounter = vent.underPressureLockoutCooldown;
 
             var difference = environment.Pressure - vent.LastPressure;
             vent.LastPressure = environment.Pressure;

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1214,6 +1214,14 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<float> AtmosHeatScale =
             CVarDef.Create("atmos.heat_scale", 8f, CVar.SERVERONLY);
 
+        /// <summary>
+        ///     A barely functioning system for stopping vents from trying to pressurize spaced rooms.
+        ///     Uses the time differential of pressure in order to determine when to close.
+        ///     Requires <see cref=MonstermosEqualization> to be true in order to work, otherwise this cvar is ignored.
+        /// </summary>
+        public static readonly CVarDef<bool> VentPressurizationLockout =
+            CVarDef.Create("atmos.vent_pressurization_lockout", true, CVar.SERVERONLY);
+
         /*
          * MIDI instruments
          */


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixed vents pumping air into rooms which are actively spacing. 
This is accomplished by keeping track of the changes in pressure, and causing a lockout if pressure is dropping.

## Why / Balance
As far as I'm aware, vents should go into a lockout if the room gets spaced. 
Because of this bug, a single hull breach may temporarily empty distro, or cause a constant strain on distro pressure until distro runs out, or the vent somehow gets fixed.
Because spacing speed was slowed down, vents pump out air fast enough to keep their immediate surroundings at high pressures, which doesn't allow the vents to go into a underpressureLockout.

## Technical details
Added a new method in GasVentPumpSystem that keeps track of the air pressure, and skips pumping air for a tick if the pressure is dropping. 
With the current values it seems to be working, though a underpressurelockout failure can still happen if you put 20 vents in the corner of some spacing room, and decrease underpressurelockouttreshold to under 10. 

Also large rooms may repressurize slightly slower, since airflows can trigger the fix I added. The variable `pressurizationLockout` can be changed to somewhat mitigate this. 

Assuming I did my profiling correctly, this fix should have negligible effect on atmospheresystem's usage.

There's probably other ways to fix this bug, like just saving the pressure from last tick and calculating a change in pressure over one tick, and using that instead of doing this averaging stuff I wrote.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Some footage of the bug in question:

https://github.com/space-wizards/space-station-14/assets/62134478/d032088c-7514-43e2-830c-c10415155793

And here's my fix: 

https://github.com/space-wizards/space-station-14/assets/62134478/893f2f97-b8e6-4507-a52e-b06cdeb3528c

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
