### PR TITLE
Further slippery object tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -311,6 +311,8 @@
     sprite: Objects/Specific/Hydroponics/banana.rsi
     heldPrefix: peel
   - type: Slippery
+    paralyzeTime: 1
+    launchForwardsMultiplier: 2
   - type: StepTrigger
     intersectRatio: 0.2
   - type: CollisionWake
@@ -383,6 +385,8 @@
     sprite: Objects/Specific/Hydroponics/mimana.rsi
     heldPrefix: peel
   - type: Slippery
+    paralyzeTime: 1.5
+    launchForwardsMultiplier: 2.5
     slipSound:
       path: /Audio/Effects/slip.ogg
       params:
@@ -400,6 +404,8 @@
     sprite: Objects/Materials/materials.rsi
     heldPrefix: peel
   - type: Slippery
+    paralyzeTime: 2
+    launchForwardsMultiplier: 3
 
 - type: entity
   name: carrot

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -258,6 +258,7 @@
   - type: Icon
     state: pda-clown
   - type: Slippery # secretly made of bananium
+    paralyzeTime: 3
   - type: StepTrigger
   - type: CollisionWake
     enabled: false

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -128,7 +128,7 @@
     fillBaseName: syndie-
   - type: Slippery
     paralyzeTime: 3
-    launchForwardsMultiplier: 3
+    launchForwardsMultiplier: 1 # Intentionally low for more combat viability
   - type: Item
     heldPrefix: syndie
   - type: FlavorProfile
@@ -218,8 +218,8 @@
   - type: SolutionContainerVisuals
     fillBaseName: omega-
   - type: Slippery
-    paralyzeTime: 5.0
-    launchForwardsMultiplier: 3.0
+    paralyzeTime: 3.0
+    launchForwardsMultiplier: 5.0
   - type: Item
     heldPrefix: omega
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -126,9 +126,14 @@
       map: ["enum.SolutionContainerLayers.Fill"]
   - type: SolutionContainerVisuals
     fillBaseName: syndie-
+  - type: TriggerOnStepTrigger
+  - type: DamageUserOnTrigger
+    damage:
+      types:
+        Blunt: 10 # Special trait to make it more distinct and viable while avoiding balancing it entirely through stun duration
   - type: Slippery
     paralyzeTime: 3
-    launchForwardsMultiplier: 1 # Intentionally low for more combat viability
+    launchForwardsMultiplier: 0.5 # Intentionally low for more combat viability
   - type: Item
     heldPrefix: syndie
   - type: FlavorProfile


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR seeks to address common feedback regarding the recent slippery object time standardization-nerf PR, and hopes to finetune the values suggested in it for more entertaining and balanced play.

Clown PDA now stuns for 3 seconds as opposed to the default (1.5).

Banana peels now stun for 1 second (prev: 1.5) and launch with a coefficient of 2 (prev: 1.5).

Minana peels now serve as an upgrade to banana peels and stun for 1.5 seconds with a launch coefficient of 2.5.

Bananium peels now serve as the final upgrade in the aforementioned chain and stun for 2 seconds and launch with a coefficient of 3.

Syndicate soap had it's launch coefficient reduced to 0.5 from 3 to make it more combat viable. It also deals 10 damage on-slip now.

Omega soap had it's stats reversed (3/5 instead of 5/3) to make it less combat viable but better for thieves and more entertaining.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
See commit description details and the above section.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Webedit, I can't run a devenv let alone build the game or test values right now due to hardware issues.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None(?)

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: BurninDreamer
- tweak: Slip stun duration and launch coefficients have been further tweaked.
