### PR TITLE
Fix borgs being unable to state laws or open other UIs without modules

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -165,10 +165,7 @@ namespace Content.Shared.Interaction
                 return;
             }
 
-            if (!uiComp.RequireHands)
-                return;
-
-            if (!_handsQuery.TryComp(ev.Actor, out var hands) || hands.Hands.Count == 0)
+            if (uiComp.RequireHands && !_handsQuery.HasComp(ev.Actor))
                 ev.Cancel();
         }
 


### PR DESCRIPTION
## About the PR
See title.
Please someone test this before merging to make sure I did not accidentally break something else.
Fixes #28582
Fixes #27439
Fixes #28306
Fixes #21145

## Why / Balance
bugfix

## Technical details
Borg have the HandsComponent, but if they have no active module their number of hands is zero. In other places where we use `ActivatableUIComponent.RequireHands` we only check for the hands component, not for the hands count. As far as I know, borgs are the only entity that have 0 hands, so this should not affect anything else.

## Media

https://github.com/user-attachments/assets/b29e13f6-38e8-4315-b060-794c545a66cc

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl:
- fix: Fixed borgs not being able to state laws or open other UIs without an active module.
