### PR TITLE
Add random seed options to tests

### DIFF
--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -252,7 +252,7 @@ public static partial class PoolManager
         }
         finally
         {
-            if (pair != null && pair.TestHistory.Count > 1)
+            if (pair != null && pair.TestHistory.Count > 0)
             {
                 await testOut.WriteLineAsync($"{nameof(GetServerClientPair)}: Pair {pair.Id} Test History Start");
                 for (var i = 0; i < pair.TestHistory.Count; i++)
@@ -268,12 +268,14 @@ public static partial class PoolManager
         var poolRetrieveTime = poolRetrieveTimeWatch.Elapsed;
         await testOut.WriteLineAsync(
             $"{nameof(GetServerClientPair)}: Retrieving pair {pair.Id} from pool took {poolRetrieveTime.TotalMilliseconds} ms");
-        await testOut.WriteLineAsync(
-            $"{nameof(GetServerClientPair)}: Returning pair {pair.Id}");
 
         pair.ClearModifiedCvars();
         pair.Settings = poolSettings;
         pair.TestHistory.Add(currentTestName);
+        pair.SetupSeed();
+        await testOut.WriteLineAsync(
+            $"{nameof(GetServerClientPair)}: Returning pair {pair.Id} with client/server seeds: {pair.ClientSeed}/{pair.ServerSeed}");
+
         pair.Watch.Restart();
         return pair;
     }

--- a/Content.IntegrationTests/PoolSettings.cs
+++ b/Content.IntegrationTests/PoolSettings.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using Robust.Shared.Random;
+
 namespace Content.IntegrationTests;
 
 /// <summary>
@@ -9,16 +11,6 @@ namespace Content.IntegrationTests;
 /// </summary>
 public sealed class PoolSettings
 {
-    /// <summary>
-    /// If the returned pair must not be reused
-    /// </summary>
-    public bool MustNotBeReused => Destructive || NoLoadContent || NoLoadTestPrototypes;
-
-    /// <summary>
-    /// If the given pair must be brand new
-    /// </summary>
-    public bool MustBeNew => Fresh || NoLoadContent || NoLoadTestPrototypes;
-
     /// <summary>
     /// Set to true if the test will ruin the server/client pair.
     /// </summary>
@@ -34,8 +26,6 @@ public sealed class PoolSettings
     /// </summary>
     public bool DummyTicker { get; init; } = true;
 
-    public bool UseDummyTicker => !InLobby && DummyTicker;
-
     /// <summary>
     /// If true, this enables the creation of admin logs during the test.
     /// </summary>
@@ -47,8 +37,6 @@ public sealed class PoolSettings
     /// If <see cref="InLobby"/> is true, this option is ignored.
     /// </summary>
     public bool Connected { get; init; }
-
-    public bool ShouldBeConnected => InLobby || Connected;
 
     /// <summary>
     /// Set to true if the given server/client pair should be in the lobby.
@@ -91,6 +79,34 @@ public sealed class PoolSettings
     /// Overrides the test name detection, and uses this in the test history instead
     /// </summary>
     public string? TestName { get; set; }
+
+    /// <summary>
+    /// If set, this will be used to call <see cref="IRobustRandom.SetSeed"/>
+    /// </summary>
+    public int? ServerSeed { get; set; }
+
+    /// <summary>
+    /// If set, this will be used to call <see cref="IRobustRandom.SetSeed"/>
+    /// </summary>
+    public int? ClientSeed { get; set; }
+
+    #region Inferred Properties
+
+    /// <summary>
+    /// If the returned pair must not be reused
+    /// </summary>
+    public bool MustNotBeReused => Destructive || NoLoadContent || NoLoadTestPrototypes;
+
+    /// <summary>
+    /// If the given pair must be brand new
+    /// </summary>
+    public bool MustBeNew => Fresh || NoLoadContent || NoLoadTestPrototypes;
+
+    public bool UseDummyTicker => !InLobby && DummyTicker;
+
+    public bool ShouldBeConnected => InLobby || Connected;
+
+    #endregion
 
     /// <summary>
     /// Tries to guess if we can skip recycling the server/client pair.


### PR DESCRIPTION
- Adds options to `PoolSettings` to make it easier for tests to use fixed seeds.
- Makes the test pool manager print the random seed information before each test, 
- Prevents tests that use a fixed seeds from unintentionally affecting other tests by re-randomizing the seed for each test.

Note that tests with fixed seeds will probably still have some randomization due to setup that occurs before the test is ran. E.g., players will probably have a randomized profile, so the seed wouldn't affect the race that a player spawns as.