### PR TITLE
Add Identity Blocker to a Couple Things

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -63,6 +63,8 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/meson.rsi
   - type: EyeProtection
+  - type: IdentityBlocker
+    coverage: EYES
 
 - type: entity
   parent: ClothingEyesBase
@@ -194,6 +196,8 @@
   - type: FlashImmunity
   - type: EyeProtection
     protectionTime: 5
+  - type: IdentityBlocker
+    coverage: EYES
 
 #Make a scanner category when these actually function and we get the trayson
 - type: entity
@@ -211,6 +215,8 @@
       coefficients:
         Heat: 0.95
   - type: GroupExamine
+  - type: IdentityBlocker
+    coverage: EYES
 
 - type: entity
   parent: ClothingEyesBase
@@ -223,6 +229,8 @@
     - type: Clothing
       sprite: Clothing/Eyes/Glasses/science.rsi
     - type: SolutionScanner
+    - type: IdentityBlocker
+      coverage: EYES
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -155,6 +155,7 @@
       coefficients:
         Heat: 0.95
         Radiation: 0.65
+  - type: IdentityBlocker
   - type: BreathMask
   - type: HideLayerClothing
     slots:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds identity blocker to the ClothingHeadHatHoodRad and identity blocker eyes to:
- Thermal Scanners
- Engineering Goggles
- Chemical Analysis Goggles
- Mercenary Glasses
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
- Rad hood: It covers your entire face
- Thermals and Goggles: They cover more of your eyes than sunglasses (IIRC someone with more authority said engi goggles should)
- Merc: They are meant to just be sunglasses that look different
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
yml
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![Screenshot 2024-07-23 222116](https://github.com/user-attachments/assets/2e1d5991-2583-4f71-adfb-def91aecd5c7)
![Screenshot 2024-07-23 222133](https://github.com/user-attachments/assets/0c79b80e-eeab-478c-ad9a-3a344d1bc03e)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Engineering goggles and other similar-looking eyewear now help block identity.
- fix: Radiation suit's hood now blocks identity.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
