### PR TITLE
Fix Bwoink Player sorting again....

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -92,12 +92,17 @@ namespace Content.Client.Administration.UI.Bwoink
                 if (a.IsPinned != b.IsPinned)
                     return a.IsPinned ? -1 : 1;
 
-                // First, sort by unread. Any chat with unread messages appears first. We just sort based on unread
-                // status, not number of unread messages, so that more recent unread messages take priority.
+                // First, sort by unread. Any chat with unread messages appears first.
                 var aUnread = ach.Unread > 0;
                 var bUnread = bch.Unread > 0;
                 if (aUnread != bUnread)
                     return aUnread ? -1 : 1;
+
+                // Sort by recent messages during the current round.
+                var aRecent = a.ActiveThisRound && ach.LastMessage != DateTime.MinValue;
+                var bRecent = b.ActiveThisRound && bch.LastMessage != DateTime.MinValue;
+                if (aRecent != bRecent)
+                    return aRecent ? -1 : 1;
 
                 // Next, sort by connection status. Any disconnected players are grouped towards the end.
                 if (a.Connected != b.Connected)


### PR DESCRIPTION
## About the PR
Refined/fixed aHelp sorting on bwoink menu so the other admins do not kill me....

## Why / Balance
Painful for admins to not have recent aHelps at top of list

## Technical details
NA

## Media
![image](https://github.com/user-attachments/assets/d588c82b-f11a-4597-b269-9cf48e1d916b)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
NA

**Changelog**

:cl: Repo
ADMIN:
- fix: Players that aHelped in Current round stay at top of bwoink list.

