### PR TITLE
Change the mimebot and killer tomato's descriptions

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -76,7 +76,7 @@
   - MobFlammable
   - MobCombat
   name: tomato killer
-  description: it seems today it's not you eating tomatoes, it's the tomatoes eating you.
+  description: Looks like it's not you eating tomatoes today, it's the tomatoes eating you.
   components:
   - type: Item
   - type: NpcFactionMember

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -303,7 +303,7 @@
   - StripableInventoryBase
   id: MobMimeBot
   name: mimebot
-  description: Why not give mimebot a friendly wave.
+  description: Why not give the mimebot a friendly wave?
   components:
   - type: Sprite
     layers:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The mimebot's current description, "Why not give mimebot a friendly wave.", is making me mad.
This also applies to the killer tomato's description, which is entirely lowercase and doesn't really read well.
So, I changed them.

## Why / Balance
bad english makes me mad

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
uh, does it need one?
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
