### PR TITLE
Grappling gun's ReelRate can be changed

### DIFF
--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -31,8 +31,6 @@ public abstract class SharedGrapplingGunSystem : EntitySystem
 
     public const string GrapplingJoint = "grappling";
 
-    public const float ReelRate = 2.5f;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -187,7 +185,7 @@ public abstract class SharedGrapplingGunSystem : EntitySystem
             }
 
             // TODO: This should be on engine.
-            distance.MaxLength = MathF.Max(distance.MinLength, distance.MaxLength - ReelRate * frameTime);
+            distance.MaxLength = MathF.Max(distance.MinLength, distance.MaxLength - grappling.ReelRate * frameTime);
             distance.Length = MathF.Min(distance.MaxLength, distance.Length);
 
             _physics.WakeBody(joint.BodyAUid);

--- a/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
@@ -8,7 +8,10 @@ namespace Content.Shared.Weapons.Ranged.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class GrapplingGunComponent : Component
 {
-    [DataField("reelRate"), AutoNetworkedField]
+    /// <summary>
+    /// Hook's reeling force and speed - the higher the number, the faster the hook rewinds.
+    /// </summary>
+    [DataField, AutoNetworkedField]
     public float ReelRate = 2.5f;
 
     [DataField("jointId"), AutoNetworkedField]

--- a/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
@@ -8,6 +8,9 @@ namespace Content.Shared.Weapons.Ranged.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class GrapplingGunComponent : Component
 {
+    [DataField("reelRate"), AutoNetworkedField]
+    public float ReelRate = 2.5f;
+
     [DataField("jointId"), AutoNetworkedField]
     public string Joint = string.Empty;
 


### PR DESCRIPTION


<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Removes ReelRate constant from SharedGrapplingGunSystem and adds a new VV datafield to the GrapplingGunComponent, so it's ReelRate can be changed.

## Why / Balance
This allows changing the speed and power of a grappling hook with VV or YAML prototypes. More customization

## Technical details
Constant deleted, added new field ReelRate at grappling gun component, using grappling.ReelRate instead of constant ReelRate.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

Video is showing how changing the number in VV will affect the grappling gun.

https://github.com/user-attachments/assets/c116b48f-6733-42a0-9d26-497d7123bf0e

**Changelog**
No cl no fun