### PR TITLE
Box Atmos Miners Grille Removal

### DIFF
--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -11448,7 +11448,7 @@ entities:
       pos: 24.5,16.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -3331.5208
+      secondsUntilStateChange: -4258.8877
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -17253,6 +17253,11 @@ entities:
     - type: Transform
       pos: -52.5,-6.5
       parent: 8364
+  - uid: 1301
+    components:
+    - type: Transform
+      pos: 25.5,-45.5
+      parent: 8364
   - uid: 1468
     components:
     - type: Transform
@@ -17668,6 +17673,16 @@ entities:
     - type: Transform
       pos: 25.5,-60.5
       parent: 8364
+  - uid: 3702
+    components:
+    - type: Transform
+      pos: 25.5,-49.5
+      parent: 8364
+  - uid: 3703
+    components:
+    - type: Transform
+      pos: 25.5,-53.5
+      parent: 8364
   - uid: 3705
     components:
     - type: Transform
@@ -17902,11 +17917,6 @@ entities:
     components:
     - type: Transform
       pos: 25.5,-51.5
-      parent: 8364
-  - uid: 4163
-    components:
-    - type: Transform
-      pos: 22.5,-67.5
       parent: 8364
   - uid: 4520
     components:
@@ -31538,71 +31548,6 @@ entities:
     - type: Transform
       pos: 24.5,-45.5
       parent: 8364
-  - uid: 16587
-    components:
-    - type: Transform
-      pos: 25.5,-45.5
-      parent: 8364
-  - uid: 16588
-    components:
-    - type: Transform
-      pos: 26.5,-45.5
-      parent: 8364
-  - uid: 16589
-    components:
-    - type: Transform
-      pos: 27.5,-45.5
-      parent: 8364
-  - uid: 16590
-    components:
-    - type: Transform
-      pos: 28.5,-45.5
-      parent: 8364
-  - uid: 16591
-    components:
-    - type: Transform
-      pos: 29.5,-45.5
-      parent: 8364
-  - uid: 16592
-    components:
-    - type: Transform
-      pos: 29.5,-44.5
-      parent: 8364
-  - uid: 16593
-    components:
-    - type: Transform
-      pos: 29.5,-43.5
-      parent: 8364
-  - uid: 16594
-    components:
-    - type: Transform
-      pos: 29.5,-42.5
-      parent: 8364
-  - uid: 16595
-    components:
-    - type: Transform
-      pos: 29.5,-41.5
-      parent: 8364
-  - uid: 16596
-    components:
-    - type: Transform
-      pos: 28.5,-41.5
-      parent: 8364
-  - uid: 16597
-    components:
-    - type: Transform
-      pos: 27.5,-41.5
-      parent: 8364
-  - uid: 16598
-    components:
-    - type: Transform
-      pos: 26.5,-41.5
-      parent: 8364
-  - uid: 16599
-    components:
-    - type: Transform
-      pos: 25.5,-41.5
-      parent: 8364
   - uid: 16600
     components:
     - type: Transform
@@ -31623,11 +31568,6 @@ entities:
     - type: Transform
       pos: 25.5,-48.5
       parent: 8364
-  - uid: 16606
-    components:
-    - type: Transform
-      pos: 25.5,-49.5
-      parent: 8364
   - uid: 16607
     components:
     - type: Transform
@@ -31643,11 +31583,6 @@ entities:
     - type: Transform
       pos: 25.5,-52.5
       parent: 8364
-  - uid: 16610
-    components:
-    - type: Transform
-      pos: 25.5,-53.5
-      parent: 8364
   - uid: 16611
     components:
     - type: Transform
@@ -31662,116 +31597,6 @@ entities:
     components:
     - type: Transform
       pos: 25.5,-56.5
-      parent: 8364
-  - uid: 16614
-    components:
-    - type: Transform
-      pos: 25.5,-57.5
-      parent: 8364
-  - uid: 16615
-    components:
-    - type: Transform
-      pos: 26.5,-57.5
-      parent: 8364
-  - uid: 16616
-    components:
-    - type: Transform
-      pos: 27.5,-57.5
-      parent: 8364
-  - uid: 16617
-    components:
-    - type: Transform
-      pos: 28.5,-57.5
-      parent: 8364
-  - uid: 16618
-    components:
-    - type: Transform
-      pos: 29.5,-57.5
-      parent: 8364
-  - uid: 16619
-    components:
-    - type: Transform
-      pos: 29.5,-56.5
-      parent: 8364
-  - uid: 16620
-    components:
-    - type: Transform
-      pos: 29.5,-55.5
-      parent: 8364
-  - uid: 16621
-    components:
-    - type: Transform
-      pos: 29.5,-54.5
-      parent: 8364
-  - uid: 16622
-    components:
-    - type: Transform
-      pos: 29.5,-53.5
-      parent: 8364
-  - uid: 16623
-    components:
-    - type: Transform
-      pos: 29.5,-52.5
-      parent: 8364
-  - uid: 16624
-    components:
-    - type: Transform
-      pos: 29.5,-51.5
-      parent: 8364
-  - uid: 16625
-    components:
-    - type: Transform
-      pos: 29.5,-50.5
-      parent: 8364
-  - uid: 16626
-    components:
-    - type: Transform
-      pos: 29.5,-49.5
-      parent: 8364
-  - uid: 16627
-    components:
-    - type: Transform
-      pos: 29.5,-48.5
-      parent: 8364
-  - uid: 16628
-    components:
-    - type: Transform
-      pos: 29.5,-47.5
-      parent: 8364
-  - uid: 16629
-    components:
-    - type: Transform
-      pos: 29.5,-46.5
-      parent: 8364
-  - uid: 16630
-    components:
-    - type: Transform
-      pos: 28.5,-49.5
-      parent: 8364
-  - uid: 16631
-    components:
-    - type: Transform
-      pos: 27.5,-49.5
-      parent: 8364
-  - uid: 16632
-    components:
-    - type: Transform
-      pos: 26.5,-49.5
-      parent: 8364
-  - uid: 16633
-    components:
-    - type: Transform
-      pos: 28.5,-53.5
-      parent: 8364
-  - uid: 16634
-    components:
-    - type: Transform
-      pos: 27.5,-53.5
-      parent: 8364
-  - uid: 16635
-    components:
-    - type: Transform
-      pos: 26.5,-53.5
       parent: 8364
   - uid: 16636
     components:
@@ -32188,140 +32013,10 @@ entities:
     - type: Transform
       pos: 22.5,-63.5
       parent: 8364
-  - uid: 16777
-    components:
-    - type: Transform
-      pos: 23.5,-63.5
-      parent: 8364
-  - uid: 16778
-    components:
-    - type: Transform
-      pos: 23.5,-64.5
-      parent: 8364
-  - uid: 16779
-    components:
-    - type: Transform
-      pos: 23.5,-65.5
-      parent: 8364
-  - uid: 16780
-    components:
-    - type: Transform
-      pos: 23.5,-66.5
-      parent: 8364
-  - uid: 16781
-    components:
-    - type: Transform
-      pos: 23.5,-67.5
-      parent: 8364
-  - uid: 16783
-    components:
-    - type: Transform
-      pos: 21.5,-67.5
-      parent: 8364
-  - uid: 16784
-    components:
-    - type: Transform
-      pos: 20.5,-67.5
-      parent: 8364
-  - uid: 16785
-    components:
-    - type: Transform
-      pos: 19.5,-67.5
-      parent: 8364
-  - uid: 16786
-    components:
-    - type: Transform
-      pos: 18.5,-67.5
-      parent: 8364
-  - uid: 16787
-    components:
-    - type: Transform
-      pos: 17.5,-67.5
-      parent: 8364
-  - uid: 16788
-    components:
-    - type: Transform
-      pos: 16.5,-67.5
-      parent: 8364
-  - uid: 16789
-    components:
-    - type: Transform
-      pos: 15.5,-67.5
-      parent: 8364
-  - uid: 16790
-    components:
-    - type: Transform
-      pos: 14.5,-67.5
-      parent: 8364
-  - uid: 16791
-    components:
-    - type: Transform
-      pos: 13.5,-67.5
-      parent: 8364
-  - uid: 16792
-    components:
-    - type: Transform
-      pos: 12.5,-67.5
-      parent: 8364
-  - uid: 16793
-    components:
-    - type: Transform
-      pos: 11.5,-67.5
-      parent: 8364
-  - uid: 16794
-    components:
-    - type: Transform
-      pos: 11.5,-66.5
-      parent: 8364
-  - uid: 16795
-    components:
-    - type: Transform
-      pos: 11.5,-65.5
-      parent: 8364
-  - uid: 16796
-    components:
-    - type: Transform
-      pos: 11.5,-64.5
-      parent: 8364
-  - uid: 16797
-    components:
-    - type: Transform
-      pos: 11.5,-63.5
-      parent: 8364
   - uid: 16798
     components:
     - type: Transform
       pos: 12.5,-63.5
-      parent: 8364
-  - uid: 16799
-    components:
-    - type: Transform
-      pos: 15.5,-64.5
-      parent: 8364
-  - uid: 16800
-    components:
-    - type: Transform
-      pos: 15.5,-65.5
-      parent: 8364
-  - uid: 16801
-    components:
-    - type: Transform
-      pos: 15.5,-66.5
-      parent: 8364
-  - uid: 16802
-    components:
-    - type: Transform
-      pos: 19.5,-64.5
-      parent: 8364
-  - uid: 16803
-    components:
-    - type: Transform
-      pos: 19.5,-65.5
-      parent: 8364
-  - uid: 16804
-    components:
-    - type: Transform
-      pos: 19.5,-66.5
       parent: 8364
   - uid: 16805
     components:
@@ -112272,11 +111967,6 @@ entities:
     - type: Transform
       pos: -6.5,2.5
       parent: 8364
-  - uid: 120
-    components:
-    - type: Transform
-      pos: 28.5,-45.5
-      parent: 8364
   - uid: 211
     components:
     - type: Transform
@@ -113040,11 +112730,6 @@ entities:
     components:
     - type: Transform
       pos: -54.5,-19.5
-      parent: 8364
-  - uid: 1301
-    components:
-    - type: Transform
-      pos: 28.5,-53.5
       parent: 8364
   - uid: 1344
     components:
@@ -114645,16 +114330,6 @@ entities:
     - type: Transform
       pos: -12.5,-77.5
       parent: 8364
-  - uid: 3702
-    components:
-    - type: Transform
-      pos: 29.5,-49.5
-      parent: 8364
-  - uid: 3703
-    components:
-    - type: Transform
-      pos: 29.5,-50.5
-      parent: 8364
   - uid: 3715
     components:
     - type: Transform
@@ -114674,36 +114349,6 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-72.5
-      parent: 8364
-  - uid: 3808
-    components:
-    - type: Transform
-      pos: 25.5,-53.5
-      parent: 8364
-  - uid: 3809
-    components:
-    - type: Transform
-      pos: 26.5,-53.5
-      parent: 8364
-  - uid: 3810
-    components:
-    - type: Transform
-      pos: 27.5,-53.5
-      parent: 8364
-  - uid: 3811
-    components:
-    - type: Transform
-      pos: 27.5,-49.5
-      parent: 8364
-  - uid: 3812
-    components:
-    - type: Transform
-      pos: 29.5,-46.5
-      parent: 8364
-  - uid: 3813
-    components:
-    - type: Transform
-      pos: 29.5,-48.5
       parent: 8364
   - uid: 3832
     components:
@@ -117966,51 +117611,6 @@ entities:
     - type: Transform
       pos: -2.5,-65.5
       parent: 8364
-  - uid: 15105
-    components:
-    - type: Transform
-      pos: 19.5,-63.5
-      parent: 8364
-  - uid: 15106
-    components:
-    - type: Transform
-      pos: 29.5,-57.5
-      parent: 8364
-  - uid: 15126
-    components:
-    - type: Transform
-      pos: 16.5,-67.5
-      parent: 8364
-  - uid: 15127
-    components:
-    - type: Transform
-      pos: 17.5,-67.5
-      parent: 8364
-  - uid: 15128
-    components:
-    - type: Transform
-      pos: 15.5,-64.5
-      parent: 8364
-  - uid: 15129
-    components:
-    - type: Transform
-      pos: 15.5,-65.5
-      parent: 8364
-  - uid: 15136
-    components:
-    - type: Transform
-      pos: 25.5,-57.5
-      parent: 8364
-  - uid: 15137
-    components:
-    - type: Transform
-      pos: 15.5,-63.5
-      parent: 8364
-  - uid: 15139
-    components:
-    - type: Transform
-      pos: 15.5,-66.5
-      parent: 8364
   - uid: 15343
     components:
     - type: Transform
@@ -118025,141 +117625,6 @@ entities:
     components:
     - type: Transform
       pos: -29.5,-26.5
-      parent: 8364
-  - uid: 15903
-    components:
-    - type: Transform
-      pos: 29.5,-56.5
-      parent: 8364
-  - uid: 15984
-    components:
-    - type: Transform
-      pos: 29.5,-55.5
-      parent: 8364
-  - uid: 16057
-    components:
-    - type: Transform
-      pos: 29.5,-54.5
-      parent: 8364
-  - uid: 16082
-    components:
-    - type: Transform
-      pos: 29.5,-53.5
-      parent: 8364
-  - uid: 16128
-    components:
-    - type: Transform
-      pos: 29.5,-51.5
-      parent: 8364
-  - uid: 16131
-    components:
-    - type: Transform
-      pos: 11.5,-67.5
-      parent: 8364
-  - uid: 16134
-    components:
-    - type: Transform
-      pos: 12.5,-67.5
-      parent: 8364
-  - uid: 16140
-    components:
-    - type: Transform
-      pos: 13.5,-67.5
-      parent: 8364
-  - uid: 16142
-    components:
-    - type: Transform
-      pos: 14.5,-67.5
-      parent: 8364
-  - uid: 16143
-    components:
-    - type: Transform
-      pos: 15.5,-67.5
-      parent: 8364
-  - uid: 16144
-    components:
-    - type: Transform
-      pos: 19.5,-66.5
-      parent: 8364
-  - uid: 16148
-    components:
-    - type: Transform
-      pos: 23.5,-63.5
-      parent: 8364
-  - uid: 16149
-    components:
-    - type: Transform
-      pos: 19.5,-64.5
-      parent: 8364
-  - uid: 16150
-    components:
-    - type: Transform
-      pos: 19.5,-65.5
-      parent: 8364
-  - uid: 16151
-    components:
-    - type: Transform
-      pos: 22.5,-67.5
-      parent: 8364
-  - uid: 16152
-    components:
-    - type: Transform
-      pos: 23.5,-67.5
-      parent: 8364
-  - uid: 16155
-    components:
-    - type: Transform
-      pos: 23.5,-66.5
-      parent: 8364
-  - uid: 16156
-    components:
-    - type: Transform
-      pos: 23.5,-65.5
-      parent: 8364
-  - uid: 16157
-    components:
-    - type: Transform
-      pos: 23.5,-64.5
-      parent: 8364
-  - uid: 16159
-    components:
-    - type: Transform
-      pos: 20.5,-67.5
-      parent: 8364
-  - uid: 16160
-    components:
-    - type: Transform
-      pos: 27.5,-57.5
-      parent: 8364
-  - uid: 16161
-    components:
-    - type: Transform
-      pos: 28.5,-57.5
-      parent: 8364
-  - uid: 16168
-    components:
-    - type: Transform
-      pos: 29.5,-52.5
-      parent: 8364
-  - uid: 16169
-    components:
-    - type: Transform
-      pos: 18.5,-67.5
-      parent: 8364
-  - uid: 16170
-    components:
-    - type: Transform
-      pos: 19.5,-67.5
-      parent: 8364
-  - uid: 16208
-    components:
-    - type: Transform
-      pos: 21.5,-67.5
-      parent: 8364
-  - uid: 16209
-    components:
-    - type: Transform
-      pos: 26.5,-57.5
       parent: 8364
   - uid: 16526
     components:
@@ -118210,11 +117675,6 @@ entities:
     components:
     - type: Transform
       pos: 20.5,-63.5
-      parent: 8364
-  - uid: 16877
-    components:
-    - type: Transform
-      pos: 29.5,-45.5
       parent: 8364
   - uid: 16884
     components:
@@ -118271,40 +117731,10 @@ entities:
     - type: Transform
       pos: 4.5,-78.5
       parent: 8364
-  - uid: 16940
-    components:
-    - type: Transform
-      pos: 11.5,-64.5
-      parent: 8364
-  - uid: 16941
-    components:
-    - type: Transform
-      pos: 11.5,-63.5
-      parent: 8364
-  - uid: 16958
-    components:
-    - type: Transform
-      pos: 11.5,-65.5
-      parent: 8364
-  - uid: 16959
-    components:
-    - type: Transform
-      pos: 11.5,-66.5
-      parent: 8364
   - uid: 16972
     components:
     - type: Transform
       pos: 3.5,-78.5
-      parent: 8364
-  - uid: 16973
-    components:
-    - type: Transform
-      pos: 26.5,-49.5
-      parent: 8364
-  - uid: 16974
-    components:
-    - type: Transform
-      pos: 25.5,-49.5
       parent: 8364
   - uid: 16986
     components:
@@ -118355,11 +117785,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-100.5
-      parent: 8364
-  - uid: 17153
-    components:
-    - type: Transform
-      pos: 29.5,-44.5
       parent: 8364
   - uid: 17154
     components:
@@ -118496,25 +117921,10 @@ entities:
     - type: Transform
       pos: -18.5,-29.5
       parent: 8364
-  - uid: 17670
-    components:
-    - type: Transform
-      pos: 26.5,-41.5
-      parent: 8364
-  - uid: 17688
-    components:
-    - type: Transform
-      pos: 29.5,-47.5
-      parent: 8364
   - uid: 17709
     components:
     - type: Transform
       pos: 13.5,-51.5
-      parent: 8364
-  - uid: 17710
-    components:
-    - type: Transform
-      pos: 25.5,-41.5
       parent: 8364
   - uid: 17721
     components:
@@ -118525,11 +117935,6 @@ entities:
     components:
     - type: Transform
       pos: -34.5,-26.5
-      parent: 8364
-  - uid: 17764
-    components:
-    - type: Transform
-      pos: 29.5,-41.5
       parent: 8364
   - uid: 17785
     components:
@@ -118897,11 +118302,6 @@ entities:
     - type: Transform
       pos: 13.5,-50.5
       parent: 8364
-  - uid: 20152
-    components:
-    - type: Transform
-      pos: 25.5,-45.5
-      parent: 8364
   - uid: 20195
     components:
     - type: Transform
@@ -118927,11 +118327,6 @@ entities:
     - type: Transform
       pos: 23.5,-34.5
       parent: 8364
-  - uid: 21110
-    components:
-    - type: Transform
-      pos: 29.5,-42.5
-      parent: 8364
   - uid: 21130
     components:
     - type: Transform
@@ -118941,16 +118336,6 @@ entities:
     components:
     - type: Transform
       pos: 76.5,-48.5
-      parent: 8364
-  - uid: 21231
-    components:
-    - type: Transform
-      pos: 28.5,-41.5
-      parent: 8364
-  - uid: 21239
-    components:
-    - type: Transform
-      pos: 26.5,-45.5
       parent: 8364
   - uid: 21337
     components:
@@ -119232,16 +118617,6 @@ entities:
     - type: Transform
       pos: 14.5,-53.5
       parent: 8364
-  - uid: 23204
-    components:
-    - type: Transform
-      pos: 27.5,-45.5
-      parent: 8364
-  - uid: 23211
-    components:
-    - type: Transform
-      pos: 28.5,-49.5
-      parent: 8364
   - uid: 23212
     components:
     - type: Transform
@@ -119346,11 +118721,6 @@ entities:
     components:
     - type: Transform
       pos: 12.5,-28.5
-      parent: 8364
-  - uid: 26088
-    components:
-    - type: Transform
-      pos: 29.5,-43.5
       parent: 8364
   - uid: 26472
     components:
@@ -132681,6 +132051,11 @@ entities:
       parent: 8364
 - proto: ReinforcedPlasmaWindow
   entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 25.5,-50.5
+      parent: 8364
   - uid: 3494
     components:
     - type: Transform
@@ -132800,11 +132175,6 @@ entities:
     components:
     - type: Transform
       pos: 25.5,-51.5
-      parent: 8364
-  - uid: 22889
-    components:
-    - type: Transform
-      pos: 25.5,-50.5
       parent: 8364
   - uid: 22890
     components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Removes the grilles and Lv cables from the walls of the gas miners in Box's Atmos. Keeps the Lv cables under the windows and the 1 wall connecting them all.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It looks weird having grilles and walls be on the same tile. Most maps don't do this, only Fland is the other map that does. It can make it hard to see if a wall has been removed from underneath the grille also. 

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
