### PR TITLE
Meteors now leave behind a bit of ore

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
@@ -15,7 +15,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors;
 public sealed partial class WeightedSpawnEntityBehavior : IThresholdBehavior
 {
     [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<WeightedRandomEntityPrototype>), required: true)]
-    public string WeightedSpawn = "MeteorSpawnAsteroidWallTable";
+    public string WeightedSpawn = string.Empty;
 
     /// <summary>
     /// How far away to spawn the entity from the parent position
@@ -33,7 +33,7 @@ public sealed partial class WeightedSpawnEntityBehavior : IThresholdBehavior
     /// The max number of entities to spawn randomly
     /// </summary>
     [DataField]
-    public int MaxSpawn = 4;
+    public int MaxSpawn = 1;
 
     /// <summary>
     /// Time in seconds to wait before spawning entities

--- a/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
@@ -53,7 +53,7 @@ public sealed partial class WeightedSpawnEntityBehavior : IThresholdBehavior
         {
             for (var i = 0; i < amountToSpawn; i++)
             {
-                var spawner = system.EntityManager.SpawnEntity("MeteorCollisionAsteroidWallSpawner", position.Offset(GetRandomVector()));
+                var spawner = system.EntityManager.SpawnEntity("TemporaryEntityForTimedDespawnSpawners", position.Offset(GetRandomVector()));
                 system.EntityManager.EnsureComponent<TimedDespawnComponent>(spawner, out var timedDespawnComponent);
                 timedDespawnComponent.Lifetime = SpawnAfter;
                 system.EntityManager.EnsureComponent<SpawnOnDespawnComponent>(spawner, out var spawnOnDespawnComponent);

--- a/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
@@ -51,13 +51,16 @@ public sealed partial class WeightedSpawnEntityBehavior : IThresholdBehavior
 
     public void Execute(EntityUid uid, DestructibleSystem system, EntityUid? cause = null)
     {
+        // Get the position at which to start initially spawning entities
         var transform = system.EntityManager.System<TransformSystem>();
         var position = transform.GetMapCoordinates(uid);
+        // Helper function used to randomly get an offset to apply to the original position
         Vector2 GetRandomVector() => new (system.Random.NextFloat(-SpawnOffset, SpawnOffset), system.Random.NextFloat(-SpawnOffset, SpawnOffset));
+        // Randomly pick the entity to spawn and randomly pick how many to spawn
         var entity = system.PrototypeManager.Index(WeightedEntityTable).Pick(system.Random);
         var amountToSpawn = system.Random.NextFloat(MinSpawn, MaxSpawn);
 
-
+        // Different behaviors for delayed spawning and immediate spawning
         if (SpawnAfter != 0)
         {
             // if it fails to get the spawner, this won't ever work so just return

--- a/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
@@ -1,0 +1,71 @@
+﻿using System.Numerics;
+using Content.Server.Spawners.Components;
+using Content.Server.Spawners.EntitySystems;
+using Content.Shared.Random;
+using Content.Shared.Random.Helpers;
+using Robust.Server.GameObjects;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Spawners;
+
+namespace Content.Server.Destructible.Thresholds.Behaviors;
+
+[Serializable]
+[DataDefinition]
+public sealed partial class WeightedSpawnEntityBehavior : IThresholdBehavior
+{
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<WeightedRandomEntityPrototype>), required: true)]
+    public string WeightedSpawn = "MeteorSpawnAsteroidWallTable";
+
+    /// <summary>
+    /// How far away to spawn the entity from the parent position
+    /// </summary>
+    [DataField]
+    public float SpawnOffset = 1;
+
+    /// <summary>
+    /// The mininum number of entities to spawn randomly
+    /// </summary>
+    [DataField]
+    public int MinSpawn = 1;
+
+    /// <summary>
+    /// The max number of entities to spawn randomly
+    /// </summary>
+    [DataField]
+    public int MaxSpawn = 4;
+
+    /// <summary>
+    /// Time in seconds to wait before spawning entities
+    /// </summary>
+    [DataField]
+    public float SpawnAfter;
+
+    public void Execute(EntityUid uid, DestructibleSystem system, EntityUid? cause = null)
+    {
+        var transform = system.EntityManager.System<TransformSystem>();
+        var position = transform.GetMapCoordinates(uid);
+        Vector2 GetRandomVector() => new (system.Random.NextFloat(-SpawnOffset, SpawnOffset), system.Random.NextFloat(-SpawnOffset, SpawnOffset));
+        var entity = system.PrototypeManager.Index<WeightedRandomEntityPrototype>(WeightedSpawn).Pick(system.Random);
+        var amountToSpawn = system.Random.NextFloat(MinSpawn, MaxSpawn);
+
+        if (SpawnAfter != 0)
+        {
+            for (var i = 0; i < amountToSpawn; i++)
+            {
+                var spawner = system.EntityManager.SpawnEntity("MeteorCollisionAsteroidWallSpawner", position.Offset(GetRandomVector()));
+                system.EntityManager.EnsureComponent<TimedDespawnComponent>(spawner, out var timedDespawnComponent);
+                timedDespawnComponent.Lifetime = SpawnAfter;
+                system.EntityManager.EnsureComponent<SpawnOnDespawnComponent>(spawner, out var spawnOnDespawnComponent);
+                system.EntityManager.System<SpawnOnDespawnSystem>().SetPrototype((spawner, spawnOnDespawnComponent), entity);
+            }
+        }
+        else
+        {
+            for (var i = 0; i < amountToSpawn; i++)
+            {
+                system.EntityManager.SpawnEntity(entity, position.Offset(GetRandomVector()));
+            }
+        }
+    }
+}

--- a/Content.Server/Spawners/EntitySystems/SpawnOnDespawnSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/SpawnOnDespawnSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Spawners.Components;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Spawners;
 
 namespace Content.Server.Spawners.EntitySystems;
@@ -18,5 +19,10 @@ public sealed class SpawnOnDespawnSystem : EntitySystem
             return;
 
         Spawn(comp.Prototype, xform.Coordinates);
+    }
+
+    public void SetPrototype(Entity<SpawnOnDespawnComponent> entity, EntProtoId prototype)
+    {
+        entity.Comp.Prototype = prototype;
     }
 }

--- a/Resources/Prototypes/Entities/Markers/Spawners/temp.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/temp.yml
@@ -6,5 +6,6 @@
     anchored: True
   - type: Physics
     bodyType: Static
+    canCollide: false
   - type: TimedDespawn
     # we can't declare the SpawnOnDespawnComponent because the entity is required on yml

--- a/Resources/Prototypes/Entities/Markers/Spawners/temp.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/temp.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: TemporaryEntityForTimedDespawnSpawners
+  categories: [ HideSpawnMenu, Spawner ]
+  components:
+  - type: Transform
+    anchored: True
+  - type: Physics
+    bodyType: Static
+  - type: TimedDespawn
+    # we can't declare the SpawnOnDespawnComponent because the entity is required on yml

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -221,12 +221,3 @@
       - !type:SpillBehavior
         solution: blood
       - !type:ExplodeBehavior
-
-- type: entity
-  id: MeteorCollisionAsteroidWallSpawner
-  categories: [ HideSpawnMenu, Spawner ]
-  components:
-  - type: Transform
-    anchored: True
-  - type: Physics
-    bodyType: Static

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -154,6 +154,7 @@
       - !type:ExplodeBehavior
       - !type:WeightedSpawnEntityBehavior
         weightedSpawn: "MeteorSpawnAsteroidWallTable"
+        spawnOffset: 2
         minSpawn: 3
         maxSpawn: 6
         spawnAfter: 0.5
@@ -181,6 +182,7 @@
       - !type:ExplodeBehavior
       - !type:WeightedSpawnEntityBehavior
         weightedSpawn: "MeteorSpawnAsteroidWallTable"
+        spawnOffset: 3
         minSpawn: 5
         maxSpawn: 8
         spawnAfter: 0.5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -113,7 +113,7 @@
           collection: MetalBreak
       - !type:ExplodeBehavior
       - !type:WeightedSpawnEntityBehavior
-        weightedSpawn: "MeteorSpawnAsteroidWallTable"
+        weightedEntityTable: "MeteorSpawnAsteroidWallTable"
         minSpawn: 2
         maxSpawn: 4
         spawnAfter: 0.5
@@ -153,7 +153,7 @@
           collection: MetalBreak
       - !type:ExplodeBehavior
       - !type:WeightedSpawnEntityBehavior
-        weightedSpawn: "MeteorSpawnAsteroidWallTable"
+        weightedEntityTable: "MeteorSpawnAsteroidWallTable"
         spawnOffset: 2
         minSpawn: 3
         maxSpawn: 6
@@ -181,7 +181,7 @@
           collection: MetalBreak
       - !type:ExplodeBehavior
       - !type:WeightedSpawnEntityBehavior
-        weightedSpawn: "MeteorSpawnAsteroidWallTable"
+        weightedEntityTable: "MeteorSpawnAsteroidWallTable"
         spawnOffset: 3
         minSpawn: 5
         maxSpawn: 8

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -112,6 +112,11 @@
         sound:
           collection: MetalBreak
       - !type:ExplodeBehavior
+      - !type:WeightedSpawnEntityBehavior
+        weightedSpawn: "MeteorSpawnAsteroidWallTable"
+        minSpawn: 2
+        maxSpawn: 4
+        spawnAfter: 0.5
 
 - type: entity
   parent: BaseMeteor
@@ -147,6 +152,11 @@
         sound:
           collection: MetalBreak
       - !type:ExplodeBehavior
+      - !type:WeightedSpawnEntityBehavior
+        weightedSpawn: "MeteorSpawnAsteroidWallTable"
+        minSpawn: 3
+        maxSpawn: 6
+        spawnAfter: 0.5
 
 - type: entity
   parent: BaseMeteor
@@ -169,6 +179,11 @@
         sound:
           collection: MetalBreak
       - !type:ExplodeBehavior
+      - !type:WeightedSpawnEntityBehavior
+        weightedSpawn: "MeteorSpawnAsteroidWallTable"
+        minSpawn: 5
+        maxSpawn: 8
+        spawnAfter: 0.5
 
 - type: entity
   parent: BaseMeteor
@@ -204,3 +219,12 @@
       - !type:SpillBehavior
         solution: blood
       - !type:ExplodeBehavior
+
+- type: entity
+  id: MeteorCollisionAsteroidWallSpawner
+  categories: [ HideSpawnMenu, Spawner ]
+  components:
+  - type: Transform
+    anchored: True
+  - type: Physics
+    bodyType: Static

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -17,6 +17,20 @@
     GameRuleMeteorSwarmLarge: 5
     GameRuleUristSwarm: 0.05
 
+- type: weightedRandomEntity
+  id: MeteorSpawnAsteroidWallTable
+  weights:
+    AsteroidRock: 10
+    AsteroidRockCoal: 5
+    AsteroidRockQuartz: 5
+    AsteroidRockTin: 5
+    AsteroidRockSilver: 2
+    AsteroidRockGold: 2
+    AsteroidRockPlasma: 2
+    AsteroidRockDiamond: 2
+    AsteroidRockUranium: 0.5
+    AsteroidRockBananium: 0.5      
+
 - type: entity
   parent: BaseGameRule
   id: GameRuleMeteorSwarm


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Made meteors leave behind asteroid rocks after the explosion

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
idk, an admin told me to do it
flavor?

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Created WeightedSpawnEntityBehavior that takes a WeightedRandomEntityPrototype and spawns a number of the same entity between a given min and max, at a random offset from the final position of the entity.
- Spawning can be delayed if, for example, the entity has an explosive behavior that would destroy your newly spawned entity. If this happens, a temporary entity is created to act as a spawner.
- Created a spawn table of possible asteroid ores that the meteors will now leave behind with values chosen at whatever I randomly decided was a number
- Arbitrarily chosen spawn values that seemed appropriate for the size of the meteors

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**KABOOM VIDEO**
https://www.youtube.com/watch?v=tgqEwkIMV7o

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Meteors now leave behind asteroid rocks on impact.