### PR TITLE
Greatly improve the usability of the Gas Analyzer.

### DIFF
--- a/Content.Client/Atmos/UI/GasAnalyzerWindow.xaml.cs
+++ b/Content.Client/Atmos/UI/GasAnalyzerWindow.xaml.cs
@@ -16,6 +16,8 @@ namespace Content.Client.Atmos.UI
     [GenerateTypedNameReferences]
     public sealed partial class GasAnalyzerWindow : DefaultWindow
     {
+        private NetEntity _currentEntity = NetEntity.Invalid;
+
         public GasAnalyzerWindow()
         {
             RobustXamlLoader.Load(this);
@@ -55,6 +57,13 @@ namespace Content.Client.Atmos.UI
             // Device Tab
             if (msg.NodeGasMixes.Length > 1)
             {
+                if (_currentEntity != msg.DeviceUid)
+                {
+                    // when we get new device data switch to the device tab
+                    CTabContainer.CurrentTab = 0;
+                    _currentEntity = msg.DeviceUid;
+                }
+
                 CTabContainer.SetTabVisible(0, true);
                 CTabContainer.SetTabTitle(0, Loc.GetString("gas-analyzer-window-tab-title-capitalized", ("title", msg.DeviceName)));
                 // Set up Grid
@@ -143,6 +152,7 @@ namespace Content.Client.Atmos.UI
                 CTabContainer.SetTabVisible(0, false);
                 CTabContainer.CurrentTab = 1;
                 minSize = new Vector2(CEnvironmentMix.DesiredSize.X + 40, MinSize.Y);
+                _currentEntity = NetEntity.Invalid;
             }
 
             MinSize = minSize;

--- a/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
@@ -11,265 +11,264 @@ using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using static Content.Shared.Atmos.Components.GasAnalyzerComponent;
 
-namespace Content.Server.Atmos.EntitySystems
+namespace Content.Server.Atmos.EntitySystems;
+
+[UsedImplicitly]
+public sealed class GasAnalyzerSystem : EntitySystem
 {
-    [UsedImplicitly]
-    public sealed class GasAnalyzerSystem : EntitySystem
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly AtmosphereSystem _atmo = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly UserInterfaceSystem _userInterface = default!;
+    [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+
+    /// <summary>
+    /// Minimum moles of a gas to be sent to the client.
+    /// </summary>
+    private const float UIMinMoles = 0.01f;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly PopupSystem _popup = default!;
-        [Dependency] private readonly AtmosphereSystem _atmo = default!;
-        [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-        [Dependency] private readonly UserInterfaceSystem _userInterface = default!;
-        [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+        base.Initialize();
 
-        /// <summary>
-        /// Minimum moles of a gas to be sent to the client.
-        /// </summary>
-        private const float UIMinMoles = 0.01f;
+        SubscribeLocalEvent<GasAnalyzerComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<GasAnalyzerComponent, GasAnalyzerDisableMessage>(OnDisabledMessage);
+        SubscribeLocalEvent<GasAnalyzerComponent, DroppedEvent>(OnDropped);
+        SubscribeLocalEvent<GasAnalyzerComponent, UseInHandEvent>(OnUseInHand);
+    }
 
-        public override void Initialize()
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<ActiveGasAnalyzerComponent>();
+        while (query.MoveNext(out var uid, out var analyzer))
         {
-            base.Initialize();
+            // Don't update every tick
+            analyzer.AccumulatedFrametime += frameTime;
 
-            SubscribeLocalEvent<GasAnalyzerComponent, AfterInteractEvent>(OnAfterInteract);
-            SubscribeLocalEvent<GasAnalyzerComponent, GasAnalyzerDisableMessage>(OnDisabledMessage);
-            SubscribeLocalEvent<GasAnalyzerComponent, DroppedEvent>(OnDropped);
-            SubscribeLocalEvent<GasAnalyzerComponent, UseInHandEvent>(OnUseInHand);
+            if (analyzer.AccumulatedFrametime < analyzer.UpdateInterval)
+                continue;
+
+            analyzer.AccumulatedFrametime -= analyzer.UpdateInterval;
+
+            if (!UpdateAnalyzer(uid))
+                RemCompDeferred<ActiveGasAnalyzerComponent>(uid);
         }
+    }
 
-        public override void Update(float frameTime)
+    /// <summary>
+    /// Activates the analyzer when used in the world, scanning the target entity (if it exists) and the tile the analyzer is in
+    /// </summary>
+    private void OnAfterInteract(Entity<GasAnalyzerComponent> entity, ref AfterInteractEvent args)
+    {
+        var target = args.Target;
+        if (target != null && !_interactionSystem.InRangeUnobstructed((args.User, null), (target.Value, null)))
         {
-            var query = EntityQueryEnumerator<ActiveGasAnalyzerComponent>();
-            while (query.MoveNext(out var uid, out var analyzer))
-            {
-                // Don't update every tick
-                analyzer.AccumulatedFrametime += frameTime;
-
-                if (analyzer.AccumulatedFrametime < analyzer.UpdateInterval)
-                    continue;
-
-                analyzer.AccumulatedFrametime -= analyzer.UpdateInterval;
-
-                if (!UpdateAnalyzer(uid))
-                    RemCompDeferred<ActiveGasAnalyzerComponent>(uid);
-            }
+            target = null; // if the target is out of reach, invalidate it
         }
+        // always run the analyzer, regardless of weather or not there is a target
+        // since we can always show the local environment.
+        ActivateAnalyzer(entity, args.User, target);
+        args.Handled = true;
+    }
 
-        /// <summary>
-        /// Activates the analyzer when used in the world, scanning the target entity (if it exists) and the tile the analyzer is in
-        /// </summary>
-        private void OnAfterInteract(Entity<GasAnalyzerComponent> entity, ref AfterInteractEvent args)
+    /// <summary>
+    /// Activates the analyzer with no target, so it only scans the tile the user was on when activated
+    /// </summary>
+    private void OnUseInHand(Entity<GasAnalyzerComponent> entity, ref UseInHandEvent args)
+    {
+        if (!entity.Comp.Enabled)
         {
-            var target = args.Target;
-            if (target != null && !_interactionSystem.InRangeUnobstructed((args.User, null), (target.Value, null)))
-            {
-                target = null; // if the target is out of reach, invalidate it
-            }
-            // always run the analyzer, regardless of weather or not there is a target
-            // since we can always show the local environment.
-            ActivateAnalyzer(entity, args.User, target);
-            args.Handled = true;
+            ActivateAnalyzer(entity, args.User);
         }
-
-        /// <summary>
-        /// Activates the analyzer with no target, so it only scans the tile the user was on when activated
-        /// </summary>
-        private void OnUseInHand(Entity<GasAnalyzerComponent> entity, ref UseInHandEvent args)
+        else
         {
-            if (!entity.Comp.Enabled)
-            {
-                ActivateAnalyzer(entity, args.User);
-            }
-            else
-            {
-                DisableAnalyzer(entity, args.User);
-            }
-            args.Handled = true;
-        }
-
-        /// <summary>
-        /// Handles analyzer activation logic
-        /// </summary>
-        private void ActivateAnalyzer(Entity<GasAnalyzerComponent> entity, EntityUid user, EntityUid? target = null)
-        {
-            if (!_userInterface.TryOpenUi(entity.Owner, GasAnalyzerUiKey.Key, user))
-                return;
-
-            entity.Comp.Target = target;
-            entity.Comp.User = user;
-            entity.Comp.Enabled = true;
-            Dirty(entity);
-            _appearance.SetData(entity.Owner, GasAnalyzerVisuals.Enabled, entity.Comp.Enabled);
-            EnsureComp<ActiveGasAnalyzerComponent>(entity.Owner);
-            UpdateAnalyzer(entity.Owner, entity.Comp);
-        }
-
-        /// <summary>
-        /// Close the UI, turn the analyzer off, and don't update when it's dropped
-        /// </summary>
-        private void OnDropped(Entity<GasAnalyzerComponent> entity, ref DroppedEvent args)
-        {
-            if (args.User is var userId && entity.Comp.Enabled)
-                _popup.PopupEntity(Loc.GetString("gas-analyzer-shutoff"), userId, userId);
             DisableAnalyzer(entity, args.User);
         }
+        args.Handled = true;
+    }
 
-        /// <summary>
-        /// Closes the UI, sets the icon to off, and removes it from the update list
-        /// </summary>
-        private void DisableAnalyzer(Entity<GasAnalyzerComponent> entity, EntityUid? user = null)
+    /// <summary>
+    /// Handles analyzer activation logic
+    /// </summary>
+    private void ActivateAnalyzer(Entity<GasAnalyzerComponent> entity, EntityUid user, EntityUid? target = null)
+    {
+        if (!_userInterface.TryOpenUi(entity.Owner, GasAnalyzerUiKey.Key, user))
+            return;
+
+        entity.Comp.Target = target;
+        entity.Comp.User = user;
+        entity.Comp.Enabled = true;
+        Dirty(entity);
+        _appearance.SetData(entity.Owner, GasAnalyzerVisuals.Enabled, entity.Comp.Enabled);
+        EnsureComp<ActiveGasAnalyzerComponent>(entity.Owner);
+        UpdateAnalyzer(entity.Owner, entity.Comp);
+    }
+
+    /// <summary>
+    /// Close the UI, turn the analyzer off, and don't update when it's dropped
+    /// </summary>
+    private void OnDropped(Entity<GasAnalyzerComponent> entity, ref DroppedEvent args)
+    {
+        if (args.User is var userId && entity.Comp.Enabled)
+            _popup.PopupEntity(Loc.GetString("gas-analyzer-shutoff"), userId, userId);
+        DisableAnalyzer(entity, args.User);
+    }
+
+    /// <summary>
+    /// Closes the UI, sets the icon to off, and removes it from the update list
+    /// </summary>
+    private void DisableAnalyzer(Entity<GasAnalyzerComponent> entity, EntityUid? user = null)
+    {
+        _userInterface.CloseUi(entity.Owner, GasAnalyzerUiKey.Key, user);
+
+        entity.Comp.Enabled = false;
+        Dirty(entity);
+        _appearance.SetData(entity.Owner, GasAnalyzerVisuals.Enabled, entity.Comp.Enabled);
+        RemCompDeferred<ActiveGasAnalyzerComponent>(entity.Owner);
+    }
+
+    /// <summary>
+    /// Disables the analyzer when the user closes the UI
+    /// </summary>
+    private void OnDisabledMessage(Entity<GasAnalyzerComponent> entity, ref GasAnalyzerDisableMessage message)
+    {
+        DisableAnalyzer(entity);
+    }
+
+    /// <summary>
+    /// Fetches fresh data for the analyzer. Should only be called by Update or when the user requests an update via refresh button
+    /// </summary>
+    private bool UpdateAnalyzer(EntityUid uid, GasAnalyzerComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return false;
+
+        // check if the user has walked away from what they scanned
+        if (component.Target.HasValue)
         {
-            _userInterface.CloseUi(entity.Owner, GasAnalyzerUiKey.Key, user);
-
-            entity.Comp.Enabled = false;
-            Dirty(entity);
-            _appearance.SetData(entity.Owner, GasAnalyzerVisuals.Enabled, entity.Comp.Enabled);
-            RemCompDeferred<ActiveGasAnalyzerComponent>(entity.Owner);
-        }
-
-        /// <summary>
-        /// Disables the analyzer when the user closes the UI
-        /// </summary>
-        private void OnDisabledMessage(Entity<GasAnalyzerComponent> entity, ref GasAnalyzerDisableMessage message)
-        {
-            DisableAnalyzer(entity);
-        }
-
-        /// <summary>
-        /// Fetches fresh data for the analyzer. Should only be called by Update or when the user requests an update via refresh button
-        /// </summary>
-        private bool UpdateAnalyzer(EntityUid uid, GasAnalyzerComponent? component = null)
-        {
-            if (!Resolve(uid, ref component))
-                return false;
-
-            // check if the user has walked away from what they scanned
-            if (component.Target.HasValue)
+            // Listen! Even if you don't want the Gas Analyzer to work on moving targets, you should use
+            // this code to determine if the object is still generally in range so that the check is consistent with the code
+            // in OnAfterInteract() and also consistent with interaction code in general.
+            if (!_interactionSystem.InRangeUnobstructed((component.User, null), (component.Target.Value, null)))
             {
-                // Listen! Even if you don't want the Gas Analyzer to work on moving targets, you should use
-                // this code to determine if the object is still generally in range so that the check is consistent with the code
-                // in OnAfterInteract() and also consistent with interaction code in general.
-                if (!_interactionSystem.InRangeUnobstructed((component.User, null), (component.Target.Value, null)))
-                {
-                    if (component.User is { } userId && component.Enabled)
-                        _popup.PopupEntity(Loc.GetString("gas-analyzer-object-out-of-range"), userId, userId);
+                if (component.User is { } userId && component.Enabled)
+                    _popup.PopupEntity(Loc.GetString("gas-analyzer-object-out-of-range"), userId, userId);
 
-                    component.Target = null;
-                }
+                component.Target = null;
+            }
+        }
+
+        var gasMixList = new List<GasMixEntry>();
+
+        // Fetch the environmental atmosphere around the scanner. This must be the first entry
+        var tileMixture = _atmo.GetContainingMixture(uid, true);
+        if (tileMixture != null)
+        {
+            gasMixList.Add(new GasMixEntry(Loc.GetString("gas-analyzer-window-environment-tab-label"), tileMixture.Volume, tileMixture.Pressure, tileMixture.Temperature,
+                GenerateGasEntryArray(tileMixture)));
+        }
+        else
+        {
+            // No gases were found
+            gasMixList.Add(new GasMixEntry(Loc.GetString("gas-analyzer-window-environment-tab-label"), 0f, 0f, 0f));
+        }
+
+        var deviceFlipped = false;
+        if (component.Target != null)
+        {
+            if (Deleted(component.Target))
+            {
+                component.Target = null;
+                DisableAnalyzer((uid, component), component.User);
+                return false;
             }
 
-            var gasMixList = new List<GasMixEntry>();
+            var validTarget = false;
 
-            // Fetch the environmental atmosphere around the scanner. This must be the first entry
-            var tileMixture = _atmo.GetContainingMixture(uid, true);
-            if (tileMixture != null)
+            // gas analyzed was used on an entity, try to request gas data via event for override
+            var ev = new GasAnalyzerScanEvent();
+            RaiseLocalEvent(component.Target.Value, ev);
+
+            if (ev.GasMixtures != null)
             {
-                gasMixList.Add(new GasMixEntry(Loc.GetString("gas-analyzer-window-environment-tab-label"), tileMixture.Volume, tileMixture.Pressure, tileMixture.Temperature,
-                    GenerateGasEntryArray(tileMixture)));
+                foreach (var mixes in ev.GasMixtures)
+                {
+                    if (mixes.Item2 != null)
+                    {
+                        gasMixList.Add(new GasMixEntry(mixes.Item1, mixes.Item2.Volume, mixes.Item2.Pressure, mixes.Item2.Temperature, GenerateGasEntryArray(mixes.Item2)));
+                        validTarget = true;
+                    }
+                }
+
+                deviceFlipped = ev.DeviceFlipped;
             }
             else
             {
-                // No gases were found
-                gasMixList.Add(new GasMixEntry(Loc.GetString("gas-analyzer-window-environment-tab-label"), 0f, 0f, 0f));
-            }
-
-            var deviceFlipped = false;
-            if (component.Target != null)
-            {
-                if (Deleted(component.Target))
+                // No override, fetch manually, to handle flippable devices you must subscribe to GasAnalyzerScanEvent
+                if (TryComp(component.Target, out NodeContainerComponent? node))
                 {
-                    component.Target = null;
-                    DisableAnalyzer((uid, component), component.User);
-                    return false;
-                }
-
-                var validTarget = false;
-
-                // gas analyzed was used on an entity, try to request gas data via event for override
-                var ev = new GasAnalyzerScanEvent();
-                RaiseLocalEvent(component.Target.Value, ev);
-
-                if (ev.GasMixtures != null)
-                {
-                    foreach (var mixes in ev.GasMixtures)
+                    foreach (var pair in node.Nodes)
                     {
-                        if (mixes.Item2 != null)
+                        if (pair.Value is PipeNode pipeNode)
                         {
-                            gasMixList.Add(new GasMixEntry(mixes.Item1, mixes.Item2.Volume, mixes.Item2.Pressure, mixes.Item2.Temperature, GenerateGasEntryArray(mixes.Item2)));
+                            // check if the volume is zero for some reason so we don't divide by zero
+                            if (pipeNode.Air.Volume == 0f)
+                                continue;
+                            // only display the gas in the analyzed pipe element, not the whole system
+                            var pipeAir = pipeNode.Air.Clone();
+                            pipeAir.Multiply(pipeNode.Volume / pipeNode.Air.Volume);
+                            pipeAir.Volume = pipeNode.Volume;
+                            gasMixList.Add(new GasMixEntry(pair.Key, pipeAir.Volume, pipeAir.Pressure, pipeAir.Temperature, GenerateGasEntryArray(pipeAir)));
                             validTarget = true;
                         }
                     }
-
-                    deviceFlipped = ev.DeviceFlipped;
-                }
-                else
-                {
-                    // No override, fetch manually, to handle flippable devices you must subscribe to GasAnalyzerScanEvent
-                    if (TryComp(component.Target, out NodeContainerComponent? node))
-                    {
-                        foreach (var pair in node.Nodes)
-                        {
-                            if (pair.Value is PipeNode pipeNode)
-                            {
-                                // check if the volume is zero for some reason so we don't divide by zero
-                                if (pipeNode.Air.Volume == 0f)
-                                    continue;
-                                // only display the gas in the analyzed pipe element, not the whole system
-                                var pipeAir = pipeNode.Air.Clone();
-                                pipeAir.Multiply(pipeNode.Volume / pipeNode.Air.Volume);
-                                pipeAir.Volume = pipeNode.Volume;
-                                gasMixList.Add(new GasMixEntry(pair.Key, pipeAir.Volume, pipeAir.Pressure, pipeAir.Temperature, GenerateGasEntryArray(pipeAir)));
-                                validTarget = true;
-                            }
-                        }
-                    }
-                }
-
-                // If the target doesn't actually have any gas mixes to add,
-                // invalidate it as the target
-                if (!validTarget)
-                {
-                    component.Target = null;
                 }
             }
 
-            // Don't bother sending a UI message with no content, and stop updating I guess?
-            if (gasMixList.Count == 0)
-                return false;
-
-            _userInterface.ServerSendUiMessage(uid, GasAnalyzerUiKey.Key,
-                new GasAnalyzerUserMessage(gasMixList.ToArray(),
-                    component.Target != null ? Name(component.Target.Value) : string.Empty,
-                    GetNetEntity(component.Target) ?? NetEntity.Invalid,
-                    deviceFlipped));
-            return true;
-        }
-
-        /// <summary>
-        /// Generates a GasEntry array for a given GasMixture
-        /// </summary>
-        private GasEntry[] GenerateGasEntryArray(GasMixture? mixture)
-        {
-            var gases = new List<GasEntry>();
-
-            for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+            // If the target doesn't actually have any gas mixes to add,
+            // invalidate it as the target
+            if (!validTarget)
             {
-                var gas = _atmo.GetGas(i);
-
-                if (mixture?[i] <= UIMinMoles)
-                    continue;
-
-                if (mixture != null)
-                {
-                    var gasName = Loc.GetString(gas.Name);
-                    gases.Add(new GasEntry(gasName, mixture[i], gas.Color));
-                }
+                component.Target = null;
             }
-
-            var gasesOrdered = gases.OrderByDescending(gas => gas.Amount);
-
-            return gasesOrdered.ToArray();
         }
+
+        // Don't bother sending a UI message with no content, and stop updating I guess?
+        if (gasMixList.Count == 0)
+            return false;
+
+        _userInterface.ServerSendUiMessage(uid, GasAnalyzerUiKey.Key,
+            new GasAnalyzerUserMessage(gasMixList.ToArray(),
+                component.Target != null ? Name(component.Target.Value) : string.Empty,
+                GetNetEntity(component.Target) ?? NetEntity.Invalid,
+                deviceFlipped));
+        return true;
+    }
+
+    /// <summary>
+    /// Generates a GasEntry array for a given GasMixture
+    /// </summary>
+    private GasEntry[] GenerateGasEntryArray(GasMixture? mixture)
+    {
+        var gases = new List<GasEntry>();
+
+        for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+        {
+            var gas = _atmo.GetGas(i);
+
+            if (mixture?[i] <= UIMinMoles)
+                continue;
+
+            if (mixture != null)
+            {
+                var gasName = Loc.GetString(gas.Name);
+                gases.Add(new GasEntry(gasName, mixture[i], gas.Color));
+            }
+        }
+
+        var gasesOrdered = gases.OrderByDescending(gas => gas.Amount);
+
+        return gasesOrdered.ToArray();
     }
 }
 

--- a/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
@@ -61,7 +61,7 @@ namespace Content.Server.Atmos.EntitySystems
         /// <summary>
         /// Activates the analyzer when used in the world, scanning the target entity (if it exists) and the tile the analyzer is in
         /// </summary>
-        private void OnAfterInteract(EntityUid uid, GasAnalyzerComponent component, AfterInteractEvent args)
+        private void OnAfterInteract(Entity<GasAnalyzerComponent> entity, ref AfterInteractEvent args)
         {
             var target = args.Target;
             if (target != null && !_interactionSystem.InRangeUnobstructed((args.User, null), (target.Value, null)))
@@ -70,22 +70,22 @@ namespace Content.Server.Atmos.EntitySystems
             }
             // always run the analyzer, regardless of weather or not there is a target
             // since we can always show the local environment.
-            ActivateAnalyzer(uid, component, args.User, target);
+            ActivateAnalyzer(entity.Owner, entity.Comp, args.User, target);
             args.Handled = true;
         }
 
         /// <summary>
         /// Activates the analyzer with no target, so it only scans the tile the user was on when activated
         /// </summary>
-        private void OnUseInHand(EntityUid uid, GasAnalyzerComponent component, UseInHandEvent args)
+        private void OnUseInHand(Entity<GasAnalyzerComponent> entity, ref UseInHandEvent args)
         {
-            if (!component.Enabled)
+            if (!entity.Comp.Enabled)
             {
-                ActivateAnalyzer(uid, component, args.User);
+                ActivateAnalyzer(entity.Owner, entity.Comp, args.User);
             }
             else
             {
-                DisableAnalyzer(uid, component, args.User);
+                DisableAnalyzer(entity.Owner, entity.Comp, args.User);
             }
             args.Handled = true;
         }
@@ -110,11 +110,11 @@ namespace Content.Server.Atmos.EntitySystems
         /// <summary>
         /// Close the UI, turn the analyzer off, and don't update when it's dropped
         /// </summary>
-        private void OnDropped(EntityUid uid, GasAnalyzerComponent component, DroppedEvent args)
+        private void OnDropped(Entity<GasAnalyzerComponent> entity, ref DroppedEvent args)
         {
-            if (args.User is var userId && component.Enabled)
+            if (args.User is var userId && entity.Comp.Enabled)
                 _popup.PopupEntity(Loc.GetString("gas-analyzer-shutoff"), userId, userId);
-            DisableAnalyzer(uid, component, args.User);
+            DisableAnalyzer(entity.Owner, entity.Comp, args.User);
         }
 
         /// <summary>
@@ -136,9 +136,9 @@ namespace Content.Server.Atmos.EntitySystems
         /// <summary>
         /// Disables the analyzer when the user closes the UI
         /// </summary>
-        private void OnDisabledMessage(EntityUid uid, GasAnalyzerComponent component, GasAnalyzerDisableMessage message)
+        private void OnDisabledMessage(Entity<GasAnalyzerComponent> entity, ref GasAnalyzerDisableMessage message)
         {
-            DisableAnalyzer(uid, component);
+            DisableAnalyzer(entity.Owner, entity.Comp);
         }
 
         private bool TryOpenUserInterface(EntityUid uid, EntityUid user, GasAnalyzerComponent? component = null)

--- a/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
@@ -170,8 +170,7 @@ namespace Content.Server.Atmos.EntitySystems
                     if (component.User is { } userId && component.Enabled)
                         _popup.PopupEntity(Loc.GetString("gas-analyzer-object-out-of-range"), userId, userId);
 
-                    DisableAnalyzer(uid, component, component.User);
-                    return false;
+                    component.Target = null;
                 }
             }
 

--- a/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
@@ -64,10 +64,8 @@ namespace Content.Server.Atmos.EntitySystems
         private void OnAfterInteract(EntityUid uid, GasAnalyzerComponent component, AfterInteractEvent args)
         {
             var target = args.Target;
-            // only show the cannot-reach message when we've actually clicked an object
             if (target != null && !_interactionSystem.InRangeUnobstructed((args.User, null), (target.Value, null)))
             {
-                //_popup.PopupEntity(Loc.GetString("gas-analyzer-component-player-cannot-reach-message"), args.User, args.User);
                 target = null; // if the target is out of reach, invalidate it
             }
             // always run the analyzer, regardless of weather or not there is a target

--- a/Content.Server/Singularity/EntitySystems/RadiationCollectorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/RadiationCollectorSystem.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Content.Server.Atmos;
+using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Components;
 using Content.Server.Popups;
 using Content.Server.Power.Components;

--- a/Content.Shared/Atmos/Components/GasAnalyzerComponent.cs
+++ b/Content.Shared/Atmos/Components/GasAnalyzerComponent.cs
@@ -13,9 +13,6 @@ public sealed partial class GasAnalyzerComponent : Component
     [ViewVariables]
     public EntityUid User;
 
-    [ViewVariables(VVAccess.ReadWrite)]
-    public EntityCoordinates? LastPosition;
-
     [DataField("enabled"), ViewVariables(VVAccess.ReadWrite)]
     public bool Enabled;
 

--- a/Resources/Locale/en-US/atmos/gas-analyzer-component.ftl
+++ b/Resources/Locale/en-US/atmos/gas-analyzer-component.ftl
@@ -1,6 +1,7 @@
 ## Entity
 
 gas-analyzer-component-player-cannot-reach-message = You can't reach there.
+gas-analyzer-object-out-of-range = The object went out of range.
 gas-analyzer-shutoff = The gas analyzer shuts off.
 
 ## UI

--- a/Resources/Locale/en-US/atmos/gas-analyzer-component.ftl
+++ b/Resources/Locale/en-US/atmos/gas-analyzer-component.ftl
@@ -1,6 +1,5 @@
 ## Entity
 
-gas-analyzer-component-player-cannot-reach-message = You can't reach there.
 gas-analyzer-object-out-of-range = The object went out of range.
 gas-analyzer-shutoff = The gas analyzer shuts off.
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Greatly improve the usability of the Gas Analyzer. **None of the information the Gas Analyzer displays has changed** but I've made actually _using_ the gas analyzer much smoother:

- Fixed a bug where clicking an object with no relevant gas data would still cause the Analyzer window to close when that object went out of range.
- The range of the Gas Analyzer is now equal to the standard interaction range. Previously the range was subtly (and not intentionally) shorter.
- Using the Analyzer in your hand has proper enable/disable behavior.
- The Analyzer now says "The object went out of range." when the analyzed object goes out of range instead of just shutting off with no explanation. 
- The Analyzer no longer shuts down when the analyzed object goes out of range. You'll lose the info about the analyzed object, but the analyzer will simply switch to the environment tab instead of shutting down.
- Don't show an "out of reach" message for objects out of reach. Tools in the game generally don't work like this. Since the range of the Analyzer is equal to the regular interaction range, the standard red outline should be sufficient. 
- If the Analyzer is open to the environment tab and a new object is analyzed, switch the the device tab automatically.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

This before gif shows some of the weird behavior 
![analyzer-bad](https://github.com/user-attachments/assets/51db996f-022a-4f90-b5ac-99b3fb1a2c44)

This gif shows some of the new behavior
![analyzer-good](https://github.com/user-attachments/assets/bb557bf8-e867-4b47-90cf-ef7b7333c35e)


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The Gas Analyzer won't spuriously shut down for seemly no reason.
- tweak: The Gas Analyzer will always switch to the device tab when a new object is scanned.
- fix: The Gas Analyzer's interaction range is now equal to the standard interaction range
- fix: Clicking the Gas Analyzer when it's in your hand has proper enable/disable behavior. 