### PR TITLE
Fix pneumatic cannon in high power mode not firing correctly

### DIFF
--- a/Content.Server/PneumaticCannon/PneumaticCannonSystem.cs
+++ b/Content.Server/PneumaticCannon/PneumaticCannonSystem.cs
@@ -128,7 +128,7 @@ public sealed class PneumaticCannonSystem : SharedPneumaticCannonSystem
     {
         return component.Power switch
         {
-            PneumaticCannonPower.High => component.BaseProjectileSpeed * 4f,
+            PneumaticCannonPower.High => component.BaseProjectileSpeed * 2f,
             PneumaticCannonPower.Medium => component.BaseProjectileSpeed,
             PneumaticCannonPower.Low or _ => component.BaseProjectileSpeed * 0.5f,
         };

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Power.EntitySystems;
 using Content.Server.Stunnable;
 using Content.Server.Weapons.Ranged.Components;
 using Content.Shared.Damage;
+using Content.Shared.PneumaticCannon;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.Effects;
@@ -304,7 +305,19 @@ public sealed partial class GunSystem : SharedGunSystem
         if (!HasComp<ProjectileComponent>(uid))
         {
             RemoveShootable(uid);
+
             // TODO: Someone can probably yeet this a billion miles so need to pre-validate input somewhere up the call stack.
+
+            // makes the high power pneumatic cannon shoot further
+            if (TryComp<PneumaticCannonComponent>(gunUid, out var pneumaticCannon))
+            {
+                if (pneumaticCannon.Power == PneumaticCannonPower.High)
+                    mapDirection *= pneumaticCannon.DistanceFactor;
+
+                ThrowingSystem.TryThrow(uid, mapDirection, gun.ProjectileSpeedModified, user, compensateSpeed: true);
+                return;
+            }
+
             ThrowingSystem.TryThrow(uid, mapDirection, gun.ProjectileSpeedModified, user);
             return;
         }

--- a/Content.Shared/PneumaticCannon/PneumaticCannonComponent.cs
+++ b/Content.Shared/PneumaticCannon/PneumaticCannonComponent.cs
@@ -13,6 +13,7 @@ public sealed partial class PneumaticCannonComponent : Component
     public const string TankSlotId = "gas_tank";
 
     [ViewVariables(VVAccess.ReadWrite)]
+
     public PneumaticCannonPower Power = PneumaticCannonPower.Medium;
 
     [DataField("toolModifyPower", customTypeSerializer:typeof(PrototypeIdSerializer<ToolQualityPrototype>))]
@@ -49,12 +50,20 @@ public sealed partial class PneumaticCannonComponent : Component
     /// </summary>
     [DataField("throwItems"), ViewVariables(VVAccess.ReadWrite)]
     public bool ThrowItems = true;
+
+    /// <summary>
+    ///    How much to multiply the distance by. This is used to make the gun shoot farther on higher Power settings.
+    /// </summary>
+    [DataField("distanceFactor"), ViewVariables(VVAccess.ReadWrite)]
+    public float DistanceFactor = 1.5f;
 }
 
 /// <summary>
-///     How strong the pneumatic cannon should be.
-///     Each tier throws items farther and with more speed, but has drawbacks.
-///     The highest power knocks the player down for a considerable amount of time.
+///    How strong the pneumatic cannon should be.
+///    Each tier throws items farther and with more speed, but has drawbacks.
+///    Low is like a regular hand throw but with more range,
+///    Medium is faster than low and will overshoot the click target because of it,
+///    High will knock the player down but is really fast and has increased range.
 /// </summary>
 public enum PneumaticCannonPower : byte
 {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Reduced the `BaseProjectileSpeed` multiplier from `4` to `2` to try and fix the pneumatic cannon projectile stopping at a fixed distance when trying to fire in High Power mode.

While this feels like a cheap fix, going any further requires changing the physics of throwing objects, which in turn may break more things. It's probably not worth it to mess with it just to fix an obscure item like the pneumatic cannon which is almost never seen in-game. It's already pretty fast at a 2x multiplier, no need to go faster any faster.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This description hints that projectiles where intended to go farther at High power, when in fact, they did not.
```
/// <summary>
///     How strong the pneumatic cannon should be.
///     Each tier throws items farther and with more speed, but has drawbacks.
///     The highest power knocks the player down for a considerable amount of time.
/// </summary>
public enum PneumaticCannonPower : byte
{
    Low = 0,
    Medium = 1,
    High = 2,
    Len = 3 // used for length calc
}
```

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
The video shows me using the pneumatic cannon at LOW, MEDIUM and HIGH power modes before the change. Then after the change I show just the new HIGH power mode speed. Before the change, notice how on HIGH power mode it abruptly stops at a fixed distance.


https://github.com/space-wizards/space-station-14/assets/33888056/c75468d9-3c77-4cd7-910d-bdc707729c18



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
No breaking changes, but I found out about other issues that I'll disclose below

## Out-of-Scope Issues

While testing the pneumatic cannon I found out that, at higher speeds, some objects will just ignore collision altogether. I guess a crowbar being shot through a pneumatic cannon _should_ deal damage, because it has the `DamageOnHighSpeedImpactComponent`, but as of right now it does not.

My guess (this is just a guess) would be the pneumatic cannon is finnicky because it uses the "throwing" system to launch it's projectiles, resulting in the weird scenario where shooting will try to "land" the item where you clicked on the screen. Ideally, the pneumatic cannon should feel more like shooting a bullet where you can only pick the direction you shoot and not like throwing a ball where you can pick where it will land.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 coffeeware
 - fix: Pneumatic cannon in High power mode now fires correctly