### PR TITLE
minor SharedInteractionSystem cleanup

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -38,8 +38,6 @@ using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
-#pragma warning disable 618
-
 namespace Content.Shared.Interaction
 {
     /// <summary>
@@ -522,11 +520,11 @@ namespace Content.Shared.Interaction
         protected bool ValidateInteractAndFace(EntityUid user, EntityCoordinates coordinates)
         {
             // Verify user is on the same map as the entity they clicked on
-            if (coordinates.GetMapId(EntityManager) != Transform(user).MapID)
+            if (_transform.GetMapId(coordinates) != Transform(user).MapID)
                 return false;
 
             if (!HasComp<NoRotateOnInteractComponent>(user))
-                _rotateToFaceSystem.TryFaceCoordinates(user, coordinates.ToMapPos(EntityManager, _transform));
+                _rotateToFaceSystem.TryFaceCoordinates(user, _transform.ToMapCoordinates(coordinates).Position);
 
             return true;
         }
@@ -859,7 +857,7 @@ namespace Content.Shared.Interaction
             Ignored? predicate = null,
             bool popup = false)
         {
-            return InRangeUnobstructed(origin, other.ToMap(EntityManager, _transform), range, collisionMask, predicate, popup);
+            return InRangeUnobstructed(origin, _transform.ToMapCoordinates(other), range, collisionMask, predicate, popup);
         }
 
         /// <summary>
@@ -966,7 +964,7 @@ namespace Content.Shared.Interaction
         /// </summary>
         public void InteractDoAfter(EntityUid user, EntityUid used, EntityUid? target, EntityCoordinates clickLocation, bool canReach)
         {
-            if (target is {Valid: false})
+            if (target is { Valid: false })
                 target = null;
 
             var afterInteractEvent = new AfterInteractEvent(user, used, target, clickLocation, canReach);


### PR DESCRIPTION
## About the PR
Project 0 warnings

## Technical details
Someone disabled obsoletion warnings in this file in #5047. They exist for a reason, so I reenabled them and fixed a few easy ones.
This was the only file I found which was doing that.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
no warnings no fun
