### PR TITLE
AntagDefinitions now specify mind reset

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -341,12 +341,17 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         if (session != null)
         {
-            var curMind = _mind.CreateMind(session.UserId, Name(antagEnt.Value));
-            _mind.SetUserId(curMind, session.UserId);
+            var curMind = session.GetMind();
+            if (curMind == null || def.ResetMind)
+            {
+                curMind = _mind.CreateMind(session.UserId, Name(antagEnt.Value));
+                _mind.SetUserId(curMind.Value, session.UserId);
+            }
 
-            _mind.TransferTo(curMind, antagEnt, ghostCheckOverride: true);
-            _role.MindAddRoles(curMind, def.MindComponents, null, true);
-            ent.Comp.SelectedMinds.Add((curMind, Name(player)));
+            _mind.TransferTo(curMind.Value, antagEnt, ghostCheckOverride: true);
+
+            _role.MindAddRoles(curMind.Value, def.MindComponents, null, true);
+            ent.Comp.SelectedMinds.Add((curMind.Value, Name(player)));
 
             SendBriefing(session, def.Briefing);
         }

--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -150,6 +150,12 @@ public partial struct AntagSelectionDefinition()
     public ComponentRegistry MindComponents = new();
 
     /// <summary>
+    /// Create a new mind for the antagonist;
+    /// </summary>
+    [DataField]
+    public bool ResetMind;
+
+    /// <summary>
     /// A set of starting gear that's equipped to the player.
     /// </summary>
     [DataField]

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -138,6 +138,7 @@
         prototype: Dragon
       - type: RoleBriefing
         briefing: dragon-role-briefing
+      resetMind: true
 
 - type: entity
   parent: BaseGameRule
@@ -188,6 +189,7 @@
       mindComponents:
       - type: NinjaRole
         prototype: SpaceNinja
+      resetMind: true
 
 - type: entity
   parent: BaseGameRule
@@ -480,6 +482,7 @@
       mindComponents:
       - type: NukeopsRole
         prototype: Nukeops
+      resetMind: true
 
 - type: entity
   parent: BaseTraitorRule


### PR DESCRIPTION
## About the PR
AntagSelectionSystem no longer gives every antag a new mind. AntagDefinitions now contain a datafield that controls this. It defaults to reusing the current mind so ghostrole antags must now specify they need a new one to be created

Fixes #30700

## Why / Balance
New mind on everything by default is causing Traitors to lose their job info which is visible to every observer on the Ghost Warp UI.
Trying to take over any mob that uses AutoTraitorComponent causes a loop of creating new mind entities, spamming errors or worse.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Antagonists now default to using their existing mind entity. If a new one is needed (such as when a player takes over a ghostrole and must lose their previous Objectives) this must be specified by setting ResetMind to True on the AntagSelectionComponent's AntagDefinition.

**Changelog**
DATA EXPUNGED