### PR TITLE
Throwing system hotfix

### DIFF
--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -42,7 +42,7 @@ public sealed partial class HandsComponent : Component
     /// </summary>
     [DataField]
     [ViewVariables(VVAccess.ReadWrite)]
-    public float BaseThrowspeed { get; set; } = 10f;
+    public float BaseThrowspeed { get; set; } = 11f;
 
     /// <summary>
     ///     Distance after which longer throw targets stop increasing throw impulse.

--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -26,11 +26,6 @@ public sealed class ThrowingSystem : EntitySystem
 
     public const float PushbackDefault = 2f;
 
-    /// <summary>
-    /// The minimum amount of time an entity needs to be thrown before the timer can be run.
-    /// Anything below this threshold never enters the air.
-    /// </summary>
-    public const float MinFlyTime = 0.15f;
     public const float FlyTimePercentage = 0.8f;
 
     private float _frictionModifier;
@@ -168,9 +163,6 @@ public sealed class ThrowingSystem : EntitySystem
         var flyTime = direction.Length() / baseThrowSpeed;
         if (compensateFriction)
             flyTime *= FlyTimePercentage;
-
-        if (flyTime < MinFlyTime)
-            flyTime = 0f;
         comp.ThrownTime = _gameTiming.CurTime;
         comp.LandTime = comp.ThrownTime + TimeSpan.FromSeconds(flyTime);
         comp.PlayLandSound = playSound;


### PR DESCRIPTION
## About the PR
Small corrections to the new throwing system changes done in #29726
This fixes items that are thrown very fast not being "in air". In particular the pneumatic cannon was affected, as using it with with throwing knifes would no longer embed them in the target.

Thanks to @luizwritescode for figuring out the reason for this.

I also buffed the base throwing speed for hands by 10%. Due to my recent change the effective throwing speed was made slightly lower to not overshoot the target. People mentioned that they were no longer able to reflect thrown items from walls in front of them. This adjustment makes it feel more similar to the behaviour before the change, but keeps the throwing precision.

## Why / Balance
fixes and adjustments

## Technical details
The code comments in the ThrowingSystem before my recent PR said that below a certain threshold flyTime was set to 0 and items never enter the air. However, this was a lie since an offset was applied to the timespan until landing in ThrownItemSystem. I had removed this offset since it was causing problems with precision. The MinFlyTime is no longer necessary due to the precision changes. This fixes items thrown very fast (even over long distances) with a flying time below 0.15s not entering the "in air" state, which prevented embeddable weapons from working.

## Media

https://github.com/user-attachments/assets/9320dc79-8a79-463e-be3c-2279f83b9ce5

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl: coffeeware, slarticodefast
- fix: Fixed items thrown very fast not being in the air. In particular this fixes the pneumatic cannon.
- tweak: Buffed base hand throwing speed by 10% to be more similar to before the recent throwing changes.
