### PR TITLE
Tweak Security resistance values

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -66,9 +66,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
+        Blunt: 0.65
+        Slash: 0.65
+        Piercing: 0.6
         Heat: 0.7
         Caustic: 0.75 # not the full 90% from ss13 because of the head
   - type: ExplosionResistance
@@ -82,10 +82,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
+        Blunt: 0.65
+        Slash: 0.65
         Piercing: 0.7
         Heat: 0.7
+        Caustic: 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.9
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -266,7 +266,7 @@
         Blunt: 0.4
         Slash: 0.5
         Piercing: 0.6
-        Heat: 0.65
+        Heat: 0.6
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.75

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -208,6 +208,7 @@
         Blunt: 0.6
         Slash: 0.6
         Piercing: 0.6
+        Heat: 0.6
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.75
@@ -262,13 +263,14 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.6
+        Blunt: 0.4
+        Slash: 0.5
         Piercing: 0.6
+        Heat: 0.65
         Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+    walkModifier: 0.75
+    sprintModifier: 0.75
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
@@ -423,13 +425,14 @@
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.6
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.6
         Slash: 0.5
         Piercing: 0.5
+        Heat: 0.4
         Radiation: 0.5
         Caustic: 0.6
   - type: ClothingSpeedModifier


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

- Added missing Heat resistances to Security Hardsuits
    All Security Hardsuits now have a 40% heat resistance, which should make fighting antags armed with energy/heat weapons in spaced rooms more "safer"
 
- Changed Warden's Hardsuit resistances to better fit its description and purpose and decreased its slowdown value to 25%
Blunt resistance got changed to 60%, slash to 50%  rest remains unchanged and except for the slowdown value being reduced from 30% to 25%

- Improved HoS's Hardsuit explosion resistance to 50% from the previous 40%   

- Buffed the Warden's Armoured Jacket to be slightly more protective from blunt and slash
    Blunt and Slash resistances were changed from 30% to 35% , it gained 10% caustic resistance

- Buffed Head of Security's Armoured Trenchcoat protection values to improve HoS's combat capability 
  Blunt and Slash resistances were changed from 30% to 35% , pierce resistance is now at 40% 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

- Hardsuit heat resistance
Before the spacing damage "nerf" Security always had a hard time fighting antagonists using heat/energy weapons, this was even worse in spaced rooms, this change should give security more of a fighting chance in those scenarios
Due to the limited amount of Security hardsuits available on current maps, and the inability to order more this should make this change balanced.

- Warden Hardsuit change
Brutal honesty but the current state of the Warden's hardsuit was a joke, 30% slowdown with no resistances to make up for the turtle like speed, which made transporting prisoners in spaced environments a nightmare, Now it should be slightly better while also being that its description portrays it as, "A specialized riot suit geared to combat low pressure environments." Due to it being a one of a kind item, locked behind Armoury access it should not affect the game balance in any major way, but it should improve Warden gameplay by a minor amount.

- HoS's Hardsuit
Its current standing is good, tho it was very weak against heat and explosive damage, with the addition of the heat resistance i though about making the HoS hardsuit slightly better at surviving explosive blasts, which would make sense as its suppose to be equipped with the most state of the art protective technology,  this should make HoS be slightly harder to kill by using explosives but not in any major way, its only changed from 40% to 50% explosion resistant. This is up for debate, im willing to revert it back into 40%.

- Warden Armoured Jacket
 This is more of a Niche change for Warden,  its only a 5% increase in blunt/slash resistance which should decrease the threat posed by uncooperative prisoners who somehow always manage to make a shiv in brig, less time spent getting treated means less time being loose and leaving brig unattended

- Head of Security's Armoured Trenchcoat
Main reason for improving it is finally making HoS the 2nd most combat capable person on station as he was always suppose to be, before he was a Glass Cannon, now he should pose a slighly bigger challenge to anyone who dares to fight the Chief Defender of the Station, If an antag manages to beat HoS and steals their coat they are now rewarded with above average protection if they did not have any or had worse,

All these changes should not affect the game balance in a major way, due to the limited amount of the changed items, and their protection values only being changed by a slight amount it shouldn't be really felt,  
I tried my best to make the new values as balanced as possible.

Im open to all feedback and i will try my best to answer all questions.


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Changed protection values of Security Hardsuits
- tweak: Made Warden/HoS coats slightly more protective to better fit their position

