### PR TITLE
fix borgs being unable to state laws with an active flashlight

### DIFF
--- a/Content.Shared/Silicons/Laws/SiliconLawPrototype.cs
+++ b/Content.Shared/Silicons/Laws/SiliconLawPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Silicons.Laws;
 
 [Virtual, DataDefinition]
 [Serializable, NetSerializable]
-public partial class SiliconLaw : IComparable<SiliconLaw>
+public partial class SiliconLaw : IComparable<SiliconLaw>, IEquatable<SiliconLaw>
 {
     /// <summary>
     /// A locale string which is the actual text of the law.
@@ -39,11 +39,25 @@ public partial class SiliconLaw : IComparable<SiliconLaw>
         return Order.CompareTo(other.Order);
     }
 
-    public bool Equals(SiliconLaw other)
+    public bool Equals(SiliconLaw? other)
     {
+        if (other == null)
+            return false;
         return LawString == other.LawString
                && Order == other.Order
                && LawIdentifierOverride == other.LawIdentifierOverride;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj == null)
+            return false;
+        return Equals(obj as SiliconLaw);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(LawString, Order, LawIdentifierOverride);
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
See title. Brainstormed this together with Reisama (Lo Doreth).

## Why / Balance
bugfix

## Technical details
![grafik](https://github.com/user-attachments/assets/16533055-72b2-4fe3-9527-b6ab32c117c0)
In `SiliconLawBoundUserInterface.cs` the old laws are compared to the new ones and the law display is updated if needed. However, the `Equals` function in `SiliconLawPrototype` was not implemented correctly, causing `Contains(law)` to compare object instances instead of the datafields and therefore always returning false. The law screen was updated every single frame, making it impossible to click the button.

This does *not* fix:
- Borgs being unable to state laws when they have no modules or battery installed.
- The fact that there is a SiliconLawBuiState message every single frame if the borg's battery is draining

However, since the logic for comparing laws was broken, this PR should be still an improvement.

## Media


https://github.com/user-attachments/assets/7213417b-1a39-4f06-a0bb-cc4e35aec6d6

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**

:cl: valquaint, slarticodefast
- fix: Fixed borgs being unable to state laws with an activated flashlight.
