### PR TITLE
Antag species whitelist for nukies

### DIFF
--- a/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
@@ -31,14 +31,15 @@ public sealed class AntagLoadProfileRuleSystem : GameRuleSystem<AntagLoadProfile
             ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
             : HumanoidCharacterProfile.RandomWithSpecies();
 
-        SpeciesPrototype? species;
-        if (ent.Comp.SpeciesOverride != null)
-        {
-            species = _proto.Index(ent.Comp.SpeciesOverride.Value);
-        }
-        else if (profile?.Species is not { } speciesId || !_proto.TryIndex(speciesId, out species))
+
+        if (profile?.Species is not { } speciesId || !_proto.TryIndex(speciesId, out var species))
         {
             species = _proto.Index<SpeciesPrototype>(SharedHumanoidAppearanceSystem.DefaultSpecies);
+        }
+
+        if (!ent.Comp.SpeciesWhitelist?.Contains(new ProtoId<SpeciesPrototype>(species.ID)) ?? false)
+        {
+            species = _proto.Index(ent.Comp.SpeciesOverride ?? SharedHumanoidAppearanceSystem.DefaultSpecies);
         }
 
         args.Entity = Spawn(species.Prototype);

--- a/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
@@ -37,9 +37,10 @@ public sealed class AntagLoadProfileRuleSystem : GameRuleSystem<AntagLoadProfile
             species = _proto.Index<SpeciesPrototype>(SharedHumanoidAppearanceSystem.DefaultSpecies);
         }
 
-        if (!ent.Comp.SpeciesWhitelist?.Contains(new ProtoId<SpeciesPrototype>(species.ID)) ?? false)
+        if (ent.Comp.SpeciesOverride != null
+            && (!ent.Comp.SpeciesOverrideWhitelist?.Contains(new ProtoId<SpeciesPrototype>(species.ID)) ?? false))
         {
-            species = _proto.Index(ent.Comp.SpeciesOverride ?? SharedHumanoidAppearanceSystem.DefaultSpecies);
+            species = _proto.Index(ent.Comp.SpeciesOverride.Value);
         }
 
         args.Entity = Spawn(species.Prototype);

--- a/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
@@ -10,8 +10,14 @@ namespace Content.Server.GameTicking.Rules.Components;
 public sealed partial class AntagLoadProfileRuleComponent : Component
 {
     /// <summary>
-    /// If specified, the profile loaded will be made into this species.
+    /// If specified, the profile loaded will be made into this species if the chosen species doesn't match the whitelist.
     /// </summary>
     [DataField]
     public ProtoId<SpeciesPrototype>? SpeciesOverride;
+
+    /// <summary>
+    /// List of allowed species
+    /// </summary>
+    [DataField]
+    public HashSet<ProtoId<SpeciesPrototype>>? SpeciesWhitelist;
 }

--- a/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/AntagLoadProfileRuleCOmponent.cs
@@ -16,8 +16,8 @@ public sealed partial class AntagLoadProfileRuleComponent : Component
     public ProtoId<SpeciesPrototype>? SpeciesOverride;
 
     /// <summary>
-    /// List of allowed species
+    /// List of species that get ignored by the override
     /// </summary>
     [DataField]
-    public HashSet<ProtoId<SpeciesPrototype>>? SpeciesWhitelist;
+    public HashSet<ProtoId<SpeciesPrototype>>? SpeciesOverrideWhitelist;
 }

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -82,6 +82,17 @@
   - type: AntagSelection
   - type: AntagLoadProfileRule
     speciesOverride: Human
+    speciesWhitelist:
+    - Human
+    - Dwarf
+    - Arachnid
+    - Moth
+    - Reptilian
+    # These species currently have issues that make them not suitable to be used with nukies.
+    # Add them back in when those issues got addressed
+    #- Vox
+    #- Diona
+    #- SlimePerson
 
 - type: entity
   parent: BaseNukeopsRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -82,7 +82,7 @@
   - type: AntagSelection
   - type: AntagLoadProfileRule
     speciesOverride: Human
-    speciesWhitelist:
+    speciesOverrideWhitelist:
     - Human
     - Dwarf
     - Arachnid


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR adds a whitelist to `AntagLoadProfileRule` that allows certain species to be used regardless of the species override

The whitelist for nukies in this PR contains:
```yaml
    - Human
    - Dwarf
    - Arachnid
    - Moth
    - Reptilian
 ```
 The other species are commented out and should be uncommented when the issues they have are fixed

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This allows better control of what species are allowed for a given antag. In this case the nuclear operatives

This is an alternative to #29707