### PR TITLE
Reset ghost role menu scroll upon search

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml
@@ -2,7 +2,7 @@
     <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="0.4">
         <Button Name="GhostnadoButton" Text="{Loc 'ghost-target-window-warp-to-most-followed'}" HorizontalAlignment="Center" Margin="0 4" />
         <LineEdit Name="SearchBar" PlaceHolder="Search" HorizontalExpand="True" Margin="0 4" />
-        <ScrollContainer VerticalExpand="True" HorizontalExpand="True" HScrollEnabled="False">
+        <ScrollContainer Name="GhostScroll" VerticalExpand="True" HorizontalExpand="True" HScrollEnabled="False">
             <BoxContainer Name="ButtonContainer" Orientation="Vertical" VerticalExpand="True" SeparationOverride="5">
                 <!-- Target buttons get added here by code -->
             </BoxContainer>

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -90,6 +90,8 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
             _searchText = args.Text;
 
             UpdateVisibleButtons();
+            // Reset scroll bar so they can see the relevant results.
+            GhostScroll.SetScrollValue(Vector2.Zero);
         }
     }
 }


### PR DESCRIPTION
Quality of life so it doesn't sit on your old spot anymore.

:cl:
- tweak: Reset the scroll bar in the ghost warp menu whenever you search for a role. Previously it remained at your previous position and you would have to scroll up to see the first entry.