### PR TITLE
Temporarily remove Vox from space ninja and Unknown Shuttle ghostroles

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -607,6 +607,8 @@
 - type: randomHumanoidSettings
   id: LostCargoTechnician
   parent: EventHumanoid
+  speciesBlacklist:
+  - Vox
   components:
     - type: GhostRole
       name: ghost-role-information-lost-cargo-technical-name
@@ -658,6 +660,8 @@
   id: ClownTroupe
   parent: EventHumanoid
   randomizeName: false
+  speciesBlacklist:
+  - Vox
   components:
     - type: GhostRole
       name: ghost-role-information-clown-troupe-name
@@ -708,6 +712,8 @@
 - type: randomHumanoidSettings
   id: TravelingChef
   parent: EventHumanoid
+  speciesBlacklist:
+  - Vox
   components:
     - type: GhostRole
       name: ghost-role-information-traveling-chef-name
@@ -768,6 +774,8 @@
 - type: randomHumanoidSettings
   id: DisasterVictimHead
   parent: EventHumanoidMindShielded
+  speciesBlacklist:
+  - Vox
   components:
     - type: GhostRole
       name: ghost-role-information-disaster-victim-name
@@ -826,6 +834,8 @@
 - type: randomHumanoidSettings
   id: SyndieDisasterVictim
   parent: EventHumanoid
+  speciesBlacklist:
+  - Vox
   components:
     - type: NpcFactionMember
       factions:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -151,6 +151,10 @@
     minimumPlayers: 30
   - type: SpaceSpawnRule
   - type: AntagLoadProfileRule
+    # Vox disabled until loadouts work on AntagSelection-based spawns
+    speciesOverride: Human
+    speciesOverrideBlacklist:
+    - Vox
   - type: AntagObjectives
     objectives:
     - StealResearchObjective


### PR DESCRIPTION
## About the PR
Players with a Vox character selected will get a human space ninja instead
Unknown shuttles will now only include non-vox random characters

## Why / Balance
Ghostrole spawns can't use loadouts yet and don't get the vox survival gear. Ninjas will quickly suffocate due to being in space with no nitrogen internals.
Shuttle Event vox will die in 2 minutes due to oxygen poisoning, and then generate  ammonia from rotting, which will kill the rest of the crew/survivors after some time.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- tweak: Vox are temporarily removed from Space Ninjas and all Unknown Shuttle ghostroles, until code supports giving them species-specific gear.