### PR TITLE
Another QSI Fix About Things Being in Places they Should not

### DIFF
--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -198,8 +198,7 @@ public sealed class SwapTeleporterSystem : EntitySystem
     private (EntityUid, BaseContainer?) GetTeleportingEntity(Entity<TransformComponent> ent)
     {
         var parent = ent.Comp.ParentUid;
-        if (_container.TryGetOuterContainer(ent, ent, out var container))
-            parent = container.Owner;
+        _container.TryGetOuterContainer(ent, ent, out var container);
 
         if (HasComp<MapGridComponent>(parent) || HasComp<MapComponent>(parent))
             return (ent, container);

--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -150,8 +150,11 @@ public sealed class SwapTeleporterSystem : EntitySystem
             return;
         }
 
-        var (teleEnt, cont) = GetTeleportingEntity((uid, xform));
-        var (otherTeleEnt, otherCont) = GetTeleportingEntity((linkedEnt, Transform(linkedEnt)));
+        var teleEnt = GetTeleportingEntity((uid, xform));
+        var otherTeleEnt = GetTeleportingEntity((linkedEnt, Transform(linkedEnt)));
+
+        _container.TryGetOuterContainer(teleEnt, Transform(teleEnt), out var cont);
+        _container.TryGetOuterContainer(otherTeleEnt, Transform(otherTeleEnt), out var otherCont);
 
         if (otherCont != null && !_container.CanInsert(teleEnt, otherCont) ||
             cont != null && !_container.CanInsert(otherTeleEnt, cont))
@@ -195,19 +198,18 @@ public sealed class SwapTeleporterSystem : EntitySystem
             DestroyLink(linked, user); // the linked one is shown globally
     }
 
-    private (EntityUid, BaseContainer?) GetTeleportingEntity(Entity<TransformComponent> ent)
+    private EntityUid GetTeleportingEntity(Entity<TransformComponent> ent)
     {
         var parent = ent.Comp.ParentUid;
-        _container.TryGetOuterContainer(ent, ent, out var container);
 
         if (HasComp<MapGridComponent>(parent) || HasComp<MapComponent>(parent))
-            return (ent, container);
+            return ent;
 
         if (!_xformQuery.TryGetComponent(parent, out var parentXform) || parentXform.Anchored)
-            return (ent, container);
+            return ent;
 
         if (!TryComp<PhysicsComponent>(parent, out var body) || body.BodyType == BodyType.Static)
-            return (ent, container);
+            return ent;
 
         return GetTeleportingEntity((parent, parentXform));
     }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Makes QSI swap the topmost unanchored container rather than swapping the QSI if the topmost container was anchored
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #29929
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
`GetTeleportingEntity` would find the topmost container and check if it was anchored. Now it checks every container in the stack and returns one right before the anchored container.

Essentially a revert to #25700, I've tested a lot of stuff and have had no issues
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/user-attachments/assets/e75ee8f6-8d25-4d7a-9d13-e1fa447b6417

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: QSI now swaps the top most valid container instead of QSI when placed in an anchored container
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
