### PR TITLE
Update UtensilSystem.cs to not use Component.Owner

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/UtensilSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/UtensilSystem.cs
@@ -31,24 +31,24 @@ namespace Content.Server.Nutrition.EntitySystems
         /// <summary>
         /// Clicked with utensil
         /// </summary>
-        private void OnAfterInteract(EntityUid uid, UtensilComponent component, AfterInteractEvent ev)
+        private void OnAfterInteract(Entity<UtensilComponent> entity, ref AfterInteractEvent ev)
         {
             if (ev.Handled || ev.Target == null || !ev.CanReach)
                 return;
 
-            var result = TryUseUtensil(ev.User, ev.Target.Value, component);
+            var result = TryUseUtensil(ev.User, ev.Target.Value, entity);
             ev.Handled = result.Handled;
         }
 
-        public (bool Success, bool Handled) TryUseUtensil(EntityUid user, EntityUid target, UtensilComponent component)
+        public (bool Success, bool Handled) TryUseUtensil(EntityUid user, EntityUid target, Entity<UtensilComponent> utensil)
         {
             if (!EntityManager.TryGetComponent(target, out FoodComponent? food))
                 return (false, true);
 
             //Prevents food usage with a wrong utensil
-            if ((food.Utensil & component.Types) == 0)
+            if ((food.Utensil & utensil.Comp.Types) == 0)
             {
-                _popupSystem.PopupEntity(Loc.GetString("food-system-wrong-utensil", ("food", target), ("utensil", component.Owner)), user, user);
+                _popupSystem.PopupEntity(Loc.GetString("food-system-wrong-utensil", ("food", target), ("utensil", utensil.Owner)), user, user);
                 return (false, true);
             }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Project 0 warnings, Component.Owner is obsolete

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- `TryUseUtensil(EntityUid user, EntityUid target, UtensilComponent component)` changed to `TryUseUtensil(EntityUid user, EntityUid target, Entity<UtensilComponent> utensil)`
- Updated the OnAfterInteract function to use the Entity<T> syntax so I could pass along the Entity<T> easier to TryUseUtensil().

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/5673755a-444e-4979-a274-ecec8266505c

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
- `TryUseUtensil(EntityUid user, EntityUid target, UtensilComponent component)` changed to `TryUseUtensil(EntityUid user, EntityUid target, Entity<UtensilComponent> utensil)`, fix it by tupling the component with its EntityUid or just sending the Entity<T> properly

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
gahhhhh