### PR TITLE
Moths can now eat produce

### DIFF
--- a/Resources/Prototypes/Body/Organs/moth.yml
+++ b/Resources/Prototypes/Body/Organs/moth.yml
@@ -8,6 +8,7 @@
       tags:
       - ClothMade
       - Paper
+      - MothFood
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -33,6 +33,9 @@
   - type: Appearance
   - type: Extractable
     grindableSolutionName: food
+  - type: Tag
+    tags:
+    - MothFood
 
 # Subclasses
 

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -928,6 +928,9 @@
   id: MopBasic
 
 - type: Tag
+  id: MothFood
+
+- type: Tag
   id: Mouse
 
 - type: Tag


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Moths can now eat produce

## Why / Balance
SS13 parity.

## Technical details
Adds a tag called MothFood to FoodProduceBase and added to moth stomachs.
## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Moths can now eat produce.

