### PR TITLE
Marathon had extra pipes under windows

### DIFF
--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -10987,7 +10987,7 @@ entities:
       pos: -20.5,-5.5
       parent: 30
     - type: Door
-      secondsUntilStateChange: -19847.316
+      secondsUntilStateChange: -19887.758
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -74165,17 +74165,6 @@ entities:
       parent: 30
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 8933
-    components:
-    - type: Transform
-      anchored: False
-      pos: 7.5,-22.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-    - type: Physics
-      canCollide: True
-      bodyType: Dynamic
   - uid: 8934
     components:
     - type: Transform
@@ -75346,17 +75335,6 @@ entities:
       parent: 30
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 9980
-    components:
-    - type: Transform
-      anchored: False
-      pos: 5.5,-22.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-    - type: Physics
-      canCollide: True
-      bodyType: Dynamic
   - uid: 9982
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Simply deletes two extra pipes that had been mistakenly placed under the windows by atmos. once the map was initialized these would be pushed out making it look like the pipe network was unanchored.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #30566 The pipe network is actually fine, there was just some extra pipes that had been placed under the windows.
