### PR TITLE
Add replacement words to Russian accent

### DIFF
--- a/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
@@ -5,14 +5,15 @@ namespace Content.Server.Speech.EntitySystems;
 
 public sealed class RussianAccentSystem : EntitySystem
 {
+    [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
     public override void Initialize()
     {
         SubscribeLocalEvent<RussianAccentComponent, AccentGetEvent>(OnAccent);
     }
 
-    public static string Accentuate(string message)
+    public string Accentuate(string message)
     {
-        var accentedMessage = new StringBuilder(message);
+        var accentedMessage = new StringBuilder(_replacement.ApplyReplacements(message, "russian"));
 
         for (var i = 0; i < accentedMessage.Length; i++)
         {
@@ -20,6 +21,7 @@ public sealed class RussianAccentSystem : EntitySystem
 
             accentedMessage[i] = c switch
             {
+                'A' => 'Д',
                 'b' => 'в',
                 'N' => 'И',
                 'n' => 'и',

--- a/Resources/Locale/en-US/accent/russian.ftl
+++ b/Resources/Locale/en-US/accent/russian.ftl
@@ -1,0 +1,19 @@
+accent-russian-words-1 = yes
+accent-russian-words-replace-1 = da
+
+accent-russian-words-2 = no
+accent-russian-words-replace-2 = nyet
+
+accent-russian-words-3 = grandma
+accent-russian-words-3-2 = grandmother
+accent-russian-words-3-3 = granny
+accent-russian-words-replace-3 = babushka
+
+accent-russian-words-4 = friend
+accent-russian-words-replace-4 = comrade
+
+accent-russian-words-5 = friends
+accent-russian-words-replace-5 = comrades
+
+accent-russian-words-6 = cheers
+accent-russian-words-replace-6 = na zdorovje

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -481,3 +481,15 @@
     liar-word-40: liar-word-replacement-40
     liar-word-41: liar-word-replacement-41
     liar-word-42: liar-word-replacement-42
+
+- type: accent
+  id: russian
+  wordReplacements:
+    accent-russian-words-1: accent-russian-words-replace-1
+    accent-russian-words-2: accent-russian-words-replace-2
+    accent-russian-words-3: accent-russian-words-replace-3
+    accent-russian-words-3-2: accent-russian-words-replace-3
+    accent-russian-words-3-3: accent-russian-words-replace-3
+    accent-russian-words-4: accent-russian-words-replace-4
+    accent-russian-words-5: accent-russian-words-replace-5
+    accent-russian-words-6: accent-russian-words-replace-6


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This adds a few replacement words to the Russian accent, in addition to the character replacements.
It also makes it replace A with Д, which it wasn't doing before.

## Why / Balance
It makes it more Russian

## Technical details
Technically this isn't how Russian works.

## Media
![image](https://github.com/user-attachments/assets/35e5a8eb-83dd-4eb6-a72e-cdeb1c719a47)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
nah