### PR TITLE
Nerf CMO's Hypospray combat capabilities

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/HypospraySystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/HypospraySystem.cs
@@ -42,7 +42,7 @@ public sealed class HypospraySystem : SharedHypospraySystem
         if (args.Cancelled || args.Handled || args.Args.Target == null)
             return;
 
-        args.Handled = TryUseHypospray(entity, args.Args.Target.Value, args.Args.User);
+        args.Handled = TryDoInject(entity, args.Args.Target.Value, args.Args.User);
     }
 
     private bool TryUseHypospray(Entity<HyposprayComponent> entity, EntityUid target, EntityUid user)

--- a/Content.Server/Chemistry/EntitySystems/HypospraySystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/HypospraySystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry;
 using Content.Shared.Database;
+using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Forensics;
 using Content.Shared.IdentityManagement;
@@ -25,6 +26,7 @@ public sealed class HypospraySystem : SharedHypospraySystem
 {
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly InteractionSystem _interaction = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
 
     public override void Initialize()
     {
@@ -33,6 +35,14 @@ public sealed class HypospraySystem : SharedHypospraySystem
         SubscribeLocalEvent<HyposprayComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<HyposprayComponent, MeleeHitEvent>(OnAttack);
         SubscribeLocalEvent<HyposprayComponent, UseInHandEvent>(OnUseInHand);
+        SubscribeLocalEvent<HyposprayComponent, HyposprayDoAfterEvent>(OnHyposprayDoAfter);
+    }
+    private void OnHyposprayDoAfter(Entity<HyposprayComponent> entity, ref HyposprayDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled || args.Args.Target == null)
+            return;
+
+        args.Handled = TryUseHypospray(entity, args.Args.Target.Value, args.Args.User);
     }
 
     private bool TryUseHypospray(Entity<HyposprayComponent> entity, EntityUid target, EntityUid user)
@@ -42,6 +52,29 @@ public sealed class HypospraySystem : SharedHypospraySystem
             && _solutionContainers.TryGetDrawableSolution(target, out var drawableSolution, out _))
         {
             return TryDraw(entity, target, drawableSolution.Value, user);
+        }
+
+        // No doAfter for self-injection
+        if (entity.Comp.DoAfterTime > 0 && target != user)
+        {
+            // Is the target a mob? If yes, use a do-after to give them time to respond.
+            if (HasComp<MobStateComponent>(target) || HasComp<BloodstreamComponent>(target))
+            {
+                //If the injection would fail the doAfter can be skipped at this step
+                if (InjectionFailureCheck(entity, target, user, out _, out _, out _, out _))
+                {
+                    _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, entity.Comp.DoAfterTime, new HyposprayDoAfterEvent(), entity.Owner, target: target, used: entity.Owner)
+                    {
+                        BreakOnMove = true,
+                        BreakOnWeightlessMove = false,
+                        BreakOnDamage = true,
+                        NeedHand = true,
+                        BreakOnHandChange = true,
+                        Hidden = true
+                    });
+                }
+                return true;
+            }
         }
 
         return TryDoInject(entity, target, user);
@@ -94,17 +127,11 @@ public sealed class HypospraySystem : SharedHypospraySystem
             target = user;
         }
 
-        if (!_solutionContainers.TryGetSolution(uid, component.SolutionName, out var hypoSpraySoln, out var hypoSpraySolution) || hypoSpraySolution.Volume == 0)
-        {
-            _popup.PopupEntity(Loc.GetString("hypospray-component-empty-message"), target, user);
-            return true;
-        }
-
-        if (!_solutionContainers.TryGetInjectableSolution(target, out var targetSoln, out var targetSolution))
-        {
-            _popup.PopupEntity(Loc.GetString("hypospray-cant-inject", ("target", Identity.Entity(target, EntityManager))), target, user);
-            return false;
-        }
+        if (!InjectionFailureCheck(entity, target, user, out var hypoSpraySoln, out var targetSoln, out var targetSolution, out var returnValue)
+            || hypoSpraySoln == null
+            || targetSoln == null
+            || targetSolution == null)
+            return returnValue;
 
         _popup.PopupEntity(Loc.GetString(msgFormat ?? "hypospray-component-inject-other-message", ("other", target)), target, user);
 
@@ -191,5 +218,29 @@ public sealed class HypospraySystem : SharedHypospraySystem
             ? entMan.HasComponent<SolutionContainerManagerComponent>(entity) &&
               entMan.HasComponent<MobStateComponent>(entity)
             : entMan.HasComponent<SolutionContainerManagerComponent>(entity);
+    }
+
+    private bool InjectionFailureCheck(Entity<HyposprayComponent> entity, EntityUid target, EntityUid user, out Entity<SolutionComponent>? hypoSpraySoln, out Entity<SolutionComponent>? targetSoln, out Solution? targetSolution, out bool returnValue)
+    {
+        hypoSpraySoln = null;
+        targetSoln = null;
+        targetSolution = null;
+        returnValue = false;
+
+        if (!_solutionContainers.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out hypoSpraySoln, out var hypoSpraySolution) || hypoSpraySolution.Volume == 0)
+        {
+            _popup.PopupEntity(Loc.GetString("hypospray-component-empty-message"), target, user);
+            returnValue = true;
+            return false;
+        }
+
+        if (!_solutionContainers.TryGetInjectableSolution(target, out targetSoln, out targetSolution))
+        {
+            _popup.PopupEntity(Loc.GetString("hypospray-cant-inject", ("target", Identity.Entity(target, EntityManager))), target, user);
+            returnValue = false;
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Content.Shared/Chemistry/Components/HyposprayComponent.cs
+++ b/Content.Shared/Chemistry/Components/HyposprayComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
@@ -37,4 +38,15 @@ public sealed partial class HyposprayComponent : Component
     /// </summary>
     [DataField]
     public bool InjectOnly = false;
+
+    /// <summary>
+    ///  If set over 0, enables a doafter for the hypospray which must be completed for injection.
+    /// </summary>
+    [DataField]
+    public float DoAfterTime = 0f;
+}
+
+[Serializable, NetSerializable]
+public sealed partial class HyposprayDoAfterEvent : SimpleDoAfterEvent
+{
 }

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -18,9 +18,8 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
-    onlyAffectsMobs: false
-  - type: UseDelay
-    delay: 0.5
+    onlyAffectsMobs: true
+    doAfterTime: 0.5
   - type: StaticPrice
     price: 750
   - type: Tag
@@ -49,7 +48,7 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
-    onlyAffectsMobs: false
+    onlyAffectsMobs: true
   - type: UseDelay
     delay: 0.5
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This PR aims to reduce the offensive combat utility of the CMO's hypospray, moving it more towards being a treatment tool and defensive utility, as opposed to being a chemical injector weapon. 

The PR has the following changes:
- The 0.5 second cooldown between injections is removed.
- A 0.5 second doAfter has been added to injecting mobs.
  - The doAfter can be broken upon movement and damage.
  - The doAfter is invisible to everyone except the person holding the hypospray.
- Self-injection is instant with no cooldown.
- Hyposprays now start with the Inject & Draw mode toggled on.

Note that this change is only applied to the CMO's hypospray; the hypopen, gorlex hypospray (i.e. Nukie hypo) and hypodarts remain unchanged.

This PR is submitted alongside #30703, though separated since they implement different functionalities.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This suggestion has generated quite a lot of discussion on Discord and github, so I've done my best to sum up key responses below.

<details>
<summary><b>Why nerf the Hypospray's combat capabilities?</b></summary>

The Hypospray is a job-specific tool given to the CMO to make them able to perform their job duties better than a normal doctor. This can be seen by how it enables quick injections and can store more chemicals than an average syringe; 30u as opposed to 15u. 

The instant injection and large chemical storage has allowed it to find a second use as an offensive tool. The instant injection means that you can deal 5u reagent worth of injury to an opponent just as long as you get in range, and since the cooldown and injection happens regardless of movement it becomes possible to follow a target and continuously injecting them with the chemical until all 30u are used up, or dash in behind cover during the cooldown. 

This was most notably observed with Chloral Hydrate, as it was a reagent easily accessible to the CMO with an effect that was far too strong for how easy it was to get. It was the go-to option for any combat CMO as it could down a Nukie in literally a second. Thankfully it has been nerfed due to being so strong and meta, but this will not fix the underlying problem of CMOs charging into battle to inject. Instead a new chemical will become meta, which will likely have to be nerfed to make sure the combat CMO playstyle is no longer viable. And so on and so forth.

And that's bad! There *should* be dangerous chemicals available to crew, because crew should be able to be exposed to them. If dangerous chemicals are exclusively available to antags it reduces the freedom we have in adding fun and deadly chemicals to the game, just on the off-chance a single role will be able to use it offensively with far too much power. Even if the CMO gets shot down, having disabled a Nukie for an extended period of time or even death is a great trade for the crew, which is a strange use of a role that is meant to be the best support role on the station.

So why the proposed changes?
</details>

<details>
<summary><b>Why the doAfter?</b></summary>

Before we talk about anything else, let me be explicitly clear here:
- The hypospray already has a cooldown between injections that is 0.5 seconds long. 
- 0.5 seconds is near-instant.

A 0.5 second doafter is slow enough to break upon _active_ movement, yet instant enough that it does not meaningfully slow down CMO's work.

Nukies move around. People in beds in medbay don't. There's some grey areas in between those two scenarios and we'll adress that in a later section, but the doAfter is a very straight-forward way to have an action that breaks upon movement. If you are a Nukie and are in active battle, you will not be standing still, and if someone approaches or ambushes you in melee range, you sure as hell will start moving. On the contrary people who move into medbay tend to be guided to a bed, where they will then be scanned (an action that requires stillness) and then treated. CMOs are working with the latter case the majority of the time.

By preventing injections in moving targets you are making it harder to use in active combat scenarios. This does impact CMO targeting crew as well, but later down I'm making a case for why this is not a big nerf.
</details>

<details>
<summary><b>But people don't stop moving! I need the hypospray to inject my patients directly because they just won't stop.</b></summary>

We've all that those moments in medbay when we've been trying to inject someone and they just move. It sucks. But that's for a **3-5 second injection** via *syringe*, not a 0.5 second injection. 0.5 seconds is slow enough that you are able to break it if you are *actively* moving, but even short stops leave room for an injection. Prying, stopping to talk, even the slowdown from bumping an airlock to open it can give enough time to inject someone. 

But what about active battles? True, you can't really run alongside someone and heal them who if they're in an active gunfight, but just getting them to round a corner for cover is likely to give you enough time to inject them. Someone gets crit? Perfect, then they got no choice in the matter. Getting someone to stand still so you can scan them or patch them up is not uncommon in battles, and even Nukies are forced to do so if the Agent isn't deft with the hypospray. 

There's also the key element that, once this change is implemented, you will know it's there. So you won't try to run and inject at the same time by virtue of it not being possible anymore.
</details>

<details>
<summary><b> Instant-injection is the hypospray's whole *thing*, why even use it? The delay will just drag out treatment.
</b></summary>

Syringes take 3-5 seconds to inject. 0.5 seconds is practically instant compared to that. Again, this change would not *add* a 0.5 delay, but *move* the *existing* 0.5 delay from being a cooldown to being a doAfter. If you are treating a patient in medbay and need to inject 15u of something, this change would result in it taking 1.5 seconds as opposed to 1 second. (`Wait > Inject > Wait > Inject > Wait > Inject` vs. `Inject > Wait > Inject > Wait > Inject`) 

Being able to fast-track patients in medbay is what the hypospray is used for the most and this change would not meaningfully impact that. Just because the injection is no longer right when you click the button doesn't mean the hypospray isn't an immensely valuable tool for a CMO injecting *patients*.
</details>

<details>
<summary><b>Chloral Hydrate is nerfed, this is unnecessary.</b>
</summary>

While the Chloral Hydrate nerf was great (it was unambiguously strong for how easy it is to make), the fact CMOs can't use it to seriously damage Nukies does not mean the CombatMO meta is over. There are still plenty of reagents that can replace Chloral Hydrate that, while not being *as* effective, are still worth going on the offensive and trying to inject Nukies with. I want you to keep in mind that the examples below inject 30u over *2.5* seconds, and most of these are devestating even at 15u (1 second!):

- Unstable Mutagen: 30u deals _180 Radiation damage_ over 1 minute. Takes 33 seconds to crit.

- Ethanol: 30u (15u OD) can deal *300* Poison damage over 5 minutes. Takes 100 seconds to crit. Now it's unlikely it will actually do the full 300 Poison due to vomiting, but even at 15u you will be throwing up and dealing with extreme blurred vision for several minutes after. 

- Licoxide: A bit jank to get so it might get patched out, but just a single 5u injection has a *98% chance* to trigger at least one stun over 10 seconds. 30u? Enjoy a full minute of being stunned on the floor.

- Amatoxin: With a bit of collaboration with Botany (or finding the right maints pill) you can get Amatoxin, which deals as much damage over time as Unstable Mutagen but has the added benefit of going on for 2.5 minutes, totaling 450 poison damage. Dylovene isn't even strong enough to counteract that.

- Heartbreaker Toxin: Can be made right in your own medbay. You just need to hit two injections, i.e. 0.5 seconds worth of interacting, to inject enough to crit. The only thing balancing it out is that it's easily treatable airloss damage, but you best hope you're not injected at the same time as a push or your Agent is down the other side of the hallway.

- Lexorin: In a similar vein to Amatoxin, this is rarer for crew to get their hands on but not impossible. It can be a botany mutation or found in space shrooms. I don't need to tell you why Lexorin, the strongest toxin in the game, is bad.

- Nocturine: You can get 20u Nocturine from maints pills. Now you know! Okay okay, the odds of a CMO getting their hands on Nocturine is pretty slim. But a CMO shouldn't be encouraged to go maints diving the moment the shift starts just to find useful maints pills and shrooms.

It'll take some time for players to discover these options, but I don't doubt we will see them in the future.
</details>

<details>
<summary><b>If you're a Nukie and let a CMO get in close combat range with you, it's a skill issue.</b>
</summary>

If a CMO is charging at you down a hallway and you're not shooting them, sure, git gud. But a CMO who knows what they're doing (and if they're gung-ho on validhunting, they likely are) will stand around corners in narrow hallways, flank via side airlocks or just hide inside of a locker to jump out as you pass. It's certainly difficult to get in range to inject a Nukie but far from impossible, and it can be a huge amount of burst damage compared to the time the CMO has to spend in combat (three injections of UM, which takes 1 second, and then dipping will put a Nukie at near-crit).

</details>

<details>
<summary><b>A CMO should be able to defend themselves.</b>
</summary>

I do not see a good reason why the CMO should be given an advantage over any other non-Sec head when it comes to self-defense. QM, RD and CE have no extra retaliatory items (HoP has a disabler, which I presume is because they don't share a space with their department employees who can step in to protect them) other than the flash, which the CMO also has. If you have an unruly patient you can still very much get them injected with the hypospray via flashing them to knock them down, an option that is not available against Nukies. See Video 2 below.

</details>

<details>
<summary><b>Just ban the problematic players!</b>
</summary>

It is not against the rules for a CMO to inject someone with poison and there are times when the line is blurred; is it validhunting if CMO steps out of medbay to pre-emptively stop a Nukie pushing in? This is a problem that can be solved mechanically and should be, since admin intervention is not scaleable.

</details>

<details>
<summary><b>Why the instant self-inject?</b>
</summary>

While the self-inject could also have a doAfter, I feel that allowing instant self-injection as a mechanic is a nice buff to balance out the doAfter nerf, and makes it an appealing option for antags to acquire without being able to use it offensively. CMOs can use it to heal themselves quickly should they take damage in battle, but since they no longer have the hypospray as an offensive option they would need to supplement themselves with actual weaponry (at which point they're just like any other doctor player with a gun). This lets the CMO have more survivability without raising the offensive capabilities. 

There's an additional bonus in that, since the CMO always has the hypospray as a self-interested option, it is more likely it'll be filled with medicine as opposed to harmful chemicals, which will make it ready to heal other people.

</details>

<details>
<summary><b>Hyposprays now start with the Inject & Draw mode toggled on. Why?</b>
</summary>

It's mostly because the toggle was a bit opaque and missable, requiring rightclicking or alt+z (with a normal z just injecting yourself). As far as I can tell the Inject & Draw mode only adds functionality to the hypospray without replacing any contextual prompts. The toggle is still there for people who prefer Inject Only though.

If you're reading this text you've likely read all of the above, so thank you for taking the time to do that. Trust me, it feels perfectly fine to use ingame, and if it ends up sucking in some way I couldn't predict we can always revert it. This is a playtest, so let's test things!
</details>

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

- Added a SimpleDoAfterEvent to the Hypospray component
- This doAfter is triggered upon trying to inject a mob that isn't oneself. It will be skipped if there would be an error upon injection (e.g. hypo is empty).
  -  Because of this, the failure injection check is moved into its own function so it can be reused.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

Video 1: Showcases the difference between the gorlex hypospray (which remains unchanged) and the CMO's hypospray on still patients:

https://github.com/user-attachments/assets/f76fa06f-b09f-4658-9f7b-bbb268dce3d5

Video 2: Shows attempting to use the CMO's hypospray on a moving target and how it fails, and how its offensive capabilities aren't completely nerfed (just requires more effort; in this case via the use of a flash):

https://github.com/user-attachments/assets/76cac7da-63c7-4fec-a459-3168fb28973d


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: CMO's hypospray now has a DoAfter bar instead of a cooldown.
- tweak: CMO's hypospray can now instantly self-inject.
- tweak: Hyposprays now start in the Draw & Inject toggle mode.
