### PR TITLE
Set input coords to invalid if mouse off-screen

### DIFF
--- a/Content.Client/Gameplay/GameplayStateBase.cs
+++ b/Content.Client/Gameplay/GameplayStateBase.cs
@@ -185,7 +185,7 @@ namespace Content.Client.Gameplay
 
             EntityCoordinates coordinates = default;
             EntityUid? entityToClick = null;
-            if (args.Viewport is IViewportControl vp)
+            if (args.Viewport is IViewportControl vp && kArgs.PointerLocation.IsValid)
             {
                 var mousePosWorld = vp.PixelToMap(kArgs.PointerLocation.Position);
                 entityToClick = GetClickedEntity(mousePosWorld);
@@ -193,6 +193,10 @@ namespace Content.Client.Gameplay
                 coordinates = _mapManager.TryFindGridAt(mousePosWorld, out _, out var grid) ?
                     grid.MapToGrid(mousePosWorld) :
                     EntityCoordinates.FromMap(_mapManager, mousePosWorld);
+            }
+            else
+            {
+                coordinates = EntityCoordinates.Invalid;
             }
 
             var message = new ClientFullInputCmdMessage(_timing.CurTick, _timing.TickFraction, funcId)

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -170,7 +170,7 @@ namespace Content.Server.Hands.Systems
 
         private bool HandleThrowItem(ICommonSession? playerSession, EntityCoordinates coordinates, EntityUid entity)
         {
-            if (playerSession?.AttachedEntity is not {Valid: true} player || !Exists(player))
+            if (playerSession?.AttachedEntity is not {Valid: true} player || !Exists(player) || !coordinates.IsValid(EntityManager))
                 return false;
 
             return ThrowHeldItem(player, coordinates);


### PR DESCRIPTION
This may be a breaking change for some stuff, I only tested basic combat stuff + throwing.

This fixes the coordinates setting an off-screen position to the top-left pixel and blocks throw attempts as a result.

:cl:
- fix: Fix being able to throw items while your cursor is off-screen.