### PR TITLE
Auto-scale sensor monitoring graph

### DIFF
--- a/Content.Client/SensorMonitoring/SensorMonitoringWindow.xaml.cs
+++ b/Content.Client/SensorMonitoring/SensorMonitoringWindow.xaml.cs
@@ -129,14 +129,7 @@ public sealed partial class SensorMonitoringWindow : FancyWindow, IComputerWindo
 
             foreach (var stream in sensor.Streams.Values)
             {
-                var maxValue = stream.Unit switch
-                {
-                    SensorUnit.PressureKpa => 5000, // 5 MPa
-                    SensorUnit.Ratio => 1,
-                    SensorUnit.PowerW => 1_000_000, // 1 MW
-                    SensorUnit.EnergyJ => 2_000_000, // 2 MJ
-                    _ => 1000
-                };
+                var maxValue = stream.Samples.Max(x => x.Value);
 
                 // TODO: Better way to do this?
                 var lastSample = stream.Samples.Last();
@@ -151,7 +144,7 @@ public sealed partial class SensorMonitoringWindow : FancyWindow, IComputerWindo
                     }
                 });
 
-                Asdf.AddChild(new GraphView(stream.Samples, startTime, curTime, maxValue) { MinHeight = 150 });
+                Asdf.AddChild(new GraphView(stream.Samples, startTime, curTime, maxValue * 1.1f) { MinHeight = 150 });
                 Asdf.AddChild(new PanelContainer { StyleClasses = { StyleBase.ClassLowDivider } });
             }
         }


### PR DESCRIPTION
## About the PR
Auto-scale the Y-axis on the sensor monitoring console, instead of hard-coding the scale.

## Why / Balance
@PJB3005 hard coded the Y-axis based on the unit. These units were useful for debugging the TEG, but not really useful in other circumstances where the numbers could be widely larger or smaller. Pointy hat for hard-coding values in the first place.

## Media
Debugging vents:

![2024-06-28_22-59](https://github.com/space-wizards/space-station-14/assets/3229565/dd8786d2-a765-46ce-92a9-86985ebde468)

![2024-06-28_23-01](https://github.com/space-wizards/space-station-14/assets/3229565/8f6e9da1-b846-4315-a61a-de7088fe1d54)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None
