### PR TITLE
Armor damage conversion

### DIFF
--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -29,7 +29,9 @@ public abstract class SharedArmorSystem : EntitySystem
         args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, component.Modifiers);
     }
 
-    private void OnBorgDamageModify(EntityUid uid, ArmorComponent component,
+    private void OnBorgDamageModify(
+        EntityUid uid,
+        ArmorComponent component,
         ref BorgModuleRelayedEvent<DamageModifyEvent> args)
     {
         args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, component.Modifiers);
@@ -45,8 +47,12 @@ public abstract class SharedArmorSystem : EntitySystem
         var ev = new ArmorExamineEvent(examineMarkup);
         RaiseLocalEvent(uid, ref ev);
 
-        _examine.AddDetailedExamineVerb(args, component, examineMarkup,
-            Loc.GetString("armor-examinable-verb-text"), "/Textures/Interface/VerbIcons/dot.svg.192dpi.png",
+        _examine.AddDetailedExamineVerb(
+            args,
+            component,
+            examineMarkup,
+            Loc.GetString("armor-examinable-verb-text"),
+            "/Textures/Interface/VerbIcons/dot.svg.192dpi.png",
             Loc.GetString("armor-examinable-verb-message"));
     }
 
@@ -54,14 +60,15 @@ public abstract class SharedArmorSystem : EntitySystem
     {
         var msg = new FormattedMessage();
 
-        msg.AddMarkup(Loc.GetString("armor-examine"));
+        msg.AddMarkupOrThrow(Loc.GetString("armor-examine"));
 
         foreach (var coefficientArmor in armorModifiers.Coefficients)
         {
             msg.PushNewline();
 
-            var armorType = Loc.GetString("armor-damage-type-" + coefficientArmor.Key.ToLower());
-            msg.AddMarkup(Loc.GetString("armor-coefficient-value",
+            var armorType =
+                Loc.GetString("armor-damage-type-" + coefficientArmor.Key.ToString().ToLower());
+            msg.AddMarkupOrThrow(Loc.GetString("armor-coefficient-value",
                 ("type", armorType),
                 ("value", MathF.Round((1f - coefficientArmor.Value) * 100, 1))
             ));
@@ -71,11 +78,29 @@ public abstract class SharedArmorSystem : EntitySystem
         {
             msg.PushNewline();
 
-            var armorType = Loc.GetString("armor-damage-type-" + flatArmor.Key.ToLower());
-            msg.AddMarkup(Loc.GetString("armor-reduction-value",
+            var armorType = Loc.GetString("armor-damage-type-" + flatArmor.ToString().ToLower());
+            msg.AddMarkupOrThrow(Loc.GetString("armor-reduction-value",
                 ("type", armorType),
                 ("value", flatArmor.Value)
             ));
+        }
+
+        foreach (var conversionArmor in armorModifiers.DamageConversions)
+        {
+            foreach (var conversionPair in conversionArmor.Value)
+            {
+                msg.PushNewline();
+
+                var convertedTo =
+                    Loc.GetString("armor-damage-type-" + conversionPair.Key.ToString().ToLower());
+                var convertedFrom =
+                    Loc.GetString("armor-damage-type-" + conversionArmor.Key.ToString().ToLower());
+                msg.AddMarkupOrThrow(Loc.GetString("armor-conversion-value",
+                    ("convertedTo", convertedTo),
+                    ("convertedFrom", convertedFrom),
+                    ("value", MathF.Round(conversionPair.Value * 100, 1))
+                ));
+            }
         }
 
         return msg;

--- a/Content.Shared/Damage/DamageModifierSet.cs
+++ b/Content.Shared/Damage/DamageModifierSet.cs
@@ -1,27 +1,35 @@
 using Content.Shared.Damage.Prototypes;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 
-namespace Content.Shared.Damage
-{
-    /// <summary>
-    ///     A set of coefficients or flat modifiers to damage types. Can be applied to <see cref="DamageSpecifier"/> using <see
-    ///     cref="DamageSpecifier.ApplyModifierSet(DamageSpecifier, DamageModifierSet)"/>. This can be done several times as the
-    ///     <see cref="DamageSpecifier"/> is passed to it's final target. By default the receiving <see cref="DamageableComponent"/>, will
-    ///     also apply it's own <see cref="DamageModifierSet"/>.
-    /// </summary>
-    /// <remarks>
-    /// The modifier will only ever be applied to damage that is being dealt. Healing is unmodified.
-    /// </remarks>
-    [DataDefinition]
-    [Serializable, NetSerializable]
-    [Virtual]
-    public partial class DamageModifierSet
-    {
-        [DataField("coefficients", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<float, DamageTypePrototype>))]
-        public Dictionary<string, float> Coefficients = new();
+namespace Content.Shared.Damage;
 
-        [DataField("flatReductions", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<float, DamageTypePrototype>))]
-        public Dictionary<string, float> FlatReduction = new();
-    }
+/// <summary>
+///     A set of coefficients or flat modifiers to damage types. Can be applied to <see cref="DamageSpecifier"/> using <see
+///     cref="DamageSpecifier.ApplyModifierSet(DamageSpecifier, DamageModifierSet)"/>. This can be done several times as the
+///     <see cref="DamageSpecifier"/> is passed to it's final target. By default the receiving <see cref="DamageableComponent"/>, will
+///     also apply it's own <see cref="DamageModifierSet"/>.
+/// </summary>
+/// <remarks>
+/// The modifier will only ever be applied to damage that is being dealt. Healing is unmodified.
+/// </remarks>
+[DataDefinition]
+[Serializable, NetSerializable]
+[Virtual]
+public partial class DamageModifierSet
+{
+    [DataField]
+    public Dictionary<ProtoId<DamageTypePrototype>, float> Coefficients = new();
+
+    [DataField("flatReductions")]
+    public Dictionary<ProtoId<DamageTypePrototype>, float> FlatReduction = new();
+
+
+    /// <summary>
+    /// Used to convert one type of damage into another.
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<DamageTypePrototype>, Dictionary<ProtoId<DamageTypePrototype>, float>> DamageConversions =
+        new();
 }

--- a/Content.Tests/Shared/DamageTest.cs
+++ b/Content.Tests/Shared/DamageTest.cs
@@ -17,7 +17,7 @@ namespace Content.Tests.Shared
     public sealed class DamageTest : ContentUnitTest
     {
 
-        private static Dictionary<string, float> _resistanceCoefficientDict = new()
+        private static Dictionary<ProtoId<DamageTypePrototype>, float> _resistanceCoefficientDict = new()
         {
             // "missing" blunt entry
             { "Piercing", -2 },// Turn Piercing into Healing
@@ -25,7 +25,7 @@ namespace Content.Tests.Shared
             { "Radiation", 1.5f },
         };
 
-        private static Dictionary<string, float> _resistanceReductionDict = new()
+        private static Dictionary<ProtoId<DamageTypePrototype>, float> _resistanceReductionDict = new()
         {
             { "Blunt", - 5 },
             // "missing" piercing entry

--- a/Resources/Locale/en-US/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/armor/armor-examine.ftl
@@ -4,6 +4,7 @@ armor-examinable-verb-message = Examine the armor values.
 armor-examine = It provides the following protection:
 armor-coefficient-value = - [color=yellow]{$type}[/color] damage reduced by [color=lightblue]{$value}%[/color].
 armor-reduction-value = - [color=yellow]{$type}[/color] damage reduced by [color=lightblue]{$value}[/color].
+armor-conversion-value = - [color=lightblue]{$value}%[/color] of [color=yellow]{$convertedFrom}[/color] damage converted to [color=yellow]{$convertedTo}[/color]
 armor-damage-type-blunt = Blunt
 armor-damage-type-slash = Slash
 armor-damage-type-piercing = Piercing

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -47,11 +47,14 @@
     sprite: Clothing/OuterClothing/Armor/riot.rsi
   - type: Armor
     modifiers:
-      damageConversions:
-        Blunt:
-          Slash: 0.25
-        Heat:
-          Caustic: 0.25
+      coefficients:
+        Blunt: 0.4
+        Slash: 0.4
+        Piercing: 0.7
+        Heat: 0.9
+        Caustic: 0.9
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
   - type: GroupExamine
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -47,14 +47,11 @@
     sprite: Clothing/OuterClothing/Armor/riot.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.4
-        Slash: 0.4
-        Piercing: 0.7
-        Heat: 0.9
-        Caustic: 0.9
-  - type: ExplosionResistance
-    damageCoefficient: 0.9
+      damageConversions:
+        Blunt:
+          Slash: 0.25
+        Heat:
+          Caustic: 0.25
   - type: GroupExamine
 
 - type: entity


### PR DESCRIPTION
## About the PR
Added conversion of one type of damage to another in DamageModifierSet
DamageModifierSet code made neater by replacing custom serializers with ProtoId

## Why / Balance
It's a pretty logical and interesting solution to how armor can be diversified with new mechanics. 
It makes sense that durable armor can withstand stabbing damage from bullets, leaving the user with only bruises and bumps (blunt damage)

This pr implements the mechanics of transforming one type of damage into another, but does not affect any existing types of armor, as the issue of equipment balance is a separate big topic for discussion.

## Technical details
How to use it in yml:
```yml
  - type: Armor
    modifiers:
      damageConversion:
        Piercing:
          Blunt: 0.6 # Convert 60% Piercing into Blunt
```
first reduction, then conversion
so
100 piercing -> 40 piercing -> 24 blunt + 16 piercing 


## Media
https://github.com/user-attachments/assets/312eb869-4e6b-47d0-ba3d-5a2a32bf6c4f

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:Not cl: CodTenAlt
no player facing changes