### PR TITLE
Debug code to locate misbehaving examine text

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -349,6 +349,16 @@ namespace Content.Shared.Examine
             // tolist/clone formatted message so calling this multiple times wont fuck shit up
             // (if that happens for some reason)
             var parts = Parts.ToList();
+#if DEBUG
+            ISawmill log = IoCManager.Resolve<ILogManager>()
+                .GetSawmill(nameof(ExaminedEvent));
+
+            foreach (var part in parts)
+                if (part.Message.Count == 0)
+                    log.Warning($"Examine group `{part.Group ?? "unknown-group"}` is empty. Please avoid this!");
+#endif
+            //parts.RemoveAll(p => p.Message.Count == 0); // remove parts with no message segments
+
             var totalMessage = new FormattedMessage(Message);
             parts.Sort(Comparison);
 
@@ -359,6 +369,10 @@ namespace Content.Shared.Examine
 
             foreach (var part in parts)
             {
+#if DEBUG
+                if (part.Message.Count > 0 && part.Message[^1].ToString().EndsWith('\n'))
+                    log.Warning($"Examine group `{part.Group ?? "unknown-group"}` ends with a trailing newline. Please avoid this!");
+#endif
                 totalMessage.AddMessage(part.Message);
                 if (part.DoNewLine && parts.Last() != part)
                     totalMessage.PushNewline();

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -361,7 +361,7 @@ namespace Content.Shared.Examine
                     Log.Warning($"Examine group `{part.Group ?? "unknown-group"}` is empty. Please avoid this!");
 #else
             // in release mode, remove empty message groups
-            parts.RemoveAll(p => p.Message == 0);
+            parts.RemoveAll(p => p.Message.Count == 0);
 #endif
 
             var totalMessage = new FormattedMessage(Message);

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -357,7 +357,6 @@ namespace Content.Shared.Examine
                 if (part.Message.Count == 0)
                     log.Warning($"Examine group `{part.Group ?? "unknown-group"}` is empty. Please avoid this!");
 #endif
-            //parts.RemoveAll(p => p.Message.Count == 0); // remove parts with no message segments
 
             var totalMessage = new FormattedMessage(Message);
             parts.Sort(Comparison);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

I was half way though my expedition into examine text when I saw #30168. Call it a case of convergent evolution.

Besides the case described in #30472, there are two ways an examine text can end up with blank new lines:
- The examine event handler uses `PushGroup` but then for whatever reason doesn't put anything in that group. `GetTotalMessage` will go ahead and emit a newline for that empty group anyway, resulting in the blank line.
- The examine text itself has a blank newline at the end. In this case you need to track down the component that is adding the examine text and fix it. Usually this involves replacing `PushMarkup` with `AddMarkup` since the former always adds a newline.

So this code checks for those two cases and prints a warning when they occur. The `part.Group` variable is normally well-defined so it makes finding the offending code very easy.

With this code you can walk around examining things and then check the log for messages like:

```
[WARN] ExaminedEvent: Examine group `ConstructionComponent` is empty. Please avoid this!
```
```
[WARN] ExaminedEvent: Examine group `WiresPanelComponent` ends with a trailing newline. Please avoid this!
```

Uses the debug directive since emitting a log when anything is examined in a live environment seems like it would crash performance, or something along those lines.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
