### PR TITLE
JobRequirement refactor

### DIFF
--- a/Content.Client/LateJoin/LateJoinGui.cs
+++ b/Content.Client/LateJoin/LateJoinGui.cs
@@ -2,9 +2,11 @@ using System.Linq;
 using System.Numerics;
 using Content.Client.CrewManifest;
 using Content.Client.GameTicking.Managers;
+using Content.Client.Lobby;
 using Content.Client.UserInterface.Controls;
 using Content.Client.Players.PlayTimeTracking;
 using Content.Shared.CCVar;
+using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Content.Shared.StatusIcon;
 using Robust.Client.Console;
@@ -26,6 +28,7 @@ namespace Content.Client.LateJoin
         [Dependency] private readonly IConfigurationManager _configManager = default!;
         [Dependency] private readonly IEntitySystemManager _entitySystem = default!;
         [Dependency] private readonly JobRequirementsManager _jobRequirements = default!;
+        [Dependency] private readonly IClientPreferencesManager _preferencesManager = default!;
 
         public event Action<(NetEntity, string)> SelectedId;
 
@@ -254,7 +257,7 @@ namespace Content.Client.LateJoin
 
                         jobButton.OnPressed += _ => SelectedId.Invoke((id, jobButton.JobId));
 
-                        if (!_jobRequirements.IsAllowed(prototype, out var reason))
+                        if (!_jobRequirements.IsAllowed(prototype, (HumanoidCharacterProfile?)_preferencesManager.Preferences?.SelectedCharacter, out var reason))
                         {
                             jobButton.Disabled = true;
 

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -634,7 +634,7 @@ namespace Content.Client.Lobby.UI
                 selector.Select(Profile?.AntagPreferences.Contains(antag.ID) == true ? 0 : 1);
 
                 var requirements = _entManager.System<SharedRoleSystem>().GetAntagRequirement(antag);
-                if (!_requirements.CheckRoleTime(requirements, out var reason))
+                if (!_requirements.CheckRoleRequirements(requirements, out var reason))
                 {
                     selector.LockRequirements(reason);
                     Profile = Profile?.WithAntagPreference(antag.ID, false);

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -634,7 +634,7 @@ namespace Content.Client.Lobby.UI
                 selector.Select(Profile?.AntagPreferences.Contains(antag.ID) == true ? 0 : 1);
 
                 var requirements = _entManager.System<SharedRoleSystem>().GetAntagRequirement(antag);
-                if (!_requirements.CheckRoleRequirements(requirements, out var reason))
+                if (!_requirements.CheckRoleRequirements(requirements, (HumanoidCharacterProfile?)_preferencesManager.Preferences?.SelectedCharacter, out var reason))
                 {
                     selector.LockRequirements(reason);
                     Profile = Profile?.WithAntagPreference(antag.ID, false);
@@ -887,7 +887,7 @@ namespace Content.Client.Lobby.UI
                     icon.Texture = jobIcon.Icon.Frame0();
                     selector.Setup(items, job.LocalizedName, 200, job.LocalizedDescription, icon, job.Guides);
 
-                    if (!_requirements.IsAllowed(job, out var reason))
+                    if (!_requirements.IsAllowed(job, (HumanoidCharacterProfile?)_preferencesManager.Preferences?.SelectedCharacter, out var reason))
                     {
                         selector.LockRequirements(reason);
                     }

--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -106,16 +106,16 @@ public sealed class JobRequirementsManager : ISharedPlaytimeManager
         if (player == null)
             return true;
 
-        return CheckRoleTime(job, out reason);
+        return CheckRoleRequirements(job, out reason);
     }
 
-    public bool CheckRoleTime(JobPrototype job, [NotNullWhen(false)] out FormattedMessage? reason)
+    public bool CheckRoleRequirements(JobPrototype job, [NotNullWhen(false)] out FormattedMessage? reason)
     {
         var reqs = _entManager.System<SharedRoleSystem>().GetJobRequirement(job);
-        return CheckRoleTime(reqs, out reason);
+        return CheckRoleRequirements(reqs, out reason);
     }
 
-    public bool CheckRoleTime(HashSet<JobRequirement>? requirements, [NotNullWhen(false)] out FormattedMessage? reason)
+    public bool CheckRoleRequirements(HashSet<JobRequirement>? requirements, [NotNullWhen(false)] out FormattedMessage? reason)
     {
         reason = null;
 
@@ -125,7 +125,7 @@ public sealed class JobRequirementsManager : ISharedPlaytimeManager
         var reasons = new List<string>();
         foreach (var requirement in requirements)
         {
-            if (JobRequirements.TryRequirementMet(requirement, _roles, out var jobReason, _entManager, _prototypes))
+            if (requirement.Check(_entManager, _prototypes, _roles, out var jobReason))
                 continue;
 
             reasons.Add(jobReason.ToMarkup());

--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -1,8 +1,10 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Content.Client.Lobby;
 using Content.Shared.CCVar;
 using Content.Shared.Players;
 using Content.Shared.Players.JobWhitelist;
 using Content.Shared.Players.PlayTimeTracking;
+using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Robust.Client;
 using Robust.Client.Player;
@@ -22,6 +24,7 @@ public sealed class JobRequirementsManager : ISharedPlaytimeManager
     [Dependency] private readonly IEntityManager _entManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
+    [Dependency] private readonly IClientPreferencesManager _preferencesManager = default!;
 
     private readonly Dictionary<string, TimeSpan> _roles = new();
     private readonly List<string> _roleBans = new();
@@ -122,10 +125,12 @@ public sealed class JobRequirementsManager : ISharedPlaytimeManager
         if (requirements == null || !_cfg.GetCVar(CCVars.GameRoleTimers))
             return true;
 
+        var profile = (HumanoidCharacterProfile?) _preferencesManager.Preferences?.SelectedCharacter;
+
         var reasons = new List<string>();
         foreach (var requirement in requirements)
         {
-            if (requirement.Check(_entManager, _prototypes, _roles, out var jobReason))
+            if (requirement.Check(_entManager, _prototypes, profile, _roles, out var jobReason))
                 continue;
 
             reasons.Add(jobReason.ToMarkup());

--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -125,12 +125,10 @@ public sealed class JobRequirementsManager : ISharedPlaytimeManager
         if (requirements == null || !_cfg.GetCVar(CCVars.GameRoleTimers))
             return true;
 
-        var profile = (HumanoidCharacterProfile?) _preferencesManager.Preferences?.SelectedCharacter;
-
         var reasons = new List<string>();
         foreach (var requirement in requirements)
         {
-            if (requirement.Check(_entManager, _prototypes, profile, _roles, out var jobReason))
+            if (requirement.Check(_entManager, _prototypes, (HumanoidCharacterProfile?)_preferencesManager.Preferences?.SelectedCharacter, _roles, out var jobReason))
                 continue;
 
             reasons.Add(jobReason.ToMarkup());

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
@@ -93,7 +93,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
                 bool hasAccess = true;
                 FormattedMessage? reason;
 
-                if (!requirementsManager.CheckRoleTime(group.Key.Requirements, out reason))
+                if (!requirementsManager.CheckRoleRequirements(group.Key.Requirements, out reason))
                 {
                     hasAccess = false;
                 }

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
@@ -93,7 +93,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
                 bool hasAccess = true;
                 FormattedMessage? reason;
 
-                if (!requirementsManager.CheckRoleRequirements(group.Key.Requirements, out reason))
+                if (!requirementsManager.CheckRoleRequirements(group.Key.Requirements, null, out reason))
                 {
                     hasAccess = false;
                 }

--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Afk.Events;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Events;
 using Content.Server.Mind;
+using Content.Server.Preferences.Managers;
 using Content.Server.Station.Events;
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
@@ -13,6 +14,7 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Players;
 using Content.Shared.Players.PlayTimeTracking;
+using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
@@ -35,6 +37,7 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
     [Dependency] private readonly MindSystem _minds = default!;
     [Dependency] private readonly PlayTimeTrackingManager _tracking = default!;
     [Dependency] private readonly IAdminManager _adminManager = default!;
+    [Dependency] private readonly IServerPreferencesManager _preferencesManager = default!;
 
     public override void Initialize()
     {
@@ -205,8 +208,9 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
             Log.Error($"Unable to check playtimes {Environment.StackTrace}");
             playTimes = new Dictionary<string, TimeSpan>();
         }
+        var profile = (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(player.UserId).SelectedCharacter;
 
-        return JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes);
+        return JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, profile);
     }
 
     public HashSet<ProtoId<JobPrototype>> GetDisallowedJobs(ICommonSession player)
@@ -221,9 +225,11 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
             playTimes = new Dictionary<string, TimeSpan>();
         }
 
+        var profile = (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(player.UserId).SelectedCharacter;
+
         foreach (var job in _prototypes.EnumeratePrototypes<JobPrototype>())
         {
-            if (JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes))
+            if (JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, profile))
                 roles.Add(job.ID);
         }
 
@@ -243,10 +249,12 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
             playTimes ??= new Dictionary<string, TimeSpan>();
         }
 
+        var profile = (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(userId).SelectedCharacter;
+
         for (var i = 0; i < jobs.Count; i++)
         {
             if (_prototypes.TryIndex(jobs[i], out var job)
-                && JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes))
+                && JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, profile))
             {
                 continue;
             }

--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
@@ -208,9 +208,8 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
             Log.Error($"Unable to check playtimes {Environment.StackTrace}");
             playTimes = new Dictionary<string, TimeSpan>();
         }
-        var profile = (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(player.UserId).SelectedCharacter;
 
-        return JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, profile);
+        return JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(player.UserId).SelectedCharacter);
     }
 
     public HashSet<ProtoId<JobPrototype>> GetDisallowedJobs(ICommonSession player)
@@ -225,11 +224,9 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
             playTimes = new Dictionary<string, TimeSpan>();
         }
 
-        var profile = (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(player.UserId).SelectedCharacter;
-
         foreach (var job in _prototypes.EnumeratePrototypes<JobPrototype>())
         {
-            if (JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, profile))
+            if (JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(player.UserId).SelectedCharacter))
                 roles.Add(job.ID);
         }
 
@@ -249,12 +246,10 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
             playTimes ??= new Dictionary<string, TimeSpan>();
         }
 
-        var profile = (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(userId).SelectedCharacter;
-
         for (var i = 0; i < jobs.Count; i++)
         {
             if (_prototypes.TryIndex(jobs[i], out var job)
-                && JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, profile))
+                && JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(userId).SelectedCharacter))
             {
                 continue;
             }

--- a/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
@@ -27,6 +27,7 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
         var playtimes = manager.GetPlayTimes(session);
         return Requirement.Check(collection.Resolve<IEntityManager>(),
             collection.Resolve<IPrototypeManager>(),
+            profile,
             playtimes,
             out reason);
     }

--- a/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
@@ -25,8 +25,9 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
 
         var manager = collection.Resolve<ISharedPlaytimeManager>();
         var playtimes = manager.GetPlayTimes(session);
-        return JobRequirements.TryRequirementMet(Requirement, playtimes, out reason,
-            collection.Resolve<IEntityManager>(),
-            collection.Resolve<IPrototypeManager>());
+        return Requirement.Check(collection.Resolve<IEntityManager>(),
+            collection.Resolve<IPrototypeManager>(),
+            playtimes,
+            out reason);
     }
 }

--- a/Content.Shared/Roles/DepartmentPrototype.cs
+++ b/Content.Shared/Roles/DepartmentPrototype.cs
@@ -9,7 +9,13 @@ public sealed partial class DepartmentPrototype : IPrototype
     public string ID { get; } = string.Empty;
 
     /// <summary>
-    /// A description string to display in the character menu as an explanation of the department's function.
+    /// The name LocId of the department that will be displayed in the various menus.
+    /// </summary>
+    [DataField(required: true)]
+    public LocId Name = string.Empty;
+
+    /// <summary>
+    /// A description LocId to display in the character menu as an explanation of the department's function.
     /// </summary>
     [DataField(required: true)]
     public string Description = string.Empty;

--- a/Content.Shared/Roles/DepartmentPrototype.cs
+++ b/Content.Shared/Roles/DepartmentPrototype.cs
@@ -18,7 +18,7 @@ public sealed partial class DepartmentPrototype : IPrototype
     /// A description LocId to display in the character menu as an explanation of the department's function.
     /// </summary>
     [DataField(required: true)]
-    public string Description = string.Empty;
+    public LocId Description = string.Empty;
 
     /// <summary>
     /// A color representing this department to use for text.

--- a/Content.Shared/Roles/JobRequirement/AgeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/AgeRequirement.cs
@@ -25,8 +25,8 @@ public sealed partial class AgeRequirement : JobRequirement
     {
         reason = new FormattedMessage();
 
-        if (profile is null)
-            return false;
+        if (profile is null) //the profile could be null if the player is a ghost. In this case we don't need to block the role selection for ghostrole
+            return true;
 
         if (!Inverted)
         {

--- a/Content.Shared/Roles/JobRequirement/AgeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/AgeRequirement.cs
@@ -7,11 +7,14 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Roles;
 
+/// <summary>
+/// Requires the character to be older or younger than a certain age (inclusive)
+/// </summary>
 [UsedImplicitly]
 [Serializable, NetSerializable]
 public sealed partial class AgeRequirement : JobRequirement
 {
-    [DataField]
+    [DataField(required: true)]
     public int RequiredAge;
 
     public override bool Check(IEntityManager entManager,

--- a/Content.Shared/Roles/JobRequirement/AgeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/AgeRequirement.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Preferences;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Roles;
+
+[UsedImplicitly]
+[Serializable, NetSerializable]
+public sealed partial class AgeRequirement : JobRequirement
+{
+    [DataField]
+    public int RequiredAge;
+
+    public override bool Check(IEntityManager entManager,
+        IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile,
+        IReadOnlyDictionary<string, TimeSpan> playTimes,
+        [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = new FormattedMessage();
+
+        if (profile is null)
+            return false;
+
+        if (!Inverted)
+        {
+            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString("role-timer-age-to-young",
+                ("age", RequiredAge)));
+
+            if (profile.Age >= RequiredAge){}
+                return false;
+        }
+        else
+        {
+            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString("role-timer-age-to-old",
+                ("age", RequiredAge)));
+
+            if (profile.Age <= RequiredAge)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/Roles/JobRequirement/AgeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/AgeRequirement.cs
@@ -30,7 +30,7 @@ public sealed partial class AgeRequirement : JobRequirement
             reason = FormattedMessage.FromMarkupPermissive(Loc.GetString("role-timer-age-to-young",
                 ("age", RequiredAge)));
 
-            if (profile.Age >= RequiredAge){}
+            if (profile.Age <= RequiredAge)
                 return false;
         }
         else
@@ -38,7 +38,7 @@ public sealed partial class AgeRequirement : JobRequirement
             reason = FormattedMessage.FromMarkupPermissive(Loc.GetString("role-timer-age-to-old",
                 ("age", RequiredAge)));
 
-            if (profile.Age <= RequiredAge)
+            if (profile.Age >= RequiredAge)
                 return false;
         }
 

--- a/Content.Shared/Roles/JobRequirement/DepartmentTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/DepartmentTimeRequirement.cs
@@ -48,6 +48,12 @@ public sealed partial class DepartmentTimeRequirement : JobRequirement
         }
 
         var deptDiff = Time.TotalMinutes - playtime.TotalMinutes;
+        var nameDepartment = "role-timer-department-unknown";
+
+        if (protoManager.TryIndex(Department, out var departmentIndexed))
+        {
+            nameDepartment = departmentIndexed.Name;
+        }
 
         if (!Inverted)
         {
@@ -57,7 +63,7 @@ public sealed partial class DepartmentTimeRequirement : JobRequirement
             reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
                 "role-timer-department-insufficient",
                 ("time", Math.Ceiling(deptDiff)),
-                ("department", Loc.GetString(Department)),
+                ("department", Loc.GetString(nameDepartment)),
                 ("departmentColor", department.Color.ToHex())));
             return false;
         }
@@ -67,7 +73,7 @@ public sealed partial class DepartmentTimeRequirement : JobRequirement
             reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
                 "role-timer-department-too-high",
                 ("time", -deptDiff),
-                ("department", Loc.GetString(Department)),
+                ("department", Loc.GetString(nameDepartment)),
                 ("departmentColor", department.Color.ToHex())));
             return false;
         }

--- a/Content.Shared/Roles/JobRequirement/DepartmentTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/DepartmentTimeRequirement.cs
@@ -1,0 +1,75 @@
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Roles;
+
+[UsedImplicitly]
+[Serializable, NetSerializable]
+public sealed partial class DepartmentTimeRequirement : JobRequirement
+{
+    /// <summary>
+    /// Which department needs the required amount of time.
+    /// </summary>
+    [DataField]
+    public ProtoId<DepartmentPrototype> Department = default!;
+
+    /// <summary>
+    /// How long (in seconds) this requirement is.
+    /// </summary>
+    [DataField]
+    public TimeSpan Time;
+
+    public override bool Check(IEntityManager entManager,
+        IPrototypeManager protoManager,
+        IReadOnlyDictionary<string, TimeSpan> playTimes,
+        [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = new FormattedMessage();
+        var playtime = TimeSpan.Zero;
+
+        // Check all jobs' departments
+        var department = protoManager.Index(Department);
+        var jobs = department.Roles;
+        string proto;
+
+        // Check all jobs' playtime
+        foreach (var other in jobs)
+        {
+            // The schema is stored on the Job role but we want to explode if the timer isn't found anyway.
+            proto = protoManager.Index(other).PlayTimeTracker;
+
+            playTimes.TryGetValue(proto, out var otherTime);
+            playtime += otherTime;
+        }
+
+        var deptDiff = Time.TotalMinutes - playtime.TotalMinutes;
+
+        if (!Inverted)
+        {
+            if (deptDiff <= 0)
+                return true;
+
+            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
+                "role-timer-department-insufficient",
+                ("time", Math.Ceiling(deptDiff)),
+                ("department", Loc.GetString(Department)),
+                ("departmentColor", department.Color.ToHex())));
+            return false;
+        }
+
+        if (deptDiff <= 0)
+        {
+            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
+                "role-timer-department-too-high",
+                ("time", -deptDiff),
+                ("department", Loc.GetString(Department)),
+                ("departmentColor", department.Color.ToHex())));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/Roles/JobRequirement/DepartmentTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/DepartmentTimeRequirement.cs
@@ -14,13 +14,13 @@ public sealed partial class DepartmentTimeRequirement : JobRequirement
     /// <summary>
     /// Which department needs the required amount of time.
     /// </summary>
-    [DataField]
+    [DataField(required: true)]
     public ProtoId<DepartmentPrototype> Department = default!;
 
     /// <summary>
     /// How long (in seconds) this requirement is.
     /// </summary>
-    [DataField]
+    [DataField(required: true)]
     public TimeSpan Time;
 
     public override bool Check(IEntityManager entManager,

--- a/Content.Shared/Roles/JobRequirement/DepartmentTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/DepartmentTimeRequirement.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Preferences;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -24,6 +25,7 @@ public sealed partial class DepartmentTimeRequirement : JobRequirement
 
     public override bool Check(IEntityManager entManager,
         IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile,
         IReadOnlyDictionary<string, TimeSpan> playTimes,
         [NotNullWhen(false)] out FormattedMessage? reason)
     {

--- a/Content.Shared/Roles/JobRequirement/OverallPlaytimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/OverallPlaytimeRequirement.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Players.PlayTimeTracking;
+using Content.Shared.Preferences;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -17,6 +18,7 @@ public sealed partial class OverallPlaytimeRequirement : JobRequirement
 
     public override bool Check(IEntityManager entManager,
         IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile,
         IReadOnlyDictionary<string, TimeSpan> playTimes,
         [NotNullWhen(false)] out FormattedMessage? reason)
     {

--- a/Content.Shared/Roles/JobRequirement/OverallPlaytimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/OverallPlaytimeRequirement.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Roles;
 public sealed partial class OverallPlaytimeRequirement : JobRequirement
 {
     /// <inheritdoc cref="DepartmentTimeRequirement.Time"/>
-    [DataField]
+    [DataField(required: true)]
     public TimeSpan Time;
 
     public override bool Check(IEntityManager entManager,

--- a/Content.Shared/Roles/JobRequirement/OverallPlaytimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/OverallPlaytimeRequirement.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Players.PlayTimeTracking;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Roles;
+
+[UsedImplicitly]
+[Serializable, NetSerializable]
+public sealed partial class OverallPlaytimeRequirement : JobRequirement
+{
+    /// <inheritdoc cref="DepartmentTimeRequirement.Time"/>
+    [DataField]
+    public TimeSpan Time;
+
+    public override bool Check(IEntityManager entManager,
+        IPrototypeManager protoManager,
+        IReadOnlyDictionary<string, TimeSpan> playTimes,
+        [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = new FormattedMessage();
+
+        var overallTime = playTimes.GetValueOrDefault(PlayTimeTrackingShared.TrackerOverall);
+        var overallDiff = Time.TotalMinutes - overallTime.TotalMinutes;
+
+        if (!Inverted)
+        {
+            if (overallDiff <= 0 || overallTime >= Time)
+                return true;
+
+            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
+                "role-timer-overall-insufficient",
+                ("time", Math.Ceiling(overallDiff))));
+            return false;
+        }
+
+        if (overallDiff <= 0 || overallTime >= Time)
+        {
+            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString("role-timer-overall-too-high",
+                ("time", -overallDiff)));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
@@ -16,11 +16,11 @@ public sealed partial class RoleTimeRequirement : JobRequirement
     /// <summary>
     /// What particular role they need the time requirement with.
     /// </summary>
-    [DataField]
+    [DataField(required: true)]
     public ProtoId<PlayTimeTrackerPrototype> Role = default!;
 
     /// <inheritdoc cref="DepartmentTimeRequirement.Time"/>
-    [DataField]
+    [DataField(required: true)]
     public TimeSpan Time;
 
     public override bool Check(IEntityManager entManager,

--- a/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Players.PlayTimeTracking;
+using Content.Shared.Preferences;
 using Content.Shared.Roles.Jobs;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
@@ -24,6 +25,7 @@ public sealed partial class RoleTimeRequirement : JobRequirement
 
     public override bool Check(IEntityManager entManager,
         IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile,
         IReadOnlyDictionary<string, TimeSpan> playTimes,
         [NotNullWhen(false)] out FormattedMessage? reason)
     {

--- a/Content.Shared/Roles/JobRequirement/SpeciesRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/SpeciesRequirement.cs
@@ -26,8 +26,8 @@ public sealed partial class SpeciesRequirement : JobRequirement
     {
         reason = new FormattedMessage();
 
-        if (profile is null)
-            return false;
+        if (profile is null) //the profile could be null if the player is a ghost. In this case we don't need to block the role selection for ghostrole
+            return true;
 
         var speciesList = "[color=yellow]";
         foreach (var s in Species)

--- a/Content.Shared/Roles/JobRequirement/SpeciesRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/SpeciesRequirement.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Preferences;
 using JetBrains.Annotations;
@@ -29,23 +30,25 @@ public sealed partial class SpeciesRequirement : JobRequirement
         if (profile is null) //the profile could be null if the player is a ghost. In this case we don't need to block the role selection for ghostrole
             return true;
 
-        var speciesList = "[color=yellow]";
+        var sb = new StringBuilder();
+        sb.Append("[color=yellow]");
         foreach (var s in Species)
         {
-            speciesList += Loc.GetString(protoManager.Index(s).Name) + " ";
+            sb.Append(Loc.GetString(protoManager.Index(s).Name) + " ");
         }
-        speciesList += "[/color]";
+
+        sb.Append("[/color]");
 
         if (!Inverted)
         {
-            reason = FormattedMessage.FromMarkupPermissive($"{Loc.GetString("role-timer-whitelisted-species")}\n{speciesList}");
+            reason = FormattedMessage.FromMarkupPermissive($"{Loc.GetString("role-timer-whitelisted-species")}\n{sb}");
 
             if (!Species.Contains(profile.Species))
                 return false;
         }
         else
         {
-            reason = FormattedMessage.FromMarkupPermissive($"{Loc.GetString("role-timer-blacklisted-species")}\n{speciesList}");
+            reason = FormattedMessage.FromMarkupPermissive($"{Loc.GetString("role-timer-blacklisted-species")}\n{sb}");
 
             if (Species.Contains(profile.Species))
                 return false;

--- a/Content.Shared/Roles/JobRequirement/SpeciesRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/SpeciesRequirement.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Humanoid.Prototypes;
+using Content.Shared.Preferences;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Roles;
+
+/// <summary>
+/// Requires the character to be or not be on the list of specified species
+/// </summary>
+[UsedImplicitly]
+[Serializable, NetSerializable]
+public sealed partial class SpeciesRequirement : JobRequirement
+{
+    [DataField(required: true)]
+    public HashSet<ProtoId<SpeciesPrototype>> Species = new();
+
+    public override bool Check(IEntityManager entManager,
+        IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile,
+        IReadOnlyDictionary<string, TimeSpan> playTimes,
+        [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = new FormattedMessage();
+
+        if (profile is null)
+            return false;
+
+        var speciesList = "[color=yellow]";
+        foreach (var s in Species)
+        {
+            speciesList += Loc.GetString(protoManager.Index(s).Name) + " ";
+        }
+        speciesList += "[/color]";
+
+        if (!Inverted)
+        {
+            reason = FormattedMessage.FromMarkupPermissive($"{Loc.GetString("role-timer-whitelisted-species")}\n{speciesList}");
+
+            if (!Species.Contains(profile.Species))
+                return false;
+        }
+        else
+        {
+            reason = FormattedMessage.FromMarkupPermissive($"{Loc.GetString("role-timer-blacklisted-species")}\n{speciesList}");
+
+            if (Species.Contains(profile.Species))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Shared/Roles/JobRequirements.cs
+++ b/Content.Shared/Roles/JobRequirements.cs
@@ -1,228 +1,48 @@
 using System.Diagnostics.CodeAnalysis;
-using Content.Shared.Players.PlayTimeTracking;
-using Content.Shared.Roles.Jobs;
-using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Utility;
 
-namespace Content.Shared.Roles
+namespace Content.Shared.Roles;
+
+public static class JobRequirements
 {
-    /// <summary>
-    /// Abstract class for playtime and other requirements for role gates.
-    /// </summary>
-    [ImplicitDataDefinitionForInheritors]
-    [Serializable, NetSerializable]
-    public abstract partial class JobRequirement{}
-
-    [UsedImplicitly]
-    [Serializable, NetSerializable]
-    public sealed partial class DepartmentTimeRequirement : JobRequirement
+    public static bool TryRequirementsMet(
+        JobPrototype job,
+        IReadOnlyDictionary<string, TimeSpan> playTimes,
+        [NotNullWhen(false)] out FormattedMessage? reason,
+        IEntityManager entManager,
+        IPrototypeManager protoManager)
     {
-        /// <summary>
-        /// Which department needs the required amount of time.
-        /// </summary>
-        [DataField("department", customTypeSerializer: typeof(PrototypeIdSerializer<DepartmentPrototype>))]
-        public string Department = default!;
-
-        /// <summary>
-        /// How long (in seconds) this requirement is.
-        /// </summary>
-        [DataField("time")] public TimeSpan Time;
-
-        /// <summary>
-        /// If true, requirement will return false if playtime above the specified time.
-        /// </summary>
-        /// <value>
-        /// <c>False</c> by default.<br />
-        /// <c>True</c> for invert general requirement
-        /// </value>
-        [DataField("inverted")] public bool Inverted;
-    }
-
-    [UsedImplicitly]
-    [Serializable, NetSerializable]
-    public sealed partial class RoleTimeRequirement : JobRequirement
-    {
-        /// <summary>
-        /// What particular role they need the time requirement with.
-        /// </summary>
-        [DataField("role", customTypeSerializer: typeof(PrototypeIdSerializer<PlayTimeTrackerPrototype>))]
-        public string Role = default!;
-
-        /// <inheritdoc cref="DepartmentTimeRequirement.Time"/>
-        [DataField("time")] public TimeSpan Time;
-
-        /// <inheritdoc cref="DepartmentTimeRequirement.Inverted"/>
-        [DataField("inverted")] public bool Inverted;
-    }
-
-    [UsedImplicitly]
-    [Serializable, NetSerializable]
-    public sealed partial class OverallPlaytimeRequirement : JobRequirement
-    {
-        /// <inheritdoc cref="DepartmentTimeRequirement.Time"/>
-        [DataField("time")] public TimeSpan Time;
-
-        /// <inheritdoc cref="DepartmentTimeRequirement.Inverted"/>
-        [DataField("inverted")] public bool Inverted;
-    }
-
-    public static class JobRequirements
-    {
-        public static bool TryRequirementsMet(
-            JobPrototype job,
-            IReadOnlyDictionary<string, TimeSpan> playTimes,
-            [NotNullWhen(false)] out FormattedMessage? reason,
-            IEntityManager entManager,
-            IPrototypeManager prototypes)
-        {
-            var sys = entManager.System<SharedRoleSystem>();
-            var requirements = sys.GetJobRequirement(job);
-            reason = null;
-            if (requirements == null)
-                return true;
-
-            foreach (var requirement in requirements)
-            {
-                if (!TryRequirementMet(requirement, playTimes, out reason, entManager, prototypes))
-                    return false;
-            }
-
+        var sys = entManager.System<SharedRoleSystem>();
+        var requirements = sys.GetJobRequirement(job);
+        reason = null;
+        if (requirements == null)
             return true;
-        }
 
-        /// <summary>
-        /// Returns a string with the reason why a particular requirement may not be met.
-        /// </summary>
-        public static bool TryRequirementMet(
-            JobRequirement requirement,
-            IReadOnlyDictionary<string, TimeSpan> playTimes,
-            [NotNullWhen(false)] out FormattedMessage? reason,
-            IEntityManager entManager,
-            IPrototypeManager prototypes)
+        foreach (var requirement in requirements)
         {
-            reason = null;
-
-            switch (requirement)
-            {
-                case DepartmentTimeRequirement deptRequirement:
-                    var playtime = TimeSpan.Zero;
-
-                    // Check all jobs' departments
-                    var department = prototypes.Index<DepartmentPrototype>(deptRequirement.Department);
-                    var jobs = department.Roles;
-                    string proto;
-
-                    // Check all jobs' playtime
-                    foreach (var other in jobs)
-                    {
-                        // The schema is stored on the Job role but we want to explode if the timer isn't found anyway.
-                        proto = prototypes.Index<JobPrototype>(other).PlayTimeTracker;
-
-                        playTimes.TryGetValue(proto, out var otherTime);
-                        playtime += otherTime;
-                    }
-
-                    var deptDiff = deptRequirement.Time.TotalMinutes - playtime.TotalMinutes;
-
-                    if (!deptRequirement.Inverted)
-                    {
-                        if (deptDiff <= 0)
-                            return true;
-
-                        reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
-                            "role-timer-department-insufficient",
-                            ("time", Math.Ceiling(deptDiff)),
-                            ("department", Loc.GetString(deptRequirement.Department)),
-                            ("departmentColor", department.Color.ToHex())));
-                        return false;
-                    }
-                    else
-                    {
-                        if (deptDiff <= 0)
-                        {
-                            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
-                                "role-timer-department-too-high",
-                                ("time", -deptDiff),
-                                ("department", Loc.GetString(deptRequirement.Department)),
-                                ("departmentColor", department.Color.ToHex())));
-                            return false;
-                        }
-
-                        return true;
-                    }
-
-                case OverallPlaytimeRequirement overallRequirement:
-                    var overallTime = playTimes.GetValueOrDefault(PlayTimeTrackingShared.TrackerOverall);
-                    var overallDiff = overallRequirement.Time.TotalMinutes - overallTime.TotalMinutes;
-
-                    if (!overallRequirement.Inverted)
-                    {
-                        if (overallDiff <= 0 || overallTime >= overallRequirement.Time)
-                            return true;
-
-                        reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
-                              "role-timer-overall-insufficient",
-                              ("time", Math.Ceiling(overallDiff))));
-                        return false;
-                    }
-                    else
-                    {
-                        if (overallDiff <= 0 || overallTime >= overallRequirement.Time)
-                        {
-                            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString("role-timer-overall-too-high", ("time", -overallDiff)));
-                            return false;
-                        }
-
-                        return true;
-                    }
-
-                case RoleTimeRequirement roleRequirement:
-                    proto = roleRequirement.Role;
-
-                    playTimes.TryGetValue(proto, out var roleTime);
-                    var roleDiff = roleRequirement.Time.TotalMinutes - roleTime.TotalMinutes;
-                    var departmentColor = Color.Yellow;
-
-                    if (entManager.EntitySysManager.TryGetEntitySystem(out SharedJobSystem? jobSystem))
-                    {
-                        var jobProto = jobSystem.GetJobPrototype(proto);
-
-                        if (jobSystem.TryGetDepartment(jobProto, out var departmentProto))
-                            departmentColor = departmentProto.Color;
-                    }
-
-                    if (!roleRequirement.Inverted)
-                    {
-                        if (roleDiff <= 0)
-                            return true;
-
-                        reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
-                            "role-timer-role-insufficient",
-                            ("time", Math.Ceiling(roleDiff)),
-                            ("job", Loc.GetString(proto)),
-                            ("departmentColor", departmentColor.ToHex())));
-                        return false;
-                    }
-                    else
-                    {
-                        if (roleDiff <= 0)
-                        {
-                            reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
-                                "role-timer-role-too-high",
-                                ("time", -roleDiff),
-                                ("job", Loc.GetString(proto)),
-                                ("departmentColor", departmentColor.ToHex())));
-                            return false;
-                        }
-
-                        return true;
-                    }
-                default:
-                    throw new NotImplementedException();
-            }
+            if (!requirement.Check(entManager, protoManager, playTimes, out reason))
+                return false;
         }
+
+        return true;
     }
+}
+
+/// <summary>
+/// Abstract class for playtime and other requirements for role gates.
+/// </summary>
+[ImplicitDataDefinitionForInheritors]
+[Serializable, NetSerializable]
+public abstract partial class JobRequirement
+{
+    [DataField]
+    public bool Inverted;
+
+    public abstract bool Check(
+        IEntityManager entManager,
+        IPrototypeManager protoManager,
+        IReadOnlyDictionary<string, TimeSpan> playTimes,
+        [NotNullWhen(false)] out FormattedMessage? reason);
 }

--- a/Content.Shared/Roles/JobRequirements.cs
+++ b/Content.Shared/Roles/JobRequirements.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Preferences;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
@@ -12,7 +13,8 @@ public static class JobRequirements
         IReadOnlyDictionary<string, TimeSpan> playTimes,
         [NotNullWhen(false)] out FormattedMessage? reason,
         IEntityManager entManager,
-        IPrototypeManager protoManager)
+        IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile)
     {
         var sys = entManager.System<SharedRoleSystem>();
         var requirements = sys.GetJobRequirement(job);
@@ -22,7 +24,7 @@ public static class JobRequirements
 
         foreach (var requirement in requirements)
         {
-            if (!requirement.Check(entManager, protoManager, playTimes, out reason))
+            if (!requirement.Check(entManager, protoManager, profile, playTimes, out reason))
                 return false;
         }
 
@@ -43,6 +45,7 @@ public abstract partial class JobRequirement
     public abstract bool Check(
         IEntityManager entManager,
         IPrototypeManager protoManager,
+        HumanoidCharacterProfile? profile,
         IReadOnlyDictionary<string, TimeSpan> playTimes,
         [NotNullWhen(false)] out FormattedMessage? reason);
 }

--- a/Resources/Locale/en-US/job/role-requirements.ftl
+++ b/Resources/Locale/en-US/job/role-requirements.ftl
@@ -4,6 +4,8 @@ role-timer-overall-insufficient = You require [color=yellow]{TOSTRING($time, "0"
 role-timer-overall-too-high = You require [color=yellow]{TOSTRING($time, "0")}[/color] fewer minutes of playtime to play this role. (Are you trying to play a trainee role?)
 role-timer-role-insufficient = You require [color=yellow]{TOSTRING($time, "0")}[/color] more minutes with [color={$departmentColor}]{$job}[/color] to play this role.
 role-timer-role-too-high = You require[color=yellow] {TOSTRING($time, "0")}[/color] fewer minutes with [color={$departmentColor}]{$job}[/color] to play this role. (Are you trying to play a trainee role?)
+role-timer-age-to-old = Your character must be under the age of [color=yellow]{$age}[/color] to play this role.
+role-timer-age-to-young = Your character must be over the age of [color=yellow]{$age}[/color] to play this role.
 
 role-timer-locked = Locked (hover for details)
 

--- a/Resources/Locale/en-US/job/role-requirements.ftl
+++ b/Resources/Locale/en-US/job/role-requirements.ftl
@@ -6,6 +6,8 @@ role-timer-role-insufficient = You require [color=yellow]{TOSTRING($time, "0")}[
 role-timer-role-too-high = You require[color=yellow] {TOSTRING($time, "0")}[/color] fewer minutes with [color={$departmentColor}]{$job}[/color] to play this role. (Are you trying to play a trainee role?)
 role-timer-age-to-old = Your character must be under the age of [color=yellow]{$age}[/color] to play this role.
 role-timer-age-to-young = Your character must be over the age of [color=yellow]{$age}[/color] to play this role.
+role-timer-whitelisted-species = Your character must be one of the following species to play this role:
+role-timer-blacklisted-species = Your character must not be one of the following species to play this role:
 
 role-timer-locked = Locked (hover for details)
 

--- a/Resources/Locale/en-US/job/role-requirements.ftl
+++ b/Resources/Locale/en-US/job/role-requirements.ftl
@@ -9,4 +9,6 @@ role-timer-age-to-young = Your character must be over the age of [color=yellow]{
 
 role-timer-locked = Locked (hover for details)
 
+role-timer-department-unknown = Unknown Department
+
 role-ban = You have been banned from this role.

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -15,6 +15,8 @@
       time: 36000 #10 hours
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
+    - !type:AgeRequirement
+      requiredAge: 20
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -16,6 +16,8 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 54000 # 15 hours
+    - !type:AgeRequirement
+      requiredAge: 20
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -16,6 +16,8 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 36000 # 10 hours
+    - !type:AgeRequirement
+      requiredAge: 20
   weight: 20
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -15,6 +15,8 @@
       time: 36000 #10 hrs
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
+    - !type:AgeRequirement
+      requiredAge: 20
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -17,6 +17,8 @@
       time: 36000 #10 hrs
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
+    - !type:AgeRequirement
+      requiredAge: 20
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -9,6 +9,8 @@
       time: 36000 #10 hrs
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
+    - !type:AgeRequirement
+      requiredAge: 20
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -15,6 +15,8 @@
       time: 108000 # 30 hrs
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
+    - !type:AgeRequirement
+      requiredAge: 20
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -1,5 +1,6 @@
 - type: department
   id: Cargo
+  name: department-Cargo
   description: department-Cargo-description
   color: "#A46106"
   roles:
@@ -9,6 +10,7 @@
 
 - type: department
   id: Civilian
+  name: department-Civilian
   description: department-Civilian-description
   color: "#9FED58"
   weight: -10
@@ -34,6 +36,7 @@
 
 - type: department
   id: Command
+  name: department-Command
   description: department-Command-description
   color: "#334E6D"
   roles:
@@ -50,6 +53,7 @@
 
 - type: department
   id: Engineering
+  name: department-Engineering
   description: department-Engineering-description
   color: "#EFB341"
   roles:
@@ -60,6 +64,7 @@
 
 - type: department
   id: Medical
+  name: department-Medical
   description: department-Medical-description
   color: "#52B4E9"
   roles:
@@ -72,6 +77,7 @@
 
 - type: department
   id: Security
+  name: department-Security
   description: department-Security-description
   color: "#DE3A3A"
   weight: 20
@@ -84,6 +90,7 @@
 
 - type: department
   id: Science
+  name: department-Science
   description: department-Science-description
   color: "#D381C9"
   roles:
@@ -93,6 +100,7 @@
 
 - type: department
   id: Specific
+  name: department-Specific
   description: department-Specific-description
   color: "#9FED58"
   weight: 10


### PR DESCRIPTION
## About the PR
Role requirements have been greatly improved. Adding new requirements is now much more convenient, obsolete syntax has been removed, and support for character profile restrictions has been added. also now any rules can be inverted, not just some.

As an example, I added a character age restriction that characters under 20 can't be plugged into command roles. This will also allow forks to use the system to restrict roles by race, gender, and other profile parameters.

also added species restriction, but not used ingame

## Why / Balance
I saw the shitcode, I fixed the shitode.
also wanna use species requirement in my fork

## Media

https://github.com/user-attachments/assets/40b4995e-9a72-40ee-ae0d-45412e4a484f

bonus: also work with loadouts (just example, not added into game)
![image](https://github.com/user-attachments/assets/12eed681-3c09-4008-8755-6c1264cb797f)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Nanotrasen has introduced recruitment rules. Characters under the age of 20 are no longer allowed to take on the role of head.
