### PR TITLE
Fix coords monitor in replays

### DIFF
--- a/Content.Client/DebugMon/DebugMonitorManager.cs
+++ b/Content.Client/DebugMon/DebugMonitorManager.cs
@@ -1,23 +1,28 @@
-using Content.Client.Administration.Managers;
+﻿using Content.Client.Administration.Managers;
 using Content.Shared.CCVar;
+using Robust.Client;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
-
 
 namespace Content.Client.DebugMon;
 
 /// <summary>
-/// This handles preventing certain debug monitors from appearing.
+/// This handles preventing certain debug monitors from being usable by non-admins.
 /// </summary>
-public sealed class DebugMonitorSystem : EntitySystem
+internal sealed class DebugMonitorManager
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IClientAdminManager _admin = default!;
     [Dependency] private readonly IUserInterfaceManager _userInterface = default!;
+    [Dependency] private readonly IBaseClient _baseClient = default!;
 
-    public override void FrameUpdate(float frameTime)
+    public void FrameUpdate()
     {
-        if (!_admin.IsActive() && _cfg.GetCVar(CCVars.DebugCoordinatesAdminOnly))
+        if (_baseClient.RunLevel == ClientRunLevel.InGame
+            && !_admin.IsActive()
+            && _cfg.GetCVar(CCVars.DebugCoordinatesAdminOnly))
+        {
             _userInterface.DebugMonitors.SetMonitor(DebugMonitor.Coords, false);
+        }
     }
 }

--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -1,6 +1,7 @@
 using Content.Client.Administration.Managers;
 using Content.Client.Changelog;
 using Content.Client.Chat.Managers;
+using Content.Client.DebugMon;
 using Content.Client.Eui;
 using Content.Client.Fullscreen;
 using Content.Client.GhostKick;
@@ -33,6 +34,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Replays;
+using Robust.Shared.Timing;
 
 namespace Content.Client.Entry
 {
@@ -68,6 +70,7 @@ namespace Content.Client.Entry
         [Dependency] private readonly IReplayLoadManager _replayLoad = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly ContentReplayPlaybackManager _replayMan = default!;
+        [Dependency] private readonly DebugMonitorManager _debugMonitorManager = default!;
 
         public override void Init()
         {
@@ -203,6 +206,14 @@ namespace Content.Client.Entry
             else
             {
                 _stateManager.RequestStateChange<MainScreen>();
+            }
+        }
+
+        public override void Update(ModUpdateLevel level, FrameEventArgs frameEventArgs)
+        {
+            if (level == ModUpdateLevel.FramePreEngine)
+            {
+                _debugMonitorManager.FrameUpdate();
             }
         }
     }

--- a/Content.Client/IoC/ClientContentIoC.cs
+++ b/Content.Client/IoC/ClientContentIoC.cs
@@ -2,6 +2,7 @@ using Content.Client.Administration.Managers;
 using Content.Client.Changelog;
 using Content.Client.Chat.Managers;
 using Content.Client.Clickable;
+using Content.Client.DebugMon;
 using Content.Client.Eui;
 using Content.Client.GhostKick;
 using Content.Client.Launcher;
@@ -48,6 +49,7 @@ namespace Content.Client.IoC
             collection.Register<DocumentParsingManager>();
             collection.Register<ContentReplayPlaybackManager, ContentReplayPlaybackManager>();
             collection.Register<ISharedPlaytimeManager, JobRequirementsManager>();
+            collection.Register<DebugMonitorManager>();
         }
     }
 }


### PR DESCRIPTION
The F3 coords manager is blocked if you're not an admin. This check happened even when playing a replay, where you actually aren't. There's now a check to make sure you are actually server-connected-to-game before running the logic.

Also moved it to a manager because this *shouldn't be a bloody entity system in the first place*.
