### PR TITLE
Make the powered examine text fully client predicted

### DIFF
--- a/Content.Client/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Client/Power/EntitySystems/PowerReceiverSystem.cs
@@ -15,6 +15,11 @@ public sealed class PowerReceiverSystem : SharedPowerReceiverSystem
         SubscribeLocalEvent<ApcPowerReceiverComponent, ComponentHandleState>(OnHandleState);
     }
 
+    private void OnExamined(Entity<ApcPowerReceiverComponent> ent, ref ExaminedEvent args)
+    {
+        args.PushMarkup(GetExamineText(ent.Comp.Powered));
+    }
+
     private void OnHandleState(EntityUid uid, ApcPowerReceiverComponent component, ref ComponentHandleState args)
     {
         if (args.Current is not ApcPowerReceiverComponentState state)

--- a/Content.Client/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Client/Power/EntitySystems/PowerReceiverSystem.cs
@@ -1,6 +1,7 @@
-﻿using Content.Client.Power.Components;
+using Content.Client.Power.Components;
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
+using Content.Shared.Examine;
 using Robust.Shared.GameStates;
 
 namespace Content.Client.Power.EntitySystems;
@@ -10,6 +11,7 @@ public sealed class PowerReceiverSystem : SharedPowerReceiverSystem
     public override void Initialize()
     {
         base.Initialize();
+        SubscribeLocalEvent<ApcPowerReceiverComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<ApcPowerReceiverComponent, ComponentHandleState>(OnHandleState);
     }
 

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -46,6 +46,11 @@ namespace Content.Server.Power.EntitySystems
             _provQuery = GetEntityQuery<ApcPowerProviderComponent>();
         }
 
+        private void OnExamined(Entity<ApcPowerReceiverComponent> ent, ref ExaminedEvent args)
+        {
+            args.PushMarkup(GetExamineText(ent.Comp.Powered));
+        }
+
         private void OnGetVerbs(EntityUid uid, ApcPowerReceiverComponent component, GetVerbsEvent<Verb> args)
         {
             if (!_adminManager.HasAdminFlag(args.User, AdminFlags.Admin))

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -61,17 +61,6 @@ namespace Content.Server.Power.EntitySystems
             });
         }
 
-        ///<summary>
-        ///Adds some markup to the examine text of whatever object is using this component to tell you if it's powered or not, even if it doesn't have an icon state to do this for you.
-        ///</summary>
-        private void OnExamined(EntityUid uid, ApcPowerReceiverComponent component, ExaminedEvent args)
-        {
-            args.PushMarkup(Loc.GetString("power-receiver-component-on-examine-main",
-                                            ("stateText", Loc.GetString( component.Powered
-                                                ? "power-receiver-component-on-examine-powered"
-                                                : "power-receiver-component-on-examine-unpowered"))));
-        }
-
         private void OnProviderShutdown(EntityUid uid, ApcPowerProviderComponent component, ComponentShutdown args)
         {
             foreach (var receiver in component.LinkedReceivers)

--- a/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
+++ b/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
@@ -5,14 +5,11 @@ namespace Content.Shared.Power.EntitySystems;
 
 public abstract class SharedPowerReceiverSystem : EntitySystem
 {
-    ///<summary>
-    ///Adds some markup to the examine text of whatever object is using this component to tell you if it's powered or not, even if it doesn't have an icon state to do this for you.
-    ///</summary>
-    protected void OnExamined(EntityUid uid, SharedApcPowerReceiverComponent component, ExaminedEvent args)
+    protected string GetExamineText(bool powered)
     {
-        args.PushMarkup(Loc.GetString("power-receiver-component-on-examine-main",
-                                        ("stateText", Loc.GetString(component.Powered
-                                            ? "power-receiver-component-on-examine-powered"
-                                            : "power-receiver-component-on-examine-unpowered"))));
+        return Loc.GetString("power-receiver-component-on-examine-main",
+                                ("stateText", Loc.GetString(powered
+                                    ? "power-receiver-component-on-examine-powered"
+                                    : "power-receiver-component-on-examine-unpowered")));
     }
 }

--- a/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
+++ b/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
@@ -1,6 +1,18 @@
-﻿namespace Content.Shared.Power.EntitySystems;
+using Content.Shared.Examine;
+using Content.Shared.Power.Components;
+
+namespace Content.Shared.Power.EntitySystems;
 
 public abstract class SharedPowerReceiverSystem : EntitySystem
 {
-
+    ///<summary>
+    ///Adds some markup to the examine text of whatever object is using this component to tell you if it's powered or not, even if it doesn't have an icon state to do this for you.
+    ///</summary>
+    protected void OnExamined(EntityUid uid, SharedApcPowerReceiverComponent component, ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("power-receiver-component-on-examine-main",
+                                        ("stateText", Loc.GetString(component.Powered
+                                            ? "power-receiver-component-on-examine-powered"
+                                            : "power-receiver-component-on-examine-unpowered"))));
+    }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

The "it appears to be (un)powered." examine text is now client predicted. Meaning all powered objects (a huge section of common objects) should now have much snappier examine text.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Work done by ShadowCommander in #28206 set the stage for this.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

B4
![power-examine-fail](https://github.com/user-attachments/assets/fc6518f6-d40e-4872-9c43-a2ad2586b05e)

After
![power-examine-good](https://github.com/user-attachments/assets/e8566030-1c9a-43b2-ab5d-648c44fc4cab)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
