### PR TITLE
Remove placing items on tabletop boards.

### DIFF
--- a/Content.Server/Tabletop/TabletopSystem.cs
+++ b/Content.Server/Tabletop/TabletopSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Popups;
 using Content.Server.Tabletop.Components;
+using Content.Shared.CCVar;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
@@ -9,6 +10,7 @@ using Content.Shared.Tabletop.Events;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
+using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
@@ -23,6 +25,7 @@ namespace Content.Server.Tabletop
         [Dependency] private readonly EyeSystem _eye = default!;
         [Dependency] private readonly ViewSubscriberSystem _viewSubscriberSystem = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
 
         public override void Initialize()
         {
@@ -73,6 +76,9 @@ namespace Content.Server.Tabletop
 
         private void OnInteractUsing(EntityUid uid, TabletopGameComponent component, InteractUsingEvent args)
         {
+            if (!_cfg.GetCVar(CCVars.GameTabletopPlace))
+                return;
+
             if (!EntityManager.TryGetComponent(args.User, out HandsComponent? hands))
                 return;
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -440,6 +440,16 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> RoundEndPVSOverrides =
             CVarDef.Create("game.round_end_pvs_overrides", true, CVar.SERVERONLY);
 
+        /// <summary>
+        /// If true, players can place objects onto tabletop games like chess boards.
+        /// </summary>
+        /// <remarks>
+        /// This feature is currently highly abusable and can easily be used to crash the server,
+        /// so it's off by default.
+        /// </remarks>
+        public static readonly CVarDef<bool> GameTabletopPlace =
+            CVarDef.Create("game.tabletop_place", false, CVar.SERVERONLY);
+
         /*
          * Discord
          */


### PR DESCRIPTION
This feature should never have been merged, it can be trivially abused to break the entire server.

It's behind a CVar because honestly that's the easiest way to 1984 the feature.

:cl:
- remove: You can no longer place items onto tabletop games. The feature could be easily abused to crash the server.