### PR TITLE
fix fish petting misprediction

### DIFF
--- a/Content.Shared/Friends/Systems/PettableFriendSystem.cs
+++ b/Content.Shared/Friends/Systems/PettableFriendSystem.cs
@@ -42,6 +42,7 @@ public sealed class PettableFriendSystem : EntitySystem
             _popup.PopupClient(Loc.GetString(comp.SuccessString, ("target", uid)), user, user);
             _factionException.IgnoreEntity(exception, user);
             args.Handled = true;
+            return;
         }
 
         if (_useDelayQuery.TryComp(uid, out var useDelay) && !_useDelay.TryResetDelay((uid, useDelay), true))

--- a/Content.Shared/Friends/Systems/PettableFriendSystem.cs
+++ b/Content.Shared/Friends/Systems/PettableFriendSystem.cs
@@ -32,23 +32,22 @@ public sealed class PettableFriendSystem : EntitySystem
     {
         var (uid, comp) = ent;
         var user = args.User;
-        if (args.Handled || !_exceptionQuery.TryGetComponent(uid, out var exceptionComp))
-            return;
-
-        if (_useDelayQuery.TryGetComponent(uid, out var useDelay) && !_useDelay.TryResetDelay((uid, useDelay), true))
+        if (args.Handled || !_exceptionQuery.TryComp(uid, out var exceptionComp))
             return;
 
         var exception = (uid, exceptionComp);
-        if (_factionException.IsIgnored(exception, user))
+        if (_factionException.!IsIgnored(exception, user))
         {
-            _popup.PopupClient(Loc.GetString(comp.FailureString, ("target", uid)), user, user);
-            return;
+            // you have made a new friend :)
+            _popup.PopupClient(Loc.GetString(comp.SuccessString, ("target", uid)), user, user);
+            _factionException.IgnoreEntity(exception, user);
+            args.Handled = true;
         }
 
-        // you have made a new friend :)
-        _popup.PopupClient(Loc.GetString(comp.SuccessString, ("target", uid)), user, user);
-        _factionException.IgnoreEntity(exception, user);
-        args.Handled = true;
+        if (_useDelayQuery.TryComp(uid, out var useDelay) && !_useDelay.TryResetDelay((uid, useDelay), true))
+            return;
+
+        _popup.PopupClient(Loc.GetString(comp.FailureString, ("target", uid)), user, user);
     }
 
     private void OnRehydrated(Entity<PettableFriendComponent> ent, ref GotRehydratedEvent args)

--- a/Content.Shared/Friends/Systems/PettableFriendSystem.cs
+++ b/Content.Shared/Friends/Systems/PettableFriendSystem.cs
@@ -36,7 +36,7 @@ public sealed class PettableFriendSystem : EntitySystem
             return;
 
         var exception = (uid, exceptionComp);
-        if (_factionException.!IsIgnored(exception, user))
+        if (!_factionException.IsIgnored(exception, user))
         {
             // you have made a new friend :)
             _popup.PopupClient(Loc.GetString(comp.SuccessString, ("target", uid)), user, user);


### PR DESCRIPTION
## About the PR
made it ignore usedelay when you pet it for the first time, and only care about it once it.
i believe this is what made it sometimes mispredict (client think it was pet, server thinks use delay is active and doesnt)

## Why / Balance
mispet bad

## Technical details
:fish:

## Media

https://github.com/user-attachments/assets/b981558a-302b-4ad5-88bf-44e196c12a82


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase