### PR TITLE
Give skeletons flash immunity

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -101,6 +101,7 @@
           probability: 0.5
   - type: FireVisuals
     alternateState: Standing
+  - type: FlashImmunity
 
 - type: entity
   parent: BaseSpeciesDummy


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added FlashImmunityComponent to BaseMobSkeleton

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I'm browsing through issues I can address, https://github.com/space-wizards/space-station-14/issues/28886 exists and I want to get it closed one way or another...? It's sort of flavor for the species but they're already pretty strong so I wouldn't be surprised if it got rejected because they have to "see" somehow

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Skeletons are now immune to flashes.