### PR TITLE
Fat extractor uses bucherable meat

### DIFF
--- a/Content.Server/Nutrition/Components/FatExtractorComponent.cs
+++ b/Content.Server/Nutrition/Components/FatExtractorComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Nutrition.EntitySystems;
+using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Nutrition.Components;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
@@ -37,12 +37,6 @@ public sealed partial class FatExtractorComponent : Component
     /// </summary>
     [DataField("nutrientPerMeat"), ViewVariables(VVAccess.ReadWrite)]
     public int NutrientPerMeat = 30;
-
-    /// <summary>
-    /// Meat spawned by the extractor.
-    /// </summary>
-    [DataField("meatPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>)), ViewVariables(VVAccess.ReadWrite)]
-    public string MeatPrototype = "FoodMeat";
 
     /// <summary>
     /// When the next update will occur

--- a/Content.Server/Nutrition/EntitySystems/FatExtractorSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FatExtractorSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.Nutrition.Components;
 using Content.Server.Power.Components;
@@ -99,6 +99,9 @@ public sealed class FatExtractorSystem : EntitySystem
         if (!TryComp<HungerComponent>(occupant, out var hunger))
             return false;
 
+        if (!HasComp<ButcherableComponent>(occupant))
+            return false;
+
         if (hunger.CurrentHunger < component.NutritionPerSecond)
             return false;
 
@@ -137,8 +140,11 @@ public sealed class FatExtractorSystem : EntitySystem
             fat.NutrientAccumulator += fat.NutritionPerSecond;
             if (fat.NutrientAccumulator >= fat.NutrientPerMeat)
             {
+                if (!TryComp<ButcherableComponent>(occupant, out var meat))
+                    return;
+
                 fat.NutrientAccumulator -= fat.NutrientPerMeat;
-                Spawn(fat.MeatPrototype, Transform(uid).Coordinates);
+                Spawn(meat.SpawnedEntities.First().PrototypeId, Transform(uid).Coordinates);
             }
         }
     }


### PR DESCRIPTION
## About the PR
Fat extractor now spawns meat depends of target butcherable meat

## Why / Balance
+ Slime people spawn meat :(
+ Pacifist way to complete corgi meat objection

## Technical details
Removed MeatPrototype datafield from FatExtractorComp
Added ButcherableComponent check to FatExtractorSystem and spawn in this system now depends on meat.SpawndEntities.First().PrototypeID

## Media


https://github.com/space-wizards/space-station-14/assets/115770678/b8acaf21-a400-40d9-9ed4-b4a69ebeef41


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Fat extractor now spawns meat depending on target's butcher meat


