### PR TITLE
Add scarf to warm clothing bounty

### DIFF
--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -1,4 +1,4 @@
-﻿- type: cargoBounty
+- type: cargoBounty
   id: BountyArtifact
   reward: 2500
   description: bounty-description-artifact
@@ -500,6 +500,8 @@
     whitelist:
       components:
       - TemperatureProtection
+      tags:
+      - Scarf
 
 - type: cargoBounty
   id: BountyBattery

--- a/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
@@ -29,3 +29,12 @@
     tags:
     - ClothMade
     - WhitelistChameleon
+
+- type: entity
+  abstract: true
+  parent: ClothingNeckBase
+  id: ClothingScarfBase
+  components:
+  - type: Tag
+    tags:
+    - Scarf

--- a/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
@@ -8,6 +8,9 @@
     sprite: Clothing/Neck/Scarfs/red.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/red.rsi
+  - type: Tag
+    tags:
+    - Scarf
 
 - type: entity
   parent: ClothingNeckBase
@@ -19,6 +22,10 @@
     sprite: Clothing/Neck/Scarfs/blue.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/blue.rsi
+  - type: Tag
+    tags:
+    - Scarf
+
 
 - type: entity
   parent: ClothingNeckBase
@@ -30,6 +37,9 @@
     sprite: Clothing/Neck/Scarfs/green.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/green.rsi
+  - type: Tag
+    tags:
+    - Scarf
 
 - type: entity
   parent: ClothingNeckBase
@@ -41,6 +51,9 @@
       sprite: Clothing/Neck/Scarfs/black.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/black.rsi
+    - type: Tag
+      tags:
+      - Scarf
 
 - type: entity
   parent: ClothingNeckBase
@@ -52,6 +65,9 @@
       sprite: Clothing/Neck/Scarfs/brown.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/brown.rsi
+    - type: Tag
+      tags:
+      - Scarf
 
 - type: entity
   parent: ClothingNeckBase
@@ -63,6 +79,9 @@
       sprite: Clothing/Neck/Scarfs/lightblue.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/lightblue.rsi
+    - type: Tag
+      tags:
+      - Scarf
 
 - type: entity
   parent: ClothingNeckBase
@@ -74,6 +93,9 @@
       sprite: Clothing/Neck/Scarfs/orange.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/orange.rsi
+    - type: Tag
+      tags:
+      - Scarf
 
 - type: entity
   parent: ClothingNeckBase
@@ -85,6 +107,9 @@
       sprite: Clothing/Neck/Scarfs/purple.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/purple.rsi
+    - type: Tag
+      tags:
+      - Scarf
 
 - type: entity
   parent: ClothingNeckBase
@@ -96,6 +121,9 @@
       sprite: Clothing/Neck/Scarfs/syndiegreen.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/syndiegreen.rsi
+    - type: Tag
+      tags:
+      - Scarf
 
 - type: entity
   parent: ClothingNeckBase
@@ -107,6 +135,9 @@
       sprite: Clothing/Neck/Scarfs/syndiered.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/syndiered.rsi
+    - type: Tag
+      tags:
+      - Scarf
 
 - type: entity
   parent: ClothingNeckBase
@@ -118,6 +149,9 @@
       sprite: Clothing/Neck/Scarfs/centcom.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/centcom.rsi
+    - type: Tag
+      tags:
+      - Scarf
 
 - type: entity
   parent: ClothingNeckBase
@@ -129,3 +163,6 @@
     sprite: Clothing/Neck/Scarfs/zebra.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/zebra.rsi
+  - type: Tag
+    tags:
+    - Scarf

--- a/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedRed
   name: striped red scarf
   description: A stylish striped red scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -8,12 +8,9 @@
     sprite: Clothing/Neck/Scarfs/red.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/red.rsi
-  - type: Tag
-    tags:
-    - Scarf
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedBlue
   name: striped blue scarf
   description: A stylish striped blue scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -22,13 +19,9 @@
     sprite: Clothing/Neck/Scarfs/blue.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/blue.rsi
-  - type: Tag
-    tags:
-    - Scarf
-
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedGreen
   name: striped green scarf
   description: A stylish striped green scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -37,12 +30,9 @@
     sprite: Clothing/Neck/Scarfs/green.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/green.rsi
-  - type: Tag
-    tags:
-    - Scarf
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedBlack
   name: striped black scarf
   description: A stylish striped black scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -51,12 +41,9 @@
       sprite: Clothing/Neck/Scarfs/black.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/black.rsi
-    - type: Tag
-      tags:
-      - Scarf
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedBrown
   name: striped brown scarf
   description: A stylish striped brown scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -65,12 +52,9 @@
       sprite: Clothing/Neck/Scarfs/brown.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/brown.rsi
-    - type: Tag
-      tags:
-      - Scarf
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedLightBlue
   name: striped light blue scarf
   description: A stylish striped light blue scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -79,12 +63,9 @@
       sprite: Clothing/Neck/Scarfs/lightblue.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/lightblue.rsi
-    - type: Tag
-      tags:
-      - Scarf
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedOrange
   name: striped orange scarf
   description: A stylish striped orange scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -93,12 +74,9 @@
       sprite: Clothing/Neck/Scarfs/orange.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/orange.rsi
-    - type: Tag
-      tags:
-      - Scarf
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedPurple
   name: striped purple scarf
   description: A stylish striped purple scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -107,12 +85,9 @@
       sprite: Clothing/Neck/Scarfs/purple.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/purple.rsi
-    - type: Tag
-      tags:
-      - Scarf
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedSyndieGreen
   name: striped syndicate green scarf
   description: A stylish striped syndicate green scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
@@ -121,12 +96,9 @@
       sprite: Clothing/Neck/Scarfs/syndiegreen.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/syndiegreen.rsi
-    - type: Tag
-      tags:
-      - Scarf
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedSyndieRed
   name: striped syndicate red scarf
   description: A stylish striped syndicate red scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
@@ -135,12 +107,9 @@
       sprite: Clothing/Neck/Scarfs/syndiered.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/syndiered.rsi
-    - type: Tag
-      tags:
-      - Scarf
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedCentcom
   name: striped CentCom scarf
   description: A stylish striped centcom colored scarf. The perfect winter accessory for those with a keen fashion sense, and those who need to do paperwork in the cold.
@@ -149,12 +118,9 @@
       sprite: Clothing/Neck/Scarfs/centcom.rsi
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/centcom.rsi
-    - type: Tag
-      tags:
-      - Scarf
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedZebra
   name: zebra scarf
   description: A striped scarf, a mandatory accessory for artists.
@@ -163,6 +129,3 @@
     sprite: Clothing/Neck/Scarfs/zebra.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/zebra.rsi
-  - type: Tag
-    tags:
-    - Scarf

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1106,6 +1106,9 @@
   id: SalvageExperiment
 
 - type: Tag
+  id: Scarf
+
+- type: Tag
   id: Screwdriver
 
 - type: Tag


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fixes #29775  
Made scarves count as warm clothing for the cargo bounty, added a Scarf tag in order to achieve it.

## Why / Balance
Scarves should count as warm clothing in the bounty.

## Technical details
Added a new `Scarf` tag, and assigned it to all of the scarves, whitelisted the `Scarf` tag on the warm clothing bounty

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/space-wizards/space-station-14/assets/69372103/4a823edb-4640-4e74-962d-049282d45058



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Lokachop
- tweak: Scarves now count as warm clothing for the warm clothing cargo bounty.