### PR TITLE
Change from using obsolete method in ExplosionOverlay

### DIFF
--- a/Content.Client/Explosion/ExplosionOverlay.cs
+++ b/Content.Client/Explosion/ExplosionOverlay.cs
@@ -16,6 +16,7 @@ public sealed class ExplosionOverlay : Overlay
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly IEntityManager _entMan = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
+    private SharedAppearanceSystem? _appearance;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
 
@@ -25,23 +26,26 @@ public sealed class ExplosionOverlay : Overlay
     {
         IoCManager.InjectDependencies(this);
         _shader = _proto.Index<ShaderPrototype>("unshaded").Instance();
+        _appearance = _entMan.System<SharedAppearanceSystem>();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
     {
+        if (_appearance is null && !_entMan.TrySystem(out _appearance))
+            return;
+
         var drawHandle = args.WorldHandle;
         drawHandle.UseShader(_shader);
 
         var xforms = _entMan.GetEntityQuery<TransformComponent>();
-        var query = _entMan
-            .EntityQuery<ExplosionVisualsComponent, ExplosionVisualsTexturesComponent, AppearanceComponent>(true);
+        var query = _entMan.EntityQueryEnumerator<ExplosionVisualsComponent, ExplosionVisualsTexturesComponent>();
 
-        foreach (var (visuals, textures, appearance) in query)
+        while (query.MoveNext(out var uid, out var visuals, out var textures))
         {
             if (visuals.Epicenter.MapId != args.MapId)
                 continue;
 
-            if (!appearance.TryGetData(ExplosionAppearanceData.Progress, out int index))
+            if (!_appearance.TryGetData(uid, ExplosionAppearanceData.Progress, out int index))
                 continue;
 
             index = Math.Min(index, visuals.Intensity.Count - 1);

--- a/Content.Client/Explosion/ExplosionOverlay.cs
+++ b/Content.Client/Explosion/ExplosionOverlay.cs
@@ -16,24 +16,21 @@ public sealed class ExplosionOverlay : Overlay
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly IEntityManager _entMan = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
-    private SharedAppearanceSystem? _appearance;
+    private SharedAppearanceSystem _appearance;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
 
     private ShaderInstance _shader;
 
-    public ExplosionOverlay()
+    public ExplosionOverlay(SharedAppearanceSystem appearanceSystem)
     {
         IoCManager.InjectDependencies(this);
         _shader = _proto.Index<ShaderPrototype>("unshaded").Instance();
-        _appearance = _entMan.System<SharedAppearanceSystem>();
+        _appearance = appearanceSystem;
     }
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (_appearance is null && !_entMan.TrySystem(out _appearance))
-            return;
-
         var drawHandle = args.WorldHandle;
         drawHandle.UseShader(_shader);
 

--- a/Content.Client/Explosion/ExplosionOverlaySystem.cs
+++ b/Content.Client/Explosion/ExplosionOverlaySystem.cs
@@ -20,6 +20,7 @@ public sealed class ExplosionOverlaySystem : EntitySystem
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
     [Dependency] private readonly SharedPointLightSystem _lights = default!;
     [Dependency] private readonly IMapManager _mapMan = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
     public override void Initialize()
     {
@@ -28,7 +29,7 @@ public sealed class ExplosionOverlaySystem : EntitySystem
         SubscribeLocalEvent<ExplosionVisualsComponent, ComponentInit>(OnExplosionInit);
         SubscribeLocalEvent<ExplosionVisualsComponent, ComponentRemove>(OnCompRemove);
         SubscribeLocalEvent<ExplosionVisualsComponent, ComponentHandleState>(OnExplosionHandleState);
-        _overlayMan.AddOverlay(new ExplosionOverlay());
+        _overlayMan.AddOverlay(new ExplosionOverlay(_appearance));
     }
 
     private void OnExplosionHandleState(EntityUid uid, ExplosionVisualsComponent component, ref ComponentHandleState args)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Changes the use of obsolete `AppearanceComponent.TryGetData` to `SharedAppearanceSystem.TryGetData` in `ExplosionOverlay`.

This PR is necessary for https://github.com/space-wizards/RobustToolbox/pull/5324 to be merged since it access-restricts `AppearanceComponent`.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

#30514 requires https://github.com/space-wizards/RobustToolbox/pull/5324, and that PR requires this PR. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

no cl
