### PR TITLE
Tweak smokable volumes and add dynamic inhalation speed

### DIFF
--- a/Content.Shared/Nutrition/Components/SmokableComponent.cs
+++ b/Content.Shared/Nutrition/Components/SmokableComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.Nutrition.Components
         ///     Solution inhale amount per second.
         /// </summary>
         [DataField("inhaleAmount"), ViewVariables(VVAccess.ReadWrite)]
-        public FixedPoint2 InhaleAmount { get; private set; } = FixedPoint2.New(0.05f);
+        public FixedPoint2 InhaleAmount { get; private set; } = FixedPoint2.New(0.1f);
 
         [DataField("state")]
         public SmokableState State { get; set; } = SmokableState.Unlit;

--- a/Content.Shared/Nutrition/Components/SmokableComponent.cs
+++ b/Content.Shared/Nutrition/Components/SmokableComponent.cs
@@ -10,12 +10,6 @@ namespace Content.Shared.Nutrition.Components
         [DataField("solution")]
         public string Solution { get; private set; } = "smokable";
 
-        /// <summary>
-        ///     Solution inhale amount per second.
-        /// </summary>
-        [DataField("inhaleAmount"), ViewVariables(VVAccess.ReadWrite)]
-        public FixedPoint2 InhaleAmount { get; private set; } = FixedPoint2.New(0.1f);
-
         [DataField("state")]
         public SmokableState State { get; set; } = SmokableState.Unlit;
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -97,7 +97,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Omnizine
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteIron
@@ -112,7 +112,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Iron
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteTricordrazine
@@ -127,7 +127,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Tricordrazine
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteDylovene
@@ -142,7 +142,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Dylovene
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteDermaline
@@ -157,7 +157,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Dermaline
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteArithrazine
@@ -172,7 +172,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Arithrazine
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteIpecac
@@ -187,7 +187,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Ipecac
-            Quantity: 2
+            Quantity: 4
 
 - type: entity
   id: CigaretteBicaridine
@@ -202,7 +202,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Bicaridine
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteDexalin
@@ -217,7 +217,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Dexalin
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigarettePax
@@ -232,7 +232,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Pax
-            Quantity: 2
+            Quantity: 4
 
 - type: entity
   id: CigaretteBbqSauce
@@ -247,7 +247,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: BbqSauce
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteBlackPepper
@@ -262,7 +262,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Blackpepper
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteCapsaicinOil
@@ -277,7 +277,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: CapsaicinOil
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteBread
@@ -290,7 +290,7 @@
         maxVol: 40
         reagents:
           - ReagentId: Nicotine
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteMilk
@@ -305,7 +305,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Milk
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteBanana
@@ -320,7 +320,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: BananaHonk
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteSpaceDrugs
@@ -335,7 +335,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: SpaceDrugs
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: CigaretteMuteToxin
@@ -350,7 +350,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: MuteToxin
-            Quantity: 2
+            Quantity: 4
 
 - type: entity
   id: CigaretteMold
@@ -365,7 +365,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Mold
-            Quantity: 2
+            Quantity: 4
 
 - type: entity
   id: CigaretteLicoxide
@@ -380,7 +380,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: Licoxide
-            Quantity: 5
+            Quantity: 10
 
 - type: entity
   id: CigaretteWeldingFuel
@@ -395,7 +395,7 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: WeldingFuel
-            Quantity: 5
+            Quantity: 10
 
 - type: entity
   id: CigaretteTHC
@@ -410,4 +410,4 @@
           - ReagentId: Nicotine
             Quantity: 10
           - ReagentId: THC
-            Quantity: 5
+            Quantity: 10

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/joints.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/joints.yml
@@ -28,7 +28,7 @@
         reagents:
           - ReagentId: THC
             Quantity: 20
-            
+
 - type: entity
   id: JointRainbow
   parent: Joint
@@ -42,7 +42,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 30
         reagents:
         - ReagentId: SpaceDrugs
           Quantity: 4
@@ -83,7 +83,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 30
+        maxVol: 40
         reagents:
           - ReagentId: THC
             Quantity: 20
@@ -101,7 +101,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
         - ReagentId: SpaceDrugs
           Quantity: 4

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -32,7 +32,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nicotine
             Quantity: 10


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
In my last PR #30053 I had increased many of the max volumes for smokable entities to align them with the base max volume for Dan's Soaked Smokes. Instead of increasing the base inhalation rate to counter their extended duration, I have set all smokables to last a set amount of time and dynamically change their inhalation rates to match the time to finish smoking.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Many chemicals and narcotics when added to cigarettes are either not abundant enough and/or do not metabolize fast enough to possess a significant threat or achieve a desired effect, allowing more room for chemicals to be added means that a higher amount of said chemicals will enter the blood stream allowing for longer or more potent effects with accumulation. This will expand upon gameplay opportunities for the entrepreneurial Chemist, Syndicate Agent with a chemical kit, or Botanist with a "Green" thumb alike. Due to these changes, the Syndicate Omnizine Smoke will be significantly buffed, making it last the set 6 minutes to smoke from the 12 minutes it used to take to completely inhale all reagents with a static inhalation amount.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The Smoking System now calculates the inhalation amount instead of using the Smokable Component's fixed inhalation amount, it will change depending on the volume of chemicals contained within the smokable making sure that you inhale the correct amount to finish all reagents within the set time frame of 360 seconds as defined by SmokableDuration float. In practice a full cigarette with 40u of chemicals will inhale ~0.33u of the total volume per update/tick in the Smoking System.

In addition to the dynamic inhalation amount, adjusted the max volume of the base cigarette/cigar entity to match the volume of "Dan's Soaked Smokes" (40u max), tweaked the max volume of other smokables such as blunts and joints to make more room for any additional chemicals added from plant mutations, and doubled the amount of extra chemicals to "Dan's Soaked Smoke's" smokes.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Smokables now all last a set 6 minutes allowing you to inhale more at once and can hold an additional 20u of chemicals
- tweak: Doubled the chemicals in all of "Dan's Soaked Smoke's"