### PR TITLE
Add examine text to the gas miner (small refactor of GasMinerSystem)

### DIFF
--- a/Content.Server/Atmos/Piping/Other/Components/GasMinerComponent.cs
+++ b/Content.Server/Atmos/Piping/Other/Components/GasMinerComponent.cs
@@ -5,14 +5,22 @@ namespace Content.Server.Atmos.Piping.Other.Components
     [RegisterComponent]
     public sealed partial class GasMinerComponent : Component
     {
+        [ViewVariables(VVAccess.ReadWrite)]
         public bool Enabled { get; set; } = true;
 
-        public bool Broken { get; set; } = false;
+        [ViewVariables(VVAccess.ReadOnly)]
+        public bool Idle { get; set; } = false;
 
+        /// <summary>
+        ///      If the number of moles in the external environment exceeds number, no gas will be mined.
+        /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("maxExternalAmount")]
         public float MaxExternalAmount { get; set; } = float.PositiveInfinity;
 
+        /// <summary>
+        ///      If the pressure (in kPA) of the external environment exceeds number, no gas will be mined.
+        /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("maxExternalPressure")]
         public float MaxExternalPressure { get; set; } = Atmospherics.GasMinerDefaultMaxExternalPressure;

--- a/Resources/Locale/en-US/atmos/gas-miner-component.ftl
+++ b/Resources/Locale/en-US/atmos/gas-miner-component.ftl
@@ -1,0 +1,11 @@
+gas-miner-examine-header-text = The nameplate reads:
+
+gas-miner-amount-text = Gas Moles: {$moles}/sec
+gas-miner-temperature-text = Gas Temperature: {$tempK}K ({$tempC}°C)
+
+gas-miner-moles-cutoff-text = Moles Cutoff: {$moles} moles
+gas-miner-pressure-cutoff-text = Pressure Cutoff: {$pressure} kPA
+
+gas-miner-state-working-text = The miner is [color=green]producing[/color] gas
+gas-miner-state-idle-text = The miner is [color=yellow]idle[/color]
+gas-miner-state-disabled-text = The miner is [color=red]disabled[/color]

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -66,8 +66,6 @@
   parent: GasMinerBase
   id: GasMinerNitrogen
   suffix: Shuttle, 300kPa
-  placement:
-    mode: SnapgridCenter
   components:
     - type: GasMiner
       spawnGas: Nitrogen
@@ -94,8 +92,6 @@
   name: CO2 gas miner
   parent: GasMinerBase
   id: GasMinerCarbonDioxide
-  placement:
-    mode: SnapgridCenter
   components:
     - type: GasMiner
       spawnGas: CarbonDioxide
@@ -104,8 +100,6 @@
   name: plasma gas miner
   parent: GasMinerBase
   id: GasMinerPlasma
-  placement:
-    mode: SnapgridCenter
   components:
     - type: GasMiner
       spawnGas: Plasma
@@ -114,8 +108,6 @@
   name: tritium gas miner
   parent: GasMinerBase
   id: GasMinerTritium
-  placement:
-    mode: SnapgridCenter
   components:
     - type: GasMiner
       spawnGas: Tritium
@@ -124,8 +116,6 @@
   name: water vapor gas miner
   parent: GasMinerBase
   id: GasMinerWaterVapor
-  placement:
-    mode: SnapgridCenter
   components:
     - type: GasMiner
       spawnGas: WaterVapor
@@ -134,8 +124,6 @@
   name: ammonia gas miner
   parent: GasMinerBase
   id: GasMinerAmmonia
-  placement:
-    mode: SnapgridCenter
   components:
     - type: GasMiner
       spawnGas: Ammonia
@@ -144,8 +132,6 @@
   name: nitrous oxide gas miner
   parent: GasMinerBase
   id: GasMinerNitrousOxide
-  placement:
-    mode: SnapgridCenter
   components:
     - type: GasMiner
       spawnGas: NitrousOxide


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds examine text to the Gas Miner so that all its stats and its current state can be seen. Thanks to @quatre for #29522 and #29569 where they sorted out the math behind the miners stalling below their rated pressure.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

- As long as the gas miner is in the game (and it will be still be in for a while, I expect) it deserves some proper examine text. 
- Combined with quatre's changes to the mole calculations, this should make it much easier for atmos techs to reason about the behavior of gas miners.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

- `Broken` renamed `Idle` to better reflect the actual state it's in.
- Separated the environment check from `CapSpawnAmount` into `GetValidEnvironment` to clean up some of the code a little, and so that examining the miner can show when the miner is in an invalid environment, instead of juts blocked by external gas.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![2024-07-01 14_25_35-Space Station 14](https://github.com/space-wizards/space-station-14/assets/6798456/5395980c-3a93-4af5-a65f-01fbc6a5522d)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
- tweak: Gas Miners now have detailed examine text
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
