### PR TITLE
Explosion resistance is now predicted!

### DIFF
--- a/Content.Client/Explosion/ExplosionSystem.cs
+++ b/Content.Client/Explosion/ExplosionSystem.cs
@@ -1,0 +1,8 @@
+using Content.Shared.Explosion.EntitySystems;
+
+namespace Content.Client.Explosion.EntitySystems;
+
+public sealed class ExplosionSystem : SharedExplosionSystem
+{
+
+}

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Airtight.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Airtight.cs
@@ -3,12 +3,12 @@ using Content.Server.Destructible;
 using Content.Shared.Atmos;
 using Content.Shared.Damage;
 using Content.Shared.Explosion;
+using Content.Shared.Explosion.EntitySystems;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Map.Components;
-
 namespace Content.Server.Explosion.EntitySystems;
 
-public sealed partial class ExplosionSystem : EntitySystem
+public sealed partial class ExplosionSystem : SharedExplosionSystem
 {
     [Dependency] private readonly DestructibleSystem _destructibleSystem = default!;
 

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.CVars.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.CVars.cs
@@ -1,8 +1,8 @@
 using Content.Shared.CCVar;
-
+using Content.Shared.Explosion.EntitySystems;
 namespace Content.Server.Explosion.EntitySystems;
 
-public sealed partial class ExplosionSystem : EntitySystem
+public sealed partial class ExplosionSystem : SharedExplosionSystem
 {
     public int MaxIterations { get; private set; }
     public int MaxArea { get; private set; }

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Shared.Atmos;
 using Content.Shared.Explosion;
 using Content.Shared.Explosion.Components;
+using Content.Shared.Explosion.EntitySystems;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
@@ -11,7 +12,7 @@ namespace Content.Server.Explosion.EntitySystems;
 // A good portion of it is focused around keeping track of what tile-indices on a grid correspond to tiles that border
 // space. AFAIK no other system currently needs to track these "edge-tiles". If they do, this should probably be a
 // property of the grid itself?
-public sealed partial class ExplosionSystem : EntitySystem
+public sealed partial class ExplosionSystem : SharedExplosionSystem
 {
     /// <summary>
     ///     Set of tiles of each grid that are directly adjacent to space, along with the directions that face space.

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -4,6 +4,7 @@ using Content.Shared.CCVar;
 using Content.Shared.Damage;
 using Content.Shared.Explosion;
 using Content.Shared.Explosion.Components;
+using Content.Shared.Explosion.EntitySystems;
 using Content.Shared.Maps;
 using Content.Shared.Physics;
 using Content.Shared.Projectiles;
@@ -17,10 +18,9 @@ using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using TimedDespawnComponent = Robust.Shared.Spawners.TimedDespawnComponent;
-
 namespace Content.Server.Explosion.EntitySystems;
 
-public sealed partial class ExplosionSystem
+public sealed partial class ExplosionSystem : SharedExplosionSystem
 {
     [Dependency] private readonly FlammableSystem _flammableSystem = default!;
 

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.TileFill.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.TileFill.cs
@@ -7,13 +7,13 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
-
+using Content.Shared.Explosion.EntitySystems;
 namespace Content.Server.Explosion.EntitySystems;
 
 // This partial part of the explosion system has all of the functions used to create the actual explosion map.
 // I.e, to get the sets of tiles & intensity values that describe an explosion.
 
-public sealed partial class ExplosionSystem : EntitySystem
+public sealed partial class ExplosionSystem : SharedExplosionSystem
 {
     /// <summary>
     ///     This is the main explosion generating function.

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Visuals.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Visuals.cs
@@ -1,14 +1,14 @@
 using System.Numerics;
 using Content.Shared.Explosion;
 using Content.Shared.Explosion.Components;
+using Content.Shared.Explosion.EntitySystems;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
-
 namespace Content.Server.Explosion.EntitySystems;
 
 // This part of the system handled send visual / overlay data to clients.
-public sealed partial class ExplosionSystem : EntitySystem
+public sealed partial class ExplosionSystem : SharedExplosionSystem
 {
     public void InitVisuals()
     {

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -16,6 +16,8 @@ using Content.Shared.GameTicking;
 using Content.Shared.Inventory;
 using Content.Shared.Projectiles;
 using Content.Shared.Throwing;
+using Content.Shared.Explosion.Components;
+using Content.Shared.Explosion.EntitySystems;
 using Robust.Server.GameStates;
 using Robust.Server.Player;
 using Robust.Shared.Audio.Systems;
@@ -29,7 +31,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Server.Explosion.EntitySystems;
 
-public sealed partial class ExplosionSystem : EntitySystem
+public sealed partial class ExplosionSystem : SharedExplosionSystem
 {
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
@@ -91,8 +93,6 @@ public sealed partial class ExplosionSystem : EntitySystem
         SubscribeLocalEvent<TileChangedEvent>(OnTileChanged);
 
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnReset);
-
-        SubscribeLocalEvent<ExplosionResistanceComponent, ArmorExamineEvent>(OnArmorExamine);
 
         // Handled by ExplosionSystem.Processing.cs
         SubscribeLocalEvent<MapChangedEvent>(OnMapChanged);
@@ -417,16 +417,5 @@ public sealed partial class ExplosionSystem : EntitySystem
             if (effect > 0.01f)
                 _recoilSystem.KickCamera(uid, -delta.Normalized() * effect);
         }
-    }
-
-    private void OnArmorExamine(EntityUid uid, ExplosionResistanceComponent component, ref ArmorExamineEvent args)
-    {
-        var value = MathF.Round((1f - component.DamageCoefficient) * 100, 1);
-
-        if (value == 0)
-            return;
-
-        args.Msg.PushNewline();
-        args.Msg.AddMarkupOrThrow(Loc.GetString(component.Examine, ("value", value)));
     }
 }

--- a/Content.Shared/Explosion/Components/ExplosionResistanceComponent.cs
+++ b/Content.Shared/Explosion/Components/ExplosionResistanceComponent.cs
@@ -1,5 +1,6 @@
-using Content.Shared.Explosion;
+using Content.Shared.Explosion.EntitySystems;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Explosion.Components;
 
@@ -12,7 +13,8 @@ namespace Content.Shared.Explosion.Components;
 ///     This is desirable over just using damage modifier sets, given that equipment like bomb-suits need to
 ///     significantly reduce the damage, but shouldn't be silly overpowered in regular combat.
 /// </remarks>
-[RegisterComponent]
+[NetworkedComponent, RegisterComponent]
+[Access(typeof(SharedExplosionSystem))]
 public sealed partial class ExplosionResistanceComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Explosion/Components/ExplosionResistanceComponent.cs
+++ b/Content.Shared/Explosion/Components/ExplosionResistanceComponent.cs
@@ -1,8 +1,7 @@
-using Content.Server.Explosion.EntitySystems;
 using Content.Shared.Explosion;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 
-namespace Content.Server.Explosion.Components;
+namespace Content.Shared.Explosion.Components;
 
 /// <summary>
 /// Component that provides entities with explosion resistance.
@@ -14,7 +13,6 @@ namespace Content.Server.Explosion.Components;
 ///     significantly reduce the damage, but shouldn't be silly overpowered in regular combat.
 /// </remarks>
 [RegisterComponent]
-[Access(typeof(ExplosionSystem))]
 public sealed partial class ExplosionResistanceComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Explosion/EntitySystems/SharedExplosionSystem.cs
+++ b/Content.Shared/Explosion/EntitySystems/SharedExplosionSystem.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Explosion.Components;
+using Content.Shared.Armor;
+
+namespace Content.Shared.Explosion.EntitySystems;
+
+public abstract class SharedExplosionSystem : EntitySystem
+{
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ExplosionResistanceComponent, ArmorExamineEvent>(OnArmorExamine);
+    }
+
+    private void OnArmorExamine(EntityUid uid, ExplosionResistanceComponent component, ref ArmorExamineEvent args)
+    {
+        var value = MathF.Round((1f - component.DamageCoefficient) * 100, 1);
+
+        if (value == 0)
+            return;
+
+        args.Msg.PushNewline();
+        args.Msg.AddMarkupOrThrow(Loc.GetString(component.Examine, ("value", value)));
+    }
+}


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
It bugged me so I had to fix it.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Just moved the `ExplosionResistanceComponent` and added the SharedExplosionSystem so the inspection would be predicted. Also had to add the client system so it actually predicted and make all the server stuff extend the shared system.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
Before:

https://github.com/user-attachments/assets/66ee35c0-e001-4334-92ac-2f177bbf4d10

After:

https://github.com/user-attachments/assets/bfc77716-7c55-48c4-bc9e-1793e891c021

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase