### PR TITLE
Objects that only have a basic description won't have extra line in examine text

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -352,7 +352,7 @@ namespace Content.Shared.Examine
             var totalMessage = new FormattedMessage(Message);
             parts.Sort(Comparison);
 
-            if (_hasDescription)
+            if (_hasDescription && parts.Count > 0)
             {
                 totalMessage.PushNewline();
             }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

There are actually a few different reasons that examine text can end up with blank lines at the end of them. One of the simplest ways is when an object has a basic description but no other components provide examine text. Now we check to make sure that examine text beyond the basic description actually exist before appending the newline.

Posters are the biggest place where you can see this specific version of the blank line issue in action.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

B4
![2024-07-29 17_05_09-Space Station 14](https://github.com/user-attachments/assets/d93639c3-3fd1-4176-a614-0374d1d5c9e8)

After
![2024-07-29 17_08_51-Space Station 14](https://github.com/user-attachments/assets/1fa59f5b-a30c-41ba-875b-0cdb469b4ce6)



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
