### PR TITLE
Make stun batons be thrown like a throwing weapon

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
@@ -148,6 +148,7 @@
     - state: tin
     - state: plain
   - type: CreamPie
+  - type: LandAtCursor
   - type: ContainerContainer
     containers:
       payloadSlot: !type:ContainerSlot

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -41,6 +41,7 @@
   - type: StaminaDamageOnCollide
     damage: 35
     sound: /Audio/Weapons/egloves.ogg
+  - type: LandAtCursor # it deals stamina damage when thrown
   - type: Battery
     maxCharge: 360
     startingCharge: 360

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -43,6 +43,7 @@
   - type: StaminaDamageOnCollide
     damage: 35
     sound: /Audio/Weapons/egloves.ogg
+  - type: LandAtCursor # it deals stamina damage when thrown
   - type: Battery
     maxCharge: 1000
     startingCharge: 1000
@@ -107,7 +108,7 @@
   - type: Item
     size: Normal
   - type: Tag
-    tags: 
+    tags:
     - Truncheon
   - type: Clothing
     sprite: Objects/Weapons/Melee/truncheon.rsi


### PR DESCRIPTION
## About the PR
Makes stun batons and stun prods fly like other throwing weapons. I missed these two in #29726.
Thanks to @liltenhead for finding this (see https://www.youtube.com/watch?v=6jUZJykNn0g).

Edit: Added the banana cream pies at well.

## Why / Balance
They deal stamina damage or paralyze when thrown and therefore should behave like other throwing weapons for consistency.

## Technical details
Added the LandAtCursorComponent to the three entities.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: Stun batons, stun prods and banana cream pies now fly like other throwing weapons when thrown.

