### PR TITLE
Fix showing tips on the login screen from the localized tip dataset

### DIFF
--- a/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
+++ b/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
@@ -116,7 +116,7 @@ namespace Content.Client.Launcher
         private void ChangeLoginTip()
         {
             var tipsDataset = _cfg.GetCVar(CCVars.LoginTipsDataset);
-            var loginTipsEnabled = _prototype.TryIndex<DatasetPrototype>(tipsDataset, out var tips);
+            var loginTipsEnabled = _prototype.TryIndex<LocalizedDatasetPrototype>(tipsDataset, out var tips);
 
             LoginTips.Visible = loginTipsEnabled;
             if (!loginTipsEnabled)
@@ -131,7 +131,7 @@ namespace Content.Client.Launcher
 
             var randomIndex = _random.Next(tipList.Count);
             var tip = tipList[randomIndex];
-            LoginTip.SetMessage(tip);
+            LoginTip.SetMessage(Loc.GetString(tip));
 
             LoginTipTitle.Text = Loc.GetString("connecting-window-tip", ("numberTip", randomIndex));
         }


### PR DESCRIPTION
Regression introduced in #28285

The tips system that sends messages to the chat was patched to use a localized tips dataset but the tips display on the launcher connecting gui wasn't.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- fix: Fixed login tips

