### PR TITLE
Make magic mirror do-after longer, add popups to notify the target

### DIFF
--- a/Content.Server/MagicMirror/MagicMirrorSystem.cs
+++ b/Content.Server/MagicMirror/MagicMirrorSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Humanoid;
 using Content.Shared.DoAfter;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.MagicMirror;
 using Content.Shared.Popups;
@@ -71,7 +72,15 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
-        _popup.PopupEntity(Loc.GetString("magic-mirror-change-slot"), component.Target.Value, component.Target.Value, PopupType.Medium);
+
+        if (component.Target == message.Actor)
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-change-slot-self"), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
+        else
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-change-slot-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
 
         component.DoAfter = doAfterId;
         _audio.PlayPvs(component.ChangeHairSound, uid);
@@ -131,7 +140,15 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
-        _popup.PopupEntity(Loc.GetString("magic-mirror-change-color"), component.Target.Value, component.Target.Value, PopupType.Medium);
+
+        if (component.Target == message.Actor)
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-change-color-self"), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
+        else
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-change-color-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
 
         component.DoAfter = doAfterId;
     }
@@ -189,7 +206,15 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
-        _popup.PopupEntity(Loc.GetString("magic-mirror-remove-slot"), component.Target.Value, component.Target.Value, PopupType.Medium);
+
+        if (component.Target == message.Actor)
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-remove-slot-self"), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
+        else
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-remove-slot-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
 
         component.DoAfter = doAfterId;
         _audio.PlayPvs(component.ChangeHairSound, uid);
@@ -247,7 +272,15 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
-        _popup.PopupEntity(Loc.GetString("magic-mirror-add-slot"), component.Target.Value, component.Target.Value, PopupType.Medium);
+
+        if (component.Target == message.Actor)
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-add-slot-self"), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
+        else
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-add-slot-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
 
         component.DoAfter = doAfterId;
         _audio.PlayPvs(component.ChangeHairSound, uid);

--- a/Content.Server/MagicMirror/MagicMirrorSystem.cs
+++ b/Content.Server/MagicMirror/MagicMirrorSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Interaction;
 using Content.Shared.MagicMirror;
+using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 
 namespace Content.Server.MagicMirror;
@@ -19,6 +20,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
     [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly MarkingManager _markings = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoid = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -65,6 +67,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
+        _popup.PopupEntity(Loc.GetString("magic-mirror-change-slot"), component.Target.Value, component.Target.Value, PopupType.Medium);
 
         component.DoAfter = doAfterId;
         _audio.PlayPvs(component.ChangeHairSound, uid);
@@ -120,6 +123,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
+        _popup.PopupEntity(Loc.GetString("magic-mirror-change-color"), component.Target.Value, component.Target.Value, PopupType.Medium);
 
         component.DoAfter = doAfterId;
     }
@@ -173,6 +177,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
+        _popup.PopupEntity(Loc.GetString("magic-mirror-remove-slot"), component.Target.Value, component.Target.Value, PopupType.Medium);
 
         component.DoAfter = doAfterId;
         _audio.PlayPvs(component.ChangeHairSound, uid);
@@ -226,6 +231,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
+        _popup.PopupEntity(Loc.GetString("magic-mirror-add-slot"), component.Target.Value, component.Target.Value, PopupType.Medium);
 
         component.DoAfter = doAfterId;
         _audio.PlayPvs(component.ChangeHairSound, uid);

--- a/Content.Server/MagicMirror/MagicMirrorSystem.cs
+++ b/Content.Server/MagicMirror/MagicMirrorSystem.cs
@@ -51,6 +51,10 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         _doAfterSystem.Cancel(component.DoAfter);
         component.DoAfter = null;
 
+        var doafterTime = component.SelectSlotTime;
+        if (component.Target == message.Actor)
+            doafterTime /= 3;
+
         var doAfter = new MagicMirrorSelectDoAfterEvent()
         {
             Category = message.Category,
@@ -58,7 +62,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             Marking = message.Marking,
         };
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, component.SelectSlotTime, doAfter, uid, target: target, used: uid)
+        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, doafterTime, doAfter, uid, target: target, used: uid)
         {
             DistanceThreshold = SharedInteractionSystem.InteractionRange,
             BreakOnDamage = true,
@@ -108,6 +112,10 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         _doAfterSystem.Cancel(component.DoAfter);
         component.DoAfter = null;
 
+        var doafterTime = component.ChangeSlotTime;
+        if (component.Target == message.Actor)
+            doafterTime /= 3;
+
         var doAfter = new MagicMirrorChangeColorDoAfterEvent()
         {
             Category = message.Category,
@@ -115,7 +123,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             Colors = message.Colors,
         };
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, component.ChangeSlotTime, doAfter, uid, target: target, used: uid)
+        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, doafterTime, doAfter, uid, target: target, used: uid)
         {
             BreakOnDamage = true,
             BreakOnMove = true,
@@ -163,13 +171,17 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         _doAfterSystem.Cancel(component.DoAfter);
         component.DoAfter = null;
 
+        var doafterTime = component.RemoveSlotTime;
+        if (component.Target == message.Actor)
+            doafterTime /= 3;
+
         var doAfter = new MagicMirrorRemoveSlotDoAfterEvent()
         {
             Category = message.Category,
             Slot = message.Slot,
         };
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, component.RemoveSlotTime, doAfter, uid, target: target, used: uid)
+        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, doafterTime, doAfter, uid, target: target, used: uid)
         {
             DistanceThreshold = SharedInteractionSystem.InteractionRange,
             BreakOnDamage = true,
@@ -218,12 +230,16 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         _doAfterSystem.Cancel(component.DoAfter);
         component.DoAfter = null;
 
+        var doafterTime = component.AddSlotTime;
+        if (component.Target == message.Actor)
+            doafterTime /= 3;
+
         var doAfter = new MagicMirrorAddSlotDoAfterEvent()
         {
             Category = message.Category,
         };
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, component.AddSlotTime, doAfter, uid, target: component.Target.Value, used: uid)
+        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, doafterTime, doAfter, uid, target: component.Target.Value, used: uid)
         {
             BreakOnDamage = true,
             BreakOnMove = true,

--- a/Content.Shared/MagicMirror/MagicMirrorComponent.cs
+++ b/Content.Shared/MagicMirror/MagicMirrorComponent.cs
@@ -20,28 +20,28 @@ public sealed partial class MagicMirrorComponent : Component
     public EntityUid? Target;
 
     /// <summary>
-    /// doafter time required to add a new slot
+    /// Do after time to add a new slot, adding hair to a person
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan AddSlotTime = TimeSpan.FromSeconds(5);
+    public TimeSpan AddSlotTime = TimeSpan.FromSeconds(7);
 
     /// <summary>
-    /// doafter time required to remove a existing slot
+    /// Do after time to remove a slot, removing hair from a person
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan RemoveSlotTime = TimeSpan.FromSeconds(2);
+    public TimeSpan RemoveSlotTime = TimeSpan.FromSeconds(7);
 
     /// <summary>
-    /// doafter time required to change slot
+    /// Do after time to change a person's hairstyle
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan SelectSlotTime = TimeSpan.FromSeconds(3);
+    public TimeSpan SelectSlotTime = TimeSpan.FromSeconds(7);
 
     /// <summary>
-    /// doafter time required to recolor slot
+    /// Do after time to change a person's hair color
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan ChangeSlotTime = TimeSpan.FromSeconds(1);
+    public TimeSpan ChangeSlotTime = TimeSpan.FromSeconds(7);
 
     /// <summary>
     /// Sound emitted when slots are changed

--- a/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
+++ b/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
@@ -1,3 +1,7 @@
 magic-mirror-component-activate-user-has-no-hair = You can't have any hair!
 
 magic-mirror-window-title = Magic Mirror
+magic-mirror-add-slot = Hair is being added to you.
+magic-mirror-remove-slot = Your hair is being cut off.
+magic-mirror-change-slot = Your hairstyle is being changed.
+magic-mirror-change-color = Your hair color is being changed.

--- a/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
+++ b/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
@@ -10,3 +10,6 @@ magic-mirror-add-slot-target = Hair is being added to you by {$user}.
 magic-mirror-remove-slot-target = Your hair is being cut off by {$user}.
 magic-mirror-change-slot-target = Your hairstyle is being changed by {$user}.
 magic-mirror-change-color-target = Your hair color is being changed by {$user}.
+
+magic-mirror-blocked-by-hat-self = You need to take off your hat before changing your hair.
+magic-mirror-blocked-by-hat-self-target = You try to change their hair but their clothes gets in the way.

--- a/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
+++ b/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
@@ -1,7 +1,12 @@
 magic-mirror-component-activate-user-has-no-hair = You can't have any hair!
 
 magic-mirror-window-title = Magic Mirror
-magic-mirror-add-slot = Hair is being added to you.
-magic-mirror-remove-slot = Your hair is being cut off.
-magic-mirror-change-slot = Your hairstyle is being changed.
-magic-mirror-change-color = Your hair color is being changed.
+magic-mirror-add-slot-self = You're giving yourself some hair.
+magic-mirror-remove-slot-self = You're removing some of your hair.
+magic-mirror-change-slot-self = You're changing your hairstyle.
+magic-mirror-change-color-self = You're changing your hair color.
+
+magic-mirror-add-slot-target = Hair is being added to you by {$user}.
+magic-mirror-remove-slot-target = Your hair is being cut off by {$user}.
+magic-mirror-change-slot-target = Your hairstyle is being changed by {$user}.
+magic-mirror-change-color-target = Your hair color is being changed by {$user}.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- Increased doafter time for barber scissors on other people to seven seconds in all categories.
- Added popup that let you know what is being done to your hair exactly.
- Hats prevent your hair from being cut.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Ruining people's appearances with barber scissors is genuinely a game-ruining experience for a lot of players. You shouldn't be able to have your appearance changed just because you decided to start typing for two seconds.

It's also weird that certain actions take shorter than others when all appearance changes are equally bad, so I just standardized it.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Doafters on other targets increased to seven seconds
- Doafters for yourselves are 3x shorter
- Localized popups for each message, different popups depending on self vs target

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/f2bbc2b5-2a87-4d6a-80b9-23feac53927f

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Wearing something that covers your head will prevent your hair from being cut.
- add: You now see a popup when your hair is being altered.
- tweak: The doafter for altering other people's hair now takes seven seconds.