### PR TITLE
Reorder priorities in `MeleeCombatCompound`

### DIFF
--- a/Resources/Prototypes/NPCs/Combat/melee.yml
+++ b/Resources/Prototypes/NPCs/Combat/melee.yml
@@ -3,48 +3,55 @@
 - type: htnCompound
   id: MeleeCombatCompound
   branches:
-    # Pickup weapon if we don't have one.
-    - preconditions:
-       - !type:ActiveHandComponentPrecondition
-          components:
-          # Just serializer things
-          - type: MeleeWeapon
-            damage:
-              types:
-                Blunt: 0
-          invert: true
-      tasks:
-        - !type:HTNCompoundTask
-          task: PickupMeleeCompound
-
-    - preconditions:
-      - !type:BuckledPrecondition
-        isBuckled: true
-      tasks:
-      - !type:HTNPrimitiveTask
-        operator: !type:UnbuckleOperator
-          shutdownState: TaskFinished
-
-    - preconditions:
-      - !type:InContainerPrecondition
-        isInContainer: true
-      tasks:
-      - !type:HTNCompoundTask
-        task: EscapeCompound
-
-    - preconditions:
-      - !type:PulledPrecondition
-        isPulled: true
-      tasks:
-      - !type:HTNPrimitiveTask
-        operator: !type:UnPullOperator
-          shutdownState: TaskFinished
-
-    # Melee combat (unarmed or otherwise)
     - tasks:
         - !type:HTNPrimitiveTask
           operator: !type:UtilityOperator
             proto: NearbyMeleeTargets
+        - !type:HTNCompoundTask
+          task: BeforeMeleeAttackTargetCompound
+
+- type: htnCompound
+  id: BeforeMeleeAttackTargetCompound
+  branches:
+    - preconditions:
+        - !type:BuckledPrecondition
+          isBuckled: true
+      tasks:
+        - !type:HTNPrimitiveTask
+          operator: !type:UnbuckleOperator
+            shutdownState: TaskFinished
+
+    - preconditions:
+        - !type:PulledPrecondition
+          isPulled: true
+      tasks:
+        - !type:HTNPrimitiveTask
+          operator: !type:UnPullOperator
+            shutdownState: TaskFinished
+
+    - preconditions:
+        - !type:InContainerPrecondition
+          isInContainer: true
+      tasks:
+        - !type:HTNCompoundTask
+          task: EscapeCompound
+
+    # Pickup weapon if we don't have one.
+    - preconditions:
+        - !type:ActiveHandComponentPrecondition
+            components:
+              # Just serializer things
+              - type: MeleeWeapon
+                damage:
+                  types:
+                    Blunt: 0
+            invert: true
+      tasks:
+        - !type:HTNCompoundTask
+          task: PickupMeleeCompound
+
+    # Melee combat (unarmed or otherwise)
+    - tasks:
         - !type:HTNCompoundTask
           task: MeleeAttackTargetCompound
 


### PR DESCRIPTION

## About the PR
 This PR makes NPCs check for hostiles before trying to unpull/unbuckle/pick up a melee weapon.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Pets would instantly unpull/unbuckle if you tried to pull them. Also Pun Pun would instantly go look for a weapon.

Now they unpull/pick up a weapon etc. only if there's someone around them whom they want to attack. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Currently, the checks for unpulling/having a weapon are made before looking for enemies. 
My change makes `MeleeCombatCompound` look for melee targets, after which `BeforeMeleeAttackTargetCompound` is called. 
This new compound task contains the branching used to check for being pulled/unarmed, and if their checks go unmet, the NPC will proceed to attack via `MeleeAttactTargetCompound`

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


Here's the new behaviour.
In this recording I can be seen pulling and buckling Pun Pun, but once I punch it, it gets a weapon and unpulls/unbuckles whenever I try to restrain it.

https://github.com/user-attachments/assets/22f42e8f-e465-40c8-a687-ff162e0c8fc5



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.

- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!

-->
:cl:
- fix: You can once again pull and buckle pets.