### PR TITLE
Prevent virtual item storage and popups

### DIFF
--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -62,11 +62,13 @@ public sealed class SmartEquipSystem : EntitySystem
         if (playerSession.AttachedEntity is not { Valid: true } uid || !Exists(uid))
             return;
 
-        if (!_actionBlocker.CanInteract(uid, null))
-            return;
-
         // early out if we don't have any hands or a valid inventory slot
         if (!TryComp<HandsComponent>(uid, out var hands) || hands.ActiveHand == null)
+            return;
+
+        var handItem = hands.ActiveHand.HeldEntity;
+
+        if (!_actionBlocker.CanInteract(uid, handItem))
             return;
 
         if (!TryComp<InventoryComponent>(uid, out var inventory) || !_inventory.HasSlot(uid, equipmentSlot, inventory))
@@ -74,8 +76,6 @@ public sealed class SmartEquipSystem : EntitySystem
             _popup.PopupClient(Loc.GetString("smart-equip-missing-equipment-slot", ("slotName", equipmentSlot)), uid, uid);
             return;
         }
-
-        var handItem = hands.ActiveHand.HeldEntity;
 
         // early out if we have an item and cant drop it at all
         if (handItem != null && !_hands.CanDropHeld(uid, hands.ActiveHand))

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -68,6 +68,7 @@ public sealed class SmartEquipSystem : EntitySystem
 
         var handItem = hands.ActiveHand.HeldEntity;
 
+        // can the user interact, and is the item interactable? e.g. virtual items
         if (!_actionBlocker.CanInteract(uid, handItem))
             return;
 

--- a/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
+++ b/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
 using Content.Shared.Popups;
@@ -43,6 +44,7 @@ public abstract class SharedVirtualItemSystem : EntitySystem
         SubscribeLocalEvent<VirtualItemComponent, BeingUnequippedAttemptEvent>(OnBeingUnequippedAttempt);
 
         SubscribeLocalEvent<VirtualItemComponent, BeforeRangedInteractEvent>(OnBeforeRangedInteract);
+        SubscribeLocalEvent<VirtualItemComponent, GettingInteractedWithAttemptEvent>(OnGettingInteractedWithAttemptEvent);
     }
 
     /// <summary>
@@ -70,6 +72,12 @@ public abstract class SharedVirtualItemSystem : EntitySystem
     {
         // No interactions with a virtual item, please.
         args.Handled = true;
+    }
+
+    private void OnGettingInteractedWithAttemptEvent(Entity<VirtualItemComponent> ent, ref GettingInteractedWithAttemptEvent args)
+    {
+        // No interactions with a virtual item, please.
+        args.Cancelled = true;
     }
 
     #region Hands

--- a/Resources/Prototypes/Entities/Virtual/virtual_item.yml
+++ b/Resources/Prototypes/Entities/Virtual/virtual_item.yml
@@ -5,5 +5,5 @@
   noSpawn: true
   components:
   - type: Item
-    size: Ginormous # no storage insertion vlsuals
+    size: Ginormous # no storage insertion visuals
   - type: VirtualItem

--- a/Resources/Prototypes/Entities/Virtual/virtual_item.yml
+++ b/Resources/Prototypes/Entities/Virtual/virtual_item.yml
@@ -5,4 +5,5 @@
   noSpawn: true
   components:
   - type: Item
+    size: Ginormous # no storage insertion vlsuals
   - type: VirtualItem


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Fixes #28475
Fixes #29924

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

ActionBlockerSystem.CanInteract() will now catch virtual items with GettingInteractedWithAttemptEvent.
SmartEquipSystem will now check that the item is interactable before even reaching popups.

I think virtual items have the ItemComponent for in hand visuals? To avoid doing a user entity lookup and actionblocker check every frame in StorageContainer.cs, I just set the item size to Ginormous to prevent the item grid thing (orange rectangle) from appearing.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

no cl needed
