### PR TITLE
Fix Markup Tags in Station News

### DIFF
--- a/Content.Client/CartridgeLoader/Cartridges/NewsReaderUi.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/NewsReaderUi.cs
@@ -26,7 +26,7 @@ public sealed partial class NewsReaderUi : UIFragment
         {
             SendNewsReaderMessage(NewsReaderUiAction.Prev, userInterface);
         };
-        _fragment.OnNotificationSwithPressed += () =>
+        _fragment.OnNotificationSwitchPressed += () =>
         {
             SendNewsReaderMessage(NewsReaderUiAction.NotificationSwitch, userInterface);
         };

--- a/Content.Client/CartridgeLoader/Cartridges/NewsReaderUi.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/NewsReaderUi.cs
@@ -26,7 +26,7 @@ public sealed partial class NewsReaderUi : UIFragment
         {
             SendNewsReaderMessage(NewsReaderUiAction.Prev, userInterface);
         };
-        _fragment.OnNotificationSwitchPressed += () =>
+        _fragment.OnNotificationSwithPressed += () =>
         {
             SendNewsReaderMessage(NewsReaderUiAction.NotificationSwitch, userInterface);
         };

--- a/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
@@ -31,7 +31,7 @@ public sealed partial class NewsReaderUiFragment : BoxContainer
         Author.Visible = true;
 
         PageName.Text = article.Title;
-        PageText.SetMarkup(article.Content);
+        PageText.SetMarkupPermissive(article.Content);
 
         PageNum.Text = $"{targetNum}/{totalNum}";
 

--- a/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
@@ -12,7 +12,7 @@ public sealed partial class NewsReaderUiFragment : BoxContainer
     public event Action? OnNextButtonPressed;
     public event Action? OnPrevButtonPressed;
 
-    public event Action? OnNotificationSwitchPressed;
+    public event Action? OnNotificationSwithPressed;
 
     public NewsReaderUiFragment()
     {
@@ -20,7 +20,7 @@ public sealed partial class NewsReaderUiFragment : BoxContainer
 
         Next.OnPressed += _ => OnNextButtonPressed?.Invoke();
         Prev.OnPressed += _ => OnPrevButtonPressed?.Invoke();
-        NotificationSwitch.OnPressed += _ => OnNotificationSwitchPressed?.Invoke();
+        NotificationSwitch.OnPressed += _ => OnNotificationSwithPressed?.Invoke();
     }
 
     public void UpdateState(NewsArticle article, int targetNum, int totalNum, bool notificationOn)
@@ -37,10 +37,10 @@ public sealed partial class NewsReaderUiFragment : BoxContainer
 
         NotificationSwitch.Text = Loc.GetString(notificationOn ? "news-read-ui-notification-on" : "news-read-ui-notification-off");
 
-        var shareTime = article.ShareTime.ToString(@"hh\:mm\:ss");
+        string shareTime = article.ShareTime.ToString(@"hh\:mm\:ss");
         ShareTime.SetMarkup(Loc.GetString("news-read-ui-time-prefix-text") + " " + shareTime);
 
-        Author.SetMarkup(Loc.GetString("news-read-ui-author-prefix") + " " + (article.Author ?? Loc.GetString("news-read-ui-no-author")));
+        Author.SetMarkup(Loc.GetString("news-read-ui-author-prefix") + " " + (article.Author != null ? article.Author : Loc.GetString("news-read-ui-no-author")));
 
         Prev.Disabled = targetNum <= 1;
         Next.Disabled = targetNum >= totalNum;

--- a/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
@@ -12,7 +12,7 @@ public sealed partial class NewsReaderUiFragment : BoxContainer
     public event Action? OnNextButtonPressed;
     public event Action? OnPrevButtonPressed;
 
-    public event Action? OnNotificationSwithPressed;
+    public event Action? OnNotificationSwitchPressed;
 
     public NewsReaderUiFragment()
     {
@@ -20,7 +20,7 @@ public sealed partial class NewsReaderUiFragment : BoxContainer
 
         Next.OnPressed += _ => OnNextButtonPressed?.Invoke();
         Prev.OnPressed += _ => OnPrevButtonPressed?.Invoke();
-        NotificationSwitch.OnPressed += _ => OnNotificationSwithPressed?.Invoke();
+        NotificationSwitch.OnPressed += _ => OnNotificationSwitchPressed?.Invoke();
     }
 
     public void UpdateState(NewsArticle article, int targetNum, int totalNum, bool notificationOn)
@@ -37,10 +37,10 @@ public sealed partial class NewsReaderUiFragment : BoxContainer
 
         NotificationSwitch.Text = Loc.GetString(notificationOn ? "news-read-ui-notification-on" : "news-read-ui-notification-off");
 
-        string shareTime = article.ShareTime.ToString(@"hh\:mm\:ss");
+        var shareTime = article.ShareTime.ToString(@"hh\:mm\:ss");
         ShareTime.SetMarkup(Loc.GetString("news-read-ui-time-prefix-text") + " " + shareTime);
 
-        Author.SetMarkup(Loc.GetString("news-read-ui-author-prefix") + " " + (article.Author != null ? article.Author : Loc.GetString("news-read-ui-no-author")));
+        Author.SetMarkup(Loc.GetString("news-read-ui-author-prefix") + " " + (article.Author ?? Loc.GetString("news-read-ui-no-author")));
 
         Prev.Disabled = targetNum <= 1;
         Next.Disabled = targetNum >= totalNum;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed an error occurring when using "[" or "]" in the station news.
This permanently bricked your PDA, causing the client to request the full server state every time the PDA was interacted with.
Fixes #30152

## Why / Balance
News Reporters should be able to use markup tags without bricking any PDAs

## Technical details
Instead of using SetMarkup it now uses SetMarkupPermissive

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl: ThatOneEnby1337
- fix: News Reporters are now able to use markup tags in their reports without bricking the PDAs of readers

