### PR TITLE
Better Inventory Window Positioning

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
+++ b/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
@@ -32,6 +32,7 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
     private StorageContainer? _container;
 
     private Vector2? _lastContainerPosition;
+    private float? _lastContainerWidth;
 
     private HotbarGui? Hotbar => UIManager.GetActiveUIWidgetOrNull<HotbarGui>();
 
@@ -94,13 +95,20 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
             }
             else
             {
-                _container.Open();
-
                 var pos = !StaticStorageUIEnabled && _lastContainerPosition != null
                     ? _lastContainerPosition.Value
                     : Vector2.Zero;
 
-                LayoutContainer.SetPosition(_container, pos);
+                _container.Open();
+                if (_lastContainerWidth == null)
+                {
+                    LayoutContainer.SetPosition(_container, pos);
+                }
+                else
+                {
+                    LayoutContainer.SetPosition(_container, new Vector2(pos.X + _lastContainerWidth.Value / 2 - _container.Width / 2, pos.Y));
+                }
+                _lastContainerWidth = _container.Width;
             }
 
             if (StaticStorageUIEnabled)
@@ -109,13 +117,12 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
                 _container.Orphan();
                 Hotbar?.StorageContainer.AddChild(_container);
             }
-            _lastContainerPosition = _container.GlobalPosition;
         }
         else
         {
-            _lastContainerPosition = _container.GlobalPosition;
             _container.Close();
         }
+        _lastContainerPosition = _container.GlobalPosition;
     }
 
     private void OnStaticStorageChanged(bool obj)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
When the user has that one bag locked position setting turned off, currently the bag will open in the same spot based off of the top left corner of the window. 

I updated the behavior for both the X axis and the Y axis.

- For the X axis, the window will now match the center position between windows.
- For the Y axis, the window will now match the gap from the bottom of the screen.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
When you have bags that are of extremely different sizes, the experience is quite poor. This is especially noticeable when you go from something tiny like a survival box to something massive like a bag of holding. Your window will be completely askew from where you would expect the "middle" of the window to be.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I think the math is pretty simple, I added comments and overly obvious variable names. The only issue at the moment is that Storage UI prediction is making the experience super jank, but this is what I would want the math to be once Storage UI prediction gets fixed.

https://github.com/space-wizards/space-station-14/issues/27637

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Before:

https://github.com/user-attachments/assets/59c2cc91-5b1b-448d-b9b0-afb0394d1e33

After:

https://github.com/user-attachments/assets/06d47b7d-121d-474e-a301-14edf5a9314e


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Changes have been made to the UI positioning of storage windows.