### PR TITLE
Update MoverController.cs to not use Component.Owner

### DIFF
--- a/Content.Client/Movement/Systems/SpriteMovementSystem.cs
+++ b/Content.Client/Movement/Systems/SpriteMovementSystem.cs
@@ -28,7 +28,7 @@ public sealed class SpriteMovementSystem : EntitySystem
             return;
 
         var oldMoving = (SharedMoverController.GetNormalizedMovement(args.OldMovement) & MoveButtons.AnyDirection) != MoveButtons.None;
-        var moving = (SharedMoverController.GetNormalizedMovement(args.Component.HeldMoveButtons) & MoveButtons.AnyDirection) != MoveButtons.None;
+        var moving = (SharedMoverController.GetNormalizedMovement(args.Entity.Comp.HeldMoveButtons) & MoveButtons.AnyDirection) != MoveButtons.None;
 
         if (oldMoving == moving || !_spriteQuery.TryGetComponent(uid, out var sprite))
             return;

--- a/Content.Client/Physics/Controllers/MoverController.cs
+++ b/Content.Client/Physics/Controllers/MoverController.cs
@@ -28,57 +28,57 @@ namespace Content.Client.Physics.Controllers
             SubscribeLocalEvent<PullableComponent, UpdateIsPredictedEvent>(OnUpdatePullablePredicted);
         }
 
-        private void OnUpdatePredicted(EntityUid uid, InputMoverComponent component, ref UpdateIsPredictedEvent args)
+        private void OnUpdatePredicted(Entity<InputMoverComponent> entity, ref UpdateIsPredictedEvent args)
         {
             // Enable prediction if an entity is controlled by the player
-            if (uid == _playerManager.LocalEntity)
+            if (entity.Owner == _playerManager.LocalEntity)
                 args.IsPredicted = true;
         }
 
-        private void OnUpdateRelayTargetPredicted(EntityUid uid, MovementRelayTargetComponent component, ref UpdateIsPredictedEvent args)
+        private void OnUpdateRelayTargetPredicted(Entity<MovementRelayTargetComponent> entity, ref UpdateIsPredictedEvent args)
         {
-            if (component.Source == _playerManager.LocalEntity)
+            if (entity.Comp.Source == _playerManager.LocalEntity)
                 args.IsPredicted = true;
         }
 
-        private void OnUpdatePullablePredicted(EntityUid uid, PullableComponent component, ref UpdateIsPredictedEvent args)
+        private void OnUpdatePullablePredicted(Entity<PullableComponent> entity, ref UpdateIsPredictedEvent args)
         {
             // Enable prediction if an entity is being pulled by the player.
             // Disable prediction if an entity is being pulled by some non-player entity.
 
-            if (component.Puller == _playerManager.LocalEntity)
+            if (entity.Comp.Puller == _playerManager.LocalEntity)
                 args.IsPredicted = true;
-            else if (component.Puller != null)
+            else if (entity.Comp.Puller != null)
                 args.BlockPrediction = true;
 
             // TODO recursive pulling checks?
             // What if the entity is being pulled by a vehicle controlled by the player?
         }
 
-        private void OnRelayPlayerAttached(EntityUid uid, RelayInputMoverComponent component, LocalPlayerAttachedEvent args)
+        private void OnRelayPlayerAttached(Entity<RelayInputMoverComponent> entity, ref LocalPlayerAttachedEvent args)
         {
-            Physics.UpdateIsPredicted(uid);
-            Physics.UpdateIsPredicted(component.RelayEntity);
-            if (MoverQuery.TryGetComponent(component.RelayEntity, out var inputMover))
-                SetMoveInput(uid, inputMover, MoveButtons.None);
+            Physics.UpdateIsPredicted(entity.Owner);
+            Physics.UpdateIsPredicted(entity.Comp.RelayEntity);
+            if (MoverQuery.TryGetComponent(entity.Comp.RelayEntity, out var inputMover))
+                SetMoveInput((entity.Owner, inputMover), MoveButtons.None);
         }
 
-        private void OnRelayPlayerDetached(EntityUid uid, RelayInputMoverComponent component, LocalPlayerDetachedEvent args)
+        private void OnRelayPlayerDetached(Entity<RelayInputMoverComponent> entity, ref LocalPlayerDetachedEvent args)
         {
-            Physics.UpdateIsPredicted(uid);
-            Physics.UpdateIsPredicted(component.RelayEntity);
-            if (MoverQuery.TryGetComponent(component.RelayEntity, out var inputMover))
-                SetMoveInput(uid, inputMover, MoveButtons.None);
+            Physics.UpdateIsPredicted(entity.Owner);
+            Physics.UpdateIsPredicted(entity.Comp.RelayEntity);
+            if (MoverQuery.TryGetComponent(entity.Comp.RelayEntity, out var inputMover))
+                SetMoveInput((entity.Owner, inputMover), MoveButtons.None);
         }
 
-        private void OnPlayerAttached(EntityUid uid, InputMoverComponent component, LocalPlayerAttachedEvent args)
+        private void OnPlayerAttached(Entity<InputMoverComponent> entity, ref LocalPlayerAttachedEvent args)
         {
-            SetMoveInput(uid, component, MoveButtons.None);
+            SetMoveInput(entity, MoveButtons.None);
         }
 
-        private void OnPlayerDetached(EntityUid uid, InputMoverComponent component, LocalPlayerDetachedEvent args)
+        private void OnPlayerDetached(Entity<InputMoverComponent> entity, ref LocalPlayerDetachedEvent args)
         {
-            SetMoveInput(uid, component, MoveButtons.None);
+            SetMoveInput(entity, MoveButtons.None);
         }
 
         public override void UpdateBeforeSolve(bool prediction, float frameTime)

--- a/Content.Client/Physics/Controllers/MoverController.cs
+++ b/Content.Client/Physics/Controllers/MoverController.cs
@@ -60,7 +60,7 @@ namespace Content.Client.Physics.Controllers
             Physics.UpdateIsPredicted(uid);
             Physics.UpdateIsPredicted(component.RelayEntity);
             if (MoverQuery.TryGetComponent(component.RelayEntity, out var inputMover))
-                SetMoveInput(inputMover, MoveButtons.None);
+                SetMoveInput(uid, inputMover, MoveButtons.None);
         }
 
         private void OnRelayPlayerDetached(EntityUid uid, RelayInputMoverComponent component, LocalPlayerDetachedEvent args)
@@ -68,17 +68,17 @@ namespace Content.Client.Physics.Controllers
             Physics.UpdateIsPredicted(uid);
             Physics.UpdateIsPredicted(component.RelayEntity);
             if (MoverQuery.TryGetComponent(component.RelayEntity, out var inputMover))
-                SetMoveInput(inputMover, MoveButtons.None);
+                SetMoveInput(uid, inputMover, MoveButtons.None);
         }
 
         private void OnPlayerAttached(EntityUid uid, InputMoverComponent component, LocalPlayerAttachedEvent args)
         {
-            SetMoveInput(component, MoveButtons.None);
+            SetMoveInput(uid, component, MoveButtons.None);
         }
 
         private void OnPlayerDetached(EntityUid uid, InputMoverComponent component, LocalPlayerDetachedEvent args)
         {
-            SetMoveInput(component, MoveButtons.None);
+            SetMoveInput(uid, component, MoveButtons.None);
         }
 
         public override void UpdateBeforeSolve(bool prediction, float frameTime)

--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -34,7 +34,7 @@ public sealed class BodySystem : SharedBodySystem
     private void OnRelayMoveInput(Entity<BodyComponent> ent, ref MoveInputEvent args)
     {
         // If they haven't actually moved then ignore it.
-        if ((args.Component.HeldMoveButtons &
+        if ((args.Entity.Comp.HeldMoveButtons &
              (MoveButtons.Down | MoveButtons.Left | MoveButtons.Up | MoveButtons.Right)) == 0x0)
         {
             return;

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -128,7 +128,7 @@ namespace Content.Server.Ghost
         private void OnRelayMoveInput(EntityUid uid, GhostOnMoveComponent component, ref MoveInputEvent args)
         {
             // If they haven't actually moved then ignore it.
-            if ((args.Component.HeldMoveButtons &
+            if ((args.Entity.Comp.HeldMoveButtons &
                  (MoveButtons.Down | MoveButtons.Left | MoveButtons.Up | MoveButtons.Right)) == 0x0)
             {
                 return;

--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -30,26 +30,26 @@ namespace Content.Server.Physics.Controllers
             SubscribeLocalEvent<InputMoverComponent, PlayerDetachedEvent>(OnPlayerDetached);
         }
 
-        private void OnRelayPlayerAttached(EntityUid uid, RelayInputMoverComponent component, PlayerAttachedEvent args)
+        private void OnRelayPlayerAttached(Entity<RelayInputMoverComponent> entity, ref PlayerAttachedEvent args)
         {
-            if (MoverQuery.TryGetComponent(component.RelayEntity, out var inputMover))
-                SetMoveInput(uid, inputMover, MoveButtons.None);
+            if (MoverQuery.TryGetComponent(entity.Comp.RelayEntity, out var inputMover))
+                SetMoveInput((entity.Owner, inputMover), MoveButtons.None);
         }
 
-        private void OnRelayPlayerDetached(EntityUid uid, RelayInputMoverComponent component, PlayerDetachedEvent args)
+        private void OnRelayPlayerDetached(Entity<RelayInputMoverComponent> entity, ref PlayerDetachedEvent args)
         {
-            if (MoverQuery.TryGetComponent(component.RelayEntity, out var inputMover))
-                SetMoveInput(uid, inputMover, MoveButtons.None);
+            if (MoverQuery.TryGetComponent(entity.Comp.RelayEntity, out var inputMover))
+                SetMoveInput((entity.Owner, inputMover), MoveButtons.None);
         }
 
-        private void OnPlayerAttached(EntityUid uid, InputMoverComponent component, PlayerAttachedEvent args)
+        private void OnPlayerAttached(Entity<InputMoverComponent> entity, ref PlayerAttachedEvent args)
         {
-            SetMoveInput(uid, component, MoveButtons.None);
+            SetMoveInput(entity, MoveButtons.None);
         }
 
-        private void OnPlayerDetached(EntityUid uid, InputMoverComponent component, PlayerDetachedEvent args)
+        private void OnPlayerDetached(Entity<InputMoverComponent> entity, ref PlayerDetachedEvent args)
         {
-            SetMoveInput(uid, component, MoveButtons.None);
+            SetMoveInput(entity, MoveButtons.None);
         }
 
         protected override bool CanSound()

--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -33,23 +33,23 @@ namespace Content.Server.Physics.Controllers
         private void OnRelayPlayerAttached(EntityUid uid, RelayInputMoverComponent component, PlayerAttachedEvent args)
         {
             if (MoverQuery.TryGetComponent(component.RelayEntity, out var inputMover))
-                SetMoveInput(inputMover, MoveButtons.None);
+                SetMoveInput(uid, inputMover, MoveButtons.None);
         }
 
         private void OnRelayPlayerDetached(EntityUid uid, RelayInputMoverComponent component, PlayerDetachedEvent args)
         {
             if (MoverQuery.TryGetComponent(component.RelayEntity, out var inputMover))
-                SetMoveInput(inputMover, MoveButtons.None);
+                SetMoveInput(uid, inputMover, MoveButtons.None);
         }
 
         private void OnPlayerAttached(EntityUid uid, InputMoverComponent component, PlayerAttachedEvent args)
         {
-            SetMoveInput(component, MoveButtons.None);
+            SetMoveInput(uid, component, MoveButtons.None);
         }
 
         private void OnPlayerDetached(EntityUid uid, InputMoverComponent component, PlayerDetachedEvent args)
         {
-            SetMoveInput(component, MoveButtons.None);
+            SetMoveInput(uid, component, MoveButtons.None);
         }
 
         protected override bool CanSound()

--- a/Content.Shared/Movement/Events/MoveInputEvent.cs
+++ b/Content.Shared/Movement/Events/MoveInputEvent.cs
@@ -9,16 +9,14 @@ namespace Content.Shared.Movement.Events;
 [ByRefEvent]
 public readonly struct MoveInputEvent
 {
-    public readonly EntityUid Entity;
-    public readonly InputMoverComponent Component;
+    public readonly Entity<InputMoverComponent> Entity;
     public readonly MoveButtons OldMovement;
 
     public bool HasDirectionalMovement => (Component.HeldMoveButtons & MoveButtons.AnyDirection) != MoveButtons.None;
 
-    public MoveInputEvent(EntityUid entity, InputMoverComponent component, MoveButtons oldMovement)
+    public MoveInputEvent(Entity<InputMoverComponent> entity, MoveButtons oldMovement)
     {
         Entity = entity;
-        Component = component;
         OldMovement = oldMovement;
     }
 }

--- a/Content.Shared/Movement/Events/MoveInputEvent.cs
+++ b/Content.Shared/Movement/Events/MoveInputEvent.cs
@@ -12,7 +12,7 @@ public readonly struct MoveInputEvent
     public readonly Entity<InputMoverComponent> Entity;
     public readonly MoveButtons OldMovement;
 
-    public bool HasDirectionalMovement => (Component.HeldMoveButtons & MoveButtons.AnyDirection) != MoveButtons.None;
+    public bool HasDirectionalMovement => (Entity.Comp.HeldMoveButtons & MoveButtons.AnyDirection) != MoveButtons.None;
 
     public MoveInputEvent(Entity<InputMoverComponent> entity, MoveButtons oldMovement)
     {

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -83,53 +83,53 @@ namespace Content.Shared.Movement.Systems
             return oldMovement;
         }
 
-        protected void SetMoveInput(EntityUid entity, InputMoverComponent component, MoveButtons buttons)
+        protected void SetMoveInput(Entity<InputMoverComponent> entity, MoveButtons buttons)
         {
-            if (component.HeldMoveButtons == buttons)
+            if (entity.Comp.HeldMoveButtons == buttons)
                 return;
 
             // Relay the fact we had any movement event.
             // TODO: Ideally we'd do these in a tick instead of out of sim.
-            var moveEvent = new MoveInputEvent(entity, component, component.HeldMoveButtons);
-            component.HeldMoveButtons = buttons;
+            var moveEvent = new MoveInputEvent(entity, entity.Comp.HeldMoveButtons);
+            entity.Comp.HeldMoveButtons = buttons;
             RaiseLocalEvent(entity, ref moveEvent);
-            Dirty(entity, component);
+            Dirty(entity, entity.Comp);
         }
 
-        private void OnMoverHandleState(EntityUid uid, InputMoverComponent component, ComponentHandleState args)
+        private void OnMoverHandleState(Entity<InputMoverComponent> entity, ref ComponentHandleState args)
         {
             if (args.Current is not InputMoverComponentState state)
                 return;
 
             // Handle state
-            component.LerpTarget = state.LerpTarget;
-            component.RelativeRotation = state.RelativeRotation;
-            component.TargetRelativeRotation = state.TargetRelativeRotation;
-            component.CanMove = state.CanMove;
-            component.RelativeEntity = EnsureEntity<InputMoverComponent>(state.RelativeEntity, uid);
+            entity.Comp.LerpTarget = state.LerpTarget;
+            entity.Comp.RelativeRotation = state.RelativeRotation;
+            entity.Comp.TargetRelativeRotation = state.TargetRelativeRotation;
+            entity.Comp.CanMove = state.CanMove;
+            entity.Comp.RelativeEntity = EnsureEntity<InputMoverComponent>(state.RelativeEntity, entity.Owner);
 
             // Reset
-            component.LastInputTick = GameTick.Zero;
-            component.LastInputSubTick = 0;
+            entity.Comp.LastInputTick = GameTick.Zero;
+            entity.Comp.LastInputSubTick = 0;
 
-            if (component.HeldMoveButtons != state.HeldMoveButtons)
+            if (entity.Comp.HeldMoveButtons != state.HeldMoveButtons)
             {
-                var moveEvent = new MoveInputEvent(uid, component, component.HeldMoveButtons);
-                component.HeldMoveButtons = state.HeldMoveButtons;
-                RaiseLocalEvent(uid, ref moveEvent);
+                var moveEvent = new MoveInputEvent(entity, entity.Comp.HeldMoveButtons);
+                entity.Comp.HeldMoveButtons = state.HeldMoveButtons;
+                RaiseLocalEvent(entity.Owner, ref moveEvent);
             }
         }
 
-        private void OnMoverGetState(EntityUid uid, InputMoverComponent component, ref ComponentGetState args)
+        private void OnMoverGetState(Entity<InputMoverComponent> entity, ref ComponentGetState args)
         {
             args.State = new InputMoverComponentState()
             {
-                CanMove = component.CanMove,
-                RelativeEntity = GetNetEntity(component.RelativeEntity),
-                LerpTarget = component.LerpTarget,
-                HeldMoveButtons = component.HeldMoveButtons,
-                RelativeRotation = component.RelativeRotation,
-                TargetRelativeRotation = component.TargetRelativeRotation,
+                CanMove = entity.Comp.CanMove,
+                RelativeEntity = GetNetEntity(entity.Comp.RelativeEntity),
+                LerpTarget = entity.Comp.LerpTarget,
+                HeldMoveButtons = entity.Comp.HeldMoveButtons,
+                RelativeRotation = entity.Comp.RelativeRotation,
+                TargetRelativeRotation = entity.Comp.TargetRelativeRotation,
             };
         }
 
@@ -142,9 +142,9 @@ namespace Content.Shared.Movement.Systems
 
         protected virtual void HandleShuttleInput(EntityUid uid, ShuttleButtons button, ushort subTick, bool state) {}
 
-        private void OnAutoParentChange(EntityUid uid, AutoOrientComponent component, ref EntParentChangedMessage args)
+        private void OnAutoParentChange(Entity<AutoOrientComponent> entity, ref EntParentChangedMessage args)
         {
-            ResetCamera(uid);
+            ResetCamera(entity.Owner);
         }
 
         public void RotateCamera(EntityUid uid, Angle angle)
@@ -233,28 +233,28 @@ namespace Content.Shared.Movement.Systems
             return rotation;
         }
 
-        private void OnFollowedParentChange(EntityUid uid, FollowedComponent component, ref EntParentChangedMessage args)
+        private void OnFollowedParentChange(Entity<FollowedComponent> entity, ref EntParentChangedMessage args)
         {
-            foreach (var foll in component.Following)
+            foreach (var foll in entity.Comp.Following)
             {
                 if (!MoverQuery.TryGetComponent(foll, out var mover))
                     continue;
 
                 var ev = new EntParentChangedMessage(foll, null, args.OldMapId, XformQuery.GetComponent(foll));
-                OnInputParentChange(foll, mover, ref ev);
+                OnInputParentChange((foll, mover), ref ev);
             }
         }
 
-        private void OnInputParentChange(EntityUid uid, InputMoverComponent component, ref EntParentChangedMessage args)
+        private void OnInputParentChange(Entity<InputMoverComponent> entity, ref EntParentChangedMessage args)
         {
             // If we change our grid / map then delay updating our LastGridAngle.
             var relative = args.Transform.GridUid;
             relative ??= args.Transform.MapUid;
 
-            if (component.LifeStage < ComponentLifeStage.Running)
+            if (entity.Comp.LifeStage < ComponentLifeStage.Running)
             {
-                component.RelativeEntity = relative;
-                Dirty(uid, component);
+                entity.Comp.RelativeEntity = relative;
+                Dirty(entity.Owner, entity.Comp);
                 return;
             }
 
@@ -264,28 +264,28 @@ namespace Content.Shared.Movement.Systems
             // If we change maps then reset eye rotation entirely.
             if (oldMapId != mapId)
             {
-                component.RelativeEntity = relative;
-                component.TargetRelativeRotation = Angle.Zero;
-                component.RelativeRotation = Angle.Zero;
-                component.LerpTarget = TimeSpan.Zero;
-                Dirty(uid, component);
+                entity.Comp.RelativeEntity = relative;
+                entity.Comp.TargetRelativeRotation = Angle.Zero;
+                entity.Comp.RelativeRotation = Angle.Zero;
+                entity.Comp.LerpTarget = TimeSpan.Zero;
+                Dirty(entity.Owner, entity.Comp);
                 return;
             }
 
             // If we go on a grid and back off then just reset the accumulator.
-            if (relative == component.RelativeEntity)
+            if (relative == entity.Comp.RelativeEntity)
             {
-                if (component.LerpTarget >= Timing.CurTime)
+                if (entity.Comp.LerpTarget >= Timing.CurTime)
                 {
-                    component.LerpTarget = TimeSpan.Zero;
-                    Dirty(uid, component);
+                    entity.Comp.LerpTarget = TimeSpan.Zero;
+                    Dirty(entity.Owner, entity.Comp);
                 }
 
                 return;
             }
 
-            component.LerpTarget = TimeSpan.FromSeconds(InputMoverComponent.LerpTime) + Timing.CurTime;
-            Dirty(uid, component);
+            entity.Comp.LerpTarget = TimeSpan.FromSeconds(InputMoverComponent.LerpTime) + Timing.CurTime;
+            Dirty(entity.Owner, entity.Comp);
         }
 
         private void HandleDirChange(EntityUid entity, Direction dir, ushort subTick, bool state)
@@ -299,7 +299,7 @@ namespace Content.Shared.Movement.Systems
                 DebugTools.AssertNotNull(relayMover.RelayEntity);
 
                 if (MoverQuery.TryGetComponent(entity, out var mover))
-                    SetMoveInput(entity, mover, MoveButtons.None);
+                    SetMoveInput((entity, mover), MoveButtons.None);
 
                 if (!_mobState.IsIncapacitated(entity))
                     HandleDirChange(relayMover.RelayEntity, dir, subTick, state);
@@ -321,18 +321,18 @@ namespace Content.Shared.Movement.Systems
                 RaiseLocalEvent(xform.ParentUid, ref relayMoveEvent);
             }
 
-            SetVelocityDirection(entity, moverComp, dir, subTick, state);
+            SetVelocityDirection((entity, moverComp), dir, subTick, state);
         }
 
-        private void OnInputInit(EntityUid uid, InputMoverComponent component, ComponentInit args)
+        private void OnInputInit(Entity<InputMoverComponent> entity, ref ComponentInit args)
         {
-            var xform = Transform(uid);
+            var xform = Transform(entity.Owner);
 
             if (!xform.ParentUid.IsValid())
                 return;
 
-            component.RelativeEntity = xform.GridUid ?? xform.MapUid;
-            component.TargetRelativeRotation = Angle.Zero;
+            entity.Comp.RelativeEntity = xform.GridUid ?? xform.MapUid;
+            entity.Comp.TargetRelativeRotation = Angle.Zero;
         }
 
         private void HandleRunChange(EntityUid uid, ushort subTick, bool walking)
@@ -344,7 +344,7 @@ namespace Content.Shared.Movement.Systems
                 // if we swap to relay then stop our existing input if we ever change back.
                 if (moverComp != null)
                 {
-                    SetMoveInput(uid, moverComp, MoveButtons.None);
+                    SetMoveInput((uid, moverComp), MoveButtons.None);
                 }
 
                 HandleRunChange(relayMover.RelayEntity, subTick, walking);
@@ -353,7 +353,7 @@ namespace Content.Shared.Movement.Systems
 
             if (moverComp == null) return;
 
-            SetSprinting(uid, moverComp, subTick, walking);
+            SetSprinting((uid, moverComp), subTick, walking);
         }
 
         public (Vector2 Walking, Vector2 Sprinting) GetVelocityInput(InputMoverComponent mover)
@@ -404,7 +404,7 @@ namespace Content.Shared.Movement.Systems
         ///     composed into a single direction vector, <see cref="VelocityDir"/>. Enabling
         ///     opposite directions will cancel each other out, resulting in no direction.
         /// </summary>
-        public void SetVelocityDirection(EntityUid entity, InputMoverComponent component, Direction direction, ushort subTick, bool enabled)
+        public void SetVelocityDirection(Entity<InputMoverComponent> entity, Direction direction, ushort subTick, bool enabled)
         {
             // Logger.Info($"[{_gameTiming.CurTick}/{subTick}] {direction}: {enabled}");
 
@@ -417,26 +417,26 @@ namespace Content.Shared.Movement.Systems
                 _ => throw new ArgumentException(nameof(direction))
             };
 
-            SetMoveInput(entity, component, subTick, enabled, bit);
+            SetMoveInput(entity, subTick, enabled, bit);
         }
 
-        private void SetMoveInput(EntityUid entity, InputMoverComponent component, ushort subTick, bool enabled, MoveButtons bit)
+        private void SetMoveInput(Entity<InputMoverComponent> entity, ushort subTick, bool enabled, MoveButtons bit)
         {
             // Modifies held state of a movement button at a certain sub tick and updates current tick movement vectors.
-            ResetSubtick(component);
+            ResetSubtick(entity.Comp);
 
-            if (subTick >= component.LastInputSubTick)
+            if (subTick >= entity.Comp.LastInputSubTick)
             {
-                var fraction = (subTick - component.LastInputSubTick) / (float) ushort.MaxValue;
+                var fraction = (subTick - entity.Comp.LastInputSubTick) / (float) ushort.MaxValue;
 
-                ref var lastMoveAmount = ref component.Sprinting ? ref component.CurTickSprintMovement : ref component.CurTickWalkMovement;
+                ref var lastMoveAmount = ref entity.Comp.Sprinting ? ref entity.Comp.CurTickSprintMovement : ref entity.Comp.CurTickWalkMovement;
 
-                lastMoveAmount += DirVecForButtons(component.HeldMoveButtons) * fraction;
+                lastMoveAmount += DirVecForButtons(entity.Comp.HeldMoveButtons) * fraction;
 
-                component.LastInputSubTick = subTick;
+                entity.Comp.LastInputSubTick = subTick;
             }
 
-            var buttons = component.HeldMoveButtons;
+            var buttons = entity.Comp.HeldMoveButtons;
 
             if (enabled)
             {
@@ -447,7 +447,7 @@ namespace Content.Shared.Movement.Systems
                 buttons &= ~bit;
             }
 
-            SetMoveInput(entity, component, buttons);
+            SetMoveInput(entity, buttons);
         }
 
         private void ResetSubtick(InputMoverComponent component)
@@ -460,11 +460,11 @@ namespace Content.Shared.Movement.Systems
             component.LastInputSubTick = 0;
         }
 
-        public void SetSprinting(EntityUid entity, InputMoverComponent component, ushort subTick, bool walking)
+        public void SetSprinting(Entity<InputMoverComponent> entity, ushort subTick, bool walking)
         {
             // Logger.Info($"[{_gameTiming.CurTick}/{subTick}] Sprint: {enabled}");
 
-            SetMoveInput(entity, component, subTick, walking, MoveButtons.Walk);
+            SetMoveInput(entity, subTick, walking, MoveButtons.Walk);
         }
 
         /// <summary>

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -83,17 +83,17 @@ namespace Content.Shared.Movement.Systems
             return oldMovement;
         }
 
-        protected void SetMoveInput(InputMoverComponent component, MoveButtons buttons)
+        protected void SetMoveInput(EntityUid entity, InputMoverComponent component, MoveButtons buttons)
         {
             if (component.HeldMoveButtons == buttons)
                 return;
 
             // Relay the fact we had any movement event.
             // TODO: Ideally we'd do these in a tick instead of out of sim.
-            var moveEvent = new MoveInputEvent(component.Owner, component, component.HeldMoveButtons);
+            var moveEvent = new MoveInputEvent(entity, component, component.HeldMoveButtons);
             component.HeldMoveButtons = buttons;
-            RaiseLocalEvent(component.Owner, ref moveEvent);
-            Dirty(component.Owner, component);
+            RaiseLocalEvent(entity, ref moveEvent);
+            Dirty(entity, component);
         }
 
         private void OnMoverHandleState(EntityUid uid, InputMoverComponent component, ComponentHandleState args)
@@ -299,7 +299,7 @@ namespace Content.Shared.Movement.Systems
                 DebugTools.AssertNotNull(relayMover.RelayEntity);
 
                 if (MoverQuery.TryGetComponent(entity, out var mover))
-                    SetMoveInput(mover, MoveButtons.None);
+                    SetMoveInput(entity, mover, MoveButtons.None);
 
                 if (!_mobState.IsIncapacitated(entity))
                     HandleDirChange(relayMover.RelayEntity, dir, subTick, state);
@@ -344,7 +344,7 @@ namespace Content.Shared.Movement.Systems
                 // if we swap to relay then stop our existing input if we ever change back.
                 if (moverComp != null)
                 {
-                    SetMoveInput(moverComp, MoveButtons.None);
+                    SetMoveInput(uid, moverComp, MoveButtons.None);
                 }
 
                 HandleRunChange(relayMover.RelayEntity, subTick, walking);
@@ -447,7 +447,7 @@ namespace Content.Shared.Movement.Systems
                 buttons &= ~bit;
             }
 
-            SetMoveInput(component, buttons);
+            SetMoveInput(entity, component, buttons);
         }
 
         private void ResetSubtick(InputMoverComponent component)

--- a/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
@@ -67,7 +67,7 @@ public abstract partial class SharedMoverController
         Physics.UpdateIsPredicted(component.RelayEntity);
 
         if (TryComp<InputMoverComponent>(component.RelayEntity, out var inputMover))
-            SetMoveInput(inputMover, MoveButtons.None);
+            SetMoveInput(uid, inputMover, MoveButtons.None);
 
         if (Timing.ApplyingState)
             return;

--- a/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
@@ -12,14 +12,14 @@ public abstract partial class SharedMoverController
         SubscribeLocalEvent<RelayInputMoverComponent, AfterAutoHandleStateEvent>(OnAfterRelayState);
     }
 
-    private void OnAfterRelayTargetState(EntityUid uid, MovementRelayTargetComponent component, ref AfterAutoHandleStateEvent args)
+    private void OnAfterRelayTargetState(Entity<MovementRelayTargetComponent> entity, ref AfterAutoHandleStateEvent args)
     {
-        Physics.UpdateIsPredicted(uid);
+        Physics.UpdateIsPredicted(entity.Owner);
     }
 
-    private void OnAfterRelayState(EntityUid uid, RelayInputMoverComponent component, ref AfterAutoHandleStateEvent args)
+    private void OnAfterRelayState(Entity<RelayInputMoverComponent> entity, ref AfterAutoHandleStateEvent args)
     {
-        Physics.UpdateIsPredicted(uid);
+        Physics.UpdateIsPredicted(entity.Owner);
     }
 
     /// <summary>
@@ -76,15 +76,15 @@ public abstract partial class SharedMoverController
             RemComp(entity.Comp.RelayEntity, target);
     }
 
-    private void OnTargetRelayShutdown(EntityUid uid, MovementRelayTargetComponent component, ComponentShutdown args)
+    private void OnTargetRelayShutdown(Entity<MovementRelayTargetComponent> entity, ref ComponentShutdown args)
     {
-        Physics.UpdateIsPredicted(uid);
-        Physics.UpdateIsPredicted(component.Source);
+        Physics.UpdateIsPredicted(entity.Owner);
+        Physics.UpdateIsPredicted(entity.Comp.Source);
 
         if (Timing.ApplyingState)
             return;
 
-        if (TryComp(component.Source, out RelayInputMoverComponent? relay) && relay.LifeStage <= ComponentLifeStage.Running)
-            RemComp(component.Source, relay);
+        if (TryComp(entity.Comp.Source, out RelayInputMoverComponent? relay) && relay.LifeStage <= ComponentLifeStage.Running)
+            RemComp(entity.Comp.Source, relay);
     }
 }

--- a/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
@@ -61,7 +61,7 @@ public abstract partial class SharedMoverController
         Dirty(relayEntity, targetComp);
     }
 
-    private void OnRelayShutdown(Entity<RelayInputMoverComponent> entity, ComponentShutdown args)
+    private void OnRelayShutdown(Entity<RelayInputMoverComponent> entity, ref ComponentShutdown args)
     {
         Physics.UpdateIsPredicted(entity.Owner);
         Physics.UpdateIsPredicted(entity.Comp.RelayEntity);

--- a/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
@@ -61,19 +61,19 @@ public abstract partial class SharedMoverController
         Dirty(relayEntity, targetComp);
     }
 
-    private void OnRelayShutdown(EntityUid uid, RelayInputMoverComponent component, ComponentShutdown args)
+    private void OnRelayShutdown(Entity<RelayInputMoverComponent> entity, ComponentShutdown args)
     {
-        Physics.UpdateIsPredicted(uid);
-        Physics.UpdateIsPredicted(component.RelayEntity);
+        Physics.UpdateIsPredicted(entity.Owner);
+        Physics.UpdateIsPredicted(entity.Comp.RelayEntity);
 
-        if (TryComp<InputMoverComponent>(component.RelayEntity, out var inputMover))
-            SetMoveInput(uid, inputMover, MoveButtons.None);
+        if (TryComp<InputMoverComponent>(entity.Comp.RelayEntity, out var inputMover))
+            SetMoveInput((entity.Comp.RelayEntity, inputMover), MoveButtons.None);
 
         if (Timing.ApplyingState)
             return;
 
-        if (TryComp(component.RelayEntity, out MovementRelayTargetComponent? target) && target.LifeStage <= ComponentLifeStage.Running)
-            RemComp(component.RelayEntity, target);
+        if (TryComp(entity.Comp.RelayEntity, out MovementRelayTargetComponent? target) && target.LifeStage <= ComponentLifeStage.Running)
+            RemComp(entity.Comp.RelayEntity, target);
     }
 
     private void OnTargetRelayShutdown(EntityUid uid, MovementRelayTargetComponent component, ComponentShutdown args)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Project 0 warnings, Component.Owner is obsolete

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- MoveInputEvent updated to store the `Entity<InputMoverComponent>` instead of storing both parts separately
- Update usages of MoveInputEvent args to get the component from the `Entity<T>`

- All LocalEvent subscriptions in SharedMoveController.Relay, SharedMoveController.Input, MoverController (client) and MoverController (server) updated to use `Entity<InputMoverComponent>` rather than the separated syntax
- SetMoveInput() arguments changed to `Entity<T>` syntax, all uses of this function updated to send the newly accessible `Entity<T>` from the LocalEvent arguments, or any necessary tupled arguments 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/6c2d4dfe-925d-42bb-9a58-f44aef8de6b3

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
SharedMoveController.Input.cs `SetMoveInput(InputMoverComponent component, MoveButtons buttons)` changed to `SetMoveInput(EntityUid entity, InputMoverComponent component, MoveButtons buttons)`, fix it by passing along the EntityUid as the first argument when using the function

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
bababababa