### PR TITLE
NPC exits MeleeOperator on invalid EntityUid

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/Melee/MeleeOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/Melee/MeleeOperator.cs
@@ -89,7 +89,8 @@ public sealed partial class MeleeOperator : HTNOperator, IHtnConditionalShutdown
         HTNOperatorStatus status;
 
         if (_entManager.TryGetComponent<NPCMeleeCombatComponent>(owner, out var combat) &&
-            blackboard.TryGetValue<EntityUid>(TargetKey, out var target, _entManager))
+            blackboard.TryGetValue<EntityUid>(TargetKey, out var target, _entManager) &&
+            target != EntityUid.Invalid)
         {
             combat.Target = target;
 

--- a/Content.Server/NPC/Systems/NPCJukeSystem.cs
+++ b/Content.Server/NPC/Systems/NPCJukeSystem.cs
@@ -143,6 +143,9 @@ public sealed class NPCJukeSystem : EntitySystem
                 if (!_melee.TryGetWeapon(uid, out var weaponUid, out var weapon))
                     return;
 
+                if (!HasComp<TransformComponent>(melee.Target))
+                    return;
+
                 var cdRemaining = weapon.NextAttack - _timing.CurTime;
                 var attackCooldown = TimeSpan.FromSeconds(1f / _melee.GetAttackRate(weaponUid, uid, weapon));
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added couple checks.

## Why / Balance
most likely fixes #20175
Not entirely sure if it fixes issue #16641
Also noticed that this can happen if you pull Renault at the same time he is exiting retaliation state. This part was discovered with unpulling disabled, due to ongoing fixing of that behaviour.

## Technical details
Extended the if clause in MeleeOperator to exit if blackboard's target is invalid.
Made jukesystem check if the target to be juked has a transform component, since it is used at line 155 or 158 without any checks. 

Haven't fully figured out the exact cause of this bug, but I noticed that sometimes combat.target gets set to 0, which most likely shouldn't be allowed. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
