### PR TITLE
Add vox naming convention to Rules

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC13CharacterNames.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC13CharacterNames.xml
@@ -52,6 +52,14 @@
   - [color=#449944]Acceptable:[/color] Loxosceles Domesticus
   - [color=#994444]Bad:[/color] Spider-Man
 
+  Vox typically use a single name made of random syllables, often with repeating patterns.
+  Names should not be excessively long or be so repetitive/convoluted as to be unreadable.
+
+  - [color=#449944]Acceptable:[/color] Hirixashahre
+  - [color=#449944]Acceptable:[/color] Xapikrikrik
+  - [color=#994444]Bad:[/color] Chipikirchitchitchitbecretretrer
+  - [color=#994444]Bad:[/color] Trololol
+
   Usernames, objects, random characters, very "low effort" names, "meta" names, or otherwise implausible names are not permitted.
   - [color=#994444]Bad:[/color] XxRobustxX
   - [color=#994444]Bad:[/color] SDpksSodjdfk


### PR DESCRIPTION
## About the PR
I present for admin review the vox naming convention (that were also roughly used to generate the default namelist). After the initial feedback I made them shorter ~~even though this resulted in the tragic loss of deep vox lore about what syllables and vowels their language may use and which ones not, which I will now explain in 200 pages~~
