### PR TITLE
Fix unlimited MaxTraitPoints for traits

### DIFF
--- a/Content.Shared/Traits/TraitCategoryPrototype.cs
+++ b/Content.Shared/Traits/TraitCategoryPrototype.cs
@@ -21,8 +21,8 @@ public sealed partial class TraitCategoryPrototype : IPrototype
     public LocId Name { get; private set; } = string.Empty;
 
     /// <summary>
-    ///     The maximum number of traits that can be taken in this category. If -1, you can take as many traits as you like.
+    ///     The maximum number of traits that can be taken in this category.
     /// </summary>
     [DataField]
-    public int MaxTraitPoints = -1;
+    public int? MaxTraitPoints;
 }


### PR DESCRIPTION
-1 is a silly API because now you have to handle it everywhere manually instead of using nullability.

:cl:
- fix: Fix trait categories not respecting unlimited points.