### PR TITLE
Add the softspoken and loudmouth accents

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -249,7 +249,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         switch (desiredType)
         {
             case InGameICChatType.Speak:
-                SendEntitySpeak(source, message, range, nameOverride, hideLog, ignoreActionBlocker);
+                SendEntitySpeak(source, message, range, null, nameOverride, hideLog, ignoreActionBlocker);
                 break;
             case InGameICChatType.Whisper:
                 SendEntityWhisper(source, message, range, null, nameOverride, hideLog, ignoreActionBlocker);
@@ -384,6 +384,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         EntityUid source,
         string originalMessage,
         ChatTransmitRange range,
+        RadioChannelPrototype? channel,
         string? nameOverride,
         bool hideLog = false,
         bool ignoreActionBlocker = false
@@ -391,6 +392,13 @@ public sealed partial class ChatSystem : SharedChatSystem
     {
         if (!_actionBlocker.CanSpeak(source) && !ignoreActionBlocker)
             return;
+
+        // if the user is forced to whisper, they will whisper
+        if (TransformSpeechType(source, InGameICChatType.Speak) != InGameICChatType.Speak)
+        {
+            SendEntityWhisper(source, originalMessage, ChatTransmitRange.Normal, channel, nameOverride, hideLog, ignoreActionBlocker);
+            return;
+        }
 
         var message = TransformSpeech(source, originalMessage);
 
@@ -426,7 +434,7 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         SendInVoiceRange(ChatChannel.Local, message, wrappedMessage, source, range);
 
-        var ev = new EntitySpokeEvent(source, message, null, null);
+        var ev = new EntitySpokeEvent(source, message, channel, null);
         RaiseLocalEvent(source, ev, true);
 
         // To avoid logging any messages sent by entities that are not players, like vendors, cloning, etc.
@@ -464,6 +472,13 @@ public sealed partial class ChatSystem : SharedChatSystem
     {
         if (!_actionBlocker.CanSpeak(source) && !ignoreActionBlocker)
             return;
+
+        // if the user is forced to speak, make them speak!
+        if (TransformSpeechType(source, InGameICChatType.Whisper) != InGameICChatType.Whisper)
+        {
+            SendEntitySpeak(source, originalMessage, ChatTransmitRange.Normal, channel, nameOverride, hideLog, ignoreActionBlocker);
+            return;
+        }
 
         var message = TransformSpeech(source, FormattedMessage.RemoveMarkup(originalMessage));
         if (message.Length == 0)
@@ -749,6 +764,14 @@ public sealed partial class ChatSystem : SharedChatSystem
         return ev.Message;
     }
 
+    private InGameICChatType TransformSpeechType(EntityUid sender, InGameICChatType chatType)
+    {
+        var ev = new TransformSpeechTypeEvent(sender, chatType);
+        RaiseLocalEvent(sender, ev);
+
+        return ev.ChatType;
+    }
+
     public bool CheckIgnoreSpeechBlocker(EntityUid sender, bool ignoreBlocker)
     {
         if (ignoreBlocker)
@@ -895,7 +918,7 @@ public sealed class TransformSpeakerNameEvent : EntityEventArgs
 }
 
 /// <summary>
-///     Raised broadcast in order to transform speech.transmit
+///     Raised broadcast in order to transform speech.
 /// </summary>
 public sealed class TransformSpeechEvent : EntityEventArgs
 {
@@ -907,6 +930,15 @@ public sealed class TransformSpeechEvent : EntityEventArgs
         Sender = sender;
         Message = message;
     }
+}
+
+/// <summary>
+/// Raised to transform speech, ideally betweeen whisper and local
+/// </summary>
+public sealed class TransformSpeechTypeEvent(EntityUid sender, InGameICChatType chatType) : EntityEventArgs
+{
+    public EntityUid Sender = sender;
+    public InGameICChatType ChatType = chatType;
 }
 
 public sealed class CheckIgnoreSpeechBlockerEvent : EntityEventArgs

--- a/Content.Server/Speech/Components/LoudmouthAccentComponent.cs
+++ b/Content.Server/Speech/Components/LoudmouthAccentComponent.cs
@@ -1,0 +1,11 @@
+﻿namespace Content.Server.Speech.Components;
+
+/// <summary>
+/// FORCES THE USER TO SHOUT AND BECOME INCAPABLE OF WHISPERING!
+/// EVEN WHEN THEY'RE USING THEIR RADIO!
+/// </summary>
+[RegisterComponent]
+public sealed partial class LoudmouthAccentComponent : Component
+{
+
+}

--- a/Content.Server/Speech/Components/SoftspokenAccentComponent.cs
+++ b/Content.Server/Speech/Components/SoftspokenAccentComponent.cs
@@ -1,0 +1,11 @@
+﻿namespace Content.Server.Speech.Components;
+
+/// <summary>
+/// forces the user to whisper...
+/// and speak with ellipses...
+/// </summary>
+[RegisterComponent]
+public sealed partial class SoftspokenAccentComponent : Component
+{
+
+}

--- a/Content.Server/Speech/EntitySystems/LoudmouthAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/LoudmouthAccentSystem.cs
@@ -1,0 +1,35 @@
+﻿using Content.Server.Chat.Systems;
+using Content.Server.Speech.Components;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class LoudmouthAccentSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<LoudmouthAccentComponent, AccentGetEvent>(OnAccent);
+        SubscribeLocalEvent<LoudmouthAccentComponent, TransformSpeechTypeEvent>(OnTransformSpeech);
+    }
+
+    /// <summary>
+    /// MAKE THE USER SPEAK IN ALL UPPERCASE, THEY ARE REALLY LOUD!
+    /// </summary>
+    private void OnAccent(Entity<LoudmouthAccentComponent> entity, ref AccentGetEvent args)
+    {
+        var message = args.Message;
+
+        if (char.IsLetter(message[^1]))
+            message += "!";
+
+        args.Message = message.ToUpper();
+    }
+
+    /// <summary>
+    /// FORCE THE USER TO SPEAK IF THEY HAVE THIS COMPONENT!
+    /// </summary>
+    private void OnTransformSpeech(Entity<LoudmouthAccentComponent> entity, ref TransformSpeechTypeEvent args)
+    {
+        args.ChatType = InGameICChatType.Speak;
+    }
+}

--- a/Content.Server/Speech/EntitySystems/SoftspokenAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/SoftspokenAccentSystem.cs
@@ -1,0 +1,37 @@
+﻿using Content.Server.Chat.Systems;
+using Content.Server.Speech.Components;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class SoftspokenAccentSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SoftspokenAccentComponent, AccentGetEvent>(OnAccent);
+        SubscribeLocalEvent<SoftspokenAccentComponent, TransformSpeechTypeEvent>(OnTransformSpeech);
+    }
+
+    /// <summary>
+    /// Make the user end their sentences with an ellipses...
+    /// to accentuate how quiet they are...
+    /// kind of like they're mumbling...
+    /// </summary>
+    private void OnAccent(Entity<SoftspokenAccentComponent> entity, ref AccentGetEvent args)
+    {
+        var message = args.Message;
+
+        if (char.IsLetter(message[^1]))
+            message += "...";
+
+        args.Message = message;
+    }
+
+    /// <summary>
+    /// force the user to whisper if they have this component
+    /// </summary>
+    private void OnTransformSpeech(Entity<SoftspokenAccentComponent> entity, ref TransformSpeechTypeEvent args)
+    {
+        args.ChatType = InGameICChatType.Whisper;
+    }
+}

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -50,3 +50,9 @@ trait-cowboy-desc = You speak with a distinct cowboy accent!
 
 trait-italian-name = Italian accent
 trait-italian-desc = Mamma mia! You seem to have lived in space italy!
+
+trait-softspoken-name = Softspoken
+trait-softspoken-desc = You can only communicate by whispering...
+
+trait-loudmouth-name = Loudmouth
+trait-loudmouth-desc = YOU YELL EVERYTHING YOU SAY!

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -64,6 +64,24 @@
     - type: ReplacementAccent
       accent: liar
 
+- type: trait
+  id: SoftspokenAccent
+  name: trait-softspoken-name
+  description: trait-softspoken-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+    - type: SoftspokenAccent
+
+- type: trait
+  id: LoudmouthAccent
+  name: trait-loudmouth-name
+  description: trait-loudmouth-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: LoudmouthAccent
+
 # 2 Cost
 
 - type: trait


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Softspoken forces you to whisper and ends your sentences with ellipses...

LOUDMOUTH FORCES YOU TO YELL AND END YOUR SENTENCES WITH AN EXCLAMATION MARK! EVEN WHEN YOU'RE TALKING ON THE RADIO! THIS IS MY INSIDE VOICE!

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I tend to whisper at all times as my Librarian, because as a Librarian I enjoy being quiet, and security thinks that anyone whispering is a fucking syndicate and I'm tired of it, so I'm hoping it becomes a bit more common sight to see with a trait people can take. That way security just looks like a dick for bullying someone that's softspoken.

The loudmouth thing is just funny because you don't even whisper when you're talking on your radio.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Updated chat code so that speaking is capable of being used for radio channels for the loudmouth  trait
- Added a new TransformSpeechType event that is thrown and caught by the new Softspoken/Loudmouth accents to change the user's chat type from Local -> Whisper or Whisper -> Local
- Pretty straightforward implementation of the two accents with comments to go along with it

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

**Softspoken:**

https://github.com/user-attachments/assets/a005a285-d60c-46ae-bc2b-f4754a710025

**Loudmouth:**

https://github.com/user-attachments/assets/f3ca35e2-36c2-4990-a925-14726edf98d7


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [ ] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Adds the softspoken and loudmouth accents.