### PR TITLE
Handless mobs can no longer wipe devices

### DIFF
--- a/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
@@ -96,7 +96,7 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
 
     private void AddWipeVerb(EntityUid uid, ToggleableGhostRoleComponent component, GetVerbsEvent<ActivationVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract)
+        if (args.Hands == null || !args.CanAccess || !args.CanInteract)
             return;
 
         if (TryComp<MindContainerComponent>(uid, out var mind) && mind.HasMind)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Mobs that do not have hands cannot wipe devices anymore.
Fixes #30142 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
added a check for hands in `TogglableGhostRoleSystem.cs`

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/e017e1f2-bcbe-440d-aace-51dfe7a3bf53

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Handless mobs can no longer wipe devices like positronic brains or pAIs.

