### PR TITLE
Geofence the nuke disk so it can't be used to stall the round

### DIFF
--- a/Content.Shared/Nuke/NukeDiskComponent.cs
+++ b/Content.Shared/Nuke/NukeDiskComponent.cs
@@ -1,12 +1,59 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Nuke;
 
 /// <summary>
-/// Used for tracking the nuke disk - isn't a tag for pinpointer purposes.
+/// Used for tracking the nuke disk.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class NukeDiskComponent : Component
 {
+    /// <summary>
+    /// Is this disk meant to be geofenced to a station?
+    /// </summary>
+    [DataField]
+    public bool Geofence = true;
 
+    /// <summary>
+    /// How long should the disk be allowed to be off station before geofencing?
+    /// </summary>
+    [DataField]
+    public TimeSpan OffStationTolerance = TimeSpan.FromSeconds(180);
+
+    /// <summary>
+    /// Is the disk currently off its origin station?
+    /// </summary>
+    [DataField]
+    public bool LeftStation = false;
+
+    /// <summary>
+    /// When the disk was most recently seen leaving the station.
+    /// </summary>
+    [DataField]
+    public TimeSpan LeftStationWhen = TimeSpan.MaxValue;
+
+    /// <summary>
+    /// When the last popup for the disk offstation occured.
+    /// </summary>
+    [DataField]
+    public TimeSpan LastPopup = TimeSpan.Zero;
+
+    ///
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string TeleportFlare = "EffectFlashBluespace";
+
+    /// <summary>
+    ///     Origin map of this disk.
+    /// </summary>
+    [DataField]
+    public EntityUid? OriginMap;
+
+    /// <summary>
+    ///     Origin grid of this disk.
+    /// </summary>
+    [DataField]
+    public EntityUid? OriginGrid;
 }

--- a/Resources/Locale/en-US/nuke/nuke-component.ftl
+++ b/Resources/Locale/en-US/nuke/nuke-component.ftl
@@ -45,3 +45,7 @@ nuke-slot-component-slot-name-disk = Disk
 ## Examine
 nuke-examine-armed = Hey uh, why's that [color=red]red light[/color] blinking?
 nuke-examine-exploding = Yeah... I think it's too late buddy.
+
+## Nuke disk geofencing
+nuke-disk-poof = The authentication disk fades from existence!
+nuke-disk-feelin-weird = The authentication disk seems to be fading from existence!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

If the nuke disk is off the station this tries to send it back.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The nuclear authentication disk now gets bluespaced back to station if its taken off for too long.
