### PR TITLE
Double base cigarette and cigar volume and inhalation speed

### DIFF
--- a/Content.Shared/Nutrition/Components/SmokableComponent.cs
+++ b/Content.Shared/Nutrition/Components/SmokableComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.Nutrition.Components
         ///     Solution inhale amount per second.
         /// </summary>
         [DataField("inhaleAmount"), ViewVariables(VVAccess.ReadWrite)]
-        public FixedPoint2 InhaleAmount { get; private set; } = FixedPoint2.New(0.05f);
+        public FixedPoint2 InhaleAmount { get; private set; } = FixedPoint2.New(0.1f);
 
         [DataField("state")]
         public SmokableState State { get; set; } = SmokableState.Unlit;

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -32,7 +32,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Doubles the volume of the base cigarette and cigar entities (aligning normal cigarettes with "Dan's soaked smokes") and doubles the rate at which chemicals in smokeables are inhaled to counter its extended duration.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Many chemicals and narcotics when added to cigarettes are either not abundant enough and/or do not metabolize fast enough to possess a significant threat or achieve a desired effect, allowing more room for chemicals to be added means that a higher amount of said chemicals will enter the blood stream allowing for longer or more potent effects with accumulation. This will expand upon gameplay opportunities for the entrepreneurial Chemist, Syndicate Agent with a chemical kit, or Botanist with a "Green" thumb alike. This change will also indirectly buff the Syndicate Omnizine cigarette, allowing it to be inhaled/metabolized faster.

**Numbers:**
Normal cigarettes containing 10u of Nicotine will be finished in ~2 minutes (from ~4 minutes)
Cigarettes as they are in game with a full 20u of chemicals normally last ~8 minutes (~4 minutes with this change)
Cigarettes with a full 40u of chemicals such as the Syndicate Omnizine smoke will be finished in ~8 minutes (from ~12 minutes)
+/- 30 seconds

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Simply doubles the smokeable max volume to the base cigarette/cigar entity to 40 from 20 and doubles the inhalation amount per second to 0.1 from 0.05, this will make cigarettes metabolize 0.30u per inhalation from 0.15 in practice.
The increase in the inhalation amount per second is done to offset the additional time that would be needed to completely smoke a cigarette with its additional volume in the event chemicals are added and increase the amount of chemicals entering the body, this would mean that normal cigarettes without chemicals will last a lot shorter however, as the time to finish a smoke is tied to remaining chemicals (when Nicotine runs out the cigarette becomes unlit/consumed).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Doubled the volume of chemicals that cigarettes/cigars can hold to 40u
- tweak: Cigarettes/cigars are now smoked and metabolize chemicals much faster