### PR TITLE
fix reagent typo

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/fun.ftl
+++ b/Resources/Locale/en-US/reagents/meta/fun.ftl
@@ -25,5 +25,5 @@ reagent-desc-fresium = A mysterious compound that slows the vibration of atoms a
 reagent-name-laughter = laughter
 reagent-desc-laughter = Some say that this is the best medicine, but recent studies have proven that to be untrue.
 
-reagent-name-weh = juice that makes you Weh
+reagent-name-weh = wehstrogen
 reagent-desc-weh = Pure essence of lizard plush. Makes you Weh!


### PR DESCRIPTION
## About the PR
whispers cat ran across their keyboard when making weh pr, instead of writing "wehstrogen" they wrote "juice that makes you weh", this pr fixes the typo

## Why / Balance
typoooooooooo

## Technical details
typo

## Media
![04:26:38](https://github.com/space-wizards/space-station-14/assets/39013340/295fa6ea-edb4-40dc-89fb-4af0169edaa6)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
typo has been fixed

**Changelog**
cee ell
- add: Added fun!
