### PR TITLE
Fix thieves rule not selecting more than one thief

### DIFF
--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -18,10 +18,8 @@
     agentName: thief-round-end-agent-name
     definitions:
     - prefRoles: [ Thief ]
-      maxRange:
-        min: 1
-        max: 3
-      playerRatio: 1
+      max: 3
+      playerRatio: 15
       lateJoinAdditional: true
       allowNonHumans: true
       multiAntagSetting: NotExclusive


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I changed it so that there are three thieves maximum with a player ratio of about 15 players.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes thieves not actually selecting enough, but as for the logic change...

I just like thieves being consistently in the shift. It gives security more people to arrest on a regular basis, I guess.

I think this'll make it so that there are around three thieves once we get up to 50 or so players, if you factor in other possible antag selections? I... I have no clue how to do the math. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
maxRange was 1 to 3 BUT max default value was still just set to one so you only ever got one

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Thief game rule now properly selects more than one thief.