### PR TITLE
Fixing Botanist role numbers in various stations

### DIFF
--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -22,7 +22,7 @@
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 2, 2 ]
-            Botanist: [ 4, 4 ]
+            Botanist: [ 3, 3 ]
             Chef: [ 2, 2 ]
             Janitor: [ 3, 3 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -20,7 +20,7 @@
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 2, 2 ]
-            Botanist: [ 4, 4 ]
+            Botanist: [ 2, 3 ]
             Chef: [ 2, 2 ]
             Janitor: [ 3, 3 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -19,7 +19,7 @@
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]
-            Botanist: [ 2, 2 ]
+            Botanist: [ 1, 2 ]
             Chef: [ 1, 1 ]
             Janitor: [ 1, 2 ]
             Chaplain: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -20,7 +20,7 @@
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]
-            Botanist: [ 2, 2 ]
+            Botanist: [ 1, 2 ]
             Chef: [ 1, 1 ]
             Janitor: [ 1, 1 ]
             Chaplain: [ 1, 1 ]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Very plainly reduced the number of botanists in some stations (Fland, Oasis, Packed, Saltern) that couldn't fit all of them.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
There is no need for (e.g.) 4 botanists in Oasis; all it will do is force 1 or 2 of them to eventually get out of the department and find something else to do.
One botanist finds it hard to work with only 3 or 4 trays unless the station is very small and cramped; if the station isn't cramped, on the other side, they should be able to utilize a higher number of trays without having to divide between many more of them.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The main thought I put behind this was that you should give a max of 5~6 trays per botanist in the bigger maps, and lower the ratio in the smaller ones, still thinking about equally splitting the trays number equally between players.
- Fland: 17 trays, that's 6 trays for one and 5 for the other 2. Doesn't need 4 players total.
- Oasis: 12 trays, it's not nearly enough for 4 players; while I was thinking of very curtly putting just 2, having another one maybe join later in the round can work, and use the dirt patches outside.
- Packed: 9 trays, small station needs less resources, so one Botanist can manage the whole department by themselves while another is able to join later.
- Saltern: 9 trays, same reasoning as Packed.

- [ ] This PR does not require an ingame showcase.

:cl: Scott Dimeling
- tweak: Reduced the number of botanists in some stations, for optimal _workflow_
