### PR TITLE
Fixed buckled players thrashing while speaking in beds

### DIFF
--- a/Content.Client/Rotation/RotationVisualizerSystem.cs
+++ b/Content.Client/Rotation/RotationVisualizerSystem.cs
@@ -23,8 +23,8 @@ public sealed class RotationVisualizerSystem : SharedRotationVisualsSystem
         if (args.Sprite == null)
             return;
 
-        // If not defined, defaults to standing.
-        _appearance.TryGetData<RotationState>(uid, RotationVisuals.RotationState, out var state, args.Component);
+        if (!_appearance.TryGetData<RotationState>(uid, RotationVisuals.RotationState, out var state, args.Component))
+            return;
 
         switch (state)
         {

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -9,6 +9,7 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Popups;
 using Content.Shared.Pulling.Events;
+using Content.Shared.Rotation;
 using Content.Shared.Standing;
 using Content.Shared.Storage.Components;
 using Content.Shared.Stunnable;
@@ -195,6 +196,7 @@ public abstract partial class SharedBuckleSystem
         buckle.Comp.BuckleTime = _gameTiming.CurTime;
         ActionBlocker.UpdateCanMove(buckle);
         Appearance.SetData(buckle, StrapVisuals.State, buckle.Comp.Buckled);
+        Appearance.SetData(buckle, RotationVisuals.RotationState, RotationState.Horizontal);
         Dirty(buckle);
     }
 
@@ -348,6 +350,7 @@ public abstract partial class SharedBuckleSystem
         SetBuckledTo(buckle, strap!);
         Appearance.SetData(strap, StrapVisuals.State, true);
         Appearance.SetData(buckle, BuckleVisuals.Buckled, true);
+        Appearance.SetData(buckle, RotationVisuals.RotationState, RotationState.Horizontal);
 
         _rotationVisuals.SetHorizontalAngle(buckle.Owner, strap.Comp.Rotation);
 
@@ -455,6 +458,7 @@ public abstract partial class SharedBuckleSystem
         _rotationVisuals.ResetHorizontalAngle(buckle.Owner);
         Appearance.SetData(strap, StrapVisuals.State, strap.Comp.BuckledEntities.Count != 0);
         Appearance.SetData(buckle, BuckleVisuals.Buckled, false);
+        Appearance.SetData(buckle, RotationVisuals.RotationState, RotationState.Vertical);
 
         if (HasComp<KnockedDownComponent>(buckle) || _mobState.IsIncapacitated(buckle))
             _standing.Down(buckle);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Characters no longer briefly appear to stand up when they speak while strapped to a bed.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #29427.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The movement was happening because `RotationVisualizerSystem` subscribes to `AppearanceChangeEvent` on the buckled player, and makes the curious choice of assuming that the player is standing if `AppearanceComponent` doesn't contain a value for `RotationState`. Meanwhile, `BuckleSystem` uses a client-only method of `RotationVisualizerSystem` to rotate the player while buckled. `RotationVisualizerSystem` would be happy to bulldoze that rotation when it got a `AppearanceChangeEvent`.

The problem happens when something else causes an `AppearanceChangeEvent` on the buckled player. And typing indicators recently became predicted (#29551) using `AppearanceComponent` to track the indicator state. So when the player types, it sends raises an `AppearanceChangeEvent`, and the `AppearanceComponent` doesn't have a value for `RotationState`, so it gets set to the default `Vertical` again before getting animated back to `Horizontal` by `BuckleSystem`. What fun!

This PR fixes the issue by removing the logic from `RotationVisualizerSystem` that causes unrelated appearance updates to default to vertical, because that's just asking for more trouble in the future. It then changes `BuckleSystem` to make deliberate calls to `AppearanceSystem` to set horizontal/vertical rotation when buckled/unbuckled.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed characters thrashing when speaking in beds.