### PR TITLE
added relevant guides to help menus

### DIFF
--- a/Resources/Prototypes/Body/Parts/silicon.yml
+++ b/Resources/Prototypes/Body/Parts/silicon.yml
@@ -24,7 +24,8 @@
       Steel: 25
   - type: GuideHelp
     guides:
-      - Cyborgs
+    - Cyborgs
+    - Robotics
 
 - type: entity
   id: BaseBorgArmLeft

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -180,6 +180,7 @@
   - type: GuideHelp
     guides:
     - Security
+    - Antagonists
   - type: IdentityBlocker
     coverage: EYES
 

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -227,7 +227,8 @@
   - type: Emoting
   - type: GuideHelp
     guides:
-      - Cyborgs
+    - Cyborgs
+    - Robotics
   - type: StepTriggerImmune
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -788,6 +788,7 @@
   - type: GuideHelp
     guides:
     - Chef
+    - FoodRecipes
 
 - type: entity
   name: crab

--- a/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
@@ -92,4 +92,4 @@
     - type: LogProbeCartridge
     - type: GuideHelp
       guides:
-        - Forensics
+      - Forensics

--- a/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
@@ -26,7 +26,7 @@
   - type: ForensicScanner
   - type: GuideHelp
     guides:
-      - Forensics
+    - Forensics
   - type: StealTarget
     stealGroup: ForensicScanner
 

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -108,6 +108,7 @@
     openOnActivation: true
     guides:
     - Bartender
+    - Drinks
 
 - type: entity
   id: BookHowToCookForFortySpaceman
@@ -130,6 +131,7 @@
     openOnActivation: true
     guides:
     - Chef
+    - FoodRecipes
 
 - type: entity
   id: BookLeafLoversSecret
@@ -155,6 +157,7 @@
     openOnActivation: true
     guides:
     - Botany
+    - Chemicals
 
 - type: entity
   id: BookEngineersHandbook
@@ -352,6 +355,7 @@
     openOnActivation: true
     guides:
     - Chemicals
+    - Chemist
 
 - type: entity
   id: BookSpaceLaw

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -234,6 +234,7 @@
     openOnActivation: true
     guides:
     - Security
+    - Antagonists
 
 - type: entity
   id: BookHowToKeepStationClean

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -26,6 +26,7 @@
   - type: GuideHelp
     guides:
     - Security
+    - Antagonists
   - type: UseDelay
     delay: 3
 

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -219,6 +219,7 @@
   - type: GuideHelp
     guides:
     - CargoBounties
+    - Cargo
 
 - type: entity
   name: character sheet

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
@@ -2,7 +2,7 @@
   parent: BaseItem
   id: DiseaseSwab
   name: sterile swab
-  description: Used for taking and transfering samples. Sterile until open. Single use only.
+  description: Used for taking and transferring samples. Sterile until open. Single use only.
   components:
   - type: Item
     size: Tiny
@@ -18,6 +18,7 @@
     guides:
   # - Virology (when it's back)
     - Botany
+    - Chemicals
 
 - type: entity
   parent: BaseAmmoProvider # this is for cycling swabs out and not spawning 30 entities, trust
@@ -39,6 +40,7 @@
     guides:
   # - Virology (when it's back)
     - Botany
+    - Chemicals
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -38,7 +38,7 @@
           False: { visible: false }
   - type: GuideHelp
     guides:
-      - Medical Doctor
+    - Medical Doctor
 
 - type: entity
   id: HandheldHealthAnalyzer

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -17,7 +17,8 @@
     - BorgModuleGeneric
   - type: GuideHelp
     guides:
-      - Cyborgs
+    - Cyborgs
+    - Robotics
 
 - type: entity
   id: BaseProviderBorgModule

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/endoskeleton.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/endoskeleton.yml
@@ -223,3 +223,4 @@
   - type: GuideHelp
     guides:
     - Cyborgs
+    - Robotics

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -124,4 +124,5 @@
             On: { state: posibrain-occupied }
     - type: GuideHelp
       guides:
+      - Cyborgs
       - Robotics

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -47,7 +47,8 @@
   - type: Appearance
   - type: GuideHelp
     guides:
-      - Cyborgs
+    - Cyborgs
+    - Robotics
 
 - type: entity
   parent: MMI
@@ -123,4 +124,4 @@
             On: { state: posibrain-occupied }
     - type: GuideHelp
       guides:
-      - Cyborgs
+      - Robotics

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -282,7 +282,7 @@
       price: 56
     - type: GuideHelp
       guides:
-        - NetworkConfigurator
+      - NetworkConfigurator
 
 #Power tools
 #Later on these should switch probably switch damage when changing the tool behavior.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -445,6 +445,7 @@
     - type: GuideHelp
       guides:
       - Security
+      - Antagonists
 
 - type: entity
   name: disabler SMG

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -44,6 +44,7 @@
   - type: GuideHelp
     guides:
     - Chef
+    - FoodRecipes
 
 - type: entity
   name: butcher's cleaver
@@ -70,6 +71,7 @@
   - type: GuideHelp
     guides:
     - Chef
+    - FoodRecipes
 
 - type: entity
   name: combat knife

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -80,6 +80,7 @@
   - type: GuideHelp
     guides:
     - Security
+    - Antagonists
 
 - type: entity
   id: GrenadeFlashEffect

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -87,6 +87,7 @@
   - type: GuideHelp
     guides:
     - Security
+    - Antagonists
 
 - type: entity
   name: truncheon
@@ -123,6 +124,7 @@
   - type: GuideHelp
     guides:
     - Security
+    - Antagonists
 
 - type: entity
   name: flash
@@ -168,6 +170,7 @@
     - type: GuideHelp
       guides:
       - Security
+      - Antagonists
 
 - type: entity
   name: flash
@@ -223,3 +226,4 @@
     - type: GuideHelp
       guides:
       - Security
+      - Antagonists

--- a/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
@@ -22,6 +22,7 @@
   - type: GuideHelp
     guides:
     - Bartender
+    - Drinks
   - type: StealTarget
     stealGroup: BoozeDispenser
 

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -22,6 +22,7 @@
   - type: GuideHelp
     guides:
     - Bartender
+    - Drinks
 
 - type: entity
   parent: SodaDispenser

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -800,6 +800,7 @@
   - type: GuideHelp
     guides:
     - CargoBounties
+    - Cargo
 
 - type: entity
   parent: BaseComputer

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -47,7 +47,7 @@
     - type: GuideHelp
       openOnActivation: true
       guides:
-        - Defusal
+      - Defusal
 
 - type: entity
   parent: BaseHardBomb

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -105,6 +105,7 @@
   - type: GuideHelp
     guides:
     - Chef
+    - FoodRecipes
 
 - type: entity
   id: SyndicateMicrowave

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -887,6 +887,7 @@
   - type: GuideHelp
     guides:
     - Security
+    - Antagonists
 
 - type: entity
   parent: VendingMachine

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -195,6 +195,7 @@
   - type: GuideHelp
     guides:
     - Bartender
+    - Drinks
 
 - type: entity
   parent: VendingMachine
@@ -2116,6 +2117,7 @@
   - type: GuideHelp
     guides:
     - Chemicals
+    - Chemist
 
 - type: entity
   parent: VendingMachineChemicals

--- a/Resources/Prototypes/Entities/Structures/hydro_tray.yml
+++ b/Resources/Prototypes/Entities/Structures/hydro_tray.yml
@@ -91,6 +91,7 @@
   - type: GuideHelp
     guides:
     - Botany
+    - Chemicals
 
 - type: entity
   parent: hydroponicsTray

--- a/Resources/Prototypes/Entities/Structures/meat_spike.yml
+++ b/Resources/Prototypes/Entities/Structures/meat_spike.yml
@@ -57,3 +57,4 @@
   - type: GuideHelp
     guides:
     - Chef
+    - FoodRecipes


### PR DESCRIPTION
The guidebooks opened by the help button on items and machines in the bar, hydroponics and the kitchen now also include the guides they link to. Fixes #30459 . Fixes #30379 .

## About the PR

Modified the yml of multiple items to expand the GuideHelp with relevant items.

## Why / Balance

Having broken links is bad UX.

## Technical details

Only yml.

## Media

https://github.com/user-attachments/assets/f9553384-8502-4818-9ee7-11d11a5644a4

https://github.com/user-attachments/assets/0367733b-a760-4bd7-9db9-4423617c5382

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

None

**Changelog**

:cl:
- fix: Help menus now include the linked guides.
