### PR TITLE
Spilling reagents on mutliple entities at once fix

### DIFF
--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
@@ -69,6 +69,8 @@ public sealed partial class PuddleSystem
         if (totalSplit == 0)
             return;
 
+        args.Handled = true;
+
         // First update the hit count so anything that is not reactive wont count towards the total!
         foreach (var hit in args.HitEntities)
         {

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
@@ -69,14 +69,17 @@ public sealed partial class PuddleSystem
         if (totalSplit == 0)
             return;
 
-        args.Handled = true;
+        // First update the hit count so anything that is not reactive wont count towards the total!
         foreach (var hit in args.HitEntities)
         {
             if (!HasComp<ReactiveComponent>(hit))
-            {
-                hitCount -= 1; // so we don't undershoot solution calculation for actual reactive entities
+                hitCount -= 1;
+        }
+
+        foreach (var hit in args.HitEntities)
+        {
+            if (!HasComp<ReactiveComponent>(hit))
                 continue;
-            }
 
             var splitSolution = _solutionContainerSystem.SplitSolution(soln.Value, totalSplit / hitCount);
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Bug fix!

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The system assumed that all the non reactive components were at the start of the array (They are not!) so the system would oftentimes get the incorrect number for the total hits resulting in reagent not being fully applied on some / all entities.

I just looped through it twice as I don't think making a new array with only the valid targets would be better performance wise and just seems like a pain compared to doing it this way. Maybe there is a C# trick that would be easier?

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

In this situation you are hitting two humans and also the machine. The machine doesn't have the reactive component but the humans do.

Before:

https://github.com/space-wizards/space-station-14/assets/107373427/d0f6dd3a-5c32-4380-ae13-35b97121c482

After:

https://github.com/space-wizards/space-station-14/assets/107373427/2828c441-3645-4d81-952f-8b5fad5a3cc4

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Beck Thompson
- fix: Splashing reagents on players will now apply the correct amounts.
