### PR TITLE
Fix MouseRotator on rotated grids

### DIFF
--- a/Content.Client/MouseRotator/MouseRotatorSystem.cs
+++ b/Content.Client/MouseRotator/MouseRotatorSystem.cs
@@ -50,9 +50,14 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
             if (angleDir == (curRot + eyeRot).GetCardinalDir())
                 return;
 
+            var rotation = angleDir.ToAngle() - eyeRot; // convert back to world frame
+            if (rotation >= Math.PI) // convert to [-PI, +PI)
+                rotation -= 2 * Math.PI;
+            else if (rotation < -Math.PI)
+                rotation += 2 * Math.PI;
             RaisePredictiveEvent(new RequestMouseRotatorRotationEvent
             {
-                Rotation = angleDir.ToAngle() - eyeRot // convert back to world frame
+                Rotation = rotation
             });
 
             return;

--- a/Content.Client/MouseRotator/MouseRotatorSystem.cs
+++ b/Content.Client/MouseRotator/MouseRotatorSystem.cs
@@ -2,7 +2,6 @@
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
-using Robust.Client.Replays.Loading;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
 
@@ -32,10 +31,9 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
         var xform = Transform(player.Value);
 
         // Get mouse loc and convert to angle based on player location
-        var coords = _input.MouseScreenPosition; // F3: Mouse Pos Screen
-        var mapPos = _eye.PixelToMap(coords); // F3: Mouse Pos Map
+        var coords = _input.MouseScreenPosition;
+        var mapPos = _eye.PixelToMap(coords);
 
-        //Log.Debug($"{coords.X}, {coords.Y}, {mapPos.X}, {mapPos.Y}");
         if (mapPos.MapId == MapId.Nullspace)
             return;
 
@@ -43,21 +41,18 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
 
         var curRot = _transform.GetWorldRotation(xform);
 
-        var eyeRot = _eye.CurrentEye.Rotation;
-
-        //Log.Debug($"{angle.Degrees}, {curRot.Degrees}, {eyeRot.Degrees}");
-
         // 4-dir handling is separate --
         // only raise event if the cardinal direction has changed
         if (rotator.Simple4DirMode)
         {
+            var eyeRot = _eye.CurrentEye.Rotation; // camera rotation
             var angleDir = (angle + eyeRot).GetCardinalDir(); // apply GetCardinalDir in the camera frame, not in the world frame
             if (angleDir == (curRot + eyeRot).GetCardinalDir())
                 return;
 
             RaisePredictiveEvent(new RequestMouseRotatorRotationEvent
             {
-                Rotation = angleDir.ToAngle() - eyeRot
+                Rotation = angleDir.ToAngle() - eyeRot // convert back to world frame
             });
 
             return;

--- a/Content.Client/MouseRotator/MouseRotatorSystem.cs
+++ b/Content.Client/MouseRotator/MouseRotatorSystem.cs
@@ -32,9 +32,10 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
         var xform = Transform(player.Value);
 
         // Get mouse loc and convert to angle based on player location
-        var coords = _input.MouseScreenPosition;
-        var mapPos = _eye.PixelToMap(coords);
+        var coords = _input.MouseScreenPosition; // F3: Mouse Pos Screen
+        var mapPos = _eye.PixelToMap(coords); // F3: Mouse Pos Map
 
+        //Log.Debug($"{coords.X}, {coords.Y}, {mapPos.X}, {mapPos.Y}");
         if (mapPos.MapId == MapId.Nullspace)
             return;
 
@@ -42,17 +43,21 @@ public sealed class MouseRotatorSystem : SharedMouseRotatorSystem
 
         var curRot = _transform.GetWorldRotation(xform);
 
+        var eyeRot = _eye.CurrentEye.Rotation;
+
+        //Log.Debug($"{angle.Degrees}, {curRot.Degrees}, {eyeRot.Degrees}");
+
         // 4-dir handling is separate --
         // only raise event if the cardinal direction has changed
         if (rotator.Simple4DirMode)
         {
-            var angleDir = angle.GetCardinalDir();
-            if (angleDir == curRot.GetCardinalDir())
+            var angleDir = (angle + eyeRot).GetCardinalDir(); // apply GetCardinalDir in the camera frame, not in the world frame
+            if (angleDir == (curRot + eyeRot).GetCardinalDir())
                 return;
 
-            RaisePredictiveEvent(new RequestMouseRotatorRotationSimpleEvent()
+            RaisePredictiveEvent(new RequestMouseRotatorRotationEvent
             {
-                Direction = angleDir,
+                Rotation = angleDir.ToAngle() - eyeRot
             });
 
             return;

--- a/Content.Shared/MouseRotator/MouseRotatorComponent.cs
+++ b/Content.Shared/MouseRotator/MouseRotatorComponent.cs
@@ -30,8 +30,7 @@ public sealed partial class MouseRotatorComponent : Component
     public double RotationSpeed = float.MaxValue;
 
     /// <summary>
-    ///     This one is important. If this is true, <see cref="AngleTolerance"/> does not apply, and the system will
-    ///     use <see cref="RequestMouseRotatorRotationSimpleEvent"/> instead. In this mode, the client will only send
+    ///     This one is important. If this is true, <see cref="AngleTolerance"/> does not apply. In this mode, the client will only send
     ///     events when an entity should snap to a different cardinal direction, rather than for every angle change.
     ///
     ///     This is useful for cases like humans, where what really matters is the visual sprite direction, as opposed to something
@@ -49,14 +48,4 @@ public sealed partial class MouseRotatorComponent : Component
 public sealed class RequestMouseRotatorRotationEvent : EntityEventArgs
 {
     public Angle Rotation;
-}
-
-/// <summary>
-///     Simpler version of <see cref="RequestMouseRotatorRotationEvent"/> for implementations
-///     that only require snapping to 4-dir and not full angle rotation.
-/// </summary>
-[Serializable, NetSerializable]
-public sealed class RequestMouseRotatorRotationSimpleEvent : EntityEventArgs
-{
-    public Direction Direction;
 }

--- a/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
+++ b/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
@@ -50,7 +50,7 @@ public abstract class SharedMouseRotatorSystem : EntitySystem
     private void OnRequestRotation(RequestMouseRotatorRotationEvent msg, EntitySessionEventArgs args)
     {
         if (args.SenderSession.AttachedEntity is not { } ent
-            || !TryComp<MouseRotatorComponent>(ent, out var rotator) || rotator.Simple4DirMode)
+            || !TryComp<MouseRotatorComponent>(ent, out var rotator))
         {
             Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting local rotation directly without a valid mouse rotator component attached!");
             return;

--- a/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
+++ b/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Shared.Interaction;
-using Robust.Shared.Timing;
 
 namespace Content.Shared.MouseRotator;
 
@@ -16,7 +15,6 @@ public abstract class SharedMouseRotatorSystem : EntitySystem
         base.Initialize();
 
         SubscribeAllEvent<RequestMouseRotatorRotationEvent>(OnRequestRotation);
-        SubscribeAllEvent<RequestMouseRotatorRotationSimpleEvent>(OnRequestSimpleRotation);
     }
 
     public override void Update(float frameTime)
@@ -57,19 +55,6 @@ public abstract class SharedMouseRotatorSystem : EntitySystem
         }
 
         rotator.GoalRotation = msg.Rotation;
-        Dirty(ent, rotator);
-    }
-
-    private void OnRequestSimpleRotation(RequestMouseRotatorRotationSimpleEvent ev, EntitySessionEventArgs args)
-    {
-        if (args.SenderSession.AttachedEntity is not { } ent
-            || !TryComp<MouseRotatorComponent>(ent, out var rotator) || !rotator.Simple4DirMode)
-        {
-            Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting 4-dir rotation directly without a valid mouse rotator component attached!");
-            return;
-        }
-
-        rotator.GoalRotation = ev.Direction.ToAngle();
         Dirty(ent, rotator);
     }
 }


### PR DESCRIPTION
## About the PR
Fixes the player sprite in harm mode behaving weirdly if the grid the player is on is rotated.
Huge thanks to @Plykiya for pointing me in the right direction (pun intended).

Fixes #24636
Fixes #20731

## Why / Balance
Bugfix

## Technical details
We convert the angle into the camera's frame of reference, then apply GetCardinalDir to snap to the grid, then convert back to the world frame. Since the conversion back needs the camera angle, we cannot do this in shared (EyeManager is client side) and have to send the full rotation instead of only the direction via the event.
Note that we cannot use the grid rotation for this, since the player can leave the grid into space and the camera will stay the same until reorientated.

For debugging, use the `showrot` command and press F3 to see the players rotation and mouse position.

## Media
before: 

https://github.com/space-wizards/space-station-14/assets/161409025/87f19e19-df24-41f8-9354-7f4c90e7d85d

after:

https://github.com/space-wizards/space-station-14/assets/161409025/0fd62130-2ade-4e81-9a1f-6427de64aa08


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed sprite rotation in harm mode on rotated grids.
