### PR TITLE
Added a SteelSheet and GlassSheet reactions to fun.yml to go along with the PlasticSheet reaction

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/fun.ftl
+++ b/Resources/Locale/en-US/reagents/meta/fun.ftl
@@ -27,3 +27,6 @@ reagent-desc-laughter = Some say that this is the best medicine, but recent stud
 
 reagent-name-weh = juice that makes you Weh
 reagent-desc-weh = Pure essence of lizard plush. Makes you Weh!
+
+reagent-name-sand = sand
+reagent-desc-sand = A grainy mix of minerals created by erosion. Useful for making glass.

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -349,3 +349,14 @@
         conditions:
         - !type:ReagentThreshold
           min: 50
+
+- type: reagent
+  id: Sand
+  name: reagent-name-sand
+  desc: reagent-desc-sand
+  physicalDesc: reagent-physical-desc-grainy
+  flavor: salty
+  color: "#c2b280"
+  recognizable: true
+  boilingPoint: 2962.0
+  meltingPoint: 1638.0

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -93,7 +93,7 @@
     Licoxide: 1
 
 - type: reaction
-  id: PlasticSheet # It's here because "haha look you can get smooth beautiful sheets of plastic from small cylindric beaker" (jokes aside: i dont know where should i put it)
+  id: PlasticSheet # plastic steel and glass should have their own .yml file named "materials.yml". also note how all material reactions total to 10 reactants to follow balance
   impact: Low
   quantized: true
   minTemp: 374
@@ -107,6 +107,37 @@
   effects:
     - !type:CreateEntityReactionEffect
       entity: SheetPlastic1
+
+- type: reaction
+  id: SteelSheet
+  impact: Low
+  quantized: true
+  minTemp: 374  # real life value is around 1700K
+  reactants:
+    Iron:
+      amount: 9
+    Carbon:
+      amount: 1
+  effects:
+    - !type:CreateEntityReactionEffect
+      entity: SheetSteel1
+
+- type: reaction
+  id: GlassSheet
+  impact: Low
+  quantized: true
+  minTemp: 374
+  reactants:  # glass is made from sand, which is made from silicon dioxide (added water to make it more balanced)
+    Silicon:
+      amount: 3
+    Oxygen:
+      amount: 6
+    Water:
+      amount: 1
+  effects:
+    - !type:CreateEntityReactionEffect
+      entity: SheetGlass1
+
 
 - type: reaction
   id: FlashFreezeIce

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -112,28 +112,43 @@
   id: SteelSheet
   impact: Low
   quantized: true
-  minTemp: 374  # real life value is around 1700K
+  minTemp: 678  # real life value is around 1700K
   reactants:
     Iron:
-      amount: 9
-    Carbon:
-      amount: 1
+      amount: 5
+    Fersilicite:
+      amount: 3
+    SodiumCarbonate:
+      amount: 2
   effects:
     - !type:CreateEntityReactionEffect
       entity: SheetSteel1
+
+- type: reaction  # glass is made from sand, which is made from silicon dioxide
+  id: Sand
+  reactants:
+    Silicon:
+      amount: 1
+    Oxygen:
+      amount: 2
+    TableSalt:
+      amount: 1
+  products:
+    Sand: 4
+
 
 - type: reaction
   id: GlassSheet
   impact: Low
   quantized: true
-  minTemp: 374
-  reactants:  # glass is made from sand, which is made from silicon dioxide (added water to make it more balanced)
-    Silicon:
-      amount: 3
+  minTemp: 583
+  reactants:  # glass is made from sand, which is made from silicon dioxide
+    Sand:
+      amount: 5
     Oxygen:
-      amount: 6
-    Water:
-      amount: 1
+      amount: 3
+    Potassium:
+      amount: 2
   effects:
     - !type:CreateEntityReactionEffect
       entity: SheetGlass1


### PR DESCRIPTION


<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

**Disclaimer**: This is my first PR and a learning experience to get used to the codebase and git colaboration. I do not expect this to get merged, however it would be _really_ cool if it did. 

Currently, you can make plastic as a chemical reaction. Why not include Steel and Glass as well? This adds two new reactions to the fun.yml file right below the Plastic reaction.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Plastic reaction is not really economic as we don't players to spam materials round start in Chemistry. It is not their job. Materials made in a beaker should be made as a last resort if Cargo is not operational or if you can't find things to salvage.

The plastic reaction reagents add up to 10 total to create a single sheet so I followed that formula to balance Glass and Steel. I tried loosely basing them on real life chemical reactions. It also gives more gameplay value to the Iron chemical.

Recipes:

1 Steel sheet:
 - 9 iron
 - 1 carbon

1 Glass sheet:
 - 3 silicon
 - 6 oxygen
 - 1 water


## Sidenote

if this gets implemented maybe move them to their own materials.yml file because they don't really fit theme of "fun"


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
🆑 
- add: Steel Sheets and Glass sheets can now be created by heating chemicals in a beaker

