### PR TITLE
Restore the longer traitor briefing message

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -122,9 +122,9 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
     {
         var sb = new StringBuilder();
         sb.AppendLine(Loc.GetString("traitor-role-greeting", ("corporation", objectiveIssuer ?? Loc.GetString("objective-issuer-unknown"))));
-        sb.AppendLine(Loc.GetString("traitor-role-codewords-short", ("codewords", string.Join(", ", codewords))));
+        sb.AppendLine(Loc.GetString("traitor-role-codewords", ("codewords", string.Join(", ", codewords))));
         if (uplinkCode != null)
-            sb.AppendLine(Loc.GetString("traitor-role-uplink-code-short", ("code", string.Join("-", uplinkCode).Replace("sharp", "#"))));
+            sb.AppendLine(Loc.GetString("traitor-role-uplink-code", ("code", string.Join("-", uplinkCode).Replace("sharp", "#"))));
 
         return sb.ToString();
     }

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -24,17 +24,17 @@ traitor-death-match-end-round-description-entry = {$originalName}'s PDA, with {$
 
 # TraitorRole
 traitor-role-greeting =
-    You are an agent sent by {$corporation} on behalf of The Syndicate.
+    You are an agent sent by {$corporation} on behalf of [color = darkred]The Syndicate.[/color]
     Your objectives and codewords are listed in the character menu.
     Use the uplink loaded into your PDA to buy the tools you'll need for this mission.
     Death to Nanotrasen!
 traitor-role-codewords =
-    The codewords are:
-    {$codewords}.
+    The codewords are: [color = lightgray]
+    {$codewords}.[/color]
     Codewords can be used in regular conversation to identify yourself discretely to other syndicate agents.
     Listen for them, and keep them secret.
 traitor-role-uplink-code =
-    Set your ringtone to the notes {$code} to lock or unlock your uplink.
+    Set your ringtone to the notes [color = lightgray]{$code}[/color] to lock or unlock your uplink.
     Remember to lock it after, or the stations crew will easily open it too!
 
 # don't need all the flavour text for character menu


### PR DESCRIPTION
## About the PR
Change traitor Briefing back to use the longer versions of the text. 
Character screen traitor text unchanged

## Why / Balance
The #23445 refactor changed Traitor briefings to the shorter version that is also used on the character screen.
This appears to have been unintentional, as there was no mention or any discussion about it. The change was in the middle of a huge code block change in a very large overall delta, and so its likely that it was simply overlooked by everyone

## Media
Live
![image](https://github.com/user-attachments/assets/a184e3ad-fbc9-4757-b624-8e8ee97be646)

Longer version, now with a little highlighting of the important elements
(the grey dashed-out part is getting removed in #30359)

![image](https://github.com/user-attachments/assets/e8f89c8f-d6bc-4505-b28b-1f010bcd2222)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase