### PR TITLE
Displaying the administrator's position in ahelp and webhook

### DIFF
--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -421,14 +421,21 @@ namespace Content.Server.Administration.Systems
             var escapedText = FormattedMessage.EscapeText(message.Text);
 
             string bwoinkText;
+            string adminPrefix = "";
+
+            //Getting an administrator position
+            if (senderAdmin is not null && senderAdmin.Title is not null)
+            {
+                adminPrefix = $"[bold]\\[{senderAdmin.Title}\\][/bold] ";
+            }
 
             if (senderAdmin is not null && senderAdmin.Flags == AdminFlags.Adminhelp) // Mentor. Not full admin. That's why it's colored differently.
             {
-                bwoinkText = $"[color=purple]{senderSession.Name}[/color]";
+                bwoinkText = $"[color=purple]{adminPrefix}{senderSession.Name}[/color]";
             }
             else if (senderAdmin is not null && senderAdmin.HasFlag(AdminFlags.Adminhelp))
             {
-                bwoinkText = $"[color=red]{senderSession.Name}[/color]";
+                bwoinkText = $"[color=red]{adminPrefix}{senderSession.Name}[/color]";
             }
             else
             {
@@ -463,11 +470,11 @@ namespace Content.Server.Administration.Systems
                         // Doing the same thing as above, but with the override name. Theres probably a better way to do this.
                         if (senderAdmin is not null && senderAdmin.Flags == AdminFlags.Adminhelp) // Mentor. Not full admin. That's why it's colored differently.
                         {
-                            overrideMsgText = $"[color=purple]{_overrideClientName}[/color]";
+                            overrideMsgText = $"[color=purple]{adminPrefix}{_overrideClientName}[/color]";
                         }
                         else if (senderAdmin is not null && senderAdmin.HasFlag(AdminFlags.Adminhelp))
                         {
-                            overrideMsgText = $"[color=red]{_overrideClientName}[/color]";
+                            overrideMsgText = $"[color=red]{adminPrefix}{_overrideClientName}[/color]";
                         }
                         else
                         {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Displaying the administrator's position in ahelp.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This way, it will be easier for people to understand what position the administrator who communicates with them in ahelp. I think it's time to add this to the official repository, since it's on many servers and it's very convenient!😎
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Gets the admin title from AdminData. If the admin does not have his own title, then the name of the admin rank that the admin has is taken. This is how it works, I checked.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/user-attachments/assets/13f2ff29-6674-412e-bf65-c2aa27196c7a)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl: to4no_fix
- tweak: The administrator's position is not displayed in ahelp and webhook


