### PR TITLE
Update BiomeSystem.cs to not use Component.Owner

### DIFF
--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -126,20 +126,18 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         var xform = Transform(uid);
         var mapId = xform.MapID;
 
-        if (mapId != MapId.Nullspace && TryComp(uid, out MapGridComponent? mapGrid))
+        if (mapId != MapId.Nullspace && HasComp<MapGridComponent>(uid))
         {
             var setTiles = new List<(Vector2i Index, Tile tile)>();
 
-            foreach (var grid in _mapManager.GetAllMapGrids(mapId))
+            foreach (var grid in _mapManager.GetAllGrids(mapId))
             {
-                var gridUid = grid.Owner;
-
-                if (!_fixturesQuery.TryGetComponent(gridUid, out var fixtures))
+                if (!_fixturesQuery.TryGetComponent(grid.Owner, out var fixtures))
                     continue;
 
                 // Don't want shuttles flying around now do we.
-                _shuttles.Disable(gridUid);
-                var pTransform = _physics.GetPhysicsTransform(gridUid);
+                _shuttles.Disable(grid.Owner);
+                var pTransform = _physics.GetPhysicsTransform(grid.Owner);
 
                 foreach (var fixture in fixtures.Fixtures.Values)
                 {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Project 0 warnings, Component.Owner() is obsolete

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Swapped a TryComp to a HasComp because the output component was unused

GetAllMapGrids returns `<MapGridComponent>`, GetAllGrids returns `Entity<MapGridComponent>`, using grid.Owner on the `Entity<T>` variant is the correct usage

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
nooothing