### PR TITLE
adds a throngler plushie, and adds it to the grand lotto

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
@@ -305,6 +305,9 @@
     - id: PlushieArachind
       prob: 0.01
       orGroup: Plushies
+    - id: PlushieThrongler #hehe
+      prob: 0.01
+      orGroup: Plushies
     #useful
     - id: AmeJar
       prob: 0.01

--- a/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
@@ -306,7 +306,7 @@
       prob: 0.01
       orGroup: Plushies
     - id: PlushieThrongler #hehe
-      prob: 0.01
+      prob: 0.0005
       orGroup: Plushies
     #useful
     - id: AmeJar

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -65,8 +65,6 @@
     - type: MeleeWeapon
       wideAnimationRotation: -135
       attackRate: 10
-      soundHit:
-        collection: ToySqueak
     - type: Item
       size: Ginormous
       sprite: Objects/Weapons/Melee/Throngler-in-hand.rsi

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -55,6 +55,21 @@
 
 - type: entity
   parent: BasePlushie
+  id: PlushieThrongler
+  name: The Throngler Plushie
+  description: A stuffed toy to remind cargo techs of what they can no longer have.
+  components:
+    - type: Sprite
+      sprite: Objects/Weapons/Melee/Throngler2.rsi
+      state: icon
+    - type: MeleeWeapon
+      wideAnimationRotation: -135
+      attackRate: 10
+      soundHit:
+        collection: ToySqueak
+
+- type: entity
+  parent: BasePlushie
   id: PlushieGhost
   name: ghost soft toy
   description: The start of your personal GHOST GANG!

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -67,6 +67,9 @@
       attackRate: 10
       soundHit:
         collection: ToySqueak
+    - type: Item
+      size: Ginormous
+      sprite: Objects/Weapons/Melee/Throngler-in-hand.rsi
 
 - type: entity
   parent: BasePlushie


### PR DESCRIPTION
## About the PR
There is now a plushie throngler, which can be found in the grand lottery. It has no combat value whatsoever, but it otherwise does the same things as the throngler (attacking fast, being huge, being funny). It has no damage, and is just a toy.

## Why / Balance
I jokingly suggested this idea in general and everyone there immediately latched on so I decided I might aswell make it since it is very little work and very funny.

## Technical details
Wrote yml, drank lemonade, made PR. Not much technical stuff to speak of here

## Media
https://github.com/user-attachments/assets/3d339e29-794d-4beb-bd67-f45098350628

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Breaks cargo techs hearts?
   (none)

**Changelog**

:cl:
- add: Added The Throngler (Plushie) to the grand lottery!!
