### PR TITLE
Allow gunpowder to be recycled from bullet cartridges

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -628,6 +628,7 @@
   name: gunpowder
   description: An explosive compound.
   components:
+  - type: Material
   - type: Stack
     stackType: Gunpowder
     count: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
@@ -40,3 +40,6 @@
         volume: -1
   - type: StaticPrice
     price: 1
+  - type: PhysicalComposition
+    materialComposition:
+      Gunpowder: 50

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -119,6 +119,7 @@
 
 - type: material
   id: Gunpowder
+  stackEntity: MaterialGunpowder
   name: materials-gunpowder
   unit: materials-unit-piece
   icon: { sprite: Objects/Misc/reagent_fillings.rsi, state: powderpile }


### PR DESCRIPTION
## Why / Balance
title

pipebombs are almost never used due to the fact that gunpowder is chemistry locked
this makes pipebombs possible to obtain as a non-chemist, as you can recycle casings after a gun fight to get gunpowder, while still being hard to mass-produce for a non-chemist

around 1 piece of gunpowder for every 2 bullet cartridges (material reclaimer)
around 1 piece of gunpowder for every 5 bullet cartridges (recycler)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- tweak: Bullet casings can now be recycled for gunpowder.
