### PR TITLE
Fixes lathe usage of EntityPrototypeView

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -217,12 +217,12 @@ public sealed partial class LatheMenu : DefaultWindow
             queuedRecipeBox.Orientation = BoxContainer.LayoutOrientation.Horizontal;
 
             var queuedRecipeProto = new EntityPrototypeView();
+            queuedRecipeBox.AddChild(queuedRecipeProto);
             if (_prototypeManager.TryIndex(recipe.Result, out EntityPrototype? entityProto) && entityProto != null)
                 queuedRecipeProto.SetPrototype(entityProto);
 
             var queuedRecipeLabel = new Label();
             queuedRecipeLabel.Text = $"{idx}. {recipe.Name}";
-            queuedRecipeBox.AddChild(queuedRecipeProto);
             queuedRecipeBox.AddChild(queuedRecipeLabel);
             QueueList.AddChild(queuedRecipeBox);
             idx++;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds the element as a child before setting the prototype which is the correct way to implement EntityPrototypeView

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
https://github.com/space-wizards/space-station-14/pull/29607 similar to this
Allows the potential to use color layers to make mag sprites rather than having a unique sprite for every mag

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
doesn't really change anything since we don't use color layers on mags yet