### PR TITLE
Chasm liquid drain

### DIFF
--- a/Content.Server/Fluids/EntitySystems/DrainSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/DrainSystem.cs
@@ -212,7 +212,7 @@ public sealed class DrainSystem : SharedDrainSystem
         }
     }
 
-private void OnExamined(Entity<DrainComponent> entity, ref ExaminedEvent args)
+    private void OnExamined(Entity<DrainComponent> entity, ref ExaminedEvent args)
     {
         if (!TryComp(args.Examined, out DrainComponent? drain) ||
             !drain.ExamineAvailableVolume ||

--- a/Content.Server/Fluids/EntitySystems/DrainSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/DrainSystem.cs
@@ -212,9 +212,11 @@ public sealed class DrainSystem : SharedDrainSystem
         }
     }
 
-    private void OnExamined(Entity<DrainComponent> entity, ref ExaminedEvent args)
+private void OnExamined(Entity<DrainComponent> entity, ref ExaminedEvent args)
     {
-        if (!args.IsInDetailsRange ||
+        if (!TryComp(args.Examined, out DrainComponent? drain) ||
+            !drain.ExamineAvailableVolume ||
+            !args.IsInDetailsRange ||
             !HasComp<SolutionContainerManagerComponent>(entity) ||
             !_solutionContainerSystem.ResolveSolution(entity.Owner, DrainComponent.SolutionName, ref entity.Comp.Solution, out var drainSolution))
         {

--- a/Content.Shared/Fluids/Components/DrainComponent.cs
+++ b/Content.Shared/Fluids/Components/DrainComponent.cs
@@ -34,6 +34,12 @@ public sealed partial class DrainComponent : Component
     public bool AutoDrain = true;
 
     /// <summary>
+    /// Does examining this drain show available volume?
+    /// </summary>
+    [DataField("examineAvailableVolume"), ViewVariables(VVAccess.ReadOnly)]
+    public bool ExamineAvailableVolume = true;
+
+    /// <summary>
     /// How many units per second the drain can absorb from the surrounding puddles.
     /// Divided by puddles, so if there are 5 puddles this will take 1/5 from each puddle.
     /// This will stay fixed to 1 second no matter what DrainFrequency is.

--- a/Resources/Prototypes/Entities/Tiles/chasm.yml
+++ b/Resources/Prototypes/Entities/Tiles/chasm.yml
@@ -14,6 +14,17 @@
     blacklist:
       tags:
       - Catwalk
+  - type: Drain
+    examineAvailableVolume: false
+    unitsPerSecond: 50
+    unitsDestroyedPerSecond: 200
+    range: 0.5
+  - type: DumpableSolution
+    solution: drainBuffer
+  - type: SolutionContainerManager
+    solutions:
+      drainBuffer:
+        maxVol: 10000
   - type: Transform
     anchored: true
   - type: Clickable
@@ -55,7 +66,7 @@
     sprite: Tiles/Planet/Chasms/chromite_chasm.rsi
   - type: Icon
     sprite: Tiles/Planet/Chasms/chromite_chasm.rsi
-    
+
 - type: entity
   parent: FloorChasmEntity
   id: FloorDesertChasm
@@ -65,7 +76,7 @@
     sprite: Tiles/Planet/Chasms/desert_chasm.rsi
   - type: Icon
     sprite: Tiles/Planet/Chasms/desert_chasm.rsi
-    
+
 - type: entity
   parent: FloorChasmEntity
   id: FloorSnowChasm


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Makes chasms remove liquids on the same tile.
![image](https://github.com/user-attachments/assets/fa687636-7931-48ba-96ff-4c8e8e975467)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Spite PR after i got roundremoved on an expedition due to a huge puddle completely hiding the chasm.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds drain component to chasms.
Adds a bool toggle to disable examinable available volume in drains so you cant see how much volume a chasm has.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- tweak: Liquids can no longer magically hover over bottomless chasms
