### PR TITLE
Borgs can no longer be freely locked/unlocked when emagged

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -144,6 +144,7 @@
     - cell_slot
   - type: Lock
     locked: true
+    breakOnEmag: false
   - type: ActivatableUIRequiresLock
   - type: LockedWiresPanel
   - type: Damageable


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The borg lock/unlock no longer breaks when emagged, preventing people from just alt clicking borgs at random to try and lock/unlock them as an emag check

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Addresses https://github.com/space-wizards/space-station-14/issues/28878

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
true to false

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The lock on emagged borgs no longer breaks, preventing unauthorized access and emag checking.