### PR TITLE
Fix ACC wire light not appearing

### DIFF
--- a/Content.Server/Access/LogWireAction.cs
+++ b/Content.Server/Access/LogWireAction.cs
@@ -25,7 +25,7 @@ public sealed partial class LogWireAction : ComponentWireAction<AccessReaderComp
         return comp.LoggingDisabled ? StatusLightState.Off : StatusLightState.On;
     }
 
-    public override object StatusKey => AccessWireActionKey.Status;
+    public override object StatusKey => LogWireActionKey.Status;
 
     public override void Initialize()
     {

--- a/Content.Shared/Access/SharedAccessWire.cs
+++ b/Content.Shared/Access/SharedAccessWire.cs
@@ -10,3 +10,12 @@ public enum AccessWireActionKey : byte
     Pulsed,
     PulseCancel
 }
+
+[Serializable, NetSerializable]
+public enum LogWireActionKey : byte
+{
+    Key,
+    Status,
+    Pulsed,
+    PulseCancel
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This fixes the ACC wire light not appearing in vending machine (and air alarm) wire layouts.

Fixes #30421 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

It was being overwritten in the array due to having the same key as the LOG wire.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![image](https://github.com/user-attachments/assets/1803235a-be36-449e-8c8c-11ca7e1febc3)

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed the ACC wire not appearing in vending machine wire layouts