### PR TITLE
Do not duplicate Job Greeting on antag selection

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -336,7 +336,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             }
 
             _mind.TransferTo(curMind.Value, antagEnt, ghostCheckOverride: true);
-            _role.MindAddRoles(curMind.Value, def.MindComponents);
+            _role.MindAddRoles(curMind.Value, def.MindComponents, null, true);
             ent.Comp.SelectedMinds.Add((curMind.Value, Name(player)));
             SendBriefing(session, def.Briefing);
         }


### PR DESCRIPTION
## About the PR

Currently, when a player gets an antag role on the station, their job greeting 
```
Your role is: Passenger
You answer to absolutely everyone yada yada
```
is repeated along with the antag briefing. 

For Head Revs, this means they see that part twice, one immediately after the other, upon spawn. This obviously looks like a bug. 
For late-reveals like traitor, they are told after X minutes what their job that they have been doing is, along with their traitor announcement. This also seems unnecessary

Now, antag announcements don't repeat the job info

## Technical details

When a MindRole is added, JobSystem catches the event and if the mind has a station job, gives them the intro message. This happens on spawn, and then on AntagSelection. Currently, JobSystem is the only thing listening for this event.
I simply made it so AntagSelectionSystem uses the already coded flag to not send out this event

## Media

Live: Duplicated job message
![Screenshot_2024-07-27_125619](https://github.com/user-attachments/assets/1b40295a-a33b-4b86-8184-3be48f8fd9ad)

PR: No job message on antagselection
![Screenshot_2024-07-27_130405](https://github.com/user-attachments/assets/36222c37-13c0-43ab-9331-f0a9e84adf2b)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

