### PR TITLE
Removes max damage threshold on healing for hyperzine

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/reagents/meta/narcotics.ftl
@@ -5,7 +5,7 @@ reagent-name-ephedrine = ephedrine
 reagent-desc-ephedrine = A caffeinated adrenaline stimulator chemical that makes you faster and harder to knock down. Also helps combat narcolepsy at dosages over thirty, at the cost of severe nerval stress.
 
 reagent-name-stimulants = hyperzine
-reagent-desc-stimulants = A chemical cocktail developed by Donk Co. that allows agents to recover from stuns faster, move more quickly, and grants a small heal while close to critical condition. Due to the complex nature of the chemical, it is much harder for the body to purge naturally.
+reagent-desc-stimulants = A chemical cocktail developed by Donk Co. that allows agents to recover from stuns faster, move more quickly, and grants a small heal when you're more dead than alive. Due to the complex nature of the chemical, it is much harder for the body to purge naturally.
 
 reagent-name-experimental-stimulants = experimental stimulants
 reagent-desc-experimental-stimulants = A prototype version of hyperzine. Usage grants virtual immunity to stun weaponry, rapid tissue regeneration, extreme running speed by reducing lactic acid buildup, and a general feeling of euphoria. Side effects may include extreme levels of anticoagulation, tunnel vision, extreme toxin buildup in the bloodstream, and rapid liver death. Do not give to animals.

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -151,8 +151,7 @@
         - !type:HealthChange
           conditions:
           - !type:TotalDamage
-            min: 70
-            max: 120 # you've got a chance to get out of crit
+            min: 70 # only heals when you're more dead than alive
           damage: # heals at the same rate as tricordrazine, doesn't heal poison because if you OD'd I'm not giving you a safety net
             groups:
               Burn: -1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removed the max damage threshold that limits the ability for Hyperzine to heal if a person goes beyond 120 total damage

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I was asked to do it by an admin but besides that, this makes hyperzine easier to use for antags without making it an effective healing option over other chems

You still only get healed to the point of having 70 damage total regardless of how much hyperzine you have in you and at which point you still need other healing options. The only difference now is you don't need to be super precise when you're injecting it into someone and worrying about whether or not they took just enough bloodloss or asphyxiation damage to go above the 120 threshold to benefit from Hyperzine's tiny bit of burn/brute heals which is basically what happens every time.

It doesn't even heal asphyx or clot bleeding so it's not going to replace other options by any means.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Hyperzine's effective healing range has been changed from 70 to 120, to anything above 70 total damage.