### PR TITLE
Still immovable rods are now actually still

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -93,6 +93,7 @@
   components:
   - type: ImmovableRod
     randomizeVelocity: false
+    maxSpeed: 0
 
 - type: entity
   parent: ImmovableRodKeepTilesStill


### PR DESCRIPTION


<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Immovable Rod [Still] (and it's children) now spawn with 0 velocity.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
addresses #29115 
Currently the [Still] rod (and children) turns off the randomization of the rod's initial velocity, which leaves it at max speed. This PR sets the [Still] rod's max speed to 0 so in turn, the velocity will be 0.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
In the yaml where ImmovableRodKeepTilesStill is defined, add a line to the ImmovableRod component setting maxSpeed to 0 for it and it's children. When the rod initializes in OnMapInit(), velocity is multiplied by this 0, then passed into the physics system for an initial linear impulse of 0.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/95712736/31a02d86-7fd6-4424-8b75-2206d4946f0a)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
