### PR TITLE
updated restricted gear list in the guidebook

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLRestrictedGear.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLRestrictedGear.xml
@@ -3,7 +3,7 @@
   - \[ERT/Central Command\] ERT and central command clothing
   - \[Command\] Command clothing
   - \[Security\] Security clothing
-  - \[Security\] Less than lethal and non-lethal weapons, excluding disablers and beanbag shotguns
+  - \[Security\] Less than lethal and non-lethal weapons including bolas but excluding disablers and beanbag shotguns
   - \[Security/Command\] Disablers
   - \[Security/Bartender/Zookeeper\] Nonlethal shotguns
   - \[Security\] Flash technology, excluding handheld flashes


### PR DESCRIPTION
## About the PR
Updated the wording of space law to allow for legal use of bolas by security

## Why / Balance
It was a minor oversight during the update of space law

## Technical details
N/A

## Media
N/A

## Requirements
- [X ] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Bolas may now be used by security again legally
