### PR TITLE
Fix Reagent Fire Stacks

### DIFF
--- a/Content.Server/EntityEffects/Effects/FlammableReaction.cs
+++ b/Content.Server/EntityEffects/Effects/FlammableReaction.cs
@@ -29,7 +29,7 @@ namespace Content.Server.EntityEffects.Effects
             if (!args.EntityManager.TryGetComponent(args.TargetEntity, out FlammableComponent? flammable))
                 return;
 
-            // Sets the multiplier for firestacks if firestacks are already on target only if MultiplierOnExisting is 0 or greater
+            // Sets the multiplier for FireStacks to MultiplierOnExisting is 0 or greater and target already has FireStacks
             var multiplier = flammable.FireStacks != 0f && MultiplierOnExisting >= 0 ? MultiplierOnExisting : Multiplier;
             var quantity = 1f;
             if (args is EntityEffectReagentArgs reagentArgs)

--- a/Content.Server/EntityEffects/Effects/FlammableReaction.cs
+++ b/Content.Server/EntityEffects/Effects/FlammableReaction.cs
@@ -13,6 +13,7 @@ namespace Content.Server.EntityEffects.Effects
         [DataField]
         public float Multiplier = 0.05f;
 
+        // The fire stack multiplier if fire stacks already exist on target, only works if 0 or greater
         [DataField]
         public float MultiplierOnExisting = -1f;
 
@@ -28,6 +29,7 @@ namespace Content.Server.EntityEffects.Effects
             if (!args.EntityManager.TryGetComponent(args.TargetEntity, out FlammableComponent? flammable))
                 return;
 
+            // Sets the multiplier for firestacks if firestacks are already on target only if MultiplierOnExisting is 0 or greater
             var multiplier = flammable.FireStacks != 0f && MultiplierOnExisting >= 0 ? MultiplierOnExisting : Multiplier;
             var quantity = 1f;
             if (args is EntityEffectReagentArgs reagentArgs)

--- a/Content.Server/EntityEffects/Effects/FlammableReaction.cs
+++ b/Content.Server/EntityEffects/Effects/FlammableReaction.cs
@@ -14,7 +14,7 @@ namespace Content.Server.EntityEffects.Effects
         public float Multiplier = 0.05f;
 
         [DataField]
-        public float MultiplierOnExisting = 1f;
+        public float MultiplierOnExisting = -1f;
 
         public override bool ShouldLog => true;
 
@@ -28,7 +28,7 @@ namespace Content.Server.EntityEffects.Effects
             if (!args.EntityManager.TryGetComponent(args.TargetEntity, out FlammableComponent? flammable))
                 return;
 
-            var multiplier = flammable.FireStacks == 0f ? Multiplier : MultiplierOnExisting;
+            var multiplier = flammable.FireStacks != 0f && MultiplierOnExisting >= 0 ? MultiplierOnExisting : Multiplier;
             var quantity = 1f;
             if (args is EntityEffectReagentArgs reagentArgs)
             {


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes reagents applying too many fire stacks to a person if they already have fire stacks
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Uh... I'm not sure if the original post was about this but the bug was found in #30595... Here is the video showing the issue:

https://github.com/user-attachments/assets/98549ffe-eb6f-475e-8ad7-730eacc2505f

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
#28168 created the bug. Fixes the issue by making `MultiplierOnExisting` get ignored if less than one and makes the default for `MultiplierOnExisting` -1. This method also fixes any other unintentional bugs from the pr that created it.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

https://github.com/user-attachments/assets/faa1c755-8253-4d68-ba58-7d0acba00c45

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

https://github.com/user-attachments/assets/0706c75d-0e62-4f90-9caa-0ab0c8fa9a6c

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
- fix: Reagents now apply the correct number of fire stacks
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
