### PR TITLE
Fix for thrown items dealing damage twice to first target

### DIFF
--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -52,12 +52,6 @@ namespace Content.Server.Damage.Systems
                     _sharedCameraRecoil.KickCamera(args.Target, direction);
                 }
             }
-
-            // TODO: If more stuff touches this then handle it after.
-            if (TryComp<PhysicsComponent>(uid, out var physics))
-            {
-                _thrownItem.LandComponent(args.Thrown, args.Component, physics, false);
-            }
         }
 
         private void OnDamageExamine(EntityUid uid, DamageOtherOnHitComponent component, ref DamageExamineEvent args)

--- a/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOtherOnHitSystem.cs
@@ -32,25 +32,25 @@ namespace Content.Server.Damage.Systems
 
         private void OnDoHit(EntityUid uid, DamageOtherOnHitComponent component, ThrowDoHitEvent args)
         {
-            if (!TerminatingOrDeleted(args.Target))
+            if (TerminatingOrDeleted(args.Target))
+                return;
+
+            var dmg = _damageable.TryChangeDamage(args.Target, component.Damage, component.IgnoreResistances, origin: args.Component.Thrower);
+
+            // Log damage only for mobs. Useful for when people throw spears at each other, but also avoids log-spam when explosions send glass shards flying.
+            if (dmg != null && HasComp<MobStateComponent>(args.Target))
+                _adminLogger.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.GetTotal():damage} damage from collision");
+
+            if (dmg is { Empty: false })
             {
-                var dmg = _damageable.TryChangeDamage(args.Target, component.Damage, component.IgnoreResistances, origin: args.Component.Thrower);
+                _color.RaiseEffect(Color.Red, new List<EntityUid>() { args.Target }, Filter.Pvs(args.Target, entityManager: EntityManager));
+            }
 
-                // Log damage only for mobs. Useful for when people throw spears at each other, but also avoids log-spam when explosions send glass shards flying.
-                if (dmg != null && HasComp<MobStateComponent>(args.Target))
-                    _adminLogger.Add(LogType.ThrowHit, $"{ToPrettyString(args.Target):target} received {dmg.GetTotal():damage} damage from collision");
-
-                if (dmg is { Empty: false })
-                {
-                    _color.RaiseEffect(Color.Red, new List<EntityUid>() { args.Target }, Filter.Pvs(args.Target, entityManager: EntityManager));
-                }
-
-                _guns.PlayImpactSound(args.Target, dmg, null, false);
-                if (TryComp<PhysicsComponent>(uid, out var body) && body.LinearVelocity.LengthSquared() > 0f)
-                {
-                    var direction = body.LinearVelocity.Normalized();
-                    _sharedCameraRecoil.KickCamera(args.Target, direction);
-                }
+            _guns.PlayImpactSound(args.Target, dmg, null, false);
+            if (TryComp<PhysicsComponent>(uid, out var body) && body.LinearVelocity.LengthSquared() > 0f)
+            {
+                var direction = body.LinearVelocity.Normalized();
+                _sharedCameraRecoil.KickCamera(args.Target, direction);
             }
         }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
All I did was delete a function call

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes https://github.com/space-wizards/space-station-14/issues/26022

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
#18574 called LandComponent() in DamageOtherOnHitSystem as soon as it hits literally anything and regenerated contacts to stop items phasing through walls. Any subsequent hit on other entities will also trigger LandComponent() but because it's already "Landed" from the first call, it doesn't do anything. LandComponent() only triggers on the first hit, regenerates the contacts, and hits the first target twice. Additionally, it doesn't even "land" the item, that's calculated elsewhere.

#18576 fixed what the previous PR was intending to do but did not remove the behavior where it calls LandComponent() on hit because it is seemingly necessary for reasons related to I don't really know. Items no longer phase through walls as a result of this PR, regardless of LandComponent() being called.

https://github.com/space-wizards/space-station-14/pull/20700 later on made it so that it calls LandComponent() in ThrownItemSystem when the time is appropriate in the lifecycle of the throw and not on the first hit. So LandComponent() is successfully being called when flyTime for the item is less than the currentTime in the game.

In summary, we have no need for that LandComponent() in DamageOtherOnHitSystem anymore so we can just delete it. The only thing it accomplished was duplicating damage on the first hit of an entity.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**FOR DEMONSTRATION PURPOSES I'M USING A PIERCING SPEAR**
Before:

https://github.com/user-attachments/assets/ccea3cff-c556-48b5-9844-92cf175bb5a5

After:

https://github.com/user-attachments/assets/da5303ea-55ba-4878-8327-b09778313ada

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
nothing

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: You no longer deal double damage to your first target when throwing an item.