### PR TITLE
Remove Flash Immunity from the Welding Gas Mask

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
@@ -38,7 +38,7 @@
   parent: ClothingMaskBase
   id: ClothingMaskWeldingGas
   name: welding gas mask
-  description: A gas mask with built in welding goggles and face shield. Looks like a skull, clearly designed by a nerd.
+  description: A gas mask with built in welding goggles. Looks like a skull, clearly designed by a nerd.
   components:
   - type: Sprite
     sprite: Clothing/Mask/welding-gas.rsi
@@ -48,7 +48,6 @@
   - type: BreathMask
   - type: IngestionBlocker
   - type: IdentityBlocker
-  - type: FlashImmunity
   - type: EyeProtection
   - type: PhysicalComposition
     materialComposition:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removing Flash Immunity from the welding gas mask,
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Flash immunity is too common, is really strong, and could completely ruin a mode such as Revolutionaries. There was a PR made to remove the sunglasses from the ClothesMate which got merged fairly quickly, then there's https://github.com/space-wizards/space-station-14/pull/28519 which is a great addition, makes the flash protection a trade-off, and not just a straight upside.

As it stands right now, the Welding Gas Mask is a 1:1 copy of the Syndicate gas mask, expect the Welding Gas Mask isn't considered contraband, restricted, or valid. Only difference being that it cannot be toggled up and down. It's a tier 1 Industrial tech, and only costs 6 steel, 2 glass to make, it could appear as your first tech in that tree, practically making this item a Syndicate gas mask that can be made at the start of a shift.

The Welding Gas Mask is still a gas mask, so I don't think that it should follow the same rules of https://github.com/space-wizards/space-station-14/pull/28519 and instead should just have the flash protection removed. Turn the T1 Industrial tech item from a Syndicate gas mask, into engineering goggles that go on the mask slot instead.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
none
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
none
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
The Welding Gas Mask no longer grants immunity to flashes.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Changed the Welding Gas Mask to not have flash immunity