### PR TITLE
Add basic test of station initial power supply

### DIFF
--- a/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
+++ b/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.Server.GameTicking;
+using Content.Server.Maps;
+using Content.Server.NodeContainer;
+using Content.Server.Power.Components;
+using Content.Server.Power.NodeGroups;
+using Content.Server.Power.Pow3r;
+using Robust.Server.GameObjects;
+
+namespace Content.IntegrationTests.Tests.Power;
+
+[TestFixture]
+public sealed class StationPowerTests
+{
+    /// <summary>
+    /// How long the station should be able to survive on stored power if nothing is changed from round start.
+    /// </summary>
+    private const float MinimumPowerDurationSeconds = 10 * 60;
+
+    private static readonly string[] GameMaps =
+    [
+        "Fland",
+        "Meta",
+        "Packed",
+        "Cluster",
+        "Omega",
+        "Bagel",
+        "Origin",
+        "Box",
+        "Saltern",
+        "Core",
+        "Marathon",
+        "Atlas",
+        "Reach",
+        "Train",
+        "Oasis"
+    ];
+
+    [Test, TestCaseSource(nameof(GameMaps))]
+    public async Task TestStationStartingPowerWindow(string mapProtoId)
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.EntMan;
+        var protoMan = server.ProtoMan;
+        var mapSystem = entMan.System<MapSystem>();
+        var ticker = entMan.System<GameTicker>();
+
+        // Load the map
+        await server.WaitAssertion(() =>
+        {
+            mapSystem.CreateMap(out var mapId);
+
+            Assert.That(protoMan.TryIndex<GameMapPrototype>(mapProtoId, out var mapProto));
+            ticker.LoadGameMap(mapProto, mapId, null);
+        });
+
+        // Let powernet set up
+        await server.WaitRunTicks(1);
+
+        // Find the power network with the greatest stored charge in its SMESes.
+        // This keeps backup SMESes out of the calculation.
+        var networks = new Dictionary<PowerState.Network, float>();
+        var smesQuery = entMan.EntityQueryEnumerator<PowerNetworkBatteryComponent, BatteryComponent, NodeContainerComponent>();
+        while (smesQuery.MoveNext(out var uid, out _, out var battery, out var nodeContainer))
+        {
+            if (!nodeContainer.Nodes.TryGetValue("output", out var node))
+                continue;
+            if (node.NodeGroup is not IBasePowerNet group)
+                continue;
+            networks.TryGetValue(group.NetworkNode, out var charge);
+            networks[group.NetworkNode] = charge + battery.CurrentCharge;
+        }
+        var totalStartingCharge = networks.MaxBy(n => n.Value).Value;
+
+        // Find how much charge all the APC-connected devices would like to use per second.
+        var totalAPCLoad = 0f;
+        var receiverQuery = entMan.EntityQueryEnumerator<ApcPowerReceiverComponent>();
+        while (receiverQuery.MoveNext(out _, out var receiver))
+        {
+            totalAPCLoad += receiver.Load;
+        }
+
+        var estimatedDuration = totalStartingCharge / totalAPCLoad;
+        Assert.That(estimatedDuration, Is.GreaterThanOrEqualTo(MinimumPowerDurationSeconds));
+
+        await pair.CleanReturnAsync();
+    }
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds an integration test that estimates how long each station's initial stored power supply will last with the initial power load. Currently set to a 10 minute target threshold, which none of the maps meet.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
We should establish a reasonable startup window on all maps so that engineering has a consistent and reasonable amount of time to get things set up.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Pretty simple logic: find the power network with the greatest initial stored charge (this should be the main SMESes and friends, and should exclude stuff like solar SMESes). Then sum up all the desired loads of all APC power consumers (direct users of HV power like the PA are typically not connected at round start), and divide the total charge by that load.

This logic may need some improvement! It's a pretty rough estimate, since it doesn't take into account stuff like the ramp-up delay on batteries, and it could potentially ignore some power storage in cases where the networks are more complicated. Help me improve it!

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Code.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.