### PR TITLE
fix(JitteringSystem): Fix warnings and double Play.

### DIFF
--- a/Content.Client/Jittering/JitteringSystem.cs
+++ b/Content.Client/Jittering/JitteringSystem.cs
@@ -53,10 +53,10 @@ namespace Content.Client.Jittering
             if (!args.Finished)
                 return;
 
-            if (HasComp<AnimationPlayerComponent>(uid)
+            if (TryComp(uid, out AnimationPlayerComponent? player)
                 && TryComp(uid, out SpriteComponent? sprite)
                 && !_animationPlayer.HasRunningAnimation(uid, _jitterAnimationKey))
-                _animationPlayer.Play(uid, GetAnimation(jittering, sprite), _jitterAnimationKey);
+                _animationPlayer.Play((uid, player), GetAnimation(jittering, sprite), _jitterAnimationKey);
         }
 
         private Animation GetAnimation(JitteringComponent jittering, SpriteComponent sprite)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fix some warnings within the Jitter system and ensure we're not playing a jitter animation before playing another animation thus throwing an exception. Saw an exception in live within OnStartup of JitteringSystem.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

