### PR TITLE
Ratking ID rework

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: Rat King
   id: MobRatKing
-  parent: [ SimpleMobBase, MobCombat ]
+  parent: [ SimpleMobBase, MobCombat, StripableInventoryBase ]
   description: He's da rat. He make da roolz.
   components:
   - type: CombatMode
@@ -42,6 +42,16 @@
         - SmallMobMask
         layer:
         - SmallMobLayer
+  - type: ComplexInteraction
+  - type: Inventory
+    speciesId: ratking
+    templateId: ratking
+  - type: InventorySlots
+  - type: Strippable
+  - type: UserInterface
+  - type: Puller
+    needsHands: false
+  - type: IdExaminable
   - type: MobState
   - type: MobThresholds
     thresholds:

--- a/Resources/Prototypes/InventoryTemplates/rat_king_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/rat_king_inventory_template.yml
@@ -1,0 +1,10 @@
+- type: inventoryTemplate
+  id: ratking
+  slots:
+  - name: id
+    slotTexture: id
+    slotFlags: IDCARD
+    stripTime: 6
+    uiWindowPos: 0,1
+    strippingWindowPos: 2,4
+    displayName: ID


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Originally #26577 Ratkings now being neutral have been given a ID slot in order to more properly play as a crew-aligned ratking.  They cannot put ID's on themselves and must be granted it by another character.  Despite the ability to pass through doors they can now open doors for others.  They have also been granted the ability to pull things.

I originally wanted to include the ability to equip comm headsets but I am not brave enough to try and figure out displacement mappings at this time.

## Why / Balance
Allows for rat kings to officially become part of the crew and be recognized as crew in space law and most importantly to borgs.

## Technical details

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
