### PR TITLE
Fixed strapped med patients standing to talk and gasp

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -44,7 +44,6 @@ public abstract partial class SharedBuckleSystem
         SubscribeLocalEvent<BuckleComponent, InsertIntoEntityStorageAttemptEvent>(OnBuckleInsertIntoEntityStorageAttempt);
 
         SubscribeLocalEvent<BuckleComponent, PreventCollideEvent>(OnBucklePreventCollide);
-        SubscribeLocalEvent<BuckleComponent, DownAttemptEvent>(OnBuckleDownAttempt);
         SubscribeLocalEvent<BuckleComponent, StandAttemptEvent>(OnBuckleStandAttempt);
         SubscribeLocalEvent<BuckleComponent, ThrowPushbackAttemptEvent>(OnBuckleThrowPushbackAttempt);
         SubscribeLocalEvent<BuckleComponent, UpdateCanMoveEvent>(OnBuckleUpdateCanMove);
@@ -145,12 +144,6 @@ public abstract partial class SharedBuckleSystem
     {
         if (args.OtherEntity == component.BuckledTo && component.DontCollide)
             args.Cancelled = true;
-    }
-
-    private void OnBuckleDownAttempt(EntityUid uid, BuckleComponent component, DownAttemptEvent args)
-    {
-        if (component.Buckled)
-            args.Cancel();
     }
 
     private void OnBuckleStandAttempt(EntityUid uid, BuckleComponent component, StandAttemptEvent args)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixed the bug where characters strapped onto a bed would visually stand to talk or gasp. 
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #29427
It was visually jarring to see strapped patients quickly rotate between standing and laying with their dying breaths
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The RotationVisualizerSystem defaults to vertical in the absence of a RotationState component. Buckling didn't set the RotationState because it relied on a call to the StandingStateSystem, but cancelled the DownAttemptEvent the StandingStateSystem raised, causing the StandingStateSystem to exit the down() function before it could set the RotationState. I removed the event handler (all it did was set the event to cancelled) so now the StandingStateSystem sets RotationState as it runs the rest of the down() function.  
I'm not sure why the buckleSystem canceled the DownAttemptEvent, but I haven't seen any unexpected behavior in my testing
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/95712736/d8223edd-f119-4d6a-b52d-3116c2ba263a)
![image](https://github.com/space-wizards/space-station-14/assets/95712736/bf8a9a6e-bac0-44a9-a3ff-5fe2aad7dfcf)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl:
- fix: Strapped medical patients no longer dramatically stand up to gasp for air.
