### PR TITLE
Borgs can no longer interact with borg panel locks

### DIFF
--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
+using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.Storage;
 using Content.Shared.Storage.Components;
 using Content.Shared.UserInterface;
@@ -228,6 +229,10 @@ public sealed class LockSystem : EntitySystem
     public bool CanToggleLock(EntityUid uid, EntityUid user, bool quiet = true)
     {
         if (!HasComp<HandsComponent>(user))
+            return false;
+
+        // This disallows borgs from locking/unlocking themselves or other borgs
+        if (HasComp<BorgChassisComponent>(user) && HasComp<BorgChassisComponent>(uid))
             return false;
 
         var ev = new LockToggleAttemptEvent(user, quiet);


### PR DESCRIPTION
## About the PR
Borgs can no longer interact with borg panel locks (so you, as a borg, cannot unlock/lock a borg panel).

## Why / Balance
emo say it unintended

## Technical details

## Media
tested ingame
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl:
- fix: Borgs can no longer interact with borg panel locks.