### PR TITLE
Air alarms check sensors upon power returning

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
@@ -151,6 +151,7 @@ public sealed class AtmosMonitorSystem : EntitySystem
                 }
 
                 _deviceNetSystem.QueuePacket(uid, args.SenderAddress, payload);
+                Alert(uid, component.LastAlarmState);
                 break;
         }
     }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
title

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
If air sensor/vent detects danger while the air alarm is unpowered, the air alarm won't be updated accordingly when it gains power.
This can cause situations where the alarm says that everything's normal, even though the alarm UI shows stuff like 10000kPa and all sensors display danger.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
When `AtmosAlarmable` (air alarm) is powered on, it runs the `Sync` method of `AtmosDeviceNetworkSystem`. 
`AtmosMonitor`s then answer by sending a `SyncData` packet back, however `AtmosAlarmable` doesn't handle this packet in any way. 
This happens because the packet doesn't have any tags set, so they are ignored, and even if they weren't, there's no case in the switch statement which handles the syncing.
The proper way to do this fix is probably by actually handling this packet in some way, but I'm lazy rn so I'll just use this quick fix:
Whenever `AtmosMonitor` gets a request to sync, it runs the `Alert` method, informing the connected air alarms of it's current state.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Before and after videos,
I remove power from the air alarm, then space the room, and then return power to the alarm. 
In the first clip, the alarm says that alarm state is Normal, in the latter, alarm state is Danger.

At the end of the first clip, the air alarm changes to danger, however this part wasn't related to power. This happened because the room temperature crossed a alarm threshold for temperature, those being 212k and 193k. 

https://github.com/space-wizards/space-station-14/assets/62134478/bebeb987-fc64-4896-a968-0520cd3db927

https://github.com/space-wizards/space-station-14/assets/62134478/985e1a52-817e-453d-a0fa-17b843993672

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.

- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!

-->
:cl:
- fix: Fix air alarms not checking sensor states upon power returning.

