### PR TITLE
Fixed Borgs Having Infinite power untill State-change

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -281,10 +281,12 @@ public sealed partial class BorgSystem : SharedBorgSystem
     /// </summary>
     public void BorgActivate(EntityUid uid, BorgChassisComponent component)
     {
-        _powerCell.SetDrawEnabled(uid, true);
+
         Popup.PopupEntity(Loc.GetString("borg-mind-added", ("name", Identity.Name(uid, EntityManager))), uid);
         Toggle.TryActivate(uid);
         _appearance.SetData(uid, BorgVisuals.HasPlayer, true);
+        if ( _mind.TryGetMind(used, out _, out var mind))
+            _powerCell.SetDrawEnabled(uid, true);
     }
 
     /// <summary>

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -285,7 +285,7 @@ public sealed partial class BorgSystem : SharedBorgSystem
         Popup.PopupEntity(Loc.GetString("borg-mind-added", ("name", Identity.Name(uid, EntityManager))), uid);
         Toggle.TryActivate(uid);
         _appearance.SetData(uid, BorgVisuals.HasPlayer, true);
-        if ( _mind.TryGetMind(uid, out _, out var mind))
+        if (_mind.TryGetMind(uid, out _, out var mind))
             _powerCell.SetDrawEnabled(uid, true);
     }
 

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -285,7 +285,7 @@ public sealed partial class BorgSystem : SharedBorgSystem
         Popup.PopupEntity(Loc.GetString("borg-mind-added", ("name", Identity.Name(uid, EntityManager))), uid);
         Toggle.TryActivate(uid);
         _appearance.SetData(uid, BorgVisuals.HasPlayer, true);
-        if ( _mind.TryGetMind(used, out _, out var mind))
+        if ( _mind.TryGetMind(uid, out _, out var mind))
             _powerCell.SetDrawEnabled(uid, true);
     }
 

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -281,6 +281,7 @@ public sealed partial class BorgSystem : SharedBorgSystem
     /// </summary>
     public void BorgActivate(EntityUid uid, BorgChassisComponent component)
     {
+        _powerCell.SetDrawEnabled(uid, true);
         Popup.PopupEntity(Loc.GetString("borg-mind-added", ("name", Identity.Name(uid, EntityManager))), uid);
         Toggle.TryActivate(uid);
         _appearance.SetData(uid, BorgVisuals.HasPlayer, true);


### PR DESCRIPTION
## About the PR
Made sure Borgs Draw Power On Round start

## Why / Balance
Borgs Used to have Unlimted Power untill They got a diffrent Power_cell or got Knockeddown etc..
fixes #30179
fixes #30315
## Technical details
i add the line actevating powerdraf to the Function that triggers wehn  a bog activactes.

## Media
- [X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
:cl:
- fix: Fixed Cyborgs Having Infinite Power On Round start

