### PR TITLE
[WIP] Hide health icons when typing as to not obscure the typing indicator

### DIFF
--- a/Content.Client/Chat/TypingIndicator/TypingIndicatorVisualizerSystem.cs
+++ b/Content.Client/Chat/TypingIndicator/TypingIndicatorVisualizerSystem.cs
@@ -3,6 +3,9 @@ using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Prototypes;
 using Content.Shared.Inventory;
+using Content.Shared.Overlays;
+using System.Numerics;
+
 
 namespace Content.Client.Chat.TypingIndicator;
 
@@ -11,6 +14,10 @@ public sealed class TypingIndicatorVisualizerSystem : VisualizerSystem<TypingInd
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
 
+    /// <summary>
+    ///     How far the typing indicator should be offset when the entity is using a HUD.
+    /// </summary>
+    private const float TypingIndicatorVerticalOffset = -0.12f;
 
     protected override void OnAppearanceChange(EntityUid uid, TypingIndicatorComponent component, ref AppearanceChangeEvent args)
     {
@@ -40,10 +47,21 @@ public sealed class TypingIndicatorVisualizerSystem : VisualizerSystem<TypingInd
         if (!layerExists)
             layer = args.Sprite.LayerMapReserveBlank(TypingIndicatorLayers.Base);
 
+        // If the entity is using eyewear that shows a HUD, offset the typing indicator slightly down so it's not obscured.
+        // TODO: Consider making the typing indicator an actual overlay instead of a sprite layer.
+        var verticalOffset = 0f;
+        if(_inventory.TryGetSlotEntity(uid, "eyes", out var slotEntity) &&
+            HasComp<ShowHealthBarsComponent>(slotEntity) && HasComp<ShowHealthIconsComponent>(slotEntity))
+        {
+            verticalOffset = TypingIndicatorVerticalOffset;
+        }
+
+        var offset = new Vector2(proto.Offset.X, proto.Offset.Y + verticalOffset);
+
         args.Sprite.LayerSetRSI(layer, proto.SpritePath);
         args.Sprite.LayerSetState(layer, proto.TypingState);
         args.Sprite.LayerSetShader(layer, proto.Shader);
-        args.Sprite.LayerSetOffset(layer, proto.Offset);
+        args.Sprite.LayerSetOffset(layer, offset);
         args.Sprite.LayerSetVisible(layer, isTyping);
     }
 }

--- a/Content.Client/Chat/TypingIndicator/TypingIndicatorVisualizerSystem.cs
+++ b/Content.Client/Chat/TypingIndicator/TypingIndicatorVisualizerSystem.cs
@@ -3,6 +3,7 @@ using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Prototypes;
 using Content.Shared.Inventory;
+using Content.Client.Overlays;
 using Content.Shared.Overlays;
 using System.Numerics;
 
@@ -13,11 +14,7 @@ public sealed class TypingIndicatorVisualizerSystem : VisualizerSystem<TypingInd
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
-
-    /// <summary>
-    ///     How far the typing indicator should be offset when the entity is using a HUD.
-    /// </summary>
-    private const float TypingIndicatorVerticalOffset = -0.12f;
+    [Dependency] private readonly ShowHealthIconsSystem _showHealthIcons = default!;
 
     protected override void OnAppearanceChange(EntityUid uid, TypingIndicatorComponent component, ref AppearanceChangeEvent args)
     {
@@ -47,21 +44,44 @@ public sealed class TypingIndicatorVisualizerSystem : VisualizerSystem<TypingInd
         if (!layerExists)
             layer = args.Sprite.LayerMapReserveBlank(TypingIndicatorLayers.Base);
 
-        // If the entity is using eyewear that shows a HUD, offset the typing indicator slightly down so it's not obscured.
-        // TODO: Consider making the typing indicator an actual overlay instead of a sprite layer.
-        var verticalOffset = 0f;
-        if(_inventory.TryGetSlotEntity(uid, "eyes", out var slotEntity) &&
-            HasComp<ShowHealthBarsComponent>(slotEntity) && HasComp<ShowHealthIconsComponent>(slotEntity))
-        {
-            verticalOffset = TypingIndicatorVerticalOffset;
-        }
-
-        var offset = new Vector2(proto.Offset.X, proto.Offset.Y + verticalOffset);
+        if(GetShowHealthIconsComponent(uid, out var showHealthIconsComp) && showHealthIconsComp != null)
+            _showHealthIcons.UpdateComponentVisibility(showHealthIconsComp, !isTyping);
 
         args.Sprite.LayerSetRSI(layer, proto.SpritePath);
         args.Sprite.LayerSetState(layer, proto.TypingState);
         args.Sprite.LayerSetShader(layer, proto.Shader);
-        args.Sprite.LayerSetOffset(layer, offset);
+        args.Sprite.LayerSetOffset(layer, proto.Offset);
         args.Sprite.LayerSetVisible(layer, isTyping);
+    }
+
+    // Utility method to get the ShowHealthIconsComponent from an entity or any of its items
+    // StatusIconSystem has a very similar method I need to pick one place and make it shared
+    private bool GetShowHealthIconsComponent(EntityUid uid, out ShowHealthIconsComponent? result)
+    {
+        if (TryComp<ShowHealthIconsComponent>(uid, out var showHealthIconsComp))
+        {
+            result = showHealthIconsComp;
+            return true;
+        }
+
+        if (TryComp<InventoryComponent>(uid, out var inventoryComp))
+        {
+            foreach (var slot in inventoryComp.Slots)
+            {
+                if (slot == null)
+                    continue;
+
+                if (_inventory.TryGetSlotEntity(uid, slot.Name, out var slotEntity))
+                {
+                    if(TryComp<ShowHealthIconsComponent>(slotEntity, out var slotComponent) && slotComponent != null)
+                    {
+                        result = slotComponent;
+                        return true;
+                    }
+                }
+            }
+        }
+        result = null;
+        return false;
     }
 }

--- a/Content.Client/IoC/ClientContentIoC.cs
+++ b/Content.Client/IoC/ClientContentIoC.cs
@@ -17,6 +17,7 @@ using Content.Shared.Administration.Logs;
 using Content.Client.Guidebook;
 using Content.Client.Lobby;
 using Content.Client.Replay;
+using Content.Client.Overlays;
 using Content.Shared.Administration.Managers;
 using Content.Shared.Players.PlayTimeTracking;
 
@@ -50,6 +51,7 @@ namespace Content.Client.IoC
             collection.Register<ContentReplayPlaybackManager, ContentReplayPlaybackManager>();
             collection.Register<ISharedPlaytimeManager, JobRequirementsManager>();
             collection.Register<DebugMonitorManager>();
+            collection.Register<ShowHealthIconsSystem, ShowHealthIconsSystem>();
         }
     }
 }

--- a/Content.Client/Overlays/ShowHealthIconsSystem.cs
+++ b/Content.Client/Overlays/ShowHealthIconsSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Atmos.Rotting;
 using Content.Shared.Damage;
+using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Overlays;
@@ -16,7 +17,6 @@ namespace Content.Client.Overlays;
 public sealed class ShowHealthIconsSystem : EquipmentHudSystem<ShowHealthIconsComponent>
 {
     [Dependency] private readonly IPrototypeManager _prototypeMan = default!;
-
     public HashSet<string> DamageContainers = new();
 
     public override void Initialize()
@@ -24,6 +24,11 @@ public sealed class ShowHealthIconsSystem : EquipmentHudSystem<ShowHealthIconsCo
         base.Initialize();
 
         SubscribeLocalEvent<DamageableComponent, GetStatusIconsEvent>(OnGetStatusIconsEvent);
+    }
+
+    public void UpdateComponentVisibility(ShowHealthIconsComponent component, bool visible)
+    {
+       component.IsVisible = visible;
     }
 
     protected override void UpdateInternal(RefreshEquipmentHudEvent<ShowHealthIconsComponent> component)

--- a/Content.Client/StatusIcon/StatusIconOverlay.cs
+++ b/Content.Client/StatusIcon/StatusIconOverlay.cs
@@ -1,16 +1,20 @@
 using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
+using Content.Client.Overlays;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Robust.Client.Player;
+using Robust.Shared.Player;
 using System.Numerics;
 
 namespace Content.Client.StatusIcon;
 
 public sealed class StatusIconOverlay : Overlay
 {
+    [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IEntityManager _entity = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -73,6 +77,10 @@ public sealed class StatusIconOverlay : Overlay
             foreach (var proto in icons)
             {
                 if (!_statusIcon.IsVisible((uid, meta), proto))
+                    continue;
+
+                //you need to change this, this only works for the local player
+                if (uid == _player.LocalSession?.AttachedEntity && _statusIcon.ShouldHideIcon(uid))
                     continue;
 
                 var curTime = _timing.RealTime;

--- a/Content.Shared/Overlays/ShowHealthIconsComponent.cs
+++ b/Content.Shared/Overlays/ShowHealthIconsComponent.cs
@@ -15,4 +15,7 @@ public sealed partial class ShowHealthIconsComponent : Component
     /// </summary>
     [DataField("damageContainers", customTypeSerializer: typeof(PrototypeIdListSerializer<DamageContainerPrototype>))]
     public List<string> DamageContainers = new();
+
+    [DataField("isVisible")]
+    public bool IsVisible = true;
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This Fixes #29984 

This is a tiny workaround

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
In game that is centered around chatting, obscuring the typing indicator is bad UX.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This changes any typing indicator's original offset if the user is wearing any eyewear that contains the ShowHealthIcons and ShowHealthBar components.

Again, this is a workaround. Ideally the typing indicator should be in the same `OverlaySpace` as the rest of `StatusIcon` . Currently, it's just a layer slapped onto the player's sprite so there is no way to actually make it render above the rest of the icons without rewritting it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

Before:
![typingindicator-old](https://github.com/user-attachments/assets/d3af99d0-b436-42f9-a916-9a9301e4ab4e)

After:
![Captura de tela 2024-07-15 183720](https://github.com/user-attachments/assets/8b6ccab4-dbd9-42b6-b047-c7cbe8c88ee5)
![imagem_2024-07-15_183806643](https://github.com/user-attachments/assets/8274a370-9848-41be-be00-1938f36e2d31)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

This won't offset the typing indicator if the player somehow get the ShowHealthBar and ShowHealthIcons components from an equip that's not eyewear

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

no cl needed

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
