### PR TITLE
Change suit sensors on other players

### DIFF
--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -14,43 +14,43 @@ public sealed partial class SuitSensorComponent : Component
     /// <summary>
     ///     Choose a random sensor mode when item is spawned.
     /// </summary>
-    [DataField("randomMode")]
+    [DataField]
     public bool RandomMode = true;
 
     /// <summary>
     ///     If true user can't change suit sensor mode
     /// </summary>
-    [DataField("controlsLocked")]
+    [DataField]
     public bool ControlsLocked = false;
 
     /// <summary>
-    ///  How many time you need to change sensors on other player
+    ///  How much time it takes to change another player's sensors
     /// </summary>
-    [DataField("sensorsTime")]
+    [DataField]
     public float SensorsTime = 1.75f;
 
     /// <summary>
     ///     Current sensor mode. Can be switched by user verbs.
     /// </summary>
-    [DataField("mode")]
+    [DataField]
     public SuitSensorMode Mode = SuitSensorMode.SensorOff;
 
     /// <summary>
     ///     Activate sensor if user wear it in this slot.
     /// </summary>
-    [DataField("activationSlot")]
+    [DataField]
     public string ActivationSlot = "jumpsuit";
 
     /// <summary>
     /// Activate sensor if user has this in a sensor-compatible container.
     /// </summary>
-    [DataField("activationContainer")]
+    [DataField]
     public string? ActivationContainer;
 
     /// <summary>
     ///     How often does sensor update its owners status (in seconds). Limited by the system update rate.
     /// </summary>
-    [DataField("updateRate")]
+    [DataField]
     public TimeSpan UpdateRate = TimeSpan.FromSeconds(2f);
 
     /// <summary>
@@ -62,7 +62,7 @@ public sealed partial class SuitSensorComponent : Component
     /// <summary>
     ///     Next time when sensor updated owners status
     /// </summary>
-    [DataField("nextUpdate", customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoPausedField]
     public TimeSpan NextUpdate = TimeSpan.Zero;
 

--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -24,6 +24,12 @@ public sealed partial class SuitSensorComponent : Component
     public bool ControlsLocked = false;
 
     /// <summary>
+    ///  How many time you need to change sensors on other player
+    /// </summary>
+    [DataField("sensorsTime")]
+    public float SensorsTime = 1.75f;
+
+    /// <summary>
     ///     Current sensor mode. Can be switched by user verbs.
     /// </summary>
     [DataField("mode")]

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -301,7 +301,7 @@ public sealed class SuitSensorSystem : EntitySystem
         return Loc.GetString(name);
     }
 
-    public void TrySetSensor(Entity<SuitSensorComponent?> sensors, SuitSensorMode mode, EntityUid userUid)
+    public void TrySetSensor(Entity<SuitSensorComponent> sensors, SuitSensorMode mode, EntityUid userUid)
     {
         var comp = sensors.Comp;
 
@@ -323,20 +323,17 @@ public sealed class SuitSensorSystem : EntitySystem
         }
     }
 
-    private void OnSuitSensorDoAfter(EntityUid uid, SuitSensorComponent component, SuitSensorChangeDoAfterEvent args)
+    private void OnSuitSensorDoAfter(Entity<SuitSensorComponent> sensors, ref SuitSensorChangeDoAfterEvent args)
     {
         if (args.Handled || args.Cancelled)
             return;
 
-        SetSensor((uid, component), args.Mode, args.User);
+        SetSensor(sensors, args.Mode, args.User);
     }
 
-    public void SetSensor(Entity<SuitSensorComponent?> sensors, SuitSensorMode mode, EntityUid? userUid = null)
+    public void SetSensor(Entity<SuitSensorComponent> sensors, SuitSensorMode mode, EntityUid? userUid = null)
     {
         var comp = sensors.Comp;
-
-        if (!Resolve(sensors, ref comp))
-            return;
 
         comp.Mode = mode;
 

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.GameTicking;
 using Content.Server.Medical.CrewMonitoring;
 using Content.Server.Popups;
 using Content.Server.Station.Systems;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Clothing;
 using Content.Shared.Damage;
 using Content.Shared.DeviceNetwork;
@@ -39,6 +40,7 @@ public sealed class SuitSensorSystem : EntitySystem
     [Dependency] private readonly MobThresholdSystem _mobThresholdSystem = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
 
     public override void Initialize()
     {
@@ -216,7 +218,7 @@ public sealed class SuitSensorSystem : EntitySystem
         if (!_interactionSystem.InRangeUnobstructed(args.User, args.Target))
             return;
 
-        if (component.User != null && args.User != component.User && _mobStateSystem.IsAlive(component.User.Value))
+        if (component.User != null && args.User != component.User && _actionBlocker.CanInteract(component.User.Value, null))
             return;
 
         args.Verbs.UnionWith(new[]
@@ -309,7 +311,7 @@ public sealed class SuitSensorSystem : EntitySystem
         else
         {
             var doAfterEvent = new SuitSensorChangeDoAfterEvent(mode);
-            var doAfterArgs = new DoAfterArgs(EntityManager, userUid, 3.0f, doAfterEvent, uid)
+            var doAfterArgs = new DoAfterArgs(EntityManager, userUid, component.SensorsTime, doAfterEvent, uid)
             {
                 BreakOnMove = true,
                 BreakOnDamage = true

--- a/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
+++ b/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
@@ -1,3 +1,4 @@
+using Content.Shared.DoAfter;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
 
@@ -66,4 +67,17 @@ public static class SuitSensorConstants
 
     ///Used by the CrewMonitoringServerSystem to send the status of all connected suit sensors to each crew monitor
     public const string NET_STATUS_COLLECTION = "suit-status-collection";
+}
+
+[Serializable, NetSerializable]
+public sealed partial class SuitSensorChangeDoAfterEvent : DoAfterEvent
+{
+    public SuitSensorMode Mode { get; private set; } = SuitSensorMode.SensorOff;
+
+    public SuitSensorChangeDoAfterEvent(SuitSensorMode mode)
+    {
+        Mode = mode;
+    }
+
+    public override DoAfterEvent Clone() => this;
 }


### PR DESCRIPTION
## About the PR
You can now change suit sensors on other players if they can't interact (crit/dead/cuffed/sleep/stunned etc)
You can easily change your suit sensor or ownerless suit sensors without delay, but when you change suit sensors on another body you'll have 1.75 sec doAfter

## Why / Balance
Just QOL tweak for med and antagonists players. Before this you had to strip off people just to hide them.

## Technical details
Some new conditions check on server's side + doafterevent in shared.

## Media

https://github.com/space-wizards/space-station-14/assets/115770678/f266cf44-10d4-4e5e-950c-083145ffec02

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: You can now change the suit's sensors on incapacitated people without taking it off


