### PR TITLE
LatheSystem independently of energy

### DIFF
--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -182,7 +182,9 @@ namespace Content.Server.Lathe
         {
             if (!Resolve(uid, ref component))
                 return false;
-            if (component.CurrentRecipe != null || component.Queue.Count <= 0 || !this.IsPowered(uid, EntityManager))
+            if (component.CurrentRecipe != null || component.Queue.Count <= 0)
+                return false;
+            if (HasComp<ApcPowerReceiverComponent>(uid) && !this.IsPowered(uid, EntityManager))
                 return false;
 
             var recipe = component.Queue.First();

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -182,9 +182,7 @@ namespace Content.Server.Lathe
         {
             if (!Resolve(uid, ref component))
                 return false;
-            if (component.CurrentRecipe != null || component.Queue.Count <= 0)
-                return false;
-            if (HasComp<ApcPowerReceiverComponent>(uid) && !this.IsPowered(uid, EntityManager))
+            if (component.CurrentRecipe != null || component.Queue.Count <= 0 || !this.IsPowered(uid, EntityManager))
                 return false;
 
             var recipe = component.Queue.First();

--- a/Content.Server/Power/EntitySystems/StaticPowerSystem.cs
+++ b/Content.Server/Power/EntitySystems/StaticPowerSystem.cs
@@ -9,7 +9,7 @@ public static class StaticPowerSystem
     public static bool IsPowered(this EntitySystem system, EntityUid uid, IEntityManager entManager, ApcPowerReceiverComponent? receiver = null)
     {
         if (receiver == null && !entManager.TryGetComponent(uid, out receiver))
-            return false;
+            return true;
 
         return receiver.Powered;
     }


### PR DESCRIPTION
## About the PR
~~If LatheComponent does not have an ApcPowerReceiverComponent, it does not need power, and can run without it.~~

~~if the component is exist, power is required for producing. So nothing has changed in the game itself.~~

### EDIT:

IsPowered when there is no ApcPowerReceiver component now defaults to true, which means that all entities without ApcPowerReceiver do not require power, and can run without it. 