### PR TITLE
Remove blurry vision examine mispredict

### DIFF
--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -1,5 +1,4 @@
 using Content.Client.Verbs;
-using Content.Shared.Eye.Blinding;
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Input;
@@ -16,8 +15,6 @@ using Robust.Shared.Utility;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
-using Content.Shared.Eye.Blinding.Components;
-using Robust.Client;
 using static Content.Shared.Interaction.SharedInteractionSystem;
 using static Robust.Client.UserInterface.Controls.BoxContainer;
 using Content.Shared.Interaction.Events;
@@ -360,10 +357,7 @@ namespace Content.Client.Examine
 
             FormattedMessage message;
 
-            // Basically this just predicts that we can't make out the entity if we have poor vision.
-            var canSeeClearly = !HasComp<BlurryVisionComponent>(playerEnt);
-
-            OpenTooltip(playerEnt.Value, entity, centeredOnCursor, false, knowTarget: canSeeClearly);
+            OpenTooltip(playerEnt.Value, entity, centeredOnCursor, false);
 
             // Always update tooltip info from client first.
             // If we get it wrong, server will correct us later anyway.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
removes the examine name mispredict effect from blurry vision.

fixes #29626

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Using a misprediction as a negative effect for a status condition is unbelievably stupid. First of all, it's inherently unfair since the actual duration of the mispredict is variant on one's ping. This alone is dumb enough to justify removing it. Beyond that, it's just a pointlessly annoying effect to stack on top of the existing shader. Reducing visible screenspace with a shader is already a strong enough deterrent without making the game feel laggy and shitty.

tl;dr shit mechanic

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- remove: Blurry vision no longer causes names to momentarily appear as "???" when examining.
