### PR TITLE
Increase lockout threshold

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -40,7 +40,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("underPressureLockoutThreshold")]
-        public float UnderPressureLockoutThreshold = 60; // this must be tuned in conjunction with atmos.mmos_spacing_speed
+        public float UnderPressureLockoutThreshold = 80; // this must be tuned in conjunction with atmos.mmos_spacing_speed
 
         /// <summary>
         ///     Pressure locked vents still leak a little (leading to eventual pressurization of sealed sections)


### PR DESCRIPTION
## About the PR
Increases vent lockout threshold some more because #28370 wasn't enough.

## Why / Balance
On live servers some vents still fail to lock out vents connected to rooms that are spaced:
![image](https://github.com/space-wizards/space-station-14/assets/3229565/dabc8efd-6f01-419e-a660-604b9437c62a)

There is a proposed fix (#29493 ), but it will take some time to finish it up and get it in. So let's band-aid it now and make sure people don't have to play a game where perfect play cannot win. This is temporary and will be obsoleted by the linked PR when it is merged.