### PR TITLE
Add admin logs to Rehydration comp.

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/RehydratableSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/RehydratableSystem.cs
@@ -1,4 +1,6 @@
+using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.Components;
+using Content.Shared.Database;
 using Content.Shared.FixedPoint;
 using Content.Shared.Popups;
 using Robust.Shared.Network;
@@ -13,6 +15,7 @@ public sealed class RehydratableSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutions = default!;
     [Dependency] private readonly SharedTransformSystem _xform = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
     public override void Initialize()
     {
@@ -24,6 +27,7 @@ public sealed class RehydratableSystem : EntitySystem
     private void OnSolutionChange(Entity<RehydratableComponent> ent, ref SolutionContainerChangedEvent args)
     {
         var quantity = _solutions.GetTotalPrototypeQuantity(ent, ent.Comp.CatalystPrototype);
+        _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ent.Owner)} was hydrated, now contains a solution of: {SharedSolutionContainerSystem.ToPrettyString(args.Solution)}.");
         if (quantity != FixedPoint2.Zero && quantity >= ent.Comp.CatalystMinimum)
         {
             Expand(ent);
@@ -41,6 +45,8 @@ public sealed class RehydratableSystem : EntitySystem
         var randomMob = _random.Pick(comp.PossibleSpawns);
 
         var target = Spawn(randomMob, Transform(uid).Coordinates);
+        _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(ent.Owner)} has been hydrated correctly and spawned: {ToPrettyString(target)}.");
+
         _popup.PopupEntity(Loc.GetString("rehydratable-component-expands-message", ("owner", uid)), target);
 
         _xform.AttachToGridOrMap(target);


### PR DESCRIPTION
## About the PR
Its currently unclear when and what spawns up when a Syndicate Sponge spawns and hard to line up who hydrated it. This should help that issue.
Also will show for all the other cubes, Monkeys, Syndi-carps etc.
Fixes #24605

## Why / Balance
Help with admin issues and logging when dangerous cubes are hydrated.

## Technical details
Add admin logs.

## Media
![image](https://github.com/user-attachments/assets/b2d9e302-44e7-4e7a-b019-c4d3947fb814)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
NA

**Changelog**

:cl: Repo
ADMIN:
- add: Admin logs for Cubes and other rehydration.
