### PR TITLE
Skeletons no longer have fingerprints

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -162,7 +162,6 @@
   - type: SleepEmitSound
   - type: SSDIndicator
   - type: StandingState
-  - type: Fingerprint
   - type: Dna
   - type: MindContainer
     showExamineInfo: true
@@ -234,6 +233,7 @@
         Heat: -0.07
       groups:
         Brute: -0.07
+  - type: Fingerprint
 
   - type: Blindable
   # Other


### PR DESCRIPTION
## About the PR
Fixes #20803
Found this old issue and was able to fix it with a simple 2 line change.

## Why / Balance
Would be a very minor buff to skeletons, even though they are already pretty powerful. But considering that everyone can simply wear gloves to prevent fingerprints it should be fine.

## Technical details
Moved the Fingerprint component from BaseMobSpecies to BaseMobSpeciesOrganic. The only entity directly inheriting from BaseMobSpecies is the skeleton, so this should not affect anything else.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- tweak: Skeletons no longer have fingerprints.

