### PR TITLE
Adds recipe for Smile the Slime

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -201,3 +201,21 @@
   effects:
     - !type:CreateEntityReactionEffect
       entity: MaterialGunpowder
+
+- type: reaction
+  id: SmileTheSlime
+  impact: Low
+  quantized: true
+  conserveEnergy: false
+  reactants:
+    Happiness:
+      amount: 4
+    Mold: #GreyMatter would be cool but too hard. Meybe replace if there's an easier way to obtain in the future.
+      amount: 5
+    JuiceThatMakesYouWeh:
+      amount: 10
+    Slime:
+      amount: 20
+  effects:
+    - !type:CreateEntityReactionEffect
+      entity: MobSlimesPet


### PR DESCRIPTION
## About the PR
Adds a recipe for Smile the Slime

## Why / Balance
Seemed very sciency to me. Like a more engaging way to obtain your science pet.
I'm def open to feedback for recipe balance and whatnot.
I considered making it a generic slime as opposed to "Smile" but...more work I guess. Figured I'd wait to see what people think of it how it is. 

## Technical details
Might want to remove map spawns 🤷‍♂️?

## Media
n/a

- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- add: Added science! Smile the Slime can be created in the lab through a mixture of reagents.