### PR TITLE
Make delay incurred from additional syringe contents modifiable + tiny syringe buff/fix

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
@@ -132,8 +132,8 @@ public sealed class InjectorSystem : SharedInjectorSystem
         }
 
         // Injections take 0.5 seconds longer per 5u of possible space/content
-        // First 5u doesn't incur delay
-        actualDelay += TimeSpan.FromSeconds((amountToInject - 5) * injector.Comp.DelayPerVolume);
+        // First 5u(MinimumTransferAmount) doesn't incur delay
+        actualDelay += TimeSpan.FromSeconds(Math.Max(0, amountToInject - injector.Comp.MinimumTransferAmount.Float()) * injector.Comp.DelayPerVolume);
 
         // Ensure that minimum delay before incapacitation checks is 1 seconds
         actualDelay = MathHelper.Max(actualDelay, TimeSpan.FromSeconds(1));

--- a/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
@@ -119,21 +119,21 @@ public sealed class InjectorSystem : SharedInjectorSystem
             return;
 
         var actualDelay = injector.Comp.Delay;
-        float amountToInject;
+        FixedPoint2 amountToInject;
         if (injector.Comp.ToggleState == InjectorToggleMode.Draw)
         {
             // additional delay is based on actual volume left to draw in syringe when smaller than transfer amount
-            amountToInject = Math.Min(injector.Comp.TransferAmount.Float(), (solution.MaxVolume - solution.Volume).Float());
+            amountToInject = FixedPoint2.Min(injector.Comp.TransferAmount, (solution.MaxVolume - solution.Volume));
         }
         else
         {
             // additional delay is based on actual volume left to inject in syringe when smaller than transfer amount
-            amountToInject = Math.Min(injector.Comp.TransferAmount.Float(), solution.Volume.Float());
+            amountToInject = FixedPoint2.Min(injector.Comp.TransferAmount, solution.Volume);
         }
 
         // Injections take 0.5 seconds longer per 5u of possible space/content
         // First 5u(MinimumTransferAmount) doesn't incur delay
-        actualDelay += TimeSpan.FromSeconds(Math.Max(0, amountToInject - injector.Comp.MinimumTransferAmount.Float()) * injector.Comp.DelayPerVolume);
+        actualDelay += injector.Comp.DelayPerVolume * FixedPoint2.Max(0, amountToInject - injector.Comp.MinimumTransferAmount).Double();
 
         // Ensure that minimum delay before incapacitation checks is 1 seconds
         actualDelay = MathHelper.Max(actualDelay, TimeSpan.FromSeconds(1));

--- a/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
@@ -118,7 +118,7 @@ public sealed class InjectorSystem : SharedInjectorSystem
         if (!SolutionContainers.TryGetSolution(injector.Owner, injector.Comp.SolutionName, out _, out var solution))
             return;
 
-        var actualDelay = MathHelper.Max(injector.Comp.Delay, TimeSpan.FromSeconds(1));
+        var actualDelay = injector.Comp.Delay;
         float amountToInject;
         if (injector.Comp.ToggleState == InjectorToggleMode.Draw)
         {
@@ -132,7 +132,11 @@ public sealed class InjectorSystem : SharedInjectorSystem
         }
 
         // Injections take 0.5 seconds longer per 5u of possible space/content
-        actualDelay += TimeSpan.FromSeconds(amountToInject / 10);
+        // First 5u doesn't incur delay
+        actualDelay += TimeSpan.FromSeconds((amountToInject - 5) * injector.Comp.DelayPerVolume);
+
+        // Ensure that minimum delay before incapacitation checks is 1 seconds
+        actualDelay = MathHelper.Max(actualDelay, TimeSpan.FromSeconds(1));
 
 
         var isTarget = user != target;

--- a/Content.Shared/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Shared/Chemistry/Components/InjectorComponent.cs
@@ -75,7 +75,7 @@ public sealed partial class InjectorComponent : Component
 
     /// <summary>
     /// Each additional 1u after first 5u increases the delay by X seconds.
-    /// <summary>
+    /// </summary>
     [DataField]
     public TimeSpan DelayPerVolume = TimeSpan.FromSeconds(0.1);
 

--- a/Content.Shared/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Shared/Chemistry/Components/InjectorComponent.cs
@@ -77,7 +77,7 @@ public sealed partial class InjectorComponent : Component
     /// Each additional 1u after first 5u increases the delay by X seconds.
     /// <summary>
     [DataField]
-    public double DelayPerVolume = 0.1;
+    public TimeSpan DelayPerVolume = TimeSpan.FromSeconds(0.1);
 
     /// <summary>
     /// The state of the injector. Determines it's attack behavior. Containers must have the

--- a/Content.Shared/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Shared/Chemistry/Components/InjectorComponent.cs
@@ -74,6 +74,12 @@ public sealed partial class InjectorComponent : Component
     public TimeSpan Delay = TimeSpan.FromSeconds(5);
 
     /// <summary>
+    /// Each additional 1u after first 5u increases the delay by X seconds.
+    /// <summary>
+    [DataField]
+    public double DelayPerVolume = 0.1;
+
+    /// <summary>
     /// The state of the injector. Determines it's attack behavior. Containers must have the
     /// right SolutionCaps to support injection/drawing. For InjectOnly injectors this should
     /// only ever be set to Inject


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
## Why / Balance
My next PR requires my new syringes to have both short doafter and a high transfer amount. 
With this change, the new prototype can be told not to do any delay scaling according to the transfer amount.

Also this PR contains a small fix/buff for syringes. 
According to #12173, the intent was to have each additional 5u cause a delay increase of 1 second. 
However, due to some bad math in #14441, and the fix for that calculation in #25890, the equation got left in a state where each 5u of the transfer amount was affected by the doafter delay increase, instead of only the additional doses being affected. 
Here's an illustration of the delays over those PRs:

|dose| 12173 | 14441 | 25890 | this pr|
|-----| ------------- | ------------- |--|--|
|5u| 0s | 0.5s |0.5s|0s|
|10u| 1s | 1.5s |1.0s|0.5s|
|15u| 2s | 2.5s |1.5s|1.0s|

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Added `DelayPerVolume` datafield to the injectorComponent, which tells how the injection doAfter increases with the transfer amount.
Also moved the minimum delay check so negative `DelayPerVolume` can't get the delay under 1 second.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.

- add: Added fun!
- remove: Removed fun!

- fix: Fixed fun!
-->
:cl:
- tweak: Syringes are now 0.5 seconds faster.