### PR TITLE
Makes the labeller automatically label PRs with shader changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,6 +12,10 @@
 - changed-files:
   - any-glob-to-any-file: '**/*.xaml*'
 
+"Changes: Shaders":
+- changed-files:
+  - any-glob-to-any-file: '**/*.swsl'
+
 "No C#":
 - changed-files:
   # Equiv to any-glob-to-all as long as this has one matcher. If ALL changed files are not C# files, then apply label.


### PR DESCRIPTION
## About the PR
This is a straight-forward PR: it makes the labeller label PRs with shader changes. This is incredibly useful for folks like us who have a fairly strong interest in reviewing shader code and other shader changes. It'll also make it incredibly easy to see what shader PRs were merged recently when figuring out which PR broke compatibility mode.

## Why / Balance
See above

## Technical details
If PR has swsl change: apply `Changes: Shaders` label to PR.

## Media
N/A

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

We're like 90% sure the labeller autocreates the necessary label

**Changelog**
No CL no fun