### PR TITLE
Fix puppy ian steal target

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -100,6 +100,8 @@
     - id: FoodMeatCorgi
       amount: 2
     - id: MaterialHideCorgi
+  - type: StealTarget
+    stealGroup: AnimalIan
 
 - type: entity
   name: Runtime


### PR DESCRIPTION
Reported on discord:
![grafik](https://github.com/user-attachments/assets/43426fb6-83a0-4437-9cdb-9998948c0564)

The corgi spawner can spawn puppy Ian, but that prototype was missing the steal target since he does not inherit from Ian, but from MobCorgiPuppy.

![grafik](https://github.com/user-attachments/assets/ee44881e-08ca-4449-9197-30cf4523794b)

## Why / Balance
bugfix

## Technical details
add steal target

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed puppy Ian not counting as a thief steal target.
