### PR TITLE
Allow construction of rotated railings

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
@@ -7,7 +7,6 @@
         - to: railing
           completed:
             - !type:SnapToGrid
-              southRotation: true
           steps:
             - material: MetalRod
               amount: 1
@@ -15,7 +14,6 @@
         - to: railingCorner
           completed:
             - !type:SnapToGrid
-              southRotation: true
           steps:
             - material: MetalRod
               amount: 2
@@ -23,7 +21,6 @@
         - to: railingCornerSmall
           completed:
             - !type:SnapToGrid
-              southRotation: true
           steps:
             - material: MetalRod
               amount: 1
@@ -31,7 +28,6 @@
         - to: railingRound
           completed:
             - !type:SnapToGrid
-              southRotation: true
           steps:
             - material: MetalRod
               amount: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
@@ -6,28 +6,28 @@
       edges:
         - to: railing
           completed:
-            - !type:SnapToGrid
+            - !type:SnapToGrid { }
           steps:
             - material: MetalRod
               amount: 1
               doAfter: 2
         - to: railingCorner
           completed:
-            - !type:SnapToGrid
+            - !type:SnapToGrid { }
           steps:
             - material: MetalRod
               amount: 2
               doAfter: 2.5
         - to: railingCornerSmall
           completed:
-            - !type:SnapToGrid
+            - !type:SnapToGrid { }
           steps:
             - material: MetalRod
               amount: 1
               doAfter: 2
         - to: railingRound
           completed:
-            - !type:SnapToGrid
+            - !type:SnapToGrid { }
           steps:
             - material: MetalRod
               amount: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Railings can now be constructed in any of the 4 directions/rotations
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #29020
Mappers can use non-south-facing railings, so why not players?
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Remove the southRotation field from the construction railing yaml
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/space-wizards/space-station-14/assets/95712736/863ec05b-8164-4b02-bac5-ba8d207c4a99)
![image](https://github.com/space-wizards/space-station-14/assets/95712736/6923d029-b2d5-446d-997f-475833da0289)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- fix: Railings can now be constructed in all 4 orientations.
