### PR TITLE
Fix double labels on pills and pill canisters

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -347,7 +347,8 @@
 
 # Pills
 - type: entity
-  name: pill (dexalin 10u)
+  name: pill
+  suffix: Dexalin 10u
   parent: Pill
   id: PillDexalin
   components:
@@ -366,10 +367,10 @@
           Quantity: 10
 
 - type: entity
-  name: pill canister (dexalin 10u)
+  name: pill canister
   parent: PillCanister
   id: PillCanisterDexalin
-  suffix: Dexalin, 7
+  suffix: Dexalin 10u, 7
   components:
   - type: Label
     currentLabel: dexalin 10u
@@ -379,7 +380,8 @@
       amount: 7
 
 - type: entity
-  name: pill (dylovene 10u)
+  name: pill
+  suffix: Dylovene 10u
   parent: Pill
   id: PillDylovene
   components:
@@ -398,10 +400,10 @@
           Quantity: 10
 
 - type: entity
-  name: pill canister (dylovene 10u)
+  name: pill canister
   parent: PillCanister
   id: PillCanisterDylovene
-  suffix: Dylovene, 5
+  suffix: Dylovene 10u, 5
   components:
   - type: Label
     currentLabel: dylovene 10u
@@ -411,7 +413,8 @@
       amount: 5
 
 - type: entity
-  name: pill (hyronalin 10u)
+  name: pill
+  suffix: Hyronalin 10u
   parent: Pill
   id: PillHyronalin
   components:
@@ -430,10 +433,10 @@
           Quantity: 10
 
 - type: entity
-  name: pill canister (hyronalin 10u)
+  name: pill canister
   parent: PillCanister
   id: PillCanisterHyronalin
-  suffix: Hyronalin, 5
+  suffix: Hyronalin 10u, 5
   components:
   - type: Label
     currentLabel: hyronalin 10u
@@ -443,7 +446,8 @@
       amount: 5
 
 - type: entity
-  name: pill (iron 10u)
+  name: pill
+  suffix: Iron 10u
   parent: Pill
   id: PillIron
   components:
@@ -462,7 +466,8 @@
           Quantity: 10
 
 - type: entity
-  name: pill (copper 10u)
+  name: pill
+  suffix: Copper 10u
   parent: Pill
   id: PillCopper
   components:
@@ -481,10 +486,10 @@
           Quantity: 10
 
 - type: entity
-  name: pill canister (iron 10u)
+  name: pill canister
   parent: PillCanister
   id: PillCanisterIron
-  suffix: Iron, 5
+  suffix: Iron 10u, 5
   components:
   - type: Label
     currentLabel: iron 10u
@@ -494,10 +499,10 @@
       amount: 5
 
 - type: entity
-  name: pill canister (copper 10u)
+  name: pill canister
   parent: PillCanister
   id: PillCanisterCopper
-  suffix: Copper, 5
+  suffix: Copper 10u, 5
   components:
   - type: Label
     currentLabel: copper 10u
@@ -507,7 +512,8 @@
       amount: 5
 
 - type: entity
-  name: pill (kelotane 10u)
+  name: pill
+  suffix: Kelotane 10u
   parent: Pill
   id: PillKelotane
   components:
@@ -526,10 +532,10 @@
           Quantity: 10
 
 - type: entity
-  name: pill canister (kelotane 10u)
+  name: pill canister
   parent: PillCanister
   id: PillCanisterKelotane
-  suffix: Kelotane, 5
+  suffix: Kelotane 10u, 5
   components:
   - type: Label
     currentLabel: kelotane 10u
@@ -539,7 +545,8 @@
       amount: 5
 
 - type: entity
-  name: pill (dermaline 10u)
+  name: pill
+  suffix: Dermaline 10u
   parent: Pill
   id: PillDermaline
   components:
@@ -558,10 +565,10 @@
           Quantity: 10
 
 - type: entity
-  name: pill canister (dermaline 10u)
+  name: pill canister
   parent: PillCanister
   id: PillCanisterDermaline
-  suffix: Dermaline, 5
+  suffix: Dermaline 10u, 5
   components:
   - type: Label
     currentLabel: dermaline 10u
@@ -584,7 +591,8 @@
           Quantity: 15
 
 - type: entity
-  name: pill (tricordrazine 10u)
+  name: pill
+  suffix: Tricordrazine 10u
   parent: Pill
   id: PillTricordrazine
   components:
@@ -603,10 +611,10 @@
           Quantity: 10
 
 - type: entity
-  name: pill canister (tricordrazine 10u)
+  name: pill canister
   parent: PillCanister
   id: PillCanisterTricordrazine
-  suffix: Tricordrazine, 5
+  suffix: Tricordrazine 10u, 5
   components:
   - type: Label
     currentLabel: tricordrazine 10u
@@ -616,7 +624,8 @@
       amount: 5
 
 - type: entity
-  name: pill (bicaridine 10u)
+  name: pill
+  suffix: Bicaridine 10u
   parent: Pill
   id: PillBicaridine
   components:
@@ -635,10 +644,10 @@
           Quantity: 10
 
 - type: entity
-  name: pill canister (bicaridine 10u)
+  name: pill canister
   parent: PillCanister
   id: PillCanisterBicaridine
-  suffix: Bicaridine, 5
+  suffix: Bicaridine 10u, 5
   components:
   - type: Label
     currentLabel: bicaridine 10u
@@ -648,7 +657,8 @@
       amount: 5
 
 - type: entity
-  name: pill (charcoal 10u)
+  name: pill
+  suffix: Charcoal 10u
   parent: Pill
   id: PillCharcoal
   components:
@@ -667,10 +677,10 @@
           Quantity: 10
 
 - type: entity
-  name: pill canister (charcoal 10u)
+  name: pill canister
   parent: PillCanister
   id: PillCanisterCharcoal
-  suffix: Charcoal, 3
+  suffix: Charcoal 10u, 3
   components:
   - type: Label
     currentLabel: charcoal 10u


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Pills and pill canisters no longer have two labels in their entity names.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #29462.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Same thing as #29137, but this time it won't break the way they show in vending machines. Suffixes added to prototypes for mapping/admin use.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Code.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Pills and pill canisters no longer have two labels.