### PR TITLE
Remove obsolete occurrences of IComponent.Owner being assigned just before AddComponent

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TwoStageTriggerSystem.cs
@@ -30,13 +30,12 @@ public sealed class TwoStageTriggerSystem : EntitySystem
     {
         foreach (var (name, entry) in component.SecondStageComponents)
         {
-            var comp = (Component) _factory.GetComponent(name);
-            var temp = (object) comp;
+            var comp = (Component)_factory.GetComponent(name);
+            var temp = (object)comp;
 
             if (EntityManager.TryGetComponent(uid, entry.Component.GetType(), out var c))
                 RemComp(uid, c);
 
-            comp.Owner = uid;
             _serializationManager.CopyTo(entry.Component, ref temp);
             EntityManager.AddComponent(uid, comp);
         }

--- a/Content.Server/Humanoid/Systems/RandomHumanoidSystem.cs
+++ b/Content.Server/Humanoid/Systems/RandomHumanoidSystem.cs
@@ -50,8 +50,7 @@ public sealed class RandomHumanoidSystem : EntitySystem
         {
             foreach (var entry in prototype.Components.Values)
             {
-                var comp = (Component) _serialization.CreateCopy(entry.Component, notNullableOverride: true);
-                comp.Owner = humanoid; // This .owner must survive for now.
+                var comp = (Component)_serialization.CreateCopy(entry.Component, notNullableOverride: true);
                 EntityManager.RemoveComponent(humanoid, comp.GetType());
                 EntityManager.AddComponent(humanoid, comp);
             }

--- a/Content.Server/Jobs/AddComponentSpecial.cs
+++ b/Content.Server/Jobs/AddComponentSpecial.cs
@@ -23,12 +23,11 @@ namespace Content.Server.Jobs
             foreach (var (name, data) in Components)
             {
                 var component = (Component) factory.GetComponent(name);
-                component.Owner = mob;
 
-                var temp = (object) component;
+                var temp = (object)component;
                 serializationManager.CopyTo(data.Component, ref temp);
                 entityManager.RemoveComponent(mob, temp!.GetType());
-                entityManager.AddComponent(mob, (Component) temp);
+                entityManager.AddComponent(mob, (Component)temp);
             }
         }
     }

--- a/Content.Server/Worldgen/Prototypes/BiomePrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/BiomePrototype.cs
@@ -54,7 +54,6 @@ public sealed partial class BiomePrototype : IPrototype, IInheritingPrototype
         foreach (var data in ChunkComponents.Values)
         {
             var comp = (Component) serialization.CreateCopy(data.Component, notNullableOverride: true);
-            comp.Owner = target; // look im sorry ok this .owner has to live until engine api exists
             entityManager.AddComponent(target, comp);
         }
     }

--- a/Content.Server/Worldgen/Prototypes/WorldgenConfigPrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/WorldgenConfigPrototype.cs
@@ -30,7 +30,6 @@ public sealed partial class WorldgenConfigPrototype : IPrototype
         foreach (var data in Components.Values)
         {
             var comp = (Component) serialization.CreateCopy(data.Component, notNullableOverride: true);
-            comp.Owner = target; // look im sorry ok this .owner has to live until engine api exists
             entityManager.AddComponent(target, comp);
         }
     }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
@@ -182,13 +182,12 @@ public sealed partial class ArtifactSystem
                 EntityManager.RemoveComponent(uid, reg.Type);
             }
 
-            var comp = (Component) _componentFactory.GetComponent(reg);
-            comp.Owner = uid;
+            var comp = (Component)_componentFactory.GetComponent(reg);
 
-            var temp = (object) comp;
+            var temp = (object)comp;
             _serialization.CopyTo(entry.Component, ref temp);
             EntityManager.RemoveComponent(uid, temp!.GetType());
-            EntityManager.AddComponent(uid, (Component) temp!);
+            EntityManager.AddComponent(uid, (Component)temp!);
         }
 
         node.Discovered = true;
@@ -218,12 +217,11 @@ public sealed partial class ArtifactSystem
             // if the entity prototype contained the component originally
             if (entityPrototype?.Components.TryGetComponent(name, out var entry) ?? false)
             {
-                var comp = (Component) _componentFactory.GetComponent(name);
-                comp.Owner = uid;
-                var temp = (object) comp;
+                var comp = (Component)_componentFactory.GetComponent(name);
+                var temp = (object)comp;
                 _serialization.CopyTo(entry, ref temp);
                 EntityManager.RemoveComponent(uid, temp!.GetType());
-                EntityManager.AddComponent(uid, (Component) temp);
+                EntityManager.AddComponent(uid, (Component)temp);
                 continue;
             }
 

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -369,11 +369,10 @@ public abstract class SharedMagicSystem : EntitySystem
             if (HasComp(ev.Target, data.Component.GetType()))
                 continue;
 
-            var component = (Component) _compFact.GetComponent(name);
-            component.Owner = ev.Target;
-            var temp = (object) component;
+            var component = (Component)_compFact.GetComponent(name);
+            var temp = (object)component;
             _seriMan.CopyTo(data.Component, ref temp);
-            EntityManager.AddComponent(ev.Target, (Component) temp!);
+            EntityManager.AddComponent(ev.Target, (Component)temp!);
         }
     }
     // End Change Component Spells


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Previously using `AddComponent` would not set `IComponent.Owner` and various things broke as a result. [Smungleaf corrected this](https://github.com/space-wizards/RobustToolbox/blame/master/Robust.Shared/GameObjects/EntityManager.Components.cs#L310-L317) and now `AddComponent` sets `Owner` so the cases where code sets the variable just before calling `AddComponent` are now redundant.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
