### PR TITLE
Jaws of Life Can Now Open Lockers and Crates 

### DIFF
--- a/Content.Client/Prying/PryingSystem.cs
+++ b/Content.Client/Prying/PryingSystem.cs
@@ -1,40 +1,8 @@
-using Content.Client.Storage.Components;
-using Content.Shared.Popups;
-using Content.Shared.Prying.Components;
 using Content.Shared.Prying.Systems;
-using Robust.Shared.Audio.Systems;
 
 namespace Content.Client.Prying;
 
 public sealed class PryingSystem : SharedPryingSystem
 {
-    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
-    public override void Initialize()
-    {
-        base.Initialize();
-        SubscribeLocalEvent<EntityStorageComponent, PryDoAfterEvent>(OnDoAfter);
-    }
 
-    private void OnDoAfter(EntityUid uid, EntityStorageComponent storage, PryDoAfterEvent args)
-    {
-        if (args.Cancelled)
-            return;
-        if (args.Target is null)
-            return;
-
-        TryComp<PryingComponent>(args.Used, out var comp);
-
-        if (!CanPry(uid, args.User, out var message, comp))
-        {
-            if (!string.IsNullOrWhiteSpace(message))
-                _popup.PopupClient(Loc.GetString(message), uid, args.User);
-            return;
-        }
-
-        if (args.Used != null && comp != null)
-        {
-            _audioSystem.PlayPredicted(comp.UseSound, args.Used.Value, args.User);
-        }
-    }
 }

--- a/Content.Client/Prying/PryingSystem.cs
+++ b/Content.Client/Prying/PryingSystem.cs
@@ -13,10 +13,10 @@ public sealed class PryingSystem : SharedPryingSystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<EntityStorageComponent, DoorPryDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<EntityStorageComponent, PryDoAfterEvent>(OnDoAfter);
     }
 
-    private void OnDoAfter(EntityUid uid, EntityStorageComponent storage, DoorPryDoAfterEvent args)
+    private void OnDoAfter(EntityUid uid, EntityStorageComponent storage, PryDoAfterEvent args)
     {
         if (args.Cancelled)
             return;

--- a/Content.Client/Prying/PryingSystem.cs
+++ b/Content.Client/Prying/PryingSystem.cs
@@ -1,0 +1,40 @@
+using Content.Client.Storage.Components;
+using Content.Shared.Popups;
+using Content.Shared.Prying.Components;
+using Content.Shared.Prying.Systems;
+using Robust.Shared.Audio.Systems;
+
+namespace Content.Client.Prying;
+
+public sealed class PryingSystem : SharedPryingSystem
+{
+    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<EntityStorageComponent, DoorPryDoAfterEvent>(OnDoAfter);
+    }
+
+    private void OnDoAfter(EntityUid uid, EntityStorageComponent storage, DoorPryDoAfterEvent args)
+    {
+        if (args.Cancelled)
+            return;
+        if (args.Target is null)
+            return;
+
+        TryComp<PryingComponent>(args.Used, out var comp);
+
+        if (!CanPry(uid, args.User, out var message, comp))
+        {
+            if (!string.IsNullOrWhiteSpace(message))
+                _popup.PopupClient(Loc.GetString(message), uid, args.User);
+            return;
+        }
+
+        if (args.Used != null && comp != null)
+        {
+            _audioSystem.PlayPredicted(comp.UseSound, args.Used.Value, args.User);
+        }
+    }
+}

--- a/Content.Client/Storage/Systems/EntityStorageSystem.cs
+++ b/Content.Client/Storage/Systems/EntityStorageSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Content.Client.Storage.Components;
 using Content.Shared.Destructible;
 using Content.Shared.Foldable;

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -37,7 +37,7 @@ namespace Content.Server.Construction
 
             // Event handling. Add your subscriptions here! Just make sure they're all handled by EnqueueEvent.
             SubscribeLocalEvent<ConstructionComponent, InteractUsingEvent>(EnqueueEvent,
-                new []{typeof(AnchorableSystem), typeof(PryingSystem), typeof(WeldableSystem)},
+                new []{typeof(AnchorableSystem), typeof(SharedPryingSystem), typeof(WeldableSystem)},
                 new []{typeof(EncryptionKeySystem)});
             SubscribeLocalEvent<ConstructionComponent, OnTemperatureChangeEvent>(EnqueueEvent);
             SubscribeLocalEvent<ConstructionComponent, PartAssemblyPartInsertedEvent>(EnqueueEvent);

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -53,7 +53,7 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly PathfindingSystem _pathfindingSystem = default!;
-    [Dependency] private readonly PryingSystem _pryingSystem = default!;
+    [Dependency] private readonly SharedPryingSystem _pryingSystem = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedMeleeWeaponSystem _melee = default!;
     [Dependency] private readonly SharedMoverController _mover = default!;

--- a/Content.Server/Prying/PryingSystem.cs
+++ b/Content.Server/Prying/PryingSystem.cs
@@ -1,11 +1,13 @@
 using Content.Server.Storage.Components;
 using Content.Shared.Prying.Components;
 using Content.Shared.Prying.Systems;
+using Robust.Shared.Audio.Systems;
 
 namespace Content.Server.Prying;
 
 public sealed class PryingSystem : SharedPryingSystem
 {
+    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -18,6 +20,11 @@ public sealed class PryingSystem : SharedPryingSystem
             return;
         if (args.Target is null)
             return;
+
+        if (args.Used != null && TryComp<PryingComponent>(args.Used, out var comp))
+        {
+            _audioSystem.PlayPvs(comp.UseSound, args.Used.Value);
+        }
 
         var ev = new PriedEvent(args.User);
         RaiseLocalEvent(uid, ref ev);

--- a/Content.Server/Prying/PryingSystem.cs
+++ b/Content.Server/Prying/PryingSystem.cs
@@ -1,0 +1,25 @@
+using Content.Server.Storage.Components;
+using Content.Shared.Prying.Components;
+using Content.Shared.Prying.Systems;
+
+namespace Content.Server.Prying;
+
+public sealed class PryingSystem : SharedPryingSystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<EntityStorageComponent, DoorPryDoAfterEvent>(OnDoAfter);
+    }
+
+    private void OnDoAfter(EntityUid uid, EntityStorageComponent storage, DoorPryDoAfterEvent args)
+    {
+        if (args.Cancelled)
+            return;
+        if (args.Target is null)
+            return;
+
+        var ev = new PriedEvent(args.User);
+        RaiseLocalEvent(uid, ref ev);
+    }
+}

--- a/Content.Server/Prying/PryingSystem.cs
+++ b/Content.Server/Prying/PryingSystem.cs
@@ -9,10 +9,10 @@ public sealed class PryingSystem : SharedPryingSystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<EntityStorageComponent, DoorPryDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<EntityStorageComponent, PryDoAfterEvent>(OnDoAfter);
     }
 
-    private void OnDoAfter(EntityUid uid, EntityStorageComponent storage, DoorPryDoAfterEvent args)
+    private void OnDoAfter(EntityUid uid, EntityStorageComponent storage, PryDoAfterEvent args)
     {
         if (args.Cancelled)
             return;

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -49,7 +49,7 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
         SubscribeLocalEvent<EntityStorageComponent, FoldAttemptEvent>(OnFoldAttempt);
         SubscribeLocalEvent<EntityStorageComponent, BeforePryEvent>(OnBeforePry);
         SubscribeLocalEvent<EntityStorageComponent, PriedEvent>(OnPried);
-        SubscribeLocalEvent<EntityStorageComponent, GetPryTimeModifierEvent>(OnGetPryMod);
+        SubscribeLocalEvent<EntityStorageComponent, GetPryTimeModifierEvent>(OnGetPryTime);
 
         SubscribeLocalEvent<EntityStorageComponent, ComponentGetState>(OnGetState);
         SubscribeLocalEvent<EntityStorageComponent, ComponentHandleState>(OnHandleState);
@@ -201,7 +201,7 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
     #endregion
 
     #region Pry event handlers
-    private void OnGetPryMod(EntityUid uid, EntityStorageComponent component, ref GetPryTimeModifierEvent args)
+    private void OnGetPryTime(EntityUid uid, EntityStorageComponent component, ref GetPryTimeModifierEvent args)
     {
         args.BaseTime = component.PryTime;
     }
@@ -209,7 +209,7 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
 
     private void OnBeforePry(EntityUid uid, EntityStorageComponent component, ref BeforePryEvent args)
     {
-        // A simple crowbar won't be enough. You need a proper prying tool.
+        // A simple crowbar won't be enough.
         if (!args.PryPowered)
             args.Cancelled = true;
 
@@ -222,6 +222,7 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
         if (component.Open)
             return;
 
+        // Bust the lock open if there is one.
         if (TryComp(uid, out LockComponent? _))
             _lockSystem.TryUnlock(uid, args.User);
 

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -123,7 +123,7 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
         var serverComp = (EntityStorageComponent) component;
         var tile = GetOffsetTileRef(uid, serverComp);
 
-        if (tile != null && _atmos.GetTileMixture(tile.Value.GridUid, null, tile.Value.GridIndices, true) is { } environment)
+        if (tile != null && _atmos.GetTileMixture(tile.Value.GridUid, null, tile.Value.GridIndices, true) is {} environment)
         {
             _atmos.Merge(serverComp.Air, environment.RemoveVolume(serverComp.Air.Volume));
         }
@@ -138,7 +138,7 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
 
         var tile = GetOffsetTileRef(uid, serverComp);
 
-        if (tile != null && _atmos.GetTileMixture(tile.Value.GridUid, null, tile.Value.GridIndices, true) is { } environment)
+        if (tile != null && _atmos.GetTileMixture(tile.Value.GridUid, null, tile.Value.GridIndices, true) is {} environment)
         {
             _atmos.Merge(environment, serverComp.Air);
             serverComp.Air.Clear();

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -38,7 +38,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
     [Dependency] protected readonly SharedAppearanceSystem AppearanceSystem = default!;
     [Dependency] private readonly OccluderSystem _occluder = default!;
     [Dependency] private readonly AccessReaderSystem _accessReaderSystem = default!;
-    [Dependency] private readonly PryingSystem _pryingSystem = default!;
+    [Dependency] private readonly SharedPryingSystem _pryingSystem = default!;
     [Dependency] protected readonly SharedPopupSystem Popup = default!;
 
     [ValidatePrototypeId<TagPrototype>]

--- a/Content.Shared/Prying/Systems/SharedPryingSystem.cs
+++ b/Content.Shared/Prying/Systems/SharedPryingSystem.cs
@@ -16,7 +16,7 @@ namespace Content.Shared.Prying.Systems;
 /// <summary>
 /// Handles prying of entities (e.g. doors)
 /// </summary>
-public sealed class PryingSystem : EntitySystem
+public abstract class SharedPryingSystem : EntitySystem
 {
     [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
@@ -103,7 +103,7 @@ public sealed class PryingSystem : EntitySystem
         return StartPry(target, user, null, modifier, out id);
     }
 
-    private bool CanPry(EntityUid target, EntityUid user, out string? message, PryingComponent? comp = null, PryUnpoweredComponent? unpoweredComp = null)
+    protected bool CanPry(EntityUid target, EntityUid user, out string? message, PryingComponent? comp = null, PryUnpoweredComponent? unpoweredComp = null)
     {
         BeforePryEvent canev;
 
@@ -152,7 +152,7 @@ public sealed class PryingSystem : EntitySystem
         return _doAfterSystem.TryStartDoAfter(doAfterArgs, out id);
     }
 
-    private void OnDoAfter(EntityUid uid, DoorComponent door, DoorPryDoAfterEvent args)
+    private void OnDoAfter(EntityUid uid, DoorComponent _, DoorPryDoAfterEvent args)
     {
         if (args.Cancelled)
             return;

--- a/Content.Shared/Prying/Systems/SharedPryingSystem.cs
+++ b/Content.Shared/Prying/Systems/SharedPryingSystem.cs
@@ -152,7 +152,7 @@ public abstract class SharedPryingSystem : EntitySystem
         return _doAfterSystem.TryStartDoAfter(doAfterArgs, out id);
     }
 
-    private void OnDoAfter(EntityUid uid, DoorComponent _, DoorPryDoAfterEvent args)
+    private void OnDoAfter(EntityUid uid, DoorComponent door, DoorPryDoAfterEvent args)
     {
         if (args.Cancelled)
             return;

--- a/Content.Shared/Prying/Systems/SharedPryingSystem.cs
+++ b/Content.Shared/Prying/Systems/SharedPryingSystem.cs
@@ -29,7 +29,7 @@ public abstract class SharedPryingSystem : EntitySystem
 
         // Mob prying doors
         SubscribeLocalEvent<DoorComponent, GetVerbsEvent<AlternativeVerb>>(OnDoorAltVerb);
-        SubscribeLocalEvent<DoorComponent, DoorPryDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<DoorComponent, PryDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<DoorComponent, InteractUsingEvent>(TryPryDoor);
     }
 
@@ -134,7 +134,7 @@ public abstract class SharedPryingSystem : EntitySystem
         var modEv = new GetPryTimeModifierEvent(user);
 
         RaiseLocalEvent(target, ref modEv);
-        var doAfterArgs = new DoAfterArgs(EntityManager, user, TimeSpan.FromSeconds(modEv.BaseTime * modEv.PryTimeModifier / toolModifier), new DoorPryDoAfterEvent(), target, target, tool)
+        var doAfterArgs = new DoAfterArgs(EntityManager, user, TimeSpan.FromSeconds(modEv.BaseTime * modEv.PryTimeModifier / toolModifier), new PryDoAfterEvent(), target, target, tool)
         {
             BreakOnDamage = true,
             BreakOnMove = true,
@@ -152,7 +152,7 @@ public abstract class SharedPryingSystem : EntitySystem
         return _doAfterSystem.TryStartDoAfter(doAfterArgs, out id);
     }
 
-    private void OnDoAfter(EntityUid uid, DoorComponent door, DoorPryDoAfterEvent args)
+    private void OnDoAfter(EntityUid uid, DoorComponent door, PryDoAfterEvent args)
     {
         if (args.Cancelled)
             return;
@@ -179,4 +179,4 @@ public abstract class SharedPryingSystem : EntitySystem
 }
 
 [Serializable, NetSerializable]
-public sealed partial class DoorPryDoAfterEvent : SimpleDoAfterEvent;
+public sealed partial class PryDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -31,6 +31,12 @@ public abstract partial class SharedEntityStorageComponent : Component
     public int RemovedMasks;
 
     /// <summary>
+    /// Time required to pry open an entitystorage.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float PryTime = 9f;
+
+    /// <summary>
     /// The total amount of items that can fit in one entitystorage
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -11,23 +11,19 @@ using Content.Shared.Lock;
 using Content.Shared.Movement.Events;
 using Content.Shared.Placeable;
 using Content.Shared.Popups;
-using Content.Shared.Prying.Components;
 using Content.Shared.Prying.Systems;
 using Content.Shared.Storage.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Verbs;
 using Content.Shared.Wall;
 using Content.Shared.Whitelist;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
-using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -35,21 +31,21 @@ namespace Content.Shared.Storage.EntitySystems;
 
 public abstract class SharedEntityStorageSystem : EntitySystem
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly INetManager _net = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!;
-    [Dependency] private readonly PlaceableSurfaceSystem _placeableSurface = default!;
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-    [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly SharedContainerSystem _container = default!;
-    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
-    [Dependency] private readonly SharedJointSystem _joints = default!;
-    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
-    [Dependency] private readonly SharedPryingSystem _pryingSystem = default!;
+    [Dependency] private   readonly IGameTiming _timing = default!;
+    [Dependency] private   readonly INetManager _net = default!;
+    [Dependency] private   readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private   readonly PlaceableSurfaceSystem _placeableSurface = default!;
+    [Dependency] private   readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private   readonly SharedAudioSystem _audio = default!;
+    [Dependency] private   readonly SharedContainerSystem _container = default!;
+    [Dependency] private   readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private   readonly SharedJointSystem _joints = default!;
+    [Dependency] private   readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private   readonly SharedPryingSystem _pryingSystem = default!;
     [Dependency] protected readonly SharedPopupSystem Popup = default!;
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
-    [Dependency] private readonly WeldableSystem _weldable = default!;
-    [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private   readonly WeldableSystem _weldable = default!;
+    [Dependency] private   readonly EntityWhitelistSystem _whitelistSystem = default!;
 
     public const string ContainerName = "entity_storage";
 
@@ -186,6 +182,7 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         verb.Act = () => ToggleOpen(args.User, args.Target, component);
         args.Verbs.Add(verb);
     }
+
 
     public void ToggleOpen(EntityUid user, EntityUid target, SharedEntityStorageComponent? component = null)
     {

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -11,6 +11,8 @@ using Content.Shared.Lock;
 using Content.Shared.Movement.Events;
 using Content.Shared.Placeable;
 using Content.Shared.Popups;
+using Content.Shared.Prying.Components;
+using Content.Shared.Prying.Systems;
 using Content.Shared.Storage.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Verbs;
@@ -33,19 +35,20 @@ namespace Content.Shared.Storage.EntitySystems;
 
 public abstract class SharedEntityStorageSystem : EntitySystem
 {
-    [Dependency] private   readonly IGameTiming _timing = default!;
-    [Dependency] private   readonly INetManager _net = default!;
-    [Dependency] private   readonly EntityLookupSystem _lookup = default!;
-    [Dependency] private   readonly PlaceableSurfaceSystem _placeableSurface = default!;
-    [Dependency] private   readonly SharedAppearanceSystem _appearance = default!;
-    [Dependency] private   readonly SharedAudioSystem _audio = default!;
-    [Dependency] private   readonly SharedContainerSystem _container = default!;
-    [Dependency] private   readonly SharedInteractionSystem _interaction = default!;
-    [Dependency] private   readonly SharedJointSystem _joints = default!;
-    [Dependency] private   readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly PlaceableSurfaceSystem _placeableSurface = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly SharedJointSystem _joints = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedPryingSystem _pryingSystem = default!;
     [Dependency] protected readonly SharedPopupSystem Popup = default!;
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
-    [Dependency] private   readonly WeldableSystem _weldable = default!;
+    [Dependency] private readonly WeldableSystem _weldable = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
     public const string ContainerName = "entity_storage";
@@ -96,6 +99,15 @@ public abstract class SharedEntityStorageSystem : EntitySystem
 
         args.Handled = true;
         ToggleOpen(args.User, uid, component);
+    }
+
+    protected void OnInteractUsing(EntityUid uid, SharedEntityStorageComponent component, InteractUsingEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!component.Open && _pryingSystem.TryPry(uid, args.User, out _, args.Used))
+            args.Handled = true;
     }
 
     public abstract bool ResolveStorage(EntityUid uid, [NotNullWhen(true)] ref SharedEntityStorageComponent? component);
@@ -174,7 +186,6 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         verb.Act = () => ToggleOpen(args.User, args.Target, component);
         args.Verbs.Add(verb);
     }
-
 
     public void ToggleOpen(EntityUid user, EntityUid target, SharedEntityStorageComponent? component = null)
     {
@@ -362,7 +373,7 @@ public abstract class SharedEntityStorageSystem : EntitySystem
 
         if (_container.IsEntityInContainer(target))
         {
-            if (_container.TryGetOuterContainer(target,Transform(target) ,out var container) &&
+            if (_container.TryGetOuterContainer(target, Transform(target), out var container) &&
                 !HasComp<HandsComponent>(container.Owner))
             {
                 Popup.PopupClient(Loc.GetString("entity-storage-component-already-contains-user-message"), user, user);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds functionality to the Jaws of Life so that than can be used to break into Lockers and crates non-destructively.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Thematically, it always felt weird that this tool was powerful enough to force open command doors, but couldn't be used to open storage lockers and crates (outside of using the Jaws as a weapons and destroying the containers)

Though it wasn't the motivation of this change, this will be a buff to the Jaws of Life items and will increase the attractiveness  of the Syndicate Jaws of Life as a purchase specifically.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
`EntityStorageSystem` now listens for an `InteractUsingEvent` and will attempt to `TryPry` so long as the storage isn't already open.
- The pry will be aborted if the storage is welded or if the prying tool isn't strong enough (i.e. Don't allow this to work with crowbars)
- The doafter timer is controlled by a new `EntityStorageComponent` field `PryTime` which is defaulted to 9.

The `PryingSystem` (that previously existed in Shared) has been renamed `SharedPryingSystem` and children `PryingSystem` classes have been added to the client/server projects. 
- This was my solution to the PryingSystem needing `SubscribeLocalEvent<EntityStorageComponent, PryDoAfterEvent>` but only having access to the parent (`SharedEntityStorageComponent`) which is was not registered.
- I'm not positive this is the best solution. This is my first foray into this codebase and is my first exposure to ECS in general. I am open to any and all feedback here

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/32338704/7f3fccd7-51d0-4ad3-b5c1-804a39da63eb

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
- `C.Sh.PryingSystem` has been renamed to `C.Sh.SharedPryingSystem`

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Quantus
- add: Lockers and Crates can now be pried open using the Jaws of Life.
