### PR TITLE
Adjustet  MobBaseAncestor class

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1250,6 +1250,17 @@
     tags:
     - VimPilot
     - DoorBumpOpener
+  - type: Reactive
+    groups:
+      Flammable: [ Touch ]
+      Extinguish: [ Touch ]
+    reactions:
+    - reagents: [ Water, SpaceCleaner ]
+      methods: [ Touch ]
+      effects:
+      - !type:WashCreamPieReaction
+
+
 
 - type: entity
   name: monkey
@@ -1282,6 +1293,7 @@
         Burn: 3
     clumsySound:
       path: /Audio/Animals/monkey_scream.ogg
+
 
 - type: entity
   name: monkey


### PR DESCRIPTION
## About the PR
Before Pun-Pun,Kobolds and other Mobs using MobBaseAncestor couldnt clean pie of their face and couldnt burn.

## Why / Balance
It makes no sense for Pun-Pun and other not to be able to clean themself and them burning like everyone else is normal.

## Technical details
i add a part in the Animals.yml wehre MobBaseAncestor is Defined it has the type: Reactions and then defines the reactions for burning and cleaning pie of your face.

## Media
- [x] I have added screens
                                       https://github.com/user-attachments/assets/1f140531-490d-4ff1-a4bb-ea82ce9a42cb


https://github.com/user-attachments/assets/8f1571e4-4e99-4e04-8975-e01b2feec71f
:cl:
- fix: Pun and similar pets are no longer firemune

