### PR TITLE
Zombie is gonna break those cuffs!

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -37,7 +37,6 @@ using Content.Shared.Traits.Assorted;
 using Robust.Shared.Audio.Systems;
 using Content.Shared.Ghost.Roles.Components;
 using Content.Shared.Cuffs.Components;
-using Content.Server.NPC.Queries.Considerations;
 using Content.Shared.Cuffs;
 
 namespace Content.Server.Zombies

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -36,6 +36,9 @@ using Content.Shared.Prying.Components;
 using Content.Shared.Traits.Assorted;
 using Robust.Shared.Audio.Systems;
 using Content.Shared.Ghost.Roles.Components;
+using Content.Shared.Cuffs.Components;
+using Content.Server.NPC.Queries.Considerations;
+using Content.Shared.Cuffs;
 
 namespace Content.Server.Zombies
 {
@@ -59,6 +62,7 @@ namespace Content.Server.Zombies
         [Dependency] private readonly MindSystem _mind = default!;
         [Dependency] private readonly SharedRoleSystem _roles = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
+        [Dependency] private readonly SharedCuffableSystem _cuffableSys = default!;
 
         /// <summary>
         /// Handles an entity turning into a zombie when they die or go into crit
@@ -255,6 +259,14 @@ namespace Content.Server.Zombies
                 ghostRole.RoleName = Loc.GetString("zombie-generic");
                 ghostRole.RoleDescription = Loc.GetString("zombie-role-desc");
                 ghostRole.RoleRules = Loc.GetString("zombie-role-rules");
+            }
+
+            if (TryComp<CuffableComponent>(target, out var cuffable) && cuffable.CuffedHandCount > 0)
+            {
+                while (cuffable.CuffedHandCount > 0)
+                {
+                    _cuffableSys.Uncuff(target, target, cuffable.LastAddedCuffs);
+                }
             }
 
             if (TryComp<HandsComponent>(target, out var handsComp))

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -601,7 +601,7 @@ namespace Content.Shared.Cuffs
                 BreakOnMove = true,
                 BreakOnWeightlessMove = false,
                 BreakOnDamage = true,
-                NeedHand = false,
+                NeedHand = true,
                 RequireCanInteract = false, // Trust in UncuffAttemptEvent
                 DistanceThreshold = 1f // shorter than default but still feels good
             };

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -601,7 +601,7 @@ namespace Content.Shared.Cuffs
                 BreakOnMove = true,
                 BreakOnWeightlessMove = false,
                 BreakOnDamage = true,
-                NeedHand = true,
+                NeedHand = false,
                 RequireCanInteract = false, // Trust in UncuffAttemptEvent
                 DistanceThreshold = 1f // shorter than default but still feels good
             };


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

fixes #30396
fixes #26060

## About the PR
<!-- What did you change in this PR? -->

Zombies uncuff when they zombify. The alternative is letting them use the uncuff action again, but, I don't really see a compelling reason for that instead of just uncuffing them.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Being a cuffed zombie sucks, and not having hands does weird shit.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Zombies will no longer remain cuffed when they turn.