### PR TITLE
Dumping a RefillableSolution into a DumpableSolution now require having at least one hand

### DIFF
--- a/Resources/Locale/en-US/fluids/components/absorbent-component.ftl
+++ b/Resources/Locale/en-US/fluids/components/absorbent-component.ftl
@@ -3,6 +3,7 @@ mopping-system-target-container-empty-water = { CAPITALIZE(THE($target)) } has n
 mopping-system-puddle-space = { CAPITALIZE(THE($used)) } is full of water
 mopping-system-puddle-evaporate = {  CAPITALIZE(THE($target)) } is evaporating
 mopping-system-no-water = { CAPITALIZE(THE($used)) } has no water!
+mopping-system-no-hands = You have no hands!
 
 mopping-system-full = { CAPITALIZE(THE($used)) } is full!
 mopping-system-empty = { CAPITALIZE(THE($used)) } is empty!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Tackles a small griefer issue I found out about while making #30016 

This was a quick fix so if you don't think this should be merged, you can safely ignore this PR. I'm just here to contribute. Not trying to instigate a debate. However, if it's genuine feedback or criticism feel free to comment.

Fixes #29139  

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Prevents griefing by mice and revenants because of a potential oversight. Why are mobs without hands able to drag drop in the first place?

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a check for having at least one hand to method `OnRefillableDragged` inside `PuddleSystem.Transfer`

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
Before:

https://github.com/user-attachments/assets/bb1bb7ac-19d2-4240-81d8-8e53bddc0b05

After:


https://github.com/user-attachments/assets/a3215c1f-de9e-4259-8c0c-ea722723a3f8



## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

This will unintentionally include borgs and anything else that does not have a hand.

The modified method is only accessed by a `DragDropDraggedEvent` so it should only affect player interactions. However, it will be a problem this event is fired by non-players, which currently doesn't seem to be the case.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
🆑 coffeeware
 - tweak: Dumping containers by drag and dropping now require at least one hand.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
