### PR TITLE
fix(AntagSelectionSystem): Only create a new mind for ghosts

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -343,7 +343,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         {
             var curMind = session.GetMind(); 
 
-            if (curMind == null || HasComp<GhostComponent>(session.AttachedEntity))
+            if (curMind == null || session.AttachedEntity != antagEnt)
             {
                 curMind = _mind.CreateMind(session.UserId, Name(antagEnt.Value));
                 _mind.SetUserId(curMind.Value, session.UserId);

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -343,15 +343,15 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         {
             var curMind = session.GetMind(); 
 
-            if (HasComp<GhostComponent>(session.AttachedEntity))
+            if (curMind == null || HasComp<GhostComponent>(session.AttachedEntity))
             {
                 curMind = _mind.CreateMind(session.UserId, Name(antagEnt.Value));
-                _mind.SetUserId(curMind, session.UserId);
+                _mind.SetUserId(curMind.Value, session.UserId);
             }
 
-            _mind.TransferTo(curMind, antagEnt, ghostCheckOverride: true);
-            _role.MindAddRoles(curMind, def.MindComponents, null, true);
-            ent.Comp.SelectedMinds.Add((curMind, Name(player)));
+            _mind.TransferTo(curMind.Value, antagEnt, ghostCheckOverride: true);
+            _role.MindAddRoles(curMind.Value, def.MindComponents, null, true);
+            ent.Comp.SelectedMinds.Add((curMind.Value, Name(player)));
 
             SendBriefing(session, def.Briefing);
         }

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -341,8 +341,13 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         if (session != null)
         {
-            var curMind = _mind.CreateMind(session.UserId, Name(antagEnt.Value));
-            _mind.SetUserId(curMind, session.UserId);
+            var curMind = session.GetMind(); 
+
+            if (HasComp<GhostComponent>(session.AttachedEntity))
+            {
+                curMind = _mind.CreateMind(session.UserId, Name(antagEnt.Value));
+                _mind.SetUserId(curMind, session.UserId);
+            }
 
             _mind.TransferTo(curMind, antagEnt, ghostCheckOverride: true);
             _role.MindAddRoles(curMind, def.MindComponents, null, true);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Made it so ``MakeAntag()`` only creates a new mind when transferring between entities
or sessions without a mind.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Resolves #30700 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
~~Are all people who take ghost roles guaranteed to have the GhostComponent, if not, this partially reintroduces the bugs that were fixed in the previous pr~~

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
# Before
![Screenshot from 2024-08-06 07-42-21](https://github.com/user-attachments/assets/4c4be30b-588e-409c-af4e-a3e530d66ac6)


# After
![Screenshot from 2024-08-06 07-40-04](https://github.com/user-attachments/assets/ea900c13-d1e5-46cc-94e1-e528ee89d87e)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
