### PR TITLE
added a defib to the courser

### DIFF
--- a/Resources/Maps/Shuttles/emergency_courser.yml
+++ b/Resources/Maps/Shuttles/emergency_courser.yml
@@ -362,105 +362,101 @@ entities:
       version: 2
       data:
         tiles:
-          -2,-1:
-            0: 61166
-          -1,-1:
-            0: 65535
-          0,-1:
-            0: 65535
           -2,-3:
-            0: 60620
+            0: 8192
+            1: 34944
           -2,-2:
-            0: 61102
-            1: 64
+            1: 52936
+          -2,-1:
+            1: 52430
           -2,-4:
-            0: 51328
-          -1,-4:
-            0: 57343
-            1: 8192
-          -1,-3:
-            0: 65535
-          -1,-2:
-            0: 49151
-            1: 16384
-          0,-4:
-            0: 65535
-          0,-3:
-            0: 65535
-          0,-2:
-            0: 65535
-          1,-4:
-            0: 12560
-          1,-3:
-            0: 29491
-          1,-2:
-            0: 30551
-            1: 32
-          1,-1:
-            0: 30583
+            0: 16512
           -2,0:
-            0: 61166
-          -2,1:
-            0: 61102
-            1: 64
-          -2,2:
-            0: 52300
-            1: 128
-          -2,3:
-            0: 136
-          -1,0:
-            0: 65535
-          -1,1:
-            0: 49151
-            1: 16384
-          -1,2:
-            0: 65535
-          -1,3:
-            0: 61439
-          0,0:
-            0: 65535
-          0,1:
-            0: 57343
-            1: 8192
-          0,2:
-            0: 65535
-          0,3:
-            0: 32767
-          1,0:
-            0: 30583
-          1,1:
-            0: 30551
-            1: 32
-          1,2:
-            0: 13091
-            1: 16
-          1,3:
-            0: 17
+            1: 52940
+          -1,-4:
+            1: 65260
+          -1,-3:
+            1: 65372
+          -1,-2:
+            1: 57297
+          -1,-1:
+            1: 65489
           -1,-5:
-            0: 61440
+            0: 4096
+          -1,0:
+            1: 8191
+          0,-4:
+            1: 63347
+          0,-3:
+            1: 65443
+          0,-2:
+            1: 49080
+          0,-1:
+            1: 65464
+          0,0:
+            1: 36863
           0,-5:
-            0: 61440
+            0: 32768
+          1,-4:
+            0: 8208
+          1,-3:
+            1: 4368
+            0: 16384
+          1,-2:
+            1: 14129
+          1,-1:
+            1: 13111
+          1,0:
+            1: 14131
+          -2,1:
+            1: 35022
+            0: 8192
+          -2,2:
+            1: 136
+            0: 16384
+          -1,1:
+            1: 56829
+          -1,2:
+            1: 62705
+          -2,3:
+            0: 128
+          -1,3:
+            1: 3310
+          0,1:
+            1: 48123
+          0,2:
+            1: 62200
+          0,3:
+            1: 887
+          1,1:
+            1: 4407
+            0: 16384
+          1,2:
+            1: 17
+            0: 8192
+          1,3:
+            0: 16
         uniqueMixes:
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.15
           moles:
           - 21.824879
           - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 19.481253
-          - 73.28662
           - 0
           - 0
           - 0
@@ -485,8 +481,6 @@ entities:
     - type: Transform
       pos: 0.5,-12.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
 - proto: AirlockCommandGlassLocked
   entities:
   - uid: 601
@@ -2023,6 +2017,14 @@ entities:
     - type: Transform
       pos: 0.5,14.5
       parent: 656
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 657
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 656
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 517
@@ -2176,8 +2178,6 @@ entities:
     - type: Transform
       pos: 0.5,-11.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
 - proto: GasPassiveVent
   entities:
   - uid: 521
@@ -2186,8 +2186,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -0.5,-11.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
 - proto: GasPipeBend
   entities:
   - uid: 523
@@ -2536,8 +2534,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,-12.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
 - proto: GasVentPump
   entities:
   - uid: 524
@@ -2546,72 +2542,54 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -0.5,-12.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
   - uid: 550
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-10.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
   - uid: 551
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-10.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
   - uid: 552
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-0.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
   - uid: 553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
   - uid: 573
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
   - uid: 574
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,11.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
   - uid: 580
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,8.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
   - uid: 589
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,8.5
       parent: 656
-    - type: AtmosDevice
-      joinedGrid: 656
 - proto: GeneratorBasic15kW
   entities:
   - uid: 66
@@ -3424,7 +3402,7 @@ entities:
     - type: Transform
       pos: 1.5,-15.5
       parent: 656
-- proto: soda_dispenser
+- proto: SodaDispenser
   entities:
   - uid: 166
     components:


### PR DESCRIPTION
I have added a defibrillator Origins evacuation shuttle (the Courser).

## About the PR

Added a defibrillator to the medbay on the Courser.

## Why / Balance

Most evacuation shuttles have one.

## Technical details

Only yml. My first map edit, so I might have made a mistake.

## Media

![Screenshot from 2024-07-30 01-37-36](https://github.com/user-attachments/assets/70a2ee55-b284-4ab7-9515-0608e33f8e3a)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

None

**Changelog**

:cl:
- tweak: The Courser now comes with a defibrillator.
