### PR TITLE
Fix weird interactions using RefillableSolutionComponent when dumping food in a drain/sink

### DIFF
--- a/Content.Shared/Chemistry/Components/RefillableSolutionComponent.cs
+++ b/Content.Shared/Chemistry/Components/RefillableSolutionComponent.cs
@@ -22,4 +22,10 @@ public sealed partial class RefillableSolutionComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public FixedPoint2? MaxRefill = null;
+
+    /// <summary>
+    /// Whether the entity should be deleted when the solution is empty.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool DeleteOnEmpty = false;
 }

--- a/Resources/Locale/en-US/fluids/components/absorbent-component.ftl
+++ b/Resources/Locale/en-US/fluids/components/absorbent-component.ftl
@@ -4,5 +4,7 @@ mopping-system-puddle-space = { CAPITALIZE(THE($used)) } is full of water
 mopping-system-puddle-evaporate = {  CAPITALIZE(THE($target)) } is evaporating
 mopping-system-no-water = { CAPITALIZE(THE($used)) } has no water!
 
+mopping-system-dump = You dump {THE($used)} in {THE($target)}!
+
 mopping-system-full = { CAPITALIZE(THE($used)) } is full!
 mopping-system-empty = { CAPITALIZE(THE($used)) } is empty!

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
@@ -28,6 +28,7 @@
     solution: food
   - type: RefillableSolution
     solution: food
+    deleteOnEmpty: true
 
 # usable by any food that can be opened
 # handles appearance with states "icon" and "icon-open"


### PR DESCRIPTION


<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes #29937 

You can no longer dump closed bottles/containers in a drain/sink. 

Most importantly this patches exploitable interactions when food gets dumped into a drain/sink by transfering the solution and then deleting the entity. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Currently you cannot draw from a food's solution but you CAN dump it in a drain and have a bugged "empty" food. For the most part this only means that when you try to eat it, it will just disappear from your hand with no sound and pop a "{Food} is empty!" message. But then nothing stops someone from dumping an Arnold's pizza and filling it with poison and at this point I don't even know if that's a fun gimmick or an exploit.  The point is the idea of a food being empty doesn't make sense. There should be better ways to fill up food with deadly doses than through using a drain.

Also, being able to dump a closed bottle is just weird



## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Currently there is a weird thing that happens when drag dropping entities with a `RefillableSolutionComponent` to a entity with a `DumpableSolutionComponent`. It gets treated by the `PuddleSystem`. The problem is that also includes food and drinks.

- Adds a field to `RefillableSolutionComponent` that can mark the entity as `DeleteOnEmpty` when it gets dumped. Only `FoodBaseInjectable` gets this set to true so it should only affect food

- Checks if there is an open `OpenableComponent` before allowing to dump. This fixes dumping closed bottles

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Before:


https://github.com/user-attachments/assets/45390fc9-e61c-4860-aeea-09593eccb101

After:


https://github.com/user-attachments/assets/0390de2f-7ed1-4bdb-9e7b-68fb77065ebf


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
any food that usually drops a byproduct when eaten (kebabs) is getting deleted and so nothing drops

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
🆑 coffeeware
 - fix: You can no longer dump a closed bottle/container in a drain
 - tweak: Food gets deleted when dumped
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
