### PR TITLE
Move vgroid much closer

### DIFF
--- a/Content.Server/Shuttles/Components/GridSpawnComponent.cs
+++ b/Content.Server/Shuttles/Components/GridSpawnComponent.cs
@@ -26,6 +26,11 @@ public interface IGridSpawnGroup
     /// </summary>
     public float MinimumDistance { get; }
 
+    /// <summary>
+    /// Minimum distance to spawn away from the station.
+    /// </summary>
+    public float MaximumDistance { get;  }
+
     /// <inheritdoc />
     public ProtoId<DatasetPrototype>? NameDataset { get; }
 
@@ -67,6 +72,8 @@ public sealed class DungeonSpawnGroup : IGridSpawnGroup
     /// <inheritdoc />
     public float MinimumDistance { get; }
 
+    public float MaximumDistance { get; }
+
     /// <inheritdoc />
     public ProtoId<DatasetPrototype>? NameDataset { get; }
 
@@ -94,7 +101,11 @@ public sealed class GridSpawnGroup : IGridSpawnGroup
 {
     public List<ResPath> Paths = new();
 
+    /// <inheritdoc />
     public float MinimumDistance { get; }
+
+    /// <inheritdoc />
+    public float MaximumDistance { get; }
     public ProtoId<DatasetPrototype>? NameDataset { get; }
     public int MinCount { get; set; } = 1;
     public int MaxCount { get; set; } = 1;

--- a/Content.Server/Shuttles/Components/GridSpawnComponent.cs
+++ b/Content.Server/Shuttles/Components/GridSpawnComponent.cs
@@ -27,7 +27,7 @@ public interface IGridSpawnGroup
     public float MinimumDistance { get; }
 
     /// <summary>
-    /// Minimum distance to spawn away from the station.
+    /// Maximum distance to spawn away from the station.
     /// </summary>
     public float MaximumDistance { get;  }
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -99,7 +99,7 @@ public sealed partial class ShuttleSystem
 
         if (group.MinimumDistance > 0f)
         {
-            spawnCoords = spawnCoords.Offset(_random.NextVector2(group.MinimumDistance, group.MinimumDistance * 1.5f));
+            spawnCoords = spawnCoords.Offset(_random.NextVector2(group.MinimumDistance, group.MaximumDistance));
         }
 
         var spawnMapCoords = _transform.ToMapCoordinates(spawnCoords);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -58,11 +58,15 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
     [Dependency] private readonly ThrusterSystem _thruster = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
 
+    private EntityQuery<MapGridComponent> _gridQuery;
+
     public const float TileMassMultiplier = 0.5f;
 
     public override void Initialize()
     {
         base.Initialize();
+
+        _gridQuery = GetEntityQuery<MapGridComponent>();
 
         InitializeFTL();
         InitializeGridFills();

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -73,7 +73,8 @@
           - /Maps/Ruins/whiteship_ancient.yml
           - /Maps/Ruins/whiteship_bluespacejumper.yml
         vgroid: !type:DungeonSpawnGroup
-          minimumDistance: 1000
+          minimumDistance: 400
+          maximumDistance: 600
           nameDataset: names_borer
           stationGrid: false
           addComponents:

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -73,8 +73,8 @@
           - /Maps/Ruins/whiteship_ancient.yml
           - /Maps/Ruins/whiteship_bluespacejumper.yml
         vgroid: !type:DungeonSpawnGroup
-          minimumDistance: 400
-          maximumDistance: 500
+          minimumDistance: 250
+          maximumDistance: 300
           nameDataset: names_borer
           stationGrid: false
           addComponents:

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -74,7 +74,7 @@
           - /Maps/Ruins/whiteship_bluespacejumper.yml
         vgroid: !type:DungeonSpawnGroup
           minimumDistance: 400
-          maximumDistance: 600
+          maximumDistance: 500
           nameDataset: names_borer
           stationGrid: false
           addComponents:

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -73,8 +73,8 @@
           - /Maps/Ruins/whiteship_ancient.yml
           - /Maps/Ruins/whiteship_bluespacejumper.yml
         vgroid: !type:DungeonSpawnGroup
-          minimumDistance: 250
-          maximumDistance: 300
+          minimumDistance: 400
+          maximumDistance: 450
           nameDataset: names_borer
           stationGrid: false
           addComponents:


### PR DESCRIPTION
General feedback is map spam + it takes way too long to get to so this fixes the latter. This is somewhat "close" (considering 1/4 of the distance is the vgroid itself) but without a jetpack / shuttle it's going to be slow but not impossible. For now because they still have the reclaimer it will be roundstart so just a matter of tweaking shuttle building.

![image](https://github.com/user-attachments/assets/7a42820d-c7ac-40b9-8e36-7c410356dd36)

Was tempted to make it closer but then it would be about the same distance as asteroids I would think.

:cl:
- tweak: Moved VGRoid from 1,000m away to ~500m.
