### PR TITLE
Massively buff the accuracy of the c20-r

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -135,7 +135,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/SMGs/c20r.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateFilledSMG
   cost:
-    Telecrystal: 17
+    Telecrystal: 20
   categories:
   - UplinkWeaponry
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -100,7 +100,7 @@
     maxAngle: -4
   - type: Gun
     minAngle: 2
-    maxAngle: 8 
+    maxAngle: 12 
     shotsPerBurst: 5
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -96,11 +96,11 @@
   - type: Wieldable
     unwieldOnUse: false
   - type: GunWieldBonus
-    minAngle: -19
-    maxAngle: -16
+    minAngle: -1
+    maxAngle: -4
   - type: Gun
-    minAngle: 21
-    maxAngle: 32 
+    minAngle: 2
+    maxAngle: 8 
     shotsPerBurst: 5
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -97,7 +97,7 @@
     unwieldOnUse: false
   - type: GunWieldBonus
     minAngle: -1
-    maxAngle: -4
+    maxAngle: -6
   - type: Gun
     minAngle: 2
     maxAngle: 12 


### PR DESCRIPTION
## About the PR
The c-20 has received a massive accuracy buff, it is able to be reliably used one-handed, and is viable at longer range when wielded.

## Why / Balance
I often feel that the c-20 got a terrible deal when gun wielding was made the standard. It was already rather weak compared to other weapons nukies have access to and now it generally isn't worth running. It eats up ammo like crazy and because of it's inaccuracy it only hits a third of it's shots, so by the time you're halfway through the station you're out of magazines and either relying on an esword or looting guns from the crew.

Now it has it's own use as a weapon for either midrange combat, or use with another weapon such as an esword or shield. If I overcompensated I'd be fine with making it a bit more inaccurate, but I feel having it be on-par with the wt550 (which doesn't need to be wielded) for accuracy when wielded is good.

The price of the c-20 has also been increased by 3 tc to be in line with the bulldog.

## Media

https://github.com/user-attachments/assets/6659b4d0-096a-481c-a432-30ef97035114


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- tweak: The c-20r is now significantly more accurate, and able to be reasonably used one-handed.
- tweak: The c-20r now costs 20 tc