### PR TITLE
Bent pipes deal 8 thrown damage

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -155,7 +155,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Blunt: 3 #This should be 6 but throwing damage is doubled at the moment for some reason so for now it's 3
+        Blunt: 8 # Woe, pipe be upon ye!
 
 - type: entity
   parent: GasPipeBase


### PR DESCRIPTION
## About the PR
Bent pipes now deal 8 thrown damage, they previously did 3.

## Why / Balance
I had it set to 3 when I originally gave pipes damage because thrown damage was doubled, but now that the bug is fixed the damage should be increased. I felt 6 was a bit low though considering flatcaps exist so I wanted to buff it a bit as well.

## Media
![image](https://github.com/user-attachments/assets/3f56236a-8876-4c04-b6ea-0a210eda6559)

## Requirements

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Bent pipes now deal 8 thrown damage instead of 3.
