### PR TITLE
Move some disabilities traits into a new category

### DIFF
--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -59,3 +59,4 @@ humanoid-profile-editor-trait-count-hint = Points available: [{$current}/{$max}]
 
 trait-category-disabilities = Disabilities
 trait-category-speech = Speech traits
+trait-category-quirks = Quirks

--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -6,3 +6,7 @@
   id: SpeechTraits
   name: trait-category-speech
   maxTraitPoints: 2
+
+- type: traitCategory
+  id: Quirks
+  name: trait-category-quirks

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -34,14 +34,6 @@
       durationOfIncident: 10, 30
 
 - type: trait
-  id: Pacifist
-  name: trait-pacifist-name
-  description: trait-pacifist-desc
-  category: Disabilities
-  components:
-    - type: Pacified
-
-- type: trait
   id: Unrevivable
   name: trait-unrevivable-name
   description: trait-unrevivable-desc
@@ -61,15 +53,6 @@
     - type: Muted
 
 - type: trait
-  id: LightweightDrunk
-  name: trait-lightweight-name
-  description: trait-lightweight-desc
-  category: Disabilities
-  components:
-    - type: LightweightDrunk
-      boozeStrengthMultiplier: 2
-
-- type: trait
   id: Paracusia
   name: trait-paracusia-name
   description: trait-paracusia-desc
@@ -81,11 +64,3 @@
       maxSoundDistance: 7
       sounds:
         collection: Paracusia
-
-- type: trait
-  id: Snoring
-  name: trait-snoring-name
-  description: trait-snoring-desc
-  category: Disabilities
-  components:
-    - type: Snoring

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -1,0 +1,24 @@
+- type: trait
+  id: Pacifist
+  name: trait-pacifist-name
+  description: trait-pacifist-desc
+  category: Quirks
+  components:
+  - type: Pacified
+
+- type: trait
+  id: LightweightDrunk
+  name: trait-lightweight-name
+  description: trait-lightweight-desc
+  category: Quirks
+  components:
+  - type: LightweightDrunk
+    boozeStrengthMultiplier: 2
+
+- type: trait
+  id: Snoring
+  name: trait-snoring-name
+  description: trait-snoring-desc
+  category: Quirks
+  components:
+  - type: Snoring


### PR DESCRIPTION
## About the PR
Some traits were moved into a new trait category called "Quirks".

## Why / Balance
No gameplay implications (yet). The plan is to make disabilities traits visible in the medical records computer (since seeing some stuff like Pacifism would be metagaming, especially for thieves).
Also, some things in "Disabilities" are not even disabilities.

## Technical details

## Media
![Screenshot_20240716_231939](https://github.com/user-attachments/assets/42797933-f10f-421b-96b5-4ecb4bcfd7dc)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
very minor not needed
