### PR TITLE
Add metal foam grenades to atmospheric cabinets

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -99,7 +99,6 @@
       - id: RCD
       - id: RCDAmmo
       - id: MetalFoamGrenade
-        amount: 2
 
 - type: entity
   id: LockerAtmosphericsFilled
@@ -117,7 +116,6 @@
       - id: RCD
       - id: RCDAmmo
       - id: MetalFoamGrenade
-        amount: 2
 
 - type: entity
   id: LockerEngineerFilledHardsuit
@@ -132,8 +130,6 @@
       - id: ClothingShoesBootsMag
       - id: RCD
       - id: RCDAmmo
-      - id: MetalFoamGrenade
-        amount: 2
 
 - type: entity
   id: LockerEngineerFilled
@@ -147,8 +143,6 @@
       - id: trayScanner
       - id: RCD
       - id: RCDAmmo
-      - id: MetalFoamGrenade
-        amount: 2
 
 - type: entity
   id: ClosetRadiationSuitFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -39,6 +39,8 @@
         prob: 0.3
       - id: SprayPainter
         prob: 0.7
+      - id: MetalFoamGrenade
+        prob: 0.3
 
 - type: entity
   id: LockerElectricalSuppliesFilled
@@ -96,6 +98,8 @@
       - id: HolofanProjector
       - id: RCD
       - id: RCDAmmo
+      - id: MetalFoamGrenade
+        amount: 2
 
 - type: entity
   id: LockerAtmosphericsFilled
@@ -112,6 +116,8 @@
       - id: HolofanProjector
       - id: RCD
       - id: RCDAmmo
+      - id: MetalFoamGrenade
+        amount: 2
 
 - type: entity
   id: LockerEngineerFilledHardsuit
@@ -126,6 +132,8 @@
       - id: ClothingShoesBootsMag
       - id: RCD
       - id: RCDAmmo
+      - id: MetalFoamGrenade
+        amount: 2
 
 - type: entity
   id: LockerEngineerFilled
@@ -139,6 +147,8 @@
       - id: trayScanner
       - id: RCD
       - id: RCDAmmo
+      - id: MetalFoamGrenade
+        amount: 2
 
 - type: entity
   id: ClosetRadiationSuitFilled


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
 Atmospheric Technician lockers now come with a metal foam grenade. Tool supply lockers have a 30% chance to spawn a metal foam grenade

## Why / Balance
Metal foam grenades are a quick and dirty way to deal with spacing now that they can also put down tiles. Locking them behind cargo disincentivizes the crew from both buying and using them. 

## Media
![image](https://github.com/user-attachments/assets/93f9fada-fd68-445e-950a-9a72ce428621)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: Atmos lockers now come with a metal foam grenade
- tweak: Tool closets now have a chance to spawn a metal foam grenade
