### PR TITLE
Make camera recoil system only refresh offset when its values change

### DIFF
--- a/Content.Shared/Camera/CameraRecoilComponent.cs
+++ b/Content.Shared/Camera/CameraRecoilComponent.cs
@@ -8,6 +8,7 @@ namespace Content.Shared.Camera;
 public sealed partial class CameraRecoilComponent : Component
 {
     public Vector2 CurrentKick { get; set; }
+    public Vector2 LastKick { get; set; }
     public float LastKickTime { get; set; }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
It was taking up 3.38% of TickUpdate time in RMC14.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

