### PR TITLE
Hide escape pods on shuttle map

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -1160,6 +1160,10 @@
   suffix: External, Escape 3x4, Glass, Docking
   components:
   - type: GridFill
+    addComponents:
+    - type: IFF
+      flags:
+      - HideLabel
 
 #HighSecDoors
 - type: entity


### PR DESCRIPTION
It clutters the list and people never really care about it as they're docked to the station anyway.

:cl:
- tweak: Escape pods won't show up on shuttle map anymore.