### PR TITLE
Fix 65 formatting warnings in botany

### DIFF
--- a/Content.Server/Botany/Components/SeedComponent.cs
+++ b/Content.Server/Botany/Components/SeedComponent.cs
@@ -24,7 +24,7 @@ namespace Content.Server.Botany.Components
         /// <summary>
         ///     Name of a base seed prototype that is used if <see cref="Seed"/> is null.
         /// </summary>
-        [DataField("seedId", customTypeSerializer:typeof(PrototypeIdSerializer<SeedPrototype>))]
+        [DataField("seedId", customTypeSerializer: typeof(PrototypeIdSerializer<SeedPrototype>))]
         public string? SeedId;
     }
 }

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -2,10 +2,8 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
-using Content.Shared.Chemistry.Reagent;
 using System.Linq;
 using Content.Shared.Atmos;
-using FastAccessors;
 
 namespace Content.Server.Botany;
 
@@ -42,6 +40,7 @@ public sealed class MutationSystem : EntitySystem
         // Add up everything in the bits column and put the number here.
         const int totalbits = 275;
 
+        #pragma warning disable IDE0055 // disable formatting warnings because this looks more readable
         // Tolerances (55)
         MutateFloat(ref seed.NutrientConsumption  , 0.05f, 1.2f, 5, totalbits, severity);
         MutateFloat(ref seed.WaterConsumption     , 3f   , 9f  , 5, totalbits, severity);
@@ -75,6 +74,7 @@ public sealed class MutationSystem : EntitySystem
         MutateBool(ref seed.TurnIntoKudzu , true , 10, totalbits, severity);
         MutateBool(ref seed.CanScream     , true , 10, totalbits, severity);
         seed.BioluminescentColor = RandomColor(seed.BioluminescentColor, 10, totalbits, severity);
+        #pragma warning restore IDE0055
 
         // ConstantUpgade (10)
         MutateHarvestType(ref seed.HarvestRepeat, 10, totalbits, severity);
@@ -155,14 +155,14 @@ public sealed class MutationSystem : EntitySystem
 
         // Starting number of bits that are high, between 0 and bits.
         // In other words, it's val mapped linearly from range [min, max] to range [0, bits], and then rounded.
-        int valInt = (int)MathF.Round((val - min) / (max - min) * bits);
+        int valInt = (int) MathF.Round((val - min) / (max - min) * bits);
         // val may be outside the range of min/max due to starting prototype values, so clamp.
         valInt = Math.Clamp(valInt, 0, bits);
 
         // Probability that the bit flip increases n.
         // The higher the current value is, the lower the probability of increasing value is, and the higher the probability of decreasive it it.
         // In other words, it tends to go to the middle.
-        float probIncrease = 1 - (float)valInt / bits;
+        float probIncrease = 1 - (float) valInt / bits;
         int valIntMutated;
         if (Random(probIncrease))
         {
@@ -174,7 +174,7 @@ public sealed class MutationSystem : EntitySystem
         }
 
         // Set value based on mutated thermometer code.
-        float valMutated = Math.Clamp((float)valIntMutated / bits * (max - min) + min, min, max);
+        float valMutated = Math.Clamp((float) valIntMutated / bits * (max - min) + min, min, max);
         val = valMutated;
     }
 
@@ -189,7 +189,7 @@ public sealed class MutationSystem : EntitySystem
         // Probability that the bit flip increases n.
         // The higher the current value is, the lower the probability of increasing value is, and the higher the probability of decreasive it it.
         // In other words, it tends to go to the middle.
-        float probIncrease = 1 - (float)val / bits;
+        float probIncrease = 1 - (float) val / bits;
         int valMutated;
         if (Random(probIncrease))
         {
@@ -261,7 +261,7 @@ public sealed class MutationSystem : EntitySystem
         {
             var pick = _randomChems.Pick(_robustRandom);
             string chemicalId = pick.reagent;
-            int amount = _robustRandom.Next(1, ((int)pick.quantity));
+            int amount = _robustRandom.Next(1, (int) pick.quantity);
             SeedChemQuantity seedChemQuantity = new SeedChemQuantity();
             if (chemicals.ContainsKey(chemicalId))
             {

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -155,14 +155,14 @@ public sealed class MutationSystem : EntitySystem
 
         // Starting number of bits that are high, between 0 and bits.
         // In other words, it's val mapped linearly from range [min, max] to range [0, bits], and then rounded.
-        int valInt = (int) MathF.Round((val - min) / (max - min) * bits);
+        int valInt = (int)MathF.Round((val - min) / (max - min) * bits);
         // val may be outside the range of min/max due to starting prototype values, so clamp.
         valInt = Math.Clamp(valInt, 0, bits);
 
         // Probability that the bit flip increases n.
         // The higher the current value is, the lower the probability of increasing value is, and the higher the probability of decreasive it it.
         // In other words, it tends to go to the middle.
-        float probIncrease = 1 - (float) valInt / bits;
+        float probIncrease = 1 - (float)valInt / bits;
         int valIntMutated;
         if (Random(probIncrease))
         {
@@ -174,7 +174,7 @@ public sealed class MutationSystem : EntitySystem
         }
 
         // Set value based on mutated thermometer code.
-        float valMutated = Math.Clamp((float) valIntMutated / bits * (max - min) + min, min, max);
+        float valMutated = Math.Clamp((float)valIntMutated / bits * (max - min) + min, min, max);
         val = valMutated;
     }
 
@@ -189,7 +189,7 @@ public sealed class MutationSystem : EntitySystem
         // Probability that the bit flip increases n.
         // The higher the current value is, the lower the probability of increasing value is, and the higher the probability of decreasive it it.
         // In other words, it tends to go to the middle.
-        float probIncrease = 1 - (float) val / bits;
+        float probIncrease = 1 - (float)val / bits;
         int valMutated;
         if (Random(probIncrease))
         {
@@ -261,7 +261,7 @@ public sealed class MutationSystem : EntitySystem
         {
             var pick = _randomChems.Pick(_robustRandom);
             string chemicalId = pick.reagent;
-            int amount = _robustRandom.Next(1, (int) pick.quantity);
+            int amount = _robustRandom.Next(1, (int)pick.quantity);
             SeedChemQuantity seedChemQuantity = new SeedChemQuantity();
             if (chemicals.ContainsKey(chemicalId))
             {
@@ -274,7 +274,7 @@ public sealed class MutationSystem : EntitySystem
                 seedChemQuantity.Max = 1 + amount;
                 seedChemQuantity.Inherent = false;
             }
-            int potencyDivisor = (int) Math.Ceiling(100.0f / seedChemQuantity.Max);
+            int potencyDivisor = (int)Math.Ceiling(100.0f / seedChemQuantity.Max);
             seedChemQuantity.PotencyDivisor = potencyDivisor;
             chemicals[chemicalId] = seedChemQuantity;
         }

--- a/Content.Server/Botany/Systems/SeedExtractorSystem.cs
+++ b/Content.Server/Botany/Systems/SeedExtractorSystem.cs
@@ -29,12 +29,12 @@ public sealed class SeedExtractorSystem : EntitySystem
             return;
         if (!_botanySystem.TryGetSeed(produce, out var seed) || seed.Seedless)
         {
-            _popupSystem.PopupCursor(Loc.GetString("seed-extractor-component-no-seeds",("name", args.Used)),
+            _popupSystem.PopupCursor(Loc.GetString("seed-extractor-component-no-seeds", ("name", args.Used)),
                 args.User, PopupType.MediumCaution);
             return;
         }
 
-        _popupSystem.PopupCursor(Loc.GetString("seed-extractor-component-interact-message",("name", args.Used)),
+        _popupSystem.PopupCursor(Loc.GetString("seed-extractor-component-interact-message", ("name", args.Used)),
             args.User, PopupType.Medium);
 
         QueueDel(args.Used);


### PR DESCRIPTION
## About the PR
Project 0 warnings
## Technical details
For better readability I decided to make some of the warnings be ignored using
`#pragma warning disable IDE0055`
`#pragma warning restore IDE0055`

## Media
![Im-doing-my-part-meme-9](https://github.com/user-attachments/assets/569c7dcd-5d18-4ce1-afbe-73e1acba53d8)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
no warnings no fun
