### PR TITLE
Raise ratking migration minimum players to 30 from 15

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -230,7 +230,7 @@
     earliestStart: 15
     weight: 6
     duration: 50
-    minimumPlayers: 15 # Hopefully this is enough for the Rat King's potential Army
+    minimumPlayers: 30 # Hopefully this is enough for the Rat King's potential Army (it was not, raised from 15 -> 30)
   - type: VentCrittersRule
     entries:
     - id: MobMouse


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Raises the minimum required players for ratking migration to 30 from 15.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Ratkings with a sizeable army can easily kill the whole station on lowpop. There may not even be a security department on lowpop. I've observed this first hand and it really sucks fighting an enemy you cannot really do anything against as 10 rats hitting you in a span of one tick is really not great.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
1 line YAML change.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Simyon
- tweak: Ratkings now require at least 30 players in order to spawn.
