### PR TITLE
Fix Syndicate Assault Cyborg Double Esword 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -536,7 +536,7 @@
       - state: icon-syndicate
     - type: ItemBorgModule
       items:
-      - EnergySwordDouble
+      - CyborgEnergySwordDouble
       - PinpointerSyndicateNuclear
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -317,3 +317,12 @@
       right:
       - state: inhand-right-blade
         shader: unshaded
+
+- type: entity
+  name: borg double-bladed energy sword # could improve name
+  parent: EnergySwordDouble
+  id: CyborgEnergySwordDouble # why is this invalid if ID is BorgEnergySwordDouble
+  description: Syndicate Command Interns thought that having one blade on the energy sword was not enough. Specially designed for syndicate cyborgs.
+  components: # could add energy-draining like the L6C
+  - type: Wieldable
+    freeHandsRequired: 0 # because borg has no off-hand to wield with.  Without this, it will be unable to activate the esword


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR fixes cyborgs with the esword module being unable to wield the titular esword.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This is to fix cyborgs being unable to wield their esword. This may increase the power and use of cyborg reinforcements, but likely not more than was originally intended by giving them a double esword. This also allows for (but does not include) separate traits from the normal double esword such as battery drain, reflect chance, and damage in case this negatively affects balance.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a child of EnergySwordDouble named CyborgEnergySwordDouble which takes no off-hand to wield, and changes the module to use it. 
## Media

https://github.com/user-attachments/assets/7f5c33bb-955a-407a-a8de-e24abe57b1a1


https://github.com/user-attachments/assets/186bbec7-9116-4516-9357-1136b55be2c9


<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: TheKittehJesus
- fix: The Syndicate Assault Borg can now wield their double esword
