### PR TITLE
Adjusts the Bingus steal target to include any of the named cats

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -123,6 +123,8 @@
     tags:
     - CannotSuicide
     - VimPilot
+  - type: StealTarget
+    stealGroup: AnimalNamedCat
 
 - type: entity
   name: Exception
@@ -141,6 +143,8 @@
     tags:
     - CannotSuicide
     - VimPilot
+  - type: StealTarget
+    stealGroup: AnimalNamedCat
 
 - type: entity
   name: Floppa
@@ -166,6 +170,8 @@
     tags:
     - CannotSuicide
     - VimPilot
+  - type: StealTarget
+    stealGroup: AnimalNamedCat
 
 - type: entity
   name: Bandito
@@ -237,7 +243,7 @@
     - CannotSuicide
     - VimPilot
   - type: StealTarget
-    stealGroup: AnimalBingus
+    stealGroup: AnimalNamedCat
 
 - type: entity
   name: McGriff

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -347,8 +347,8 @@
     state: ian
 
 - type: stealTargetGroup
-  id: AnimalBingus
-  name: Bingus
+  id: AnimalNamedCat
+  name: Cat
   sprite:
     sprite: Mobs/Pets/bingus.rsi
     state: bingus

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -348,7 +348,7 @@
 
 - type: stealTargetGroup
   id: AnimalNamedCat
-  name: Cat
+  name: CMO's Cat
   sprite:
     sprite: Mobs/Pets/bingus.rsi
     state: bingus

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -436,7 +436,7 @@
   id: BingusStealObjective
   components:
   - type: StealCondition
-    stealGroup: AnimalBingus
+    stealGroup: AnimalNamedCat
   - type: Objective
     difficulty: 1
 


### PR DESCRIPTION
## About the PR
Title basically.

## Why / Balance
Bingus isn't spawned on every map as a lot of maps use the Cat Spawner which includes several cute and famous cats. This adjusts the target group so it an be fulfilled regardless of which cat spawns.  

## Technical details
n/a

## Media
n/a

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
n/a

**Changelog**
n/a
