### PR TITLE
Remove outdated steps from Test Packaging workflow

### DIFF
--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -64,11 +64,3 @@ jobs:
 
       - name: Package client
         run: dotnet run --project Content.Packaging client --no-wipe-release
-
-      - name: Update Build Info
-        run: Tools/gen_build_info.py
-
-      - name: Shuffle files around
-        run: |
-          mkdir "release/${{ github.sha }}"
-          mv release/*.zip "release/${{ github.sha }}"


### PR DESCRIPTION
gen build info was removed in 5e800e0ece7beadeb06bba901dd573e84fa4c133 but I didn't realize this workflow also tested it. Gone now.
