### PR TITLE
Improve communications console countdown formatting

### DIFF
--- a/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml.cs
+++ b/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml.cs
@@ -130,9 +130,7 @@ namespace Content.Client.Communications.UI
 
             EmergencyShuttleButton.Text = Loc.GetString("comms-console-menu-recall-shuttle");
             var infoText = Loc.GetString($"comms-console-menu-time-remaining",
-                ("hours", diff.Hours.ToString("D2", CultureInfo.CurrentCulture)), // it won't be more than 24 hours, right?
-                ("minutes", diff.Minutes.ToString("D2", CultureInfo.CurrentCulture)),
-                ("seconds", diff.Seconds.ToString("D2", CultureInfo.CurrentCulture)));
+                ("time", diff.ToString(@"hh\:mm\:ss", CultureInfo.CurrentCulture)));
             CountdownLabel.SetMessage(infoText);
         }
     }

--- a/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml.cs
+++ b/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml.cs
@@ -130,7 +130,9 @@ namespace Content.Client.Communications.UI
 
             EmergencyShuttleButton.Text = Loc.GetString("comms-console-menu-recall-shuttle");
             var infoText = Loc.GetString($"comms-console-menu-time-remaining",
-            ("time", diff.TotalSeconds.ToString(CultureInfo.CurrentCulture)));
+                ("hours", diff.Hours.ToString("D2", CultureInfo.CurrentCulture)), // it won't be more than 24 hours, right?
+                ("minutes", diff.Minutes.ToString("D2", CultureInfo.CurrentCulture)),
+                ("seconds", diff.Seconds.ToString("D2", CultureInfo.CurrentCulture)));
             CountdownLabel.SetMessage(infoText);
         }
     }

--- a/Resources/Locale/en-US/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/communications/communications-console-component.ftl
@@ -5,7 +5,7 @@ comms-console-menu-announcement-button = Announce
 comms-console-menu-broadcast-button = Broadcast
 comms-console-menu-call-shuttle = Call emergency shuttle
 comms-console-menu-recall-shuttle = Recall emergency shuttle
-comms-console-menu-time-remaining = Time remaining: {$time}
+comms-console-menu-time-remaining = Time remaining: {$hours}:{$minutes}:{$seconds}
 
 # Popup
 comms-console-permission-denied = Permission denied

--- a/Resources/Locale/en-US/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/communications/communications-console-component.ftl
@@ -5,7 +5,7 @@ comms-console-menu-announcement-button = Announce
 comms-console-menu-broadcast-button = Broadcast
 comms-console-menu-call-shuttle = Call emergency shuttle
 comms-console-menu-recall-shuttle = Recall emergency shuttle
-comms-console-menu-time-remaining = Time remaining: {$hours}:{$minutes}:{$seconds}
+comms-console-menu-time-remaining = Time remaining: {$time}
 
 # Popup
 comms-console-permission-denied = Permission denied


### PR DESCRIPTION
## About the PR
Fixes #30491
Fixes #30279

I decided it to format it into hh:mm:ss instead. The hours might be neccessary for "survive 90 minutes until evac arrives" type events.

## Why / Balance
better UI

## Technical details
Use hours, minutes and seconds instead.
If anyone knows how to do this purely in fluent, please tell me.

## Media
![Screenshot (211)](https://github.com/user-attachments/assets/a2674b0a-b7a2-4d5d-8539-139f9bf6ee58)

![Screenshot (212)](https://github.com/user-attachments/assets/5de95750-4d1a-413f-8b5a-332b8686b77e)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
nah
