### PR TITLE
require the warden to notify admins on disconnect

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -9,6 +9,7 @@
       time: 36000 #10 hrs
   startingGear: WardenGear
   icon: "JobIconWarden"
+  requireAdminNotify: true
   supervisors: job-supervisors-hos
   canBeAntag: false
   access:


### PR DESCRIPTION
## About the PR

The warden is now required to notify admins via ahelp on disconnect.

## Why / Balance

The warden is more often than not the only one that can prevent abuse/neglect of inmates and is also one of the roles that I have seen SSD the most. This leads to situations where inmates are forgotten about or receive harsher punishments than expected under space-law.

This PR aims to rectify this by marking the job of the warden as "important" and requiring a swift replacement or admin intervention to not let inmates come to unnecessary harm.

## Technical details

Only yml.

## Media

![Screenshot from 2024-08-07 17-44-11](https://github.com/user-attachments/assets/8d758007-7565-44cd-9800-b218a99550f2)

## Requirements

- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

None

**Changelog**

:cl:
- tweak: The warden is now an important job.
