### PR TITLE
Implement Health Consideration for NPCs

### DIFF
--- a/Content.Server/NPC/Queries/Considerations/TargetHealthCon.cs
+++ b/Content.Server/NPC/Queries/Considerations/TargetHealthCon.cs
@@ -1,6 +1,16 @@
+using Content.Shared.Mobs;
+
 namespace Content.Server.NPC.Queries.Considerations;
 
+/// <summary>
+/// Goes linearly from 1f to 0f, with 0 damage returning 1f and <see cref=TargetState> damage returning 0f
+/// </summary>
 public sealed partial class TargetHealthCon : UtilityConsideration
 {
 
+    /// <summary>
+    /// Which MobState the consideration returns 0f at, defaults to choosing earliest incapacitating MobState
+    /// </summary>
+    [DataField("targetState")]
+    public MobState TargetState = MobState.Invalid;
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Implemented the `TargetHealthCon` consideration, which was never fully implemented. 

## Why / Balance
This consideration lets NPCs use the target's health in deciding which one to choose. 

For example shooting the fully healthed enemy a few meters away might be more important than the dying one next to you, whom can be left to bleed out.

Also I'm planning on using this in my Medibot improvements.

## Technical details
Optional MobState `targetState` may be passed to the `TargetHealthCon` consideration, by default it is `Invalid`.
Use either `TryGetPercentageForState` or `TryGetIncapPercentage` depending on whether we gave a `targetState`, to figure out how close we are to the selected damage threshold. That value is clamped to 0-1, which is what the next stage of target selection uses. 

Currently this consideration is used by `NearbyMeleeTargets`, `NearbyGunTargets`, and `OrderedTargets`, even though it hadn't been implemented yet. 
Most notable users of these compound tasks are Rat Servants, Holoclowns, and Holoparasites. Others would be NPC Salvagers, Spirates, and Syndicate Footsoldiers.

I have left the curve used to determine the importance of this consideration untouched. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

old, the salvager attacks the 80 damage urist 3 tiles away: 

https://github.com/user-attachments/assets/98858c73-eaa6-4ebf-b2b3-adb403315cd3

new, the salvager attacks the unharmed Urist 6 tiles away instead of 80damage Urist 3 tiles away.

https://github.com/user-attachments/assets/eccdaf8f-7399-45e8-b872-8ad7e46082f5



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
