### PR TITLE
Additive lighting

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -11,6 +11,7 @@ using Content.Client.IoC;
 using Content.Client.Launcher;
 using Content.Client.Lobby;
 using Content.Client.MainMenu;
+using Content.Client.Overlays;
 using Content.Client.Parallax.Managers;
 using Content.Client.Players.PlayTimeTracking;
 using Content.Client.Radiation.Overlays;
@@ -150,6 +151,7 @@ namespace Content.Client.Entry
 
             _parallaxManager.LoadDefaultParallax();
 
+            _overlayManager.AddOverlay(new BasePostProcessOverlay());
             _overlayManager.AddOverlay(new SingularityOverlay());
             _overlayManager.AddOverlay(new RadiationPulseOverlay());
             _chatManager.Initialize();

--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
@@ -14,6 +14,7 @@
                 <ui:OptionDropDown Name="DropDownLightingQuality" Title="{Loc 'ui-options-lighting-label'}" />
                 <CheckBox Name="ViewportLowResCheckBox" Text="{Loc 'ui-options-vp-low-res'}" />
                 <CheckBox Name="ParallaxLowQualityCheckBox" Text="{Loc 'ui-options-parallax-low-quality'}" />
+                <CheckBox Name="PostProcessCheckBox" Text="{Loc 'ui-options-postprocess'}" ToolTip="{Loc 'ui-options-postprocess-tooltip'}" />
 
                 <!-- Interface -->
                 <Label Text="{Loc 'ui-options-interface-label'}" StyleClasses="LabelKeyText"/>

--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
@@ -59,6 +59,7 @@ public sealed partial class GraphicsTab : Control
         Control.AddOption(new OptionIntegerScaling(Control, _cfg, IntegerScalingCheckBox));
         Control.AddOptionCheckBox(CCVars.ViewportScaleRender, ViewportLowResCheckBox, invert: true);
         Control.AddOptionCheckBox(CCVars.ParallaxLowQuality, ParallaxLowQualityCheckBox);
+        Control.AddOptionCheckBox(CCVars.PostProcess, PostProcessCheckBox);
         Control.AddOptionCheckBox(CCVars.HudFpsCounterVisible, FpsCounterCheckBox);
 
         Control.Initialize();

--- a/Content.Client/Overlays/BasePostProcessOverlay.cs
+++ b/Content.Client/Overlays/BasePostProcessOverlay.cs
@@ -1,0 +1,80 @@
+using Content.Shared.CCVar;
+using System.Numerics;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Configuration;
+using Robust.Shared.Enums;
+using Robust.Shared.Graphics;
+using Robust.Shared.Physics;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client.Overlays;
+
+// This overlay serves as the foundational post processing overlay.
+// Ideally, for performance reasons, post processing designed to be present at all times, such as additive light blending or tonemapping, should be done as part of a single shader pass.
+public sealed class BasePostProcessOverlay : Overlay
+{
+    [Dependency] private readonly IConfigurationManager _configManager = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly ILightManager _lightManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public override bool RequestScreenTexture => true;
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+    private readonly ShaderInstance _basePostProcessShader;
+
+    public BasePostProcessOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _basePostProcessShader = _prototypeManager.Index<ShaderPrototype>("BasePostProcess").InstanceUnique();
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (!_configManager.GetCVar(CCVars.PostProcess))
+            return false;
+
+        if (!_entityManager.TryGetComponent(_playerManager.LocalSession?.AttachedEntity, out EyeComponent? eyeComp))
+            return false;
+
+        if (args.Viewport.Eye != eyeComp.Eye)
+            return false;
+
+        if (!_lightManager.Enabled || !eyeComp.Eye.DrawLight)
+            return false;
+
+        var playerEntity = _playerManager.LocalSession?.AttachedEntity;
+
+        if (playerEntity == null)
+            return false;
+
+        return true;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (ScreenTexture == null)
+            return;
+
+        var playerEntity = _playerManager.LocalSession?.AttachedEntity;
+
+        var worldHandle = args.WorldHandle;
+        var viewport = args.WorldBounds;
+
+        var zoom = 1.0f;
+        if (_entityManager.TryGetComponent<EyeComponent>(playerEntity, out var eyeComponent))
+        {
+            zoom = eyeComponent.Zoom.X;
+        }
+
+        _basePostProcessShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
+        _basePostProcessShader.SetParameter("LIGHT_TEXTURE", args.Viewport.LightRenderTarget.Texture);
+
+        _basePostProcessShader.SetParameter("Zoom", zoom);
+
+        worldHandle.UseShader(_basePostProcessShader);
+        worldHandle.DrawRect(viewport, Color.White);
+        worldHandle.UseShader(null);
+    }
+}

--- a/Content.Client/Overlays/BasePostProcessOverlay.cs
+++ b/Content.Client/Overlays/BasePostProcessOverlay.cs
@@ -57,21 +57,18 @@ public sealed class BasePostProcessOverlay : Overlay
         if (ScreenTexture == null)
             return;
 
+        if (args.Viewport.Eye == null)
+            return;
+
         var playerEntity = _playerManager.LocalSession?.AttachedEntity;
 
         var worldHandle = args.WorldHandle;
         var viewport = args.WorldBounds;
 
-        var zoom = 1.0f;
-        if (_entityManager.TryGetComponent<EyeComponent>(playerEntity, out var eyeComponent))
-        {
-            zoom = eyeComponent.Zoom.X;
-        }
-
         _basePostProcessShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
         _basePostProcessShader.SetParameter("LIGHT_TEXTURE", args.Viewport.LightRenderTarget.Texture);
 
-        _basePostProcessShader.SetParameter("Zoom", zoom);
+        _basePostProcessShader.SetParameter("Zoom", args.Viewport.Eye.Zoom.X);
 
         worldHandle.UseShader(_basePostProcessShader);
         worldHandle.DrawRect(viewport, Color.White);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1731,6 +1731,18 @@ namespace Content.Shared.CCVar
             CVarDef.Create("accessibility.colorblind_friendly", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 
         /*
+         * GRAPHICS
+         */
+
+        /// <summary>
+        /// Toggle for non-gameplay-affecting or otherwise status indicative post-process effects, such additive lighting.
+        /// In the future, this could probably be turned into an enum that allows only disabling more expensive post-process shaders.
+        /// However, for now (mid-July of 2024), this only applies specifically to a particularly cheap shader: additive lighting.
+        /// </summary>
+        public static readonly CVarDef<bool> PostProcess =
+            CVarDef.Create("graphics.post_process", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+        /*
          * CHAT
          */
 

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -94,6 +94,11 @@ ui-options-parallax-low-quality = Low-quality Parallax (background)
 ui-options-fps-counter = Show FPS counter
 ui-options-vp-width = Viewport width:
 ui-options-hud-layout = HUD layout:
+ui-options-postprocess = Cosmetic Post-processing
+ui-options-postprocess-tooltip = When enabled, cosmetic post-processing effects such as
+                                 additive lighting will be present. This does not control
+                                 post-process effects that affect the game or otherwise
+                                 carry some form of gameplay-related meaning.
 
 ## Controls menu
 

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -131,7 +131,7 @@
     lowPressureMultiplier: 1000
   - type: PointLight
     radius: 7
-    energy: 3
+    energy: 2
 
 - type: entity
   parent: ClothingHeadHardsuitBase

--- a/Resources/Prototypes/Entities/Effects/bluespace_flash.yml
+++ b/Resources/Prototypes/Entities/Effects/bluespace_flash.yml
@@ -4,7 +4,7 @@
   components:
   - type: PointLight
     radius: 10.5
-    energy: 15
+    energy: 6
     color: "#18abf5"
   - type: TimedDespawn
     lifetime: 1

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -237,7 +237,7 @@
   components:
   - type: LightBulb
     color: "#B4FCF0"
-    lightEnergy: 4.5
+    lightEnergy: 2.5
     lightRadius: 12
     lightSoftness: 0.5
     BurningTemperature: 350
@@ -251,7 +251,7 @@
   components:
   - type: LightBulb
     color: "#FFAF38"
-    lightEnergy: 4
+    lightEnergy: 2.5
     lightRadius: 10
     lightSoftness: 0.5
     BurningTemperature: 350
@@ -265,7 +265,7 @@
   components:
   - type: LightBulb
     color: "#47f8ff"
-    lightEnergy: 3
+    lightEnergy: 2
     lightRadius: 8
     lightSoftness: 0.5
     BurningTemperature: 350
@@ -285,7 +285,7 @@
   components:
   - type: LightBulb
     color: "#39a1ff"
-    lightEnergy: 3
+    lightEnergy: 2
     lightRadius: 8
     lightSoftness: 0.5
     BurningTemperature: 350
@@ -305,7 +305,7 @@
   components:
   - type: LightBulb
     color: "#ff66cc"
-    lightEnergy: 3
+    lightEnergy: 2
     lightRadius: 8
     lightSoftness: 0.5
     BurningTemperature: 350
@@ -325,7 +325,7 @@
   components:
   - type: LightBulb
     color: "#ff8227"
-    lightEnergy: 3
+    lightEnergy: 2
     lightRadius: 8
     lightSoftness: 0.5
     BurningTemperature: 350
@@ -345,7 +345,7 @@
   components:
   - type: LightBulb
     color: "#fb4747"
-    lightEnergy: 3
+    lightEnergy: 2
     lightRadius: 8
     lightSoftness: 0.5
     BurningTemperature: 350
@@ -365,7 +365,7 @@
   components:
   - type: LightBulb
     color: "#52ff39"
-    lightEnergy: 3
+    lightEnergy: 2
     lightRadius: 8
     lightSoftness: 0.5
     BurningTemperature: 350

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -51,7 +51,7 @@
     enabled: false
     color: "#FF8080"
     radius: 1.0
-    energy: 9.0
+    energy: 4.0
     netsync: false
   - type: IgnitionSource
     temperature: 1000
@@ -67,8 +67,8 @@
         interpolate: Nearest
         minDuration: 0.001
         maxDuration: 0.001
-        startValue: 4.0
-        endValue: 8.0
+        startValue: 3.0
+        endValue: 4.0
         property: Energy
         isLooped: true
       - !type:FadeBehaviour # fade out radius as it burns out

--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -45,13 +45,13 @@
           interpolate: Linear
           maxDuration: 10.0
           startValue: 0.0
-          endValue: 3.0
+          endValue: 2.0
           property: Energy
         - !type:FadeBehaviour # fade out energy as it burns out
           id: fade_out
           interpolate: Linear
           maxDuration: 10 # 300.0
-          startValue: 3.0
+          startValue: 2.0
           endValue: 0.2
           property: Energy
         - !type:FadeBehaviour # fade out radius as it burns out

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -38,7 +38,7 @@
     - type: PointLight
       enabled: false
       radius: 3
-      energy: 2.5
+      energy: 2
       color: "#FFC458"
       netsync: false
     - type: Appearance
@@ -84,7 +84,7 @@
         visible: false
     - type: PointLight
       radius: 5
-      energy: 10
+      energy: 3
     - type: Flash
     - type: LimitedCharges
       maxCharges: 15

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -58,6 +58,11 @@
         Heat: 7
   - type: IgnitionSource
     ignited: true
+  - type: PointLight
+    enabled: true
+    color: "#ff4300"
+    radius: 2.0
+    energy: 0.75
 
 - type: entity
   id: PelletShotgunPractice
@@ -156,7 +161,7 @@
     enabled: true
     color: "#FF8080"
     radius: 15.0
-    energy: 9.0
+    energy: 4.0
   - type: Projectile
     deleteOnCollide: false
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -88,7 +88,7 @@
     - type: PointLight
       enabled: true
       radius: 5
-      energy: 8
+      energy: 6
       netsync: false
     - type: LightFade
       duration: 0.5
@@ -196,7 +196,7 @@
       - type: PointLight
         enabled: true
         color: "#ffaa44"
-        energy: 8
+        energy: 4
         radius: 6
         softness: 1
         offset: "0, 0"
@@ -243,7 +243,7 @@
       - type: PointLight
         enabled: true
         color: "#ffffff"
-        energy: 8
+        energy: 4
         radius: 6
         softness: 1
         offset: "0, 0"
@@ -365,7 +365,7 @@
     delay: 3 # by canon
   - type: PointLight
     radius: 7
-    energy: 3
+    energy: 1
     netsync: false
   - type: TimerTriggerVisuals
     primingSound:

--- a/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
@@ -12,7 +12,7 @@
       - state: burning
   - type: PointLight
     radius: 5
-    energy: 3
+    energy: 2.5
     color: "#FFC90C"
   - type: Damageable
     damageContainer: Inorganic

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -189,7 +189,7 @@
   components:
   - type: PointLight
     radius: 12
-    energy: 4.5
+    energy: 2.5
     softness: 0.5
     color: "#B4FCF0"
 

--- a/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
@@ -33,7 +33,7 @@
   - type: PointLight
     mask: /Textures/Effects/LightMasks/double_cone.png
     color: "#FFE4CE"
-    energy: 5
+    energy: 2.5
     radius: 10
     softness: 1
     offset: "0, 0.35"

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -75,7 +75,7 @@
       visible: false
   - type: PointLight
     radius: 6.0
-    energy: 7.5
+    energy: 5
     color: "#E25822"
     castShadows: false
   - type: PyroclasticAnomaly
@@ -149,7 +149,7 @@
       visible: false
   - type: PointLight
     radius: 2.0
-    energy: 5.0
+    energy: 2.5
     color: "#ffffaa"
     castShadows: false
   - type: ElectricityAnomaly
@@ -262,7 +262,7 @@
       visible: false
   - type: PointLight
     radius: 2.0
-    energy: 7.5
+    energy: 5
     color: "#00ccff"
     castShadows: false
   - type: BluespaceAnomaly
@@ -366,7 +366,7 @@
       visible: false
   - type: PointLight
     radius: 2.0
-    energy: 7.5
+    energy: 4
     color: "#5ca8cb"
     castShadows: false
   - type: TileSpawnAnomaly
@@ -393,7 +393,7 @@
     color: "#52ff39"
   - type: PointLight
     radius: 2.0
-    energy: 7.5
+    energy: 4
     color: "#52ff39"
   - type: EntitySpawnAnomaly
     entries:
@@ -443,7 +443,7 @@
     color: "#fb4747"
   - type: PointLight
     radius: 2.0
-    energy: 7.5
+    energy: 4
     color: "#fb4747"
   - type: EntitySpawnAnomaly
     entries:
@@ -493,7 +493,7 @@
     color: "#47f8ff"
   - type: PointLight
     radius: 2.0
-    energy: 7.5
+    energy: 4
     color: "#47f8ff"
   - type: EntitySpawnAnomaly
     entries:
@@ -543,7 +543,7 @@
     color: "#ff8227"
   - type: PointLight
     radius: 2.0
-    energy: 7.5
+    energy: 4
     color: "#ff8227"
   - type: EntitySpawnAnomaly
     entries:

--- a/Resources/Prototypes/Shaders/shaders.yml
+++ b/Resources/Prototypes/Shaders/shaders.yml
@@ -99,3 +99,19 @@
   id: Cataracts
   kind: source
   path: "/Textures/Shaders/cataracts.swsl"
+
+# Base post-processing
+- type: shader
+  id: BasePostProcess
+  kind: source
+  path: "/Textures/Shaders/base_postprocess.swsl"
+  params:
+    CircleRadius: 420.0
+    CircleMinDist: 0.0
+    CirclePow: 1.0
+    CircleMax: 4.0
+    CircleMult: 0.25
+    FalloffClampMin: 0.075
+    FalloffClampMax: 1.0
+    FalloffStrength: 0.75
+    FalloffPow: 3.0

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -109,7 +109,7 @@
   components:
   - type: PointLight
     radius: 8
-    energy: 10
+    energy: 2.5
     color: "#daa3fd"
   - type: TriggerArtifact
   - type: FlashOnTrigger

--- a/Resources/Textures/Shaders/base_postprocess.swsl
+++ b/Resources/Textures/Shaders/base_postprocess.swsl
@@ -23,8 +23,7 @@ void fragment() {
 	highp float circle = clamp(zCircleGradient(aspect, FRAGCOORD.xy, CircleMax, CircleRadius / actualZoom, CircleMinDist / actualZoom, CirclePow) * CircleMult, FalloffClampMin, FalloffClampMax);
 
 	highp vec3 lightsampleraw = texture2D(LIGHT_TEXTURE, Pos).rgb;
-	highp float rawgrayscale = zGrayscale(lightsampleraw);
-	highp float graylight = max(rawgrayscale - max((1.0 - circle)*FalloffStrength, 0.0), 0.0);
+	highp float graylight = max(zGrayscale(lightsampleraw) - max((1.0 - circle) * FalloffStrength, 0.0), 0.0);
 	graylight = pow(graylight, FalloffPow);
 
 	highp vec3 lightsample = lightsampleraw * vec3(graylight);

--- a/Resources/Textures/Shaders/base_postprocess.swsl
+++ b/Resources/Textures/Shaders/base_postprocess.swsl
@@ -1,0 +1,33 @@
+//Boilerplate
+uniform sampler2D SCREEN_TEXTURE;
+uniform sampler2D LIGHT_TEXTURE;
+
+uniform highp float Zoom;
+
+//Variables for controlling the falloff of the additive lighting effect.
+uniform highp float CircleRadius; //= 420.0;
+uniform highp float CircleMinDist; //= 0.0;
+uniform highp float CirclePow; //= 0.75;
+uniform highp float CircleMax; //= 4.0;
+uniform highp float CircleMult; //= 0.5;
+uniform highp float FalloffClampMin; //= 0.25;
+uniform highp float FalloffClampMax; //= 1.0;
+uniform highp float FalloffStrength; //= 0.6;
+uniform highp float FalloffPow; //= 3.0;
+
+void fragment() {
+	COLOR = zTextureSpec(SCREEN_TEXTURE, Pos);
+	highp vec2 aspect = vec2(1.0/SCREEN_PIXEL_SIZE.x, 1.0/SCREEN_PIXEL_SIZE.y);
+	highp float actualZoom = Zoom;
+
+	highp float circle = clamp(zCircleGradient(aspect, FRAGCOORD.xy, CircleMax, CircleRadius / actualZoom, CircleMinDist / actualZoom, CirclePow) * CircleMult, FalloffClampMin, FalloffClampMax);
+
+	highp vec3 lightsampleraw = texture2D(LIGHT_TEXTURE, Pos).rgb;
+	highp float rawgrayscale = zGrayscale(lightsampleraw);
+	highp float graylight = max(rawgrayscale - max((1.0 - circle)*FalloffStrength, 0.0), 0.0);
+	graylight = pow(graylight, FalloffPow);
+
+	highp vec3 lightsample = lightsampleraw * vec3(graylight);
+
+	COLOR.rgb = COLOR.rgb + lightsample;
+}


### PR DESCRIPTION
## About the PR
This PR started off as a simple thought: "how *easy* would it be to do additive lighting without touching the engine?"

As it turns out: it's incredibly straight-forward! We wrote the initial code months ago for Illucid Fieldtrip (a fork we've been chipping away at on our own), and even shared a heavily stripped-down variant of IF's postprocess shader (containing *exclusively* the additive lighting effect) back in May for code example purposes (https://discord.com/channels/310555209753690112/770682801607278632/1241912021700837487). This PR is a cleaning-up of our example code.

Additive lighting is a post-process pass wherein excess light is processed and added on top of the existing image.

In laymen's terms, that means this:
![image](https://github.com/user-attachments/assets/3b9623ff-ba6a-4562-aad7-8ea2148dc24d)

Now looks like this:
![image](https://github.com/user-attachments/assets/5bfc706b-d6ac-449d-824a-fec409895fed)

Additionally, the effect is stronger at the edges of the screen, which achieves an effect somewhat similar in spirit to what volumetric lighting achieves. Here's that same bonfire, except it's near the far edge of the screen:
![image](https://github.com/user-attachments/assets/9a57d63b-c8c1-45db-b938-693fc5093720)

This effect can be toggled on and off via the settings menu, through the new "Cosmetic Post-processing" option in the graphics tab, under the quality section.

## Why / Balance
We're gonna be real: this is a change that does not have any strong reasoning behind it beyond that it simply looks nice. Whenever we've shared screenshots of our experimentations with post-processing (such as ones we've shared during *extremely* early development of Illucid Fieldtrip), the reception tends to be fairly positive across the board. Additive lighting is one such effect in particular that we've noticed consistently garner positive responses, and is one that we feel genuinely fits pretty nicely within baseline SS14.

However, with additive lighting comes a drawback: quite a few lights with outright absurd values (such as the xenoarchaeology effect that gives an artifact a light strength of 10) simply need to be nerfed. Without this light value audit pass, this PR would otherwise result in sights like this:

![image](https://github.com/user-attachments/assets/a06f95ac-9f78-4b7a-a7e6-915ca5d18185)

![image](https://github.com/user-attachments/assets/83c9697e-c980-40a4-85b7-a7f86d431a17)

(That last one is just a standard flare!)

## Technical details
The primary thing that makes this PR tick is the addition of a new overlay that client's entrypoint.cs will automatically add on startup: `BasePostProcessOverlay`. This single overlay and its associated shader (`base_postprocess.swsl`) is intended to serve as the foundation for future omnipresent post-processing effects (for example: if someone were to want to add tonemapping, this would just be added on top of the existing base post processing shader). The reason this isn't instead designated as its own isolated shader is to encourage devs to try to keep future global post-processing effects within that file for the sake of keeping needless overhead to a minimum (as many effects can be achieved fairly efficiently with just one single shader pass).

The additive lighting shader itself is fairly self-explanatory for anyone familiar with shader code. It sets up a circle gradient to use as a falloff, multiplies a grayscale of the lighting sample to get the target luminosity for the additive light on a given pixel, multiplies the light sample by that target luminosity, then adds the result directly to the underlying image. Additionally, every major value within the shader can be modified at runtime, as they're all exposed as uniforms.

## Media
Here is set of a before/afters of a few maps. Do note that this effect is extremely subtle under normal conditions! The following are all under spoilers, and the maps have been cherrypicked specifically for being ones where the effect is noticeable out of the box.

<details>
<summary>Oasis</summary>
BEFORE:

![image](https://github.com/user-attachments/assets/6201d705-996d-41da-942f-4977744e9504)

AFTER:

![image](https://github.com/user-attachments/assets/5277f4ed-d44b-4c09-8666-513674827c57)

</details>

<details>
<summary>Core</summary>
BEFORE:

![image](https://github.com/user-attachments/assets/8337c9ac-c7a6-49ee-a308-e7a095ee1c28)

AFTER:

![image](https://github.com/user-attachments/assets/eb1f00d4-d0b5-4d5f-99de-0527a06bbf05)

</details>

<details>
<summary>Fland</summary>
BEFORE:

![image](https://github.com/user-attachments/assets/ab18c727-b4cb-43cb-aa6e-f0dbba0c6f02)

AFTER:

![image](https://github.com/user-attachments/assets/d260c49b-8711-4f05-b43e-a936d44c9e9c)

</details>

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- add: Added additive lighting. In laymen's terms, this means excessively bright lights in a given spot will end up creating an overbright bloom effect, instead of just oversaturating the image! This effect can be toggled in the options menu through the "Cosmetic Post-processing" checkbox under the graphics tab.
- tweak: Due to the introduction of additive lighting, many lights that previously had excessively high energy values have had those values toned down. This is for the integrity of your eyes. You do not want to know how bad some of the previous values were when additive lighting was added in, trust us.
