### PR TITLE
Change the price of traitor reinforcements to 14, nukie reinforcements to 35

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -906,7 +906,7 @@
   productEntity: ReinforcementRadioSyndicate
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-urist }
   cost:
-    Telecrystal: 16
+    Telecrystal: 14
   categories:
   - UplinkAllies
   conditions:
@@ -922,7 +922,7 @@
   productEntity: ReinforcementRadioSyndicateNukeops
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-urist }
   cost:
-    Telecrystal: 16
+    Telecrystal: 35
   categories:
   - UplinkAllies
   conditions:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changes the TC cost of syndicate traitor reinforcements from 16 TC to14 TC (matching holoparas)
And setting nukie reinforcements from 16 TC to 35 TC (TG station values)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Maintainer requested, but for the most part nuke ops lately have been doing nothing but getting as many reinforcements as possible due to the pure efficiency cost of getting a completely new op for 16 TC. This brings the value of nuclear ops reinforcements closer to their actual provided value and makes the nukie borg a bit more cost effective in comparison without making reinforcements completely worthless to go for.

Other part of the argument was that the nukie count in midpop is way too high. If this nerf doesn't solve any problems, it's likely that they'll just adjust the player ratio number for nukeops and lower the price of reinforcements.

As for the syndicate traitor thing, holoparasites are preferred 100% in favor of syndicate reinforcements because regular humans don't provide as much value during a regular round with little TC leftover to arm the reinforcement with. Holoparasites provide natural protection to their owner in place of an EMP implant (stops stun cuffing) and can gib targets easily, whereas a syndicate reinforcement is much less forgiving and requires a lot of coordination and planning to make anything work. This hopefully incentivizes more uses of the reinforcement in normal traitor rounds. Lowering the TC any further will just cause them to buy north stars for their reinforcement, turning them into a human holopara....

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
yaml

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Syndicate traitor reinforcements price has been changed from 16 TC to 14 TC.
- tweak: Nuclear ops reinforcements price has been changed from 16 TC to 35 TC.