### PR TITLE
fix passive vent sprite in construction menu

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -489,12 +489,12 @@
   canBuildInImpassable: false
   icon:
     sprite: Structures/Piping/Atmospherics/vent.rsi
-    state: vent_off
+    state: vent_passive
   layers:
   - sprite: Structures/Piping/Atmospherics/pipe.rsi
     state: pipeHalf
   - sprite: Structures/Piping/Atmospherics/vent.rsi
-    state: vent_off
+    state: vent_passive
   conditions:
     - !type:NoUnstackableInTile
 


### PR DESCRIPTION
## About the PR
I missed this one in #29536.
The construction menu and building preview now show the new passive vent sprite instead of the gas vent.

## Why / Balance
bugfix

## Technical details
corrected the sprite state

## Media
![Screenshot (188)](https://github.com/space-wizards/space-station-14/assets/161409025/4158725f-ce1d-4434-a492-e5a2af2312a9)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: The construction menu and building preview now show the correct passive vent sprite.
