### PR TITLE
Made the dank pizza actually dank

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -318,6 +318,8 @@
       food:
         maxVol: 50
         reagents:
+        - ReagentId: Nutriment
+          Quantity: 20
         - ReagentId: THC
           Quantity: 30
 
@@ -341,6 +343,8 @@
       food:
         maxVol: 10
         reagents:
+        - ReagentId: Nutriment
+          Quantity: 3.5
         - ReagentId: THC
           Quantity: 5
 # Tastes like crust, tomato, cheese, meat, satisfaction.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pizza.yml
@@ -318,12 +318,8 @@
       food:
         maxVol: 50
         reagents:
-        - ReagentId: Nutriment
-          Quantity: 25
-        - ReagentId: Vitamin
-          Quantity: 5
-        - ReagentId: DoctorsDelight
-          Quantity: 6
+        - ReagentId: THC
+          Quantity: 30
 
 - type: entity
   name: slice of dank pizza
@@ -345,12 +341,8 @@
       food:
         maxVol: 10
         reagents:
-        - ReagentId: Nutriment
-          Quantity: 4.2
-        - ReagentId: Vitamin
-          Quantity: 0.8
-        - ReagentId: DoctorsDelight
-          Quantity: 1
+        - ReagentId: THC
+          Quantity: 5
 # Tastes like crust, tomato, cheese, meat, satisfaction.
 
 - type: entity

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -576,7 +576,7 @@
   time: 30
   solids:
     FoodDoughFlat: 1
-    FoodAmbrosiaVulgaris: 3
+    LeavesCannabis: 2
     FoodCheeseSlice: 1
     FoodTomato: 1
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changed the recipe for the dank pizza to be made with cannabis leaves instead of ambrosia vulgaris. Now the pizza lives up to the name and the hippies will be happy.

## Why / Balance
As the name "dank pizza" suggests one would expect it to be cooked using some dank weed, so that's what I changed the recipe to include, a few cannabis leaves. It only requires two cannabis leaves so the leaves and pizza both has the same amount of THC.

## Technical details
- Changed the cooking recipe to be cooked with 2x cannabis leaves instead of 3x ambrosia vulgaris.
- Changed the solutions to have 30u THC in a whole pizza, or 5u in a slice.

## Media
https://github.com/user-attachments/assets/132558d8-5d44-4642-81cb-0719de04e229

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Dank pizza is now cooked with cannabis leaves instead of ambrosia vulgaris.
