### PR TITLE
Silence ringtones on admin PDAs

### DIFF
--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -20,6 +20,7 @@ using Content.Server.Station.Systems;
 using Content.Shared.Popups;
 using Content.Shared.StationRecords;
 using Robust.Shared.Audio.Systems;
+using Content.Server.Chat.Managers;
 
 namespace Content.Server.MassMedia.Systems;
 
@@ -35,6 +36,7 @@ public sealed class NewsSystem : SharedNewsSystem
     [Dependency] private readonly GameTicker _ticker = default!;
     [Dependency] private readonly AccessReaderSystem _accessReader = default!;
     [Dependency] private readonly IdCardSystem _idCardSystem = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!;
 
     public override void Initialize()
     {
@@ -160,6 +162,12 @@ public sealed class NewsSystem : SharedNewsSystem
             LogImpact.Medium,
             $"{ToPrettyString(msg.Actor):actor} created news article {article.Title} by {article.Author}: {article.Content}"
             );
+
+        _chatManager.SendAdminAnnouncement(Loc.GetString("news-publish-admin-announcement",
+            ("actor", msg.Actor),
+            ("title", article.Title),
+            ("author", article.Author ?? Loc.GetString("news-read-ui-no-author"))
+            ));
 
         articles.Add(article);
 

--- a/Resources/Locale/en-US/mass-media/news-ui.ftl
+++ b/Resources/Locale/en-US/mass-media/news-ui.ftl
@@ -34,3 +34,4 @@ news-write-ui-richtext-tooltip = News articles support rich text
     {"[bullet/]bullet[/color]"}
 
 news-pda-notification-header = New news article
+news-publish-admin-announcement = {$actor} published news article {$title} by {$author}"

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -667,6 +667,7 @@
     scanDelay: 0
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key
+    notificationsEnabled: false
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Admin PDAs now have notification sounds disabled.
Also adds an admin chat announcement when news articles are published, to compensate for removing the PDA notification.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
No more spooky ringtones from nowhere, and no aghosts becoming visible when their ringtones sound.
Fixes #27697
Fixes #29799

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
One line of YAML to disable notifications. A bit of C# and one Fluent line to add the announcement.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Code
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed admin ghosts briefly becoming visible when a news article is published.