### PR TITLE
Allow ai to understand if its handcuffed.

### DIFF
--- a/Content.Server/NPC/HTN/Preconditions/HandcuffedPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/HandcuffedPrecondition.cs
@@ -16,5 +16,4 @@ public sealed partial class HandcuffedPrecondition : HTNPrecondition
 
         return cuffable.IsCuffed(owner, ReactOnlyWhenFullyCuffed);
     }
-
 }

--- a/Content.Server/NPC/HTN/Preconditions/HandcuffedPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/HandcuffedPrecondition.cs
@@ -1,0 +1,20 @@
+using Content.Server.Cuffs;
+
+namespace Content.Server.NPC.HTN.Preconditions;
+
+public sealed partial class HandcuffedPrecondition : HTNPrecondition
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    [DataField]
+    public bool ReactOnlyWhenFullyCuffed = true;
+
+    public override bool IsMet(NPCBlackboard blackboard)
+    {
+        var cuffable = _entManager.System<CuffableSystem>();
+        var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
+
+        return cuffable.IsCuffed(owner, ReactOnlyWhenFullyCuffed);
+    }
+
+}

--- a/Content.Server/NPC/HTN/Preconditions/HandcuffedPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/HandcuffedPrecondition.cs
@@ -1,4 +1,5 @@
 using Content.Server.Cuffs;
+using Content.Shared.Cuffs.Components;
 
 namespace Content.Server.NPC.HTN.Preconditions;
 
@@ -14,7 +15,12 @@ public sealed partial class HandcuffedPrecondition : HTNPrecondition
         var cuffable = _entManager.System<CuffableSystem>();
         var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
 
-        return cuffable.IsCuffed(owner, ReactOnlyWhenFullyCuffed);
+        if (!_entManager.TryGetComponent<CuffableComponent>(owner, out var cuffComp))
+            return false;
+
+        var target = (owner, cuffComp);
+
+        return cuffable.IsCuffed(target, ReactOnlyWhenFullyCuffed);
     }
 
 }

--- a/Content.Server/NPC/HTN/Preconditions/HandcuffedPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/HandcuffedPrecondition.cs
@@ -16,4 +16,5 @@ public sealed partial class HandcuffedPrecondition : HTNPrecondition
 
         return cuffable.IsCuffed(owner, ReactOnlyWhenFullyCuffed);
     }
+
 }

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -530,18 +530,15 @@ namespace Content.Shared.Cuffs
             return true;
         }
 
-        public bool IsCuffed(EntityUid target, bool requireFullyCuffed = true, CuffableComponent? cuffable = null)
+        public bool IsCuffed(Entity<CuffableComponent> target, bool requireFullyCuffed = true)
         {
-            if (!Resolve(target, ref cuffable, false))
-                return false;
-
             if (!TryComp<HandsComponent>(target, out var hands))
                 return false;
 
-            if (cuffable.CuffedHandCount <= 0)
+            if (target.Comp.CuffedHandCount <= 0)
                 return false;
 
-            if (requireFullyCuffed == true && hands.Count > cuffable.CuffedHandCount)
+            if (requireFullyCuffed && hands.Count > target.Comp.CuffedHandCount)
                 return false;
 
             return true;

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -530,7 +530,7 @@ namespace Content.Shared.Cuffs
             return true;
         }
 
-        public bool IsCuffed(EntityUid target, bool requireFullyCuffed = false, CuffableComponent? cuffable = null)
+        public bool IsCuffed(EntityUid target, bool requireFullyCuffed = true, CuffableComponent? cuffable = null)
         {
             if (!Resolve(target, ref cuffable, false))
                 return false;

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -530,6 +530,11 @@ namespace Content.Shared.Cuffs
             return true;
         }
 
+        /// <summary>
+        /// Checks if the target is handcuffed.
+        /// </summary>
+        /// <param name="requireFullyCuffed">return false if the target is only partially cuffed (for things with more than 2 hands)</param>
+        /// <returns></returns>
         public bool IsCuffed(Entity<CuffableComponent> target, bool requireFullyCuffed = true)
         {
             if (!TryComp<HandsComponent>(target, out var hands))

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -530,6 +530,23 @@ namespace Content.Shared.Cuffs
             return true;
         }
 
+        public bool IsCuffed(EntityUid target, bool requireFullyCuffed = false, CuffableComponent? cuffable = null)
+        {
+            if (!Resolve(target, ref cuffable, false))
+                return false;
+
+            if (!TryComp<HandsComponent>(target, out var hands))
+                return false;
+
+            if (cuffable.CuffedHandCount <= 0)
+                return false;
+
+            if (requireFullyCuffed == true && hands.Count > cuffable.CuffedHandCount)
+                return false;
+
+            return true;
+        }
+
         /// <summary>
         /// Attempt to uncuff a cuffed entity. Can be called by the cuffed entity, or another entity trying to help uncuff them.
         /// If the uncuffing succeeds, the cuffs will drop on the floor.

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -533,7 +533,7 @@ namespace Content.Shared.Cuffs
         /// <summary>
         /// Checks if the target is handcuffed.
         /// </summary>
-        /// <param name="requireFullyCuffed">return false if the target is only partially cuffed (for things with more than 2 hands)</param>
+        /// <param name="requireFullyCuffed">when true, return false if the target is only partially cuffed (for things with more than 2 hands)</param>
         /// <returns></returns>
         public bool IsCuffed(Entity<CuffableComponent> target, bool requireFullyCuffed = true)
         {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

related at #30397
maybe useful at #30066
partially fixes #27460
partially fixes #28006

## About the PR
<!-- What did you change in this PR? -->

Allows Ai to understand if its handcuffed by checking this precondition.

@osjarw useful?

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Can be used to avoid ai constantly trying to do stuff it cant do because of handcuffs, when it should instead do something else, such as run away.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl