### PR TITLE
Make all nukies humans

### DIFF
--- a/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
@@ -30,10 +30,18 @@ public sealed class AntagLoadProfileRuleSystem : GameRuleSystem<AntagLoadProfile
         var profile = args.Session != null
             ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
             : HumanoidCharacterProfile.RandomWithSpecies();
-        if (profile?.Species is not {} speciesId || !_proto.TryIndex<SpeciesPrototype>(speciesId, out var species))
+
+        SpeciesPrototype? species;
+        if (ent.Comp.SpeciesOverride != null)
+        {
+            species = _proto.Index(ent.Comp.SpeciesOverride.Value);
+        }
+        else if (profile?.Species is not { } speciesId || !_proto.TryIndex(speciesId, out species))
+        {
             species = _proto.Index<SpeciesPrototype>(SharedHumanoidAppearanceSystem.DefaultSpecies);
+        }
 
         args.Entity = Spawn(species.Prototype);
-        _humanoid.LoadProfile(args.Entity.Value, profile);
+        _humanoid.LoadProfile(args.Entity.Value, profile?.WithSpecies(species.ID));
     }
 }

--- a/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
@@ -1,7 +1,17 @@
+using Content.Shared.Humanoid.Prototypes;
+using Robust.Shared.Prototypes;
+
 namespace Content.Server.GameTicking.Rules.Components;
 
 /// <summary>
 /// Makes this rules antags spawn a humanoid, either from the player's profile or a random one.
 /// </summary>
 [RegisterComponent]
-public sealed partial class AntagLoadProfileRuleComponent : Component;
+public sealed partial class AntagLoadProfileRuleComponent : Component
+{
+    /// <summary>
+    /// If specified, the profile loaded will be made into this species.
+    /// </summary>
+    [DataField]
+    public ProtoId<SpeciesPrototype>? SpeciesOverride;
+}

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -81,6 +81,7 @@
   - type: RuleGrids
   - type: AntagSelection
   - type: AntagLoadProfileRule
+    speciesOverride: Human
 
 - type: entity
   parent: BaseNukeopsRule


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changes nukie operative spawning to make all operatives human.
if your character was a human, they'll be preserved. If they're a lizard, moth, etc, it will replace the species with human and preserve whatever else it can (usually just eye color)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Species design is diverging a lot more and with Vox on the horizon, the variance in difficulty and mechanics from species to species is only widening. Not being able to guarantee basic things about operatives like damage resistances, diet, air type, etc. makes balance incredibly difficult as certain items that may be bad for one species are overpowered for another. Furthermore, it requires an endless mill of continual updates and safeguards to the mode for every species change, lest a balance tweak meant to affect regular station roles and gameplay spirals into the team balance and dynamics of Ops.

The easiest way to solve this is just standardizing nukies to just humans. This removes a lot of the potential negative variance in balance and gives people an even playing field for balance.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: All nuclear operatives are now humans.
