### PR TITLE
Move ratking crown to grand lottery

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
@@ -268,6 +268,9 @@
     - id: ClothingBeltChampion
       prob: 0.01
       orGroup: Swag
+    - id: ClothingHeadHatFancyCrown
+      prob: 0.01
+      orGroup: Swag
     #plushies
     - id: PlushieRGBee
       prob: 0.01

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -104,10 +104,6 @@
   - type: MobsterAccent
   - type: Speech
     speechVerb: SmallMob
-  - type: Butcherable
-    spawned:
-    - id: ClothingHeadHatFancyCrown #how did that get there?
-      amount: 1
   - type: MobPrice
     price: 2500 # rat wealth
   - type: RandomMetadata


### PR DESCRIPTION
## About the PR
Ratkings can no longer be butchered. You can obtain the crown in a grand lottery instead.

## Why / Balance
Giving any kind of loot for killing a neutral role is a recipe for validhunting, which is exactly what happens now.

## Technical details

## Media
changes tested
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl:
- add: Fancy crowns can be now found in grand lottery crates.
- remove: Rat kings no longer can be butchered.
