### PR TITLE
Meta Robotics Console

### DIFF
--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -10635,7 +10635,7 @@ entities:
       pos: -42.5,29.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -99.68158
+      secondsUntilStateChange: -206.70142
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 2
@@ -62287,6 +62287,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-38.5
+      parent: 5350
+- proto: ComputerRoboticsControl
+  entities:
+  - uid: 24793
+    components:
+    - type: Transform
+      pos: 21.5,-34.5
       parent: 5350
 - proto: ComputerSalvageExpedition
   entities:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds the Robotics Console to RD's office on Meta. There seems to be some debate about if it should go in RD's Office or Robotics instelf. I just thought I would add it to RD's office for now as people can always move it to robotics if they prefer.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
#27832 Seems like just Meta and Europa need them but tbf I haven't checked every map to make sure.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
![Robotics console meta](https://github.com/user-attachments/assets/4e8b9478-f0dc-4fdc-9a5b-90bf6a86e820)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
