### PR TITLE
all toggle light actions have a 1 second use delay

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -37,6 +37,7 @@
   description: Turn the light on and off.
   components:
   - type: InstantAction
+    useDelay: 1
     icon: { sprite: Objects/Tools/flashlight.rsi, state: flashlight }
     iconOn: { sprite: Objects/Tools/flashlight.rsi, state: flashlight-on }
     event: !type:ToggleActionEvent


### PR DESCRIPTION
- Adds a usedelay of one second to any items that grant a toggle light action
- Prevents epileptic seizures

**Changelog**

:cl: Whisper

- tweak: Light toggle actions now have a 1 second cooldown between uses.
