### PR TITLE
Fix exploding pen clicking

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
@@ -20,6 +20,8 @@
   - type: DeviceLinkSink
     ports:
       - Trigger
+  - type: EmitSoundOnUse
+    handle: false # don't want the sound to stop the explosion from triggering
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

@VasilisThePikachu thanks for merging the other PR #30531. I tested the energy pen and hypopen, but I forgot to test the exploding pen.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

I needed to add 'handled: false' to the exploding pen, otherwise the click sound handles the interaction before it could reach the exploding part. Derp.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

no, other PR not published yet
