### PR TITLE
fix: give reptilians species mask sprites in lobby

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -71,5 +71,11 @@
   components:
   - type: HumanoidAppearance
     species: Reptilian
+    hideLayersOnEquip:
+    - Snout
+    - HeadTop
+    - HeadSide
+  - type: Inventory
+    speciesId: reptilian
 
 #Weh


### PR DESCRIPTION
## About the PR
species can support unique equipment sprites, especially for snouted species with masks. reptilians are one such species that use this feature a lot but for some reason it did not show in the lobby. now it does

## Why / Balance
was pissing me off

## Technical details
gave `speciesId` to the reptilian dummy that the lobby uses, which is the property equipment uses to determine alt sprites

## Media
![Screenshot_136](https://github.com/user-attachments/assets/033ca708-3623-4f89-996b-13c2ac86e8f2)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: portfiend
- fix: Reptilians display correct mask sprites in character customization screen.