### PR TITLE
fix microwave construction

### DIFF
--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -79,6 +79,9 @@ namespace Content.Server.Kitchen.Components
 
         public Container Storage = default!;
 
+        [DataField]
+        public string ContainerId = "microwave_entity_container";
+
         [DataField, ViewVariables(VVAccess.ReadWrite)]
         public int Capacity = 10;
 

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -252,7 +252,7 @@ namespace Content.Server.Kitchen.EntitySystems
         private void OnInit(Entity<MicrowaveComponent> ent, ref ComponentInit args)
         {
             // this really does have to be in ComponentInit
-            ent.Comp.Storage = _container.EnsureContainer<Container>(ent, "microwave_entity_container");
+            ent.Comp.Storage = _container.EnsureContainer<Container>(ent, ent.Comp.ContainerId);
         }
 
         private void OnMapInit(Entity<MicrowaveComponent> ent, ref MapInitEvent args)
@@ -312,6 +312,9 @@ namespace Content.Server.Kitchen.EntitySystems
 
         private void OnInsertAttempt(Entity<MicrowaveComponent> ent, ref ContainerIsInsertingAttemptEvent args)
         {
+            if (args.Container.ID != ent.Comp.ContainerId)
+                return;
+
             if (ent.Comp.Broken)
             {
                 args.Cancel();


### PR DESCRIPTION
## About the PR
Fixes #30231

## Why / Balance
bugfix

## Technical details
#29200 added an OnInsertAttempt function to the microwave. However, the microwave has three containers and it was called for all of them, not just the inventory.

![grafik](https://github.com/user-attachments/assets/91547f51-715e-4975-8eef-605a5516e2c5)

Upon finishing construction, the machine board and machine parts are inserted into their respective containers, causing a crash. We fix this by using the OnInsertAttempt function only for the correct "microwave_entity_container".

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed microwave construction.
