### PR TITLE
Update TriggerSystem.TimedCollide.cs to not use Component.Owner

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.TimedCollide.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.TimedCollide.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server.Explosion.Components;
 using Content.Server.Explosion.EntitySystems;
 using Robust.Shared.Physics.Dynamics;
@@ -42,14 +42,15 @@ public sealed partial class TriggerSystem
 
     private void UpdateTimedCollide(float frameTime)
     {
-        foreach (var (activeTrigger, triggerOnTimedCollide) in EntityQuery<ActiveTriggerOnTimedCollideComponent, TriggerOnTimedCollideComponent>())
+        var query = EntityQueryEnumerator<ActiveTriggerOnTimedCollideComponent, TriggerOnTimedCollideComponent>();
+        while (query.MoveNext(out var uid, out _, out var triggerOnTimedCollide))
         {
             foreach (var (collidingEntity, collidingTimer) in triggerOnTimedCollide.Colliding)
             {
                 triggerOnTimedCollide.Colliding[collidingEntity] += frameTime;
                 if (collidingTimer > triggerOnTimedCollide.Threshold)
                 {
-                    RaiseLocalEvent(activeTrigger.Owner, new TriggerEvent(activeTrigger.Owner, collidingEntity), true);
+                    RaiseLocalEvent(uid, new TriggerEvent(uid, collidingEntity), true);
                     triggerOnTimedCollide.Colliding[collidingEntity] -= triggerOnTimedCollide.Threshold;
                 }
             }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Project 0 warnings, Component.Owner is obsolete

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
"Use EntityQueryEnumerator if you need the EntityUid"... so I did that.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/f2406cdc-3638-4f4f-b09e-e45b2ca6f7fc

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
meow