### PR TITLE
Revert "Picking a ghostrole as an admin will now deadmin you. (#29790)"

### DIFF
--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -31,9 +31,6 @@ using Robust.Shared.Utility;
 using Content.Server.Popups;
 using Content.Shared.Verbs;
 using Robust.Shared.Collections;
-using Content.Server.Administration.Managers;
-using Content.Shared.CCVar;
-using Robust.Shared.Configuration;
 
 namespace Content.Server.Ghost.Roles
 {
@@ -51,8 +48,6 @@ namespace Content.Server.Ghost.Roles
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
         [Dependency] private readonly IPrototypeManager _prototype = default!;
-        [Dependency] private readonly IAdminManager _adminManager = default!;
-        [Dependency] private readonly IConfigurationManager _cfg = default!;
 
         private uint _nextRoleIdentifier;
         private bool _needsUpdateGhostRoleCount = true;
@@ -592,14 +587,6 @@ namespace Content.Server.Ghost.Roles
             // forced into a ghost role.
             LeaveAllRaffles(message.Player);
             CloseEui(message.Player);
-
-            // The player is no longer a ghost, so they should not be adminned anymore. Deadmin them.
-            // Ensures that admins do not forget to deadmin themselves upon entering a ghost role.
-            var autoDeAdmin = _cfg.GetCVar(CCVars.AdminDeadminOnJoin);
-            if (autoDeAdmin && _adminManager.IsAdmin(message.Entity))
-            {
-                _adminManager.DeAdmin(message.Player);
-            }
         }
 
         private void OnMindAdded(EntityUid uid, GhostTakeoverAvailableComponent component, MindAddedMessage args)

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -870,7 +870,7 @@ namespace Content.Shared.CCVar
             CVarDef.Create("admin.show_pii_onban", false, CVar.SERVERONLY);
 
         /// <summary>
-        /// If an admin joins a round by readying up or using the late join button, automatically
+        /// If an admin joins a round by reading up or using the late join button, automatically
         /// de-admin them.
         /// </summary>
         public static readonly CVarDef<bool> AdminDeadminOnJoin =


### PR DESCRIPTION
This reverts commit 1a50760e674134de6065bff3bc76739526ea5429.

Upon further discussion it's a bad idea to globally deadmin on every change. Ideally it would only affect admins taking it via the ghost role menu and not via verbs or anything else.