### PR TITLE
Removed Revolutionary Secret Weight

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,7 +2,6 @@
   id: Secret
   weights:
     Nukeops: 0.20
-    Traitor: 0.60
+    Traitor: 0.65
     Zombie: 0.05
     Survival: 0.10
-    Revolutionary: 0.05


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Disable Revolutionary Gamemode pending rework. 

## Why / Balance
Revolutionary mode is by far the worst gamemode to not only play, but also moderate. There's too many rule issues around this mode- such as metagaming and what is ok and what's not ok to call for a Revolution amongst the station. By the time a revolution could be called out legally it's likely too late. In order for a revolution to safely come to a halt within a good time limit it sadly has to be metagamed. As for it being awful to play; people can easily snitch out the head revs or other revs after being de-converted. Along with that, people are always complaining in LOOC or OOC about the rules around this mode claiming "you metagamed". Another issue I've seen is the flashes for Revs. They struggle to get more unless they're Sci. 

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
-->
:cl:
- Removed Revolutionaries Gamemode pending rework.
