### PR TITLE
Fix EmbeddableProjectileComponent and ThrowingAngleComponent interaction

### DIFF
--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -120,7 +120,10 @@ public abstract partial class SharedProjectileSystem : EntitySystem
 
         if (component.Offset != Vector2.Zero)
         {
-            _transform.SetLocalPosition(uid, xform.LocalPosition + xform.LocalRotation.RotateVec(component.Offset),
+            var rotation = xform.LocalRotation;
+            if (TryComp<ThrowingAngleComponent>(uid, out var throwingAngleComp))
+                rotation += throwingAngleComp.Angle;
+            _transform.SetLocalPosition(uid, xform.LocalPosition + rotation.RotateVec(component.Offset),
                 xform);
         }
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -5,7 +5,7 @@
   description: Definition of a Classic. Keeping murder affordable since 200,000 BCE.
   components:
   - type: EmbeddableProjectile
-    offset: 0.15,0.15
+    offset: 0.15,0.0
   - type: ThrowingAngle
     angle: 225
   - type: LandAtCursor

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -5,7 +5,7 @@
   description: Definition of a Classic. Keeping murder affordable since 200,000 BCE.
   components:
   - type: EmbeddableProjectile
-    offset: 0.15,0.0
+    offset: -0.15,0.0
   - type: ThrowingAngle
     angle: 225
   - type: LandAtCursor


### PR DESCRIPTION
## About the PR
Fixes embedable throwing weapons having an incorrect offset if their sprite has an angle.
In particular this fixes exploding pens not embedding correctly.

## Why / Balance
bugfix
Fixes #30103

## Technical details
Rotate the offset vector by the sprite rotation given in ThrowingAngleComponent
Adjusted some offsets

## Media
before: The pens are offset to the left and into the target for an offset of (0.3, 0)
![grafik](https://github.com/user-attachments/assets/0d0c751e-8170-4e92-b729-c30c86094491)

now: The offset works as intended, here an extreme example with (-0.5, 0).
![grafik](https://github.com/user-attachments/assets/db877fc9-3180-496b-815e-aa9d2891145c)


https://github.com/user-attachments/assets/874f6868-1e0f-4f25-9e66-7d16b99b6b0b


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
the offset in EmbeddableProjectileComponent now works as intended, meaning that items in forks that use it might need adjustments

**Changelog**
:cl: Plykiya, slarticodefast
- fix: Explosive pens now correctly embed into their target.
