### PR TITLE
Fix double interaction popups

### DIFF
--- a/Content.Shared/Interaction/InteractionPopupSystem.cs
+++ b/Content.Shared/Interaction/InteractionPopupSystem.cs
@@ -113,7 +113,7 @@ public sealed class InteractionPopupSystem : EntitySystem
                 Spawn(component.InteractFailureSpawn, _transform.GetMapCoordinates(uid));
         }
 
-        if (component.MessagePerceivedByOthers != null)
+        if (!string.IsNullOrEmpty(component.MessagePerceivedByOthers))
         {
             var msgOthers = Loc.GetString(component.MessagePerceivedByOthers,
                 ("user", Identity.Entity(user, EntityManager)), ("target", Identity.Entity(uid, EntityManager)));
@@ -131,7 +131,7 @@ public sealed class InteractionPopupSystem : EntitySystem
             return;
         }
 
-        _popupSystem.PopupPredicted(msg, uid, user);
+        _popupSystem.PopupClient(msg, uid, user);
 
         if (sfx == null)
             return;


### PR DESCRIPTION
The issue is it plays the "you hug xyz" to everyone in range as well as the target client so they overlap. IDK if anything else is broken by this but this control flow is pretty bad so I wouldn't be surprised.

:cl:
- fix: Fix some popups playing twice.