### PR TITLE
Fixes objects changing physics behavior after being pulled

### DIFF
--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -455,9 +455,7 @@ public sealed class PullingSystem : EntitySystem
             joint.MinLength = 0f;
             joint.Stiffness = 1f;
 
-            // check if we actually need to set the FixedRotation to false to save a dirty call
-            if (pullablePhysics.FixedRotation && !pullableComp.FixedRotationOnPull)
-                _physics.SetFixedRotation(pullableUid, false, body: pullablePhysics);
+            _physics.SetFixedRotation(pullableUid, pullableComp.FixedRotationOnPull, body: pullablePhysics);
         }
 
         // Messaging

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -458,9 +458,8 @@ public sealed class PullingSystem : EntitySystem
             // if the entity has a FixedRotation, and the pulling comp says don't keep it on pull,
             // set FixedRotation to false while the object is being pulled.
             // because we stored the setting in PrevFixedRotation, it gets restored when pulling stops.
-            if (pullablePhysics.FixedRotation)
-                if (!pullableComp.FixedRotationOnPull)
-                    _physics.SetFixedRotation(pullableUid, false, body: pullablePhysics);
+            if (pullablePhysics.FixedRotation && !pullableComp.FixedRotationOnPull)
+                _physics.SetFixedRotation(pullableUid, false, body: pullablePhysics);
         }
 
         // Messaging

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -255,7 +255,9 @@ public sealed class PullingSystem : EntitySystem
 
             if (TryComp<PhysicsComponent>(pullableUid, out var pullablePhysics))
             {
-                _physics.SetFixedRotation(pullableUid, pullableComp.PrevFixedRotation, body: pullablePhysics);
+                // check if we even need to set the FixedRotation to save a dirty call
+                if (pullablePhysics.FixedRotation != pullableComp.PrevFixedRotation)
+                    _physics.SetFixedRotation(pullableUid, pullableComp.PrevFixedRotation, body: pullablePhysics);
             }
         }
 
@@ -455,7 +457,9 @@ public sealed class PullingSystem : EntitySystem
             joint.MinLength = 0f;
             joint.Stiffness = 1f;
 
-            _physics.SetFixedRotation(pullableUid, pullableComp.FixedRotationOnPull, body: pullablePhysics);
+            // check if we actually need to set the FixedRotation to false to save a dirty call
+            if (pullablePhysics.FixedRotation && !pullableComp.FixedRotationOnPull)
+                _physics.SetFixedRotation(pullableUid, false, body: pullablePhysics);
         }
 
         // Messaging

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -255,9 +255,7 @@ public sealed class PullingSystem : EntitySystem
 
             if (TryComp<PhysicsComponent>(pullableUid, out var pullablePhysics))
             {
-                // check if we even need to set the FixedRotation to save a dirty call
-                if (pullablePhysics.FixedRotation != pullableComp.PrevFixedRotation)
-                    _physics.SetFixedRotation(pullableUid, pullableComp.PrevFixedRotation, body: pullablePhysics);
+                _physics.SetFixedRotation(pullableUid, pullableComp.PrevFixedRotation, body: pullablePhysics);
             }
         }
 

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -455,11 +455,7 @@ public sealed class PullingSystem : EntitySystem
             joint.MinLength = 0f;
             joint.Stiffness = 1f;
 
-            // if the entity has a FixedRotation, and the pulling comp says don't keep it on pull,
-            // set FixedRotation to false while the object is being pulled.
-            // because we stored the setting in PrevFixedRotation, it gets restored when pulling stops.
-            if (pullablePhysics.FixedRotation && !pullableComp.FixedRotationOnPull)
-                _physics.SetFixedRotation(pullableUid, false, body: pullablePhysics);
+            _physics.SetFixedRotation(pullableUid, pullableComp.FixedRotationOnPull, body: pullablePhysics);
         }
 
         // Messaging


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
When you pulled an entity, it would change the entity's FixedRotation setting incorrectly due to saving the incorrect value

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes https://github.com/space-wizards/space-station-14/issues/29618

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The entity's FixedRotation setting was being saved in PrevFixedRotation **after the change** to the setting had already been applied, so I flipped the order so that PrevFixedRotation was saved beforehand. This properly restores the setting when you stop pulling rather than permanently overriding it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Before:

https://github.com/space-wizards/space-station-14/assets/58439124/41adc38d-c940-4b5d-8381-3cfc7bd6c9fa


After:

https://github.com/space-wizards/space-station-14/assets/58439124/40ad35ab-434b-4dcd-a5c1-2ed65e5f82bd

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: An object's physics properly returns to normal after being pulled.