### PR TITLE
Rework EmbeddableProjectile Offset and Fix Exploding Pens

### DIFF
--- a/Content.Shared/Projectiles/EmbeddableProjectileComponent.cs
+++ b/Content.Shared/Projectiles/EmbeddableProjectileComponent.cs
@@ -36,10 +36,12 @@ public sealed partial class EmbeddableProjectileComponent : Component
     public bool EmbedOnThrow = true;
 
     /// <summary>
-    /// How far into the entity should we offset (0 is wherever we collided).
+    /// How deep to embed the projectile into the target
+    /// 0.0f is the point of initial collision,
+    /// 1.0f sets the position directly onto the target
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
-    public Vector2 Offset = Vector2.Zero;
+    [DataField, AutoNetworkedField]
+    public float EmbedPercent = 0.0f;
 
     /// <summary>
     /// Sound to play after embedding into a hit target.

--- a/Content.Shared/Projectiles/EmbeddableProjectileComponent.cs
+++ b/Content.Shared/Projectiles/EmbeddableProjectileComponent.cs
@@ -41,7 +41,7 @@ public sealed partial class EmbeddableProjectileComponent : Component
     /// 1.0f sets the position directly onto the target
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float EmbedPercent = 0.0f;
+    public float EmbedPercent = 0.15f;
 
     /// <summary>
     /// Sound to play after embedding into a hit target.

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -118,10 +118,14 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         var xform = Transform(uid);
         _transform.SetParent(uid, xform, target);
 
-        if (component.Offset != Vector2.Zero)
+        if (component.EmbedPercent != 0.0f)
         {
-            _transform.SetLocalPosition(uid, xform.LocalPosition + xform.LocalRotation.RotateVec(component.Offset),
-                xform);
+            // Calculate the difference in position from one entity to the other
+            // and adjust the projectile's position by the embed percentage
+            var projectilePosition = _transform.GetWorldPosition(uid);
+            var targetPosition = _transform.GetWorldPosition(target);
+            var direction = targetPosition - projectilePosition;
+            _transform.SetWorldPosition(uid, projectilePosition + direction * component.EmbedPercent);
         }
 
         _audio.PlayPredicted(component.Sound, uid, null);

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -125,7 +125,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
             var projectilePosition = _transform.GetWorldPosition(uid);
             var targetPosition = _transform.GetWorldPosition(target);
             var direction = targetPosition - projectilePosition;
-            _transform.SetWorldPosition(uid, projectilePosition + direction * component.EmbedPercent);
+            _transform.SetWorldPosition(uid, projectilePosition + direction * Math.Clamp(component.EmbedPercent, 0.0f, 1.0f));
         }
 
         _audio.PlayPredicted(component.Sound, uid, null);

--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -7,7 +7,6 @@
   - type: EmbeddableProjectile
     minimumSpeed: 3
     removalTime: 0.5
-    offset: 0.0,0.0
   - type: ThrowingAngle
     angle: 315
   - type: LandAtCursor

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -25,7 +25,7 @@
   abstract: true
   components:
   - type: EmbeddableProjectile
-    offset: 0.3,0.0
+    embedPercent: 0.6
     removalTime: 0.0
   - type: ThrowingAngle
     angle: 315

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -92,6 +92,7 @@
         Slash: 12
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/star_hit.ogg
+    embedPercent: 0.3
   - type: LandAtCursor
   - type: DamageOtherOnHit
     damage:
@@ -276,6 +277,7 @@
         Slash: 5
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/star_hit.ogg
+    embedPercent: 0.3
   - type: LandAtCursor
   - type: DamageOtherOnHit
     ignoreResistances: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -5,7 +5,6 @@
   description: Definition of a Classic. Keeping murder affordable since 200,000 BCE.
   components:
   - type: EmbeddableProjectile
-    embedPercent: 0.15
   - type: ThrowingAngle
     angle: 225
   - type: LandAtCursor

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -5,7 +5,7 @@
   description: Definition of a Classic. Keeping murder affordable since 200,000 BCE.
   components:
   - type: EmbeddableProjectile
-    offset: 0.15,0.15
+    embedPercent: 0.15
   - type: ThrowingAngle
     angle: 225
   - type: LandAtCursor


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I played with how the offset was previously and regardless of what I did, I could not get it to function in any way that made sense, so I just reworked how it does it

EmbeddableProjectile's `Offset` is removed in favor of an `EmbedPercent`, which allows you to dictate just how "deep" into the target you want the projectile to go. For example, an `EmbedPercent` of 0.15 will mean the object will clip into the target by 15%. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes https://github.com/space-wizards/space-station-14/issues/30103

With how offset was done previously, there wasn't any really indication as to what part of the Vector2 would help, and changing the values just sent the object in some insane directions away from your intended target. There wasn't any kind of limit to the value either, so you could set the number to a value that didn't make any sense. 

With how I've done it, the projectile's possible positions are strictly limited to the edge of the target's hit box, or directly on the target itself.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/0277d322-0b46-4874-b9dc-adf1db3708bc

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
EmbeddableProjectileComponent.Offset has been removed in favor of an EmbedPercent

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- tweak: The calculation for the position of embedded projectiles has been changed to make exploding pens more consistent.