### PR TITLE
Changes prototype IDs for Space drugs to Space Mirage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -363,7 +363,7 @@
       drink:
         maxVol: 30
         reagents:
-        - ReagentId: Stimulants
+        - ReagentId: Hyperzine
           Quantity: 5
         - ReagentId: NuclearCola
           Quantity: 20

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -977,5 +977,5 @@
       injector:
         maxVol: 15
         reagents:
-        - ReagentId: Stimulants
+        - ReagentId: Hyperzine
           Quantity: 15

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -580,14 +580,14 @@
 - type: entity
   name: space mirage
   parent: Pill
-  id: PillSpaceDrugs
+  id: PillSpaceMirage
   components:
   - type: SolutionContainerManager
     solutions:
       food:
         maxVol: 20
         reagents:
-        - ReagentId: SpaceDrugs
+        - ReagentId: SpaceMirage
           Quantity: 15
 
 - type: entity
@@ -787,7 +787,7 @@
       prob: 0.075
       maxAmount: 7
       orGroup: RandomPill
-    - id: PillSpaceDrugs
+    - id: PillSpaceMirage
       prob: 0.075
       maxAmount: 7
       orGroup: RandomPill

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -333,7 +333,7 @@
       pen:
         maxVol: 30
         reagents:
-        - ReagentId: Stimulants
+        - ReagentId: Hyperzine
           Quantity: 30
   - type: SolutionContainerVisuals
     maxFillLevels: 1
@@ -365,7 +365,7 @@
       pen:
         maxVol: 15
         reagents:
-        - ReagentId: Stimulants
+        - ReagentId: Hyperzine
           Quantity: 15
   - type: SolutionContainerVisuals
     maxFillLevels: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
@@ -41,7 +41,7 @@
   - quantity: 20
     weight: 5
     reagents:
-    - SpaceDrugs
+    - SpaceMirage
   - quantity: 10
     weight: 5
     reagents:

--- a/Resources/Prototypes/Hydroponics/mutations.yml
+++ b/Resources/Prototypes/Hydroponics/mutations.yml
@@ -77,7 +77,7 @@
     - Acetone
     - Ash
     - SodiumCarbonate
-    - SpaceDrugs
+    - SpaceMirage
     - MuteToxin
     - JuiceBerryPoison
     - Pilk

--- a/Resources/Prototypes/Hydroponics/mutations.yml
+++ b/Resources/Prototypes/Hydroponics/mutations.yml
@@ -9,7 +9,7 @@
     - Lexorin
     - Honk
     - BuzzochloricBees
-    - Stimulants
+    - Hyperzine
   - quantity: 5
     weight: 1
     reagents:

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -225,7 +225,7 @@
         boozePower: 5
 
 - type: reagent
-  id: SpaceDrugs
+  id: SpaceMirage
   name: reagent-name-space-drugs
   group: Narcotics
   desc: reagent-desc-space-drugs

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -93,7 +93,7 @@
           min: 30
 
 - type: reagent
-  id: Stimulants
+  id: Hyperzine
   name: reagent-name-stimulants
   group: Narcotics
   desc: reagent-desc-stimulants

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -295,7 +295,7 @@
     Desoxyephedrine: 4 #I kinda remember having to heat this up, and if you heated it up too much, it went boom, I can't remember the specific values tho.
 
 - type: reaction
-  id: Stimulants
+  id: Hyperzine
   impact: Medium
   minTemp: 370
   reactants:
@@ -306,7 +306,7 @@
     Oxygen:
       amount: 2
   products:
-    Stimulants: 2
+    Hyperzine: 2
 
 - type: reaction
   id: Ephedrine

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -324,7 +324,7 @@
     MindbreakerToxin: 3
 
 - type: reaction
-  id: SpaceDrugs
+  id: SpaceMirage
   reactants:
     Mercury:
       amount: 1
@@ -333,7 +333,7 @@
     Lithium:
       amount: 1
   products:
-    SpaceDrugs: 3
+    SpaceMirage: 3
 
 - type: reaction
   id: Ultravasculine


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changed prototype IDs for Space drugs to Space Mirage.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I changed the prototype IDs for Stimulants to Hyperzine in #29734 , and it was mentioned that the same thing could be done for space drugs to space mirage. I wasn't sure if it was proper to just edit that PR to include these changes as well, so here they are in a separate one!


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None.

