### PR TITLE
Remove geras description in Slime Person guidebook page

### DIFF
--- a/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
@@ -10,16 +10,8 @@
   They exhale nitrous oxide and are unaffected by it.
   Their body can process 6 reagents at the same time instead of just 2.
 
-  Slimepeople can morph into a [bold]"geras"[/bold] (an archaic slimefolk term), which is a smaller slime form that can [bold]pass through grilles[/bold],
-  but forces them to drop their inventory and held items. It's handy for a quick getaway. A geras is small enough to pick up (with two hands)
-  and fits in a duffelbag.
-
-  <Box>
-    <GuideEntityEmbed Entity="MobSlimesGeras" Caption="A typical geras."/>
-  </Box>
-
   Slimepeople have an [bold]internal 2x3 storage inventory[/bold] inside of their slime membrane. Anyone can see what's inside and take it out of you without asking,
-  so be careful. They [bold]don't drop their internal storage when they morph into a geras, however![/bold]
+  so be careful.
 
   Slimepeople have slight accelerated regeneration compared to other humanoids. They're also capable of hardening their fists, and as such have stronger punches,
   although they punch a little slower.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Removed the entry pertaining to the now removed geras mechanic. No reason to have it anymore as geras no longer exist. 
I wouldn't do a CL for something like this usually but I feel like players, especially new ones, need to know about guidebook changes. 

## Why / Balance
See above

## Media
![image](https://github.com/user-attachments/assets/db1d7df0-c490-4cfd-9c01-b60a3564b047)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- remove: Removed the description about geras in the Slime guidebook section.
