### PR TITLE
Fix some markup related obsolete warnings in research and anomaly related systems

### DIFF
--- a/Content.Client/Research/UI/DiskConsoleBoundUserInterface.cs
+++ b/Content.Client/Research/UI/DiskConsoleBoundUserInterface.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Research;
 using Content.Shared.Research.Components;
-using Robust.Client.GameObjects;
 
 namespace Content.Client.Research.UI
 {

--- a/Content.Client/Research/UI/ResearchClientBoundUserInterface.cs
+++ b/Content.Client/Research/UI/ResearchClientBoundUserInterface.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Research.Components;
-using Robust.Client.GameObjects;
 
 namespace Content.Client.Research.UI
 {

--- a/Content.Client/Research/UI/ResearchConsoleBoundUserInterface.cs
+++ b/Content.Client/Research/UI/ResearchConsoleBoundUserInterface.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Research.Components;
 using JetBrains.Annotations;
-using Robust.Client.GameObjects;
 
 namespace Content.Client.Research.UI;
 

--- a/Content.Client/Research/UI/ResearchConsoleMenu.xaml.cs
+++ b/Content.Client/Research/UI/ResearchConsoleMenu.xaml.cs
@@ -81,7 +81,7 @@ public sealed partial class ResearchConsoleMenu : FancyWindow
     public void UpdateInformationPanel(ResearchConsoleBoundInterfaceState state)
     {
         var amountMsg = new FormattedMessage();
-        amountMsg.AddMarkup(Loc.GetString("research-console-menu-research-points-text",
+        amountMsg.AddMarkupOrThrow(Loc.GetString("research-console-menu-research-points-text",
             ("points", state.Points)));
         ResearchAmountLabel.SetMessage(amountMsg);
 
@@ -98,7 +98,7 @@ public sealed partial class ResearchConsoleMenu : FancyWindow
         }
 
         var msg = new FormattedMessage();
-        msg.AddMarkup(Loc.GetString("research-console-menu-main-discipline",
+        msg.AddMarkupOrThrow(Loc.GetString("research-console-menu-main-discipline",
             ("name", disciplineText), ("color", disciplineColor)));
         MainDisciplineLabel.SetMessage(msg);
 

--- a/Content.Client/Research/UI/TechnologyCardControl.xaml.cs
+++ b/Content.Client/Research/UI/TechnologyCardControl.xaml.cs
@@ -23,7 +23,7 @@ public sealed partial class TechnologyCardControl : Control
         DisciplineTexture.Texture = spriteSys.Frame0(discipline.Icon);
         TechnologyNameLabel.Text = Loc.GetString(technology.Name);
         var message = new FormattedMessage();
-        message.AddMarkup(Loc.GetString("research-console-tier-discipline-info",
+        message.AddMarkupOrThrow(Loc.GetString("research-console-tier-discipline-info",
             ("tier", technology.Tier), ("color", discipline.Color), ("discipline", Loc.GetString(discipline.Name))));
         TierLabel.SetMessage(message);
         UnlocksLabel.SetMessage(description);

--- a/Content.Server/Anomaly/AnomalySystem.Scanner.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Scanner.cs
@@ -141,7 +141,7 @@ public sealed partial class AnomalySystem
         var msg = new FormattedMessage();
         if (component.ScannedAnomaly is not { } anomaly || !TryComp<AnomalyComponent>(anomaly, out var anomalyComp))
         {
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-no-anomaly"));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-no-anomaly"));
             return msg;
         }
 
@@ -149,14 +149,14 @@ public sealed partial class AnomalySystem
 
         //Severity
         if (secret != null && secret.Secret.Contains(AnomalySecretData.Severity))
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-severity-percentage-unknown"));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-severity-percentage-unknown"));
         else
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-severity-percentage", ("percent", anomalyComp.Severity.ToString("P"))));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-severity-percentage", ("percent", anomalyComp.Severity.ToString("P"))));
         msg.PushNewline();
 
         //Stability
         if (secret != null && secret.Secret.Contains(AnomalySecretData.Stability))
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-stability-unknown"));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-stability-unknown"));
         else
         {
             string stateLoc;
@@ -166,54 +166,54 @@ public sealed partial class AnomalySystem
                 stateLoc = Loc.GetString("anomaly-scanner-stability-high");
             else
                 stateLoc = Loc.GetString("anomaly-scanner-stability-medium");
-            msg.AddMarkup(stateLoc);
+            msg.AddMarkupOrThrow(stateLoc);
         }
         msg.PushNewline();
 
         //Point output
         if (secret != null && secret.Secret.Contains(AnomalySecretData.OutputPoint))
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-point-output-unknown"));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-point-output-unknown"));
         else
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-point-output", ("point", GetAnomalyPointValue(anomaly, anomalyComp))));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-point-output", ("point", GetAnomalyPointValue(anomaly, anomalyComp))));
         msg.PushNewline();
         msg.PushNewline();
 
         //Particles title
-        msg.AddMarkup(Loc.GetString("anomaly-scanner-particle-readout"));
+        msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-particle-readout"));
         msg.PushNewline();
 
         //Danger
         if (secret != null && secret.Secret.Contains(AnomalySecretData.ParticleDanger))
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-particle-danger-unknown"));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-particle-danger-unknown"));
         else
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-particle-danger", ("type", GetParticleLocale(anomalyComp.SeverityParticleType))));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-particle-danger", ("type", GetParticleLocale(anomalyComp.SeverityParticleType))));
         msg.PushNewline();
 
         //Unstable
         if (secret != null && secret.Secret.Contains(AnomalySecretData.ParticleUnstable))
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-particle-unstable-unknown"));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-particle-unstable-unknown"));
         else
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-particle-unstable", ("type", GetParticleLocale(anomalyComp.DestabilizingParticleType))));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-particle-unstable", ("type", GetParticleLocale(anomalyComp.DestabilizingParticleType))));
         msg.PushNewline();
 
         //Containment
         if (secret != null && secret.Secret.Contains(AnomalySecretData.ParticleContainment))
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-particle-containment-unknown"));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-particle-containment-unknown"));
         else
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-particle-containment", ("type", GetParticleLocale(anomalyComp.WeakeningParticleType))));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-particle-containment", ("type", GetParticleLocale(anomalyComp.WeakeningParticleType))));
         msg.PushNewline();
 
         //Transformation
         if (secret != null && secret.Secret.Contains(AnomalySecretData.ParticleTransformation))
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-particle-transformation-unknown"));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-particle-transformation-unknown"));
         else
-            msg.AddMarkup(Loc.GetString("anomaly-scanner-particle-transformation", ("type", GetParticleLocale(anomalyComp.TransformationParticleType))));
+            msg.AddMarkupOrThrow(Loc.GetString("anomaly-scanner-particle-transformation", ("type", GetParticleLocale(anomalyComp.TransformationParticleType))));
 
 
         //Behavior
         msg.PushNewline();
         msg.PushNewline();
-        msg.AddMarkup(Loc.GetString("anomaly-behavior-title"));
+        msg.AddMarkupOrThrow(Loc.GetString("anomaly-behavior-title"));
         msg.PushNewline();
 
         if (secret != null && secret.Secret.Contains(AnomalySecretData.Behavior))
@@ -224,14 +224,14 @@ public sealed partial class AnomalySystem
             {
                 var behavior = _prototype.Index(anomalyComp.CurrentBehavior.Value);
 
-                msg.AddMarkup("- " + Loc.GetString(behavior.Description));
+                msg.AddMarkupOrThrow("- " + Loc.GetString(behavior.Description));
                 msg.PushNewline();
                 var mod = Math.Floor((behavior.EarnPointModifier) * 100);
-                msg.AddMarkup("- " + Loc.GetString("anomaly-behavior-point", ("mod", mod)));
+                msg.AddMarkupOrThrow("- " + Loc.GetString("anomaly-behavior-point", ("mod", mod)));
             }
             else
             {
-                msg.AddMarkup(Loc.GetString("anomaly-behavior-balanced"));
+                msg.AddMarkupOrThrow(Loc.GetString("anomaly-behavior-balanced"));
             }
         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removes unused using directives and replaces obsoleted methods with un-obsoleted methods. In research and anomaly related systems.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Project 0 warnings (it will never happen)

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I've replaced the methods with AddMarkupOrThrow instead of the permissive ones, as LOC strings generally shouldn't contain any rich text errors.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
no cl