### PR TITLE
fix(FaxVisualsSystem): Fax can Play() when a anim key has been added.

### DIFF
--- a/Content.Client/Fax/System/FaxVisualsSystem.cs
+++ b/Content.Client/Fax/System/FaxVisualsSystem.cs
@@ -25,24 +25,30 @@ public sealed class FaxVisualsSystem : EntitySystem
         if (args.Sprite == null)
             return;
 
-        if (_appearance.TryGetData(uid, FaxMachineVisuals.VisualState, out FaxMachineVisualState visuals) && visuals == FaxMachineVisualState.Inserting)
+        if (_player.HasRunningAnimation(uid, "faxecute"))
+            return;
+
+        if (_appearance.TryGetData(uid, FaxMachineVisuals.VisualState, out FaxMachineVisualState visuals) &&
+            visuals == FaxMachineVisualState.Inserting)
         {
-            _player.Play(uid, new Animation()
-            {
-                Length = TimeSpan.FromSeconds(2.4),
-                AnimationTracks =
+            _player.Play(uid,
+                new Animation()
                 {
-                    new AnimationTrackSpriteFlick()
+                    Length = TimeSpan.FromSeconds(2.4),
+                    AnimationTracks =
                     {
-                        LayerKey = FaxMachineVisuals.VisualState,
-                        KeyFrames =
+                        new AnimationTrackSpriteFlick()
                         {
-                            new AnimationTrackSpriteFlick.KeyFrame(component.InsertingState, 0f),
-                            new AnimationTrackSpriteFlick.KeyFrame("icon", 2.4f),
-                        }
-                    }
-                }
-            }, "faxecute");
+                            LayerKey = FaxMachineVisuals.VisualState,
+                            KeyFrames =
+                            {
+                                new AnimationTrackSpriteFlick.KeyFrame(component.InsertingState, 0f),
+                                new AnimationTrackSpriteFlick.KeyFrame("icon", 2.4f),
+                            },
+                        },
+                    },
+                },
+                "faxecute");
         }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds a check to see if a "faxecute" animation is being played before playing another "faxecute" animation. The old code can throw an exception which I've seen on live while ghosting.

Can provide a screenshot of the error if needed. Also do a bit of code reformatting on this file.