### PR TITLE
Fix for issue #30781

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/ship_vs_ship.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/ship_vs_ship.yml
@@ -17,8 +17,8 @@
 - type: entity
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitRecruitSyndie
-  name: syndicate recuit jumpsuit
-  description: A dubious,, dark-grey jumpsuit. As if passengers weren't dubious enough already.
+  name: syndicate recruit jumpsuit
+  description: A dubious, dark-grey jumpsuit. As if passengers weren't dubious enough already.
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpsuit/recruit_syndie.rsi


### PR DESCRIPTION
Fixed typos in name and description of syndicate recruit jumpsuit.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Typo in syndicate recruit jumpsuit name and description.

## Why / Balance
Fix for issue #30781 

## Technical details
Simple YAML edit.

## Media
N/A

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
- fix: Typos in syndicate recruit jumpsuit name and description.