### PR TITLE
Fix 6pack sprite layers not appearing

### DIFF
--- a/Content.Client/Storage/Systems/ItemCounterSystem.cs
+++ b/Content.Client/Storage/Systems/ItemCounterSystem.cs
@@ -31,7 +31,10 @@ public sealed class ItemCounterSystem : SharedItemCounterSystem
 
         if (!_appearanceSystem.TryGetData<bool>(uid, StackVisuals.Hide, out var hidden, args.Component))
             hidden = false;
-        
+
+        if (comp.NeverHidden)
+            hidden = false;
+
         if (comp.IsComposite)
             ProcessCompositeSprite(uid, actual, maxCount, comp.LayerStates, hidden, sprite: args.Sprite);
         else

--- a/Content.Shared/Storage/Components/ItemCounterComponent.cs
+++ b/Content.Shared/Storage/Components/ItemCounterComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Whitelist;
 
 namespace Content.Shared.Storage.Components
@@ -56,5 +56,13 @@ namespace Content.Shared.Storage.Components
         [DataField("layerStates")]
         [ViewVariables(VVAccess.ReadWrite)]
         public List<string> LayerStates = new();
+
+        /// <summary>
+        /// Should the sprite layers always be visible regardless of storage open/closed status?
+        /// e.g. 6pack of soda never 'closes' to hide the cans, so they're always visable.
+        /// </summary>
+        [DataField]
+        [ViewVariables]
+        public bool NeverHidden;
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -440,6 +440,7 @@
     count:
       tags: [Cola]
     composite: true
+    neverHidden: true
     layerStates:
     - 6pack1
     - 6pack2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Fixes #28721

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The soda 6pack is unique in that it is the only item with ItemCounter sprite layers, but it doesn't have lid to open/close.
Things like cigarette packs and donut boxes hide or reveal the extra layers depending on if the UI is open, but with a 6pack, we want them to always be revealed.

Given this is a single special case, I just added a field to grant it an exception, and put the logic in ItemCounterSystem to avoid scrungling up anything with SharedStorageSystem, where the lid logic lives.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

no cl for sprite changes/fixes
