### PR TITLE
Make the Detective's Access match the Security Officer more closely

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -17,6 +17,8 @@
   - Maintenance
   - Service
   - Detective
+  - Cryogenics
+  - External
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
## About the PR
This PR gives the Detective External and Cryogenics access.

## Why / Balance
All of sec was supposed to have Cryogenics access as far as I can tell from the original PR, which was then done in #25752 but didn't include the Detective, as they were independent between #23114 and #25986 when the "Fix" PR was made. Additionally, External access is also added, to match the Security Officer, if there is a reason they don't have it, then it would be kept that way.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- tweak: The Detective can now access Externals and Cryogenics like their Officer counterpart.
