### PR TITLE
Fix pancakes stacks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -257,14 +257,12 @@
 
 - type: entity
   name: blueberry pancake
-  parent: FoodBakedBase
+  parent: FoodBakedPancake
   id: FoodBakedPancakeBb
   description: A fluffy and delicious blueberry pancake.
   components:
   - type: Stack
-    stackType: Pancake
-    count: 1
-    composite: true
+    stackType: PancakeBb
     layerStates:
     - pancakesbb1
     - pancakesbb2
@@ -281,7 +279,6 @@
     - state: pancakesbb3
       map: ["pancakesbb3"]
       visible: false
-  - type: Appearance
   - type: Tag
     tags:
     - Pancake
@@ -289,14 +286,12 @@
 
 - type: entity
   name: chocolate chip pancake
-  parent: FoodBakedBase
+  parent: FoodBakedPancake
   id: FoodBakedPancakeCc
   description: A fluffy and delicious chocolate chip pancake.
   components:
   - type: Stack
-    stackType: Pancake
-    count: 1
-    composite: true
+    stackType: PancakeCc
     layerStates:
     - pancakescc1
     - pancakescc2
@@ -313,7 +308,6 @@
     - state: pancakescc3
       map: ["pancakescc3"]
       visible: false
-  - type: Appearance
   - type: SolutionContainerManager
     solutions:
       food:
@@ -323,9 +317,6 @@
           Quantity: 5
         - ReagentId: Theobromine
           Quantity: 1
-  - type: Tag
-    tags:
-    - Pancake
 
 - type: entity
   name: waffles

--- a/Resources/Prototypes/Stacks/consumable_stacks.yml
+++ b/Resources/Prototypes/Stacks/consumable_stacks.yml
@@ -4,6 +4,18 @@
   id: Pancake
   name: pancake
   spawn: FoodBakedPancake
+  maxCount: 9
+
+- type: stack
+  id: PancakeBb
+  name: blueberry pancake
+  spawn: FoodBakedPancakeBb
+  maxCount: 3
+
+- type: stack
+  id: PancakeCc
+  name: chocolate chip pancake
+  spawn: FoodBakedPancakeCc
   maxCount: 3
 
 # Food Containers


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
All different pancakes now has their own stack prototypes (fixes bug, look below for media)
default pancake stack size is increased from 3 to 9 (Stack sprites were in the game but they displayed the wrong number (for 3 pancakes there was a sprite with nine pancakes)) 
little cleaning and using parents in yml

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
this bug is more than one year old

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

### Before
https://github.com/user-attachments/assets/c8a64dca-7d08-4f34-96cd-069669df673a
### After
https://github.com/user-attachments/assets/0d8b9299-3878-44e5-b478-8bc1133e0722



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed pancakes stacks. Before it, splitting not default pancakes stacks would give you default pancakes.

