### PR TITLE
Add whitelist to cryostorage

### DIFF
--- a/Content.Shared/Bed/Cryostorage/CanEnterCryostorageComponent.cs
+++ b/Content.Shared/Bed/Cryostorage/CanEnterCryostorageComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Bed.Cryostorage;
+
+/// <summary>
+/// Serves as a whitelist that allows an entity with this component to enter cryostorage.
+/// It will also require MindContainerComponent.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CanEnterCryostorageComponent : Component { }

--- a/Content.Shared/Bed/Cryostorage/SharedCryostorageSystem.cs
+++ b/Content.Shared/Bed/Cryostorage/SharedCryostorageSystem.cs
@@ -89,7 +89,7 @@ public abstract class SharedCryostorageSystem : EntitySystem
             return;
         }
 
-        if (!TryComp<MindContainerComponent>(args.EntityUid, out var mindContainer))
+        if (!HasComp<CanEnterCryostorageComponent>(args.EntityUid) || !TryComp<MindContainerComponent>(args.EntityUid, out var mindContainer))
         {
             args.Cancel();
             return;

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -165,6 +165,7 @@
   - type: Dna
   - type: MindContainer
     showExamineInfo: true
+  - type: CanEnterCryostorage
   - type: InteractionPopup
     successChance: 1
     interactSuccessString: hugging-success-generic


### PR DESCRIPTION
## About the PR
Fixes borgs, animals or aghosts being able to enter cryosleep.
Fixes #27410
Fixes #27498
Fixes #26815


## Why / Balance
Borgs can just disconnect and someone can reset their positronic brain. This also fixes the exploit to be able to get the borgs tools as items.
Animals like Ian should not be able to be removed via cryo since they can be steal objectives for other players. Ghosting or disconnecting will allow the mob AI to take over again.
Aghosts should just disconnect.

## Technical details
Added a new CanEnterCryostorageComponent which serves as a whitelist. It has been a added to the BaseMobSpecies prototype.
Previously anything with MindContainerComponent was able to enter.

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed borgs, animals and aghosts being able to enter cryosleep.
