### PR TITLE
Fix singularity overlay mouse position correction when zooming

### DIFF
--- a/Content.Client/Singularity/SingularityOverlay.cs
+++ b/Content.Client/Singularity/SingularityOverlay.cs
@@ -100,6 +100,8 @@ namespace Content.Client.Singularity
         /// </summary>
         private void OnProjectFromScreenToMap(ref PixelToMapEvent args)
         {   // Mostly copypasta from the singularity shader.
+            if (args.Viewport.Eye == null)
+                return;
             var maxDistance = MaxDistance * EyeManager.PixelsPerMeter;
             var finalCoords = args.VisiblePosition;
 
@@ -112,10 +114,11 @@ namespace Content.Client.Singularity
                 // and in local space 'Y' is measured in pixels from the top of the viewport.
                 // As a minor optimization the locations of the singularities are transformed into fragment space in BeforeDraw so the shader doesn't need to.
                 // We need to undo that here or this will transform the cursor position as if the singularities were mirrored vertically relative to the center of the viewport.
+
                 var localPosition = _positions[i];
                 localPosition.Y = args.Viewport.Size.Y - localPosition.Y;
                 var delta = args.VisiblePosition - localPosition;
-                var distance = (delta / args.Viewport.RenderScale).Length();
+                var distance = (delta / (args.Viewport.RenderScale * args.Viewport.Eye.Scale)).Length();
 
                 var deformation = _intensities[i] / MathF.Pow(distance, _falloffPowers[i]);
 


### PR DESCRIPTION
## About the PR
Fixes #19224

## Why / Balance
bugfix

## Technical details
#17964 corrected the singularity shader for the zoom level, but forgot to do the same for the mouse position correction.

## Media

https://github.com/user-attachments/assets/7aba7ace-f587-4fd3-9c6d-4309591530f5

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed the mouse position when it is over a singularity distortion effect while zoomed in or out.



