### PR TITLE
Bolt and pump action avilable again

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -242,4 +242,5 @@ public enum SelectiveFire : byte
     SemiAuto = 1 << 0,
     Burst = 1 << 1,
     FullAuto = 1 << 2, // Not in the building!
+    PumpAction = 1 << 3,
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -288,6 +288,9 @@ public abstract partial class SharedGunSystem : EntitySystem
                 break;
             case SelectiveFire.FullAuto:
                 break;
+            case SelectiveFire.PumpAction:
+                shots = Math.Min(shots, 1);
+                break;
             default:
                 throw new ArgumentOutOfRangeException($"No implemented shooting behavior for {gun.SelectedMode}!");
         }

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -11,6 +11,7 @@ gun-set-fire-mode = Set to {$mode}
 gun-SemiAuto = semi-auto
 gun-Burst = burst
 gun-FullAuto = full-auto
+gun-PumpAction = pump action
 
 # BallisticAmmoProvider
 gun-ballistic-cycle = Cycle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -21,9 +21,9 @@
   - type: AmmoCounter
   - type: Gun
     fireRate: 2
-    selectedMode: SemiAuto
+    selectedMode: PumpAction
     availableModes:
-    - SemiAuto
+    - PumpAction
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/shotgun.ogg
     soundEmpty:
@@ -116,6 +116,9 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 2
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
   - type: BallisticAmmoProvider
     capacity: 2
   - type: Construction

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -20,9 +20,9 @@
   - type: AmmoCounter
   - type: Gun
     fireRate: 0.75
-    selectedMode: SemiAuto
+    selectedMode: PumpAction
     availableModes:
-    - SemiAuto
+    - PumpAction
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
   - type: BallisticAmmoProvider


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Now we have new fire mode: pump action. But it's weird that bolt action rifles have pump action mode, i think it must be bolt action. They have similar or same sence, but named differently. If something like manual mode will be fine, just leave comment.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Resolves #19250 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/space-wizards/space-station-14/assets/70820551/c1d62f6d-6bb2-4a40-936d-ecb262c40023


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Bolt action and pump action rifles must be cycled again.
