### PR TITLE
Little saw debuff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -173,12 +173,12 @@
     sprite: Objects/Specific/Medical/Surgery/saw.rsi
     state: saw
   - type: Item
+    size: Normal
     sprite: Objects/Specific/Medical/Surgery/saw.rsi
     storedRotation: 90
   - type: Tool
     qualities:
       - Sawing
-    speedModifier: 1.0
 # No melee for regular saw because have you ever seen someone use a band saw as a weapon? It's dumb.
 
 - type: entity
@@ -190,6 +190,7 @@
   - type: Sprite
     state: improv
   - type: Item
+    size: Small
     heldPrefix: improv
   - type: MeleeWeapon
     damage:
@@ -198,8 +199,6 @@
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
   - type: Tool
-    qualities:
-      - Sawing
     speedModifier: 0.5
 
 - type: entity
@@ -212,7 +211,6 @@
     state: electric
   - type: Item
     heldPrefix: electric
-    storedRotation: 90
   - type: MeleeWeapon
     damage:
       groups:
@@ -220,29 +218,19 @@
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: Tool
-    qualities:
-      - Sawing
     speedModifier: 1.5
 
 - type: entity
   name: advanced circular saw
   id: SawAdvanced
-  parent: Saw
+  parent: SawElectric
   description: You think you can cut anything with it.
   components:
   - type: Sprite
     state: advanced
   - type: Item
     heldPrefix: advanced
-    storedRotation: 90
   - type: MeleeWeapon
     attackRate: 1.5
-    damage:
-      groups:
-        Brute: 15
-    soundHit:
-      path: /Audio/Items/drill_hit.ogg
   - type: Tool
-    qualities:
-      - Sawing
     speedModifier: 2.0


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
make saws normal size (no more pocket circulaw saw)
cleanup yml a little

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
balance

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Surgery saws now are normal-sized (no more pocket circular saw).
