### PR TITLE
Fix missing logging for commands used at round start.

### DIFF
--- a/Content.Client/UserInterface/Systems/Info/InfoUIController.cs
+++ b/Content.Client/UserInterface/Systems/Info/InfoUIController.cs
@@ -39,7 +39,8 @@ public sealed class InfoUIController : UIController, IOnStateExited<GameplayStat
             "",
             (_, _, _) =>
         {
-            OnAcceptPressed();
+
+            OnAcceptPressed(true);
         });
     }
 
@@ -71,7 +72,7 @@ public sealed class InfoUIController : UIController, IOnStateExited<GameplayStat
         };
 
         _rulesPopup.OnQuitPressed += OnQuitPressed;
-        _rulesPopup.OnAcceptPressed += OnAcceptPressed;
+        _rulesPopup.OnAcceptPressed += ActionOnAcceptPressed;
         UIManager.WindowRoot.AddChild(_rulesPopup);
         LayoutContainer.SetAnchorPreset(_rulesPopup, LayoutContainer.LayoutPreset.Wide);
     }
@@ -81,9 +82,14 @@ public sealed class InfoUIController : UIController, IOnStateExited<GameplayStat
         _consoleHost.ExecuteCommand("quit");
     }
 
-    private void OnAcceptPressed()
+    private void ActionOnAcceptPressed()
     {
-        _netManager.ClientSendMessage(new RulesAcceptedMessage());
+        OnAcceptPressed();
+    }
+
+    private void OnAcceptPressed(bool fuckedRules = false)
+    {
+        _netManager.ClientSendMessage(new RulesAcceptedMessage {FuckedRules = fuckedRules});
 
         _rulesPopup?.Orphan();
         _rulesPopup = null;

--- a/Content.Server/Info/RulesManager.cs
+++ b/Content.Server/Info/RulesManager.cs
@@ -1,7 +1,13 @@
 using System.Net;
+using Content.Server.Administration.Commands;
+using Content.Server.Chat.Managers;
 using Content.Server.Database;
+using Content.Server.Players.PlayTimeTracking;
+using Content.Shared.Administration.Logs;
 using Content.Shared.CCVar;
+using Content.Shared.Database;
 using Content.Shared.Info;
+using Robust.Server.Player;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
 
@@ -12,6 +18,10 @@ public sealed class RulesManager
     [Dependency] private readonly IServerDbManager _dbManager = default!;
     [Dependency] private readonly INetManager _netManager = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly PlayTimeTrackingManager _playTimeTracking = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
     private static DateTime LastValidReadTime => DateTime.UtcNow - TimeSpan.FromDays(60);
 
@@ -24,8 +34,8 @@ public sealed class RulesManager
 
     private async void OnConnected(object? sender, NetChannelArgs e)
     {
-         var isLocalhost = IPAddress.IsLoopback(e.Channel.RemoteEndPoint.Address) &&
-                               _cfg.GetCVar(CCVars.RulesExemptLocal);
+        var isLocalhost = IPAddress.IsLoopback(e.Channel.RemoteEndPoint.Address) &&
+                          _cfg.GetCVar(CCVars.RulesExemptLocal);
 
         var lastRead = await _dbManager.GetLastReadRules(e.Channel.UserId);
         var hasCooldown = lastRead > LastValidReadTime;
@@ -43,5 +53,19 @@ public sealed class RulesManager
     {
         var date = DateTime.UtcNow;
         await _dbManager.SetLastReadRules(message.MsgChannel.UserId, date);
+
+        if (_playerManager.TryGetSessionById(message.MsgChannel.UserId, out var session))
+        {
+            var playTime = _playTimeTracking.GetOverallPlaytime(session);
+            if (message.FuckedRules && playTime < TimeSpan.FromHours(1))
+            {
+                var skippedMessage = Loc.GetString("admin-alert-new-player-skipping-rules", ("username", session.Name));
+                _chatManager.SendAdminAlert(skippedMessage);
+
+                _adminLogger.Add(LogType.Action,
+                    LogImpact.Medium,
+                    $"{skippedMessage}");
+            }
+        }
     }
 }

--- a/Content.Shared/Info/RulesMessages.cs
+++ b/Content.Shared/Info/RulesMessages.cs
@@ -37,11 +37,15 @@ public sealed class RulesAcceptedMessage : NetMessage
 {
     public override MsgGroups MsgGroup => MsgGroups.Command;
 
+    public bool FuckedRules { get; set; }
+
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
     {
+        FuckedRules = buffer.ReadBoolean();
     }
 
     public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
     {
+        buffer.Write(FuckedRules);
     }
 }

--- a/Resources/Locale/en-US/administration/admin-alerts.ftl
+++ b/Resources/Locale/en-US/administration/admin-alerts.ftl
@@ -1,1 +1,2 @@
 ﻿admin-alert-shared-connection = {$player} is sharing a connection with {$otherCount} connected player(s): {$otherList}
+admin-alert-new-player-skipping-rules = User {$username} skipped the rules and has less than 1 hour of playtime.


### PR DESCRIPTION
## About the PR
When someone skips the rules with low playtime, admins get alerted in chat and it is logged.

## Why / Balance
Another tool in the belt against alt accounts. Can be used as an partial indicator to id raiding and alt accounts as they probably don't want to read/wait for the rules.

## Technical details
If account is less than 1hr old and they used 'fuckrules' command to skip the rules. Logs it, alerts it.

## Media
![image](https://github.com/user-attachments/assets/a144105d-5178-4814-9168-1c8bbad6004f)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
NA

**Changelog**

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl: Repo
ADMIN:
- fix: Admins now know if you use fuckrules.
