### PR TITLE
Revert "Change wristwatch meta description"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/wristwatch.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/wristwatch.yml
@@ -2,7 +2,7 @@
   id: Wristwatch
   parent: BaseItem
   name: wristwatch
-  description: A cheap watch for telling time. How much did you waste working on this shift?
+  description: A cheap watch for telling time. How much did you waste playing Space Station 14?
   components:
   - type: Sprite
     sprite: Objects/Devices/wristwatch.rsi


### PR DESCRIPTION
Reverts space-wizards/space-station-14#30036

So a few main thoughts on this:
- There's no issue with having descriptions that are referential or OOC. We have tons of items and references in item deacriptions that make 0 sense IC. The tone of the game is innately a bit silly and having funny descriptions adds to that.
- - The PR pointed to the chef cookbook as a reason. Its not really comparable, though? The issue with that isn't the fact that it isn't IC, it's that it references a meme prominently in a manner that implies it to be the actual name of the book, which feels weird.
- the replacement just kinda misses the joke and feels like a complete downgrade compared to the original.

In brief summary: theres no point in sticking to strict IC descriptions in a primarily LRP server where we already have a longass history of joke items and references. Its certainly not a "no no".