### PR TITLE
Fix air vent and scrubber not requiring power

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
     public sealed partial class GasVentPumpComponent : Component
     {
         [ViewVariables(VVAccess.ReadWrite)]
-        public bool Enabled { get; set; } = true;
+        public bool Enabled { get; set; } = false;
 
         [ViewVariables]
         public bool IsDirty { get; set; } = false;

--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentScrubberComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentScrubberComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
     public sealed partial class GasVentScrubberComponent : Component
     {
         [ViewVariables(VVAccess.ReadWrite)]
-        public bool Enabled { get; set; } = true;
+        public bool Enabled { get; set; } = false;
 
         [ViewVariables]
         public bool IsDirty { get; set; } = false;


### PR DESCRIPTION
## About the PR
Found this bug while working on #29527

If you build or spawn a gas vent or scrubber outside the range of a LV power network they work without power. This happens because Enabled is true by default and only updated via a PowerChangedEvent, which does not happen without a cable connected.

As far as I am aware other atmos devices do not have this bug.

## Why / Balance
bugfix

## Technical details
true -> false

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
I hope I'm not breaking any maps with this.

**Changelog**

- fix: Fix some gas vents and scrubbers working without power.
