### PR TITLE
Fix AtmosDeviceSystem debug assert Heisenbug

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/GridJoinTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GridJoinTest.cs
@@ -1,0 +1,53 @@
+using Content.Server.Atmos.Components;
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Atmos.Piping.Components;
+using Content.Server.Atmos.Piping.EntitySystems;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.Atmos;
+
+[TestFixture]
+public sealed class GridJoinTest
+{
+    private const string CanisterProtoId = "AirCanister";
+
+    [Test]
+    public async Task TestGridJoinAtmosphere()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.EntMan;
+        var protoMan = server.ProtoMan;
+        var atmosSystem = entMan.System<AtmosphereSystem>();
+        var atmosDeviceSystem = entMan.System<AtmosDeviceSystem>();
+        var transformSystem = entMan.System<SharedTransformSystem>();
+
+        var testMap = await pair.CreateTestMap();
+
+        await server.WaitPost(() =>
+        {
+            // Spawn an atmos device on the grid
+            var canister = entMan.Spawn(CanisterProtoId);
+            transformSystem.SetCoordinates(canister, testMap.GridCoords);
+            var deviceComp = entMan.GetComponent<AtmosDeviceComponent>(canister);
+            var canisterEnt = (canister, deviceComp);
+
+            // Make sure the canister is tracked as an off-grid device
+            Assert.That(atmosDeviceSystem.IsJoinedOffGrid(canisterEnt));
+
+            // Add an atmosphere to the grid
+            entMan.AddComponent<GridAtmosphereComponent>(testMap.Grid);
+
+            // Force AtmosDeviceSystem to update off-grid devices
+            // This means the canister is now considered on-grid,
+            // but it's still tracked as off-grid!
+            Assert.DoesNotThrow(() => atmosDeviceSystem.Update(atmosSystem.AtmosTime));
+
+            // Make sure that the canister is now properly tracked as on-grid
+            Assert.That(atmosDeviceSystem.IsJoinedOffGrid(canisterEnt), Is.False);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosDeviceSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosDeviceSystem.cs
@@ -132,10 +132,19 @@ namespace Content.Server.Atmos.Piping.EntitySystems
             var ev = new AtmosDeviceUpdateEvent(_atmosphereSystem.AtmosTime, null, null);
             foreach (var device in _joinedDevices)
             {
-                DebugTools.Assert(!HasComp<GridAtmosphereComponent>(Transform(device).GridUid));
+                var deviceGrid = Transform(device).GridUid;
+                if (HasComp<GridAtmosphereComponent>(deviceGrid))
+                {
+                    RejoinAtmosphere(device);
+                }
                 RaiseLocalEvent(device, ref ev);
                 device.Comp.LastProcess = time;
             }
+        }
+
+        public bool IsJoinedOffGrid(Entity<AtmosDeviceComponent> device)
+        {
+            return _joinedDevices.Contains(device);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Kills the pesky debug assert that sometimes triggers on certain integration tests.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #28908.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The assertion is triggered when an atmos device that is being tracked as off-grid (more accurately, on a grid that doesn't have an atmosphere) is updated and turns out to actually be on-grid (a grid with an atmosphere). There are a few ways this can happen, with grid splitting, automatic atmosphere addition when a grid is big enough, and possibly more.

The assertion is replaced by code to gracefully handle the issue by making the device try to RejoinAtmosphere and get properly tracked.

The PR includes a test that reproduces the error with the current master and passes with the changes from this PR. A method was added to AtmosDeviceSystem to check whether a given entity is considered off-grid.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Code.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.