### PR TITLE
Added ID slot to ratking, allowed for pulling and door opening

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: rat king
   id: MobRatKing
-  parent: [ SimpleMobBase, MobCombat ]
+  parent: [ SimpleMobBase, MobCombat, StripableInventoryBase ]
   description: He's da rat. He make da roolz.
   components:
   - type: CombatMode
@@ -42,6 +42,16 @@
         - SmallMobMask
         layer:
         - SmallMobLayer
+  - type: ComplexInteraction
+  - type: Inventory
+    speciesId: ratking
+    templateId: ratking
+  - type: InventorySlots
+  - type: Strippable
+  - type: UserInterface
+  - type: Puller
+    needsHands: false
+  - type: IdExaminable
   - type: MobState
   - type: MobThresholds
     thresholds:

--- a/Resources/Prototypes/InventoryTemplates/rat_king_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/rat_king_inventory_template.yml
@@ -1,0 +1,10 @@
+- type: inventoryTemplate
+  id: ratking
+  slots:
+  - name: id
+    slotTexture: id
+    slotFlags: IDCARD
+    stripTime: 6
+    uiWindowPos: 0,1
+    strippingWindowPos: 2,4
+    displayName: ID


### PR DESCRIPTION
## About the PR
Originally #26577 Ratkings now being neutral have been given a ID slot in order to more properly play as a crew-aligned ratking.  They cannot put ID's on themselves and must be granted it by another character.  Despite the ability to pass through doors they can now open doors for others.  They have also been granted the ability to pull things.

I originally wanted to include the ability to equip comm headsets but I am not brave enough to try and figure out displacement mappings at this time.

## Why / Balance
Allows for rat kings to officially become part of the crew and be recognized as crew in space law and most importantly to borgs.

## Technical details
Simple YML changes

## Media

https://github.com/user-attachments/assets/7d0ffbcc-18c6-46bb-bfa3-915702b0f27a



- [x ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- tweak: Rat Kings can be given an ID to become part of the crew and can pull things
