### PR TITLE
Remove bad annotation from GasMinerSystem

### DIFF
--- a/Content.Server/Atmos/Piping/Other/EntitySystems/GasMinerSystem.cs
+++ b/Content.Server/Atmos/Piping/Other/EntitySystems/GasMinerSystem.cs
@@ -39,7 +39,7 @@ namespace Content.Server.Atmos.Piping.Other.EntitySystems
             _atmosphereSystem.Merge(environment, merger);
         }
 
-        private float CapSpawnAmount(Entity<GasMinerComponent> ent, float toSpawnTarget, [NotNullWhen(true)] out GasMixture? environment)
+        private float CapSpawnAmount(Entity<GasMinerComponent> ent, float toSpawnTarget, out GasMixture? environment)
         {
             var (uid, miner) = ent;
             var transform = Transform(uid);


### PR DESCRIPTION
The NotNullWhen was making Rider's linter show an error

I don't think it was applicable because CapSpawnAmount returns a float and NotNullWhen only deals with a boolean.