### PR TITLE
Remove slippery from whoopie cushions

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1382,12 +1382,6 @@
         variation: 0.125
   - type: UseDelay
     delay: 0.8
-  - type: Slippery
-    paralyzeTime: 0
-    slipSound:
-      collection: Parp
-      params:
-        variation: 0.125
   - type: MeleeWeapon
     soundHit:
       collection: Parp


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
It was being used to trigger sound when stepped on, then it was fixed to use the proper component, but the slippery component never got removed

