### PR TITLE
Remove shard damage from non-humanoids

### DIFF
--- a/Content.Shared/StepTrigger/Components/StepTriggerImmuneComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerImmuneComponent.cs
@@ -1,13 +1,14 @@
+using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.StepTrigger.Components;
 
 /// <summary>
-/// Grants the attached entity to step triggers.
+/// Grants the attached entity immunity to step triggers.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class StepTriggerImmuneComponent : Component
 {
-    [DataField, ViewVariables]
-    public bool ImmuneToMousetrap = false;
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public EntityWhitelist? Whitelist;
 }

--- a/Content.Shared/StepTrigger/Components/StepTriggerImmuneComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerImmuneComponent.cs
@@ -6,4 +6,8 @@ namespace Content.Shared.StepTrigger.Components;
 /// Grants the attached entity to step triggers.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class StepTriggerImmuneComponent : Component;
+public sealed partial class StepTriggerImmuneComponent : Component
+{
+    [DataField, ViewVariables]
+    public bool ImmuneToMousetrap = false;
+}

--- a/Content.Shared/StepTrigger/Systems/StepTriggerImmuneSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerImmuneSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Examine;
 using Content.Shared.Inventory;
+using Content.Shared.Mousetrap;
 using Content.Shared.StepTrigger.Components;
 using Content.Shared.Tag;
 
@@ -12,13 +13,19 @@ public sealed class StepTriggerImmuneSystem : EntitySystem
     /// <inheritdoc/>
     public override void Initialize()
     {
-        SubscribeLocalEvent<StepTriggerImmuneComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt);
+        SubscribeLocalEvent<StepTriggerComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt);
         SubscribeLocalEvent<ClothingRequiredStepTriggerComponent, StepTriggerAttemptEvent>(OnStepTriggerClothingAttempt);
         SubscribeLocalEvent<ClothingRequiredStepTriggerComponent, ExaminedEvent>(OnExamined);
     }
 
-    private void OnStepTriggerAttempt(Entity<StepTriggerImmuneComponent> ent, ref StepTriggerAttemptEvent args)
+    private void OnStepTriggerAttempt(EntityUid uid, StepTriggerComponent component, ref StepTriggerAttemptEvent args)
     {
+        if (!TryComp<StepTriggerImmuneComponent>(args.Tripper, out var comp))
+            return;
+
+        if (EntityManager.HasComponent<MousetrapComponent>(uid) && !comp.ImmuneToMousetrap)
+            return;
+
         args.Cancelled = true;
     }
 

--- a/Content.Shared/StepTrigger/Systems/StepTriggerImmuneSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerImmuneSystem.cs
@@ -1,14 +1,14 @@
 ﻿using Content.Shared.Examine;
 using Content.Shared.Inventory;
-using Content.Shared.Mousetrap;
+using Content.Shared.Whitelist;
 using Content.Shared.StepTrigger.Components;
-using Content.Shared.Tag;
 
 namespace Content.Shared.StepTrigger.Systems;
 
 public sealed class StepTriggerImmuneSystem : EntitySystem
 {
     [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -23,7 +23,7 @@ public sealed class StepTriggerImmuneSystem : EntitySystem
         if (!TryComp<StepTriggerImmuneComponent>(args.Tripper, out var comp))
             return;
 
-        if (EntityManager.HasComponent<MousetrapComponent>(uid) && !comp.ImmuneToMousetrap)
+        if (_whitelistSystem.IsWhitelistFailOrNull(comp.Whitelist, args.Source))
             return;
 
         args.Cancelled = true;

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -64,6 +64,9 @@
     price: 1000 # Living critters are valuable in space.
   - type: Perishable
   - type: StepTriggerImmune
+    whitelist:
+      tags:
+        - Trash
 
 - type: entity
   parent:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -63,6 +63,7 @@
   - type: MobPrice
     price: 1000 # Living critters are valuable in space.
   - type: Perishable
+  - type: StepTriggerImmune
 
 - type: entity
   parent:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
All mobs that are instances of SimpleSpaceMobBase (mice, rats, roaches, etc.) will no longer be stunned/damaged by sharp objects with this behavior excluding mouse traps.

Humanoid mobs like humans (excluding mobs that already have protection *cough* vox *cough*) will still take damage from sharp objects when not wearing footwear.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Most mobs that aren't humanoids can't wear footwear and most of them are weak enough to die or be sent into critical health from stepping on a sharp object, and since maint dweller mobs like mice and roaches can't even see in the dark they are extremely susceptible to dying from glass shards / sharp trash left in maints without even knowing it was there.

This change would prevent death to a mechanic that doesn't bring much to the table in terms of an interesting challenge. It also makes maintenance shafts a bit safer from random death to mobs that *should* be able to survive in those areas

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
-->
:cl:
- tweak: Mice, rats and all other non-humanoid creatures will not longer take damage from sharp objects such as glass shards and broken lights, this excludes mouse traps.
