### PR TITLE
Make Vox blood able to be used to make space cleaner

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/cleaning.yml
+++ b/Resources/Prototypes/Recipes/Reactions/cleaning.yml
@@ -11,6 +11,15 @@
     Bleach: 5
 
 - type: reaction
+  id: AmmoniaFromBlood
+  minTemp: 370
+  reactants:
+    AmmoniaBlood:
+      amount: 2
+  products:
+    Ammonia: 1
+
+- type: reaction
   id: SpaceCleaner
   reactants:
     Ammonia:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Make boiling vox blood give Ammonia

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Given that space cleaner is just water and ammonia I would assume that the
concentration of ammonia in vox blood is enough that it could be used as a
substitute. The other stuff that is found in vox blood is likely to be
irrelevant for it's effectiveness as a space cleaner. It requires two units of
blood to represent that the ammonia concentration is lower then pure ammonia.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
YAML change

## Requirements
<!--
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl: Aquif
- add: Boiling Vox blood results in ammonia.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
