### PR TITLE
better examine text for radiation collectors

### DIFF
--- a/Content.Server/Singularity/EntitySystems/RadiationCollectorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/RadiationCollectorSystem.cs
@@ -137,13 +137,22 @@ public sealed class RadiationCollectorSystem : EntitySystem
 
     private void OnExamined(EntityUid uid, RadiationCollectorComponent component, ExaminedEvent args)
     {
-        if (!TryGetLoadedGasTank(uid, out var gasTank))
+        using (args.PushGroup(nameof(RadiationCollectorComponent)))
         {
-            args.PushMarkup(Loc.GetString("power-radiation-collector-gas-tank-missing"));
-            return;
-        }
+            args.PushMarkup(Loc.GetString("power-radiation-collector-enabled", ("state", component.Enabled)));
 
-        args.PushMarkup(Loc.GetString("power-radiation-collector-gas-tank-present"));
+            if (!TryGetLoadedGasTank(uid, out var gasTank))
+            {
+                args.PushMarkup(Loc.GetString("power-radiation-collector-gas-tank-missing"));
+            }
+            else
+            {
+                _appearance.TryGetData<int>(uid, RadiationCollectorVisuals.PressureState, out var state);
+
+                args.PushMarkup(Loc.GetString("power-radiation-collector-gas-tank-present",
+                    ("fullness", state)));
+            }
+        }
     }
 
     private void OnAnalyzed(EntityUid uid, RadiationCollectorComponent component, GasAnalyzerScanEvent args)

--- a/Resources/Locale/en-US/power/components/radiation-collector.ftl
+++ b/Resources/Locale/en-US/power/components/radiation-collector.ftl
@@ -1,2 +1,11 @@
-power-radiation-collector-gas-tank-missing = [color=darkred]No plasma tank attached.[/color]
-power-radiation-collector-gas-tank-present = A plasma tank is [color=darkgreen]connected[/color].
+power-radiation-collector-gas-tank-missing = The plasma tank slot is [color=darkred]empty[/color]
+power-radiation-collector-gas-tank-present = The plasma tank slot is [color=darkgreen]filled[/color] and the tank indicator reads [color={$fullness ->
+    *[0]red] empty
+    [1]red] low
+    [2]yellow] half-full
+    [3]lime] full
+}[/color].
+power-radiation-collector-enabled = It's switched [color={$state ->
+    [true] darkgreen] on
+    *[false] darkred] off
+}[/color].

--- a/Resources/Locale/en-US/power/components/radiation-collector.ftl
+++ b/Resources/Locale/en-US/power/components/radiation-collector.ftl
@@ -1,4 +1,4 @@
-power-radiation-collector-gas-tank-missing = The plasma tank slot is [color=darkred]empty[/color]
+power-radiation-collector-gas-tank-missing = The plasma tank slot is [color=darkred]empty[/color].
 power-radiation-collector-gas-tank-present = The plasma tank slot is [color=darkgreen]filled[/color] and the tank indicator reads [color={$fullness ->
     *[0]red]empty
     [1]red]low

--- a/Resources/Locale/en-US/power/components/radiation-collector.ftl
+++ b/Resources/Locale/en-US/power/components/radiation-collector.ftl
@@ -1,11 +1,11 @@
 power-radiation-collector-gas-tank-missing = The plasma tank slot is [color=darkred]empty[/color]
 power-radiation-collector-gas-tank-present = The plasma tank slot is [color=darkgreen]filled[/color] and the tank indicator reads [color={$fullness ->
-    *[0]red] empty
-    [1]red] low
-    [2]yellow] half-full
-    [3]lime] full
+    *[0]red]empty
+    [1]red]low
+    [2]yellow]half-full
+    [3]lime]full
 }[/color].
 power-radiation-collector-enabled = It's switched [color={$state ->
-    [true] darkgreen] on
-    *[false] darkred] off
+    [true] darkgreen]on
+    *[false] darkred]off
 }[/color].


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I LOVE CRITICAL INFO ONLY BEING VISIBLE AS A TINY LITTLE SPRITE CHANGE.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Critical information that's 100% useful for checking if rad collectors are working should be clearly visible in the examine menu.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
![image](https://github.com/user-attachments/assets/867ba76a-cc0c-4441-af65-877017e429aa)
![image](https://github.com/user-attachments/assets/eb17699b-8e08-4135-811e-0a5327d8e586)
![image](https://github.com/user-attachments/assets/c51e3b51-00bf-445e-b3cc-651ae1f16a48)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
none 

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun