### PR TITLE
Make miners respect AtmosDeviceUpdateEvent.dt

### DIFF
--- a/Content.Server/Atmos/Piping/Other/Components/GasMinerComponent.cs
+++ b/Content.Server/Atmos/Piping/Other/Components/GasMinerComponent.cs
@@ -25,6 +25,9 @@ namespace Content.Server.Atmos.Piping.Other.Components
         [DataField("spawnTemperature")]
         public float SpawnTemperature { get; set; } = Atmospherics.T20C;
 
+        /// <summary>
+        ///     Number of moles created per second when the miner is working.
+        /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("spawnAmount")]
         public float SpawnAmount { get; set; } = Atmospherics.MolesCellStandard * 20f;

--- a/Content.Server/Atmos/Piping/Other/EntitySystems/GasMinerSystem.cs
+++ b/Content.Server/Atmos/Piping/Other/EntitySystems/GasMinerSystem.cs
@@ -24,18 +24,22 @@ namespace Content.Server.Atmos.Piping.Other.EntitySystems
         private void OnMinerUpdated(Entity<GasMinerComponent> ent, ref AtmosDeviceUpdateEvent args)
         {
             var miner = ent.Comp;
-            if (!CheckMinerOperation(ent, out var environment) || !miner.Enabled || !miner.SpawnGas.HasValue || miner.SpawnAmount <= 0f)
+
+            // SpawnAmount is declared in mol/s so to get the amount of gas we hope to mine, we have to multiply this by
+            // how long we have been waiting to spawn it.
+            var toSpawn = miner.SpawnAmount * args.dt;
+            if (!CheckMinerOperation(ent, toSpawn, out var environment) || !miner.Enabled || !miner.SpawnGas.HasValue || toSpawn <= 0f)
                 return;
 
             // Time to mine some gas.
 
             var merger = new GasMixture(1) { Temperature = miner.SpawnTemperature };
-            merger.SetMoles(miner.SpawnGas.Value, miner.SpawnAmount);
+            merger.SetMoles(miner.SpawnGas.Value, toSpawn);
 
             _atmosphereSystem.Merge(environment, merger);
         }
 
-        private bool CheckMinerOperation(Entity<GasMinerComponent> ent, [NotNullWhen(true)] out GasMixture? environment)
+        private bool CheckMinerOperation(Entity<GasMinerComponent> ent, float toSpawn, [NotNullWhen(true)] out GasMixture? environment)
         {
             var (uid, miner) = ent;
             var transform = Transform(uid);
@@ -59,7 +63,7 @@ namespace Content.Server.Atmos.Piping.Other.EntitySystems
 
             // External pressure above threshold.
             if (!float.IsInfinity(miner.MaxExternalPressure) &&
-                environment.Pressure > miner.MaxExternalPressure - miner.SpawnAmount * miner.SpawnTemperature * Atmospherics.R / environment.Volume)
+                environment.Pressure > miner.MaxExternalPressure - toSpawn * miner.SpawnTemperature * Atmospherics.R / environment.Volume)
             {
                 miner.Broken = true;
                 return false;

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -30,7 +30,7 @@
     - type: AtmosDevice
     - type: GasMiner
       maxExternalPressure: 300
-      spawnAmount: 200
+      spawnAmount: 400
 
 - type: entity
   name: O2 gas miner


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Make miners respect AtmosDeviceUpdateEvent.dt

Miners' prototype have been changed to reflect this (I read somewhere that we have about 1 atmos tick/0.5s, my tests show more like 1/0.53 but that looks close enough).

This also means that miner's spawnAmount is now expressed in mol/s.

See: #18781

## Why / Balance
People were reporting miners "stopped working after a while". Not sure this is the fix (or there is even a problem), but it looks right.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->