### PR TITLE
Fix VGRoid grid spam

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
@@ -1,4 +1,5 @@
 using Content.Server.Shuttles.Components;
+using Content.Shared.CCVar;
 using Content.Shared.Shuttles.BUIStates;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.Events;
@@ -12,6 +13,26 @@ public sealed partial class ShuttleSystem
         SubscribeLocalEvent<IFFConsoleComponent, AnchorStateChangedEvent>(OnIFFConsoleAnchor);
         SubscribeLocalEvent<IFFConsoleComponent, IFFShowIFFMessage>(OnIFFShow);
         SubscribeLocalEvent<IFFConsoleComponent, IFFShowVesselMessage>(OnIFFShowVessel);
+        SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
+    }
+
+    private void OnGridSplit(ref GridSplitEvent ev)
+    {
+        var splitMass = _cfg.GetCVar(CCVars.HideSplitGridsUnder);
+
+        if (splitMass < 0)
+            return;
+
+        foreach (var grid in ev.NewGrids)
+        {
+            if (!_physicsQuery.TryGetComponent(grid, out var physics) ||
+                physics.Mass > splitMass)
+            {
+                continue;
+            }
+
+            AddIFFFlag(grid, IFFFlags.HideLabel);
+        }
     }
 
     private void OnIFFShow(EntityUid uid, IFFConsoleComponent component, IFFShowIFFMessage args)

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1496,6 +1496,13 @@ namespace Content.Shared.CCVar
             CVarDef.Create("shuttle.godmode_arrivals", false, CVar.SERVERONLY);
 
         /// <summary>
+        /// If a grid is split then hide any smaller ones under this mass (kg) from the map.
+        /// This is useful to avoid split grids spamming out labels.
+        /// </summary>
+        public static readonly CVarDef<int> HideSplitGridsUnder =
+            CVarDef.Create("shuttle.hide_split_grids_under", 30, CVar.SERVERONLY);
+
+        /// <summary>
         /// Whether to automatically spawn escape shuttles.
         /// </summary>
         public static readonly CVarDef<bool> GridFill =


### PR DESCRIPTION
Specifically if a grid splits under the cvar size it doesn't get a label. This also stops stuff like shuttles splitting in half creating new entries for the new grids. Splitting code leaves the largest grid as the existing one so this will always prefer to keep it large (but if there's multiple splits it won't adjust).

:cl:
- fix: Fix grid labels getting spammed from VGRoid.