### PR TITLE
Updated slime storage capacity text in guidebook

### DIFF
--- a/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
@@ -18,7 +18,7 @@
     <GuideEntityEmbed Entity="MobSlimesGeras" Caption="A typical geras."/>
   </Box>
 
-  Slimepeople have an [bold]internal 2x2 storage inventory[/bold] inside of their slime membrane. Anyone can see what's inside and take it out of you without asking,
+  Slimepeople have an [bold]internal 2x3 storage inventory[/bold] inside of their slime membrane. Anyone can see what's inside and take it out of you without asking,
   so be careful. They [bold]don't drop their internal storage when they morph into a geras, however![/bold]
 
   Slimepeople have slight accelerated regeneration compared to other humanoids. They're also capable of hardening their fists, and as such have stronger punches,


### PR DESCRIPTION
Guidebook currently says 2x2 for slime internal storage, it is now 2x3