### PR TITLE
fix(ChargerSystem): Don't show battery level twice.

### DIFF
--- a/Content.Server/Power/EntitySystems/ChargerSystem.cs
+++ b/Content.Server/Power/EntitySystems/ChargerSystem.cs
@@ -52,9 +52,12 @@ internal sealed class ChargerSystem : EntitySystem
             if (!_container.TryGetContainer(uid, component.SlotId, out var container))
                 return;
 
+            if (HasComp<PowerCellSlotComponent>(uid))
+                return;
+
             // if charger is empty and not a power cell type charger, add empty message
             // power cells have their own empty message by default, for things like flash lights
-            if (container.ContainedEntities.Count == 0 && !HasComp<PowerCellSlotComponent>(uid))
+            if (container.ContainedEntities.Count == 0)
             {
                 args.PushMarkup(Loc.GetString("charger-empty"));
             }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Stopped showing battery level twice in some devies.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Resolves #30604

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
**BEFORE**
![Screenshot from 2024-08-03 21-30-33](https://github.com/user-attachments/assets/ea03a575-7cbe-41ce-9fc1-b2329a5d93eb)
![Screenshot from 2024-08-03 21-30-39](https://github.com/user-attachments/assets/89e0a374-5114-402e-9774-63204d84a4ac)
![Screenshot from 2024-08-03 21-30-44](https://github.com/user-attachments/assets/5d3367a6-6d67-47ef-9e40-4a80bfef904e)
![Screenshot from 2024-08-03 21-30-49](https://github.com/user-attachments/assets/be3a45d7-2234-42ac-9e13-6f05a5b35dc9)
![Screenshot from 2024-08-03 21-30-54](https://github.com/user-attachments/assets/79fd39bc-eaaa-4857-831a-54b7c0451648)
![Screenshot from 2024-08-03 21-48-55](https://github.com/user-attachments/assets/bc939f66-d4cb-4970-9f48-5a4ac04c7467)

# After 
![Screenshot from 2024-08-03 21-36-02](https://github.com/user-attachments/assets/b35dc854-9f4f-44c3-830d-e45d92515d16)
![Screenshot from 2024-08-03 21-36-10](https://github.com/user-attachments/assets/94db78cc-aa4e-4e47-a480-bb94ade38cc7)
![Screenshot from 2024-08-03 21-30-33](https://github.com/user-attachments/assets/140f85b5-60b2-4b60-b3fc-d490adb12bfd)
![Screenshot from 2024-08-03 21-41-36](https://github.com/user-attachments/assets/3cfeee76-15bc-4760-958d-734628c3a63a)
![Screenshot from 2024-08-03 21-41-42](https://github.com/user-attachments/assets/e9c0c86d-f867-4a6c-ad1a-537372b5b9e7)
![Screenshot from 2024-08-03 21-41-47](https://github.com/user-attachments/assets/6a1839e3-c839-49a1-b5bb-11eb2001b493)
![Screenshot from 2024-08-03 21-46-17](https://github.com/user-attachments/assets/1fe6bf07-905e-443f-a0cc-8c2422866f39)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
