### PR TITLE
command is no longer allowed to have security HUDs

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLRestrictedGear.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLRestrictedGear.xml
@@ -11,7 +11,7 @@
   - \[Security\] Helmets and shields
   - \[Security/Command/Bartender\] Protective vests and chest rigs
   - \[Security/Command\] Restraining gear
-  - \[Security/Command\] Security HUDs
+  - \[Security\] Security HUDs
   - \[Engineering\] Engineering goggles
   - \[None\] Improvised less lethal and non-lethal weaponry
   - \[None\] Unauthorized PDA software


### PR DESCRIPTION
## About the PR
Space Law no longer allows security HUDs for command.

## Why / Balance
1. This encourages validhunting, especially due to sechud having wanted status. None of command (except HoS) needs that information to do their job. 
2. Roundstart security glasses for captain were not accepted, however, right now captain can just grab them from security, which makes zero sense.
3. Command having sechuds is also an indirect nerf to antagonists that conceal their identity.

## Technical details

## Media
no
## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl:
- tweak: Command no longer has security HUDs as permitted gear in Space Law.
