### PR TITLE
Bring kobold ghostrole chance inline with monkey

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1446,7 +1446,7 @@
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-kobold
   - type: GhostRole
-    prob: 0.1
+    prob: 0.05
     makeSentient: true
     name: ghost-role-information-kobold-name
     description: ghost-role-information-kobold-description


### PR DESCRIPTION
## About the PR
See title

## Why / Balance
yaml copypasting will be the death of us all. 
brings kobold ghostrole chance inline with their should be parent, leaving current parent as SimpleMobBase because hold moly this mob has so many components....

## Technical details
0.1 is bigger than 0.05

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
n/a

**Changelog**

:cl:
- tweak: Reduced Kobold ghostrole chance to mirror Monkey