### PR TITLE
De-duplicate loadout gear

### DIFF
--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -43,6 +43,7 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
     [UISystemDependency] private readonly ClientInventorySystem _inventory = default!;
     [UISystemDependency] private readonly StationSpawningSystem _spawn = default!;
     [UISystemDependency] private readonly GuidebookSystem _guide = default!;
+    [UISystemDependency] private readonly LoadoutSystem _loadouts = default!;
 
     private CharacterSetupGui? _characterSetup;
     private HumanoidProfileEditor? _profileEditor;
@@ -364,7 +365,7 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
                 if (!_prototypeManager.TryIndex(loadout.Prototype, out var loadoutProto))
                     continue;
 
-                _spawn.EquipStartingGear(uid, _prototypeManager.Index(loadoutProto.Equipment));
+                _spawn.EquipStartingGear(uid, loadoutProto);
             }
         }
     }
@@ -387,36 +388,51 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
                     if (!_prototypeManager.TryIndex(loadout.Prototype, out var loadoutProto))
                         continue;
 
-                    // TODO: Need some way to apply starting gear to an entity coz holy fucking shit dude.
-                    var loadoutGear = _prototypeManager.Index(loadoutProto.Equipment);
-
+                    // TODO: Need some way to apply starting gear to an entity and replace existing stuff coz holy fucking shit dude.
                     foreach (var slot in slots)
                     {
-                        var itemType = loadoutGear.GetGear(slot.Name);
-
-                        if (_inventory.TryUnequip(dummy, slot.Name, out var unequippedItem, silent: true, force: true, reparent: false))
+                        // Try startinggear first
+                        if (_prototypeManager.TryIndex(loadoutProto.StartingGear, out var loadoutGear))
                         {
-                            EntityManager.DeleteEntity(unequippedItem.Value);
+                            var itemType = ((IEquipmentLoadout) loadoutGear).GetGear(slot.Name);
+
+                            if (_inventory.TryUnequip(dummy, slot.Name, out var unequippedItem, silent: true, force: true, reparent: false))
+                            {
+                                EntityManager.DeleteEntity(unequippedItem.Value);
+                            }
+
+                            if (itemType != string.Empty)
+                            {
+                                var item = EntityManager.SpawnEntity(itemType, MapCoordinates.Nullspace);
+                                _inventory.TryEquip(dummy, item, slot.Name, true, true);
+                            }
                         }
-
-                        if (itemType != string.Empty)
+                        else
                         {
-                            var item = EntityManager.SpawnEntity(itemType, MapCoordinates.Nullspace);
-                            _inventory.TryEquip(dummy, item, slot.Name, true, true);
+                            var itemType = ((IEquipmentLoadout) loadoutProto).GetGear(slot.Name);
+
+                            if (_inventory.TryUnequip(dummy, slot.Name, out var unequippedItem, silent: true, force: true, reparent: false))
+                            {
+                                EntityManager.DeleteEntity(unequippedItem.Value);
+                            }
+
+                            if (itemType != string.Empty)
+                            {
+                                var item = EntityManager.SpawnEntity(itemType, MapCoordinates.Nullspace);
+                                _inventory.TryEquip(dummy, item, slot.Name, true, true);
+                            }
                         }
                     }
                 }
             }
         }
 
-        if (job.StartingGear == null)
+        if (!_prototypeManager.TryIndex(job.StartingGear, out var gear))
             return;
-
-        var gear = _prototypeManager.Index<StartingGearPrototype>(job.StartingGear);
 
         foreach (var slot in slots)
         {
-            var itemType = gear.GetGear(slot.Name);
+            var itemType = ((IEquipmentLoadout) gear).GetGear(slot.Name);
 
             if (_inventory.TryUnequip(dummy, slot.Name, out var unequippedItem, silent: true, force: true, reparent: false))
             {

--- a/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
+++ b/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
@@ -19,10 +19,6 @@ public sealed class LoadoutTests
 
 - type: loadout
   id: TestJumpsuit
-  equipment: TestJumpsuit
-
-- type: startingGear
-  id: TestJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorGrey
 

--- a/Content.IntegrationTests/Tests/Roles/StartingGearStorageTests.cs
+++ b/Content.IntegrationTests/Tests/Roles/StartingGearStorageTests.cs
@@ -35,7 +35,7 @@ public sealed class StartingGearPrototypeStorageTest
         {
             foreach (var gearProto in protos)
             {
-                var backpackProto = gearProto.GetGear("back");
+                var backpackProto = ((IEquipmentLoadout) gearProto).GetGear("back");
                 if (backpackProto == string.Empty)
                     continue;
 

--- a/Content.Server/Administration/Commands/SetOutfitCommand.cs
+++ b/Content.Server/Administration/Commands/SetOutfitCommand.cs
@@ -97,11 +97,12 @@ namespace Content.Server.Administration.Commands
                 foreach (var slot in slots)
                 {
                     invSystem.TryUnequip(target, slot.Name, true, true, false, inventoryComponent);
-                    var gearStr = startingGear.GetGear(slot.Name);
+                    var gearStr = ((IEquipmentLoadout) startingGear).GetGear(slot.Name);
                     if (gearStr == string.Empty)
                     {
                         continue;
                     }
+
                     var equipmentEntity = entityManager.SpawnEntity(gearStr, entityManager.GetComponent<TransformComponent>(target).Coordinates);
                     if (slot.Name == "id" &&
                         entityManager.TryGetComponent(equipmentEntity, out PdaComponent? pdaComponent) &&

--- a/Content.Shared/Clothing/LoadoutSystem.cs
+++ b/Content.Shared/Clothing/LoadoutSystem.cs
@@ -45,7 +45,7 @@ public sealed class LoadoutSystem : EntitySystem
     /// </summary>
     public EntProtoId? GetFirstOrNull(LoadoutPrototype loadout)
     {
-        if (!_protoMan.TryIndex(loadout.Equipment, out var gear))
+        if (!_protoMan.TryIndex(loadout.StartingGear, out var gear))
             return null;
 
         var count = gear.Equipment.Count + gear.Inhand.Count + gear.Storage.Values.Sum(x => x.Count);
@@ -80,7 +80,7 @@ public sealed class LoadoutSystem : EntitySystem
     /// </summary>
     public string GetName(LoadoutPrototype loadout)
     {
-        if (!_protoMan.TryIndex(loadout.Equipment, out var gear))
+        if (!_protoMan.TryIndex(loadout.StartingGear, out var gear))
             return Loc.GetString("loadout-unknown");
 
         var count = gear.Equipment.Count + gear.Storage.Values.Sum(o => o.Count) + gear.Inhand.Count;
@@ -119,8 +119,7 @@ public sealed class LoadoutSystem : EntitySystem
         // Use starting gear if specified
         if (component.StartingGear != null)
         {
-            var gear = _protoMan.Index(_random.Pick(component.StartingGear));
-            _station.EquipStartingGear(uid, gear);
+            _station.EquipStartingGear(uid, _random.Pick(component.StartingGear));
             return;
         }
 

--- a/Content.Shared/Clothing/LoadoutSystem.cs
+++ b/Content.Shared/Clothing/LoadoutSystem.cs
@@ -40,12 +40,25 @@ public sealed class LoadoutSystem : EntitySystem
         return "Job" + loadout;
     }
 
+    public EntProtoId? GetFirstOrNull(LoadoutPrototype loadout)
+    {
+        EntProtoId? proto = null;
+
+        if (_protoMan.TryIndex(loadout.StartingGear, out var gear))
+        {
+            proto = GetFirstOrNull(gear);
+        }
+
+        proto ??= GetFirstOrNull((IEquipmentLoadout)loadout);
+        return proto;
+    }
+
     /// <summary>
     /// Tries to get the first entity prototype for operations such as sprite drawing.
     /// </summary>
-    public EntProtoId? GetFirstOrNull(LoadoutPrototype loadout)
+    public EntProtoId? GetFirstOrNull(IEquipmentLoadout? gear)
     {
-        if (!_protoMan.TryIndex(loadout.StartingGear, out var gear))
+        if (gear == null)
             return null;
 
         var count = gear.Equipment.Count + gear.Inhand.Count + gear.Storage.Values.Sum(x => x.Count);
@@ -75,13 +88,23 @@ public sealed class LoadoutSystem : EntitySystem
         return null;
     }
 
+    public string GetName(LoadoutPrototype loadout)
+    {
+        if (_protoMan.TryIndex(loadout.StartingGear, out var gear))
+        {
+            return GetName(gear);
+        }
+
+        return GetName((IEquipmentLoadout) loadout);
+    }
+
     /// <summary>
     /// Tries to get the name of a loadout.
     /// </summary>
-    public string GetName(LoadoutPrototype loadout)
+    public string GetName(IEquipmentLoadout? gear)
     {
-        if (!_protoMan.TryIndex(loadout.StartingGear, out var gear))
-            return Loc.GetString("loadout-unknown");
+        if (gear == null)
+            return string.Empty;
 
         var count = gear.Equipment.Count + gear.Storage.Values.Sum(o => o.Count) + gear.Inhand.Count;
 
@@ -111,7 +134,7 @@ public sealed class LoadoutSystem : EntitySystem
             }
         }
 
-        return Loc.GetString($"loadout-{loadout.ID}");
+        return Loc.GetString($"unknown");
     }
 
     private void OnMapInit(EntityUid uid, LoadoutComponent component, MapInitEvent args)

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -8,13 +8,17 @@ namespace Content.Shared.Preferences.Loadouts;
 /// Individual loadout item to be applied.
 /// </summary>
 [Prototype]
-public sealed partial class LoadoutPrototype : IPrototype
+public sealed partial class LoadoutPrototype : IPrototype, IEquipmentLoadout
 {
     [IdDataField]
     public string ID { get; } = string.Empty;
 
-    [DataField(required: true)]
-    public ProtoId<StartingGearPrototype> Equipment;
+    /*
+     * You can either use an existing StartingGearPrototype or specify it inline to avoid bloating yaml.
+     */
+
+    [DataField]
+    public ProtoId<StartingGearPrototype>? StartingGear;
 
     /// <summary>
     /// Effects to be applied when the loadout is applied.
@@ -22,4 +26,16 @@ public sealed partial class LoadoutPrototype : IPrototype
     /// </summary>
     [DataField]
     public List<LoadoutEffect> Effects = new();
+
+    /// <inheritdoc />
+    [DataField]
+    public Dictionary<string, EntProtoId> Equipment { get; set; } = new();
+
+    /// <inheritdoc />
+    [DataField]
+    public List<EntProtoId> Inhand { get; set; } = new();
+
+    /// <inheritdoc />
+    [DataField]
+    public Dictionary<string, List<EntProtoId>> Storage { get; set; } = new();
 }

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -87,8 +87,8 @@ namespace Content.Shared.Roles
         [DataField("antagAdvantage")]
         public int AntagAdvantage = 0;
 
-        [DataField("startingGear", customTypeSerializer: typeof(PrototypeIdSerializer<StartingGearPrototype>))]
-        public string? StartingGear { get; private set; }
+        [DataField]
+        public ProtoId<StartingGearPrototype>? StartingGear { get; private set; }
 
         /// <summary>
         /// Use this to spawn in as a non-humanoid (borg, test subject, etc.)

--- a/Content.Shared/Roles/StartingGearPrototype.cs
+++ b/Content.Shared/Roles/StartingGearPrototype.cs
@@ -21,14 +21,17 @@ public sealed partial class StartingGearPrototype : IPrototype, IInheritingProto
 
     /// <inheritdoc />
     [DataField]
+    [AlwaysPushInheritance]
     public Dictionary<string, EntProtoId> Equipment { get; set; } = new();
 
     /// <inheritdoc />
     [DataField]
+    [AlwaysPushInheritance]
     public List<EntProtoId> Inhand { get; set; } = new();
 
     /// <inheritdoc />
     [DataField]
+    [AlwaysPushInheritance]
     public Dictionary<string, List<EntProtoId>> Storage { get; set; } = new();
 }
 

--- a/Content.Shared/Roles/StartingGearPrototype.cs
+++ b/Content.Shared/Roles/StartingGearPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Shared.Roles;
 
 [Prototype]
-public sealed partial class StartingGearPrototype : IPrototype, IInheritingPrototype
+public sealed partial class StartingGearPrototype : IPrototype, IInheritingPrototype, IEquipmentLoadout
 {
     /// <inheritdoc/>
     [ViewVariables]
@@ -19,26 +19,38 @@ public sealed partial class StartingGearPrototype : IPrototype, IInheritingProto
     [AbstractDataField]
     public bool Abstract { get; }
 
+    /// <inheritdoc />
+    [DataField]
+    public Dictionary<string, EntProtoId> Equipment { get; set; } = new();
+
+    /// <inheritdoc />
+    [DataField]
+    public List<EntProtoId> Inhand { get; set; } = new();
+
+    /// <inheritdoc />
+    [DataField]
+    public Dictionary<string, List<EntProtoId>> Storage { get; set; } = new();
+}
+
+/// <summary>
+/// Specifies the starting entity prototypes and where to equip them for the specified class.
+/// </summary>
+public interface IEquipmentLoadout
+{
     /// <summary>
     /// The slot and entity prototype ID of the equipment that is to be spawned and equipped onto the entity.
     /// </summary>
-    [DataField]
-    [AlwaysPushInheritance]
-    public Dictionary<string, EntProtoId> Equipment = new();
+    public Dictionary<string, EntProtoId> Equipment { get; set; }
 
     /// <summary>
     /// The inhand items that are equipped when this starting gear is equipped onto an entity.
     /// </summary>
-    [DataField]
-    [AlwaysPushInheritance]
-    public List<EntProtoId> Inhand = new(0);
+    public List<EntProtoId> Inhand { get; set; }
 
     /// <summary>
     /// Inserts entities into the specified slot's storage (if it does have storage).
     /// </summary>
-    [DataField]
-    [AlwaysPushInheritance]
-    public Dictionary<string, List<EntProtoId>> Storage = new();
+    public Dictionary<string, List<EntProtoId>> Storage { get; set; }
 
     /// <summary>
     /// Gets the entity prototype ID of a slot in this starting gear.

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -66,7 +66,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
     public void EquipStartingGear(EntityUid entity, ProtoId<StartingGearPrototype>? startingGear, bool raiseEvent = true)
     {
         PrototypeManager.TryIndex(startingGear, out var gearProto);
-        EquipStartingGear(entity, gearProto);
+        EquipStartingGear(entity, gearProto, raiseEvent);
     }
 
     /// <summary>

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -49,16 +49,15 @@ public abstract class SharedStationSpawningSystem : EntitySystem
                     continue;
                 }
 
-                if (!PrototypeManager.TryIndex(loadoutProto.Equipment, out var startingGear))
-                {
-                    Log.Error($"Unable to find starting gear {loadoutProto.Equipment} for loadout {loadoutProto}");
-                    continue;
-                }
-
-                // Handle any extra data here.
-                EquipStartingGear(entity, startingGear, raiseEvent: false);
+                EquipStartingGear(entity, loadoutProto, raiseEvent: false);
             }
         }
+    }
+
+    public void EquipStartingGear(EntityUid entity, LoadoutPrototype loadout, bool raiseEvent = true)
+    {
+        EquipStartingGear(entity, loadout.StartingGear, raiseEvent);
+        EquipStartingGear(entity, (IEquipmentLoadout) loadout, raiseEvent);
     }
 
     /// <summary>
@@ -71,12 +70,20 @@ public abstract class SharedStationSpawningSystem : EntitySystem
     }
 
     /// <summary>
+    /// <see cref="EquipStartingGear(Robust.Shared.GameObjects.EntityUid,System.Nullable{Robust.Shared.Prototypes.ProtoId{Content.Shared.Roles.StartingGearPrototype}},bool)"/>
+    /// </summary>
+    public void EquipStartingGear(EntityUid entity, StartingGearPrototype? startingGear, bool raiseEvent = true)
+    {
+        EquipStartingGear(entity, (IEquipmentLoadout?) startingGear, raiseEvent);
+    }
+
+    /// <summary>
     /// Equips starting gear onto the given entity.
     /// </summary>
     /// <param name="entity">Entity to load out.</param>
     /// <param name="startingGear">Starting gear to use.</param>
     /// <param name="raiseEvent">Should we raise the event for equipped. Set to false if you will call this manually</param>
-    public void EquipStartingGear(EntityUid entity, StartingGearPrototype? startingGear, bool raiseEvent = true)
+    public void EquipStartingGear(EntityUid entity, IEquipmentLoadout? startingGear, bool raiseEvent = true)
     {
         if (startingGear == null)
             return;

--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/cargo_technician.yml
@@ -1,28 +1,16 @@
 # Head
 - type: loadout
   id: CargoTechnicianHead
-  equipment: CargoTechnicianHead
-
-- type: startingGear
-  id: CargoTechnicianHead
   equipment:
     head: ClothingHeadHatCargosoft
 
 # Jumpsuit
 - type: loadout
   id: CargoTechnicianJumpsuit
-  equipment: CargoTechnicianJumpsuit
-
-- type: startingGear
-  id: CargoTechnicianJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitCargo
 
 - type: loadout
-  id: CargoTechnicianJumpskirt
-  equipment: CargoTechnicianJumpskirt
-
-- type: startingGear
   id: CargoTechnicianJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtCargo
@@ -30,27 +18,15 @@
 # Back
 - type: loadout
   id: CargoTechnicianBackpack
-  equipment: CargoTechnicianBackpack
-
-- type: startingGear
-  id: CargoTechnicianBackpack
   equipment:
     back: ClothingBackpackCargo
 
 - type: loadout
   id: CargoTechnicianSatchel
-  equipment: CargoTechnicianSatchel
-
-- type: startingGear
-  id: CargoTechnicianSatchel
   equipment:
     back: ClothingBackpackSatchelCargo
 
 - type: loadout
-  id: CargoTechnicianDuffel
-  equipment: CargoTechnicianDuffel
-
-- type: startingGear
   id: CargoTechnicianDuffel
   equipment:
     back: ClothingBackpackDuffelCargo
@@ -58,19 +34,11 @@
 # OuterClothing
 - type: loadout
   id: CargoTechnicianWintercoat
-  equipment: CargoTechnicianWintercoat
-
-- type: startingGear
-  id: CargoTechnicianWintercoat
   equipment:
     outerClothing: ClothingOuterWinterCargo
 
 # Shoes
 - type: loadout
-  id: CargoWinterBoots
-  equipment: CargoWinterBoots
-
-- type: startingGear
   id: CargoWinterBoots
   equipment:
     shoes: ClothingShoesBootsWinterCargo

--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -1,45 +1,25 @@
 # Jumpsuit
 - type: loadout
   id: QuartermasterJumpsuit
-  equipment: QuartermasterJumpsuit
-
-- type: startingGear
-  id: QuartermasterJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitQM
 
 - type: loadout
-  id: QuartermasterJumpskirt
-  equipment: QuartermasterJumpskirt
-
-- type: startingGear
   id: QuartermasterJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtQM
 
 - type: loadout
   id: QuartermasterTurtleneck
-  equipment: QuartermasterTurtleneck
-
-- type: startingGear
-  id: QuartermasterTurtleneck
   equipment:
     jumpsuit: ClothingUniformJumpsuitQMTurtleneck
 
 - type: loadout
   id: QuartermasterTurtleneckSkirt
-  equipment: QuartermasterTurtleneckSkirt
-
-- type: startingGear
-  id: QuartermasterTurtleneckSkirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtQMTurtleneck
 
 - type: loadout
-  id: QuartermasterFormalSuit
-  equipment: QuartermasterFormalSuit
-
-- type: startingGear
   id: QuartermasterFormalSuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitQMFormal
@@ -47,18 +27,10 @@
 # Head
 - type: loadout
   id: QuartermasterHead
-  equipment: QuartermasterHead
-
-- type: startingGear
-  id: QuartermasterHead
   equipment:
     head: ClothingHeadHatQMsoft
 
 - type: loadout
-  id: QuartermasterBeret
-  equipment: QuartermasterBeret
-
-- type: startingGear
   id: QuartermasterBeret
   equipment:
     head: ClothingHeadHatBeretQM
@@ -66,28 +38,16 @@
 # Neck
 - type: loadout
   id: QuartermasterCloak
-  equipment: QuartermasterCloak
-
-- type: startingGear
-  id: QuartermasterCloak
   equipment:
     neck: ClothingNeckCloakQm
 
 - type: loadout
-  id: QuartermasterMantle
-  equipment: QuartermasterMantle
-
-- type: startingGear
   id: QuartermasterMantle
   equipment:
     neck: ClothingNeckMantleQM
 
 # OuterClothing
 - type: loadout
-  id: QuartermasterWintercoat
-  equipment: QuartermasterWintercoat
-
-- type: startingGear
   id: QuartermasterWintercoat
   equipment:
     outerClothing: ClothingOuterWinterQM

--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/salvage_specialist.yml
@@ -1,27 +1,15 @@
 # Back
 - type: loadout
   id: SalvageSpecialistBackpack
-  equipment: SalvageSpecialistBackpack
-
-- type: startingGear
-  id: SalvageSpecialistBackpack
   equipment:
     back: ClothingBackpackSalvage
 
 - type: loadout
   id: SalvageSpecialistSatchel
-  equipment: SalvageSpecialistSatchel
-
-- type: startingGear
-  id: SalvageSpecialistSatchel
   equipment:
     back: ClothingBackpackSatchelSalvage
 
 - type: loadout
-  id: SalvageSpecialistDuffel
-  equipment: SalvageSpecialistDuffel
-
-- type: startingGear
   id: SalvageSpecialistDuffel
   equipment:
     back: ClothingBackpackDuffelSalvage
@@ -29,19 +17,11 @@
 # OuterClothing
 - type: loadout
   id: SalvageSpecialistWintercoat
-  equipment: SalvageSpecialistWintercoat
-
-- type: startingGear
-  id: SalvageSpecialistWintercoat
   equipment:
     outerClothing: ClothingOuterWinterMiner
 
 # Shoes
 - type: loadout
-  id: SalvageBoots
-  equipment: SalvageBoots
-
-- type: startingGear
   id: SalvageBoots
   equipment:
     shoes: ClothingShoesBootsSalvage

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
@@ -1,18 +1,10 @@
 # Head
 - type: loadout
   id: BartenderHead
-  equipment: BartenderHead
-
-- type: startingGear
-  id: BartenderHead
   equipment:
     head: ClothingHeadHatTophat
 
 - type: loadout
-  id: BartenderBowler
-  equipment: BartenderBowler
-
-- type: startingGear
   id: BartenderBowler
   equipment:
     head: ClothingHeadHatBowlerHat
@@ -20,27 +12,15 @@
 # Jumpsuit
 - type: loadout
   id: BartenderJumpsuit
-  equipment: BartenderJumpsuit
-
-- type: startingGear
-  id: BartenderJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitBartender
 
 - type: loadout
   id: BartenderJumpskirt
-  equipment: BartenderJumpskirt
-
-- type: startingGear
-  id: BartenderJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtBartender
 
 - type: loadout
-  id: BartenderJumpsuitPurple
-  equipment: BartenderJumpsuitPurple
-
-- type: startingGear
   id: BartenderJumpsuitPurple
   equipment:
     jumpsuit: ClothingUniformJumpsuitBartenderPurple
@@ -48,27 +28,15 @@
 # Outer clothing
 - type: loadout
   id: BartenderApron
-  equipment: BartenderApron
-
-- type: startingGear
-  id: BartenderApron
   equipment:
     outerClothing: ClothingOuterApronBar
 
 - type: loadout
   id: BartenderVest
-  equipment: BartenderVest
-
-- type: startingGear
-  id: BartenderVest
   equipment:
     outerClothing: ClothingOuterVest
 
 - type: loadout
-  id: BartenderWintercoat
-  equipment: BartenderWintercoat
-
-- type: startingGear
   id: BartenderWintercoat
   equipment:
     outerClothing: ClothingOuterWinterBar

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/botanist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/botanist.yml
@@ -1,18 +1,10 @@
 # Head
 - type: loadout
   id: BotanistHead
-  equipment: BotanistHead
-
-- type: startingGear
-  id: BotanistHead
   equipment:
     head: ClothingHeadHatTrucker
 
 - type: loadout
-  id: BotanistBandana
-  equipment: BotanistBandana
-
-- type: startingGear
   id: BotanistBandana
   equipment:
     head: ClothingHeadBandBotany
@@ -20,27 +12,15 @@
 # Jumpsuit
 - type: loadout
   id: BotanistJumpsuit
-  equipment: BotanistJumpsuit
-
-- type: startingGear
-  id: BotanistJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitHydroponics
 
 - type: loadout
   id: BotanistJumpskirt
-  equipment: BotanistJumpskirt
-
-- type: startingGear
-  id: BotanistJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtHydroponics
 
 - type: loadout
-  id: BotanistOveralls
-  equipment: BotanistOveralls
-
-- type: startingGear
   id: BotanistOveralls
   equipment:
     jumpsuit: ClothingUniformOveralls
@@ -48,27 +28,15 @@
 # Back
 - type: loadout
   id: BotanistBackpack
-  equipment: BotanistBackpack
-
-- type: startingGear
-  id: BotanistBackpack
   equipment:
     back: ClothingBackpackHydroponics
 
 - type: loadout
   id: BotanistSatchel
-  equipment: BotanistSatchel
-
-- type: startingGear
-  id: BotanistSatchel
   equipment:
     back: ClothingBackpackSatchelHydroponics
 
 - type: loadout
-  id: BotanistDuffel
-  equipment: BotanistDuffel
-
-- type: startingGear
   id: BotanistDuffel
   equipment:
     back: ClothingBackpackDuffelHydroponics
@@ -76,18 +44,10 @@
 # Outer clothing
 - type: loadout
   id: BotanistApron
-  equipment: BotanistApron
-
-- type: startingGear
-  id: BotanistApron
   equipment:
     outerClothing: ClothingOuterApronBotanist
 
 - type: loadout
-  id: BotanistWintercoat
-  equipment: BotanistWintercoat
-
-- type: startingGear
   id: BotanistWintercoat
   equipment:
     outerClothing: ClothingOuterWinterHydro

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/chaplain.yml
@@ -1,45 +1,25 @@
 # Head
 - type: loadout
   id: ChaplainHead
-  equipment: ChaplainHead
-
-- type: startingGear
-  id: ChaplainHead
   equipment:
     head: ClothingHeadHatFez
 
 - type: loadout
-  id: ChaplainNunHood
-  equipment: ChaplainNunHood
-
-- type: startingGear
   id: ChaplainNunHood
   equipment:
     head: ClothingHeadHatHoodNunHood
 
 - type: loadout
   id: ChaplainPlagueHat
-  equipment: ChaplainPlagueHat
-
-- type: startingGear
-  id: ChaplainPlagueHat
   equipment:
     head: ClothingHeadHatPlaguedoctor
 
 - type: loadout
   id: ChaplainWitchHat
-  equipment: ChaplainWitchHat
-
-- type: startingGear
-  id: ChaplainWitchHat
   equipment:
     head: ClothingHeadHatWitch
 
 - type: loadout
-  id: ChaplainWitchHatAlt
-  equipment: ChaplainWitchHatAlt
-
-- type: startingGear
   id: ChaplainWitchHatAlt
   equipment:
     head: ClothingHeadHatWitch1
@@ -47,46 +27,26 @@
 # Mask
 - type: loadout
   id: ChaplainMask
-  equipment: ChaplainMask
-
-- type: startingGear
-  id: ChaplainMask
   equipment:
     mask: ClothingMaskPlague
 
 # Jumpsuit
 - type: loadout
   id: ChaplainJumpsuit
-  equipment: ChaplainJumpsuit
-
-- type: startingGear
-  id: ChaplainJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitChaplain
 
 - type: loadout
-  id: ChaplainJumpskirt
-  equipment: ChaplainJumpskirt
-
-- type: startingGear
   id: ChaplainJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtChaplain
 
 - type: loadout
   id: ChaplainRobesDark
-  equipment: ChaplainRobesDark
-
-- type: startingGear
-  id: ChaplainRobesDark
   equipment:
     jumpsuit: ClothingUniformJumpsuitMonasticRobeDark
 
 - type: loadout
-  id: ChaplainRobesLight
-  equipment: ChaplainRobesLight
-
-- type: startingGear
   id: ChaplainRobesLight
   equipment:
     jumpsuit: ClothingUniformJumpsuitMonasticRobeLight
@@ -94,46 +54,26 @@
 # Neck
 - type: loadout
   id: ChaplainNeck
-  equipment: ChaplainNeck
-
-- type: startingGear
-  id: ChaplainNeck
   equipment:
     neck: ClothingNeckStoleChaplain
 
 # Outer clothing
 - type: loadout
   id: ChaplainPlagueSuit
-  equipment: ChaplainPlagueSuit
-
-- type: startingGear
-  id: ChaplainPlagueSuit
   equipment:
     outerClothing: ClothingOuterPlagueSuit
 
 - type: loadout
-  id: ChaplainNunRobe
-  equipment: ChaplainNunRobe
-
-- type: startingGear
   id: ChaplainNunRobe
   equipment:
     outerClothing: ClothingOuterNunRobe
 
 - type: loadout
   id: ChaplainBlackHoodie
-  equipment: ChaplainBlackHoodie
-
-- type: startingGear
-  id: ChaplainBlackHoodie
   equipment:
     outerClothing: ClothingOuterHoodieBlack
 
 - type: loadout
-  id: ChaplainHoodie
-  equipment: ChaplainHoodie
-
-- type: startingGear
   id: ChaplainHoodie
   equipment:
     outerClothing: ClothingOuterHoodieChaplain

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/chef.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/chef.yml
@@ -1,19 +1,11 @@
 # Head
 - type: loadout
   id: ChefHead
-  equipment: ChefHead
-
-- type: startingGear
-  id: ChefHead
   equipment:
     head: ClothingHeadHatChef
 
 # Mask
 - type: loadout
-  id: ChefMask
-  equipment: ChefMask
-
-- type: startingGear
   id: ChefMask
   equipment:
     mask: ClothingMaskItalianMoustache
@@ -21,18 +13,10 @@
 # Jumpsuit
 - type: loadout
   id: ChefJumpsuit
-  equipment: ChefJumpsuit
-
-- type: startingGear
-  id: ChefJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitChef
 
 - type: loadout
-  id: ChefJumpskirt
-  equipment: ChefJumpskirt
-
-- type: startingGear
   id: ChefJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtChef
@@ -40,27 +24,15 @@
 # Outer clothing
 - type: loadout
   id: ChefApron
-  equipment: ChefApron
-
-- type: startingGear
-  id: ChefApron
   equipment:
     outerClothing: ClothingOuterApronChef
 
 - type: loadout
   id: ChefJacket
-  equipment: ChefJacket
-
-- type: startingGear
-  id: ChefJacket
   equipment:
     outerClothing: ClothingOuterJacketChef
 
 - type: loadout
-  id: ChefWintercoat
-  equipment: ChefWintercoat
-
-- type: startingGear
   id: ChefWintercoat
   equipment:
     outerClothing: ClothingOuterWinterChef

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/clown.yml
@@ -1,28 +1,16 @@
 # Head
 - type: loadout
   id: JesterHat
-  equipment: JesterHat
-
-- type: startingGear
-  id: JesterHat
   equipment:
     head: ClothingHeadHatJesterAlt
 
 # Jumpsuit
 - type: loadout
   id: ClownSuit
-  equipment: ClownSuit
-
-- type: startingGear
-  id: ClownSuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitClown
 
 - type: loadout
-  id: JesterSuit
-  equipment: JesterSuit
-
-- type: startingGear
   id: JesterSuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitJesterAlt
@@ -30,27 +18,15 @@
 # Back
 - type: loadout
   id: ClownBackpack
-  equipment: ClownBackpack
-
-- type: startingGear
-  id: ClownBackpack
   equipment:
     back: ClothingBackpackClown
 
 - type: loadout
   id: ClownSatchel
-  equipment: ClownSatchel
-
-- type: startingGear
-  id: ClownSatchel
   equipment:
     back: ClothingBackpackSatchelClown
 
 - type: loadout
-  id: ClownDuffel
-  equipment: ClownDuffel
-
-- type: startingGear
   id: ClownDuffel
   equipment:
     back: ClothingBackpackDuffelClown
@@ -58,18 +34,10 @@
 # Shoes
 - type: loadout
   id: ClownShoes
-  equipment: ClownShoes
-
-- type: startingGear
-  id: ClownShoes
   equipment:
     shoes: ClothingShoesClown
 
 - type: loadout
-  id: JesterShoes
-  equipment: JesterShoes
-
-- type: startingGear
   id: JesterShoes
   equipment:
     shoes: ClothingShoesJester
@@ -77,18 +45,10 @@
 # Outer clothing
 - type: loadout
   id: ClownRobes
-  equipment: ClownRobes
-
-- type: startingGear
-  id: ClownRobes
   equipment:
     outerClothing: ClothingOuterClownPriest
 
 - type: loadout
-  id: ClownWintercoat
-  equipment: ClownWintercoat
-
-- type: startingGear
   id: ClownWintercoat
   equipment:
     outerClothing: ClothingOuterWinterClown

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -49,13 +49,9 @@
 # Misc
 - type: loadout
   id: JanitorGoldenPlunger
-  equipment: JanitorGoldenPlunger
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorJanitorial
-
-- type: startingGear
-  id: JanitorGoldenPlunger
   storage:
     back:
     - GoldenPlunger

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -10,28 +10,16 @@
 # Head
 - type: loadout
   id: JanitorHead
-  equipment: JanitorHead
-
-- type: startingGear
-  id: JanitorHead
   equipment:
     head: ClothingHeadHatPurplesoft
 
 # Jumpsuit
 - type: loadout
   id: JanitorJumpsuit
-  equipment: JanitorJumpsuit
-
-- type: startingGear
-  id: JanitorJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitJanitor
 
 - type: loadout
-  id: JanitorJumpskirt
-  equipment: JanitorJumpskirt
-
-- type: startingGear
   id: JanitorJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtJanitor
@@ -39,37 +27,21 @@
 # Gloves
 - type: loadout
   id: JanitorRubberGloves
-  equipment: JanitorRubberGloves
-
-- type: startingGear
-  id: JanitorRubberGloves
   equipment:
     gloves: ClothingHandsGlovesJanitor
 
 - type: loadout
-  id: OrangeGloves
-  equipment: OrangeGloves
-
-- type: startingGear
   id: OrangeGloves
   equipment:
     gloves: ClothingHandsGlovesColorOrange
 
 - type: loadout
   id: PurpleGloves
-  equipment: PurpleGloves
-
-- type: startingGear
-  id: PurpleGloves
   equipment:
     gloves: ClothingHandsGlovesColorPurple
 
 # Outer clothing
 - type: loadout
-  id: JanitorWintercoat
-  equipment: JanitorWintercoat
-
-- type: startingGear
   id: JanitorWintercoat
   equipment:
     outerClothing: ClothingOuterWinterJani

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/lawyer.yml
@@ -1,100 +1,56 @@
 # Jumpsuit
 - type: loadout
   id: LawyerJumpsuit
-  equipment: LawyerJumpsuit
-
-- type: startingGear
-  id: LawyerJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitLawyerBlack
 
 - type: loadout
-  id: LawyerJumpskirt
-  equipment: LawyerJumpskirt
-
-- type: startingGear
   id: LawyerJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtLawyerBlack
 
 - type: loadout
   id: LawyerJumpsuitBlue
-  equipment: LawyerJumpsuitBlue
-
-- type: startingGear
-  id: LawyerJumpsuitBlue
   equipment:
     jumpsuit: ClothingUniformJumpsuitLawyerBlue
 
 - type: loadout
-  id: LawyerJumpskirtBlue
-  equipment: LawyerJumpskirtBlue
-
-- type: startingGear
   id: LawyerJumpskirtBlue
   equipment:
     jumpsuit: ClothingUniformJumpskirtLawyerBlue
 
 - type: loadout
   id: LawyerJumpsuitPurple
-  equipment: LawyerJumpsuitPurple
-
-- type: startingGear
-  id: LawyerJumpsuitPurple
   equipment:
     jumpsuit: ClothingUniformJumpsuitLawyerPurple
 
 - type: loadout
-  id: LawyerJumpskirtPurple
-  equipment: LawyerJumpskirtPurple
-
-- type: startingGear
   id: LawyerJumpskirtPurple
   equipment:
     jumpsuit: ClothingUniformJumpskirtLawyerPurple
 
 - type: loadout
   id: LawyerJumpsuitRed
-  equipment: LawyerJumpsuitRed
-
-- type: startingGear
-  id: LawyerJumpsuitRed
   equipment:
     jumpsuit: ClothingUniformJumpsuitLawyerRed
 
 - type: loadout
-  id: LawyerJumpskirtRed
-  equipment: LawyerJumpskirtRed
-
-- type: startingGear
   id: LawyerJumpskirtRed
   equipment:
     jumpsuit: ClothingUniformJumpskirtLawyerRed
 
 - type: loadout
   id: LawyerJumpsuitGood
-  equipment: LawyerJumpsuitGood
-
-- type: startingGear
-  id: LawyerJumpsuitGood
   equipment:
     jumpsuit: ClothingUniformJumpsuitLawyerGood
 
 - type: loadout
-  id: LawyerJumpskirtGood
-  equipment: LawyerJumpskirtGood
-
-- type: startingGear
   id: LawyerJumpskirtGood
   equipment:
     jumpsuit: ClothingUniformJumpskirtLawyerGood
 
 # Neck
 - type: loadout
-  id: LawyerNeck
-  equipment: LawyerNeck
-
-- type: startingGear
   id: LawyerNeck
   equipment:
     neck: ClothingNeckLawyerbadge

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/librarian.yml
@@ -1,36 +1,20 @@
 # Jumpsuit
 - type: loadout
   id: LibrarianJumpsuit
-  equipment: LibrarianJumpsuit
-
-- type: startingGear
-  id: LibrarianJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitLibrarian
 
 - type: loadout
-  id: LibrarianJumpskirt
-  equipment: LibrarianJumpskirt
-
-- type: startingGear
   id: LibrarianJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtLibrarian
 
 - type: loadout
   id: CuratorJumpsuit
-  equipment: CuratorJumpsuit
-
-- type: startingGear
-  id: CuratorJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitCurator
 
 - type: loadout
-  id: CuratorJumpskirt
-  equipment: CuratorJumpskirt
-
-- type: startingGear
   id: CuratorJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtCurator

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/mime.yml
@@ -1,27 +1,15 @@
 # Head
 - type: loadout
   id: MimeHead
-  equipment: MimeHead
-
-- type: startingGear
-  id: MimeHead
   equipment:
     head: ClothingHeadHatBeret
 
 - type: loadout
   id: MimeFrenchBeret
-  equipment: MimeFrenchBeret
-
-- type: startingGear
-  id: MimeFrenchBeret
   equipment:
     head: ClothingHeadHatBeretFrench
 
 - type: loadout
-  id: MimeCap
-  equipment: MimeCap
-
-- type: startingGear
   id: MimeCap
   equipment:
     head: ClothingHeadHatMimesoft
@@ -29,27 +17,15 @@
 # Mask
 - type: loadout
   id: MimeMask
-  equipment: MimeMask
-
-- type: startingGear
-  id: MimeMask
   equipment:
     mask: ClothingMaskMime
 
 - type: loadout
   id: MimeMaskSad
-  equipment: MimeMaskSad
-
-- type: startingGear
-  id: MimeMaskSad
   equipment:
     mask: ClothingMaskSadMime
 
 - type: loadout
-  id: MimeMaskScared
-  equipment: MimeMaskScared
-
-- type: startingGear
   id: MimeMaskScared
   equipment:
     mask: ClothingMaskScaredMime
@@ -57,18 +33,10 @@
 # Jumpsuit
 - type: loadout
   id: MimeJumpsuit
-  equipment: MimeJumpsuit
-
-- type: startingGear
-  id: MimeJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitMime
 
 - type: loadout
-  id: MimeJumpskirt
-  equipment: MimeJumpskirt
-
-- type: startingGear
   id: MimeJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtMime
@@ -76,37 +44,21 @@
 # Back
 - type: loadout
   id: MimeBackpack
-  equipment: MimeBackpack
-
-- type: startingGear
-  id: MimeBackpack
   equipment:
     back: ClothingBackpackMime
 
 - type: loadout
-  id: MimeSatchel
-  equipment: MimeSatchel
-
-- type: startingGear
   id: MimeSatchel
   equipment:
     back: ClothingBackpackSatchelMime
 
 - type: loadout
   id: MimeDuffel
-  equipment: MimeDuffel
-
-- type: startingGear
-  id: MimeDuffel
   equipment:
     back: ClothingBackpackDuffelMime
 
 # Outerclothing
 - type: loadout
-  id: MimeWintercoat
-  equipment: MimeWintercoat
-
-- type: startingGear
   id: MimeWintercoat
   equipment:
     outerClothing: ClothingOuterWinterMime

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/musician.yml
@@ -1,28 +1,16 @@
 # Jumpsuit
 - type: loadout
   id: MusicianJumpsuit
-  equipment: MusicianJumpsuit
-
-- type: startingGear
-  id: MusicianJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitMusician
 
 - type: loadout
-  id: MusicianJumpskirt
-  equipment: MusicianJumpskirt
-
-- type: startingGear
   id: MusicianJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtMusician
 
 # Outerclothing
 - type: loadout
-  id: MusicianWintercoat
-  equipment: MusicianWintercoat
-
-- type: startingGear
   id: MusicianWintercoat
   equipment:
     outerClothing: ClothingOuterWinterMusician

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -25,18 +25,10 @@
 # Grey
 - type: loadout
   id: GreyJumpsuit
-  equipment: GreyJumpsuit
-
-- type: startingGear
-  id: GreyJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorGrey
 
 - type: loadout
-  id: GreyJumpskirt
-  equipment: GreyJumpskirt
-
-- type: startingGear
   id: GreyJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorGrey
@@ -70,27 +62,15 @@
 # Back
 - type: loadout
   id: CommonBackpack
-  equipment: CommonBackpack
-
-- type: startingGear
-  id: CommonBackpack
   equipment:
     back: ClothingBackpack
 
 - type: loadout
   id: CommonSatchel
-  equipment: CommonSatchel
-
-- type: startingGear
-  id: CommonSatchel
   equipment:
     back: ClothingBackpackSatchel
 
 - type: loadout
-  id: CommonDuffel
-  equipment: CommonDuffel
-
-- type: startingGear
   id: CommonDuffel
   equipment:
     back: ClothingBackpackDuffel
@@ -111,28 +91,16 @@
 # Outerclothing
 - type: loadout
   id: PassengerWintercoat
-  equipment: PassengerWintercoat
-
-- type: startingGear
-  id: PassengerWintercoat
   equipment:
     outerClothing: ClothingOuterWinterCoat
 
 # Shoes
 - type: loadout
   id: BlackShoes
-  equipment: BlackShoes
-
-- type: startingGear
-  id: BlackShoes
   equipment:
     shoes: ClothingShoesColorBlack
 
 - type: loadout
-  id: WinterBoots
-  equipment: WinterBoots
-
-- type: startingGear
   id: WinterBoots
   equipment:
     shoes: ClothingShoesBootsWinter

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -11,13 +11,9 @@
 # Face
 - type: loadout
   id: PassengerFace
-  equipment: GasMask
   effects:
   - !type:GroupLoadoutEffect
     proto: GreyTider
-
-- type: startingGear
-  id: GasMask
   equipment:
     mask: ClothingMaskGas
 
@@ -36,26 +32,18 @@
 # Rainbow
 - type: loadout
   id: RainbowJumpsuit
-  equipment: RainbowJumpsuit
   effects:
   - !type:GroupLoadoutEffect
     proto: GreyTider
-
-- type: startingGear
-  id: RainbowJumpsuit
   equipment:
     jumpsuit: ClothingUniformColorRainbow
 
 # Ancient
 - type: loadout
   id: AncientJumpsuit
-  equipment: AncientJumpsuit
   effects:
   - !type:GroupLoadoutEffect
     proto: GreyTider
-
-- type: startingGear
-  id: AncientJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitAncient
 
@@ -78,13 +66,9 @@
 # Gloves
 - type: loadout
   id: PassengerGloves
-  equipment: FingerlessInsulatedGloves
   effects:
   - !type:GroupLoadoutEffect
     proto: GreyTider
-
-- type: startingGear
-  id: FingerlessInsulatedGloves
   equipment:
     gloves: ClothingHandsGlovesFingerlessInsulated
 

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -1,36 +1,20 @@
 # Jumpsuit
 - type: loadout
   id: CaptainJumpsuit
-  equipment: CaptainJumpsuit
-
-- type: startingGear
-  id: CaptainJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitCaptain
 
 - type: loadout
-  id: CaptainJumpskirt
-  equipment: CaptainJumpskirt
-
-- type: startingGear
   id: CaptainJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtCaptain
 
 - type: loadout
   id: CaptainFormalSuit
-  equipment: CaptainFormalSuit
-
-- type: startingGear
-  id: CaptainFormalSuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitCapFormal
 
 - type: loadout
-  id: CaptainFormalSkirt
-  equipment: CaptainFormalSkirt
-
-- type: startingGear
   id: CaptainFormalSkirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtCapFormalDress
@@ -38,18 +22,10 @@
 # Head
 - type: loadout
   id: CaptainHead
-  equipment: CaptainHead
-
-- type: startingGear
-  id: CaptainHead
   equipment:
     head: ClothingHeadHatCaptain
 
 - type: loadout
-  id: CaptainCap
-  equipment: CaptainCap
-
-- type: startingGear
   id: CaptainCap
   equipment:
     head: ClothingHeadHatCapcap
@@ -57,27 +33,15 @@
 # Neck
 - type: loadout
   id: CaptainCloak
-  equipment: CaptainCloak
-
-- type: startingGear
-  id: CaptainCloak
   equipment:
     neck: ClothingNeckCloakCap
-  
-- type: loadout
-  id: CaptainCloakFormal
-  equipment: CaptainCloakFormal
 
-- type: startingGear
+- type: loadout
   id: CaptainCloakFormal
   equipment:
     neck: ClothingNeckCloakCapFormal
 
 - type: loadout
-  id: CaptainMantle
-  equipment: CaptainMantle
-
-- type: startingGear
   id: CaptainMantle
   equipment:
     neck: ClothingNeckMantleCap
@@ -85,27 +49,15 @@
 # Back
 - type: loadout
   id: CaptainBackpack
-  equipment: CaptainBackpack
-
-- type: startingGear
-  id: CaptainBackpack
   equipment:
     back: ClothingBackpackCaptain
 
 - type: loadout
   id: CaptainSatchel
-  equipment: CaptainSatchel
-
-- type: startingGear
-  id: CaptainSatchel
   equipment:
     back: ClothingBackpackSatchelCaptain
 
 - type: loadout
-  id: CaptainDuffel
-  equipment: CaptainDuffel
-
-- type: startingGear
   id: CaptainDuffel
   equipment:
     back: ClothingBackpackDuffelCaptain
@@ -113,18 +65,10 @@
 # Outer clothing
 - type: loadout
   id: CaptainOuterClothing
-  equipment: CaptainOuterClothing
-
-- type: startingGear
-  id: CaptainOuterClothing
   equipment:
     outerClothing: ClothingOuterArmorCaptainCarapace
 
 - type: loadout
-  id: CaptainWintercoat
-  equipment: CaptainWintercoat
-
-- type: startingGear
   id: CaptainWintercoat
   equipment:
     outerClothing: ClothingOuterWinterCap

--- a/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -39,13 +39,9 @@
 # Back
 - type: loadout
   id: HoPBackpackIan
-  equipment: HoPBackpackIan
   effects:
   - !type:GroupLoadoutEffect
     proto: ProfessionalHoP
-
-- type: startingGear
-  id: HoPBackpackIan
   equipment:
     back: ClothingBackpackIan
 

--- a/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -11,18 +11,10 @@
 # Jumpsuit
 - type: loadout
   id: HoPJumpsuit
-  equipment: HoPJumpsuit
-
-- type: startingGear
-  id: HoPJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitHoP
 
 - type: loadout
-  id: HoPJumpskirt
-  equipment: HoPJumpskirt
-
-- type: startingGear
   id: HoPJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtHoP
@@ -30,28 +22,16 @@
 # Head
 - type: loadout
   id: HoPHead
-  equipment: HoPHead
-
-- type: startingGear
-  id: HoPHead
   equipment:
     head: ClothingHeadHatHopcap
 
 # Neck
 - type: loadout
   id: HoPCloak
-  equipment: HoPCloak
-
-- type: startingGear
-  id: HoPCloak
   equipment:
     neck: ClothingNeckCloakHop
 
 - type: loadout
-  id: HoPMantle
-  equipment: HoPMantle
-
-- type: startingGear
   id: HoPMantle
   equipment:
     neck: ClothingNeckMantleHOP
@@ -71,10 +51,6 @@
 
 # Outerclothing
 - type: loadout
-  id: HoPWintercoat
-  equipment: HoPWintercoat
-
-- type: startingGear
   id: HoPWintercoat
   equipment:
     outerClothing: ClothingOuterWinterHoP

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/atmospheric_technician.yml
@@ -1,27 +1,15 @@
 # Jumpsuit
 - type: loadout
   id: AtmosphericTechnicianJumpsuit
-  equipment: AtmosphericTechnicianJumpsuit
-
-- type: startingGear
-  id: AtmosphericTechnicianJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitAtmos
 
 - type: loadout
   id: AtmosphericTechnicianJumpskirt
-  equipment: AtmosphericTechnicianJumpskirt
-
-- type: startingGear
-  id: AtmosphericTechnicianJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtAtmos
 
 - type: loadout
-  id: AtmosphericTechnicianJumpsuitCasual
-  equipment: AtmosphericTechnicianJumpsuitCasual
-
-- type: startingGear
   id: AtmosphericTechnicianJumpsuitCasual
   equipment:
     jumpsuit: ClothingUniformJumpsuitAtmosCasual
@@ -29,27 +17,15 @@
 # Back
 - type: loadout
   id: AtmosphericTechnicianBackpack
-  equipment: AtmosphericTechnicianBackpack
-
-- type: startingGear
-  id: AtmosphericTechnicianBackpack
   equipment:
     back: ClothingBackpackAtmospherics
 
 - type: loadout
   id: AtmosphericTechnicianSatchel
-  equipment: AtmosphericTechnicianSatchel
-
-- type: startingGear
-  id: AtmosphericTechnicianSatchel
   equipment:
     back: ClothingBackpackSatchelAtmospherics
 
 - type: loadout
-  id: AtmosphericTechnicianDuffel
-  equipment: AtmosphericTechnicianDuffel
-
-- type: startingGear
   id: AtmosphericTechnicianDuffel
   equipment:
     back: ClothingBackpackDuffelAtmospherics
@@ -57,19 +33,11 @@
 # OuterClothing
 - type: loadout
   id: AtmosphericTechnicianWintercoat
-  equipment: AtmosphericTechnicianWintercoat
-
-- type: startingGear
-  id: AtmosphericTechnicianWintercoat
   equipment:
     outerClothing: ClothingOuterWinterAtmos
 
 # Shoes
 - type: loadout
-  id: WhiteShoes
-  equipment: WhiteShoes
-
-- type: startingGear
   id: WhiteShoes
   equipment:
     shoes: ClothingShoesColorWhite

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
@@ -1,46 +1,26 @@
 # Jumpsuit
 - type: loadout
   id: ChiefEngineerJumpsuit
-  equipment: ChiefEngineerJumpsuit
-
-- type: startingGear
-  id: ChiefEngineerJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitChiefEngineer
 
 - type: loadout
-  id: ChiefEngineerJumpskirt
-  equipment: ChiefEngineerJumpskirt
-
-- type: startingGear
   id: ChiefEngineerJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtChiefEngineer
 
 - type: loadout
   id: ChiefEngineerTurtleneck
-  equipment: ChiefEngineerTurtleneck
-
-- type: startingGear
-  id: ChiefEngineerTurtleneck
   equipment:
     jumpsuit: ClothingUniformJumpsuitChiefEngineerTurtle
 
 - type: loadout
-  id: ChiefEngineerTurtleneckSkirt
-  equipment: ChiefEngineerTurtleneckSkirt
-
-- type: startingGear
   id: ChiefEngineerTurtleneckSkirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtChiefEngineerTurtle
 
 # Head
 - type: loadout
-  id: ChiefEngineerHead
-  equipment: ChiefEngineerHead
-
-- type: startingGear
   id: ChiefEngineerHead
   equipment:
     head: ClothingHeadHatHardhatWhite
@@ -52,18 +32,10 @@
 # Neck
 - type: loadout
   id: ChiefEngineerCloak
-  equipment: ChiefEngineerCloak
-
-- type: startingGear
-  id: ChiefEngineerCloak
   equipment:
     neck: ClothingNeckCloakCe
 
 - type: loadout
-  id: ChiefEngineerMantle
-  equipment: ChiefEngineerMantle
-
-- type: startingGear
   id: ChiefEngineerMantle
   equipment:
     neck: ClothingNeckMantleCE
@@ -71,19 +43,11 @@
 # OuterClothing
 - type: loadout
   id: ChiefEngineerWintercoat
-  equipment: ChiefEngineerWintercoat
-
-- type: startingGear
-  id: ChiefEngineerWintercoat
   equipment:
     outerClothing: ClothingOuterWinterCE
 
 # Shoes
 - type: loadout
-  id: BrownShoes
-  equipment: BrownShoes
-
-- type: startingGear
   id: BrownShoes
   equipment:
     shoes: ClothingShoesColorBrown

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
@@ -27,7 +27,7 @@
 
 - type: loadout
   id: ChiefEngineerBeret
-  equipment: EngineeringBeret
+  startingGear: EngineeringBeret
 
 # Neck
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -19,6 +19,11 @@
       time: 216000 # 60 hrs
 
 # Head
+- type: startingGear
+  id: EngineeringBeret
+  equipment:
+    head: ClothingHeadHatBeretEngineering
+
 - type: loadout
   id: StationEngineerHardhatYellow
   equipment:
@@ -36,15 +41,10 @@
 
 - type: loadout
   id: SeniorEngineerBeret
-  equipment: EngineeringBeret
+  startingGear: EngineeringBeret
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorEngineering
-
-- type: startingGear
-  id: EngineeringBeret
-  equipment:
-    head: ClothingHeadHatBeretEngineering
 
 # Jumpsuit
 - type: loadout
@@ -64,25 +64,17 @@
 
 - type: loadout
   id: SeniorEngineerJumpsuit
-  equipment: SeniorEngineerJumpsuit
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorEngineering
-
-- type: startingGear
-  id: SeniorEngineerJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorEngineer
 
 - type: loadout
   id: SeniorEngineerJumpskirt
-  equipment: SeniorEngineerJumpskirt
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorEngineering
-
-- type: startingGear
-  id: SeniorEngineerJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtSeniorEngineer
 
@@ -132,12 +124,8 @@
 
 - type: loadout
   id: SeniorEngineerPDA
-  equipment: SeniorEngineerPDA
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorEngineering
-
-- type: startingGear
-  id: SeniorEngineerPDA
   equipment:
     id: SeniorEngineerPDA

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -21,27 +21,15 @@
 # Head
 - type: loadout
   id: StationEngineerHardhatYellow
-  equipment: StationEngineerHardhatYellow
-
-- type: startingGear
-  id: StationEngineerHardhatYellow
   equipment:
     head: ClothingHeadHatHardhatYellow
 
 - type: loadout
   id: StationEngineerHardhatOrange
-  equipment: StationEngineerHardhatOrange
-
-- type: startingGear
-  id: StationEngineerHardhatOrange
   equipment:
     head: ClothingHeadHatHardhatOrange
 
 - type: loadout
-  id: StationEngineerHardhatRed
-  equipment: StationEngineerHardhatRed
-
-- type: startingGear
   id: StationEngineerHardhatRed
   equipment:
     head: ClothingHeadHatHardhatRed
@@ -61,27 +49,15 @@
 # Jumpsuit
 - type: loadout
   id: StationEngineerJumpsuit
-  equipment: StationEngineerJumpsuit
-
-- type: startingGear
-  id: StationEngineerJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitEngineering
 
 - type: loadout
   id: StationEngineerJumpskirt
-  equipment: StationEngineerJumpskirt
-
-- type: startingGear
-  id: StationEngineerJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtEngineering
 
 - type: loadout
-  id: StationEngineerHazardsuit
-  equipment: StationEngineerHazardsuit
-
-- type: startingGear
   id: StationEngineerHazardsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitEngineeringHazard
@@ -113,27 +89,15 @@
 # Back
 - type: loadout
   id: StationEngineerBackpack
-  equipment: StationEngineerBackpack
-
-- type: startingGear
-  id: StationEngineerBackpack
   equipment:
     back: ClothingBackpackEngineering
 
 - type: loadout
   id: StationEngineerSatchel
-  equipment: StationEngineerSatchel
-
-- type: startingGear
-  id: StationEngineerSatchel
   equipment:
     back: ClothingBackpackSatchelEngineering
 
 - type: loadout
-  id: StationEngineerDuffel
-  equipment: StationEngineerDuffel
-
-- type: startingGear
   id: StationEngineerDuffel
   equipment:
     back: ClothingBackpackDuffelEngineering
@@ -141,47 +105,27 @@
 # OuterClothing
 - type: loadout
   id: StationEngineerOuterVest
-  equipment: StationEngineerOuterVest
-
-- type: startingGear
-  id: StationEngineerOuterVest
   equipment:
     outerClothing: ClothingOuterVestHazard
-  
-- type: loadout
-  id: StationEngineerWintercoat
-  equipment: StationEngineerWintercoat
 
-- type: startingGear
+- type: loadout
   id: StationEngineerWintercoat
   equipment:
     outerClothing: ClothingOuterWinterEngi
-  
+
 # Shoes
 - type: loadout
-  id: WorkBoots
-  equipment: WorkBoots
-
-- type: startingGear
   id: WorkBoots
   equipment:
     shoes: ClothingShoesBootsWork
 
 - type: loadout
   id: EngineeringWinterBoots
-  equipment: EngineeringWinterBoots
-
-- type: startingGear
-  id: EngineeringWinterBoots
   equipment:
     shoes: ClothingShoesBootsWinterEngi
 
 # ID
 - type: loadout
-  id: StationEngineerPDA
-  equipment: StationEngineerPDA
-
-- type: startingGear
   id: StationEngineerPDA
   equipment:
     id: EngineerPDA

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/technical_assistant.yml
@@ -1,18 +1,10 @@
 # Jumpsuit
 - type: loadout
   id: YellowJumpsuit
-  equipment: YellowJumpsuit
-
-- type: startingGear
-  id: YellowJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorYellow
 
 - type: loadout
-  id: YellowJumpskirt
-  equipment: YellowJumpskirt
-
-- type: startingGear
   id: YellowJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorYellow

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chemist.yml
@@ -1,18 +1,10 @@
 # Jumpsuit
 - type: loadout
   id: ChemistJumpsuit
-  equipment: ChemistJumpsuit
-
-- type: startingGear
-  id: ChemistJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitChemistry
 
 - type: loadout
-  id: ChemistJumpskirt
-  equipment: ChemistJumpskirt
-
-- type: startingGear
   id: ChemistJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtChemistry
@@ -20,27 +12,15 @@
 # Back
 - type: loadout
   id: ChemistBackpack
-  equipment: ChemistBackpack
-
-- type: startingGear
-  id: ChemistBackpack
   equipment:
     back: ClothingBackpackChemistry
 
 - type: loadout
   id: ChemistSatchel
-  equipment: ChemistSatchel
-
-- type: startingGear
-  id: ChemistSatchel
   equipment:
     back: ClothingBackpackSatchelChemistry
 
 - type: loadout
-  id: ChemistDuffel
-  equipment: ChemistDuffel
-
-- type: startingGear
   id: ChemistDuffel
   equipment:
     back: ClothingBackpackDuffelChemistry
@@ -48,18 +28,10 @@
 # Outer clothing
 - type: loadout
   id: ChemistLabCoat
-  equipment: ChemistLabCoat
-
-- type: startingGear
-  id: ChemistLabCoat
   equipment:
     outerClothing: ClothingOuterCoatLabChem
 
 - type: loadout
-  id: ChemistWintercoat
-  equipment: ChemistWintercoat
-
-- type: startingGear
   id: ChemistWintercoat
   equipment:
     outerClothing: ClothingOuterWinterChem

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -1,36 +1,20 @@
 # Jumpsuit
 - type: loadout
   id: ChiefMedicalOfficerJumpsuit
-  equipment: ChiefMedicalOfficerJumpsuit
-
-- type: startingGear
-  id: ChiefMedicalOfficerJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitCMO
 
 - type: loadout
-  id: ChiefMedicalOfficerJumpskirt
-  equipment: ChiefMedicalOfficerJumpskirt
-
-- type: startingGear
   id: ChiefMedicalOfficerJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtCMO
 
 - type: loadout
   id: ChiefMedicalOfficerTurtleneckJumpsuit
-  equipment: ChiefMedicalOfficerTurtleneckJumpsuit
-
-- type: startingGear
-  id: ChiefMedicalOfficerTurtleneckJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitCMOTurtle
 
 - type: loadout
-  id: ChiefMedicalOfficerTurtleneckJumpskirt
-  equipment: ChiefMedicalOfficerTurtleneckJumpskirt
-
-- type: startingGear
   id: ChiefMedicalOfficerTurtleneckJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtCMOTurtle
@@ -38,18 +22,10 @@
 # Head
 - type: loadout
   id: ChiefMedicalOfficerBeret
-  equipment: ChiefMedicalOfficerBeret
-
-- type: startingGear
-  id: ChiefMedicalOfficerBeret
   equipment:
     head: ClothingHeadHatBeretCmo
 
 - type: loadout
-  id: CMOMedicalHeadMirror
-  equipment: CMOMedicalHeadMirror
-
-- type: startingGear
   id: CMOMedicalHeadMirror
   equipment:
     head: ClothingHeadMirror
@@ -57,18 +33,10 @@
 # Neck
 - type: loadout
   id: ChiefMedicalOfficerCloak
-  equipment: ChiefMedicalOfficerCloak
-
-- type: startingGear
-  id: ChiefMedicalOfficerCloak
   equipment:
     neck: ClothingCloakCmo
 
 - type: loadout
-  id: ChiefMedicalOfficerMantle
-  equipment: ChiefMedicalOfficerMantle
-
-- type: startingGear
   id: ChiefMedicalOfficerMantle
   equipment:
     neck: ClothingNeckMantleCMO
@@ -76,18 +44,10 @@
 # Outer clothing
 - type: loadout
   id: ChiefMedicalOfficerLabCoat
-  equipment: ChiefMedicalOfficerLabCoat
-
-- type: startingGear
-  id: ChiefMedicalOfficerLabCoat
   equipment:
     outerClothing: ClothingOuterCoatLabCmo
 
 - type: loadout
-  id: ChiefMedicalOfficerWintercoat
-  equipment: ChiefMedicalOfficerWintercoat
-
-- type: startingGear
   id: ChiefMedicalOfficerWintercoat
   equipment:
     outerClothing: ClothingOuterWinterCMO

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -57,45 +57,25 @@
 
 - type: loadout
   id: MedicalBeret
-  equipment: MedicalBeret
-
-- type: startingGear
-  id: MedicalBeret
   equipment:
     head: ClothingHeadHatBeretMedic
 
 - type: loadout
-  id: BlueSurgeryCap
-  equipment: BlueSurgeryCap
-
-- type: startingGear
   id: BlueSurgeryCap
   equipment:
     head: ClothingHeadHatSurgcapBlue
 
 - type: loadout
   id: GreenSurgeryCap
-  equipment: GreenSurgeryCap
-
-- type: startingGear
-  id: GreenSurgeryCap
   equipment:
     head: ClothingHeadHatSurgcapGreen
 
 - type: loadout
   id: PurpleSurgeryCap
-  equipment: PurpleSurgeryCap
-
-- type: startingGear
-  id: PurpleSurgeryCap
   equipment:
     head: ClothingHeadHatSurgcapPurple
 
 - type: loadout
-  id: NurseHat
-  equipment: NurseHat
-
-- type: startingGear
   id: NurseHat
   equipment:
     head: ClothingHeadNurseHat
@@ -103,18 +83,10 @@
 # Jumpsuit
 - type: loadout
   id: MedicalDoctorJumpsuit
-  equipment: MedicalDoctorJumpsuit
-
-- type: startingGear
-  id: MedicalDoctorJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitMedicalDoctor
 
 - type: loadout
-  id: MedicalDoctorJumpskirt
-  equipment: MedicalDoctorJumpskirt
-
-- type: startingGear
   id: MedicalDoctorJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtMedicalDoctor
@@ -145,27 +117,15 @@
 
 - type: loadout
   id: MedicalBlueScrubs
-  equipment: MedicalBlueScrubs
-
-- type: startingGear
-  id: MedicalBlueScrubs
   equipment:
     jumpsuit: UniformScrubsColorBlue
 
 - type: loadout
   id: MedicalGreenScrubs
-  equipment: MedicalGreenScrubs
-
-- type: startingGear
-  id: MedicalGreenScrubs
   equipment:
     jumpsuit: UniformScrubsColorGreen
 
 - type: loadout
-  id: MedicalPurpleScrubs
-  equipment: MedicalPurpleScrubs
-
-- type: startingGear
   id: MedicalPurpleScrubs
   equipment:
     jumpsuit: UniformScrubsColorPurple
@@ -173,37 +133,21 @@
 # Back
 - type: loadout
   id: MedicalDoctorBackpack
-  equipment: MedicalDoctorBackpack
-
-- type: startingGear
-  id: MedicalDoctorBackpack
   equipment:
     back: ClothingBackpackMedical
 
 - type: loadout
-  id: MedicalDoctorSatchel
-  equipment: MedicalDoctorSatchel
-
-- type: startingGear
   id: MedicalDoctorSatchel
   equipment:
     back: ClothingBackpackSatchelMedical
 
 - type: loadout
   id: MedicalDoctorDuffel
-  equipment: MedicalDoctorDuffel
-
-- type: startingGear
-  id: MedicalDoctorDuffel
   equipment:
     back: ClothingBackpackDuffelMedical
 
 # OuterClothing
 - type: loadout
-  id: MedicalDoctorWintercoat
-  equipment: MedicalDoctorWintercoat
-
-- type: startingGear
   id: MedicalDoctorWintercoat
   equipment:
     outerClothing: ClothingOuterWinterMed
@@ -223,19 +167,11 @@
 # Shoes
 - type: loadout
   id: MedicalWinterBoots
-  equipment: MedicalWinterBoots
-
-- type: startingGear
-  id: MedicalWinterBoots
   equipment:
     shoes: ClothingShoesBootsWinterMed
 
 # ID
 - type: loadout
-  id: MedicalDoctorPDA
-  equipment: MedicalDoctorPDA
-
-- type: startingGear
   id: MedicalDoctorPDA
   equipment:
     id: MedicalPDA
@@ -255,19 +191,11 @@
 # Gloves
 - type: loadout
   id: NitrileGloves
-  equipment: NitrileGloves
-
-- type: startingGear
-  id: NitrileGloves
   equipment:
     gloves: ClothingHandsGlovesNitrile
 
 #Masks
 - type: loadout
-  id: SterileMask
-  equipment: SterileMask
-
-- type: startingGear
   id: SterileMask
   equipment:
     mask: ClothingMaskSterile

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -33,25 +33,17 @@
 
 - type: loadout
   id: SeniorPhysicianBeret
-  equipment: SeniorPhysicianBeret
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorPhysician
-
-- type: startingGear
-  id: SeniorPhysicianBeret
   equipment:
     head: ClothingHeadHatBeretSeniorPhysician
 
 - type: loadout
   id: MedicalHeadMirror
-  equipment: MedicalHeadMirror
   effects:
   - !type:GroupLoadoutEffect
     proto: MedicalHeadMirrorTimer
-
-- type: startingGear
-  id: MedicalHeadMirror
   equipment:
     head: ClothingHeadMirror
 
@@ -93,25 +85,17 @@
 
 - type: loadout
   id: SeniorPhysicianJumpsuit
-  equipment: SeniorPhysicianJumpsuit
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorPhysician
-
-- type: startingGear
-  id: SeniorPhysicianJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorPhysician
 
 - type: loadout
   id: SeniorPhysicianJumpskirt
-  equipment: SeniorPhysicianJumpskirt
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorPhysician
-
-- type: startingGear
-  id: SeniorPhysicianJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtSeniorPhysician
 
@@ -154,13 +138,9 @@
 
 - type: loadout
   id: SeniorPhysicianLabCoat
-  equipment: SeniorPhysicianLabCoat
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorPhysician
-
-- type: startingGear
-  id: SeniorPhysicianLabCoat
   equipment:
     outerClothing: ClothingOuterCoatLabSeniorPhysician
 
@@ -178,13 +158,9 @@
 
 - type: loadout
   id: SeniorPhysicianPDA
-  equipment: SeniorPhysicianPDA
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorPhysician
-
-- type: startingGear
-  id: SeniorPhysicianPDA
   equipment:
     id: SeniorPhysicianPDA
 

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_intern.yml
@@ -1,18 +1,10 @@
 # Jumpsuit
 - type: loadout
   id: WhiteJumpsuit
-  equipment: WhiteJumpsuit
-
-- type: startingGear
-  id: WhiteJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorWhite
 
 - type: loadout
-  id: WhiteJumpskirt
-  equipment: WhiteJumpskirt
-
-- type: startingGear
   id: WhiteJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorWhite

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/paramedic.yml
@@ -1,28 +1,16 @@
 # Head
 - type: loadout
   id: ParamedicHead
-  equipment: ParamedicHead
-
-- type: startingGear
-  id: ParamedicHead
   equipment:
     head: ClothingHeadHatParamedicsoft
 
 # Jumpsuit
 - type: loadout
   id: ParamedicJumpsuit
-  equipment: ParamedicJumpsuit
-
-- type: startingGear
-  id: ParamedicJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitParamedic
 
 - type: loadout
-  id: ParamedicJumpskirt
-  equipment: ParamedicJumpskirt
-
-- type: startingGear
   id: ParamedicJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtParamedic
@@ -30,28 +18,16 @@
 # Outer clothing
 - type: loadout
   id: ParamedicWindbreaker
-  equipment: ParamedicWindbreaker
-
-- type: startingGear
-  id: ParamedicWindbreaker
   equipment:
     outerClothing: ClothingOuterCoatParamedicWB
 
 - type: loadout
-  id: ParamedicWintercoat
-  equipment: ParamedicWintercoat
-
-- type: startingGear
   id: ParamedicWintercoat
   equipment:
     outerClothing: ClothingOuterWinterPara
 
 # Shoes
 - type: loadout
-  id: BlueShoes
-  equipment: BlueShoes
-
-- type: startingGear
   id: BlueShoes
   equipment:
     shoes: ClothingShoesColorBlue

--- a/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
@@ -2,7 +2,7 @@
 
 - type: loadout
   id: ResearchDirectorBeret
-  equipment: ScientificBeret
+  startingGear: ScientificBeret
 
 # Neck
 

--- a/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
@@ -8,18 +8,10 @@
 
 - type: loadout
   id: ResearchDirectorMantle
-  equipment: ResearchDirectorMantle
-
-- type: startingGear
-  id: ResearchDirectorMantle
   equipment:
     neck: ClothingNeckMantleRD
 
 - type: loadout
-  id: ResearchDirectorCloak
-  equipment: ResearchDirectorCloak
-
-- type: startingGear
   id: ResearchDirectorCloak
   equipment:
     neck: ClothingNeckCloakRd
@@ -27,18 +19,10 @@
 # Jumpsuit
 - type: loadout
   id: ResearchDirectorJumpsuit
-  equipment: ResearchDirectorJumpsuit
-
-- type: startingGear
-  id: ResearchDirectorJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitResearchDirector
 
 - type: loadout
-  id: ResearchDirectorJumpskirt
-  equipment: ResearchDirectorJumpskirt
-
-- type: startingGear
   id: ResearchDirectorJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtResearchDirector
@@ -46,18 +30,10 @@
 # OuterClothing
 - type: loadout
   id: ResearchDirectorLabCoat
-  equipment: ResearchDirectorLabCoat
-
-- type: startingGear
-  id: ResearchDirectorLabCoat
   equipment:
     outerClothing: ClothingOuterCoatRD
 
 - type: loadout
-  id: ResearchDirectorWintercoat
-  equipment: ResearchDirectorWintercoat
-
-- type: startingGear
   id: ResearchDirectorWintercoat
   equipment:
     outerClothing: ClothingOuterWinterRD

--- a/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
@@ -9,18 +9,17 @@
       time: 216000 #60 hrs
 
 # Head
-
-- type: loadout
-  id: ScientificBeret
-  equipment: ScientificBeret
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorResearcher
-
 - type: startingGear
   id: ScientificBeret
   equipment:
     head: ClothingHeadHatBeretRND
+
+- type: loadout
+  id: ScientificBeret
+  startingGear: ScientificBeret
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorResearcher
 
 - type: loadout
   id: RoboticistCap
@@ -62,25 +61,17 @@
 
 - type: loadout
   id: SeniorResearcherJumpsuit
-  equipment: SeniorResearcherJumpsuit
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorResearcher
-
-- type: startingGear
-  id: SeniorResearcherJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorResearcher
 
 - type: loadout
   id: SeniorResearcherJumpskirt
-  equipment: SeniorResearcherJumpskirt
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorResearcher
-
-- type: startingGear
-  id: SeniorResearcherJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtSeniorResearcher
 
@@ -128,13 +119,9 @@
 
 - type: loadout
   id: SeniorResearcherLabCoat
-  equipment: SeniorResearcherLabCoat
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorResearcher
-
-- type: startingGear
-  id: SeniorResearcherLabCoat
   equipment:
     outerClothing: ClothingOuterCoatLabSeniorResearcher
 
@@ -163,12 +150,8 @@
 
 - type: loadout
   id: SeniorResearcherPDA
-  equipment: SeniorResearcherPDA
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorResearcher
-
-- type: startingGear
-  id: SeniorResearcherPDA
   equipment:
     id: SeniorResearcherPDA

--- a/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
@@ -24,18 +24,10 @@
 
 - type: loadout
   id: RoboticistCap
-  equipment: RoboticistCap
-
-- type: startingGear
-  id: RoboticistCap
   equipment:
     head: ClothingHeadHatCorpsoft
 
 - type: loadout
-  id: SkullBandana
-  equipment: SkullBandana
-
-- type: startingGear
   id: SkullBandana
   equipment:
     head: ClothingHeadBandSkull
@@ -44,46 +36,26 @@
 
 - type: loadout
   id: ScientistTie
-  equipment: ScientistTie
-
-- type: startingGear
-  id: ScientistTie
   equipment:
     neck: ClothingNeckTieSci
 
 # Jumpsuit
 - type: loadout
   id: ScientistJumpsuit
-  equipment: ScientistJumpsuit
-
-- type: startingGear
-  id: ScientistJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitScientist
 
 - type: loadout
-  id: ScientistJumpskirt
-  equipment: ScientistJumpskirt
-
-- type: startingGear
   id: ScientistJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtScientist
 
 - type: loadout
   id: RoboticistJumpsuit
-  equipment: RoboticistJumpsuit
-
-- type: startingGear
-  id: RoboticistJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitRoboticist
 
 - type: loadout
-  id: RoboticistJumpskirt
-  equipment: RoboticistJumpskirt
-
-- type: startingGear
   id: RoboticistJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtRoboticist
@@ -115,27 +87,15 @@
 # Back
 - type: loadout
   id: ScientistBackpack
-  equipment: ScientistBackpack
-
-- type: startingGear
-  id: ScientistBackpack
   equipment:
     back: ClothingBackpackScience
 
 - type: loadout
   id: ScientistSatchel
-  equipment: ScientistSatchel
-
-- type: startingGear
-  id: ScientistSatchel
   equipment:
     back: ClothingBackpackSatchelScience
 
 - type: loadout
-  id: ScientistDuffel
-  equipment: ScientistDuffel
-
-- type: startingGear
   id: ScientistDuffel
   equipment:
     back: ClothingBackpackDuffelScience
@@ -143,45 +103,25 @@
 # OuterClothing
 - type: loadout
   id: RegularLabCoat
-  equipment: RegularLabCoat
-
-- type: startingGear
-  id: RegularLabCoat
   equipment:
     outerClothing: ClothingOuterCoatLab
 
 - type: loadout
-  id: ScienceLabCoat
-  equipment: ScienceLabCoat
-
-- type: startingGear
   id: ScienceLabCoat
   equipment:
     outerClothing: ClothingOuterCoatRnd
 
 - type: loadout
   id: ScienceWintercoat
-  equipment: ScienceWintercoat
-
-- type: startingGear
-  id: ScienceWintercoat
   equipment:
     outerClothing: ClothingOuterWinterSci
 
 - type: loadout
   id: RoboticistLabCoat
-  equipment: RoboticistLabCoat
-
-- type: startingGear
-  id: RoboticistLabCoat
   equipment:
     outerClothing: ClothingOuterCoatRobo
 
 - type: loadout
-  id: RoboticistWintercoat
-  equipment: RoboticistWintercoat
-
-- type: startingGear
   id: RoboticistWintercoat
   equipment:
     outerClothing: ClothingOuterWinterRobo
@@ -201,18 +141,10 @@
 # Gloves
 - type: loadout
   id: LatexGloves
-  equipment: LatexGloves
-
-- type: startingGear
-  id: LatexGloves
   equipment:
     gloves: ClothingHandsGlovesLatex
 
 - type: loadout
-  id: RobohandsGloves
-  equipment: RobohandsGloves
-
-- type: startingGear
   id: RobohandsGloves
   equipment:
     gloves: ClothingHandsGlovesRobohands
@@ -220,19 +152,11 @@
 # Shoes
 - type: loadout
   id: ScienceWinterBoots
-  equipment: ScienceWinterBoots
-
-- type: startingGear
-  id: ScienceWinterBoots
   equipment:
     shoes: ClothingShoesBootsWinterSci
 
 # ID
 - type: loadout
-  id: ScientistPDA
-  equipment: ScientistPDA
-
-- type: startingGear
   id: ScientistPDA
   equipment:
     id: SciencePDA

--- a/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
@@ -1,28 +1,16 @@
 # Head
 - type: loadout
   id: DetectiveFedora
-  equipment: DetectiveFedora
-
-- type: startingGear
-  id: DetectiveFedora
   equipment:
     head: ClothingHeadHatFedoraBrown
 
 - type: loadout
   id: DetectiveFedoraGrey
-  equipment: DetectiveFedoraGrey
-
-- type: startingGear
-  id: DetectiveFedoraGrey
   equipment:
     head: ClothingHeadHatFedoraGrey
-  
+
 # Neck
 - type: loadout
-  id: DetectiveTie
-  equipment: DetectiveTie
-
-- type: startingGear
   id: DetectiveTie
   equipment:
     neck: ClothingNeckTieDet
@@ -30,36 +18,20 @@
 # Jumpsuit
 - type: loadout
   id: DetectiveJumpsuit
-  equipment: DetectiveJumpsuit
-
-- type: startingGear
-  id: DetectiveJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitDetective
 
 - type: loadout
-  id: DetectiveJumpskirt
-  equipment: DetectiveJumpskirt
-
-- type: startingGear
   id: DetectiveJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtDetective
 
 - type: loadout
   id: NoirJumpsuit
-  equipment: NoirJumpsuit
-
-- type: startingGear
-  id: NoirJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitDetectiveGrey
 
 - type: loadout
-  id: NoirJumpskirt
-  equipment: NoirJumpskirt
-
-- type: startingGear
   id: NoirJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtDetectiveGrey
@@ -67,18 +39,10 @@
 # OuterClothing
 - type: loadout
   id: DetectiveArmorVest
-  equipment: DetectiveArmorVest
-
-- type: startingGear
-  id: DetectiveArmorVest
   equipment:
     outerClothing: ClothingOuterVestDetective
 
 - type: loadout
-  id: DetectiveCoat
-  equipment: DetectiveCoat
-
-- type: startingGear
   id: DetectiveCoat
   equipment:
     outerClothing: ClothingOuterCoatDetectiveLoadout

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -1,54 +1,30 @@
 # Jumpsuit
 - type: loadout
   id: HeadofSecurityJumpsuit
-  equipment: HeadofSecurityJumpsuit
-
-- type: startingGear
-  id: HeadofSecurityJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitHoS
 
 - type: loadout
-  id: HeadofSecurityJumpskirt
-  equipment: HeadofSecurityJumpskirt
-
-- type: startingGear
   id: HeadofSecurityJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtHoS
 
 - type: loadout
   id: HeadofSecurityTurtleneck
-  equipment: HeadofSecurityTurtleneck
-
-- type: startingGear
-  id: HeadofSecurityTurtleneck
   equipment:
     jumpsuit: ClothingUniformJumpsuitHoSAlt
 
 - type: loadout
-  id: HeadofSecurityTurtleneckSkirt
-  equipment: HeadofSecurityTurtleneckSkirt
-
-- type: startingGear
   id: HeadofSecurityTurtleneckSkirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtHoSAlt
 
 - type: loadout
   id: HeadofSecurityFormalSuit
-  equipment: HeadofSecurityFormalSuit
-
-- type: startingGear
-  id: HeadofSecurityFormalSuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitHosFormal
 
 - type: loadout
-  id: HeadofSecurityFormalSkirt
-  equipment: HeadofSecurityFormalSkirt
-
-- type: startingGear
   id: HeadofSecurityFormalSkirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtHosFormal
@@ -56,18 +32,10 @@
 # Head
 - type: loadout
   id: HeadofSecurityHead
-  equipment: HeadofSecurityHead
-
-- type: startingGear
-  id: HeadofSecurityHead
   equipment:
     head: ClothingHeadHatHoshat
 
 - type: loadout
-  id: HeadofSecurityBeret
-  equipment: HeadofSecurityBeret
-
-- type: startingGear
   id: HeadofSecurityBeret
   equipment:
     head: ClothingHeadHatBeretHoS
@@ -75,18 +43,10 @@
 # Neck
 - type: loadout
   id: HeadofSecurityCloak
-  equipment: HeadofSecurityCloak
-
-- type: startingGear
-  id: HeadofSecurityCloak
   equipment:
     neck: ClothingNeckCloakHos
 
 - type: loadout
-  id: HeadofSecurityMantle
-  equipment: HeadofSecurityMantle
-
-- type: startingGear
   id: HeadofSecurityMantle
   equipment:
     neck: ClothingNeckMantleHOS
@@ -94,18 +54,10 @@
 # OuterClothing
 - type: loadout
   id: HeadofSecurityCoat
-  equipment: HeadofSecurityCoat
-
-- type: startingGear
-  id: HeadofSecurityCoat
   equipment:
     outerClothing: ClothingOuterCoatHoSTrench
 
 - type: loadout
-  id: HeadofSecurityWinterCoat
-  equipment: HeadofSecurityWinterCoat
-
-- type: startingGear
   id: HeadofSecurityWinterCoat
   equipment:
     outerClothing: ClothingOuterWinterHoS

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
@@ -1,18 +1,10 @@
 # Jumpsuit
 - type: loadout
   id: RedJumpsuit
-  equipment: RedJumpsuit
-
-- type: startingGear
-  id: RedJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorRed
 
 - type: loadout
-  id: RedJumpskirt
-  equipment: RedJumpskirt
-
-- type: startingGear
   id: RedJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorRed

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -52,25 +52,17 @@
 
 - type: loadout
   id: SeniorOfficerJumpsuit
-  equipment: SeniorOfficerJumpsuit
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorOfficer
-
-- type: startingGear
-  id: SeniorOfficerJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitSeniorOfficer
 
 - type: loadout
   id: SeniorOfficerJumpskirt
-  equipment: SeniorOfficerJumpskirt
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorOfficer
-
-- type: startingGear
-  id: SeniorOfficerJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtSeniorOfficer
 
@@ -141,12 +133,8 @@
 
 - type: loadout
   id: SeniorOfficerPDA
-  equipment: SeniorOfficerPDA
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorOfficer
-
-- type: startingGear
-  id: SeniorOfficerPDA
   equipment:
     id: SeniorOfficerPDA

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -16,27 +16,15 @@
 # Head
 - type: loadout
   id: SecurityHelmet
-  equipment: SecurityHelmet
-
-- type: startingGear
-  id: SecurityHelmet
   equipment:
     head: ClothingHeadHelmetBasic
 
 - type: loadout
   id: SecurityHat
-  equipment: SecurityHat
-
-- type: startingGear
-  id: SecurityHat
   equipment:
     head: ClothingHeadHatSecsoft
 
 - type: loadout
-  id: SecurityBeret
-  equipment: SecurityBeret
-
-- type: startingGear
   id: SecurityBeret
   equipment:
     head: ClothingHeadHatBeretSecurity
@@ -44,36 +32,20 @@
 # Jumpsuit
 - type: loadout
   id: SecurityJumpsuit
-  equipment: SecurityJumpsuit
-
-- type: startingGear
-  id: SecurityJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitSec
 
 - type: loadout
-  id: SecurityJumpskirt
-  equipment: SecurityJumpskirt
-
-- type: startingGear
   id: SecurityJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtSec
 
 - type: loadout
   id: SecurityJumpsuitGrey
-  equipment: SecurityJumpsuitGrey
-
-- type: startingGear
-  id: SecurityJumpsuitGrey
   equipment:
     jumpsuit: ClothingUniformJumpsuitSecGrey
 
 - type: loadout
-  id: SecurityJumpskirtGrey
-  equipment: SecurityJumpskirtGrey
-
-- type: startingGear
   id: SecurityJumpskirtGrey
   equipment:
     jumpsuit: ClothingUniformJumpskirtSecGrey
@@ -105,27 +77,15 @@
 # Back
 - type: loadout
   id: SecurityBackpack
-  equipment: SecurityBackpack
-
-- type: startingGear
-  id: SecurityBackpack
   equipment:
     back: ClothingBackpackSecurity
 
 - type: loadout
   id: SecuritySatchel
-  equipment: SecuritySatchel
-
-- type: startingGear
-  id: SecuritySatchel
   equipment:
     back: ClothingBackpackSatchelSecurity
 
 - type: loadout
-  id: SecurityDuffel
-  equipment: SecurityDuffel
-
-- type: startingGear
   id: SecurityDuffel
   equipment:
     back: ClothingBackpackDuffelSecurity
@@ -133,18 +93,10 @@
 # Belt
 - type: loadout
   id: SecurityBelt
-  equipment: SecurityBelt
-
-- type: startingGear
-  id: SecurityBelt
   equipment:
     belt: ClothingBeltSecurityFilled
 
 - type: loadout
-  id: SecurityWebbing
-  equipment: SecurityWebbing
-
-- type: startingGear
   id: SecurityWebbing
   equipment:
     belt: ClothingBeltSecurityWebbingFilled
@@ -152,27 +104,15 @@
 # Outerclothing
 - type: loadout
   id: ArmorVest
-  equipment: ArmorVest
-
-- type: startingGear
-  id: ArmorVest
   equipment:
     outerClothing: ClothingOuterArmorBasic
 
 - type: loadout
   id: ArmorVestSlim
-  equipment: ArmorVestSlim
-
-- type: startingGear
-  id: ArmorVestSlim
   equipment:
     outerClothing: ClothingOuterArmorBasicSlim
 
 - type: loadout
-  id: SecurityOfficerWintercoat
-  equipment: SecurityOfficerWintercoat
-
-- type: startingGear
   id: SecurityOfficerWintercoat
   equipment:
     outerClothing: ClothingOuterWinterSec
@@ -180,37 +120,21 @@
 # Shoes
 - type: loadout
   id: CombatBoots
-  equipment: CombatBoots
-
-- type: startingGear
-  id: CombatBoots
   equipment:
     shoes: ClothingShoesBootsCombatFilled
 
 - type: loadout
-  id: JackBoots
-  equipment: JackBoots
-
-- type: startingGear
   id: JackBoots
   equipment:
     shoes: ClothingShoesBootsJackFilled
 
 - type: loadout
   id: SecurityWinterBoots
-  equipment: SecurityWinterBoots
-
-- type: startingGear
-  id: SecurityWinterBoots
   equipment:
     shoes: ClothingShoesBootsWinterSecFilled
 
 # PDA
 - type: loadout
-  id: SecurityPDA
-  equipment: SecurityPDA
-
-- type: startingGear
   id: SecurityPDA
   equipment:
     id: SecurityPDA

--- a/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
@@ -1,18 +1,10 @@
 # Head
 - type: loadout
   id: WardenHead
-  equipment: WardenHead
-
-- type: startingGear
-  id: WardenHead
   equipment:
     head: ClothingHeadHatWarden
 
 - type: loadout
-  id: WardenBeret
-  equipment: WardenBeret
-
-- type: startingGear
   id: WardenBeret
   equipment:
     head: ClothingHeadHatBeretWarden
@@ -20,18 +12,10 @@
 # Jumpsuit
 - type: loadout
   id: WardenJumpsuit
-  equipment: WardenJumpsuit
-
-- type: startingGear
-  id: WardenJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitWarden
 
 - type: loadout
-  id: WardenJumpskirt
-  equipment: WardenJumpskirt
-
-- type: startingGear
   id: WardenJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtWarden
@@ -39,18 +23,10 @@
 # OuterClothing
 - type: loadout
   id: WardenCoat
-  equipment: WardenCoat
-
-- type: startingGear
-  id: WardenCoat
   equipment:
     outerClothing: ClothingOuterCoatWarden
 
 - type: loadout
-  id: WardenArmoredWinterCoat
-  equipment: WardenArmoredWinterCoat
-
-- type: startingGear
   id: WardenArmoredWinterCoat
   equipment:
     outerClothing: ClothingOuterWinterWarden

--- a/Resources/Prototypes/Loadouts/Jobs/Wildcards/boxer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Wildcards/boxer.yml
@@ -1,18 +1,10 @@
 # Jumpsuit
 - type: loadout
   id: BoxerShorts
-  equipment: BoxerShorts
-
-- type: startingGear
-  id: BoxerShorts
   equipment:
     jumpsuit: UniformShortsRed
 
 - type: loadout
-  id: BoxerShortsWithTop
-  equipment: BoxerShortsWithTop
-
-- type: startingGear
   id: BoxerShortsWithTop
   equipment:
     jumpsuit: UniformShortsRedWithTop
@@ -20,36 +12,20 @@
 # Gloves
 - type: loadout
   id: RedBoxingGloves
-  equipment: RedBoxingGloves
-
-- type: startingGear
-  id: RedBoxingGloves
   equipment:
     gloves: ClothingHandsGlovesBoxingRed
 
 - type: loadout
-  id: BlueBoxingGloves
-  equipment: BlueBoxingGloves
-
-- type: startingGear
   id: BlueBoxingGloves
   equipment:
     gloves: ClothingHandsGlovesBoxingBlue
 
 - type: loadout
   id: GreenBoxingGloves
-  equipment: GreenBoxingGloves
-
-- type: startingGear
-  id: GreenBoxingGloves
   equipment:
     gloves: ClothingHandsGlovesBoxingGreen
 
 - type: loadout
-  id: YellowBoxingGloves
-  equipment: YellowBoxingGloves
-
-- type: startingGear
   id: YellowBoxingGloves
   equipment:
     gloves: ClothingHandsGlovesBoxingYellow

--- a/Resources/Prototypes/Loadouts/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Wildcards/reporter.yml
@@ -1,18 +1,10 @@
 # Jumpsuit
 - type: loadout
   id: ReporterJumpsuit
-  equipment: ReporterJumpsuit
-
-- type: startingGear
-  id: ReporterJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitReporter
 
 - type: loadout
-  id: JournalistJumpsuit
-  equipment: JournalistJumpsuit
-
-- type: startingGear
   id: JournalistJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitJournalist

--- a/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
@@ -28,25 +28,17 @@
 # Jamjar
 - type: loadout
   id: GlassesJamjar
-  equipment: GlassesJamjar
   effects:
   - !type:GroupLoadoutEffect
     proto: JamjarTimer
-
-- type: startingGear
-  id: GlassesJamjar
   equipment:
     eyes: ClothingEyesGlassesJamjar
 
 # Jensen
 - type: loadout
   id: GlassesJensen
-  equipment: GlassesJensen
   effects:
   - !type:GroupLoadoutEffect
     proto: JensenTimer
-
-- type: startingGear
-  id: GlassesJensen
   equipment:
     eyes: ClothingEyesGlassesJensen

--- a/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
@@ -21,15 +21,11 @@
 # Glasses
 - type: loadout
   id: Glasses
-  equipment: Glasses
-
-- type: startingGear
-  id: Glasses
   equipment:
     eyes: ClothingEyesGlasses
 
 # Special options
-# Jamjar    
+# Jamjar
 - type: loadout
   id: GlassesJamjar
   equipment: GlassesJamjar

--- a/Resources/Prototypes/Loadouts/Miscellaneous/instruments.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/instruments.yml
@@ -1,19 +1,11 @@
 # Instruments
 - type: loadout
   id: Glockenspiel
-  equipment: Glockenspiel
-
-- type: startingGear
-  id: Glockenspiel
   storage:
     back:
     - GlockenspielInstrument
 
 - type: loadout
-  id: MusicBox
-  equipment: MusicBox
-
-- type: startingGear
   id: MusicBox
   storage:
     back:
@@ -21,19 +13,11 @@
 
 - type: loadout
   id: Xylophone
-  equipment: Xylophone
-
-- type: startingGear
-  id: Xylophone
   storage:
     back:
     - XylophoneInstrument
 
 - type: loadout
-  id: Microphone
-  equipment: Microphone
-
-- type: startingGear
   id: Microphone
   storage:
     back:
@@ -41,19 +25,11 @@
 
 - type: loadout
   id: Synthesizer
-  equipment: Synthesizer
-
-- type: startingGear
-  id: Synthesizer
   storage:
     back:
     - SynthesizerInstrument
 
 - type: loadout
-  id: Kalimba
-  equipment: Kalimba
-
-- type: startingGear
   id: Kalimba
   storage:
     back:
@@ -61,19 +37,11 @@
 
 - type: loadout
   id: Woodblock
-  equipment: Woodblock
-
-- type: startingGear
-  id: Woodblock
   storage:
     back:
     - WoodblockInstrument
 
 - type: loadout
-  id: ElectricGuitar
-  equipment: ElectricGuitar
-
-- type: startingGear
   id: ElectricGuitar
   storage:
     back:
@@ -81,19 +49,11 @@
 
 - type: loadout
   id: BassGuitar
-  equipment: BassGuitar
-
-- type: startingGear
-  id: BassGuitar
   storage:
     back:
     - BassGuitarInstrument
 
 - type: loadout
-  id: RockGuitar
-  equipment: RockGuitar
-
-- type: startingGear
   id: RockGuitar
   storage:
     back:
@@ -101,19 +61,11 @@
 
 - type: loadout
   id: AcousticGuitar
-  equipment: AcousticGuitar
-
-- type: startingGear
-  id: AcousticGuitar
   storage:
     back:
     - AcousticGuitarInstrument
 
 - type: loadout
-  id: Banjo
-  equipment: Banjo
-
-- type: startingGear
   id: Banjo
   storage:
     back:
@@ -121,19 +73,11 @@
 
 - type: loadout
   id: Violin
-  equipment: Violin
-
-- type: startingGear
-  id: Violin
   storage:
     back:
     - ViolinInstrument
 
 - type: loadout
-  id: Viola
-  equipment: Viola
-
-- type: startingGear
   id: Viola
   storage:
     back:
@@ -141,19 +85,11 @@
 
 - type: loadout
   id: Cello
-  equipment: Cello
-
-- type: startingGear
-  id: Cello
   storage:
     back:
     - CelloInstrument
 
 - type: loadout
-  id: Trumpet
-  equipment: Trumpet
-
-- type: startingGear
   id: Trumpet
   storage:
     back:
@@ -161,19 +97,11 @@
 
 - type: loadout
   id: Trombone
-  equipment: Trombone
-
-- type: startingGear
-  id: Trombone
   storage:
     back:
     - TromboneInstrument
 
 - type: loadout
-  id: FrenchHorn
-  equipment: FrenchHorn
-
-- type: startingGear
   id: FrenchHorn
   storage:
     back:
@@ -181,19 +109,11 @@
 
 - type: loadout
   id: Euphonium
-  equipment: Euphonium
-
-- type: startingGear
-  id: Euphonium
   storage:
     back:
     - EuphoniumInstrument
 
 - type: loadout
-  id: Saxophone
-  equipment: Saxophone
-
-- type: startingGear
   id: Saxophone
   storage:
     back:
@@ -201,19 +121,11 @@
 
 - type: loadout
   id: Accordion
-  equipment: Accordion
-
-- type: startingGear
-  id: Accordion
   storage:
     back:
     - AccordionInstrument
 
 - type: loadout
-  id: Harmonica
-  equipment: Harmonica
-
-- type: startingGear
   id: Harmonica
   storage:
     back:
@@ -221,19 +133,11 @@
 
 - type: loadout
   id: Clarinet
-  equipment: Clarinet
-
-- type: startingGear
-  id: Clarinet
   storage:
     back:
     - ClarinetInstrument
 
 - type: loadout
-  id: Flute
-  equipment: Flute
-
-- type: startingGear
   id: Flute
   storage:
     back:
@@ -241,19 +145,11 @@
 
 - type: loadout
   id: Recorder
-  equipment: Recorder
-
-- type: startingGear
-  id: Recorder
   storage:
     back:
     - RecorderInstrument
 
 - type: loadout
-  id: PanFlute
-  equipment: PanFlute
-
-- type: startingGear
   id: PanFlute
   storage:
     back:
@@ -261,19 +157,11 @@
 
 - type: loadout
   id: Ocarina
-  equipment: Ocarina
-
-- type: startingGear
-  id: Ocarina
   storage:
     back:
     - OcarinaInstrument
 
 - type: loadout
-  id: Bagpipe
-  equipment: Bagpipe
-
-- type: startingGear
   id: Bagpipe
   storage:
     back:

--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -29,26 +29,18 @@
 # Basic
 - type: loadout
   id: EmergencyOxygen
-  equipment: EmergencyOxygen
   effects:
   - !type:GroupLoadoutEffect
     proto: OxygenBreather
-
-- type: startingGear
-  id: EmergencyOxygen
   storage:
     back:
     - BoxSurvival
 
 - type: loadout
   id: EmergencyNitrogen
-  equipment: EmergencyNitrogen
   effects:
   - !type:GroupLoadoutEffect
     proto: NitrogenBreather
-
-- type: startingGear
-  id: EmergencyNitrogen
   storage:
     back:
     - BoxSurvivalNitrogen
@@ -56,26 +48,18 @@
 # Clown
 - type: loadout
   id: EmergencyOxygenClown
-  equipment: EmergencyOxygenClown
   effects:
   - !type:GroupLoadoutEffect
     proto: OxygenBreather
-
-- type: startingGear
-  id: EmergencyOxygenClown
   storage:
     back:
     - BoxHug
 
 - type: loadout
   id: EmergencyNitrogenClown
-  equipment: EmergencyNitrogenClown
   effects:
   - !type:GroupLoadoutEffect
     proto: NitrogenBreather
-
-- type: startingGear
-  id: EmergencyNitrogenClown
   storage:
     back:
     - BoxHugNitrogen
@@ -83,26 +67,18 @@
 # Engineering / Extended
 - type: loadout
   id: EmergencyOxygenExtended
-  equipment: EmergencyOxygenExtended
   effects:
   - !type:GroupLoadoutEffect
     proto: OxygenBreather
-
-- type: startingGear
-  id: EmergencyOxygenExtended
   storage:
     back:
     - BoxSurvivalEngineering
 
 - type: loadout
   id: EmergencyNitrogenExtended
-  equipment: EmergencyNitrogenExtended
   effects:
   - !type:GroupLoadoutEffect
     proto: NitrogenBreather
-
-- type: startingGear
-  id: EmergencyNitrogenExtended
   storage:
     back:
     - BoxSurvivalEngineeringNitrogen
@@ -110,26 +86,18 @@
 # Medical
 - type: loadout
   id: EmergencyOxygenMedical
-  equipment: EmergencyOxygenMedical
   effects:
   - !type:GroupLoadoutEffect
     proto: OxygenBreather
-
-- type: startingGear
-  id: EmergencyOxygenMedical
   storage:
     back:
     - BoxSurvivalMedical
 
 - type: loadout
   id: EmergencyNitrogenMedical
-  equipment: EmergencyNitrogenMedical
   effects:
   - !type:GroupLoadoutEffect
     proto: NitrogenBreather
-
-- type: startingGear
-  id: EmergencyNitrogenMedical
   storage:
     back:
     - BoxSurvivalMedicalNitrogen
@@ -137,26 +105,18 @@
 # Security
 - type: loadout
   id: EmergencyOxygenSecurity
-  equipment: EmergencyOxygenSecurity
   effects:
   - !type:GroupLoadoutEffect
     proto: OxygenBreather
-
-- type: startingGear
-  id: EmergencyOxygenSecurity
   storage:
     back:
     - BoxSurvivalSecurity
 
 - type: loadout
   id: EmergencyNitrogenSecurity
-  equipment: EmergencyNitrogenSecurity
   effects:
   - !type:GroupLoadoutEffect
     proto: NitrogenBreather
-
-- type: startingGear
-  id: EmergencyNitrogenSecurity
   storage:
     back:
     - BoxSurvivalSecurityNitrogen
@@ -164,26 +124,18 @@
 # Syndicate
 - type: loadout
   id: EmergencyOxygenSyndicate
-  equipment: EmergencyOxygenSyndicate
   effects:
   - !type:GroupLoadoutEffect
     proto: OxygenBreather
-
-- type: startingGear
-  id: EmergencyOxygenSyndicate
   storage:
     back:
     - BoxSurvivalSyndicate
 
 - type: loadout
   id: EmergencyNitrogenSyndicate
-  equipment: EmergencyNitrogenSyndicate
   effects:
   - !type:GroupLoadoutEffect
     proto: NitrogenBreather
-
-- type: startingGear
-  id: EmergencyNitrogenSyndicate
   storage:
     back:
     - BoxSurvivalSyndicateNitrogen
@@ -193,62 +145,42 @@
 # Full Tank Equipped
 - type: loadout
   id: LoadoutSpeciesEVANitrogen
-  equipment: GearEVANitrogen
   effects:
   - !type:GroupLoadoutEffect
     proto: EffectSpeciesVox
-
-- type: startingGear
-  id: GearEVANitrogen
   equipment:
     suitstorage: NitrogenTankFilled
 
 # Tank Harness
 - type: loadout
   id: LoadoutTankHarness
-  equipment: GearTankHarness
   effects:
   - !type:GroupLoadoutEffect
     proto: EffectSpeciesVox
-
-- type: startingGear
-  id: GearTankHarness
   equipment:
     outerClothing: ClothingOuterVestTank
 
 # Breaths Tool On Face
 - type: loadout
   id: LoadoutSpeciesBreathTool
-  equipment: GearSpeciesBreathTool
   effects:
   - !type:GroupLoadoutEffect
     proto: EffectSpeciesVox
-
-- type: startingGear
-  id: GearSpeciesBreathTool
   equipment:
     mask: ClothingMaskBreath
 
 - type: loadout
   id: LoadoutSpeciesBreathToolMedical
-  equipment: GearSpeciesBreathToolMedical
   effects:
   - !type:GroupLoadoutEffect
     proto: EffectSpeciesVox
-
-- type: startingGear
-  id: GearSpeciesBreathToolMedical
   equipment:
     mask: ClothingMaskBreathMedical
 
 - type: loadout
   id: LoadoutSpeciesBreathToolSecurity
-  equipment: GearSpeciesBreathToolSecurity
   effects:
   - !type:GroupLoadoutEffect
     proto: EffectSpeciesVox
-
-- type: startingGear
-  id: GearSpeciesBreathToolSecurity
   equipment:
     mask: ClothingMaskGasSecurity

--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -11,19 +11,11 @@
 # Plushies
 - type: loadout
   id: PlushieLizard
-  equipment: PlushieLizard
-
-- type: startingGear
-  id: PlushieLizard
   storage:
     back:
     - PlushieLizard
-    
-- type: loadout
-  id: PlushieSpaceLizard
-  equipment: PlushieSpaceLizard
 
-- type: startingGear
+- type: loadout
   id: PlushieSpaceLizard
   storage:
     back:
@@ -32,19 +24,11 @@
 # Smokeables
 - type: loadout
   id: Lighter
-  equipment: Lighter
-
-- type: startingGear
-  id: Lighter
   storage:
     back:
     - Lighter
 
 - type: loadout
-  id: CigPackGreen
-  equipment: CigPackGreen
-
-- type: startingGear
   id: CigPackGreen
   storage:
     back:
@@ -52,19 +36,11 @@
 
 - type: loadout
   id: CigPackRed
-  equipment: CigPackRed
-
-- type: startingGear
-  id: CigPackRed
   storage:
     back:
     - CigPackRed
 
 - type: loadout
-  id: CigPackBlue
-  equipment: CigPackBlue
-
-- type: startingGear
   id: CigPackBlue
   storage:
     back:
@@ -72,36 +48,24 @@
 
 - type: loadout
   id: CigPackBlack
-  equipment: CigPackBlack
-
-- type: startingGear
-  id: CigPackBlack
   storage:
     back:
     - CigPackBlack
 
 - type: loadout
   id: CigarCase
-  equipment: CigarCase
   effects:
   - !type:GroupLoadoutEffect
     proto: Command
-
-- type: startingGear
-  id: CigarCase
   storage:
     back:
     - CigarCase
 
 - type: loadout
   id: CigarGold
-  equipment: CigarGold
   effects:
   - !type:GroupLoadoutEffect
     proto: Command
-
-- type: startingGear
-  id: CigarGold
   storage:
     back:
     - CigarGold
@@ -109,19 +73,11 @@
 # Pins
 - type: loadout
   id: ClothingNeckLGBTPin
-  equipment: ClothingNeckLGBTPin
-
-- type: startingGear
-  id: ClothingNeckLGBTPin
   storage:
     back:
     - ClothingNeckLGBTPin
 
 - type: loadout
-  id: ClothingNeckAromanticPin
-  equipment: ClothingNeckAromanticPin
-
-- type: startingGear
   id: ClothingNeckAromanticPin
   storage:
     back:
@@ -129,19 +85,11 @@
 
 - type: loadout
   id: ClothingNeckAsexualPin
-  equipment: ClothingNeckAsexualPin
-
-- type: startingGear
-  id: ClothingNeckAsexualPin
   storage:
     back:
     - ClothingNeckAsexualPin
 
 - type: loadout
-  id: ClothingNeckBisexualPin
-  equipment: ClothingNeckBisexualPin
-
-- type: startingGear
   id: ClothingNeckBisexualPin
   storage:
     back:
@@ -149,19 +97,11 @@
 
 - type: loadout
   id: ClothingNeckIntersexPin
-  equipment: ClothingNeckIntersexPin
-
-- type: startingGear
-  id: ClothingNeckIntersexPin
   storage:
     back:
     - ClothingNeckIntersexPin
 
 - type: loadout
-  id: ClothingNeckLesbianPin
-  equipment: ClothingNeckLesbianPin
-
-- type: startingGear
   id: ClothingNeckLesbianPin
   storage:
     back:
@@ -169,19 +109,11 @@
 
 - type: loadout
   id: ClothingNeckNonBinaryPin
-  equipment: ClothingNeckNonBinaryPin
-
-- type: startingGear
-  id: ClothingNeckNonBinaryPin
   storage:
     back:
     - ClothingNeckNonBinaryPin
 
 - type: loadout
-  id: ClothingNeckPansexualPin
-  equipment: ClothingNeckPansexualPin
-
-- type: startingGear
   id: ClothingNeckPansexualPin
   storage:
     back:
@@ -189,29 +121,17 @@
 
 - type: loadout
   id: ClothingNeckTransPin
-  equipment: ClothingNeckTransPin
-
-- type: startingGear
-  id: ClothingNeckTransPin
   storage:
     back:
     - ClothingNeckTransPin
 
 - type: loadout
   id: ClothingNeckAutismPin
-  equipment: ClothingNeckAutismPin
-
-- type: startingGear
-  id: ClothingNeckAutismPin
   storage:
     back:
     - ClothingNeckAutismPin
 
 - type: loadout
-  id: ClothingNeckGoldAutismPin
-  equipment: ClothingNeckGoldAutismPin
-
-- type: startingGear
   id: ClothingNeckGoldAutismPin
   storage:
     back:


### PR DESCRIPTION
Needs supporting code, probably with an interface with StartingGearPrototype which would also use it, but I regexed the yaml.

regex:
```
ONE
Find
- type: loadout
  id: (.*)
  equipment: (.*)

- type: startingGear
  id: (\2)
  (.*):
    (.*)

Replace
- type: loadout
  id: $1
  $4:
    $5

TWO
Find
- type: loadout
  id: (.*)
  equipment: (.*)
  effects:
  (.*)
  (.*)

- type: startingGear
  id: (\2)
  (.*):
    (.*)

Replace
- type: loadout
  id: $1
  effects:
  $3
  $4
  $6:
    $7

LAST
Find:
- type: loadout
  id: (.*)
  equipment: (.*)

Replace:
- type: loadout
  id: (.*)
  startingGear: (.*)

Prototypes to fix manually, anything where the startinggear was being shared:
- EngineeringBeret
- ScientificBeret
```

Needs a contrib notif for this with the regex attached.