### PR TITLE
Updates GasTankSystem and InternalsSystem to not use Component.Owner

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -225,41 +225,45 @@ namespace Content.Server.Atmos.EntitySystems
 
         public void ConnectToInternals(Entity<GasTankComponent> ent)
         {
-            if (ent.Comp.IsConnected || !CanConnectToInternals(ent))
+            var (owner, component) = ent;
+
+            if (component.IsConnected || !CanConnectToInternals(ent))
                 return;
 
             TryGetInternalsComp(ent, out var internalsUid, out var internalsComp, ent.Comp.User);
             if (internalsUid == null || internalsComp == null)
                 return;
 
-            if (_internals.TryConnectTank((internalsUid.Value, internalsComp), ent.Owner))
-                ent.Comp.User = internalsUid.Value;
+            if (_internals.TryConnectTank((internalsUid.Value, internalsComp), owner))
+                component.User = internalsUid.Value;
 
-            _actions.SetToggled(ent.Comp.ToggleActionEntity, ent.Comp.IsConnected);
+            _actions.SetToggled(component.ToggleActionEntity, component.IsConnected);
 
             // Couldn't toggle!
-            if (!ent.Comp.IsConnected)
+            if (!component.IsConnected)
                 return;
 
-            ent.Comp.ConnectStream = _audioSys.Stop(ent.Comp.ConnectStream);
-            ent.Comp.ConnectStream = _audioSys.PlayPvs(ent.Comp.ConnectSound, ent.Owner)?.Entity;
+            component.ConnectStream = _audioSys.Stop(component.ConnectStream);
+            component.ConnectStream = _audioSys.PlayPvs(component.ConnectSound, ent.Owner)?.Entity;
 
             UpdateUserInterface(ent);
         }
 
         public void DisconnectFromInternals(Entity<GasTankComponent> ent)
         {
-            if (ent.Comp.User == null)
+            var (owner, component) = ent;
+
+            if (component.User == null)
                 return;
 
-            TryGetInternalsComp(ent, out _, out var internalsComp, ent.Comp.User);
-            ent.Comp.User = null;
+            TryGetInternalsComp(ent, out _, out var internalsComp, component.User);
+            component.User = null;
 
-            _actions.SetToggled(ent.Comp.ToggleActionEntity, false);
+            _actions.SetToggled(component.ToggleActionEntity, false);
 
             _internals.DisconnectTank(internalsComp);
-            ent.Comp.DisconnectStream = _audioSys.Stop(ent.Comp.DisconnectStream);
-            ent.Comp.DisconnectStream = _audioSys.PlayPvs(ent.Comp.DisconnectSound, ent.Owner)?.Entity;
+            component.DisconnectStream = _audioSys.Stop(component.DisconnectStream);
+            component.DisconnectStream = _audioSys.PlayPvs(component.DisconnectSound, owner)?.Entity;
 
             UpdateUserInterface(ent);
         }

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -226,7 +226,6 @@ namespace Content.Server.Atmos.EntitySystems
         public void ConnectToInternals(Entity<GasTankComponent> ent)
         {
             var (owner, component) = ent;
-
             if (component.IsConnected || !CanConnectToInternals(ent))
                 return;
 
@@ -244,7 +243,7 @@ namespace Content.Server.Atmos.EntitySystems
                 return;
 
             component.ConnectStream = _audioSys.Stop(component.ConnectStream);
-            component.ConnectStream = _audioSys.PlayPvs(component.ConnectSound, ent.Owner)?.Entity;
+            component.ConnectStream = _audioSys.PlayPvs(component.ConnectSound, owner)?.Entity;
 
             UpdateUserInterface(ent);
         }
@@ -256,12 +255,13 @@ namespace Content.Server.Atmos.EntitySystems
             if (component.User == null)
                 return;
 
-            TryGetInternalsComp(ent, out _, out var internalsComp, component.User);
+            TryGetInternalsComp(ent, out var internalsUid, out var internalsComp, component.User);
             component.User = null;
 
             _actions.SetToggled(component.ToggleActionEntity, false);
 
-            _internals.DisconnectTank(internalsComp);
+            if (internalsUid != null && internalsComp != null)
+                _internals.DisconnectTank((internalsUid.Value, internalsComp));
             component.DisconnectStream = _audioSys.Stop(component.DisconnectStream);
             component.DisconnectStream = _audioSys.PlayPvs(component.DisconnectSound, owner)?.Entity;
 

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -266,6 +266,13 @@ namespace Content.Server.Atmos.EntitySystems
             UpdateUserInterface(ent);
         }
 
+        private Entity<InternalsComponent>? GetInternalsEntity(Entity<GasTankComponent> entity, EntityUid? owner = null)
+        {
+            // the owner is the player or mob
+            owner ??= entity.Comp.User;
+
+            if (TerminatingOrDeleted(entity.Owner))
+        }
         private InternalsComponent? GetInternalsComponent(GasTankComponent component, EntityUid? owner = null)
         {
             owner ??= component.User;

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -81,7 +81,7 @@ namespace Content.Server.Atmos.EntitySystems
                     TankPressure = component.Air?.Pressure ?? 0,
                     OutputPressure = initialUpdate ? component.OutputPressure : null,
                     InternalsConnected = component.IsConnected,
-                    CanConnectInternals = CanConnectToInternals(component)
+                    CanConnectInternals = CanConnectToInternals(ent)
                 });
         }
 
@@ -217,70 +217,89 @@ namespace Content.Server.Atmos.EntitySystems
             return air;
         }
 
-        public bool CanConnectToInternals(GasTankComponent component)
+        public bool CanConnectToInternals(Entity<GasTankComponent> ent)
         {
-            var internals = GetInternalsComponent(component, component.User);
-            return internals != null && internals.BreathTools.Count != 0 && !component.IsValveOpen;
+            TryGetInternalsComp(ent, out _, out var internalsComp, ent.Comp.User);
+            return internalsComp != null && internalsComp.BreathTools.Count != 0 && !ent.Comp.IsValveOpen;
         }
 
         public void ConnectToInternals(Entity<GasTankComponent> ent)
         {
-            var (owner, component) = ent;
-            if (component.IsConnected || !CanConnectToInternals(component))
+            if (ent.Comp.IsConnected || !CanConnectToInternals(ent))
                 return;
 
-            var internals = GetInternalsComponent(component);
-            if (internals == null)
+            TryGetInternalsComp(ent, out var internalsUid, out var internalsComp, ent.Comp.User);
+            if (internalsUid == null || internalsComp == null)
                 return;
 
-            if (_internals.TryConnectTank((internals.Owner, internals), owner))
-                component.User = internals.Owner;
+            if (_internals.TryConnectTank((internalsUid.Value, internalsComp), ent.Owner))
+                ent.Comp.User = internalsUid.Value;
 
-            _actions.SetToggled(component.ToggleActionEntity, component.IsConnected);
+            _actions.SetToggled(ent.Comp.ToggleActionEntity, ent.Comp.IsConnected);
 
             // Couldn't toggle!
-            if (!component.IsConnected)
+            if (!ent.Comp.IsConnected)
                 return;
 
-            component.ConnectStream = _audioSys.Stop(component.ConnectStream);
-            component.ConnectStream = _audioSys.PlayPvs(component.ConnectSound, component.Owner)?.Entity;
+            ent.Comp.ConnectStream = _audioSys.Stop(ent.Comp.ConnectStream);
+            ent.Comp.ConnectStream = _audioSys.PlayPvs(ent.Comp.ConnectSound, ent.Owner)?.Entity;
 
             UpdateUserInterface(ent);
         }
 
         public void DisconnectFromInternals(Entity<GasTankComponent> ent)
         {
-            var (owner, component) = ent;
-            if (component.User == null)
+            if (ent.Comp.User == null)
                 return;
 
-            var internals = GetInternalsComponent(component);
-            component.User = null;
+            TryGetInternalsComp(ent, out _, out var internalsComp, ent.Comp.User);
+            ent.Comp.User = null;
 
-            _actions.SetToggled(component.ToggleActionEntity, false);
+            _actions.SetToggled(ent.Comp.ToggleActionEntity, false);
 
-            _internals.DisconnectTank(internals);
-            component.DisconnectStream = _audioSys.Stop(component.DisconnectStream);
-            component.DisconnectStream = _audioSys.PlayPvs(component.DisconnectSound, component.Owner)?.Entity;
+            _internals.DisconnectTank(internalsComp);
+            ent.Comp.DisconnectStream = _audioSys.Stop(ent.Comp.DisconnectStream);
+            ent.Comp.DisconnectStream = _audioSys.PlayPvs(ent.Comp.DisconnectSound, ent.Owner)?.Entity;
 
             UpdateUserInterface(ent);
         }
 
-        private Entity<InternalsComponent>? GetInternalsEntity(Entity<GasTankComponent> entity, EntityUid? owner = null)
+        /// <summary>
+        /// Tries to retrieve the internals component of either the gas tank's user,
+        /// or the gas tank's... containing container
+        /// </summary>
+        /// <param name="user">The user of the gas tank</param>
+        /// <returns>True if internals comp isn't null, false if it is null</returns>
+        private bool TryGetInternalsComp(Entity<GasTankComponent> ent, out EntityUid? internalsUid, out InternalsComponent? internalsComp, EntityUid? user = null)
         {
-            // the owner is the player or mob
-            owner ??= entity.Comp.User;
+            internalsUid = default;
+            internalsComp = default;
 
-            if (TerminatingOrDeleted(entity.Owner))
-        }
-        private InternalsComponent? GetInternalsComponent(GasTankComponent component, EntityUid? owner = null)
-        {
-            owner ??= component.User;
-            if (Deleted(component.Owner))return null;
-            if (owner != null) return CompOrNull<InternalsComponent>(owner.Value);
-            return _containers.TryGetContainingContainer(component.Owner, out var container)
-                ? CompOrNull<InternalsComponent>(container.Owner)
-                : null;
+            // If the gas tank doesn't exist for whatever reason, don't even bother
+            if (TerminatingOrDeleted(ent.Owner))
+                return false;
+
+            user ??= ent.Comp.User;
+            // Check if the gas tank's user actually has the component that allows them to use a gas tank and mask
+            if (TryComp<InternalsComponent>(user, out var userInternalsComp) && userInternalsComp != null)
+            {
+                internalsUid = user;
+                internalsComp = userInternalsComp;
+                return true;
+            }
+
+            // Yeah I have no clue what this actually does, I appreciate the lack of comments on the original function
+            if (_containers.TryGetContainingContainer((ent.Owner, Transform(ent.Owner)), out var container) && container != null)
+            {
+                if (TryComp<InternalsComponent>(container.Owner, out var containerInternalsComp) && containerInternalsComp != null)
+                {
+                    internalsUid = container.Owner;
+                    internalsComp = containerInternalsComp;
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public void AssumeAir(Entity<GasTankComponent> ent, GasMixture giver)
@@ -328,7 +347,7 @@ namespace Content.Server.Atmos.EntitySystems
                     if(environment != null)
                         _atmosphereSystem.Merge(environment, component.Air);
 
-                    _audioSys.PlayPvs(component.RuptureSound, Transform(component.Owner).Coordinates, AudioParams.Default.WithVariation(0.125f));
+                    _audioSys.PlayPvs(component.RuptureSound, Transform(owner).Coordinates, AudioParams.Default.WithVariation(0.125f));
 
                     QueueDel(owner);
                     return;

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -102,7 +102,7 @@ public sealed class InternalsSystem : EntitySystem
         {
             if (force)
             {
-                DisconnectTank(internals);
+                DisconnectTank((uid, internals));
                 return;
             }
 
@@ -199,16 +199,13 @@ public sealed class InternalsSystem : EntitySystem
         _alerts.ShowAlert(ent, ent.Comp.InternalsAlert, GetSeverity(ent));
     }
 
-    public void DisconnectTank(InternalsComponent? component)
+    public void DisconnectTank(Entity<InternalsComponent> ent)
     {
-        if (component is null)
-            return;
+        if (TryComp(ent.Comp.GasTankEntity, out GasTankComponent? tank))
+            _gasTank.DisconnectFromInternals((ent.Comp.GasTankEntity.Value, tank));
 
-        if (TryComp(component.GasTankEntity, out GasTankComponent? tank))
-            _gasTank.DisconnectFromInternals((component.GasTankEntity.Value, tank));
-
-        component.GasTankEntity = null;
-        _alerts.ShowAlert(component.Owner, component.InternalsAlert, GetSeverity(component));
+        ent.Comp.GasTankEntity = null;
+        _alerts.ShowAlert(ent.Owner, ent.Comp.InternalsAlert, GetSeverity(ent.Comp));
     }
 
     public bool TryConnectTank(Entity<InternalsComponent> ent, EntityUid tankEntity)

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -267,21 +267,21 @@ public sealed class InternalsSystem : EntitySystem
 
         if (_inventory.TryGetSlotEntity(user, "back", out var backEntity, user.Comp2, user.Comp3) &&
             TryComp<GasTankComponent>(backEntity, out var backGasTank) &&
-            _gasTank.CanConnectToInternals(backGasTank))
+            _gasTank.CanConnectToInternals((backEntity.Value, backGasTank)))
         {
             return (backEntity.Value, backGasTank);
         }
 
         if (_inventory.TryGetSlotEntity(user, "suitstorage", out var entity, user.Comp2, user.Comp3) &&
             TryComp<GasTankComponent>(entity, out var gasTank) &&
-            _gasTank.CanConnectToInternals(gasTank))
+            _gasTank.CanConnectToInternals((entity.Value, gasTank)))
         {
             return (entity.Value, gasTank);
         }
 
         foreach (var item in _inventory.GetHandOrInventoryEntities((user.Owner, user.Comp1, user.Comp2)))
         {
-            if (TryComp(item, out gasTank) && _gasTank.CanConnectToInternals(gasTank))
+            if (TryComp(item, out gasTank) && _gasTank.CanConnectToInternals((item, gasTank)))
                 return (item, gasTank);
         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Project 0 warnings, Component.Owner() is obsolete

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

- `InternalsComponent? GetInternalsComponent(GasTankComponent component, EntityUid? owner = null)` replaced by `private bool TryGetInternalsComp(Entity<GasTankComponent> ent, out EntityUid? internalsUid, out InternalsComponent? internalsComp, EntityUid? user = null)` due to using Component.Owner and not returning the EntityUid of the internalsComp, which results in even more usages of Component.Owner
- CanConnectToInternals changed to use `Entity<T>` and removed the use of GetInternalsComponent for TryGetInternalsComp, usages updated 
- DisconnectTank changed to use `Entity<T>` and removed the usage of Component.Owner in it, usages updated
- Some random Component.Owner usages replaced with the Owner EntityUid that it already had access to

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/18a1c2ca-429c-4c96-b46b-e537f292b1d4

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
- `InternalsComponent? GetInternalsComponent(GasTankComponent component, EntityUid? owner = null)` replaced by `private bool TryGetInternalsComp(Entity<GasTankComponent> ent, out EntityUid? internalsUid, out InternalsComponent? internalsComp, EntityUid? user = null)`, use the out var internalsComp instead of the return value of the function
- CanConnectToInternals changed to use `Entity<GasTankComponent>`, solve it by tupling the GasTank EntityUid with the GasTankComponent
- DisconnectTank changed to use `Entity<InternalsComponent>`, solve it by tupling the Internals EntityUid with the InternalsComponent