### PR TITLE
Thief objectives for figurines and stamps ask for less items

### DIFF
--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -61,7 +61,7 @@
   - type: StealCondition
     stealGroup: Figurines
     minCollectionSize: 10
-    maxCollectionSize: 50 #will be limited to the number of figures on the station anyway.
+    maxCollectionSize: 18 #will be limited to the number of figures on the station anyway.
   - type: Objective
     difficulty: 0.25
 
@@ -94,7 +94,7 @@
   - type: StealCondition
     stealGroup: Stamp
     minCollectionSize: 5
-    maxCollectionSize: 15
+    maxCollectionSize: 8
   - type: Objective
     difficulty: 1.0
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Lowered the maximum amount of figurines for "steal figurines" thief objective from 50 -> 18, and maximum amount of stamps for "steal stamps" thief objective from 15 -> 8.
 
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #29595
Additionally, stamps are MUCH harder to get than figurines and cannot be ordered like how figurines can. I don't even think every station has 15 stamps on it.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
N/A
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
-->
:cl:
- tweak: Thief objectives for figurines and stamps now require less items


