### PR TITLE
Bump operative reinforcement cost

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -938,7 +938,7 @@
   productEntity: ReinforcementRadioSyndicateCyborgAssault
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-borg-assault }
   cost:
-    Telecrystal: 40
+    Telecrystal: 65
   categories:
     - UplinkAllies
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -890,7 +890,7 @@
   icon: { sprite: /Textures/Objects/Misc/guardian_info.rsi, state: icon }
   productEntity: BoxHoloparasite
   cost:
-    Telecrystal: 35
+    Telecrystal: 14
   categories:
   - UplinkAllies
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -122,7 +122,7 @@
   name: uplink-sniper-bundle-name
   description: uplink-sniper-bundle-desc
   icon: { sprite: /Textures/Objects/Weapons/Guns/Snipers/heavy_sniper.rsi, state: base }
-  productEntity: BriefcaseSyndieSniperBundleFilled  
+  productEntity: BriefcaseSyndieSniperBundleFilled
   cost:
     Telecrystal: 12
   categories:
@@ -890,7 +890,7 @@
   icon: { sprite: /Textures/Objects/Misc/guardian_info.rsi, state: icon }
   productEntity: BoxHoloparasite
   cost:
-    Telecrystal: 14
+    Telecrystal: 35
   categories:
   - UplinkAllies
   conditions:
@@ -922,7 +922,7 @@
   productEntity: ReinforcementRadioSyndicateNukeops
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-urist }
   cost:
-    Telecrystal: 16
+    Telecrystal: 35  # It's incredibly easy for nukies to scrounge, particularly on warops, and arm them.
   categories:
   - UplinkAllies
   conditions:
@@ -938,7 +938,7 @@
   productEntity: ReinforcementRadioSyndicateCyborgAssault
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-borg-assault }
   cost:
-    Telecrystal: 65
+    Telecrystal: 40
   categories:
     - UplinkAllies
   conditions:
@@ -1004,7 +1004,7 @@
     Telecrystal: 6
   categories:
     - UplinkAllies
-  
+
 - type: listing
   id: UplinkSyndicatePersonalAI
   name: uplink-syndicate-pai-name


### PR DESCRIPTION
See https://github.com/tgstation/tgstation/blob/838742297ee2cd692362c42b8bccde8a5e307376/code/modules/uplink/uplink_items/nukeops.dm for tg values

Few issues:
1. I wanted to make borgs cheaper but we don't have as many tools to deal with borgs as in 13 so I left that higher for now until they're more fleshed out and we can balance them better (though they can be super squishy in some situations which is eh).
2. Operatives seem to be getting used frequently as they're easy to arm up and bump nukie numbers where they might've been 3-5 to 5-8.

:cl:
tweak: Bumped nukie operative cost from 16 to 35TC.