### PR TITLE
changed some radio colors to be more distinguishable

### DIFF
--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -3,7 +3,7 @@
   name: chat-radio-common
   keycode: ";"
   frequency: 1459
-  color: "#32cd32"
+  color: "#2cdb2c"
 
 - type: radioChannel
   id: CentCom
@@ -25,7 +25,7 @@
   name: chat-radio-engineering
   keycode: 'e'
   frequency: 1357
-  color: "#f37746"
+  color: "#ff662a"
 
 - type: radioChannel
   id: Medical
@@ -39,7 +39,7 @@
   name: chat-radio-science
   keycode: 'n'
   frequency: 1351
-  color: "#c68cfa"
+  color: "#b05efa"
 
 - type: radioChannel
   id: Security
@@ -53,7 +53,7 @@
   name: chat-radio-service
   keycode: 'v'
   frequency: 1349
-  color: "#6ca729"
+  color: "#539c00"
 
 - type: radioChannel
   id: Supply
@@ -74,7 +74,7 @@
   id: Handheld
   name: chat-radio-handheld
   frequency: 1330
-  color: "#d39f01"
+  color: "#967101"
   # long range since otherwise it'd defeat the point of a handheld radio independent of telecomms
   longRange: true
 


### PR DESCRIPTION
## About the PR
People have complained before about Common and Service being hard to distinguish due to being close shades of the same color. I am colorblind (a pretty mild case of protanomaly) and have struggled to distinguish Supply and Engineering. So I made some changes to radio channel colors to make them easier to distinguish in general.

## Why / Balance
It should be clear at a glance what channel you're reading so that replies go where they are supposed to. I can't count how many times I've mixed up engineering and supply, or how many times people have replied to service over common.

## Media
![radio colors comparison](https://github.com/user-attachments/assets/94d20de7-c1b0-4992-b570-c12f2e076df8)
Here's what these radio colors look like ingame
![keys new](https://github.com/user-attachments/assets/331bb564-9697-497d-9292-7fd16faba8ae)
![2024-07-15_22-21](https://github.com/user-attachments/assets/0b598c9f-76b4-41b6-9bc0-bd01b4d735dc)
It's a small, subtle change. None of the colors changed in hue, just brightness/saturation in order to make their shades more distinct from other channels, however I think even the minor adjustments will make a big difference in distinguishability.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

### User definable colors:
It was suggested that a more ideal solution would just be to let users set custom colors for channels. I don't know how to implement that so you can see this as a stopgap for the meantime; however even if we do implement that down the line we'd still want the default set of colors to be a good and distinguishable set. So either way I feel this change is important.

**Changelog**


:cl:
- tweak: Some radio channel colors have been tweaked in order to be more easily distinguishable.

