### PR TITLE
make the digital audio workstation rotatable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
@@ -148,7 +148,7 @@
     state: toms
 
 - type: entity
-  parent: [ BasePlaceableInstrument, ConstructibleMachine]
+  parent: [ BasePlaceableInstrumentRotatable, ConstructibleMachine]
   id: DawInstrument
   name: digital audio workstation
   description: Cutting edge music technology, straight from the 90s.


### PR DESCRIPTION
## About the PR
see title

## Why / Balance
same as piano or other big instruments

## Technical details
yaml only

## Media
![grafik](https://github.com/user-attachments/assets/1ef4dbcb-c6d7-4093-9e44-dbc87ac3a65f)

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- tweak: The digital audio workstation can now be rotated.
