### PR TITLE
Update migration to remove maint detective armor

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -350,7 +350,7 @@ DoorRemoteFirefight: null
 AirlockServiceCaptainLocked: AirlockCaptainLocked
 
 # 2024-06-15
-ClothingOuterCoatInspector: ClothingOuterCoatDetectiveLoadout
+ClothingOuterCoatInspector: ClothingOuterCoatJensen
 
 # 2024-06-23
 FloorTileItemReinforced: PartRodMetal1


### PR DESCRIPTION

## About the PR
fixes https://github.com/space-wizards/space-station-14/issues/29534

## Why / Balance
Free sec armor in maint is bad. 

## Technical details
n/a

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
n/a
