### PR TITLE
Update RespiratorSystem.cs to not use Component.Owner

### DIFF
--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -114,7 +114,7 @@ public sealed class RespiratorSystem : EntitySystem
         if (!Resolve(uid, ref body, logMissing: false))
             return;
 
-        var organs = _bodySystem.GetBodyOrganComponents<LungComponent>(uid, body);
+        var organs = _bodySystem.GetBodyOrganEntityComps<LungComponent>((uid, body));
 
         // Inhale gas
         var ev = new InhaleLocationEvent();
@@ -131,11 +131,11 @@ public sealed class RespiratorSystem : EntitySystem
 
         var lungRatio = 1.0f / organs.Count;
         var gas = organs.Count == 1 ? actualGas : actualGas.RemoveRatio(lungRatio);
-        foreach (var (lung, _) in organs)
+        foreach (var (organUid, lung, _) in organs)
         {
             // Merge doesn't remove gas from the giver.
             _atmosSys.Merge(lung.Air, gas);
-            _lungSystem.GasToReagent(lung.Owner, lung);
+            _lungSystem.GasToReagent(organUid, lung);
         }
     }
 
@@ -144,7 +144,7 @@ public sealed class RespiratorSystem : EntitySystem
         if (!Resolve(uid, ref body, logMissing: false))
             return;
 
-        var organs = _bodySystem.GetBodyOrganComponents<LungComponent>(uid, body);
+        var organs = _bodySystem.GetBodyOrganEntityComps<LungComponent>((uid, body));
 
         // exhale gas
 
@@ -161,12 +161,12 @@ public sealed class RespiratorSystem : EntitySystem
         }
 
         var outGas = new GasMixture(ev.Gas.Volume);
-        foreach (var (lung, _) in organs)
+        foreach (var (organUid, lung, _) in organs)
         {
             _atmosSys.Merge(outGas, lung.Air);
             lung.Air.Clear();
 
-            if (_solutionContainerSystem.ResolveSolution(lung.Owner, lung.SolutionName, ref lung.Solution))
+            if (_solutionContainerSystem.ResolveSolution(organUid, lung.SolutionName, ref lung.Solution))
                 _solutionContainerSystem.RemoveAllSolution(lung.Solution.Value);
         }
 
@@ -201,7 +201,7 @@ public sealed class RespiratorSystem : EntitySystem
         if (!Resolve(ent, ref ent.Comp))
             return false;
 
-        var organs = _bodySystem.GetBodyOrganComponents<LungComponent>(ent);
+        var organs = _bodySystem.GetBodyOrganEntityComps<LungComponent>((ent, null));
         if (organs.Count == 0)
             return false;
 
@@ -213,7 +213,7 @@ public sealed class RespiratorSystem : EntitySystem
         float saturation = 0;
         foreach (var organ in organs)
         {
-            saturation += GetSaturation(solution, organ.Comp.Owner, out var toxic);
+            saturation += GetSaturation(solution, organ.Owner, out var toxic);
             if (toxic)
                 return false;
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Project 0 warnings, Component.Owner is obsolete

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Replace `GetBodyOrganComponents` with `GetBodyOrganEntityComps` which gives us the `Entity<T>` version, use the uid from that instead of taking it from the component.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/user-attachments/assets/8f7e9c65-79dd-4242-bcf4-3b74967c8cc0

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Breathing is great