### PR TITLE
Fix timer deconstruction

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/timer.yml
@@ -44,6 +44,14 @@
   - type: Construction
     graph: Timer
     node: signal
+    containers:
+    - board
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
+  - type: ContainerFill
+    containers:
+      board: [ SignalTimerElectronics ]
 
 - type: entity
   id: ScreenTimer
@@ -67,6 +75,11 @@
   - type: Construction
     graph: Timer
     node: screen
+    containers:
+    - board
+  - type: ContainerFill
+    containers:
+      board: [ ScreenTimerElectronics ]
 
 - type: entity
   id: BrigTimer
@@ -79,6 +92,11 @@
   - type: Construction
     graph: Timer
     node: brig
+    containers:
+    - board
+  - type: ContainerFill
+    containers:
+      board: [ BrigTimerElectronics ]
 
 # Construction Frame
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Fixes #29430 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Timers were missing the container for their board, so they would get stuck on the step to remove the board.
I tested with both spawned timers and manually constructed ones, and all scenarios are working.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Timers can now be deconstructed

