### PR TITLE
Extends entity heat capacity to use multiple sources

### DIFF
--- a/Content.Server/Temperature/Components/TemperatureComponent.cs
+++ b/Content.Server/Temperature/Components/TemperatureComponent.cs
@@ -40,6 +40,20 @@ public sealed partial class TemperatureComponent : Component
     public float? ParentColdDamageThreshold;
 
     /// <summary>
+    /// The total heat capacity of this entity given all available sources.
+    /// <see cref="HeatCapacityDirty"/> handles tracking whether this is out of date given changes to the sources. 
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly), Access(typeof(TemperatureSystem), Other = AccessPermissions.None)]
+    public float TotalHeatCapacity;
+
+    /// <summary>
+    /// Whether any sources of heat capacity for this entity have changed since the last time <see cref="TotalHeatCapacity"/> was calculated.
+    /// If this is true the next attempt to fetch the heat capacity of this entity using <see cref="TemperatureSystem.GetHeatCapacity"/> will recalculate it.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly), Access(typeof(TemperatureSystem), Other = AccessPermissions.None)]
+    public bool HeatCapacityDirty = true; // Force the first fetch to calculate the total heat capacity.
+
+    /// <summary>
     /// Heat capacity per kg of mass.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Temperature/Components/TemperatureComponent.cs
+++ b/Content.Server/Temperature/Components/TemperatureComponent.cs
@@ -43,14 +43,14 @@ public sealed partial class TemperatureComponent : Component
     /// The total heat capacity of this entity given all available sources.
     /// <see cref="HeatCapacityDirty"/> handles tracking whether this is out of date given changes to the sources. 
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadOnly), Access(typeof(TemperatureSystem), Other = AccessPermissions.None)]
+    [ViewVariables(VVAccess.ReadOnly), Access(typeof(TemperatureSystem), Other = AccessPermissions.None)]
     public float TotalHeatCapacity;
 
     /// <summary>
     /// Whether any sources of heat capacity for this entity have changed since the last time <see cref="TotalHeatCapacity"/> was calculated.
     /// If this is true the next attempt to fetch the heat capacity of this entity using <see cref="TemperatureSystem.GetHeatCapacity"/> will recalculate it.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadOnly), Access(typeof(TemperatureSystem), Other = AccessPermissions.None)]
+    [ViewVariables(VVAccess.ReadOnly), Access(typeof(TemperatureSystem), Other = AccessPermissions.None)]
     public bool HeatCapacityDirty = true; // Force the first fetch to calculate the total heat capacity.
 
     /// <summary>

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -14,7 +14,6 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
-using Robust.Shared.ViewVariables;
 
 namespace Content.Server.Temperature.Systems;
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I made it possible for any system to contribute to an entities heat capacity and added a caching system to not completely crash the performance of doing so.

WIP:
- API for heat capacity changes that implicitly conserve thermal energy.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I needed a way to hook reagent/material composition into the heat capacity for entities as their snowflake temperature system is going to get the axe. This makes that possible.
Also, recalculating the heat capacity for the entity every time it was fetched could be unperformant so the caching system was added to offset that.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The total heat capacity for entities is now stored on the temperature component using a caching field. This is accompanied by a couple other fields tracking whether the cached value is out of date. Whenever the heat capacity for the entity is fetched the tracking variables are checked and if the heat capacity is out of date it is recalculated.

Calculating the total heat capacity for the entity is done through a directed event raised on the entity with an accumulator field. Any system that wants to add heat capacity to the entity should contribute to the accumulator and mark the heat capacity as dirty when whatever source of heat capacity it's managing changes.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
The `TemperatureComponent.SpecificHeat` field has had its write access restricted to `TemperatureSystem`. Please use the provided setter `TemperatureSystem.SetSpecificHeat`.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
