### PR TITLE
Fix dev map warnings

### DIFF
--- a/Resources/Maps/Test/dev_map.yml
+++ b/Resources/Maps/Test/dev_map.yml
@@ -5164,20 +5164,6 @@ entities:
     - type: Transform
       pos: -3.5,4.5
       parent: 179
-- proto: SpawnVehicleATV
-  entities:
-  - uid: 1176
-    components:
-    - type: Transform
-      pos: -7.5,1.5
-      parent: 179
-- proto: SpawnVehicleJanicart
-  entities:
-  - uid: 904
-    components:
-    - type: Transform
-      pos: 5.5,16.5
-      parent: 179
 - proto: Spear
   entities:
   - uid: 185
@@ -5808,20 +5794,6 @@ entities:
     components:
     - type: Transform
       pos: -7.5,4.5
-      parent: 179
-- proto: VehicleKeyATV
-  entities:
-  - uid: 1187
-    components:
-    - type: Transform
-      pos: -6.8905525,1.5128828
-      parent: 179
-- proto: VehicleKeyJanicart
-  entities:
-  - uid: 14
-    components:
-    - type: Transform
-      pos: 6.5,16.5
       parent: 179
 - proto: VendingMachineCigs
   entities:


### PR DESCRIPTION
## About the PR

Remove old vehicles prototypes from the dev test map.

## Why / Balance

(See media) - I hate that.

Also it will make error logs smaller (and thus more readable), which is a good thing.

## Technical details

I modified map file with a text editor. Maybe it's wrong, but I haven't noticed any problems yet.

## Media

![image](https://github.com/user-attachments/assets/74ada2aa-05fe-4cab-ab82-8543b7e445ab)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

None
