### PR TITLE
Don't disable collision on dead mobs, fixes an issue with pulling

### DIFF
--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -80,11 +80,6 @@ public partial class MobStateSystem
             case MobState.Dead:
                 RemComp<CollisionWakeComponent>(target);
                 _standing.Stand(target);
-                if (!_standing.IsDown(target) && TryComp<PhysicsComponent>(target, out var physics))
-                {
-                    _physics.SetCanCollide(target, true, body: physics);
-                }
-
                 break;
             case MobState.Invalid:
                 //unused
@@ -115,12 +110,6 @@ public partial class MobStateSystem
             case MobState.Dead:
                 EnsureComp<CollisionWakeComponent>(target);
                 _standing.Down(target);
-
-                if (_standing.IsDown(target) && TryComp<PhysicsComponent>(target, out var physics))
-                {
-                    _physics.SetCanCollide(target, false, body: physics);
-                }
-
                 _appearance.SetData(target, MobStateVisuals.State, MobState.Dead);
                 break;
             case MobState.Invalid:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
title

## Why / Balance
since dead mobs no longer collide with projectiles unless aimed at, there is no point to disable collision
this fixes an issue with pulling a mob that just died:
- pull mob that is crit
- mob dies
- pull lags and mispredicts, you'll be sent back a few tiles

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
none