### PR TITLE
fix(SharedGunSystem): Return and debug log on CreateEffect.

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -276,6 +276,14 @@ public sealed partial class GunSystem : SharedGunSystem
         if (!Timing.IsFirstTimePredicted)
             return;
 
+        // EntityUid check added to stop throwing exceptions due to https://github.com/space-wizards/space-station-14/issues/28252
+        // TODO: Check to see why invalid entities are firing effects.
+        if (gunUid == EntityUid.Invalid)
+        {
+            Log.Debug($"Invalid Entity sent MuzzleFlashEvent (proto: {message.Prototype}, user: {user})");
+            return;
+        }
+
         var gunXform = Transform(gunUid);
         var gridUid = gunXform.GridUid;
         EntityCoordinates coordinates;


### PR DESCRIPTION
## About the PR
Sometimes CreateEffect is called on a Invalid Entity. This now causes that to check, thus returning out and printing some hopefully helpful logs to try to track down the real source of this issue.

Any suggestions on how to make the debug line more useful would be nice, it's hard to report this.

Related: https://github.com/space-wizards/space-station-14/issues/28252