### PR TITLE
Replace ProtoId<EntityPrototype> uses with EntProtoId

### DIFF
--- a/Content.Server/Geras/GerasComponent.cs
+++ b/Content.Server/Geras/GerasComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class GerasComponent : Component
 {
     [DataField] public ProtoId<PolymorphPrototype> GerasPolymorphId = "SlimeMorphGeras";
 
-    [DataField] public ProtoId<EntityPrototype> GerasAction = "ActionMorphGeras";
+    [DataField] public EntProtoId GerasAction = "ActionMorphGeras";
 
     [DataField] public EntityUid? GerasActionEntity;
 }

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -34,8 +34,8 @@ public sealed partial class SleepingSystem : EntitySystem
     [Dependency] private readonly SharedEmitSoundSystem _emitSound = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
 
-    public static readonly ProtoId<EntityPrototype> SleepActionId = "ActionSleep";
-    public static readonly ProtoId<EntityPrototype> WakeActionId = "ActionWake";
+    public static readonly EntProtoId SleepActionId = "ActionSleep";
+    public static readonly EntProtoId WakeActionId = "ActionWake";
 
     public override void Initialize()
     {

--- a/Content.Shared/Explosion/Components/OnTrigger/SmokeOnTriggerComponent.cs
+++ b/Content.Shared/Explosion/Components/OnTrigger/SmokeOnTriggerComponent.cs
@@ -29,7 +29,7 @@ public sealed partial class SmokeOnTriggerComponent : Component
     /// Defaults to smoke but you can use foam if you want.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public ProtoId<EntityPrototype> SmokePrototype = "Smoke";
+    public EntProtoId SmokePrototype = "Smoke";
 
     /// <summary>
     /// Solution to add to each smoke cloud.

--- a/Content.Shared/PAI/PAIComponent.cs
+++ b/Content.Shared/PAI/PAIComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class PAIComponent : Component
     public EntityUid? MidiAction;
 
     [DataField]
-    public ProtoId<EntityPrototype> MapActionId = "ActionPAIOpenMap";
+    public EntProtoId MapActionId = "ActionPAIOpenMap";
 
     [DataField, AutoNetworkedField]
     public EntityUid? MapAction;


### PR DESCRIPTION
YAML Linter trips a debug assert when it sees ProtoId<EntityPrototype> used instead of EntProtoId. This will appease it.