### PR TITLE
Small strange jackboots buff

### DIFF
--- a/Content.Shared/Damage/Components/ClothingSlowOnDamageModifierComponent.cs
+++ b/Content.Shared/Damage/Components/ClothingSlowOnDamageModifierComponent.cs
@@ -4,6 +4,7 @@ namespace Content.Shared.Damage.Components;
 
 /// <summary>
 /// This is used for a clothing item that modifies the slowdown from taking damage.
+/// Used for entities with <see cref="SlowOnDamageComponent"/>
 /// </summary>
 [RegisterComponent, NetworkedComponent, Access(typeof(SlowOnDamageSystem))]
 public sealed partial class ClothingSlowOnDamageModifierComponent : Component

--- a/Content.Shared/Damage/Components/ClothingSlowOnDamageModifierComponent.cs
+++ b/Content.Shared/Damage/Components/ClothingSlowOnDamageModifierComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Damage.Components;
+
+/// <summary>
+/// This is used for a clothing item that modifies the slowdown from taking damage.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(SlowOnDamageSystem))]
+public sealed partial class ClothingSlowOnDamageModifierComponent : Component
+{
+    /// <summary>
+    /// A coefficient modifier for the slowdown
+    /// </summary>
+    [DataField]
+    public float Modifier = 1;
+}

--- a/Content.Shared/Damage/Systems/SlowOnDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/SlowOnDamageSystem.cs
@@ -1,5 +1,8 @@
+using Content.Shared.Clothing;
 using Content.Shared.Damage.Components;
+using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
+using Content.Shared.Inventory;
 using Content.Shared.Movement.Systems;
 
 namespace Content.Shared.Damage
@@ -14,6 +17,11 @@ namespace Content.Shared.Damage
 
             SubscribeLocalEvent<SlowOnDamageComponent, DamageChangedEvent>(OnDamageChanged);
             SubscribeLocalEvent<SlowOnDamageComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
+
+            SubscribeLocalEvent<ClothingSlowOnDamageModifierComponent, InventoryRelayedEvent<ModifySlowOnDamageSpeedEvent>>(OnModifySpeed);
+            SubscribeLocalEvent<ClothingSlowOnDamageModifierComponent, ExaminedEvent>(OnExamined);
+            SubscribeLocalEvent<ClothingSlowOnDamageModifierComponent, ClothingGotEquippedEvent>(OnGotEquipped);
+            SubscribeLocalEvent<ClothingSlowOnDamageModifierComponent, ClothingGotUnequippedEvent>(OnGotUnequipped);
         }
 
         private void OnRefreshMovespeed(EntityUid uid, SlowOnDamageComponent component, RefreshMovementSpeedModifiersEvent args)
@@ -36,7 +44,10 @@ namespace Content.Shared.Damage
             if (closest != FixedPoint2.Zero)
             {
                 var speed = component.SpeedModifierThresholds[closest];
-                args.ModifySpeed(speed, speed);
+
+                var ev = new ModifySlowOnDamageSpeedEvent(speed);
+                RaiseLocalEvent(uid, ref ev);
+                args.ModifySpeed(ev.Speed, ev.Speed);
             }
         }
 
@@ -47,5 +58,37 @@ namespace Content.Shared.Damage
 
             _movementSpeedModifierSystem.RefreshMovementSpeedModifiers(uid);
         }
+
+        private void OnModifySpeed(Entity<ClothingSlowOnDamageModifierComponent> ent, ref InventoryRelayedEvent<ModifySlowOnDamageSpeedEvent> args)
+        {
+            var dif = 1 - args.Args.Speed;
+            if (dif <= 0)
+                return;
+
+            // reduces the slowness modifier by the given coefficient
+            args.Args.Speed += dif * ent.Comp.Modifier;
+        }
+
+        private void OnExamined(Entity<ClothingSlowOnDamageModifierComponent> ent, ref ExaminedEvent args)
+        {
+            var msg = Loc.GetString("slow-on-damage-modifier-examine", ("mod", (1 - ent.Comp.Modifier) * 100));
+            args.PushMarkup(msg);
+        }
+
+        private void OnGotEquipped(Entity<ClothingSlowOnDamageModifierComponent> ent, ref ClothingGotEquippedEvent args)
+        {
+            _movementSpeedModifierSystem.RefreshMovementSpeedModifiers(args.Wearer);
+        }
+
+        private void OnGotUnequipped(Entity<ClothingSlowOnDamageModifierComponent> ent, ref ClothingGotUnequippedEvent args)
+        {
+            _movementSpeedModifierSystem.RefreshMovementSpeedModifiers(args.Wearer);
+        }
+    }
+
+    [ByRefEvent]
+    public record struct ModifySlowOnDamageSpeedEvent(float Speed) : IInventoryRelayEvent
+    {
+        public SlotFlags TargetSlots => SlotFlags.WITHOUT_POCKET;
     }
 }

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -34,6 +34,7 @@ public partial class InventorySystem
         // by-ref events
         SubscribeLocalEvent<InventoryComponent, GetExplosionResistanceEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, IsWeightlessEvent>(RefRelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, ModifySlowOnDamageSpeedEvent>(RefRelayInventoryEvent);
 
         // Eye/vision events
         SubscribeLocalEvent<InventoryComponent, CanSeeAttemptEvent>(RelayInventoryEvent);

--- a/Resources/Locale/en-US/damage/stamina.ftl
+++ b/Resources/Locale/en-US/damage/stamina.ftl
@@ -1,1 +1,2 @@
 melee-stamina = Not enough stamina
+slow-on-damage-modifier-examine = Slowness from injuries is reduced by [color=yellow]{$mod}%[/color]

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -20,6 +20,8 @@
     sprite: Clothing/Shoes/Boots/jackboots.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/jackboots.rsi
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
 
 - type: entity
   parent: ClothingShoesBaseButcherable

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -968,7 +968,6 @@
   id: SecurityShoes
   name: loadout-group-security-shoes
   loadouts:
-  - CombatBoots
   - JackBoots
   - SecurityWinterBoots
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Makes jackboots reduce slowness from SlowOnDamage by 50%.

In a practical sense:
- Light damage (>40) goes from a 30% slowdown to a 15% slowdown.
- Heavy damage (>80) goes from a 50% slowdown to a 25% slowdown.

Removes combat boots from the sec loadout as this makes them objectively worse and turns them into a silly noob trap.

Credit to Bhijn & Myr for the idea

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This PR is primarily aimed to help reduce the prevalence of traitor contraband abuse from security players.

NoSlips are one of the most over represented items when it comes to syndicate contraband being illegally used by sec. This is largely because of a distinct power vacuum when it comes to footwear: there are basically only 3 options commonly available
- Regular shoes, which are legal and everyone has by default
- Magboots, which are legal but have a shitty combat downside (reduced speed) in exchange for the antigrav and noslip properties.
- NoSlips/galoshes, illegal or unobtainable but have a situationally good combat upside (specifically in the wake of a lot of slip nerfs)

Sec themselves (the only ones who are particularly relevant in terms of contraband abuse in this situation) have no mechanical reason to _not_ use noslips, even though the rules prohibit it and the upside is relatively minor. Compared to no upside or even a combat downside, noslips are an obvious choice.

My solution for this--this PR--is to buff jackboots with a _generally useful_ upside to serve as a natural alternative to the _situational utility_ of noslips. Reducing sec's slowdown in combat situations when injured is great for allowing them to carry on fighting in tense situations as well as escaping ambushes. 

I don't think this is a 100% silver bullet to the entire situation, but my hope is that it'll serve as an alternative that will at least greatly reduce sec's usage of syndicate equipment, or at the very least, make the usage of said equipment into an interesting tactical decision rather than a flagrant showing-off of contraband.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a new `ClothingSlowOnDamageModifierComponent` and some events to hook into `SlowOnDamageSystem`.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
![image](https://github.com/user-attachments/assets/2bef5eea-8f5e-41bb-941d-46f93a915137)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Jackboots now reduce slowness from injuries by 50%.
- remove: Removed combat boots from the security loadout.
