### PR TITLE
Use reinforced glass damage modifier for secure windoors

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -172,6 +172,9 @@
     - state: panel_open
       map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       visible: false
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: RGlass
   - type: Destructible
     thresholds:
     - trigger:
@@ -257,7 +260,7 @@
 
 - type: entity
   id: BaseSecurePlasmaWindoor
-  parent: BaseWindoor
+  parent: BaseSecureWindoor
   abstract: true
   components:
   - type: Sprite
@@ -367,7 +370,7 @@
 
 - type: entity
   id: BaseSecureUraniumWindoor
-  parent: BaseWindoor
+  parent: BaseSecureWindoor
   abstract: true
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -173,7 +173,6 @@
       map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       visible: false
   - type: Damageable
-    damageContainer: Inorganic
     damageModifierSet: RGlass
   - type: Destructible
     thresholds:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
title
previously reinforced windoors used default glass modifier

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
resolves #29925 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
changed parents of other secure windoors to inherit modifier
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Secure windoors now use reinforced glass damage modifier.

