### PR TITLE
Fix Chameleon Scarf menu being blank

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
@@ -39,3 +39,4 @@
     tags:
     - Scarf
     - ClothMade
+    - WhitelistChameleon

--- a/Resources/Prototypes/Entities/Clothing/Neck/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/specific.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: ClothingNeckBase
   id: ClothingNeckChameleon
   name: striped red scarf
@@ -12,7 +12,7 @@
     - type: Clothing
       sprite: Clothing/Neck/Scarfs/red.rsi
     - type: ChameleonClothing
-      slot: [neck]
+      slot: [NECK]
       default: ClothingNeckScarfStripedRed
     - type: UserInterface
       interfaces:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
BaseScarf was introduced and redefined tags in https://github.com/space-wizards/space-station-14/pull/29779 and forgot to redefine WhitelistChameleon, adding the tag back fixes the chameleon options for scarves

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes https://github.com/space-wizards/space-station-14/issues/30155

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Chameleon scarves now work again.