### PR TITLE
fix(RequireProjectileTargetSystem): Add ent invalid check.

### DIFF
--- a/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
+++ b/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
@@ -31,7 +31,7 @@ public sealed class RequireProjectileTargetSystem : EntitySystem
         {
             // Prevents shooting out of while inside of crates
             var shooter = projectile.Shooter;
-            if (!shooter.HasValue)
+            if (!shooter.HasValue || shooter.Value == EntityUid.Invalid)
                 return;
 
             if (!_container.IsEntityOrParentInContainer(shooter.Value))


### PR DESCRIPTION
## About the PR
A situation can happen where shooter.value references entity 0. Check for that and treat it like it's null.