### PR TITLE
Change Diphenhydramine recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -518,7 +518,7 @@
   reactants:
     Diethylamine:
       amount: 1
-    Oil:
+    Ethylredoxrazine:
       amount: 1
     TableSalt:
       amount: 1


### PR DESCRIPTION
## About the PR
Oil in Diphenhydraimne recipe was replaced with Ethylredoxrazine

## Why / Balance
Broken reagent temperature system leads to situation when you constantly getting Ash and Charcoal when trying to mix it. If you don't know how to manage with it, you won't be able to craft more then 60 diphen. Newbies just won't understand why they can't craft it.

Ethylredoxrazine crafts from dylovene and cost about the same as Oil, so I believe this change is justified

- [X] This PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Diphenhydramine now requires Ethylredoxrazine instead of Oil in recipe
