### PR TITLE
Passenger Loadout Additions

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -34,6 +34,7 @@ loadout-group-passenger-mask = Passenger mask
 loadout-group-passenger-gloves = Passenger gloves
 loadout-group-passenger-outerclothing = Passenger outer clothing
 loadout-group-passenger-shoes = Passenger shoes
+loadout-group-passenger-head = Passenger hats
 
 loadout-group-bartender-head = Bartender head
 loadout-group-bartender-jumpsuit = Bartender jumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -652,33 +652,6 @@
     shoes: ClothingShoesColorBlack
 
 - type: loadout
-  id: WhiteShoes
-  equipment: WhiteShoes
-
-- type: startingGear
-  id: WhiteShoes
-  equipment:
-    shoes: ClothingShoesColorWhite
-
-- type: loadout
-  id: BrownShoes
-  equipment: BrownShoes
-
-- type: startingGear
-  id: BrownShoes
-  equipment:
-    shoes: ClothingShoesColorBrown
-
-- type: loadout
-  id: BlueShoes
-  equipment: BlueShoes
-
-- type: startingGear
-  id: BlueShoes
-  equipment:
-    shoes: ClothingShoesColorBlue
-
-- type: loadout
   id: YellowShoes
   equipment: YellowShoes
 
@@ -722,7 +695,6 @@
   id: PurpleShoes
   equipment:
     shoes: ClothingShoesColorPurple
-
 
 - type: loadout
   id: WinterBoots

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -612,25 +612,6 @@
   equipment:
     gloves: ClothingHandsGlovesColorGreen
 
-- type: loadout
-  id: OrangeGloves
-  equipment: OrangeGloves
-
-- type: startingGear
-  id: OrangeGloves
-  equipment:
-    gloves: ClothingHandsGlovesColorOrange
-
-- type: loadout
-  id: PurpleGloves
-  equipment: PurpleGloves
-
-- type: startingGear
-  id: PurpleGloves
-  equipment:
-    gloves: ClothingHandsGlovesColorPurple
-
-
 # Outerclothing
 - type: loadout
   id: PassengerWintercoat

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -212,25 +212,7 @@
   id: GreyJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorGrey
-
-- type: loadout
-  id: WhiteJumpsuit
-  equipment: WhiteJumpsuit
-
-- type: startingGear
-  id: WhiteJumpsuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitColorWhite
-
-- type: loadout
-  id: WhiteJumpskirt
-  equipment: WhiteJumpskirt
-
-- type: startingGear
-  id: WhiteJumpskirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtColorWhite
-
+    
 - type: loadout
   id: BlackJumpsuit
   equipment: BlackJumpsuit
@@ -268,24 +250,6 @@
     jumpsuit: ClothingUniformJumpskirtColorBlue
 
 - type: loadout
-  id: YellowJumpsuit
-  equipment: YellowJumpsuit
-
-- type: startingGear
-  id: YellowJumpsuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitColorYellow
-
-- type: loadout
-  id: YellowJumpskirt
-  equipment: YellowJumpskirt
-
-- type: startingGear
-  id: YellowJumpskirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtColorYellow
-
-- type: loadout
   id: GreenJumpsuit
   equipment: GreenJumpsuit
 
@@ -320,24 +284,6 @@
   id: OrangeJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorOrange
-
-- type: loadout
-  id: RedJumpsuit
-  equipment: RedJumpsuit
-
-- type: startingGear
-  id: RedJumpsuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitColorRed
-
-- type: loadout
-  id: RedJumpskirt
-  equipment: RedJumpskirt
-
-- type: startingGear
-  id: RedJumpskirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtColorRed
 
 - type: loadout
   id: PurpleJumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -8,6 +8,178 @@
       role: JobPassenger
       time: 36000 #10 hrs, silly reward for people who play passenger a lot
 
+# Head
+- type: loadout
+  id: BlackHeadBand
+  equipment: BlackHeadBand
+
+- type: startingGear
+  id: BlackHeadBand
+  equipment:
+    head: ClothingHeadBandBlack
+
+- type: loadout
+  id: BlueHeadBand
+  equipment: BlueHeadBand
+
+- type: startingGear
+  id: BlueHeadBand
+  equipment:
+    head: ClothingHeadBandBlue
+
+- type: loadout
+  id: GreenHeadBand
+  equipment: GreenHeadBand
+
+- type: startingGear
+  id: GreenHeadBand
+  equipment:
+    head: ClothingHeadBandGreen
+
+- type: loadout
+  id: RedHeadBand
+  equipment: RedHeadBand
+
+- type: startingGear
+  id: RedHeadBand
+  equipment:
+    head: ClothingHeadBandRed
+
+- type: loadout
+  id: SkullHeadBand
+  equipment: SkullHeadBand
+
+- type: startingGear
+  id: SkullHeadBand
+  equipment:
+    head: ClothingHeadBandSkull
+
+- type: loadout
+  id: HatGrey
+  equipment: HatGrey
+
+- type: startingGear
+  id: HatGrey
+  equipment:
+    head: ClothingHeadHatGreysoft
+
+- type: loadout
+  id: HatMime
+  equipment: HatMime
+
+- type: startingGear
+  id: HatMime
+  equipment:
+    head: ClothingHeadHatMimesoft
+
+- type: loadout
+  id: HatBlue
+  equipment: HatBlue
+
+- type: startingGear
+  id: HatBlue
+  equipment:
+    head: ClothingHeadHatBluesoft
+
+- type: loadout
+  id: HatYellow
+  equipment: HatYellow
+
+- type: startingGear
+  id: HatYellow
+  equipment:
+    head: ClothingHeadHatYellowsoft
+
+- type: loadout
+  id: HatGreen
+  equipment: HatGreen
+
+- type: startingGear
+  id: HatGreen
+  equipment:
+    head: ClothingHeadHatGreensoft
+
+- type: loadout
+  id: HatOrange
+  equipment: HatOrange
+
+- type: startingGear
+  id: HatOrange
+  equipment:
+    head: ClothingHeadHatOrangesoft
+
+- type: loadout
+  id: HatRed
+  equipment: HatRed
+
+- type: startingGear
+  id: HatRed
+  equipment:
+    head: ClothingHeadHatRedsoft
+
+- type: loadout
+  id: HatBlack
+  equipment: HatBlack
+
+- type: startingGear
+  id: HatBlack
+  equipment:
+    head: ClothingHeadHatBlacksoft
+
+- type: loadout
+  id: HatPurple
+  equipment: HatPurple
+
+- type: startingGear
+  id: HatPurple
+  equipment:
+    head: ClothingHeadHatPurplesoft
+
+- type: loadout
+  id: HatCorp
+  equipment: HatCorp
+
+- type: startingGear
+  id: HatCorp
+  equipment:
+    head: ClothingHeadHatCorpsoft
+
+- type: loadout
+  id: HatFishing
+  equipment: HatFishing
+
+- type: startingGear
+  id: HatFishing
+  equipment:
+    head: ClothingHeadFishCap
+
+- type: loadout
+  id: HatRasta
+  equipment: HatRasta
+
+- type: startingGear
+  id: HatRasta
+  equipment:
+    head: ClothingHeadRastaHat    
+
+- type: loadout
+  id: GreyFlatcap
+  equipment: GreyFlatcap
+
+- type: startingGear
+  id: GreyFlatcap
+  equipment:
+    head: ClothingHeadHatGreyFlatcap
+
+- type: loadout
+  id: BrownFlatcap
+  equipment: BrownFlatcap
+
+- type: startingGear
+  id: BrownFlatcap
+  equipment:
+    head: ClothingHeadHatBrownFlatcap
+
 # Face
 - type: loadout
   id: PassengerFace
@@ -41,7 +213,331 @@
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorGrey
 
-# Rainbow
+- type: loadout
+  id: WhiteJumpsuit
+  equipment: WhiteJumpsuit
+
+- type: startingGear
+  id: WhiteJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorWhite
+
+- type: loadout
+  id: WhiteJumpskirt
+  equipment: WhiteJumpskirt
+
+- type: startingGear
+  id: WhiteJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorWhite
+
+- type: loadout
+  id: BlackJumpsuit
+  equipment: BlackJumpsuit
+
+- type: startingGear
+  id: BlackJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorBlack
+
+- type: loadout
+  id: BlackJumpskirt
+  equipment: BlackJumpskirt
+
+- type: startingGear
+  id: BlackJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorBlack
+
+- type: loadout
+  id: BlueJumpsuit
+  equipment: BlueJumpsuit
+
+- type: startingGear
+  id: BlueJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorBlue
+
+- type: loadout
+  id: BlueJumpskirt
+  equipment: BlueJumpskirt
+
+- type: startingGear
+  id: BlueJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorBlue
+
+- type: loadout
+  id: YellowJumpsuit
+  equipment: YellowJumpsuit
+
+- type: startingGear
+  id: YellowJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorYellow
+
+- type: loadout
+  id: YellowJumpskirt
+  equipment: YellowJumpskirt
+
+- type: startingGear
+  id: YellowJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorYellow
+
+- type: loadout
+  id: GreenJumpsuit
+  equipment: GreenJumpsuit
+
+- type: startingGear
+  id: GreenJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorGreen
+
+- type: loadout
+  id: GreenJumpskirt
+  equipment: GreenJumpskirt
+
+- type: startingGear
+  id: GreenJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorGreen
+
+- type: loadout
+  id: OrangeJumpsuit
+  equipment: OrangeJumpsuit
+
+- type: startingGear
+  id: OrangeJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorOrange
+
+- type: loadout
+  id: OrangeJumpskirt
+  equipment: OrangeJumpskirt
+
+- type: startingGear
+  id: OrangeJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorOrange
+
+- type: loadout
+  id: RedJumpsuit
+  equipment: RedJumpsuit
+
+- type: startingGear
+  id: RedJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorRed
+
+- type: loadout
+  id: RedJumpskirt
+  equipment: RedJumpskirt
+
+- type: startingGear
+  id: RedJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorRed
+
+- type: loadout
+  id: PurpleJumpsuit
+  equipment: PurpleJumpsuit
+
+- type: startingGear
+  id: PurpleJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorPurple
+
+- type: loadout
+  id: PurpleJumpskirt
+  equipment: PurpleJumpskirt
+
+- type: startingGear
+  id: PurpleJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorPurple
+
+- type: loadout
+  id: PinkJumpsuit
+  equipment: PinkJumpsuit
+
+- type: startingGear
+  id: PinkJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorPink
+
+- type: loadout
+  id: PinkJumpskirt
+  equipment: PinkJumpskirt
+
+- type: startingGear
+  id: PinkJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorPink
+
+- type: loadout
+  id: DarkBlueJumpsuit
+  equipment: DarkBlueJumpsuit
+
+- type: startingGear
+  id: DarkBlueJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorDarkBlue
+
+- type: loadout
+  id: DarkBlueJumpskirt
+  equipment: DarkBlueJumpskirt
+
+- type: startingGear
+  id: DarkBlueJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorDarkBlue
+
+- type: loadout
+  id: DarkGreenJumpsuit
+  equipment: DarkGreenJumpsuit
+
+- type: startingGear
+  id: DarkGreenJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorDarkGreen
+
+- type: loadout
+  id: DarkGreenJumpskirt
+  equipment: DarkGreenJumpskirt
+
+- type: startingGear
+  id: DarkGreenJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorDarkGreen
+
+- type: loadout
+  id: TealJumpsuit
+  equipment: TealJumpsuit
+
+- type: startingGear
+  id: TealJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorTeal
+
+- type: loadout
+  id: TealJumpskirt
+  equipment: TealJumpskirt
+
+- type: startingGear
+  id: TealJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorTeal
+    
+- type: loadout # Rom Killinger Buff
+  id: BlackHawaiian
+  equipment: BlackHawaiian
+
+- type: startingGear
+  id: BlackHawaiian
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHawaiBlack
+
+- type: loadout
+  id: BlueHawaiian
+  equipment: BlueHawaiian
+
+- type: startingGear
+  id: BlueHawaiian
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHawaiBlue
+
+- type: loadout
+  id: RedHawaiian
+  equipment: RedHawaiian
+
+- type: startingGear
+  id: RedHawaiian
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHawaiRed
+
+- type: loadout
+  id: YellowHawaiian
+  equipment: YellowHawaiian
+
+- type: startingGear
+  id: YellowHawaiian
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHawaiYellow
+
+- type: loadout
+  id: FlannelJumpsuit
+  equipment: FlannelJumpsuit
+
+- type: startingGear
+  id: FlannelJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitFlannel
+
+- type: loadout
+  id: CasualBlueSuit
+  equipment: CasualBlueSuit
+
+- type: startingGear
+  id: CasualBlueSuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCasualBlue
+
+- type: loadout
+  id: CasualBlueSkirt
+  equipment: CasualBlueSkirt
+
+- type: startingGear
+  id: CasualBlueSkirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCasualBlue
+
+- type: loadout
+  id: CasualPurpleSuit
+  equipment: CasualPurpleSuit
+
+- type: startingGear
+  id: CasualPurpleSuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCasualPurple
+
+- type: loadout
+  id: CasualPurpleSkirt
+  equipment: CasualPurpleSkirt
+
+- type: startingGear
+  id: CasualPurpleSkirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCasualPurple
+
+- type: loadout
+  id: CasualRedSuit
+  equipment: CasualRedSuit
+
+- type: startingGear
+  id: CasualRedSuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCasualRed
+
+- type: loadout
+  id: CasualRedSkirt
+  equipment: CasualRedSkirt
+
+- type: startingGear
+  id: CasualRedSkirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCasualRed
+
+- type: loadout
+  id: RandomColorful
+  equipment: RandomColorful
+
+- type: startingGear
+  id: RandomColorful
+  equipment:
+    jumpsuit: ClothingUniformRandomShirt
+
+# GreyTider
 - type: loadout
   id: RainbowJumpsuit
   equipment: RainbowJumpsuit
@@ -54,7 +550,6 @@
   equipment:
     jumpsuit: ClothingUniformColorRainbow
 
-# Ancient
 - type: loadout
   id: AncientJumpsuit
   equipment: AncientJumpsuit
@@ -108,6 +603,88 @@
   equipment:
     gloves: ClothingHandsGlovesFingerlessInsulated
 
+- type: loadout
+  id: BlackGloves
+  equipment: BlackGloves
+
+- type: startingGear
+  id: BlackGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorBlack
+
+- type: loadout
+  id: GreyGloves
+  equipment: GreyGloves
+
+- type: startingGear
+  id: GreyGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorGray
+
+- type: loadout
+  id: BrownGloves
+  equipment: BrownGloves
+
+- type: startingGear
+  id: BrownGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorBrown
+
+- type: loadout
+  id: WhiteGloves
+  equipment: WhiteGloves
+
+- type: startingGear
+  id: WhiteGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorWhite
+
+- type: loadout
+  id: RedGloves
+  equipment: RedGloves
+
+- type: startingGear
+  id: RedGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorRed
+
+- type: loadout
+  id: BlueGloves
+  equipment: BlueGloves
+
+- type: startingGear
+  id: BlueGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorBlue
+
+- type: loadout
+  id: GreenGloves
+  equipment: GreenGloves
+
+- type: startingGear
+  id: GreenGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorGreen
+
+- type: loadout
+  id: OrangeGloves
+  equipment: OrangeGloves
+
+- type: startingGear
+  id: OrangeGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorOrange
+
+- type: loadout
+  id: PurpleGloves
+  equipment: PurpleGloves
+
+- type: startingGear
+  id: PurpleGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorPurple
+
+
 # Outerclothing
 - type: loadout
   id: PassengerWintercoat
@@ -127,6 +704,79 @@
   id: BlackShoes
   equipment:
     shoes: ClothingShoesColorBlack
+
+- type: loadout
+  id: WhiteShoes
+  equipment: WhiteShoes
+
+- type: startingGear
+  id: WhiteShoes
+  equipment:
+    shoes: ClothingShoesColorWhite
+
+- type: loadout
+  id: BrownShoes
+  equipment: BrownShoes
+
+- type: startingGear
+  id: BrownShoes
+  equipment:
+    shoes: ClothingShoesColorBrown
+
+- type: loadout
+  id: BlueShoes
+  equipment: BlueShoes
+
+- type: startingGear
+  id: BlueShoes
+  equipment:
+    shoes: ClothingShoesColorBlue
+
+- type: loadout
+  id: YellowShoes
+  equipment: YellowShoes
+
+- type: startingGear
+  id: YellowShoes
+  equipment:
+    shoes: ClothingShoesColorYellow
+
+- type: loadout
+  id: GreenShoes
+  equipment: GreenShoes
+
+- type: startingGear
+  id: GreenShoes
+  equipment:
+    shoes: ClothingShoesColorGreen
+
+- type: loadout
+  id: OrangeShoes
+  equipment: OrangeShoes
+
+- type: startingGear
+  id: OrangeShoes
+  equipment:
+    shoes: ClothingShoesColorOrange
+
+- type: loadout
+  id: RedShoes
+  equipment: RedShoes
+
+- type: startingGear
+  id: RedShoes
+  equipment:
+    shoes: ClothingShoesColorRed
+
+- type: loadout
+  id: PurpleShoes
+  equipment: PurpleShoes
+
+- type: startingGear
+  id: PurpleShoes
+  equipment:
+    shoes: ClothingShoesColorPurple
+
 
 - type: loadout
   id: WinterBoots

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -140,8 +140,70 @@
   loadouts:
   - GreyJumpsuit
   - GreyJumpskirt
+  - WhiteJumpsuit
+  - WhiteJumpskirt
+  - BlackJumpsuit
+  - BlackJumpskirt
+  - BlueJumpsuit
+  - BlueJumpskirt
+  - YellowJumpsuit
+  - YellowJumpskirt
+  - GreenJumpsuit
+  - GreenJumpskirt
+  - OrangeJumpsuit
+  - OrangeJumpskirt
+  - RedJumpsuit
+  - RedJumpskirt
+  - PurpleJumpsuit
+  - PurpleJumpskirt
+  - PinkJumpsuit
+  - PinkJumpskirt
+  - DarkBlueJumpsuit
+  - DarkBlueJumpskirt
+  - DarkGreenJumpsuit
+  - DarkGreenJumpskirt
+  - TealJumpsuit
+  - TealJumpskirt
+  - BlackHawaiian
+  - BlueHawaiian
+  - RedHawaiian
+  - YellowHawaiian
+  - FlannelJumpsuit
+  - CasualBlueSuit
+  - CasualBlueSkirt
+  - CasualPurpleSuit
+  - CasualPurpleSkirt
+  - CasualRedSuit
+  - CasualRedSkirt
+  - RandomColorful
   - AncientJumpsuit
   - RainbowJumpsuit
+
+- type: loadoutGroup
+  id: PassengerHead
+  name: loadout-group-passenger-head
+  minLimit: 0
+  loadouts:
+  - MimeHead
+  - BlackHeadBand
+  - BlueHeadBand
+  - GreenHeadBand
+  - RedHeadBand
+  - SkullHeadBand
+  - HatGrey
+  - HatMime
+  - HatBlue
+  - HatYellow
+  - HatGreen
+  - HatOrange
+  - HatRed
+  - HatBlack
+  - HatPurple
+  - HatCorp
+  - HatFishing
+  - HatRasta
+  - GreyFlatcap
+  - BrownFlatcap
 
 - type: loadoutGroup
   id: PassengerFace
@@ -156,6 +218,15 @@
   minLimit: 0
   loadouts:
   - PassengerGloves
+  - BlackGloves
+  - GreyGloves
+  - BrownGloves
+  - WhiteGloves
+  - RedGloves
+  - BlueGloves
+  - GreenGloves
+  - OrangeGloves
+  - PurpleGloves
 
 - type: loadoutGroup
   id: CommonBackpack
@@ -178,6 +249,14 @@
   loadouts:
   - BlackShoes
   - WinterBoots
+  - WhiteShoes
+  - BrownShoes
+  - BlueShoes
+  - YellowShoes
+  - GreenShoes
+  - OrangeShoes
+  - RedShoes
+  - PurpleShoes
 
 - type: loadoutGroup
   id: BartenderHead

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -32,6 +32,7 @@
   - GroupTankHarness
   - PassengerJumpsuit
   - CommonBackpack
+  - PassengerHead
   - PassengerFace
   - PassengerGloves
   - PassengerOuterClothing


### PR DESCRIPTION
## About the PR
I added a bunch of the items found in the ClothesMate machine into the Passenger loadout options.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I made this change to give passengers a little bit more variety and uniqueness to their loadout if they ended up as a passenger since the passenger loadout is quite sparse and it saves the rush of passengers running to a ClothesMate.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
YML changes

## Media
![Medal_eWfjJ2gJ4q](https://github.com/space-wizards/space-station-14/assets/64847293/965b1ef8-9b18-4789-9c50-1d438eb857ec)
![Medal_FxfKwfYEQs](https://github.com/space-wizards/space-station-14/assets/64847293/3cd4aeae-638a-43be-8fe0-264457f805cd)
![Medal_jSUII2fipU](https://github.com/space-wizards/space-station-14/assets/64847293/e06bc12b-f419-48d1-8c8b-074f5d6a3e18)
![Medal_TIfXI1cCQ1](https://github.com/space-wizards/space-station-14/assets/64847293/63d3a340-7e76-400f-9501-9de890979609)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
n/a

**Changelog**
:cl:
- add: The budget for clothes for passengers has been increased to include common ClothesMate items!