### PR TITLE
Make airlocks on station enter emergency access mode when nuke is close to detonation

### DIFF
--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -1,5 +1,8 @@
+using Content.Server.AlertLevel;
+using Content.Server.Chat.Systems;
 using Content.Server.DeviceLinking.Events;
 using Content.Server.Power.Components;
+using Content.Server.Station.Systems;
 using Content.Server.Wires;
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
@@ -11,7 +14,12 @@ namespace Content.Server.Doors.Systems;
 
 public sealed class AirlockSystem : SharedAirlockSystem
 {
+    [Dependency] private readonly ChatSystem _chatSystem = default!;
     [Dependency] private readonly WiresSystem _wiresSystem = default!;
+    [Dependency] private readonly StationSystem _station = default!;
+
+    private static bool _hasNotifiedEAChanges = false;
+    private static bool _previousDeltaEA = false;
 
     public override void Initialize()
     {
@@ -22,6 +30,70 @@ public sealed class AirlockSystem : SharedAirlockSystem
 
         SubscribeLocalEvent<AirlockComponent, PowerChangedEvent>(OnPowerChanged);
         SubscribeLocalEvent<AirlockComponent, ActivateInWorldEvent>(OnActivate, before: new[] { typeof(DoorSystem) });
+        SubscribeLocalEvent<AlertLevelChangedEvent>(OnAlertLevelChanged);
+    }
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<AirlockComponent>();
+        while (query.MoveNext(out var uid, out var airlock))
+        {
+
+            if (airlock.DeltaAlertOngoing && !_hasNotifiedEAChanges && airlock.DeltaAlertRemainingEmergencyAccessTimer <= 0)
+            {
+                _hasNotifiedEAChanges = true;
+                _previousDeltaEA = true;
+                // Play a station-wide announcement indicating that all doors have had their locks disabled and urge the players to 'evacuate'.
+                var airlockXform = Transform(uid);
+                var stationUid = _station.GetStationInMap(airlockXform.MapID);
+                var announcement = Loc.GetString("alert-level-delta-emergencyaccess");
+                _chatSystem.DispatchStationAnnouncement(stationUid ?? uid, announcement, null, false, null, Color.Yellow);
+            }
+        }
+    }
+
+    private void OnAlertLevelChanged(AlertLevelChangedEvent ev)
+    {
+        Log.Info("AlertLevelReceived");
+        if (ev.AlertLevel == "delta")
+        {
+            var query = EntityQueryEnumerator<AirlockComponent>();
+            while (query.MoveNext(out var uid, out var airlock))
+            {
+
+                var airlockXform = Transform(uid);
+                var stationUid = _station.GetStationInMap(airlockXform.MapID);
+                if (stationUid != ev.Station) continue;
+                airlock.DeltaAlertOngoing = true;
+                // Immediately EA doors if we have had the emergency access flag trigger prior; this
+                // helps in cases such as a nuke being defused, disarmed, and later armed again.
+                if (_previousDeltaEA)
+                    airlock.DeltaAlertRemainingEmergencyAccessTimer = 0;
+                else
+                    airlock.DeltaAlertRemainingEmergencyAccessTimer = airlock.DeltaAlertEmergencyAccessDelayTime;
+                airlock.DeltaAlertRecentlyEnded = false;
+            }
+        }
+        else
+        {
+            _hasNotifiedEAChanges = false;
+            var query = EntityQueryEnumerator<AirlockComponent>();
+            while (query.MoveNext(out var uid, out var airlock))
+            {
+
+                var airlockXform = Transform(uid);
+                var stationUid = _station.GetStationInMap(airlockXform.MapID);
+                if (stationUid != ev.Station) continue;
+
+                if (airlock.DeltaAlertOngoing)
+                {
+                    airlock.DeltaAlertRecentlyEnded = true;
+                    airlock.PostDeltaAlertRemainingEmergencyAccessTimer = airlock.PostDeltaAlertEmergencyAccessTimer;
+                }
+                airlock.DeltaAlertOngoing = false;
+            }
+        }
     }
 
     private void OnAirlockInit(EntityUid uid, AirlockComponent component, ComponentInit args)

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -22,8 +22,6 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
-using Content.Shared.Doors.Components;
-using Content.Shared.Doors.Systems;
 
 namespace Content.Server.Nuke;
 
@@ -298,17 +296,6 @@ public sealed class NukeSystem : EntitySystem
         {
             _sound.DispatchStationEventMusic(uid, _selectedNukeSong, StationEventMusicType.Nuke);
             nuke.PlayedNukeSong = true;
-
-            // Play a station-wide announcement indicating that all doors have had their locks disabled and urge the players to 'evacuate'.
-            var nukeXform = Transform(uid);
-            var stationUid = _station.GetStationInMap(nukeXform.MapID);
-            var announcement = Loc.GetString("nuke-component-announcement-emergencyaccess",
-                ("time", (int) nuke.RemainingTime));
-            var sender = Loc.GetString("nuke-component-announcement-sender");
-            _chatSystem.DispatchStationAnnouncement(stationUid ?? uid, announcement, sender, false, null, Color.Yellow);
-
-
-            ToggleNukeAirlockEA(stationUid, true);
         }
 
         // play alert sound if time is running out
@@ -537,7 +524,6 @@ public sealed class NukeSystem : EntitySystem
         component.Status = NukeStatus.COOLDOWN;
         component.CooldownTime = component.Cooldown;
 
-        ToggleNukeAirlockEA(stationUid, false);
         UpdateUserInterface(uid, component);
         UpdateAppearance(uid, component);
     }
@@ -645,23 +631,7 @@ public sealed class NukeSystem : EntitySystem
             args.PushMarkup(Loc.GetString("examinable-unanchored"));
     }
 
-    private void ToggleNukeAirlockEA(EntityUid? stationUid, bool nukeEnabled)
-    {
-        var enumerator = _entMan.AllEntityQueryEnumerator<AirlockComponent>();
 
-        var airlockSystem = EntityManager.System<SharedAirlockSystem>();
-        while (enumerator.MoveNext(out var airlockUid, out var airlock))
-        {
-            if (_station.GetStationInMap(Transform(airlockUid).MapID) != stationUid) continue;
-            if (!Resolve(airlockUid, ref airlock)) continue;
-
-            if (nukeEnabled)
-                airlockSystem.NukeArm(airlockUid, airlock);
-            else
-                airlockSystem.NukeDisarm(airlockUid, airlock);
-
-        }
-    }
 }
 
 public sealed class NukeExplodedEvent : EntityEventArgs

--- a/Content.Shared/Doors/Components/AirlockComponent.cs
+++ b/Content.Shared/Doors/Components/AirlockComponent.cs
@@ -25,33 +25,62 @@ public sealed partial class AirlockComponent : Component
     public bool EmergencyAccess = false;
 
     /// <summary>
-    /// Used to hold the state of emergency access on the door prior to a nuke.  This allows us to return to the saved state
-    /// after the nuke is disarmed.
+    /// Used to hold the state of emergency access on the door prior to a station-destroying event.  This allows us to return to the saved state
+    /// after the station-destroying threat is eliminated.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField, AutoNetworkedField]
-    public bool PreNukeEmergencyAccessState = false;
+    public bool PreDeltaAlertEmergencyAccessState = false;
 
     /// <summary>
-    ///     Time before nuke emergency access is reverted, in seconds, after a nuke is disarmed.
+    ///     Time before delta alert emergency access is reverted, in seconds, after a station-destroying threat is averted.
     /// </summary>
-    [DataField("nukeemergencytimer")]
+    [DataField("deltaemergencytimer")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public int PostNukeEmergencyAccessTimer = 10;
+    public int PostDeltaAlertEmergencyAccessTimer = 10;
 
     /// <summary>
-    ///     Time remaining until the door reverts its emergency access settings after a nuke is disarmed.
+    ///     Time remaining until the door reverts its emergency access settings after a station-destroying threat is averted.
     /// </summary>
-    [DataField("nukeemergencyaccesstimeremaining")]
+    [DataField("deltaemergencyaccesstimeremaining")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public float PostNukeRemainingEmergencyAccessTimer;
+    public float PostDeltaAlertRemainingEmergencyAccessTimer;
 
     /// <summary>
-    /// Tells us if the nuke was recently disarmed on this airlock's grid.
+    /// Tells us if the a station-destroying threat was recently averted on this airlock's grid.
     /// </summary>
-    [DataField("nukerecentlydisarmed")]
+    [DataField("deltarecentlyended")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public bool NukeRecentlyDisarmed;
+    public bool DeltaAlertRecentlyEnded;
+
+    /// <summary>
+    /// Tells us if the a station-destroying threat is currently ongoing.
+    /// </summary>
+    [DataField("deltaongoing")]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public bool DeltaAlertOngoing;
+
+    /// <summary>
+    /// Determines how long to wait during a delta-level event before triggering emergency access.
+    /// </summary>
+    [DataField("deltaeadelaytime")]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public int DeltaAlertEmergencyAccessDelayTime = 180;
+
+    /// <summary>
+    /// Timer that keeps track of how long until the door enters emergency access.
+    /// </summary>
+    [DataField("deltaeadelaytimetimer")]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float DeltaAlertRemainingEmergencyAccessTimer;
+    /// <summary>
+    /// Determines if the door is currently under delta-level emergency access rules.
+    /// </summary>
+    [DataField("deltaeaenabled")]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public bool DeltaEmergencyAccessEnabled;
+
+
 
     /// <summary>
     /// Pry modifier for a powered airlock.

--- a/Content.Shared/Doors/Components/AirlockComponent.cs
+++ b/Content.Shared/Doors/Components/AirlockComponent.cs
@@ -25,6 +25,35 @@ public sealed partial class AirlockComponent : Component
     public bool EmergencyAccess = false;
 
     /// <summary>
+    /// Used to hold the state of emergency access on the door prior to a nuke.  This allows us to return to the saved state
+    /// after the nuke is disarmed.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField]
+    public bool PreNukeEmergencyAccessState = false;
+
+    /// <summary>
+    ///     Time before nuke emergency access is reverted, in seconds, after a nuke is disarmed.
+    /// </summary>
+    [DataField("nukeemergencytimer")]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public int PostNukeEmergencyAccessTimer = 10;
+
+    /// <summary>
+    ///     Time remaining until the door reverts its emergency access settings after a nuke is disarmed.
+    /// </summary>
+    [DataField("nukeemergencyaccesstimeremaining")]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float PostNukeRemainingEmergencyAccessTimer;
+
+    /// <summary>
+    /// Tells us if the nuke was recently disarmed on this airlock's grid.
+    /// </summary>
+    [DataField("nukerecentlydisarmed")]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public bool NukeRecentlyDisarmed;
+
+    /// <summary>
     /// Pry modifier for a powered airlock.
     /// Most anything that can pry powered has a pry speed bonus,
     /// so this default is closer to 6 effectively on e.g. jaws (9 seconds when applied to other default.)

--- a/Resources/Locale/en-US/alert-levels/alert-levels.ftl
+++ b/Resources/Locale/en-US/alert-levels/alert-levels.ftl
@@ -30,6 +30,7 @@ alert-level-gamma-instructions = All civilians are to immediately seek their nea
 alert-level-delta = Delta
 alert-level-delta-announcement = The station is currently under threat of imminent destruction. Crewmembers are advised to listen to heads of staff for more information.
 alert-level-delta-instructions = Crewmembers are advised to listen to heads of staff for more information.
+alert-level-delta-emergencyaccess = Station destruction is imminent.  For your safety, all door locks have been disabled.  Please evacuate in a safe and timely fashion.
 
 alert-level-epsilon = Epsilon
 alert-level-epsilon-announcement = Central Command has ordered the Epsilon security level on the station. Consider all contracts terminated.

--- a/Resources/Locale/en-US/nuke/nuke-component.ftl
+++ b/Resources/Locale/en-US/nuke/nuke-component.ftl
@@ -3,7 +3,6 @@ nuke-component-announcement-sender = Nuclear Fission Explosive
 nuke-component-announcement-armed = Attention! The station's self-destruct mechanism has been engaged {$location}. {$time} seconds until detonation. If this was made in error, the mechanism may still be disarmed.
 nuke-component-announcement-unarmed = The station's self-destruct was deactivated! Have a nice day!
 nuke-component-announcement-send-codes = Attention! Self-destruction codes have been sent to designated fax machines.
-nuke-component-announcement-emergencyaccess = There are {$time} seconds remaining until the station's self-destruct mechanism detonates.  For your safety, all door locks have been disabled.  Please evacuate in a safe and timely fashion.
 nuke-component-doafter-warning = You start fiddling with wires and knobs in order to disarm the nuke.. This may take a while.
 
 # Nuke UI

--- a/Resources/Locale/en-US/nuke/nuke-component.ftl
+++ b/Resources/Locale/en-US/nuke/nuke-component.ftl
@@ -3,6 +3,7 @@ nuke-component-announcement-sender = Nuclear Fission Explosive
 nuke-component-announcement-armed = Attention! The station's self-destruct mechanism has been engaged {$location}. {$time} seconds until detonation. If this was made in error, the mechanism may still be disarmed.
 nuke-component-announcement-unarmed = The station's self-destruct was deactivated! Have a nice day!
 nuke-component-announcement-send-codes = Attention! Self-destruction codes have been sent to designated fax machines.
+nuke-component-announcement-emergencyaccess = There are {$time} seconds remaining until the station's self-destruct mechanism detonates.  For your safety, all door locks have been disabled.  Please evacuate in a safe and timely fashion.
 nuke-component-doafter-warning = You start fiddling with wires and knobs in order to disarm the nuke.. This may take a while.
 
 # Nuke UI


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I have changed the endgame for nukie rounds such that, as soon as the nuke music begins playing, all doors on the station enter emergency access.  This attempts to encourage a bit more action or force players together at the endgame of a round.
If the nuke is disarmed, all doors will return to their normal state (or whatever emergency access state was already set) after ten seconds.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This change was made in response to something I find is a common issue in nukie rounds.
If the nuke is set in a secure zone, it is often going to be able to detonate without any issue.  Oftentimes, the nukies get ahold of AA or something close to it and move the nuke very far into a secured zone to minimize the degree to which they have to defend the nuke.
In these situations, there can often be a couple dozen people or so alive, but none of them have adequate access to reach the nuke, and if they do, the process of actually getting to the nuke in time for any reasonable combat to change the pace of the round to occur makes it happen late enough for the effort not to matter.

The change here would hook into a familiar audio cue - when the nuke music plays - and unlock all station doors to emergency access.  Usually by this point the round is either decided, or there is just enough time for a final push.  This allows for more dramatic gameplay moments at the critical climax of the round.  
I understand not all nuke music is the same, some lasting between 1m50s to 3 minutes.  I'd still argue that timing it to the randomly-selected music helps push players into one last push, if at all.  This time between nuke arming and the granting of  emergency access also allows players to prepare for what may inevitably become a planned counter-attack, rather than running around in circles trying to find the nuke and despairing that nobody left alive can access wherever the nuke is.

In the event the nuke is disarmed, the emergency access restrictions on the doors will be reverted after ten seconds, giving players some time to reposition themselves.  This also maintains the status of emergency access on doors that already had it set.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This modifies the shared classes AirlockComponent and SharedAirlockSystem, as well as modification to the server-side NukeSystem class.
The changes therein are minimal, but this being my first PR, there's bound to be something wrong with my approach.
I tried using event calls, but I couldn't manage to get them to receive.  My next best bet was to use the EntityManager to find all airlocks belonging to the nuked station's grid and toggle their Emergency Access state.  I had to add a variable to store their emergency access state prior to all doors being EA so that I could revert the permissions if the nuke was disarmed.  Additionally, I took notes from the Nuke's timer use and learned that each component has an update function called each tick.  I leveraged that to make all airlocks revert their emergency access state after a certain amount of time has elapsed since the nuke disarmed.  I have set this to ten seconds by default.


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/user-attachments/assets/3314da82-66dd-463b-ace8-2897b6f0d6b2)

https://github.com/user-attachments/assets/96c13135-7dd2-4677-9500-5a1ba7e0c11b



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

🆑 
- tweak: All airlocks enter emergency access mode when an armed nuke gets close to detonation.
- add: All airlocks revert to previous emergency access mode settings on nuke disarm.

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
