### PR TITLE
Correct .editorconfig to use no space after casting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -129,7 +129,7 @@ csharp_indent_braces = false
 csharp_indent_switch_labels = true
 
 # Space preferences
-csharp_space_after_cast = true
+csharp_space_after_cast = false
 csharp_space_after_colon_in_inheritance_clause = true
 csharp_space_after_comma = true
 csharp_space_after_dot = false


### PR DESCRIPTION
@Partmedia informed me in the  #30122 review that we use [the C# convention on casting](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/types/casting-and-type-conversions).
The .editorconfig file is currently set to have a space after a cast, so we should adjust it.

See the C# [formatting options](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#csharp_space_after_cast):

old:
`// csharp_space_after_cast = true`
`int y = (int) x;`

new:
`// csharp_space_after_cast = false`
`int y = (int)x;`