### PR TITLE
Strip drag drop test

### DIFF
--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -212,7 +212,7 @@ public sealed class DragDropSystem : SharedDragDropSystem
 
         _draggedEntity = entity;
         _state = DragState.MouseDown;
-        _mouseDownScreenPos = _inputManager.MouseScreenPosition;
+        _mouseDownScreenPos = args.ScreenCoordinates;
         _mouseDownTime = 0;
 
         // don't want anything else to process the click,
@@ -240,8 +240,13 @@ public sealed class DragDropSystem : SharedDragDropSystem
 
         if (TryComp<SpriteComponent>(_draggedEntity, out var draggedSprite))
         {
+            var screenPos = _inputManager.MouseScreenPosition;
+            // No _draggedEntity in null window (Happens in tests)
+            if (!screenPos.IsValid)
+                return;
+
             // pop up drag shadow under mouse
-            var mousePos = _eyeManager.PixelToMap(_inputManager.MouseScreenPosition);
+            var mousePos = _eyeManager.PixelToMap(screenPos);
             _dragShadow = EntityManager.SpawnEntity("dragshadow", mousePos);
             var dragSprite = Comp<SpriteComponent>(_dragShadow.Value);
             dragSprite.CopyFrom(draggedSprite);

--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -90,7 +90,7 @@ public sealed class DragDropSystem : SharedDragDropSystem
     /// </summary>
     private bool _isReplaying;
 
-    private float _deadzone;
+    public float Deadzone;
 
     private DragState _state = DragState.NotDragging;
 
@@ -122,7 +122,7 @@ public sealed class DragDropSystem : SharedDragDropSystem
 
     private void SetDeadZone(float deadZone)
     {
-        _deadzone = deadZone;
+        Deadzone = deadZone;
     }
 
     public override void Shutdown()
@@ -539,7 +539,7 @@ public sealed class DragDropSystem : SharedDragDropSystem
             case DragState.MouseDown:
             {
                 var screenPos = _inputManager.MouseScreenPosition;
-                if ((_mouseDownScreenPos!.Value.Position - screenPos.Position).Length() > _deadzone)
+                if ((_mouseDownScreenPos!.Value.Position - screenPos.Position).Length() > Deadzone)
                 {
                     StartDrag();
                 }

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.Helpers.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.Helpers.cs
@@ -1207,11 +1207,12 @@ public abstract partial class InteractionTest
         BoundKeyFunction key,
         BoundKeyState state,
         NetCoordinates? coordinates = null,
-        NetEntity? cursorEntity = null)
+        NetEntity? cursorEntity = null,
+        ScreenCoordinates? screenCoordinates = null)
     {
         var coords = coordinates ?? TargetCoords;
         var target = cursorEntity ?? Target ?? default;
-        ScreenCoordinates screen = default;
+        var screen = screenCoordinates ?? default;
 
         var funcId = InputManager.NetworkBindMap.KeyFunctionID(key);
         var message = new ClientFullInputCmdMessage(CTiming.CurTick, CTiming.TickFraction, funcId)

--- a/Content.IntegrationTests/Tests/Strip/StrippableTest.cs
+++ b/Content.IntegrationTests/Tests/Strip/StrippableTest.cs
@@ -1,0 +1,43 @@
+﻿using Content.IntegrationTests.Tests.Interaction;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Input;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.Strip;
+
+public sealed class StrippableTest : InteractionTest
+{
+    protected override string PlayerPrototype => "MobHuman";
+
+    [Test]
+    public async Task DragDropOpensStrip()
+    {
+        // Spawn one tile away
+        TargetCoords = SEntMan.GetNetCoordinates(new EntityCoordinates(MapData.MapUid, 1, 0));
+        await SpawnTarget("MobHuman");
+
+        var userInterface = Comp<UserInterfaceComponent>(Target);
+        Assert.That(userInterface.Actors.Count == 0);
+
+        // Start drag
+        await SetKey(EngineKeyFunctions.Use,
+            BoundKeyState.Down,
+            TargetCoords,
+            Target,
+            screenCoordinates: new ScreenCoordinates(50f, 0f, WindowId.Main));
+        // screenCoordinates diff needs to be larger than DragDropSystem._deadzone
+
+        await RunTicks(5);
+
+        // End drag
+        await SetKey(EngineKeyFunctions.Use,
+            BoundKeyState.Up,
+            PlayerCoords,
+            Player,
+            screenCoordinates: new ScreenCoordinates(0f, 0f, WindowId.Main));
+
+        await RunTicks(5);
+
+        Assert.That(userInterface.Actors.Count > 0);
+    }
+}

--- a/Content.IntegrationTests/Tests/Strip/StrippableTest.cs
+++ b/Content.IntegrationTests/Tests/Strip/StrippableTest.cs
@@ -1,4 +1,5 @@
-﻿using Content.IntegrationTests.Tests.Interaction;
+﻿using Content.Client.Interaction;
+using Content.IntegrationTests.Tests.Interaction;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Input;
 using Robust.Shared.Map;
@@ -19,13 +20,15 @@ public sealed class StrippableTest : InteractionTest
         var userInterface = Comp<UserInterfaceComponent>(Target);
         Assert.That(userInterface.Actors.Count == 0);
 
+        // screenCoordinates diff needs to be larger than DragDropSystem._deadzone
+        var screenX = CEntMan.System<DragDropSystem>().Deadzone + 1f;
+
         // Start drag
         await SetKey(EngineKeyFunctions.Use,
             BoundKeyState.Down,
             TargetCoords,
             Target,
-            screenCoordinates: new ScreenCoordinates(50f, 0f, WindowId.Main));
-        // screenCoordinates diff needs to be larger than DragDropSystem._deadzone
+            screenCoordinates: new ScreenCoordinates(screenX, 0f, WindowId.Main));
 
         await RunTicks(5);
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds a test for strippable drag drop.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Changed DragDropSystem.Deadzone to public for access in tests.

DragDrop OnUseMouseDown mouse position fetching changed from `_inputManager.MouseScreenPosition` to `args.ScreenCoordinates`.

Disabled DragDrop ghost when ScreenCoordinates window is not valid.


Added screenCoordinates parameter to `InteractionTest.Helpers.SetKey`.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
