### PR TITLE
Remove Walking out of Containers while You can't Walk

### DIFF
--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -26,6 +26,7 @@ using Content.Shared.Item;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
 using Content.Shared.Standing;
+using Content.Shared.Cuffs.Components;
 using Content.Shared.Throwing;
 using Content.Shared.Verbs;
 using Robust.Server.Audio;
@@ -332,18 +333,18 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
     {
         var currentTime = GameTiming.CurTime;
 
+        if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
+            !standing.Standing)
+            return;
+
         if (!TryComp(args.Entity, out HandsComponent? hands) ||
             hands.Count == 0 ||
             currentTime < component.LastExitAttempt + ExitAttemptDelay)
-        {
             return;
-        }
 
-        if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
-            !standing.Standing)
-        {
+        if (TryComp<CuffableComponent>(args.Entity, out var cuffable) &&
+            !cuffable.CanStillInteract)
             return;
-        }
 
         component.LastExitAttempt = currentTime;
         Remove(uid, component, args.Entity);

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -25,6 +25,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Item;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
+using Content.Shared.Standing;
 using Content.Shared.Throwing;
 using Content.Shared.Verbs;
 using Robust.Server.Audio;
@@ -334,6 +335,12 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         if (!TryComp(args.Entity, out HandsComponent? hands) ||
             hands.Count == 0 ||
             currentTime < component.LastExitAttempt + ExitAttemptDelay)
+        {
+            return;
+        }
+
+        if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
+            !standing.Standing)
         {
             return;
         }

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -25,9 +25,6 @@ using Content.Shared.Interaction;
 using Content.Shared.Item;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
-using Content.Shared.Standing;
-using Content.Shared.Cuffs.Components;
-using Content.Shared.Throwing;
 using Content.Shared.Verbs;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
@@ -37,7 +34,6 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Player;
-using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Disposal.Unit.EntitySystems;
@@ -333,17 +329,12 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
     {
         var currentTime = GameTiming.CurTime;
 
-        if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
-            !standing.Standing)
+        if (!_actionBlockerSystem.CanMove(args.Entity))
             return;
 
         if (!TryComp(args.Entity, out HandsComponent? hands) ||
             hands.Count == 0 ||
             currentTime < component.LastExitAttempt + ExitAttemptDelay)
-            return;
-
-        if (TryComp<CuffableComponent>(args.Entity, out var cuffable) &&
-            !cuffable.CanStillInteract)
             return;
 
         component.LastExitAttempt = currentTime;

--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Resist;
 using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Standing;
+using Content.Shared.Cuffs.Components;
 
 namespace Content.Server.Resist;
 
@@ -37,6 +38,10 @@ public sealed class ResistLockerSystem : EntitySystem
 
         if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
             !standing.Standing)
+            return;
+
+        if (TryComp<CuffableComponent>(args.Entity, out var cuffable) &&
+            !cuffable.CanStillInteract)
             return;
 
         if (TryComp<LockComponent>(uid, out var lockComponent) && lockComponent.Locked || _weldable.IsWelded(uid))

--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -8,7 +8,6 @@ using Content.Shared.Popups;
 using Content.Shared.Resist;
 using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
-using Content.Shared.Standing;
 using Content.Shared.ActionBlocker;
 
 namespace Content.Server.Resist;

--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Popups;
 using Content.Shared.Resist;
 using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
+using Content.Shared.Standing;
 
 namespace Content.Server.Resist;
 
@@ -32,6 +33,10 @@ public sealed class ResistLockerSystem : EntitySystem
             return;
 
         if (!TryComp(uid, out EntityStorageComponent? storageComponent))
+            return;
+
+        if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
+            !standing.Standing)
             return;
 
         if (TryComp<LockComponent>(uid, out var lockComponent) && lockComponent.Locked || _weldable.IsWelded(uid))

--- a/Content.Server/Resist/ResistLockerSystem.cs
+++ b/Content.Server/Resist/ResistLockerSystem.cs
@@ -9,7 +9,7 @@ using Content.Shared.Resist;
 using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Standing;
-using Content.Shared.Cuffs.Components;
+using Content.Shared.ActionBlocker;
 
 namespace Content.Server.Resist;
 
@@ -20,6 +20,7 @@ public sealed class ResistLockerSystem : EntitySystem
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly WeldableSystem _weldable = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
 
     public override void Initialize()
     {
@@ -36,12 +37,7 @@ public sealed class ResistLockerSystem : EntitySystem
         if (!TryComp(uid, out EntityStorageComponent? storageComponent))
             return;
 
-        if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
-            !standing.Standing)
-            return;
-
-        if (TryComp<CuffableComponent>(args.Entity, out var cuffable) &&
-            !cuffable.CanStillInteract)
+        if (!_actionBlocker.CanMove(args.Entity))
             return;
 
         if (TryComp<LockComponent>(uid, out var lockComponent) && lockComponent.Locked || _weldable.IsWelded(uid))

--- a/Content.Shared/Burial/BurialSystem.cs
+++ b/Content.Shared/Burial/BurialSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Placeable;
 using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Standing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 
@@ -160,6 +161,10 @@ public sealed class BurialSystem : EntitySystem
         // We track a separate doAfter here, as we want someone with a shovel to
         // be able to come along and help someone trying to claw their way out
         if (component.HandDiggingDoAfter != null)
+            return;
+
+        if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
+            !standing.Standing)
             return;
 
         var doAfterEventArgs = new DoAfterArgs(EntityManager, args.Entity, component.DigDelay / component.DigOutByHandModifier, new GraveDiggingDoAfterEvent(), uid, target: uid)

--- a/Content.Shared/Burial/BurialSystem.cs
+++ b/Content.Shared/Burial/BurialSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.ActionBlocker;
 using Content.Shared.Burial;
 using Content.Shared.Burial.Components;
 using Content.Shared.DoAfter;
@@ -7,10 +8,7 @@ using Content.Shared.Placeable;
 using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
-using Content.Shared.Standing;
-using Content.Shared.Cuffs.Components;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Player;
 
 namespace Content.Server.Burial.Systems;
 
@@ -20,6 +18,7 @@ public sealed class BurialSystem : EntitySystem
     [Dependency] private readonly SharedEntityStorageSystem _storageSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
 
     public override void Initialize()
     {
@@ -164,12 +163,7 @@ public sealed class BurialSystem : EntitySystem
         if (component.HandDiggingDoAfter != null)
             return;
 
-        if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
-            !standing.Standing)
-            return;
-
-        if (TryComp<CuffableComponent>(args.Entity, out var cuffable) &&
-            !cuffable.CanStillInteract)
+        if (!_actionBlocker.CanMove(args.Entity))
             return;
 
         var doAfterEventArgs = new DoAfterArgs(EntityManager, args.Entity, component.DigDelay / component.DigOutByHandModifier, new GraveDiggingDoAfterEvent(), uid, target: uid)

--- a/Content.Shared/Burial/BurialSystem.cs
+++ b/Content.Shared/Burial/BurialSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Standing;
+using Content.Shared.Cuffs.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 
@@ -165,6 +166,10 @@ public sealed class BurialSystem : EntitySystem
 
         if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
             !standing.Standing)
+            return;
+
+        if (TryComp<CuffableComponent>(args.Entity, out var cuffable) &&
+            !cuffable.CanStillInteract)
             return;
 
         var doAfterEventArgs = new DoAfterArgs(EntityManager, args.Entity, component.DigDelay / component.DigOutByHandModifier, new GraveDiggingDoAfterEvent(), uid, target: uid)

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Lock;
 using Content.Shared.Movement.Events;
 using Content.Shared.Placeable;
 using Content.Shared.Popups;
+using Content.Shared.Standing;
 using Content.Shared.Storage.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Verbs;
@@ -132,6 +133,10 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (!HasComp<HandsComponent>(args.Entity))
             return;
 
+        if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
+            standing.Standing)
+            return;
+
         if (_timing.CurTime < component.NextInternalOpenAttempt)
             return;
 
@@ -139,9 +144,7 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         Dirty(uid, component);
 
         if (component.OpenOnMove)
-        {
             TryOpenStorage(args.Entity, uid);
-        }
     }
 
     protected void OnFoldAttempt(EntityUid uid, SharedEntityStorageComponent component, ref FoldAttemptEvent args)

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -134,7 +134,7 @@ public abstract class SharedEntityStorageSystem : EntitySystem
             return;
 
         if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
-            standing.Standing)
+            !standing.Standing)
             return;
 
         if (_timing.CurTime < component.NextInternalOpenAttempt)

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using Content.Shared.Body.Components;
+using Content.Shared.Cuffs.Components;
 using Content.Shared.Destructible;
 using Content.Shared.Foldable;
 using Content.Shared.Hands.Components;
@@ -135,6 +136,10 @@ public abstract class SharedEntityStorageSystem : EntitySystem
 
         if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
             !standing.Standing)
+            return;
+
+        if (TryComp<CuffableComponent>(args.Entity, out var cuffable) &&
+            !cuffable.CanStillInteract)
             return;
 
         if (_timing.CurTime < component.NextInternalOpenAttempt)

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using Content.Shared.Body.Components;
-using Content.Shared.Cuffs.Components;
 using Content.Shared.Destructible;
 using Content.Shared.Foldable;
 using Content.Shared.Hands.Components;
@@ -12,22 +11,19 @@ using Content.Shared.Lock;
 using Content.Shared.Movement.Events;
 using Content.Shared.Placeable;
 using Content.Shared.Popups;
-using Content.Shared.Standing;
 using Content.Shared.Storage.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Verbs;
 using Content.Shared.Wall;
 using Content.Shared.Whitelist;
-using Robust.Shared.Audio;
+using Content.Shared.ActionBlocker;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
-using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -49,6 +45,7 @@ public abstract class SharedEntityStorageSystem : EntitySystem
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
     [Dependency] private   readonly WeldableSystem _weldable = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
 
     public const string ContainerName = "entity_storage";
 
@@ -134,12 +131,7 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (!HasComp<HandsComponent>(args.Entity))
             return;
 
-        if (TryComp<StandingStateComponent>(args.Entity, out var standing) &&
-            !standing.Standing)
-            return;
-
-        if (TryComp<CuffableComponent>(args.Entity, out var cuffable) &&
-            !cuffable.CanStillInteract)
+        if (!_actionBlocker.CanMove(args.Entity))
             return;
 
         if (_timing.CurTime < component.NextInternalOpenAttempt)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Prevents players from exiting containers while asleep or stunned
Ie: you can put someone to sleep someone then dump them in a bin without them instantly getting out now
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Its quite annoying stunning someone or putting them to sleep and being unable to seal them in a locker or disposal bin because they can hold one button to remove themself from the container instantly.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
adds a check to see if the player is standing or cuffed when attempting to move to open a locker
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
I'm uh... trying to walk while asleep, its kinda hard to show without me setting up a key input overlay or something(I'm lazy)

https://github.com/user-attachments/assets/b501e62d-bfb5-44fa-8c25-8efe67ce018b

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: You can no longer get out of a disposal chute or container while knocked over by trying to walk
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
