### PR TITLE
tweak(marathon): Remove vents from airlock

### DIFF
--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -10985,7 +10985,7 @@ entities:
       pos: -20.5,-5.5
       parent: 30
     - type: Door
-      secondsUntilStateChange: -21151.791
+      secondsUntilStateChange: -21403.99
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -60040,8 +60040,8 @@ entities:
       pos: -21.5,-39.5
       parent: 30
     - type: FaxMachine
-      destinationAddress: Engineering
       name: Engineering
+      destinationAddress: Engineering
   - uid: 14477
     components:
     - type: Transform
@@ -63690,14 +63690,14 @@ entities:
       pos: -53.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 943
     components:
     - type: Transform
       pos: -47.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 946
     components:
     - type: Transform
@@ -63720,7 +63720,7 @@ entities:
       pos: -49.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2576
     components:
     - type: Transform
@@ -63735,7 +63735,7 @@ entities:
       pos: -31.5,53.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2578
     components:
     - type: Transform
@@ -63743,7 +63743,7 @@ entities:
       pos: -29.5,53.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2579
     components:
     - type: Transform
@@ -63766,7 +63766,7 @@ entities:
       pos: -29.5,57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2681
     components:
     - type: Transform
@@ -63774,7 +63774,7 @@ entities:
       pos: -50.5,57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2700
     components:
     - type: Transform
@@ -63782,14 +63782,14 @@ entities:
       pos: -50.5,67.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2701
     components:
     - type: Transform
       pos: -46.5,67.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2711
     components:
     - type: Transform
@@ -63850,7 +63850,7 @@ entities:
       pos: -25.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3078
     components:
     - type: Transform
@@ -63858,7 +63858,7 @@ entities:
       pos: -40.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3114
     components:
     - type: Transform
@@ -63866,14 +63866,14 @@ entities:
       pos: -47.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3116
     components:
     - type: Transform
       pos: -44.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3271
     components:
     - type: Transform
@@ -63890,13 +63890,22 @@ entities:
       parent: 30
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 3286
+  - uid: 3284
     components:
     - type: Transform
-      pos: -57.5,23.5
+      rot: 3.141592653589793 rad
+      pos: -57.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
+  - uid: 3285
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -57.5,18.5
+      parent: 30
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 3307
     components:
     - type: Transform
@@ -63911,7 +63920,7 @@ entities:
       pos: -16.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3356
     components:
     - type: Transform
@@ -63926,7 +63935,7 @@ entities:
       pos: -24.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3372
     components:
     - type: Transform
@@ -63941,7 +63950,7 @@ entities:
       pos: -26.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3375
     components:
     - type: Transform
@@ -63949,7 +63958,7 @@ entities:
       pos: -24.5,12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 4141
     components:
     - type: Transform
@@ -63957,14 +63966,14 @@ entities:
       pos: -63.5,-62.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 4424
     components:
     - type: Transform
       pos: -24.5,7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6148
     components:
     - type: Transform
@@ -63986,14 +63995,14 @@ entities:
       pos: -3.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6200
     components:
     - type: Transform
       pos: -7.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6201
     components:
     - type: Transform
@@ -64001,7 +64010,7 @@ entities:
       pos: -11.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6202
     components:
     - type: Transform
@@ -64009,7 +64018,7 @@ entities:
       pos: -11.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6203
     components:
     - type: Transform
@@ -64017,7 +64026,7 @@ entities:
       pos: -15.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6250
     components:
     - type: Transform
@@ -64067,7 +64076,7 @@ entities:
       pos: -17.5,-0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6936
     components:
     - type: Transform
@@ -64082,7 +64091,7 @@ entities:
       pos: -18.5,-0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7001
     components:
     - type: Transform
@@ -64108,14 +64117,14 @@ entities:
       pos: -30.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7154
     components:
     - type: Transform
       pos: -30.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7204
     components:
     - type: Transform
@@ -64123,7 +64132,7 @@ entities:
       pos: -34.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7353
     components:
     - type: Transform
@@ -64206,7 +64215,7 @@ entities:
       pos: -22.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8576
     components:
     - type: Transform
@@ -64316,21 +64325,21 @@ entities:
       pos: 13.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8966
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8978
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9023
     components:
     - type: Transform
@@ -64345,7 +64354,7 @@ entities:
       pos: -13.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9063
     components:
     - type: Transform
@@ -64414,7 +64423,7 @@ entities:
       pos: -1.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9770
     components:
     - type: Transform
@@ -64453,7 +64462,7 @@ entities:
       pos: -24.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9898
     components:
     - type: Transform
@@ -64468,7 +64477,7 @@ entities:
       pos: -11.5,-29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9983
     components:
     - type: Transform
@@ -64476,7 +64485,7 @@ entities:
       pos: 7.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10604
     components:
     - type: Transform
@@ -64484,7 +64493,7 @@ entities:
       pos: -1.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10606
     components:
     - type: Transform
@@ -64492,7 +64501,7 @@ entities:
       pos: -12.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10636
     components:
     - type: Transform
@@ -64546,7 +64555,7 @@ entities:
       pos: 34.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11778
     components:
     - type: Transform
@@ -64561,7 +64570,7 @@ entities:
       pos: 33.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11874
     components:
     - type: Transform
@@ -64584,7 +64593,7 @@ entities:
       pos: 33.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12493
     components:
     - type: Transform
@@ -64592,7 +64601,7 @@ entities:
       pos: 9.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12514
     components:
     - type: Transform
@@ -64608,14 +64617,14 @@ entities:
       pos: 23.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12588
     components:
     - type: Transform
       pos: 26.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12589
     components:
     - type: Transform
@@ -64623,7 +64632,7 @@ entities:
       pos: 26.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12610
     components:
     - type: Transform
@@ -64631,7 +64640,7 @@ entities:
       pos: 27.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12618
     components:
     - type: Transform
@@ -64647,14 +64656,14 @@ entities:
       pos: -24.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12659
     components:
     - type: Transform
       pos: -52.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12750
     components:
     - type: Transform
@@ -64674,7 +64683,7 @@ entities:
       pos: -62.5,-62.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12883
     components:
     - type: Transform
@@ -64690,7 +64699,7 @@ entities:
       pos: 43.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12909
     components:
     - type: Transform
@@ -64698,7 +64707,7 @@ entities:
       pos: 42.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12926
     components:
     - type: Transform
@@ -64712,14 +64721,14 @@ entities:
       pos: 23.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12995
     components:
     - type: Transform
       pos: 18.5,20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12996
     components:
     - type: Transform
@@ -64727,7 +64736,7 @@ entities:
       pos: 18.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13016
     components:
     - type: Transform
@@ -64789,7 +64798,7 @@ entities:
       pos: 31.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13791
     components:
     - type: Transform
@@ -64805,7 +64814,7 @@ entities:
       pos: -25.5,7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14451
     components:
     - type: Transform
@@ -64813,7 +64822,7 @@ entities:
       pos: -25.5,12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14978
     components:
     - type: Transform
@@ -64821,7 +64830,7 @@ entities:
       pos: 16.5,43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15452
     components:
     - type: Transform
@@ -64829,7 +64838,7 @@ entities:
       pos: 52.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15888
     components:
     - type: Transform
@@ -64837,7 +64846,7 @@ entities:
       pos: 42.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15890
     components:
     - type: Transform
@@ -64845,7 +64854,7 @@ entities:
       pos: 32.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15963
     components:
     - type: Transform
@@ -64853,7 +64862,7 @@ entities:
       pos: 42.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 16099
     components:
     - type: Transform
@@ -64880,7 +64889,7 @@ entities:
       pos: 16.5,12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18075
     components:
     - type: Transform
@@ -64888,7 +64897,7 @@ entities:
       pos: 16.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18385
     components:
     - type: Transform
@@ -64912,7 +64921,7 @@ entities:
       pos: -44.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18447
     components:
     - type: Transform
@@ -64920,7 +64929,7 @@ entities:
       pos: -63.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18478
     components:
     - type: Transform
@@ -64936,7 +64945,7 @@ entities:
       pos: -61.5,-38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18484
     components:
     - type: Transform
@@ -64951,7 +64960,7 @@ entities:
       pos: -58.5,-38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18498
     components:
     - type: Transform
@@ -64982,7 +64991,7 @@ entities:
       pos: -68.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18613
     components:
     - type: Transform
@@ -64998,7 +65007,7 @@ entities:
       pos: -58.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18648
     components:
     - type: Transform
@@ -65006,7 +65015,7 @@ entities:
       pos: -79.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18661
     components:
     - type: Transform
@@ -65014,7 +65023,7 @@ entities:
       pos: -77.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18743
     components:
     - type: Transform
@@ -65113,7 +65122,7 @@ entities:
       pos: -0.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22264
     components:
     - type: Transform
@@ -65121,14 +65130,14 @@ entities:
       pos: 42.5,16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22266
     components:
     - type: Transform
       pos: 43.5,16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
 - proto: GasPipeFourway
   entities:
   - uid: 2101
@@ -65137,7 +65146,7 @@ entities:
       pos: 32.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2430
     components:
     - type: Transform
@@ -65151,7 +65160,7 @@ entities:
       pos: -48.5,67.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2770
     components:
     - type: Transform
@@ -65165,7 +65174,7 @@ entities:
       pos: -10.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2807
     components:
     - type: Transform
@@ -65200,28 +65209,28 @@ entities:
       pos: -34.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2950
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2957
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2986
     components:
     - type: Transform
       pos: 10.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7002
     components:
     - type: Transform
@@ -65240,7 +65249,7 @@ entities:
       pos: -34.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7603
     components:
     - type: Transform
@@ -65259,7 +65268,7 @@ entities:
       pos: 10.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8845
     components:
     - type: Transform
@@ -65273,14 +65282,14 @@ entities:
       pos: 5.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8870
     components:
     - type: Transform
       pos: 13.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8955
     components:
     - type: Transform
@@ -65294,14 +65303,14 @@ entities:
       pos: -12.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10439
     components:
     - type: Transform
       pos: -6.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11876
     components:
     - type: Transform
@@ -65315,14 +65324,14 @@ entities:
       pos: 20.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12001
     components:
     - type: Transform
       pos: 30.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12541
     components:
     - type: Transform
@@ -65336,7 +65345,7 @@ entities:
       pos: 23.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12886
     components:
     - type: Transform
@@ -65360,7 +65369,7 @@ entities:
       pos: -50.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 475
     components:
     - type: Transform
@@ -65400,7 +65409,7 @@ entities:
       pos: -48.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 935
     components:
     - type: Transform
@@ -65416,7 +65425,7 @@ entities:
       pos: -46.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 942
     components:
     - type: Transform
@@ -65424,7 +65433,7 @@ entities:
       pos: -49.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 944
     components:
     - type: Transform
@@ -65445,7 +65454,7 @@ entities:
       pos: -44.5,-4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 1076
     components:
     - type: Transform
@@ -65453,7 +65462,7 @@ entities:
       pos: -47.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 1307
     components:
     - type: Transform
@@ -65461,7 +65470,7 @@ entities:
       pos: -52.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 1308
     components:
     - type: Transform
@@ -65469,14 +65478,14 @@ entities:
       pos: -51.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 1415
     components:
     - type: Transform
       pos: -47.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 1929
     components:
     - type: Transform
@@ -65491,7 +65500,7 @@ entities:
       pos: 32.5,7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2432
     components:
     - type: Transform
@@ -65531,7 +65540,7 @@ entities:
       pos: -34.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2437
     components:
     - type: Transform
@@ -65539,7 +65548,7 @@ entities:
       pos: -34.5,33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2438
     components:
     - type: Transform
@@ -65555,7 +65564,7 @@ entities:
       pos: -34.5,32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2443
     components:
     - type: Transform
@@ -65563,7 +65572,7 @@ entities:
       pos: -35.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2444
     components:
     - type: Transform
@@ -65571,7 +65580,7 @@ entities:
       pos: -36.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2445
     components:
     - type: Transform
@@ -65579,7 +65588,7 @@ entities:
       pos: -37.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2446
     components:
     - type: Transform
@@ -65587,7 +65596,7 @@ entities:
       pos: -38.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2447
     components:
     - type: Transform
@@ -65595,7 +65604,7 @@ entities:
       pos: -39.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2448
     components:
     - type: Transform
@@ -65627,7 +65636,7 @@ entities:
       pos: -40.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2457
     components:
     - type: Transform
@@ -65643,7 +65652,7 @@ entities:
       pos: -42.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2461
     components:
     - type: Transform
@@ -65651,7 +65660,7 @@ entities:
       pos: -44.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2462
     components:
     - type: Transform
@@ -65659,7 +65668,7 @@ entities:
       pos: -43.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2464
     components:
     - type: Transform
@@ -65667,7 +65676,7 @@ entities:
       pos: -46.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2465
     components:
     - type: Transform
@@ -65675,7 +65684,7 @@ entities:
       pos: -47.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2466
     components:
     - type: Transform
@@ -65683,7 +65692,7 @@ entities:
       pos: -48.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2467
     components:
     - type: Transform
@@ -65746,14 +65755,14 @@ entities:
       pos: -49.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2477
     components:
     - type: Transform
       pos: -49.5,33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2478
     components:
     - type: Transform
@@ -65788,14 +65797,14 @@ entities:
       pos: -41.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2485
     components:
     - type: Transform
       pos: -41.5,33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2486
     components:
     - type: Transform
@@ -65845,7 +65854,7 @@ entities:
       pos: -34.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2499
     components:
     - type: Transform
@@ -65853,7 +65862,7 @@ entities:
       pos: -34.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2500
     components:
     - type: Transform
@@ -65861,7 +65870,7 @@ entities:
       pos: -34.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2501
     components:
     - type: Transform
@@ -65869,7 +65878,7 @@ entities:
       pos: -34.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2502
     components:
     - type: Transform
@@ -65909,7 +65918,7 @@ entities:
       pos: -32.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2515
     components:
     - type: Transform
@@ -65917,7 +65926,7 @@ entities:
       pos: -31.5,43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2516
     components:
     - type: Transform
@@ -65925,7 +65934,7 @@ entities:
       pos: -31.5,44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2517
     components:
     - type: Transform
@@ -65933,7 +65942,7 @@ entities:
       pos: -31.5,45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2518
     components:
     - type: Transform
@@ -65949,7 +65958,7 @@ entities:
       pos: -31.5,47.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2528
     components:
     - type: Transform
@@ -65997,7 +66006,7 @@ entities:
       pos: -32.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2535
     components:
     - type: Transform
@@ -66005,7 +66014,7 @@ entities:
       pos: -33.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2536
     components:
     - type: Transform
@@ -66013,7 +66022,7 @@ entities:
       pos: -34.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2537
     components:
     - type: Transform
@@ -66021,7 +66030,7 @@ entities:
       pos: -35.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2538
     components:
     - type: Transform
@@ -66029,7 +66038,7 @@ entities:
       pos: -36.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2539
     components:
     - type: Transform
@@ -66037,7 +66046,7 @@ entities:
       pos: -37.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2540
     components:
     - type: Transform
@@ -66045,7 +66054,7 @@ entities:
       pos: -38.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2541
     components:
     - type: Transform
@@ -66053,7 +66062,7 @@ entities:
       pos: -39.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2543
     components:
     - type: Transform
@@ -66077,7 +66086,7 @@ entities:
       pos: -40.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2548
     components:
     - type: Transform
@@ -66101,7 +66110,7 @@ entities:
       pos: -40.5,50.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2555
     components:
     - type: Transform
@@ -66129,21 +66138,21 @@ entities:
       pos: -31.5,50.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2559
     components:
     - type: Transform
       pos: -31.5,51.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2560
     components:
     - type: Transform
       pos: -31.5,52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2561
     components:
     - type: Transform
@@ -66207,7 +66216,7 @@ entities:
       pos: -30.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2569
     components:
     - type: Transform
@@ -66215,7 +66224,7 @@ entities:
       pos: -29.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2570
     components:
     - type: Transform
@@ -66223,7 +66232,7 @@ entities:
       pos: -28.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2571
     components:
     - type: Transform
@@ -66231,7 +66240,7 @@ entities:
       pos: -27.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2572
     components:
     - type: Transform
@@ -66239,7 +66248,7 @@ entities:
       pos: -26.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2575
     components:
     - type: Transform
@@ -66255,7 +66264,7 @@ entities:
       pos: -29.5,54.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2585
     components:
     - type: Transform
@@ -66287,7 +66296,7 @@ entities:
       pos: -29.5,56.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2589
     components:
     - type: Transform
@@ -66295,7 +66304,7 @@ entities:
       pos: -29.5,55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2590
     components:
     - type: Transform
@@ -66303,7 +66312,7 @@ entities:
       pos: -30.5,57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2591
     components:
     - type: Transform
@@ -66318,7 +66327,7 @@ entities:
       pos: -46.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2603
     components:
     - type: Transform
@@ -66367,7 +66376,7 @@ entities:
       pos: -42.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2610
     components:
     - type: Transform
@@ -66395,7 +66404,7 @@ entities:
       pos: -38.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2614
     components:
     - type: Transform
@@ -66403,7 +66412,7 @@ entities:
       pos: -35.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2615
     components:
     - type: Transform
@@ -66411,7 +66420,7 @@ entities:
       pos: -36.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2616
     components:
     - type: Transform
@@ -66419,7 +66428,7 @@ entities:
       pos: -37.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2617
     components:
     - type: Transform
@@ -66427,7 +66436,7 @@ entities:
       pos: -39.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2618
     components:
     - type: Transform
@@ -66435,7 +66444,7 @@ entities:
       pos: -40.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2620
     components:
     - type: Transform
@@ -66443,7 +66452,7 @@ entities:
       pos: -43.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2621
     components:
     - type: Transform
@@ -66451,7 +66460,7 @@ entities:
       pos: -44.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2622
     components:
     - type: Transform
@@ -66459,7 +66468,7 @@ entities:
       pos: -45.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2623
     components:
     - type: Transform
@@ -66531,7 +66540,7 @@ entities:
       pos: -46.5,43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2633
     components:
     - type: Transform
@@ -66539,7 +66548,7 @@ entities:
       pos: -46.5,44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2634
     components:
     - type: Transform
@@ -66547,7 +66556,7 @@ entities:
       pos: -46.5,45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2635
     components:
     - type: Transform
@@ -66555,7 +66564,7 @@ entities:
       pos: -46.5,46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2636
     components:
     - type: Transform
@@ -66595,7 +66604,7 @@ entities:
       pos: -46.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2652
     components:
     - type: Transform
@@ -66603,7 +66612,7 @@ entities:
       pos: -46.5,47.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2653
     components:
     - type: Transform
@@ -66619,7 +66628,7 @@ entities:
       pos: -46.5,53.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2656
     components:
     - type: Transform
@@ -66627,7 +66636,7 @@ entities:
       pos: -46.5,50.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2657
     components:
     - type: Transform
@@ -66635,7 +66644,7 @@ entities:
       pos: -46.5,51.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2660
     components:
     - type: Transform
@@ -66667,7 +66676,7 @@ entities:
       pos: -46.5,54.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2665
     components:
     - type: Transform
@@ -66675,7 +66684,7 @@ entities:
       pos: -46.5,55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2666
     components:
     - type: Transform
@@ -66699,7 +66708,7 @@ entities:
       pos: -47.5,52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2673
     components:
     - type: Transform
@@ -66707,7 +66716,7 @@ entities:
       pos: -48.5,52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2674
     components:
     - type: Transform
@@ -66715,7 +66724,7 @@ entities:
       pos: -49.5,52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2678
     components:
     - type: Transform
@@ -66723,7 +66732,7 @@ entities:
       pos: -47.5,57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2679
     components:
     - type: Transform
@@ -66731,7 +66740,7 @@ entities:
       pos: -48.5,57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2680
     components:
     - type: Transform
@@ -66739,7 +66748,7 @@ entities:
       pos: -49.5,57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2682
     components:
     - type: Transform
@@ -66747,7 +66756,7 @@ entities:
       pos: -50.5,58.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2683
     components:
     - type: Transform
@@ -66755,7 +66764,7 @@ entities:
       pos: -46.5,58.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2684
     components:
     - type: Transform
@@ -66763,7 +66772,7 @@ entities:
       pos: -46.5,59.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2685
     components:
     - type: Transform
@@ -66771,7 +66780,7 @@ entities:
       pos: -46.5,60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2686
     components:
     - type: Transform
@@ -66779,7 +66788,7 @@ entities:
       pos: -50.5,60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2687
     components:
     - type: Transform
@@ -66787,77 +66796,77 @@ entities:
       pos: -50.5,59.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2690
     components:
     - type: Transform
       pos: -50.5,62.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2691
     components:
     - type: Transform
       pos: -46.5,62.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2692
     components:
     - type: Transform
       pos: -46.5,63.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2693
     components:
     - type: Transform
       pos: -46.5,64.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2694
     components:
     - type: Transform
       pos: -46.5,65.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2695
     components:
     - type: Transform
       pos: -46.5,66.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2696
     components:
     - type: Transform
       pos: -50.5,63.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2697
     components:
     - type: Transform
       pos: -50.5,64.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2698
     components:
     - type: Transform
       pos: -50.5,65.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2699
     components:
     - type: Transform
       pos: -50.5,66.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2703
     components:
     - type: Transform
@@ -66865,7 +66874,7 @@ entities:
       pos: -49.5,67.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2704
     components:
     - type: Transform
@@ -66873,7 +66882,7 @@ entities:
       pos: -47.5,67.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2710
     components:
     - type: Transform
@@ -67009,7 +67018,7 @@ entities:
       pos: -30.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2740
     components:
     - type: Transform
@@ -67017,7 +67026,7 @@ entities:
       pos: -29.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2747
     components:
     - type: Transform
@@ -67883,154 +67892,154 @@ entities:
       pos: -34.5,30.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2890
     components:
     - type: Transform
       pos: -34.5,29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2891
     components:
     - type: Transform
       pos: -34.5,28.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2892
     components:
     - type: Transform
       pos: -34.5,27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2894
     components:
     - type: Transform
       pos: -34.5,24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2895
     components:
     - type: Transform
       pos: -34.5,23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2896
     components:
     - type: Transform
       pos: -34.5,22.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2897
     components:
     - type: Transform
       pos: -34.5,21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2898
     components:
     - type: Transform
       pos: -34.5,20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2900
     components:
     - type: Transform
       pos: -34.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2901
     components:
     - type: Transform
       pos: -34.5,17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2902
     components:
     - type: Transform
       pos: -34.5,16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2903
     components:
     - type: Transform
       pos: -34.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2904
     components:
     - type: Transform
       pos: -34.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2906
     components:
     - type: Transform
       pos: -34.5,12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2907
     components:
     - type: Transform
       pos: -34.5,11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2908
     components:
     - type: Transform
       pos: -34.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2911
     components:
     - type: Transform
       pos: -34.5,7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2912
     components:
     - type: Transform
       pos: -34.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2914
     components:
     - type: Transform
       pos: -34.5,4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2915
     components:
     - type: Transform
       pos: -34.5,3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2916
     components:
     - type: Transform
       pos: -34.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2918
     components:
     - type: Transform
@@ -68038,7 +68047,7 @@ entities:
       pos: -33.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2920
     components:
     - type: Transform
@@ -68046,7 +68055,7 @@ entities:
       pos: -31.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2921
     components:
     - type: Transform
@@ -68054,7 +68063,7 @@ entities:
       pos: -30.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2922
     components:
     - type: Transform
@@ -68062,7 +68071,7 @@ entities:
       pos: -29.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2923
     components:
     - type: Transform
@@ -68070,7 +68079,7 @@ entities:
       pos: -28.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2925
     components:
     - type: Transform
@@ -68078,7 +68087,7 @@ entities:
       pos: -26.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2926
     components:
     - type: Transform
@@ -68086,7 +68095,7 @@ entities:
       pos: -25.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2927
     components:
     - type: Transform
@@ -68094,7 +68103,7 @@ entities:
       pos: -24.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2928
     components:
     - type: Transform
@@ -68102,7 +68111,7 @@ entities:
       pos: -23.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2929
     components:
     - type: Transform
@@ -68110,7 +68119,7 @@ entities:
       pos: -22.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2930
     components:
     - type: Transform
@@ -68118,7 +68127,7 @@ entities:
       pos: -21.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2931
     components:
     - type: Transform
@@ -68126,7 +68135,7 @@ entities:
       pos: -20.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2934
     components:
     - type: Transform
@@ -68134,7 +68143,7 @@ entities:
       pos: -16.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2936
     components:
     - type: Transform
@@ -68142,7 +68151,7 @@ entities:
       pos: -15.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2937
     components:
     - type: Transform
@@ -68150,7 +68159,7 @@ entities:
       pos: -14.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2938
     components:
     - type: Transform
@@ -68158,7 +68167,7 @@ entities:
       pos: -13.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2939
     components:
     - type: Transform
@@ -68166,7 +68175,7 @@ entities:
       pos: -12.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2940
     components:
     - type: Transform
@@ -68174,7 +68183,7 @@ entities:
       pos: -11.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2942
     components:
     - type: Transform
@@ -68182,7 +68191,7 @@ entities:
       pos: -9.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2943
     components:
     - type: Transform
@@ -68190,7 +68199,7 @@ entities:
       pos: -8.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2944
     components:
     - type: Transform
@@ -68198,7 +68207,7 @@ entities:
       pos: -7.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2945
     components:
     - type: Transform
@@ -68206,7 +68215,7 @@ entities:
       pos: -6.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2946
     components:
     - type: Transform
@@ -68214,7 +68223,7 @@ entities:
       pos: -5.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2947
     components:
     - type: Transform
@@ -68222,7 +68231,7 @@ entities:
       pos: -4.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2948
     components:
     - type: Transform
@@ -68230,7 +68239,7 @@ entities:
       pos: -3.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2949
     components:
     - type: Transform
@@ -68238,7 +68247,7 @@ entities:
       pos: -2.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2951
     components:
     - type: Transform
@@ -68246,7 +68255,7 @@ entities:
       pos: -0.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2952
     components:
     - type: Transform
@@ -68254,7 +68263,7 @@ entities:
       pos: 0.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2953
     components:
     - type: Transform
@@ -68262,7 +68271,7 @@ entities:
       pos: 2.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2954
     components:
     - type: Transform
@@ -68270,7 +68279,7 @@ entities:
       pos: 1.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2955
     components:
     - type: Transform
@@ -68278,7 +68287,7 @@ entities:
       pos: 3.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2956
     components:
     - type: Transform
@@ -68286,7 +68295,7 @@ entities:
       pos: 4.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2958
     components:
     - type: Transform
@@ -68294,7 +68303,7 @@ entities:
       pos: 6.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2959
     components:
     - type: Transform
@@ -68302,7 +68311,7 @@ entities:
       pos: 7.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2960
     components:
     - type: Transform
@@ -68310,7 +68319,7 @@ entities:
       pos: 9.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2961
     components:
     - type: Transform
@@ -68318,7 +68327,7 @@ entities:
       pos: 8.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2963
     components:
     - type: Transform
@@ -68326,7 +68335,7 @@ entities:
       pos: 10.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2964
     components:
     - type: Transform
@@ -68334,7 +68343,7 @@ entities:
       pos: 10.5,3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2965
     components:
     - type: Transform
@@ -68342,7 +68351,7 @@ entities:
       pos: 10.5,4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2966
     components:
     - type: Transform
@@ -68350,7 +68359,7 @@ entities:
       pos: 10.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2967
     components:
     - type: Transform
@@ -68358,7 +68367,7 @@ entities:
       pos: 10.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2968
     components:
     - type: Transform
@@ -68366,7 +68375,7 @@ entities:
       pos: 10.5,7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2969
     components:
     - type: Transform
@@ -68374,7 +68383,7 @@ entities:
       pos: 10.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2970
     components:
     - type: Transform
@@ -68382,7 +68391,7 @@ entities:
       pos: 10.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2971
     components:
     - type: Transform
@@ -68390,7 +68399,7 @@ entities:
       pos: 10.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2972
     components:
     - type: Transform
@@ -68398,7 +68407,7 @@ entities:
       pos: 10.5,11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2973
     components:
     - type: Transform
@@ -68406,7 +68415,7 @@ entities:
       pos: 10.5,12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2974
     components:
     - type: Transform
@@ -68414,7 +68423,7 @@ entities:
       pos: 10.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2976
     components:
     - type: Transform
@@ -68422,7 +68431,7 @@ entities:
       pos: 11.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2977
     components:
     - type: Transform
@@ -68430,7 +68439,7 @@ entities:
       pos: 10.5,16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2978
     components:
     - type: Transform
@@ -68438,7 +68447,7 @@ entities:
       pos: 10.5,17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2979
     components:
     - type: Transform
@@ -68446,7 +68455,7 @@ entities:
       pos: 10.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2980
     components:
     - type: Transform
@@ -68454,7 +68463,7 @@ entities:
       pos: 10.5,20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2981
     components:
     - type: Transform
@@ -68462,7 +68471,7 @@ entities:
       pos: 10.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2982
     components:
     - type: Transform
@@ -68470,7 +68479,7 @@ entities:
       pos: 10.5,21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2983
     components:
     - type: Transform
@@ -68478,7 +68487,7 @@ entities:
       pos: 10.5,22.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2984
     components:
     - type: Transform
@@ -68486,7 +68495,7 @@ entities:
       pos: 10.5,23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2987
     components:
     - type: Transform
@@ -68494,7 +68503,7 @@ entities:
       pos: 9.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2988
     components:
     - type: Transform
@@ -68502,7 +68511,7 @@ entities:
       pos: 8.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2989
     components:
     - type: Transform
@@ -68510,7 +68519,7 @@ entities:
       pos: 7.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2990
     components:
     - type: Transform
@@ -68518,7 +68527,7 @@ entities:
       pos: 6.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2991
     components:
     - type: Transform
@@ -68526,7 +68535,7 @@ entities:
       pos: 5.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2992
     components:
     - type: Transform
@@ -68534,7 +68543,7 @@ entities:
       pos: 4.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2993
     components:
     - type: Transform
@@ -68542,7 +68551,7 @@ entities:
       pos: 2.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2995
     components:
     - type: Transform
@@ -68550,7 +68559,7 @@ entities:
       pos: 0.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2996
     components:
     - type: Transform
@@ -68558,7 +68567,7 @@ entities:
       pos: 1.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2998
     components:
     - type: Transform
@@ -68566,7 +68575,7 @@ entities:
       pos: -2.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2999
     components:
     - type: Transform
@@ -68574,7 +68583,7 @@ entities:
       pos: -1.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3001
     components:
     - type: Transform
@@ -68582,7 +68591,7 @@ entities:
       pos: -4.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3002
     components:
     - type: Transform
@@ -68590,7 +68599,7 @@ entities:
       pos: -5.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3003
     components:
     - type: Transform
@@ -68598,7 +68607,7 @@ entities:
       pos: -6.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3004
     components:
     - type: Transform
@@ -68606,7 +68615,7 @@ entities:
       pos: -7.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3005
     components:
     - type: Transform
@@ -68614,7 +68623,7 @@ entities:
       pos: -9.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3007
     components:
     - type: Transform
@@ -68622,7 +68631,7 @@ entities:
       pos: -10.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3008
     components:
     - type: Transform
@@ -68630,7 +68639,7 @@ entities:
       pos: -11.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3009
     components:
     - type: Transform
@@ -68638,7 +68647,7 @@ entities:
       pos: -12.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3010
     components:
     - type: Transform
@@ -68646,7 +68655,7 @@ entities:
       pos: -13.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3011
     components:
     - type: Transform
@@ -68654,7 +68663,7 @@ entities:
       pos: -14.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3013
     components:
     - type: Transform
@@ -68662,7 +68671,7 @@ entities:
       pos: -16.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3014
     components:
     - type: Transform
@@ -68670,7 +68679,7 @@ entities:
       pos: -17.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3015
     components:
     - type: Transform
@@ -68678,7 +68687,7 @@ entities:
       pos: -18.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3016
     components:
     - type: Transform
@@ -68686,7 +68695,7 @@ entities:
       pos: -19.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3017
     components:
     - type: Transform
@@ -68694,7 +68703,7 @@ entities:
       pos: -20.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3018
     components:
     - type: Transform
@@ -68702,7 +68711,7 @@ entities:
       pos: -21.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3021
     components:
     - type: Transform
@@ -68710,7 +68719,7 @@ entities:
       pos: -24.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3024
     components:
     - type: Transform
@@ -68718,7 +68727,7 @@ entities:
       pos: -27.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3025
     components:
     - type: Transform
@@ -68726,7 +68735,7 @@ entities:
       pos: -29.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3026
     components:
     - type: Transform
@@ -68734,7 +68743,7 @@ entities:
       pos: -28.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3028
     components:
     - type: Transform
@@ -68742,7 +68751,7 @@ entities:
       pos: -31.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3029
     components:
     - type: Transform
@@ -68750,7 +68759,7 @@ entities:
       pos: -32.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3030
     components:
     - type: Transform
@@ -68758,7 +68767,7 @@ entities:
       pos: -33.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3031
     components:
     - type: Transform
@@ -68790,7 +68799,7 @@ entities:
       pos: -25.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3035
     components:
     - type: Transform
@@ -68798,7 +68807,7 @@ entities:
       pos: -25.5,27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3036
     components:
     - type: Transform
@@ -68806,7 +68815,7 @@ entities:
       pos: -25.5,28.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3037
     components:
     - type: Transform
@@ -68814,7 +68823,7 @@ entities:
       pos: -25.5,29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3038
     components:
     - type: Transform
@@ -68822,21 +68831,21 @@ entities:
       pos: -25.5,30.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3043
     components:
     - type: Transform
       pos: -30.5,24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3044
     components:
     - type: Transform
       pos: -30.5,23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3045
     components:
     - type: Transform
@@ -68871,7 +68880,7 @@ entities:
       pos: -26.5,24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3052
     components:
     - type: Transform
@@ -68899,7 +68908,7 @@ entities:
       pos: -22.5,24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3058
     components:
     - type: Transform
@@ -68935,7 +68944,7 @@ entities:
       pos: -35.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3071
     components:
     - type: Transform
@@ -68943,7 +68952,7 @@ entities:
       pos: -36.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3072
     components:
     - type: Transform
@@ -68951,7 +68960,7 @@ entities:
       pos: -37.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3073
     components:
     - type: Transform
@@ -68959,7 +68968,7 @@ entities:
       pos: -38.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3074
     components:
     - type: Transform
@@ -68983,7 +68992,7 @@ entities:
       pos: -39.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3080
     components:
     - type: Transform
@@ -68991,7 +69000,7 @@ entities:
       pos: -35.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3081
     components:
     - type: Transform
@@ -68999,7 +69008,7 @@ entities:
       pos: -36.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3082
     components:
     - type: Transform
@@ -69007,7 +69016,7 @@ entities:
       pos: -37.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3083
     components:
     - type: Transform
@@ -69015,7 +69024,7 @@ entities:
       pos: -38.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3085
     components:
     - type: Transform
@@ -69023,7 +69032,7 @@ entities:
       pos: -40.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3086
     components:
     - type: Transform
@@ -69031,7 +69040,7 @@ entities:
       pos: -41.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3088
     components:
     - type: Transform
@@ -69039,7 +69048,7 @@ entities:
       pos: -43.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3089
     components:
     - type: Transform
@@ -69143,7 +69152,7 @@ entities:
       pos: -39.5,4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3108
     components:
     - type: Transform
@@ -69151,7 +69160,7 @@ entities:
       pos: -39.5,3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3109
     components:
     - type: Transform
@@ -69159,7 +69168,7 @@ entities:
       pos: -39.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3110
     components:
     - type: Transform
@@ -69167,7 +69176,7 @@ entities:
       pos: -39.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3113
     components:
     - type: Transform
@@ -69183,7 +69192,7 @@ entities:
       pos: -51.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3122
     components:
     - type: Transform
@@ -69191,7 +69200,7 @@ entities:
       pos: -50.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3124
     components:
     - type: Transform
@@ -69199,7 +69208,7 @@ entities:
       pos: -48.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3127
     components:
     - type: Transform
@@ -69207,7 +69216,7 @@ entities:
       pos: -45.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3128
     components:
     - type: Transform
@@ -69215,7 +69224,7 @@ entities:
       pos: -44.5,7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3129
     components:
     - type: Transform
@@ -69223,7 +69232,7 @@ entities:
       pos: -44.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3132
     components:
     - type: Transform
@@ -69274,21 +69283,21 @@ entities:
       pos: -44.5,3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3144
     components:
     - type: Transform
       pos: -44.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3145
     components:
     - type: Transform
       pos: -44.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3146
     components:
     - type: Transform
@@ -69323,35 +69332,35 @@ entities:
       pos: -44.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3157
     components:
     - type: Transform
       pos: -44.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3158
     components:
     - type: Transform
       pos: -44.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3159
     components:
     - type: Transform
       pos: -44.5,-0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3160
     components:
     - type: Transform
       pos: -44.5,0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3164
     components:
     - type: Transform
@@ -69404,7 +69413,7 @@ entities:
       pos: -52.5,11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3205
     components:
     - type: Transform
@@ -69452,7 +69461,7 @@ entities:
       pos: -44.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3212
     components:
     - type: Transform
@@ -69460,7 +69469,7 @@ entities:
       pos: -44.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3214
     components:
     - type: Transform
@@ -69468,7 +69477,7 @@ entities:
       pos: -44.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3215
     components:
     - type: Transform
@@ -69476,7 +69485,7 @@ entities:
       pos: -44.5,-10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3216
     components:
     - type: Transform
@@ -69484,7 +69493,7 @@ entities:
       pos: -44.5,-11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3217
     components:
     - type: Transform
@@ -69506,7 +69515,7 @@ entities:
       pos: -45.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3220
     components:
     - type: Transform
@@ -69514,7 +69523,7 @@ entities:
       pos: -46.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3222
     components:
     - type: Transform
@@ -69522,7 +69531,7 @@ entities:
       pos: -33.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3223
     components:
     - type: Transform
@@ -69530,7 +69539,7 @@ entities:
       pos: -32.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3224
     components:
     - type: Transform
@@ -69570,7 +69579,7 @@ entities:
       pos: -35.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3233
     components:
     - type: Transform
@@ -69578,7 +69587,7 @@ entities:
       pos: -36.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3234
     components:
     - type: Transform
@@ -69586,7 +69595,7 @@ entities:
       pos: -37.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3235
     components:
     - type: Transform
@@ -69594,7 +69603,7 @@ entities:
       pos: -38.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3236
     components:
     - type: Transform
@@ -69602,7 +69611,7 @@ entities:
       pos: -39.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3237
     components:
     - type: Transform
@@ -69642,7 +69651,7 @@ entities:
       pos: -40.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3243
     components:
     - type: Transform
@@ -69650,7 +69659,7 @@ entities:
       pos: -41.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3244
     components:
     - type: Transform
@@ -69658,7 +69667,7 @@ entities:
       pos: -42.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3247
     components:
     - type: Transform
@@ -69666,7 +69675,7 @@ entities:
       pos: -43.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3248
     components:
     - type: Transform
@@ -69674,7 +69683,7 @@ entities:
       pos: -43.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3249
     components:
     - type: Transform
@@ -69690,7 +69699,7 @@ entities:
       pos: -43.5,16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3251
     components:
     - type: Transform
@@ -69698,7 +69707,7 @@ entities:
       pos: -43.5,17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3252
     components:
     - type: Transform
@@ -69754,7 +69763,7 @@ entities:
       pos: -45.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3262
     components:
     - type: Transform
@@ -69762,7 +69771,7 @@ entities:
       pos: -46.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3263
     components:
     - type: Transform
@@ -69770,7 +69779,7 @@ entities:
       pos: -47.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3264
     components:
     - type: Transform
@@ -69778,7 +69787,7 @@ entities:
       pos: -48.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3265
     components:
     - type: Transform
@@ -69816,7 +69825,7 @@ entities:
       pos: -49.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3276
     components:
     - type: Transform
@@ -69824,14 +69833,14 @@ entities:
       pos: -51.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3277
     components:
     - type: Transform
       pos: -52.5,12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3279
     components:
     - type: Transform
@@ -69839,7 +69848,7 @@ entities:
       pos: -53.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3280
     components:
     - type: Transform
@@ -69847,7 +69856,7 @@ entities:
       pos: -54.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3281
     components:
     - type: Transform
@@ -69855,7 +69864,7 @@ entities:
       pos: -55.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3282
     components:
     - type: Transform
@@ -69863,39 +69872,15 @@ entities:
       pos: -56.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3287
+      color: '#0055CCFF'
+  - uid: 3283
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -58.5,13.5
+      rot: 3.141592653589793 rad
+      pos: -57.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3288
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -59.5,13.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3289
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -58.5,15.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3290
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -59.5,15.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3291
     components:
     - type: Transform
@@ -69903,7 +69888,7 @@ entities:
       pos: -57.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3292
     components:
     - type: Transform
@@ -69911,7 +69896,7 @@ entities:
       pos: -57.5,16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3293
     components:
     - type: Transform
@@ -69919,62 +69904,7 @@ entities:
       pos: -57.5,17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3295
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -57.5,19.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3296
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -57.5,20.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3297
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -58.5,21.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3298
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -59.5,21.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3299
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -58.5,23.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3300
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -59.5,23.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3301
-    components:
-    - type: Transform
-      pos: -57.5,22.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3308
     components:
     - type: Transform
@@ -70051,7 +69981,7 @@ entities:
       pos: -50.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3320
     components:
     - type: Transform
@@ -70059,7 +69989,7 @@ entities:
       pos: -50.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3321
     components:
     - type: Transform
@@ -70067,7 +69997,7 @@ entities:
       pos: -50.5,16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3322
     components:
     - type: Transform
@@ -70075,7 +70005,7 @@ entities:
       pos: -50.5,17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3329
     components:
     - type: Transform
@@ -70083,7 +70013,7 @@ entities:
       pos: -19.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3330
     components:
     - type: Transform
@@ -70091,7 +70021,7 @@ entities:
       pos: -19.5,3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3331
     components:
     - type: Transform
@@ -70099,7 +70029,7 @@ entities:
       pos: -19.5,4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3332
     components:
     - type: Transform
@@ -70107,7 +70037,7 @@ entities:
       pos: -19.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3334
     components:
     - type: Transform
@@ -70115,7 +70045,7 @@ entities:
       pos: -18.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3335
     components:
     - type: Transform
@@ -70123,7 +70053,7 @@ entities:
       pos: -17.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3337
     components:
     - type: Transform
@@ -70131,7 +70061,7 @@ entities:
       pos: -20.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3338
     components:
     - type: Transform
@@ -70139,7 +70069,7 @@ entities:
       pos: -21.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3339
     components:
     - type: Transform
@@ -70147,7 +70077,7 @@ entities:
       pos: -22.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3340
     components:
     - type: Transform
@@ -70155,7 +70085,7 @@ entities:
       pos: -23.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3350
     components:
     - type: Transform
@@ -70224,7 +70154,7 @@ entities:
       pos: -62.5,-61.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3366
     components:
     - type: Transform
@@ -70232,7 +70162,7 @@ entities:
       pos: -24.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3367
     components:
     - type: Transform
@@ -70240,7 +70170,7 @@ entities:
       pos: -24.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3369
     components:
     - type: Transform
@@ -70272,7 +70202,7 @@ entities:
       pos: -25.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3378
     components:
     - type: Transform
@@ -70327,21 +70257,21 @@ entities:
       pos: -16.5,7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3386
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3387
     components:
     - type: Transform
       pos: -16.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3389
     components:
     - type: Transform
@@ -70376,21 +70306,21 @@ entities:
       pos: -16.5,11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3394
     components:
     - type: Transform
       pos: -16.5,12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3395
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3396
     components:
     - type: Transform
@@ -70405,7 +70335,7 @@ entities:
       pos: -14.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3403
     components:
     - type: Transform
@@ -70413,42 +70343,42 @@ entities:
       pos: -15.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3411
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3412
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3413
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3414
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3415
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3416
     components:
     - type: Transform
@@ -70517,7 +70447,7 @@ entities:
       pos: -1.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3431
     components:
     - type: Transform
@@ -70525,7 +70455,7 @@ entities:
       pos: -1.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3432
     components:
     - type: Transform
@@ -70533,7 +70463,7 @@ entities:
       pos: -1.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3433
     components:
     - type: Transform
@@ -70541,7 +70471,7 @@ entities:
       pos: -1.5,11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3434
     components:
     - type: Transform
@@ -70549,7 +70479,7 @@ entities:
       pos: -1.5,12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3435
     components:
     - type: Transform
@@ -70557,7 +70487,7 @@ entities:
       pos: -1.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3436
     components:
     - type: Transform
@@ -70613,7 +70543,7 @@ entities:
       pos: 0.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3444
     components:
     - type: Transform
@@ -70621,7 +70551,7 @@ entities:
       pos: 1.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3445
     components:
     - type: Transform
@@ -70629,7 +70559,7 @@ entities:
       pos: 2.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3446
     components:
     - type: Transform
@@ -70637,7 +70567,7 @@ entities:
       pos: -2.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3447
     components:
     - type: Transform
@@ -70645,7 +70575,7 @@ entities:
       pos: -3.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3448
     components:
     - type: Transform
@@ -70653,7 +70583,7 @@ entities:
       pos: -4.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3449
     components:
     - type: Transform
@@ -70661,7 +70591,7 @@ entities:
       pos: -5.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3450
     components:
     - type: Transform
@@ -70669,7 +70599,7 @@ entities:
       pos: -6.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3451
     components:
     - type: Transform
@@ -70677,7 +70607,7 @@ entities:
       pos: -7.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3453
     components:
     - type: Transform
@@ -70733,7 +70663,7 @@ entities:
       pos: -10.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3464
     components:
     - type: Transform
@@ -70741,7 +70671,7 @@ entities:
       pos: -11.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3465
     components:
     - type: Transform
@@ -70749,7 +70679,7 @@ entities:
       pos: -12.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3466
     components:
     - type: Transform
@@ -70757,7 +70687,7 @@ entities:
       pos: -13.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3467
     components:
     - type: Transform
@@ -70765,7 +70695,7 @@ entities:
       pos: -14.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3468
     components:
     - type: Transform
@@ -70773,7 +70703,7 @@ entities:
       pos: -15.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3470
     components:
     - type: Transform
@@ -70825,21 +70755,21 @@ entities:
       pos: -9.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3477
     components:
     - type: Transform
       pos: -9.5,16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3478
     components:
     - type: Transform
       pos: -9.5,17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3487
     components:
     - type: Transform
@@ -70867,7 +70797,7 @@ entities:
       pos: -1.5,0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3491
     components:
     - type: Transform
@@ -70916,14 +70846,14 @@ entities:
       pos: -18.5,-47.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 4371
     components:
     - type: Transform
       pos: -25.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 4894
     components:
     - type: Transform
@@ -70969,7 +70899,7 @@ entities:
       pos: -53.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 5428
     components:
     - type: Transform
@@ -71001,7 +70931,7 @@ entities:
       pos: -30.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 5841
     components:
     - type: Transform
@@ -71015,7 +70945,7 @@ entities:
       pos: -2.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6114
     components:
     - type: Transform
@@ -71057,21 +70987,21 @@ entities:
       pos: -0.5,24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6120
     components:
     - type: Transform
       pos: -0.5,23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6121
     components:
     - type: Transform
       pos: -0.5,22.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6124
     components:
     - type: Transform
@@ -71310,182 +71240,182 @@ entities:
       pos: -15.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6160
     components:
     - type: Transform
       pos: -15.5,27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6161
     components:
     - type: Transform
       pos: -15.5,28.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6162
     components:
     - type: Transform
       pos: -15.5,29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6163
     components:
     - type: Transform
       pos: -15.5,30.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6164
     components:
     - type: Transform
       pos: -15.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6165
     components:
     - type: Transform
       pos: -15.5,32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6166
     components:
     - type: Transform
       pos: -15.5,33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6167
     components:
     - type: Transform
       pos: -15.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6168
     components:
     - type: Transform
       pos: -15.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6169
     components:
     - type: Transform
       pos: -15.5,36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6171
     components:
     - type: Transform
       pos: -15.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6173
     components:
     - type: Transform
       pos: -15.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6174
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6175
     components:
     - type: Transform
       pos: -3.5,27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6176
     components:
     - type: Transform
       pos: -3.5,28.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6177
     components:
     - type: Transform
       pos: -3.5,29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6178
     components:
     - type: Transform
       pos: -3.5,30.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6180
     components:
     - type: Transform
       pos: -3.5,32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6181
     components:
     - type: Transform
       pos: -3.5,33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6182
     components:
     - type: Transform
       pos: -3.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6183
     components:
     - type: Transform
       pos: -3.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6184
     components:
     - type: Transform
       pos: -3.5,36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6186
     components:
     - type: Transform
       pos: -3.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6187
     components:
     - type: Transform
       pos: -3.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6188
     components:
     - type: Transform
       pos: -3.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6189
     components:
     - type: Transform
@@ -71493,7 +71423,7 @@ entities:
       pos: -4.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6190
     components:
     - type: Transform
@@ -71501,7 +71431,7 @@ entities:
       pos: -5.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6191
     components:
     - type: Transform
@@ -71509,7 +71439,7 @@ entities:
       pos: -6.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6192
     components:
     - type: Transform
@@ -71517,7 +71447,7 @@ entities:
       pos: -8.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6194
     components:
     - type: Transform
@@ -71525,7 +71455,7 @@ entities:
       pos: -10.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6195
     components:
     - type: Transform
@@ -71533,7 +71463,7 @@ entities:
       pos: -14.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6196
     components:
     - type: Transform
@@ -71541,7 +71471,7 @@ entities:
       pos: -13.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6197
     components:
     - type: Transform
@@ -71549,7 +71479,7 @@ entities:
       pos: -12.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6206
     components:
     - type: Transform
@@ -71577,28 +71507,28 @@ entities:
       pos: -7.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6210
     components:
     - type: Transform
       pos: -7.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6211
     components:
     - type: Transform
       pos: -7.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6212
     components:
     - type: Transform
       pos: -7.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6215
     components:
     - type: Transform
@@ -71638,7 +71568,7 @@ entities:
       pos: -2.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6220
     components:
     - type: Transform
@@ -71646,7 +71576,7 @@ entities:
       pos: -1.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6221
     components:
     - type: Transform
@@ -71654,7 +71584,7 @@ entities:
       pos: -0.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6226
     components:
     - type: Transform
@@ -71662,7 +71592,7 @@ entities:
       pos: -16.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6227
     components:
     - type: Transform
@@ -71670,7 +71600,7 @@ entities:
       pos: -17.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6228
     components:
     - type: Transform
@@ -71678,7 +71608,7 @@ entities:
       pos: -18.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6230
     components:
     - type: Transform
@@ -71686,7 +71616,7 @@ entities:
       pos: -16.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6231
     components:
     - type: Transform
@@ -71694,7 +71624,7 @@ entities:
       pos: -17.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6232
     components:
     - type: Transform
@@ -71702,7 +71632,7 @@ entities:
       pos: -18.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6233
     components:
     - type: Transform
@@ -71710,7 +71640,7 @@ entities:
       pos: -19.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6235
     components:
     - type: Transform
@@ -71718,7 +71648,7 @@ entities:
       pos: -21.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6236
     components:
     - type: Transform
@@ -71726,7 +71656,7 @@ entities:
       pos: -22.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6237
     components:
     - type: Transform
@@ -71734,7 +71664,7 @@ entities:
       pos: -23.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6238
     components:
     - type: Transform
@@ -71742,35 +71672,35 @@ entities:
       pos: -24.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6241
     components:
     - type: Transform
       pos: -20.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6242
     components:
     - type: Transform
       pos: -20.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6243
     components:
     - type: Transform
       pos: -20.5,33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6244
     components:
     - type: Transform
       pos: -20.5,32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6247
     components:
     - type: Transform
@@ -71864,7 +71794,7 @@ entities:
       pos: -11.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6685
     components:
     - type: Transform
@@ -71872,7 +71802,7 @@ entities:
       pos: -17.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6686
     components:
     - type: Transform
@@ -71880,14 +71810,14 @@ entities:
       pos: -14.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6724
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6729
     components:
     - type: Transform
@@ -71895,7 +71825,7 @@ entities:
       pos: -15.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6812
     components:
     - type: Transform
@@ -71903,7 +71833,7 @@ entities:
       pos: -16.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6813
     components:
     - type: Transform
@@ -71911,7 +71841,7 @@ entities:
       pos: -17.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6814
     components:
     - type: Transform
@@ -71919,7 +71849,7 @@ entities:
       pos: -17.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6816
     components:
     - type: Transform
@@ -71927,7 +71857,7 @@ entities:
       pos: -30.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6819
     components:
     - type: Transform
@@ -71967,7 +71897,7 @@ entities:
       pos: -17.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6896
     components:
     - type: Transform
@@ -71975,7 +71905,7 @@ entities:
       pos: -33.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6897
     components:
     - type: Transform
@@ -71983,7 +71913,7 @@ entities:
       pos: -18.5,0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6898
     components:
     - type: Transform
@@ -71991,7 +71921,7 @@ entities:
       pos: -32.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6901
     components:
     - type: Transform
@@ -71999,7 +71929,7 @@ entities:
       pos: -29.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6902
     components:
     - type: Transform
@@ -72007,7 +71937,7 @@ entities:
       pos: -31.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6909
     components:
     - type: Transform
@@ -72015,7 +71945,7 @@ entities:
       pos: -30.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6910
     components:
     - type: Transform
@@ -72030,7 +71960,7 @@ entities:
       pos: -31.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6925
     components:
     - type: Transform
@@ -72038,7 +71968,7 @@ entities:
       pos: -32.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6930
     components:
     - type: Transform
@@ -72103,7 +72033,7 @@ entities:
       pos: -28.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7060
     components:
     - type: Transform
@@ -72111,7 +72041,7 @@ entities:
       pos: -26.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7069
     components:
     - type: Transform
@@ -72119,7 +72049,7 @@ entities:
       pos: -25.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7070
     components:
     - type: Transform
@@ -72127,7 +72057,7 @@ entities:
       pos: -27.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7073
     components:
     - type: Transform
@@ -72135,7 +72065,7 @@ entities:
       pos: -24.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7091
     components:
     - type: Transform
@@ -72191,7 +72121,7 @@ entities:
       pos: -33.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7157
     components:
     - type: Transform
@@ -72206,14 +72136,14 @@ entities:
       pos: -34.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7205
     components:
     - type: Transform
       pos: -34.5,-4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7212
     components:
     - type: Transform
@@ -72229,7 +72159,7 @@ entities:
       pos: -29.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7216
     components:
     - type: Transform
@@ -72251,7 +72181,7 @@ entities:
       pos: -18.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7303
     components:
     - type: Transform
@@ -72347,14 +72277,14 @@ entities:
       pos: -1.5,-0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7320
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7324
     components:
     - type: Transform
@@ -72362,7 +72292,7 @@ entities:
       pos: -3.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7325
     components:
     - type: Transform
@@ -72370,7 +72300,7 @@ entities:
       pos: -4.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7326
     components:
     - type: Transform
@@ -72378,7 +72308,7 @@ entities:
       pos: -5.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7327
     components:
     - type: Transform
@@ -72386,7 +72316,7 @@ entities:
       pos: -6.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7328
     components:
     - type: Transform
@@ -72394,7 +72324,7 @@ entities:
       pos: -7.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7329
     components:
     - type: Transform
@@ -72402,7 +72332,7 @@ entities:
       pos: -8.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7330
     components:
     - type: Transform
@@ -72410,28 +72340,28 @@ entities:
       pos: -9.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7331
     components:
     - type: Transform
       pos: -10.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7332
     components:
     - type: Transform
       pos: -10.5,-0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7333
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7334
     components:
     - type: Transform
@@ -72439,7 +72369,7 @@ entities:
       pos: -11.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7335
     components:
     - type: Transform
@@ -72462,35 +72392,35 @@ entities:
       pos: -12.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7342
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7343
     components:
     - type: Transform
       pos: -12.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7344
     components:
     - type: Transform
       pos: -12.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7345
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7347
     components:
     - type: Transform
@@ -72550,7 +72480,7 @@ entities:
       pos: -10.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7362
     components:
     - type: Transform
@@ -72558,7 +72488,7 @@ entities:
       pos: -8.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7363
     components:
     - type: Transform
@@ -72566,7 +72496,7 @@ entities:
       pos: -9.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7375
     components:
     - type: Transform
@@ -72595,7 +72525,7 @@ entities:
       pos: -17.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7406
     components:
     - type: Transform
@@ -72610,14 +72540,14 @@ entities:
       pos: -34.5,0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7410
     components:
     - type: Transform
       pos: -34.5,-0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7480
     components:
     - type: Transform
@@ -72631,7 +72561,7 @@ entities:
       pos: -20.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7495
     components:
     - type: Transform
@@ -72639,7 +72569,7 @@ entities:
       pos: -21.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7505
     components:
     - type: Transform
@@ -72654,7 +72584,7 @@ entities:
       pos: -34.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7531
     components:
     - type: Transform
@@ -72662,7 +72592,7 @@ entities:
       pos: -16.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7551
     components:
     - type: Transform
@@ -72678,7 +72608,7 @@ entities:
       pos: -19.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7568
     components:
     - type: Transform
@@ -72686,7 +72616,7 @@ entities:
       pos: -21.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7570
     components:
     - type: Transform
@@ -72702,7 +72632,7 @@ entities:
       pos: -22.5,-12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7599
     components:
     - type: Transform
@@ -72710,7 +72640,7 @@ entities:
       pos: -22.5,-17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7604
     components:
     - type: Transform
@@ -72718,7 +72648,7 @@ entities:
       pos: -27.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7661
     components:
     - type: Transform
@@ -72726,7 +72656,7 @@ entities:
       pos: -19.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7662
     components:
     - type: Transform
@@ -72734,7 +72664,7 @@ entities:
       pos: -30.5,-18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7664
     components:
     - type: Transform
@@ -72742,7 +72672,7 @@ entities:
       pos: -30.5,-19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7665
     components:
     - type: Transform
@@ -72758,7 +72688,7 @@ entities:
       pos: -30.5,-17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7755
     components:
     - type: Transform
@@ -72782,7 +72712,7 @@ entities:
       pos: -26.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7763
     components:
     - type: Transform
@@ -72798,7 +72728,7 @@ entities:
       pos: -28.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7816
     components:
     - type: Transform
@@ -72806,7 +72736,7 @@ entities:
       pos: -29.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7817
     components:
     - type: Transform
@@ -72814,7 +72744,7 @@ entities:
       pos: -26.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7818
     components:
     - type: Transform
@@ -72822,7 +72752,7 @@ entities:
       pos: -27.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7821
     components:
     - type: Transform
@@ -72830,7 +72760,7 @@ entities:
       pos: -32.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7832
     components:
     - type: Transform
@@ -72838,7 +72768,7 @@ entities:
       pos: -17.5,-4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7884
     components:
     - type: Transform
@@ -72846,7 +72776,7 @@ entities:
       pos: -31.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7925
     components:
     - type: Transform
@@ -72892,7 +72822,7 @@ entities:
       pos: -22.5,-18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7999
     components:
     - type: Transform
@@ -72908,7 +72838,7 @@ entities:
       pos: -22.5,-10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8030
     components:
     - type: Transform
@@ -72916,7 +72846,7 @@ entities:
       pos: -22.5,-13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8031
     components:
     - type: Transform
@@ -72924,7 +72854,7 @@ entities:
       pos: -22.5,-11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8032
     components:
     - type: Transform
@@ -72932,7 +72862,7 @@ entities:
       pos: -22.5,-14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8037
     components:
     - type: Transform
@@ -72940,7 +72870,7 @@ entities:
       pos: -22.5,-19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8041
     components:
     - type: Transform
@@ -72948,7 +72878,7 @@ entities:
       pos: -20.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8042
     components:
     - type: Transform
@@ -72956,7 +72886,7 @@ entities:
       pos: -17.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8049
     components:
     - type: Transform
@@ -73017,7 +72947,7 @@ entities:
       pos: -18.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8068
     components:
     - type: Transform
@@ -73056,14 +72986,14 @@ entities:
       pos: -22.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8094
     components:
     - type: Transform
       pos: -13.5,-18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8095
     components:
     - type: Transform
@@ -73071,7 +73001,7 @@ entities:
       pos: -15.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8097
     components:
     - type: Transform
@@ -73079,14 +73009,14 @@ entities:
       pos: -24.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8098
     components:
     - type: Transform
       pos: -13.5,-19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8099
     components:
     - type: Transform
@@ -73150,7 +73080,7 @@ entities:
       pos: -20.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8218
     components:
     - type: Transform
@@ -73158,7 +73088,7 @@ entities:
       pos: -21.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8221
     components:
     - type: Transform
@@ -73174,7 +73104,7 @@ entities:
       pos: -22.5,-4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8264
     components:
     - type: Transform
@@ -73600,7 +73530,7 @@ entities:
       pos: 11.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8780
     components:
     - type: Transform
@@ -73664,7 +73594,7 @@ entities:
       pos: 14.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8840
     components:
     - type: Transform
@@ -73672,7 +73602,7 @@ entities:
       pos: 13.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8841
     components:
     - type: Transform
@@ -73688,7 +73618,7 @@ entities:
       pos: 15.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8843
     components:
     - type: Transform
@@ -73696,7 +73626,7 @@ entities:
       pos: 12.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8844
     components:
     - type: Transform
@@ -73712,7 +73642,7 @@ entities:
       pos: 9.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8854
     components:
     - type: Transform
@@ -73814,7 +73744,7 @@ entities:
       pos: 7.5,-25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8874
     components:
     - type: Transform
@@ -73829,7 +73759,7 @@ entities:
       pos: 7.5,-22.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8878
     components:
     - type: Transform
@@ -73837,7 +73767,7 @@ entities:
       pos: 5.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8879
     components:
     - type: Transform
@@ -74072,7 +74002,7 @@ entities:
       pos: -0.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8915
     components:
     - type: Transform
@@ -74080,7 +74010,7 @@ entities:
       pos: 0.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8916
     components:
     - type: Transform
@@ -74088,7 +74018,7 @@ entities:
       pos: 1.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8917
     components:
     - type: Transform
@@ -74096,7 +74026,7 @@ entities:
       pos: 2.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8918
     components:
     - type: Transform
@@ -74104,7 +74034,7 @@ entities:
       pos: 3.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8921
     components:
     - type: Transform
@@ -74112,7 +74042,7 @@ entities:
       pos: 6.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8922
     components:
     - type: Transform
@@ -74120,7 +74050,7 @@ entities:
       pos: 7.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8923
     components:
     - type: Transform
@@ -74128,7 +74058,7 @@ entities:
       pos: 8.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8924
     components:
     - type: Transform
@@ -74136,7 +74066,7 @@ entities:
       pos: 5.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8925
     components:
     - type: Transform
@@ -74144,7 +74074,7 @@ entities:
       pos: 5.5,-0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8926
     components:
     - type: Transform
@@ -74152,7 +74082,7 @@ entities:
       pos: 5.5,0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8927
     components:
     - type: Transform
@@ -74160,7 +74090,7 @@ entities:
       pos: 8.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8928
     components:
     - type: Transform
@@ -74168,7 +74098,7 @@ entities:
       pos: 5.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8929
     components:
     - type: Transform
@@ -74176,14 +74106,14 @@ entities:
       pos: 4.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8930
     components:
     - type: Transform
       pos: 7.5,-26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8931
     components:
     - type: Transform
@@ -74191,7 +74121,7 @@ entities:
       pos: 3.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8932
     components:
     - type: Transform
@@ -74206,7 +74136,7 @@ entities:
       pos: 7.5,-23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8935
     components:
     - type: Transform
@@ -74222,7 +74152,7 @@ entities:
       pos: 6.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8938
     components:
     - type: Transform
@@ -74230,7 +74160,7 @@ entities:
       pos: 8.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8941
     components:
     - type: Transform
@@ -74238,7 +74168,7 @@ entities:
       pos: 10.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8942
     components:
     - type: Transform
@@ -74246,7 +74176,7 @@ entities:
       pos: 11.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8943
     components:
     - type: Transform
@@ -74254,7 +74184,7 @@ entities:
       pos: 12.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8945
     components:
     - type: Transform
@@ -74262,7 +74192,7 @@ entities:
       pos: 13.5,-19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8946
     components:
     - type: Transform
@@ -74270,7 +74200,7 @@ entities:
       pos: 13.5,-18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8948
     components:
     - type: Transform
@@ -74278,7 +74208,7 @@ entities:
       pos: 13.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8949
     components:
     - type: Transform
@@ -74286,7 +74216,7 @@ entities:
       pos: 13.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8950
     components:
     - type: Transform
@@ -74294,7 +74224,7 @@ entities:
       pos: 13.5,-14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8951
     components:
     - type: Transform
@@ -74302,7 +74232,7 @@ entities:
       pos: 13.5,-13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8952
     components:
     - type: Transform
@@ -74310,7 +74240,7 @@ entities:
       pos: 13.5,-12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8953
     components:
     - type: Transform
@@ -74318,7 +74248,7 @@ entities:
       pos: 13.5,-11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8954
     components:
     - type: Transform
@@ -74326,7 +74256,7 @@ entities:
       pos: 13.5,-10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8956
     components:
     - type: Transform
@@ -74334,7 +74264,7 @@ entities:
       pos: 13.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8958
     components:
     - type: Transform
@@ -74342,7 +74272,7 @@ entities:
       pos: 13.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8959
     components:
     - type: Transform
@@ -74350,7 +74280,7 @@ entities:
       pos: 13.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8961
     components:
     - type: Transform
@@ -74358,7 +74288,7 @@ entities:
       pos: 13.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8962
     components:
     - type: Transform
@@ -74366,7 +74296,7 @@ entities:
       pos: 13.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8963
     components:
     - type: Transform
@@ -74374,7 +74304,7 @@ entities:
       pos: 13.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8964
     components:
     - type: Transform
@@ -74382,7 +74312,7 @@ entities:
       pos: 13.5,-0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8965
     components:
     - type: Transform
@@ -74390,7 +74320,7 @@ entities:
       pos: 13.5,0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8967
     components:
     - type: Transform
@@ -74398,7 +74328,7 @@ entities:
       pos: 11.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8969
     components:
     - type: Transform
@@ -74406,7 +74336,7 @@ entities:
       pos: 12.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8970
     components:
     - type: Transform
@@ -74414,7 +74344,7 @@ entities:
       pos: 11.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8971
     components:
     - type: Transform
@@ -74422,7 +74352,7 @@ entities:
       pos: 10.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8972
     components:
     - type: Transform
@@ -74430,7 +74360,7 @@ entities:
       pos: 9.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8973
     components:
     - type: Transform
@@ -74438,7 +74368,7 @@ entities:
       pos: 9.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8974
     components:
     - type: Transform
@@ -74446,7 +74376,7 @@ entities:
       pos: 9.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8975
     components:
     - type: Transform
@@ -74454,7 +74384,7 @@ entities:
       pos: 9.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8976
     components:
     - type: Transform
@@ -74462,7 +74392,7 @@ entities:
       pos: 9.5,-4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8977
     components:
     - type: Transform
@@ -74470,7 +74400,7 @@ entities:
       pos: 9.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9015
     components:
     - type: Transform
@@ -74543,14 +74473,14 @@ entities:
       pos: -13.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9052
     components:
     - type: Transform
       pos: -13.5,-17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9053
     components:
     - type: Transform
@@ -74558,7 +74488,7 @@ entities:
       pos: -14.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9075
     components:
     - type: Transform
@@ -74580,7 +74510,7 @@ entities:
       pos: 7.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9294
     components:
     - type: Transform
@@ -74604,56 +74534,56 @@ entities:
       pos: -49.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9416
     components:
     - type: Transform
       pos: -24.5,-44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9417
     components:
     - type: Transform
       pos: -24.5,-45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9424
     components:
     - type: Transform
       pos: -18.5,-49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9425
     components:
     - type: Transform
       pos: -18.5,-45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9426
     components:
     - type: Transform
       pos: -18.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9431
     components:
     - type: Transform
       pos: -12.5,-42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9432
     components:
     - type: Transform
       pos: -24.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9433
     components:
     - type: Transform
@@ -74728,7 +74658,7 @@ entities:
       pos: -6.5,-38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9590
     components:
     - type: Transform
@@ -74736,7 +74666,7 @@ entities:
       pos: -7.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9608
     components:
     - type: Transform
@@ -74744,21 +74674,21 @@ entities:
       pos: -8.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9638
     components:
     - type: Transform
       pos: 2.5,-37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9639
     components:
     - type: Transform
       pos: 2.5,-38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9640
     components:
     - type: Transform
@@ -74766,7 +74696,7 @@ entities:
       pos: 1.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9670
     components:
     - type: Transform
@@ -74790,7 +74720,7 @@ entities:
       pos: -23.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9687
     components:
     - type: Transform
@@ -74806,7 +74736,7 @@ entities:
       pos: -24.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9701
     components:
     - type: Transform
@@ -74965,7 +74895,7 @@ entities:
       pos: -1.5,-25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9756
     components:
     - type: Transform
@@ -74973,7 +74903,7 @@ entities:
       pos: -1.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9757
     components:
     - type: Transform
@@ -74981,7 +74911,7 @@ entities:
       pos: -1.5,-23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9758
     components:
     - type: Transform
@@ -74989,7 +74919,7 @@ entities:
       pos: -1.5,-22.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9759
     components:
     - type: Transform
@@ -74997,7 +74927,7 @@ entities:
       pos: -1.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9760
     components:
     - type: Transform
@@ -75005,7 +74935,7 @@ entities:
       pos: -0.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9761
     components:
     - type: Transform
@@ -75013,7 +74943,7 @@ entities:
       pos: 0.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9762
     components:
     - type: Transform
@@ -75021,7 +74951,7 @@ entities:
       pos: 1.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9764
     components:
     - type: Transform
@@ -75029,7 +74959,7 @@ entities:
       pos: 3.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9765
     components:
     - type: Transform
@@ -75037,7 +74967,7 @@ entities:
       pos: 4.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9766
     components:
     - type: Transform
@@ -75045,7 +74975,7 @@ entities:
       pos: -0.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9767
     components:
     - type: Transform
@@ -75053,7 +74983,7 @@ entities:
       pos: 0.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9768
     components:
     - type: Transform
@@ -75061,35 +74991,35 @@ entities:
       pos: 1.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9771
     components:
     - type: Transform
       pos: 2.5,-28.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9772
     components:
     - type: Transform
       pos: 2.5,-29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9773
     components:
     - type: Transform
       pos: 2.5,-30.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9775
     components:
     - type: Transform
       pos: 2.5,-31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9776
     components:
     - type: Transform
@@ -75131,28 +75061,28 @@ entities:
       pos: 2.5,-33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9785
     components:
     - type: Transform
       pos: 2.5,-34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9786
     components:
     - type: Transform
       pos: 2.5,-35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9787
     components:
     - type: Transform
       pos: 2.5,-36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9788
     components:
     - type: Transform
@@ -75168,7 +75098,7 @@ entities:
       pos: 2.5,-40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9795
     components:
     - type: Transform
@@ -75176,7 +75106,7 @@ entities:
       pos: 2.5,-41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9806
     components:
     - type: Transform
@@ -75184,7 +75114,7 @@ entities:
       pos: 2.5,-42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9807
     components:
     - type: Transform
@@ -75215,7 +75145,7 @@ entities:
       pos: -34.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9853
     components:
     - type: Transform
@@ -75223,7 +75153,7 @@ entities:
       pos: -23.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9860
     components:
     - type: Transform
@@ -75247,7 +75177,7 @@ entities:
       pos: -18.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9886
     components:
     - type: Transform
@@ -75262,7 +75192,7 @@ entities:
       pos: -0.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9893
     components:
     - type: Transform
@@ -75270,7 +75200,7 @@ entities:
       pos: -15.5,-29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9900
     components:
     - type: Transform
@@ -75278,7 +75208,7 @@ entities:
       pos: -10.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9901
     components:
     - type: Transform
@@ -75286,7 +75216,7 @@ entities:
       pos: -9.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9904
     components:
     - type: Transform
@@ -75294,7 +75224,7 @@ entities:
       pos: -4.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9906
     components:
     - type: Transform
@@ -75302,7 +75232,7 @@ entities:
       pos: -3.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9907
     components:
     - type: Transform
@@ -75310,7 +75240,7 @@ entities:
       pos: -5.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9920
     components:
     - type: Transform
@@ -75318,14 +75248,14 @@ entities:
       pos: -13.5,-29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9921
     components:
     - type: Transform
       pos: -11.5,-30.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9922
     components:
     - type: Transform
@@ -75333,28 +75263,28 @@ entities:
       pos: -12.5,-29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9923
     components:
     - type: Transform
       pos: -11.5,-32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9924
     components:
     - type: Transform
       pos: -11.5,-33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9925
     components:
     - type: Transform
       pos: -11.5,-36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9936
     components:
     - type: Transform
@@ -75362,7 +75292,7 @@ entities:
       pos: -1.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9966
     components:
     - type: Transform
@@ -75405,21 +75335,21 @@ entities:
       pos: -11.5,-34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10020
     components:
     - type: Transform
       pos: -11.5,-37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10021
     components:
     - type: Transform
       pos: -11.5,-38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10091
     components:
     - type: Transform
@@ -75433,7 +75363,7 @@ entities:
       pos: -18.5,-44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10128
     components:
     - type: Transform
@@ -75456,7 +75386,7 @@ entities:
       pos: 0.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10131
     components:
     - type: Transform
@@ -75464,7 +75394,7 @@ entities:
       pos: -2.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10132
     components:
     - type: Transform
@@ -75472,7 +75402,7 @@ entities:
       pos: -22.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10133
     components:
     - type: Transform
@@ -75480,7 +75410,7 @@ entities:
       pos: -14.5,-29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10167
     components:
     - type: Transform
@@ -75523,7 +75453,7 @@ entities:
       pos: -18.5,-50.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10212
     components:
     - type: Transform
@@ -75553,7 +75483,7 @@ entities:
       pos: -9.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10217
     components:
     - type: Transform
@@ -75561,7 +75491,7 @@ entities:
       pos: -19.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10218
     components:
     - type: Transform
@@ -75569,7 +75499,7 @@ entities:
       pos: -14.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10219
     components:
     - type: Transform
@@ -75577,14 +75507,14 @@ entities:
       pos: -17.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10220
     components:
     - type: Transform
       pos: -12.5,-41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10262
     components:
     - type: Transform
@@ -75598,14 +75528,14 @@ entities:
       pos: -12.5,-44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10264
     components:
     - type: Transform
       pos: -12.5,-45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10267
     components:
     - type: Transform
@@ -75621,7 +75551,7 @@ entities:
       pos: -10.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10273
     components:
     - type: Transform
@@ -75629,14 +75559,14 @@ entities:
       pos: -11.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10275
     components:
     - type: Transform
       pos: -18.5,-51.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10276
     components:
     - type: Transform
@@ -75682,7 +75612,7 @@ entities:
       pos: -13.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10290
     components:
     - type: Transform
@@ -75690,7 +75620,7 @@ entities:
       pos: -15.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10397
     components:
     - type: Transform
@@ -75698,14 +75628,14 @@ entities:
       pos: -16.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10435
     components:
     - type: Transform
       pos: -12.5,-40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10436
     components:
     - type: Transform
@@ -75719,7 +75649,7 @@ entities:
       pos: -12.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10438
     components:
     - type: Transform
@@ -75734,7 +75664,7 @@ entities:
       pos: -21.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10536
     components:
     - type: Transform
@@ -75742,7 +75672,7 @@ entities:
       pos: -20.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10557
     components:
     - type: Transform
@@ -75836,7 +75766,7 @@ entities:
       pos: 2.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11102
     components:
     - type: Transform
@@ -75890,7 +75820,7 @@ entities:
       pos: 2.5,-44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11135
     components:
     - type: Transform
@@ -75905,7 +75835,7 @@ entities:
       pos: -6.5,-37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11168
     components:
     - type: Transform
@@ -75929,7 +75859,7 @@ entities:
       pos: 10.5,-25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11182
     components:
     - type: Transform
@@ -75937,7 +75867,7 @@ entities:
       pos: 10.5,-26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11183
     components:
     - type: Transform
@@ -75945,7 +75875,7 @@ entities:
       pos: 10.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11184
     components:
     - type: Transform
@@ -75985,7 +75915,7 @@ entities:
       pos: 9.5,-19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11203
     components:
     - type: Transform
@@ -75993,7 +75923,7 @@ entities:
       pos: 9.5,-18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11204
     components:
     - type: Transform
@@ -76001,7 +75931,7 @@ entities:
       pos: 9.5,-17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11205
     components:
     - type: Transform
@@ -76009,7 +75939,7 @@ entities:
       pos: 9.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11206
     components:
     - type: Transform
@@ -76041,7 +75971,7 @@ entities:
       pos: 29.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11640
     components:
     - type: Transform
@@ -76049,7 +75979,7 @@ entities:
       pos: 28.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11641
     components:
     - type: Transform
@@ -76057,7 +75987,7 @@ entities:
       pos: 34.5,-11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11665
     components:
     - type: Transform
@@ -76073,7 +76003,7 @@ entities:
       pos: 30.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11686
     components:
     - type: Transform
@@ -76089,7 +76019,7 @@ entities:
       pos: 25.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11701
     components:
     - type: Transform
@@ -76103,7 +76033,7 @@ entities:
       pos: 33.5,-4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11713
     components:
     - type: Transform
@@ -76150,7 +76080,7 @@ entities:
       pos: 35.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11870
     components:
     - type: Transform
@@ -76166,7 +76096,7 @@ entities:
       pos: 34.5,-10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11878
     components:
     - type: Transform
@@ -76181,7 +76111,7 @@ entities:
       pos: 22.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11881
     components:
     - type: Transform
@@ -76260,7 +76190,7 @@ entities:
       pos: 14.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11907
     components:
     - type: Transform
@@ -76268,7 +76198,7 @@ entities:
       pos: 15.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11908
     components:
     - type: Transform
@@ -76276,7 +76206,7 @@ entities:
       pos: 16.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11909
     components:
     - type: Transform
@@ -76284,7 +76214,7 @@ entities:
       pos: 29.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11910
     components:
     - type: Transform
@@ -76292,7 +76222,7 @@ entities:
       pos: 18.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11911
     components:
     - type: Transform
@@ -76300,7 +76230,7 @@ entities:
       pos: 19.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11912
     components:
     - type: Transform
@@ -76316,7 +76246,7 @@ entities:
       pos: 21.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11914
     components:
     - type: Transform
@@ -76324,7 +76254,7 @@ entities:
       pos: 22.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11915
     components:
     - type: Transform
@@ -76332,7 +76262,7 @@ entities:
       pos: 23.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11916
     components:
     - type: Transform
@@ -76363,7 +76293,7 @@ entities:
       pos: 35.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11921
     components:
     - type: Transform
@@ -76371,7 +76301,7 @@ entities:
       pos: 27.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11927
     components:
     - type: Transform
@@ -76422,7 +76352,7 @@ entities:
       pos: 20.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11951
     components:
     - type: Transform
@@ -76430,7 +76360,7 @@ entities:
       pos: 14.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11952
     components:
     - type: Transform
@@ -76438,7 +76368,7 @@ entities:
       pos: 15.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11953
     components:
     - type: Transform
@@ -76446,7 +76376,7 @@ entities:
       pos: 16.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11954
     components:
     - type: Transform
@@ -76454,7 +76384,7 @@ entities:
       pos: 17.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11955
     components:
     - type: Transform
@@ -76462,7 +76392,7 @@ entities:
       pos: 18.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11956
     components:
     - type: Transform
@@ -76470,7 +76400,7 @@ entities:
       pos: 19.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11957
     components:
     - type: Transform
@@ -76584,35 +76514,35 @@ entities:
       pos: 20.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11975
     components:
     - type: Transform
       pos: 20.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11976
     components:
     - type: Transform
       pos: 20.5,-4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11977
     components:
     - type: Transform
       pos: 20.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11980
     components:
     - type: Transform
       pos: 20.5,-0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11983
     components:
     - type: Transform
@@ -76636,7 +76566,7 @@ entities:
       pos: 21.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11988
     components:
     - type: Transform
@@ -76644,7 +76574,7 @@ entities:
       pos: 23.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11989
     components:
     - type: Transform
@@ -76652,7 +76582,7 @@ entities:
       pos: 27.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11990
     components:
     - type: Transform
@@ -76668,7 +76598,7 @@ entities:
       pos: 28.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11993
     components:
     - type: Transform
@@ -76676,7 +76606,7 @@ entities:
       pos: 31.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12000
     components:
     - type: Transform
@@ -76692,7 +76622,7 @@ entities:
       pos: 30.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12005
     components:
     - type: Transform
@@ -76700,7 +76630,7 @@ entities:
       pos: 30.5,-0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12006
     components:
     - type: Transform
@@ -76708,7 +76638,7 @@ entities:
       pos: 30.5,0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12008
     components:
     - type: Transform
@@ -76716,7 +76646,7 @@ entities:
       pos: 25.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12009
     components:
     - type: Transform
@@ -76724,7 +76654,7 @@ entities:
       pos: 25.5,-0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12016
     components:
     - type: Transform
@@ -76755,7 +76685,7 @@ entities:
       pos: 26.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12024
     components:
     - type: Transform
@@ -76763,7 +76693,7 @@ entities:
       pos: 36.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12036
     components:
     - type: Transform
@@ -76811,7 +76741,7 @@ entities:
       pos: 32.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12065
     components:
     - type: Transform
@@ -76819,7 +76749,7 @@ entities:
       pos: 34.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12066
     components:
     - type: Transform
@@ -76827,7 +76757,7 @@ entities:
       pos: 36.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12082
     components:
     - type: Transform
@@ -76843,7 +76773,7 @@ entities:
       pos: 34.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12127
     components:
     - type: Transform
@@ -76851,7 +76781,7 @@ entities:
       pos: 31.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12130
     components:
     - type: Transform
@@ -76859,7 +76789,7 @@ entities:
       pos: 34.5,-13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12236
     components:
     - type: Transform
@@ -76867,49 +76797,49 @@ entities:
       pos: 32.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12464
     components:
     - type: Transform
       pos: 10.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12465
     components:
     - type: Transform
       pos: 10.5,27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12466
     components:
     - type: Transform
       pos: 10.5,28.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12467
     components:
     - type: Transform
       pos: 10.5,29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12468
     components:
     - type: Transform
       pos: 10.5,30.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12469
     components:
     - type: Transform
       pos: 10.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12470
     components:
     - type: Transform
@@ -76939,7 +76869,7 @@ entities:
       pos: 10.5,32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12476
     components:
     - type: Transform
@@ -77003,7 +76933,7 @@ entities:
       pos: 10.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12484
     components:
     - type: Transform
@@ -77011,7 +76941,7 @@ entities:
       pos: 10.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12485
     components:
     - type: Transform
@@ -77019,7 +76949,7 @@ entities:
       pos: 10.5,36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12486
     components:
     - type: Transform
@@ -77027,7 +76957,7 @@ entities:
       pos: 10.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12487
     components:
     - type: Transform
@@ -77035,7 +76965,7 @@ entities:
       pos: 10.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12494
     components:
     - type: Transform
@@ -77043,7 +76973,7 @@ entities:
       pos: 9.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12496
     components:
     - type: Transform
@@ -77179,7 +77109,7 @@ entities:
       pos: 11.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12517
     components:
     - type: Transform
@@ -77187,7 +77117,7 @@ entities:
       pos: 12.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12518
     components:
     - type: Transform
@@ -77195,7 +77125,7 @@ entities:
       pos: 13.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12519
     components:
     - type: Transform
@@ -77203,7 +77133,7 @@ entities:
       pos: 14.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12520
     components:
     - type: Transform
@@ -77211,7 +77141,7 @@ entities:
       pos: 15.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12521
     components:
     - type: Transform
@@ -77219,7 +77149,7 @@ entities:
       pos: 16.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12522
     components:
     - type: Transform
@@ -77227,7 +77157,7 @@ entities:
       pos: 17.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12524
     components:
     - type: Transform
@@ -77235,7 +77165,7 @@ entities:
       pos: 19.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12525
     components:
     - type: Transform
@@ -77243,7 +77173,7 @@ entities:
       pos: 20.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12526
     components:
     - type: Transform
@@ -77251,7 +77181,7 @@ entities:
       pos: 21.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12527
     components:
     - type: Transform
@@ -77259,7 +77189,7 @@ entities:
       pos: 22.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12529
     components:
     - type: Transform
@@ -77267,7 +77197,7 @@ entities:
       pos: 23.5,27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12530
     components:
     - type: Transform
@@ -77275,7 +77205,7 @@ entities:
       pos: 23.5,28.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12531
     components:
     - type: Transform
@@ -77283,7 +77213,7 @@ entities:
       pos: 23.5,30.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12532
     components:
     - type: Transform
@@ -77291,7 +77221,7 @@ entities:
       pos: 23.5,29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12533
     components:
     - type: Transform
@@ -77299,7 +77229,7 @@ entities:
       pos: 23.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12534
     components:
     - type: Transform
@@ -77307,7 +77237,7 @@ entities:
       pos: 23.5,32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12535
     components:
     - type: Transform
@@ -77315,7 +77245,7 @@ entities:
       pos: 23.5,33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12546
     components:
     - type: Transform
@@ -77355,7 +77285,7 @@ entities:
       pos: 23.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12551
     components:
     - type: Transform
@@ -77363,7 +77293,7 @@ entities:
       pos: 23.5,36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12552
     components:
     - type: Transform
@@ -77395,7 +77325,7 @@ entities:
       pos: 20.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12556
     components:
     - type: Transform
@@ -77403,7 +77333,7 @@ entities:
       pos: 20.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12557
     components:
     - type: Transform
@@ -77411,7 +77341,7 @@ entities:
       pos: 21.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12558
     components:
     - type: Transform
@@ -77419,14 +77349,14 @@ entities:
       pos: 22.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12560
     components:
     - type: Transform
       pos: 23.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12561
     components:
     - type: Transform
@@ -77434,7 +77364,7 @@ entities:
       pos: 22.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12562
     components:
     - type: Transform
@@ -77442,7 +77372,7 @@ entities:
       pos: 21.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12563
     components:
     - type: Transform
@@ -77450,7 +77380,7 @@ entities:
       pos: 20.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12564
     components:
     - type: Transform
@@ -77458,7 +77388,7 @@ entities:
       pos: 19.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12565
     components:
     - type: Transform
@@ -77498,7 +77428,7 @@ entities:
       pos: 22.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12570
     components:
     - type: Transform
@@ -77506,7 +77436,7 @@ entities:
       pos: 21.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12571
     components:
     - type: Transform
@@ -77514,7 +77444,7 @@ entities:
       pos: 20.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12572
     components:
     - type: Transform
@@ -77522,7 +77452,7 @@ entities:
       pos: 19.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12573
     components:
     - type: Transform
@@ -77546,7 +77476,7 @@ entities:
       pos: 19.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12585
     components:
     - type: Transform
@@ -77554,14 +77484,14 @@ entities:
       pos: 24.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12586
     components:
     - type: Transform
       pos: 25.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12590
     components:
     - type: Transform
@@ -77569,7 +77499,7 @@ entities:
       pos: 26.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12591
     components:
     - type: Transform
@@ -77577,7 +77507,7 @@ entities:
       pos: 26.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12592
     components:
     - type: Transform
@@ -77585,7 +77515,7 @@ entities:
       pos: 27.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12593
     components:
     - type: Transform
@@ -77593,7 +77523,7 @@ entities:
       pos: 28.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12594
     components:
     - type: Transform
@@ -77601,7 +77531,7 @@ entities:
       pos: 29.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12595
     components:
     - type: Transform
@@ -77609,7 +77539,7 @@ entities:
       pos: 30.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12596
     components:
     - type: Transform
@@ -77673,7 +77603,7 @@ entities:
       pos: 24.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12608
     components:
     - type: Transform
@@ -77681,7 +77611,7 @@ entities:
       pos: 25.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12609
     components:
     - type: Transform
@@ -77689,7 +77619,7 @@ entities:
       pos: 26.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12612
     components:
     - type: Transform
@@ -77753,14 +77683,14 @@ entities:
       pos: 26.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12745
     components:
     - type: Transform
       pos: 16.5,56.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12752
     components:
     - type: Transform
@@ -77835,7 +77765,7 @@ entities:
       pos: 24.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12887
     components:
     - type: Transform
@@ -77843,7 +77773,7 @@ entities:
       pos: 25.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12888
     components:
     - type: Transform
@@ -77864,7 +77794,7 @@ entities:
       pos: 26.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12924
     components:
     - type: Transform
@@ -77877,7 +77807,7 @@ entities:
       pos: 12.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12939
     components:
     - type: Transform
@@ -77885,7 +77815,7 @@ entities:
       pos: 13.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12941
     components:
     - type: Transform
@@ -77893,7 +77823,7 @@ entities:
       pos: 15.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12942
     components:
     - type: Transform
@@ -77901,7 +77831,7 @@ entities:
       pos: 16.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12945
     components:
     - type: Transform
@@ -77909,7 +77839,7 @@ entities:
       pos: 19.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12946
     components:
     - type: Transform
@@ -77917,7 +77847,7 @@ entities:
       pos: 20.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12947
     components:
     - type: Transform
@@ -77925,7 +77855,7 @@ entities:
       pos: 21.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12948
     components:
     - type: Transform
@@ -77933,7 +77863,7 @@ entities:
       pos: 22.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12950
     components:
     - type: Transform
@@ -77941,7 +77871,7 @@ entities:
       pos: 23.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12952
     components:
     - type: Transform
@@ -77949,7 +77879,7 @@ entities:
       pos: 23.5,12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12953
     components:
     - type: Transform
@@ -77957,7 +77887,7 @@ entities:
       pos: 23.5,11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12955
     components:
     - type: Transform
@@ -77965,7 +77895,7 @@ entities:
       pos: 23.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12957
     components:
     - type: Transform
@@ -77973,7 +77903,7 @@ entities:
       pos: 25.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12958
     components:
     - type: Transform
@@ -77981,7 +77911,7 @@ entities:
       pos: 24.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12962
     components:
     - type: Transform
@@ -77989,7 +77919,7 @@ entities:
       pos: 27.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12964
     components:
     - type: Transform
@@ -77997,7 +77927,7 @@ entities:
       pos: 29.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12965
     components:
     - type: Transform
@@ -78005,7 +77935,7 @@ entities:
       pos: 30.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12966
     components:
     - type: Transform
@@ -78013,21 +77943,21 @@ entities:
       pos: 31.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12967
     components:
     - type: Transform
       pos: 32.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12968
     components:
     - type: Transform
       pos: 32.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12969
     components:
     - type: Transform
@@ -78035,7 +77965,7 @@ entities:
       pos: 33.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12970
     components:
     - type: Transform
@@ -78043,7 +77973,7 @@ entities:
       pos: 34.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12971
     components:
     - type: Transform
@@ -78051,7 +77981,7 @@ entities:
       pos: 35.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12972
     components:
     - type: Transform
@@ -78059,7 +77989,7 @@ entities:
       pos: 36.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12977
     components:
     - type: Transform
@@ -78067,7 +77997,7 @@ entities:
       pos: 22.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12978
     components:
     - type: Transform
@@ -78075,7 +78005,7 @@ entities:
       pos: 21.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12979
     components:
     - type: Transform
@@ -78083,7 +78013,7 @@ entities:
       pos: 20.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12980
     components:
     - type: Transform
@@ -78091,7 +78021,7 @@ entities:
       pos: 19.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12981
     components:
     - type: Transform
@@ -78099,7 +78029,7 @@ entities:
       pos: 18.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12982
     components:
     - type: Transform
@@ -78107,21 +78037,21 @@ entities:
       pos: 17.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12984
     components:
     - type: Transform
       pos: 23.5,16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12985
     components:
     - type: Transform
       pos: 23.5,17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12987
     components:
     - type: Transform
@@ -78129,7 +78059,7 @@ entities:
       pos: 14.5,16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12988
     components:
     - type: Transform
@@ -78137,7 +78067,7 @@ entities:
       pos: 14.5,17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12990
     components:
     - type: Transform
@@ -78145,7 +78075,7 @@ entities:
       pos: 14.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12992
     components:
     - type: Transform
@@ -78153,7 +78083,7 @@ entities:
       pos: 15.5,20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12993
     components:
     - type: Transform
@@ -78161,7 +78091,7 @@ entities:
       pos: 16.5,20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12994
     components:
     - type: Transform
@@ -78169,7 +78099,7 @@ entities:
       pos: 17.5,20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12998
     components:
     - type: Transform
@@ -78177,7 +78107,7 @@ entities:
       pos: 22.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12999
     components:
     - type: Transform
@@ -78185,7 +78115,7 @@ entities:
       pos: 21.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13000
     components:
     - type: Transform
@@ -78193,7 +78123,7 @@ entities:
       pos: 20.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13001
     components:
     - type: Transform
@@ -78201,7 +78131,7 @@ entities:
       pos: 19.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13008
     components:
     - type: Transform
@@ -78587,7 +78517,7 @@ entities:
       pos: 24.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13090
     components:
     - type: Transform
@@ -78595,7 +78525,7 @@ entities:
       pos: 25.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13152
     components:
     - type: Transform
@@ -78665,7 +78595,7 @@ entities:
       pos: 16.5,55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13635
     components:
     - type: Transform
@@ -78673,7 +78603,7 @@ entities:
       pos: 51.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13636
     components:
     - type: Transform
@@ -78681,7 +78611,7 @@ entities:
       pos: 49.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13637
     components:
     - type: Transform
@@ -78689,7 +78619,7 @@ entities:
       pos: 47.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13638
     components:
     - type: Transform
@@ -78697,7 +78627,7 @@ entities:
       pos: 45.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13639
     components:
     - type: Transform
@@ -78705,7 +78635,7 @@ entities:
       pos: 43.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13640
     components:
     - type: Transform
@@ -78713,7 +78643,7 @@ entities:
       pos: 34.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13641
     components:
     - type: Transform
@@ -78721,7 +78651,7 @@ entities:
       pos: 36.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13754
     components:
     - type: Transform
@@ -78817,7 +78747,7 @@ entities:
       pos: 32.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13770
     components:
     - type: Transform
@@ -78825,7 +78755,7 @@ entities:
       pos: 33.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13771
     components:
     - type: Transform
@@ -78833,7 +78763,7 @@ entities:
       pos: 34.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13773
     components:
     - type: Transform
@@ -78841,7 +78771,7 @@ entities:
       pos: 36.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13774
     components:
     - type: Transform
@@ -78849,7 +78779,7 @@ entities:
       pos: 37.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13775
     components:
     - type: Transform
@@ -78857,7 +78787,7 @@ entities:
       pos: 38.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13777
     components:
     - type: Transform
@@ -78865,7 +78795,7 @@ entities:
       pos: 40.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13778
     components:
     - type: Transform
@@ -78873,7 +78803,7 @@ entities:
       pos: 41.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13779
     components:
     - type: Transform
@@ -78881,7 +78811,7 @@ entities:
       pos: 42.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13780
     components:
     - type: Transform
@@ -78889,7 +78819,7 @@ entities:
       pos: 43.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13781
     components:
     - type: Transform
@@ -78897,28 +78827,28 @@ entities:
       pos: 44.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13785
     components:
     - type: Transform
       pos: 30.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13786
     components:
     - type: Transform
       pos: 30.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13787
     components:
     - type: Transform
       pos: 30.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13792
     components:
     - type: Transform
@@ -78990,7 +78920,7 @@ entities:
       pos: -53.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14448
     components:
     - type: Transform
@@ -79004,7 +78934,7 @@ entities:
       pos: -25.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14461
     components:
     - type: Transform
@@ -79042,7 +78972,7 @@ entities:
       pos: -25.5,11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14500
     components:
     - type: Transform
@@ -79050,7 +78980,7 @@ entities:
       pos: 18.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14501
     components:
     - type: Transform
@@ -79066,7 +78996,7 @@ entities:
       pos: -64.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14503
     components:
     - type: Transform
@@ -79074,7 +79004,7 @@ entities:
       pos: -59.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14511
     components:
     - type: Transform
@@ -79082,7 +79012,7 @@ entities:
       pos: 15.5,12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14517
     components:
     - type: Transform
@@ -79097,21 +79027,21 @@ entities:
       pos: 16.5,45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14975
     components:
     - type: Transform
       pos: 16.5,47.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14977
     components:
     - type: Transform
       pos: 16.5,44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14980
     components:
     - type: Transform
@@ -79119,7 +79049,7 @@ entities:
       pos: 19.5,43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14981
     components:
     - type: Transform
@@ -79127,63 +79057,63 @@ entities:
       pos: 18.5,43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14988
     components:
     - type: Transform
       pos: 16.5,52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14990
     components:
     - type: Transform
       pos: 16.5,53.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15018
     components:
     - type: Transform
       pos: 16.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15049
     components:
     - type: Transform
       pos: 16.5,51.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15053
     components:
     - type: Transform
       pos: 16.5,50.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15054
     components:
     - type: Transform
       pos: 16.5,46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15055
     components:
     - type: Transform
       pos: 16.5,54.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15061
     components:
     - type: Transform
       pos: 16.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15453
     components:
     - type: Transform
@@ -79191,7 +79121,7 @@ entities:
       pos: 50.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15454
     components:
     - type: Transform
@@ -79199,7 +79129,7 @@ entities:
       pos: 48.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15455
     components:
     - type: Transform
@@ -79207,7 +79137,7 @@ entities:
       pos: 46.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15456
     components:
     - type: Transform
@@ -79215,7 +79145,7 @@ entities:
       pos: 44.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15457
     components:
     - type: Transform
@@ -79223,7 +79153,7 @@ entities:
       pos: 33.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15458
     components:
     - type: Transform
@@ -79231,7 +79161,7 @@ entities:
       pos: 35.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15459
     components:
     - type: Transform
@@ -79239,7 +79169,7 @@ entities:
       pos: 37.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15618
     components:
     - type: Transform
@@ -79247,7 +79177,7 @@ entities:
       pos: 52.5,22.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15624
     components:
     - type: Transform
@@ -79255,21 +79185,21 @@ entities:
       pos: 38.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15734
     components:
     - type: Transform
       pos: 42.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15735
     components:
     - type: Transform
       pos: 42.5,17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15740
     components:
     - type: Transform
@@ -79277,7 +79207,7 @@ entities:
       pos: 39.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15741
     components:
     - type: Transform
@@ -79285,7 +79215,7 @@ entities:
       pos: 40.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15743
     components:
     - type: Transform
@@ -79293,35 +79223,35 @@ entities:
       pos: 41.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15744
     components:
     - type: Transform
       pos: 42.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15745
     components:
     - type: Transform
       pos: 42.5,7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15746
     components:
     - type: Transform
       pos: 42.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15747
     components:
     - type: Transform
       pos: 42.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15748
     components:
     - type: Transform
@@ -79329,14 +79259,14 @@ entities:
       pos: 52.5,21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15994
     components:
     - type: Transform
       pos: 32.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 16101
     components:
     - type: Transform
@@ -79344,7 +79274,7 @@ entities:
       pos: 34.5,-12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 16102
     components:
     - type: Transform
@@ -79352,7 +79282,7 @@ entities:
       pos: 26.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 16122
     components:
     - type: Transform
@@ -79368,7 +79298,7 @@ entities:
       pos: 17.5,43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 17715
     components:
     - type: Transform
@@ -79376,14 +79306,14 @@ entities:
       pos: -54.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18077
     components:
     - type: Transform
       pos: 16.5,11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18211
     components:
     - type: Transform
@@ -79520,7 +79450,7 @@ entities:
       pos: -51.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18400
     components:
     - type: Transform
@@ -79551,70 +79481,70 @@ entities:
       pos: -44.5,-12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18405
     components:
     - type: Transform
       pos: -44.5,-14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18406
     components:
     - type: Transform
       pos: -44.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18407
     components:
     - type: Transform
       pos: -44.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18408
     components:
     - type: Transform
       pos: -44.5,-17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18409
     components:
     - type: Transform
       pos: -44.5,-18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18410
     components:
     - type: Transform
       pos: -44.5,-19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18411
     components:
     - type: Transform
       pos: -44.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18413
     components:
     - type: Transform
       pos: -44.5,-22.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18414
     components:
     - type: Transform
       pos: -44.5,-23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18417
     components:
     - type: Transform
@@ -79636,7 +79566,7 @@ entities:
       pos: -60.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18420
     components:
     - type: Transform
@@ -79644,7 +79574,7 @@ entities:
       pos: -59.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18422
     components:
     - type: Transform
@@ -79652,7 +79582,7 @@ entities:
       pos: -57.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18423
     components:
     - type: Transform
@@ -79660,7 +79590,7 @@ entities:
       pos: -56.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18424
     components:
     - type: Transform
@@ -79668,7 +79598,7 @@ entities:
       pos: -55.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18425
     components:
     - type: Transform
@@ -79676,7 +79606,7 @@ entities:
       pos: -54.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18427
     components:
     - type: Transform
@@ -79684,7 +79614,7 @@ entities:
       pos: -52.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18428
     components:
     - type: Transform
@@ -79700,7 +79630,7 @@ entities:
       pos: -50.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18431
     components:
     - type: Transform
@@ -79708,7 +79638,7 @@ entities:
       pos: -48.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18432
     components:
     - type: Transform
@@ -79716,7 +79646,7 @@ entities:
       pos: -47.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18433
     components:
     - type: Transform
@@ -79724,7 +79654,7 @@ entities:
       pos: -46.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18434
     components:
     - type: Transform
@@ -79732,7 +79662,7 @@ entities:
       pos: -45.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18443
     components:
     - type: Transform
@@ -79740,21 +79670,21 @@ entities:
       pos: -62.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18444
     components:
     - type: Transform
       pos: -63.5,-23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18445
     components:
     - type: Transform
       pos: -63.5,-22.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18448
     components:
     - type: Transform
@@ -79762,7 +79692,7 @@ entities:
       pos: -63.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18452
     components:
     - type: Transform
@@ -79860,91 +79790,91 @@ entities:
       pos: -61.5,-37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18466
     components:
     - type: Transform
       pos: -61.5,-36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18467
     components:
     - type: Transform
       pos: -61.5,-35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18468
     components:
     - type: Transform
       pos: -61.5,-34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18469
     components:
     - type: Transform
       pos: -61.5,-33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18470
     components:
     - type: Transform
       pos: -61.5,-32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18471
     components:
     - type: Transform
       pos: -61.5,-31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18472
     components:
     - type: Transform
       pos: -61.5,-30.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18473
     components:
     - type: Transform
       pos: -61.5,-29.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18474
     components:
     - type: Transform
       pos: -61.5,-28.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18475
     components:
     - type: Transform
       pos: -61.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18476
     components:
     - type: Transform
       pos: -61.5,-26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18477
     components:
     - type: Transform
       pos: -61.5,-25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18480
     components:
     - type: Transform
@@ -79960,7 +79890,7 @@ entities:
       pos: -60.5,-38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18482
     components:
     - type: Transform
@@ -79968,7 +79898,7 @@ entities:
       pos: -59.5,-38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18483
     components:
     - type: Transform
@@ -80428,56 +80358,56 @@ entities:
       pos: -55.5,-59.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18564
     components:
     - type: Transform
       pos: -55.5,-58.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18565
     components:
     - type: Transform
       pos: -55.5,-57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18567
     components:
     - type: Transform
       pos: -55.5,-55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18569
     components:
     - type: Transform
       pos: -55.5,-53.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18571
     components:
     - type: Transform
       pos: -55.5,-51.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18572
     components:
     - type: Transform
       pos: -55.5,-50.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18573
     components:
     - type: Transform
       pos: -55.5,-49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18574
     components:
     - type: Transform
@@ -80485,7 +80415,7 @@ entities:
       pos: -56.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18575
     components:
     - type: Transform
@@ -80493,7 +80423,7 @@ entities:
       pos: -57.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18576
     components:
     - type: Transform
@@ -80501,7 +80431,7 @@ entities:
       pos: -58.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18577
     components:
     - type: Transform
@@ -80509,7 +80439,7 @@ entities:
       pos: -59.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18579
     components:
     - type: Transform
@@ -80517,7 +80447,7 @@ entities:
       pos: -62.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18580
     components:
     - type: Transform
@@ -80525,7 +80455,7 @@ entities:
       pos: -63.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18581
     components:
     - type: Transform
@@ -80533,7 +80463,7 @@ entities:
       pos: -64.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18582
     components:
     - type: Transform
@@ -80541,7 +80471,7 @@ entities:
       pos: -65.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18583
     components:
     - type: Transform
@@ -80549,7 +80479,7 @@ entities:
       pos: -66.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18584
     components:
     - type: Transform
@@ -80557,7 +80487,7 @@ entities:
       pos: -67.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18585
     components:
     - type: Transform
@@ -80565,7 +80495,7 @@ entities:
       pos: -68.5,-49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18586
     components:
     - type: Transform
@@ -80573,7 +80503,7 @@ entities:
       pos: -68.5,-50.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18587
     components:
     - type: Transform
@@ -80581,7 +80511,7 @@ entities:
       pos: -68.5,-51.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18588
     components:
     - type: Transform
@@ -80589,7 +80519,7 @@ entities:
       pos: -68.5,-52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18589
     components:
     - type: Transform
@@ -80597,7 +80527,7 @@ entities:
       pos: -68.5,-53.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18590
     components:
     - type: Transform
@@ -80605,7 +80535,7 @@ entities:
       pos: -68.5,-54.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18592
     components:
     - type: Transform
@@ -80613,7 +80543,7 @@ entities:
       pos: -68.5,-56.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18593
     components:
     - type: Transform
@@ -80621,7 +80551,7 @@ entities:
       pos: -68.5,-57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18594
     components:
     - type: Transform
@@ -80629,7 +80559,7 @@ entities:
       pos: -68.5,-59.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18595
     components:
     - type: Transform
@@ -80637,7 +80567,7 @@ entities:
       pos: -68.5,-58.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18596
     components:
     - type: Transform
@@ -80645,7 +80575,7 @@ entities:
       pos: -67.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18597
     components:
     - type: Transform
@@ -80653,7 +80583,7 @@ entities:
       pos: -66.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18598
     components:
     - type: Transform
@@ -80661,7 +80591,7 @@ entities:
       pos: -65.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18600
     components:
     - type: Transform
@@ -80669,7 +80599,7 @@ entities:
       pos: -63.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18602
     components:
     - type: Transform
@@ -80677,7 +80607,7 @@ entities:
       pos: -61.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18605
     components:
     - type: Transform
@@ -80685,7 +80615,7 @@ entities:
       pos: -58.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18606
     components:
     - type: Transform
@@ -80693,7 +80623,7 @@ entities:
       pos: -57.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18607
     components:
     - type: Transform
@@ -80701,7 +80631,7 @@ entities:
       pos: -56.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18617
     components:
     - type: Transform
@@ -80709,7 +80639,7 @@ entities:
       pos: -61.5,-47.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18619
     components:
     - type: Transform
@@ -80717,7 +80647,7 @@ entities:
       pos: -60.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18620
     components:
     - type: Transform
@@ -80725,7 +80655,7 @@ entities:
       pos: -59.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18622
     components:
     - type: Transform
@@ -80733,7 +80663,7 @@ entities:
       pos: -58.5,-45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18624
     components:
     - type: Transform
@@ -80741,7 +80671,7 @@ entities:
       pos: -58.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18625
     components:
     - type: Transform
@@ -80749,7 +80679,7 @@ entities:
       pos: -58.5,-42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18626
     components:
     - type: Transform
@@ -80757,7 +80687,7 @@ entities:
       pos: -58.5,-41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18627
     components:
     - type: Transform
@@ -80765,7 +80695,7 @@ entities:
       pos: -58.5,-40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18628
     components:
     - type: Transform
@@ -80773,7 +80703,7 @@ entities:
       pos: -58.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18631
     components:
     - type: Transform
@@ -80781,7 +80711,7 @@ entities:
       pos: -62.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18632
     components:
     - type: Transform
@@ -80789,7 +80719,7 @@ entities:
       pos: -63.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18633
     components:
     - type: Transform
@@ -80797,7 +80727,7 @@ entities:
       pos: -64.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18634
     components:
     - type: Transform
@@ -80805,7 +80735,7 @@ entities:
       pos: -65.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18635
     components:
     - type: Transform
@@ -80813,7 +80743,7 @@ entities:
       pos: -66.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18638
     components:
     - type: Transform
@@ -80821,7 +80751,7 @@ entities:
       pos: -69.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18639
     components:
     - type: Transform
@@ -80829,7 +80759,7 @@ entities:
       pos: -70.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18640
     components:
     - type: Transform
@@ -80837,7 +80767,7 @@ entities:
       pos: -71.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18641
     components:
     - type: Transform
@@ -80845,7 +80775,7 @@ entities:
       pos: -72.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18642
     components:
     - type: Transform
@@ -80853,7 +80783,7 @@ entities:
       pos: -73.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18643
     components:
     - type: Transform
@@ -80861,7 +80791,7 @@ entities:
       pos: -74.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18645
     components:
     - type: Transform
@@ -80869,7 +80799,7 @@ entities:
       pos: -76.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18646
     components:
     - type: Transform
@@ -80877,7 +80807,7 @@ entities:
       pos: -77.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18647
     components:
     - type: Transform
@@ -80885,7 +80815,7 @@ entities:
       pos: -78.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18649
     components:
     - type: Transform
@@ -80893,7 +80823,7 @@ entities:
       pos: -79.5,-45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18650
     components:
     - type: Transform
@@ -80901,7 +80831,7 @@ entities:
       pos: -79.5,-44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18651
     components:
     - type: Transform
@@ -80909,7 +80839,7 @@ entities:
       pos: -79.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18652
     components:
     - type: Transform
@@ -80917,7 +80847,7 @@ entities:
       pos: -79.5,-42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18653
     components:
     - type: Transform
@@ -80925,7 +80855,7 @@ entities:
       pos: -79.5,-41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18654
     components:
     - type: Transform
@@ -80933,28 +80863,28 @@ entities:
       pos: -79.5,-40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18656
     components:
     - type: Transform
       pos: -75.5,-45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18657
     components:
     - type: Transform
       pos: -75.5,-44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18659
     components:
     - type: Transform
       pos: -75.5,-42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18660
     components:
     - type: Transform
@@ -80962,7 +80892,7 @@ entities:
       pos: -76.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18664
     components:
     - type: Transform
@@ -80970,7 +80900,7 @@ entities:
       pos: -67.5,-45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18665
     components:
     - type: Transform
@@ -80978,7 +80908,7 @@ entities:
       pos: -67.5,-44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18666
     components:
     - type: Transform
@@ -80986,7 +80916,7 @@ entities:
       pos: -67.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18669
     components:
     - type: Transform
@@ -81018,7 +80948,7 @@ entities:
       pos: -55.5,-47.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18673
     components:
     - type: Transform
@@ -81026,7 +80956,7 @@ entities:
       pos: -55.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18680
     components:
     - type: Transform
@@ -81034,7 +80964,7 @@ entities:
       pos: -54.5,-52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18681
     components:
     - type: Transform
@@ -81042,7 +80972,7 @@ entities:
       pos: -53.5,-52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18682
     components:
     - type: Transform
@@ -81074,7 +81004,7 @@ entities:
       pos: -54.5,-56.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18686
     components:
     - type: Transform
@@ -81082,7 +81012,7 @@ entities:
       pos: -53.5,-56.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18687
     components:
     - type: Transform
@@ -81114,7 +81044,7 @@ entities:
       pos: -55.5,-54.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18701
     components:
     - type: Transform
@@ -81122,7 +81052,7 @@ entities:
       pos: -69.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18702
     components:
     - type: Transform
@@ -81130,7 +81060,7 @@ entities:
       pos: -70.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18703
     components:
     - type: Transform
@@ -81138,7 +81068,7 @@ entities:
       pos: -71.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18705
     components:
     - type: Transform
@@ -81186,7 +81116,7 @@ entities:
       pos: -73.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18712
     components:
     - type: Transform
@@ -81194,7 +81124,7 @@ entities:
       pos: -75.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18713
     components:
     - type: Transform
@@ -81202,7 +81132,7 @@ entities:
       pos: -76.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18714
     components:
     - type: Transform
@@ -81210,7 +81140,7 @@ entities:
       pos: -77.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18715
     components:
     - type: Transform
@@ -81218,7 +81148,7 @@ entities:
       pos: -78.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18716
     components:
     - type: Transform
@@ -81226,7 +81156,7 @@ entities:
       pos: -79.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18718
     components:
     - type: Transform
@@ -81234,7 +81164,7 @@ entities:
       pos: -81.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18719
     components:
     - type: Transform
@@ -81242,7 +81172,7 @@ entities:
       pos: -82.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18721
     components:
     - type: Transform
@@ -81274,7 +81204,7 @@ entities:
       pos: -72.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18725
     components:
     - type: Transform
@@ -81370,7 +81300,7 @@ entities:
       pos: -69.5,-55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18747
     components:
     - type: Transform
@@ -81378,7 +81308,7 @@ entities:
       pos: -70.5,-55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18749
     components:
     - type: Transform
@@ -81386,7 +81316,7 @@ entities:
       pos: -72.5,-55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18750
     components:
     - type: Transform
@@ -81394,7 +81324,7 @@ entities:
       pos: -73.5,-55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18751
     components:
     - type: Transform
@@ -81402,7 +81332,7 @@ entities:
       pos: -74.5,-55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18752
     components:
     - type: Transform
@@ -81410,7 +81340,7 @@ entities:
       pos: -75.5,-55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18755
     components:
     - type: Transform
@@ -81418,7 +81348,7 @@ entities:
       pos: -71.5,-54.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18760
     components:
     - type: Transform
@@ -81432,35 +81362,35 @@ entities:
       pos: 4.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 20330
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 20331
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 20332
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 20333
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 20640
     components:
     - type: Transform
@@ -81628,21 +81558,21 @@ entities:
       pos: 39.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21547
     components:
     - type: Transform
       pos: 39.5,36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21548
     components:
     - type: Transform
       pos: 39.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21550
     components:
     - type: Transform
@@ -81674,7 +81604,7 @@ entities:
       pos: -0.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21988
     components:
     - type: Transform
@@ -81682,7 +81612,7 @@ entities:
       pos: -0.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21989
     components:
     - type: Transform
@@ -81690,7 +81620,7 @@ entities:
       pos: -0.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21990
     components:
     - type: Transform
@@ -81698,7 +81628,7 @@ entities:
       pos: -0.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21991
     components:
     - type: Transform
@@ -81706,7 +81636,7 @@ entities:
       pos: -0.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21992
     components:
     - type: Transform
@@ -81714,7 +81644,7 @@ entities:
       pos: -0.5,43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21993
     components:
     - type: Transform
@@ -81722,7 +81652,7 @@ entities:
       pos: -0.5,44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21994
     components:
     - type: Transform
@@ -81730,7 +81660,7 @@ entities:
       pos: -0.5,45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21995
     components:
     - type: Transform
@@ -81738,7 +81668,7 @@ entities:
       pos: -0.5,46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21996
     components:
     - type: Transform
@@ -81746,7 +81676,7 @@ entities:
       pos: -0.5,47.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21997
     components:
     - type: Transform
@@ -81754,7 +81684,7 @@ entities:
       pos: -0.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21998
     components:
     - type: Transform
@@ -81762,7 +81692,7 @@ entities:
       pos: -0.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21999
     components:
     - type: Transform
@@ -81770,7 +81700,7 @@ entities:
       pos: -0.5,50.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22000
     components:
     - type: Transform
@@ -81778,7 +81708,7 @@ entities:
       pos: -0.5,51.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22001
     components:
     - type: Transform
@@ -81786,7 +81716,7 @@ entities:
       pos: -0.5,52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22002
     components:
     - type: Transform
@@ -81794,7 +81724,7 @@ entities:
       pos: -0.5,53.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22003
     components:
     - type: Transform
@@ -81802,7 +81732,7 @@ entities:
       pos: -0.5,54.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22004
     components:
     - type: Transform
@@ -81810,7 +81740,7 @@ entities:
       pos: -0.5,55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22005
     components:
     - type: Transform
@@ -81818,7 +81748,7 @@ entities:
       pos: -0.5,56.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22006
     components:
     - type: Transform
@@ -81826,7 +81756,7 @@ entities:
       pos: -0.5,57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22007
     components:
     - type: Transform
@@ -81834,7 +81764,7 @@ entities:
       pos: -0.5,58.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22008
     components:
     - type: Transform
@@ -81842,7 +81772,7 @@ entities:
       pos: -0.5,59.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22009
     components:
     - type: Transform
@@ -81850,7 +81780,7 @@ entities:
       pos: -0.5,60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22010
     components:
     - type: Transform
@@ -81858,7 +81788,7 @@ entities:
       pos: -0.5,61.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22011
     components:
     - type: Transform
@@ -81866,7 +81796,7 @@ entities:
       pos: -0.5,62.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22012
     components:
     - type: Transform
@@ -81874,7 +81804,7 @@ entities:
       pos: -0.5,63.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22013
     components:
     - type: Transform
@@ -81882,98 +81812,98 @@ entities:
       pos: -0.5,64.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22015
     components:
     - type: Transform
       pos: -0.5,66.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22016
     components:
     - type: Transform
       pos: -0.5,67.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22017
     components:
     - type: Transform
       pos: -0.5,68.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22018
     components:
     - type: Transform
       pos: -0.5,69.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22019
     components:
     - type: Transform
       pos: -0.5,70.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22020
     components:
     - type: Transform
       pos: -0.5,71.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22021
     components:
     - type: Transform
       pos: -0.5,72.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22022
     components:
     - type: Transform
       pos: -0.5,73.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22267
     components:
     - type: Transform
       pos: 43.5,11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22268
     components:
     - type: Transform
       pos: 43.5,12.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22269
     components:
     - type: Transform
       pos: 43.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22270
     components:
     - type: Transform
       pos: 43.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22271
     components:
     - type: Transform
       pos: 43.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
 - proto: GasPipeTJunction
   entities:
   - uid: 336
@@ -82005,7 +81935,7 @@ entities:
       pos: -34.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2440
     components:
     - type: Transform
@@ -82013,7 +81943,7 @@ entities:
       pos: -34.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2441
     components:
     - type: Transform
@@ -82029,7 +81959,7 @@ entities:
       pos: -34.5,36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2456
     components:
     - type: Transform
@@ -82050,7 +81980,7 @@ entities:
       pos: -41.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2463
     components:
     - type: Transform
@@ -82058,7 +81988,7 @@ entities:
       pos: -45.5,35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2496
     components:
     - type: Transform
@@ -82074,7 +82004,7 @@ entities:
       pos: -34.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2507
     components:
     - type: Transform
@@ -82088,7 +82018,7 @@ entities:
       pos: -34.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2509
     components:
     - type: Transform
@@ -82103,7 +82033,7 @@ entities:
       pos: -33.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2512
     components:
     - type: Transform
@@ -82119,7 +82049,7 @@ entities:
       pos: -31.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2519
     components:
     - type: Transform
@@ -82135,7 +82065,7 @@ entities:
       pos: -31.5,46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2521
     components:
     - type: Transform
@@ -82143,7 +82073,7 @@ entities:
       pos: -31.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2527
     components:
     - type: Transform
@@ -82167,7 +82097,7 @@ entities:
       pos: -40.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2553
     components:
     - type: Transform
@@ -82175,7 +82105,7 @@ entities:
       pos: -31.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2554
     components:
     - type: Transform
@@ -82197,14 +82127,14 @@ entities:
       pos: -30.5,53.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2596
     components:
     - type: Transform
       pos: -38.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2597
     components:
     - type: Transform
@@ -82218,7 +82148,7 @@ entities:
       pos: -42.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2599
     components:
     - type: Transform
@@ -82233,7 +82163,7 @@ entities:
       pos: -46.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2601
     components:
     - type: Transform
@@ -82249,7 +82179,7 @@ entities:
       pos: -41.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2628
     components:
     - type: Transform
@@ -82280,7 +82210,7 @@ entities:
       pos: -46.5,52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2662
     components:
     - type: Transform
@@ -82288,7 +82218,7 @@ entities:
       pos: -46.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2667
     components:
     - type: Transform
@@ -82304,7 +82234,7 @@ entities:
       pos: -46.5,56.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2677
     components:
     - type: Transform
@@ -82312,7 +82242,7 @@ entities:
       pos: -46.5,57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2688
     components:
     - type: Transform
@@ -82320,7 +82250,7 @@ entities:
       pos: -50.5,61.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2689
     components:
     - type: Transform
@@ -82328,7 +82258,7 @@ entities:
       pos: -46.5,61.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2709
     components:
     - type: Transform
@@ -82398,7 +82328,7 @@ entities:
       pos: -34.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2777
     components:
     - type: Transform
@@ -82406,7 +82336,7 @@ entities:
       pos: -34.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2779
     components:
     - type: Transform
@@ -82414,7 +82344,7 @@ entities:
       pos: -32.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2786
     components:
     - type: Transform
@@ -82422,7 +82352,7 @@ entities:
       pos: -27.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2788
     components:
     - type: Transform
@@ -82438,7 +82368,7 @@ entities:
       pos: -17.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2802
     components:
     - type: Transform
@@ -82475,7 +82405,7 @@ entities:
       pos: 10.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2833
     components:
     - type: Transform
@@ -82483,7 +82413,7 @@ entities:
       pos: 10.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2842
     components:
     - type: Transform
@@ -82499,7 +82429,7 @@ entities:
       pos: 3.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2854
     components:
     - type: Transform
@@ -82530,7 +82460,7 @@ entities:
       pos: -23.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2873
     components:
     - type: Transform
@@ -82552,7 +82482,7 @@ entities:
       pos: -34.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2893
     components:
     - type: Transform
@@ -82560,7 +82490,7 @@ entities:
       pos: -34.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2899
     components:
     - type: Transform
@@ -82568,7 +82498,7 @@ entities:
       pos: -34.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2905
     components:
     - type: Transform
@@ -82576,7 +82506,7 @@ entities:
       pos: -34.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2913
     components:
     - type: Transform
@@ -82584,7 +82514,7 @@ entities:
       pos: -34.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2919
     components:
     - type: Transform
@@ -82606,7 +82536,7 @@ entities:
       pos: -19.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2935
     components:
     - type: Transform
@@ -82628,7 +82558,7 @@ entities:
       pos: 10.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2975
     components:
     - type: Transform
@@ -82644,7 +82574,7 @@ entities:
       pos: 10.5,24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2994
     components:
     - type: Transform
@@ -82658,7 +82588,7 @@ entities:
       pos: -0.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3000
     components:
     - type: Transform
@@ -82666,7 +82596,7 @@ entities:
       pos: -3.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3012
     components:
     - type: Transform
@@ -82674,14 +82604,14 @@ entities:
       pos: -15.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3019
     components:
     - type: Transform
       pos: -22.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3020
     components:
     - type: Transform
@@ -82695,7 +82625,7 @@ entities:
       pos: -26.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3023
     components:
     - type: Transform
@@ -82703,14 +82633,14 @@ entities:
       pos: -25.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3027
     components:
     - type: Transform
       pos: -30.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3084
     components:
     - type: Transform
@@ -82718,7 +82648,7 @@ entities:
       pos: -42.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3087
     components:
     - type: Transform
@@ -82732,7 +82662,7 @@ entities:
       pos: -39.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3093
     components:
     - type: Transform
@@ -82747,7 +82677,7 @@ entities:
       pos: -44.5,5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3098
     components:
     - type: Transform
@@ -82770,7 +82700,7 @@ entities:
       pos: -52.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3137
     components:
     - type: Transform
@@ -82778,7 +82708,7 @@ entities:
       pos: -44.5,4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3138
     components:
     - type: Transform
@@ -82794,7 +82724,7 @@ entities:
       pos: -44.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3213
     components:
     - type: Transform
@@ -82802,7 +82732,7 @@ entities:
       pos: -44.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3241
     components:
     - type: Transform
@@ -82810,7 +82740,7 @@ entities:
       pos: -44.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3245
     components:
     - type: Transform
@@ -82818,7 +82748,7 @@ entities:
       pos: -43.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3246
     components:
     - type: Transform
@@ -82849,46 +82779,14 @@ entities:
       pos: -50.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3278
     components:
     - type: Transform
       pos: -52.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3283
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -57.5,13.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3284
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -57.5,15.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3285
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -57.5,21.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3294
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -57.5,18.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3306
     components:
     - type: Transform
@@ -82903,7 +82801,7 @@ entities:
       pos: -19.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3349
     components:
     - type: Transform
@@ -82934,7 +82832,7 @@ entities:
       pos: -16.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3397
     components:
     - type: Transform
@@ -82950,7 +82848,7 @@ entities:
       pos: -16.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3404
     components:
     - type: Transform
@@ -82972,7 +82870,7 @@ entities:
       pos: -1.5,7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3423
     components:
     - type: Transform
@@ -82986,7 +82884,7 @@ entities:
       pos: -1.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3442
     components:
     - type: Transform
@@ -83001,14 +82899,14 @@ entities:
       pos: -0.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3458
     components:
     - type: Transform
       pos: -8.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3459
     components:
     - type: Transform
@@ -83024,7 +82922,7 @@ entities:
       pos: -9.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3461
     components:
     - type: Transform
@@ -83052,7 +82950,7 @@ entities:
       pos: -8.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6111
     components:
     - type: Transform
@@ -83097,7 +82995,7 @@ entities:
       pos: -15.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6172
     components:
     - type: Transform
@@ -83105,7 +83003,7 @@ entities:
       pos: -15.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6179
     components:
     - type: Transform
@@ -83113,7 +83011,7 @@ entities:
       pos: -3.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6185
     components:
     - type: Transform
@@ -83121,7 +83019,7 @@ entities:
       pos: -3.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6193
     components:
     - type: Transform
@@ -83129,7 +83027,7 @@ entities:
       pos: -9.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6199
     components:
     - type: Transform
@@ -83137,14 +83035,14 @@ entities:
       pos: -7.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6234
     components:
     - type: Transform
       pos: -20.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6240
     components:
     - type: Transform
@@ -83152,7 +83050,7 @@ entities:
       pos: -20.5,36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6252
     components:
     - type: Transform
@@ -83182,7 +83080,7 @@ entities:
       pos: -30.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6687
     components:
     - type: Transform
@@ -83190,7 +83088,7 @@ entities:
       pos: -17.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6713
     components:
     - type: Transform
@@ -83198,7 +83096,7 @@ entities:
       pos: -13.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6933
     components:
     - type: Transform
@@ -83214,7 +83112,7 @@ entities:
       pos: -23.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7044
     components:
     - type: Transform
@@ -83222,14 +83120,14 @@ entities:
       pos: -19.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7045
     components:
     - type: Transform
       pos: -22.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7058
     components:
     - type: Transform
@@ -83237,7 +83135,7 @@ entities:
       pos: -30.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7061
     components:
     - type: Transform
@@ -83282,7 +83180,7 @@ entities:
       pos: -1.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7322
     components:
     - type: Transform
@@ -83290,7 +83188,7 @@ entities:
       pos: -10.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7323
     components:
     - type: Transform
@@ -83298,7 +83196,7 @@ entities:
       pos: -2.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7337
     components:
     - type: Transform
@@ -83314,14 +83212,14 @@ entities:
       pos: -12.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7351
     components:
     - type: Transform
       pos: -18.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7374
     components:
     - type: Transform
@@ -83336,7 +83234,7 @@ entities:
       pos: -17.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7545
     components:
     - type: Transform
@@ -83365,7 +83263,7 @@ entities:
       pos: -28.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7878
     components:
     - type: Transform
@@ -83380,7 +83278,7 @@ entities:
       pos: -12.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7924
     components:
     - type: Transform
@@ -83388,7 +83286,7 @@ entities:
       pos: -22.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7926
     components:
     - type: Transform
@@ -83396,7 +83294,7 @@ entities:
       pos: -22.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7946
     components:
     - type: Transform
@@ -83411,7 +83309,7 @@ entities:
       pos: -29.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7949
     components:
     - type: Transform
@@ -83427,7 +83325,7 @@ entities:
       pos: -17.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8018
     components:
     - type: Transform
@@ -83443,7 +83341,7 @@ entities:
       pos: -22.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8089
     components:
     - type: Transform
@@ -83451,7 +83349,7 @@ entities:
       pos: -30.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8104
     components:
     - type: Transform
@@ -83489,7 +83387,7 @@ entities:
       pos: -1.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8408
     components:
     - type: Transform
@@ -83535,7 +83433,7 @@ entities:
       pos: 9.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8876
     components:
     - type: Transform
@@ -83543,14 +83441,14 @@ entities:
       pos: 7.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8877
     components:
     - type: Transform
       pos: 2.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8884
     components:
     - type: Transform
@@ -83566,7 +83464,7 @@ entities:
       pos: 9.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8901
     components:
     - type: Transform
@@ -83590,14 +83488,14 @@ entities:
       pos: 12.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8919
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8920
     components:
     - type: Transform
@@ -83619,7 +83517,7 @@ entities:
       pos: 7.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8940
     components:
     - type: Transform
@@ -83635,7 +83533,7 @@ entities:
       pos: 13.5,-17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8957
     components:
     - type: Transform
@@ -83643,7 +83541,7 @@ entities:
       pos: 20.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8960
     components:
     - type: Transform
@@ -83651,7 +83549,7 @@ entities:
       pos: 13.5,-4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8968
     components:
     - type: Transform
@@ -83725,7 +83623,7 @@ entities:
       pos: -25.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9694
     components:
     - type: Transform
@@ -83740,7 +83638,7 @@ entities:
       pos: -25.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9728
     components:
     - type: Transform
@@ -83748,7 +83646,7 @@ entities:
       pos: 2.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9744
     components:
     - type: Transform
@@ -83756,7 +83654,7 @@ entities:
       pos: -1.5,-26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9754
     components:
     - type: Transform
@@ -83787,7 +83685,7 @@ entities:
       pos: 2.5,-32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9847
     components:
     - type: Transform
@@ -83811,7 +83709,7 @@ entities:
       pos: -18.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9896
     components:
     - type: Transform
@@ -83827,14 +83725,14 @@ entities:
       pos: -11.5,-35.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9981
     components:
     - type: Transform
       pos: 6.5,-27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9992
     components:
     - type: Transform
@@ -83850,7 +83748,7 @@ entities:
       pos: -11.5,-31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10160
     components:
     - type: Transform
@@ -83866,7 +83764,7 @@ entities:
       pos: 2.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10265
     components:
     - type: Transform
@@ -83874,7 +83772,7 @@ entities:
       pos: -23.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10266
     components:
     - type: Transform
@@ -83882,7 +83780,7 @@ entities:
       pos: -11.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10279
     components:
     - type: Transform
@@ -83912,7 +83810,7 @@ entities:
       pos: -18.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10440
     components:
     - type: Transform
@@ -83943,14 +83841,14 @@ entities:
       pos: 33.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11763
     components:
     - type: Transform
       pos: 24.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11776
     components:
     - type: Transform
@@ -83982,7 +83880,7 @@ entities:
       pos: 25.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11877
     components:
     - type: Transform
@@ -83998,7 +83896,7 @@ entities:
       pos: 20.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11904
     components:
     - type: Transform
@@ -84021,7 +83919,7 @@ entities:
       pos: 17.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11936
     components:
     - type: Transform
@@ -84037,7 +83935,7 @@ entities:
       pos: 13.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11968
     components:
     - type: Transform
@@ -84045,7 +83943,7 @@ entities:
       pos: 20.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11999
     components:
     - type: Transform
@@ -84060,14 +83958,14 @@ entities:
       pos: 24.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12020
     components:
     - type: Transform
       pos: 33.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12062
     components:
     - type: Transform
@@ -84091,14 +83989,14 @@ entities:
       pos: 10.5,33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12488
     components:
     - type: Transform
       pos: 10.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12503
     components:
     - type: Transform
@@ -84121,7 +84019,7 @@ entities:
       pos: 18.5,25.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12528
     components:
     - type: Transform
@@ -84129,7 +84027,7 @@ entities:
       pos: 23.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12540
     components:
     - type: Transform
@@ -84137,7 +84035,7 @@ entities:
       pos: 23.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12542
     components:
     - type: Transform
@@ -84145,7 +84043,7 @@ entities:
       pos: 23.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12543
     components:
     - type: Transform
@@ -84160,7 +84058,7 @@ entities:
       pos: 23.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12545
     components:
     - type: Transform
@@ -84168,7 +84066,7 @@ entities:
       pos: 20.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12559
     components:
     - type: Transform
@@ -84184,7 +84082,7 @@ entities:
       pos: 20.5,43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12584
     components:
     - type: Transform
@@ -84192,7 +84090,7 @@ entities:
       pos: 25.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12599
     components:
     - type: Transform
@@ -84200,7 +84098,7 @@ entities:
       pos: 23.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12600
     components:
     - type: Transform
@@ -84227,7 +84125,7 @@ entities:
       pos: 23.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12885
     components:
     - type: Transform
@@ -84242,7 +84140,7 @@ entities:
       pos: 14.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12951
     components:
     - type: Transform
@@ -84250,7 +84148,7 @@ entities:
       pos: 23.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12954
     components:
     - type: Transform
@@ -84258,14 +84156,14 @@ entities:
       pos: 23.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12963
     components:
     - type: Transform
       pos: 28.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12989
     components:
     - type: Transform
@@ -84273,7 +84171,7 @@ entities:
       pos: 14.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12991
     components:
     - type: Transform
@@ -84281,14 +84179,14 @@ entities:
       pos: 14.5,20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12997
     components:
     - type: Transform
       pos: 23.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13007
     components:
     - type: Transform
@@ -84359,14 +84257,14 @@ entities:
       pos: 52.5,20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13753
     components:
     - type: Transform
       pos: 31.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13757
     components:
     - type: Transform
@@ -84397,14 +84295,14 @@ entities:
       pos: 35.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13776
     components:
     - type: Transform
       pos: 39.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13784
     components:
     - type: Transform
@@ -84412,7 +84310,7 @@ entities:
       pos: 30.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13790
     components:
     - type: Transform
@@ -84428,7 +84326,7 @@ entities:
       pos: -55.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14455
     components:
     - type: Transform
@@ -84436,21 +84334,21 @@ entities:
       pos: -25.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14512
     components:
     - type: Transform
       pos: 17.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 16802
     components:
     - type: Transform
       pos: -62.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 17718
     components:
     - type: Transform
@@ -84487,7 +84385,7 @@ entities:
       pos: -53.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18403
     components:
     - type: Transform
@@ -84495,7 +84393,7 @@ entities:
       pos: -44.5,-13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18412
     components:
     - type: Transform
@@ -84503,14 +84401,14 @@ entities:
       pos: -44.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18416
     components:
     - type: Transform
       pos: -61.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18421
     components:
     - type: Transform
@@ -84518,7 +84416,7 @@ entities:
       pos: -58.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18426
     components:
     - type: Transform
@@ -84533,7 +84431,7 @@ entities:
       pos: -49.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18446
     components:
     - type: Transform
@@ -84541,7 +84439,7 @@ entities:
       pos: -63.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18492
     components:
     - type: Transform
@@ -84595,7 +84493,7 @@ entities:
       pos: -60.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18542
     components:
     - type: Transform
@@ -84603,7 +84501,7 @@ entities:
       pos: -60.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18550
     components:
     - type: Transform
@@ -84627,7 +84525,7 @@ entities:
       pos: -55.5,-52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18568
     components:
     - type: Transform
@@ -84643,7 +84541,7 @@ entities:
       pos: -55.5,-56.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18578
     components:
     - type: Transform
@@ -84659,7 +84557,7 @@ entities:
       pos: -68.5,-55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18603
     components:
     - type: Transform
@@ -84682,7 +84580,7 @@ entities:
       pos: -68.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18614
     components:
     - type: Transform
@@ -84698,7 +84596,7 @@ entities:
       pos: -55.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18616
     components:
     - type: Transform
@@ -84706,14 +84604,14 @@ entities:
       pos: -61.5,-48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18618
     components:
     - type: Transform
       pos: -61.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18623
     components:
     - type: Transform
@@ -84721,7 +84619,7 @@ entities:
       pos: -58.5,-44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18636
     components:
     - type: Transform
@@ -84729,7 +84627,7 @@ entities:
       pos: -67.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18637
     components:
     - type: Transform
@@ -84737,7 +84635,7 @@ entities:
       pos: -68.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18644
     components:
     - type: Transform
@@ -84745,7 +84643,7 @@ entities:
       pos: -75.5,-46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18658
     components:
     - type: Transform
@@ -84753,14 +84651,14 @@ entities:
       pos: -75.5,-43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18704
     components:
     - type: Transform
       pos: -74.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18711
     components:
     - type: Transform
@@ -84774,7 +84672,7 @@ entities:
       pos: -80.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18739
     components:
     - type: Transform
@@ -84790,7 +84688,7 @@ entities:
       pos: -71.5,-55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 20668
     components:
     - type: Transform
@@ -84806,7 +84704,7 @@ entities:
       pos: -0.5,65.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
 - proto: GasPort
   entities:
   - uid: 6757
@@ -84927,7 +84825,7 @@ entities:
       pos: -52.5,-61.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7140
     components:
     - type: MetaData
@@ -84956,7 +84854,7 @@ entities:
       pos: -30.5,-10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8781
     components:
     - type: Transform
@@ -84964,7 +84862,7 @@ entities:
       pos: 16.5,-24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8792
     components:
     - type: Transform
@@ -85150,7 +85048,7 @@ entities:
       pos: -35.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2454
     components:
     - type: Transform
@@ -85158,7 +85056,7 @@ entities:
       pos: -35.5,36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2482
     components:
     - type: Transform
@@ -85166,7 +85064,7 @@ entities:
       pos: -49.5,32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2491
     components:
     - type: Transform
@@ -85174,14 +85072,14 @@ entities:
       pos: -41.5,32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2493
     components:
     - type: Transform
       pos: -45.5,36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2503
     components:
     - type: Transform
@@ -85189,14 +85087,14 @@ entities:
       pos: -35.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2523
     components:
     - type: Transform
       pos: -33.5,43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2524
     components:
     - type: Transform
@@ -85204,7 +85102,7 @@ entities:
       pos: -30.5,46.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2544
     components:
     - type: Transform
@@ -85212,14 +85110,14 @@ entities:
       pos: -41.5,48.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2551
     components:
     - type: Transform
       pos: -40.5,51.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2573
     components:
     - type: Transform
@@ -85227,7 +85125,7 @@ entities:
       pos: -25.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2592
     components:
     - type: Transform
@@ -85235,7 +85133,7 @@ entities:
       pos: -31.5,57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2594
     components:
     - type: Transform
@@ -85243,7 +85141,7 @@ entities:
       pos: -30.5,52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2638
     components:
     - type: Transform
@@ -85251,7 +85149,7 @@ entities:
       pos: -38.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2639
     components:
     - type: Transform
@@ -85259,7 +85157,7 @@ entities:
       pos: -42.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2640
     components:
     - type: Transform
@@ -85267,14 +85165,14 @@ entities:
       pos: -46.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2644
     components:
     - type: Transform
       pos: -41.5,43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2669
     components:
     - type: Transform
@@ -85282,7 +85180,7 @@ entities:
       pos: -47.5,49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2676
     components:
     - type: Transform
@@ -85290,14 +85188,14 @@ entities:
       pos: -50.5,52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2705
     components:
     - type: Transform
       pos: -48.5,68.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2706
     components:
     - type: Transform
@@ -85305,7 +85203,7 @@ entities:
       pos: -48.5,66.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2707
     components:
     - type: Transform
@@ -85313,7 +85211,7 @@ entities:
       pos: -49.5,61.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2708
     components:
     - type: Transform
@@ -85321,7 +85219,7 @@ entities:
       pos: -45.5,61.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2734
     components:
     - type: Transform
@@ -85329,7 +85227,7 @@ entities:
       pos: -47.5,56.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2743
     components:
     - type: Transform
@@ -85337,14 +85235,14 @@ entities:
       pos: -28.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 2862
     components:
     - type: Transform
       pos: -8.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3042
     components:
     - type: Transform
@@ -85352,7 +85250,7 @@ entities:
       pos: -26.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3050
     components:
     - type: Transform
@@ -85360,7 +85258,7 @@ entities:
       pos: -30.5,22.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3056
     components:
     - type: Transform
@@ -85368,7 +85266,7 @@ entities:
       pos: -26.5,23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3062
     components:
     - type: Transform
@@ -85376,7 +85274,7 @@ entities:
       pos: -22.5,23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3064
     components:
     - type: Transform
@@ -85384,7 +85282,7 @@ entities:
       pos: -35.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3066
     components:
     - type: Transform
@@ -85392,7 +85290,7 @@ entities:
       pos: -35.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3069
     components:
     - type: Transform
@@ -85400,21 +85298,21 @@ entities:
       pos: -35.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3077
     components:
     - type: Transform
       pos: -40.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3099
     components:
     - type: Transform
       pos: -42.5,6.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3111
     components:
     - type: Transform
@@ -85422,7 +85320,7 @@ entities:
       pos: -39.5,0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3135
     components:
     - type: Transform
@@ -85430,7 +85328,7 @@ entities:
       pos: -53.5,9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3148
     components:
     - type: Transform
@@ -85438,7 +85336,7 @@ entities:
       pos: -45.5,4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3171
     components:
     - type: Transform
@@ -85446,7 +85344,7 @@ entities:
       pos: -45.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3228
     components:
     - type: Transform
@@ -85454,60 +85352,28 @@ entities:
       pos: -31.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3230
     components:
     - type: Transform
       pos: -32.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3253
     components:
     - type: Transform
       pos: -43.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3266
     components:
     - type: Transform
       pos: -44.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3302
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -60.5,13.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3303
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -60.5,15.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3304
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -60.5,21.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 3305
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -60.5,23.5
-      parent: 30
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3323
     components:
     - type: Transform
@@ -85515,35 +85381,35 @@ entities:
       pos: -56.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3324
     components:
     - type: Transform
       pos: -50.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3325
     components:
     - type: Transform
       pos: -27.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3327
     components:
     - type: Transform
       pos: -17.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3376
     components:
     - type: Transform
       pos: -26.5,16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3401
     components:
     - type: Transform
@@ -85551,21 +85417,21 @@ entities:
       pos: -13.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3407
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3410
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3422
     components:
     - type: Transform
@@ -85573,14 +85439,14 @@ entities:
       pos: -0.5,7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3469
     components:
     - type: Transform
       pos: -16.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3479
     components:
     - type: Transform
@@ -85588,14 +85454,14 @@ entities:
       pos: -8.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3480
     components:
     - type: Transform
       pos: -9.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3481
     components:
     - type: Transform
@@ -85603,7 +85469,7 @@ entities:
       pos: 3.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 3485
     components:
     - type: Transform
@@ -85611,21 +85477,21 @@ entities:
       pos: -0.5,13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6109
     components:
     - type: Transform
       pos: -23.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6113
     components:
     - type: Transform
       pos: 3.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6123
     components:
     - type: Transform
@@ -85633,14 +85499,14 @@ entities:
       pos: -0.5,21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6205
     components:
     - type: Transform
       pos: -9.5,43.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6214
     components:
     - type: Transform
@@ -85648,7 +85514,7 @@ entities:
       pos: -7.5,36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6223
     components:
     - type: Transform
@@ -85656,7 +85522,7 @@ entities:
       pos: 0.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6229
     components:
     - type: Transform
@@ -85664,7 +85530,7 @@ entities:
       pos: -19.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6239
     components:
     - type: Transform
@@ -85672,7 +85538,7 @@ entities:
       pos: -25.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6245
     components:
     - type: Transform
@@ -85680,7 +85546,7 @@ entities:
       pos: -20.5,31.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6246
     components:
     - type: Transform
@@ -85688,7 +85554,7 @@ entities:
       pos: -19.5,36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6834
     components:
     - type: Transform
@@ -85696,7 +85562,7 @@ entities:
       pos: -25.5,-22.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6900
     components:
     - type: Transform
@@ -85704,7 +85570,7 @@ entities:
       pos: -28.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6920
     components:
     - type: Transform
@@ -85712,7 +85578,7 @@ entities:
       pos: -33.5,-16.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 6939
     components:
     - type: Transform
@@ -85720,7 +85586,7 @@ entities:
       pos: -18.5,-2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7099
     components:
     - type: Transform
@@ -85731,14 +85597,14 @@ entities:
       deviceLists:
       - 13957
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7115
     components:
     - type: Transform
       pos: -28.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7136
     components:
     - type: Transform
@@ -85748,7 +85614,7 @@ entities:
       deviceLists:
       - 8267
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7137
     components:
     - type: Transform
@@ -85758,14 +85624,14 @@ entities:
       deviceLists:
       - 8267
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7340
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7373
     components:
     - type: Transform
@@ -85773,7 +85639,7 @@ entities:
       pos: -7.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7424
     components:
     - type: Transform
@@ -85781,7 +85647,7 @@ entities:
       pos: -35.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7443
     components:
     - type: Transform
@@ -85792,7 +85658,7 @@ entities:
       deviceLists:
       - 13957
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 7569
     components:
     - type: Transform
@@ -85803,14 +85669,14 @@ entities:
       deviceLists:
       - 8254
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8033
     components:
     - type: Transform
       pos: -13.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8100
     components:
     - type: Transform
@@ -85818,14 +85684,14 @@ entities:
       pos: -13.5,-20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8224
     components:
     - type: Transform
       pos: -22.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8297
     components:
     - type: Transform
@@ -85836,7 +85702,7 @@ entities:
       deviceLists:
       - 13958
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8311
     components:
     - type: Transform
@@ -85847,7 +85713,7 @@ entities:
       deviceLists:
       - 19570
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8316
     components:
     - type: Transform
@@ -85855,7 +85721,7 @@ entities:
       pos: -29.5,-7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8335
     components:
     - type: Transform
@@ -85866,7 +85732,7 @@ entities:
       deviceLists:
       - 19570
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 8454
     components:
     - type: Transform
@@ -85877,14 +85743,14 @@ entities:
       deviceLists:
       - 13957
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9046
     components:
     - type: Transform
       pos: -25.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9686
     components:
     - type: Transform
@@ -85895,7 +85761,7 @@ entities:
       deviceLists:
       - 9671
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9811
     components:
     - type: Transform
@@ -85903,7 +85769,7 @@ entities:
       pos: -54.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9884
     components:
     - type: Transform
@@ -85913,7 +85779,7 @@ entities:
       deviceLists:
       - 13958
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9903
     components:
     - type: Transform
@@ -85924,7 +85790,7 @@ entities:
       deviceLists:
       - 13966
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 9908
     components:
     - type: Transform
@@ -85935,7 +85801,7 @@ entities:
       deviceLists:
       - 13966
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10022
     components:
     - type: Transform
@@ -85946,7 +85812,7 @@ entities:
       deviceLists:
       - 13966
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10233
     components:
     - type: Transform
@@ -85954,14 +85820,14 @@ entities:
       pos: -63.5,-63.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11026
     components:
     - type: Transform
       pos: -6.5,-36.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11134
     components:
     - type: Transform
@@ -85972,7 +85838,7 @@ entities:
       deviceLists:
       - 9996
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11165
     components:
     - type: Transform
@@ -85980,7 +85846,7 @@ entities:
       pos: 1.5,-32.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11178
     components:
     - type: Transform
@@ -85988,7 +85854,7 @@ entities:
       pos: -2.5,-26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11180
     components:
     - type: Transform
@@ -85998,7 +85864,7 @@ entities:
       deviceLists:
       - 10010
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11188
     components:
     - type: Transform
@@ -86009,21 +85875,21 @@ entities:
       deviceLists:
       - 10010
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11200
     components:
     - type: Transform
       pos: 2.5,-19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11208
     components:
     - type: Transform
       pos: 9.5,-15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11211
     components:
     - type: Transform
@@ -86031,14 +85897,14 @@ entities:
       pos: 12.5,-17.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11216
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11217
     components:
     - type: Transform
@@ -86046,7 +85912,7 @@ entities:
       pos: 5.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11220
     components:
     - type: Transform
@@ -86054,7 +85920,7 @@ entities:
       pos: 8.5,-9.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11222
     components:
     - type: Transform
@@ -86062,14 +85928,14 @@ entities:
       pos: 14.5,-4.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11224
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11664
     components:
     - type: Transform
@@ -86077,7 +85943,7 @@ entities:
       pos: 33.5,-10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11868
     components:
     - type: Transform
@@ -86085,7 +85951,7 @@ entities:
       pos: 24.5,-10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11872
     components:
     - type: Transform
@@ -86093,7 +85959,7 @@ entities:
       pos: 24.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11922
     components:
     - type: Transform
@@ -86101,7 +85967,7 @@ entities:
       pos: 37.5,-5.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11938
     components:
     - type: Transform
@@ -86109,7 +85975,7 @@ entities:
       pos: 17.5,-10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11939
     components:
     - type: Transform
@@ -86117,14 +85983,14 @@ entities:
       pos: 20.5,-10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11981
     components:
     - type: Transform
       pos: 20.5,0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11991
     components:
     - type: Transform
@@ -86132,21 +85998,21 @@ entities:
       pos: 19.5,-1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12007
     components:
     - type: Transform
       pos: 30.5,1.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12010
     components:
     - type: Transform
       pos: 25.5,0.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12060
     components:
     - type: Transform
@@ -86154,7 +86020,7 @@ entities:
       pos: 37.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12081
     components:
     - type: Transform
@@ -86162,7 +86028,7 @@ entities:
       pos: 30.5,-3.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12230
     components:
     - type: Transform
@@ -86170,7 +86036,7 @@ entities:
       pos: 34.5,-14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12491
     components:
     - type: Transform
@@ -86178,7 +86044,7 @@ entities:
       pos: 9.5,33.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12492
     components:
     - type: Transform
@@ -86186,14 +86052,14 @@ entities:
       pos: 11.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12495
     components:
     - type: Transform
       pos: 9.5,41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12537
     components:
     - type: Transform
@@ -86201,14 +86067,14 @@ entities:
       pos: 9.5,24.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12538
     components:
     - type: Transform
       pos: 18.5,26.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12579
     components:
     - type: Transform
@@ -86216,7 +86082,7 @@ entities:
       pos: 18.5,40.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12580
     components:
     - type: Transform
@@ -86224,7 +86090,7 @@ entities:
       pos: 18.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12581
     components:
     - type: Transform
@@ -86232,14 +86098,14 @@ entities:
       pos: 18.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12587
     components:
     - type: Transform
       pos: 25.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12605
     components:
     - type: Transform
@@ -86247,14 +86113,14 @@ entities:
       pos: 24.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12611
     components:
     - type: Transform
       pos: 27.5,27.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12756
     components:
     - type: Transform
@@ -86267,7 +86133,7 @@ entities:
       pos: 32.5,11.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12959
     components:
     - type: Transform
@@ -86275,7 +86141,7 @@ entities:
       pos: 27.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12976
     components:
     - type: Transform
@@ -86283,7 +86149,7 @@ entities:
       pos: 37.5,8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13002
     components:
     - type: Transform
@@ -86294,7 +86160,7 @@ entities:
       deviceLists:
       - 14365
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13003
     components:
     - type: Transform
@@ -86302,7 +86168,7 @@ entities:
       pos: 28.5,7.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13004
     components:
     - type: Transform
@@ -86310,14 +86176,14 @@ entities:
       pos: 24.5,19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13005
     components:
     - type: Transform
       pos: 14.5,21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13006
     components:
     - type: Transform
@@ -86325,7 +86191,7 @@ entities:
       pos: 13.5,18.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13085
     components:
     - type: Transform
@@ -86336,7 +86202,7 @@ entities:
       deviceLists:
       - 14365
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13335
     components:
     - type: Transform
@@ -86344,7 +86210,7 @@ entities:
       pos: 9.5,14.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13360
     components:
     - type: Transform
@@ -86352,28 +86218,28 @@ entities:
       pos: 26.5,15.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13469
     components:
     - type: Transform
       pos: 16.5,57.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13470
     components:
     - type: Transform
       pos: 20.5,44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13593
     components:
     - type: Transform
       pos: 35.5,39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13783
     components:
     - type: Transform
@@ -86381,7 +86247,7 @@ entities:
       pos: 45.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13788
     components:
     - type: Transform
@@ -86389,14 +86255,14 @@ entities:
       pos: 30.5,37.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13789
     components:
     - type: Transform
       pos: 30.5,42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 14510
     components:
     - type: Transform
@@ -86404,7 +86270,7 @@ entities:
       pos: -26.5,10.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15441
     components:
     - type: Transform
@@ -86412,14 +86278,14 @@ entities:
       pos: 51.5,20.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 15619
     components:
     - type: Transform
       pos: 52.5,23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 16096
     components:
     - type: Transform
@@ -86427,7 +86293,7 @@ entities:
       pos: 6.5,-28.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18074
     components:
     - type: Transform
@@ -86438,7 +86304,7 @@ entities:
       deviceLists:
       - 14365
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18436
     components:
     - type: Transform
@@ -86446,7 +86312,7 @@ entities:
       pos: -45.5,-13.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18437
     components:
     - type: Transform
@@ -86454,35 +86320,35 @@ entities:
       pos: -45.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18438
     components:
     - type: Transform
       pos: -58.5,-23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18439
     components:
     - type: Transform
       pos: -49.5,-23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18440
     components:
     - type: Transform
       pos: -53.5,-23.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18449
     components:
     - type: Transform
       pos: -63.5,-19.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18450
     components:
     - type: Transform
@@ -86490,7 +86356,7 @@ entities:
       pos: -62.5,-21.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18629
     components:
     - type: Transform
@@ -86498,49 +86364,49 @@ entities:
       pos: -59.5,-44.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18655
     components:
     - type: Transform
       pos: -79.5,-39.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18662
     components:
     - type: Transform
       pos: -77.5,-42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18663
     components:
     - type: Transform
       pos: -75.5,-41.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18667
     components:
     - type: Transform
       pos: -68.5,-45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18668
     components:
     - type: Transform
       pos: -67.5,-42.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18674
     components:
     - type: Transform
       pos: -55.5,-45.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18678
     components:
     - type: Transform
@@ -86548,7 +86414,7 @@ entities:
       pos: -52.5,-56.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18679
     components:
     - type: Transform
@@ -86556,7 +86422,7 @@ entities:
       pos: -52.5,-52.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18720
     components:
     - type: Transform
@@ -86564,7 +86430,7 @@ entities:
       pos: -83.5,-60.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18731
     components:
     - type: Transform
@@ -86572,7 +86438,7 @@ entities:
       pos: -80.5,-61.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18732
     components:
     - type: Transform
@@ -86580,7 +86446,7 @@ entities:
       pos: -74.5,-61.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18753
     components:
     - type: Transform
@@ -86588,21 +86454,21 @@ entities:
       pos: -76.5,-55.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18754
     components:
     - type: Transform
       pos: -71.5,-53.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18757
     components:
     - type: Transform
       pos: -60.5,-59.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 18758
     components:
     - type: Transform
@@ -86610,7 +86476,7 @@ entities:
       pos: -60.5,-49.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 20335
     components:
     - type: Transform
@@ -86618,7 +86484,7 @@ entities:
       pos: 4.5,-8.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 21549
     components:
     - type: Transform
@@ -86626,14 +86492,14 @@ entities:
       pos: 39.5,34.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22023
     components:
     - type: Transform
       pos: -0.5,74.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22024
     components:
     - type: Transform
@@ -86641,14 +86507,14 @@ entities:
       pos: 0.5,65.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 22025
     components:
     - type: Transform
       pos: -1.5,38.5
       parent: 30
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
   - uid: 2324


### PR DESCRIPTION
# Why
Why are there vents in a airlock?

# Why (is the diff large)
I used ``colornetwork [entity id] Pipe [color]`` and used the standard distro color to color the uncolored pipes I had to add in.

``Distro loop: #0055cc (subdued blue)``
https://docs.spacestation14.com/en/space-station-14/mapping/guides/general-guide.html#standard-pipe-colors
# Before:
![Screenshot from 2024-08-09 10-25-12](https://github.com/user-attachments/assets/d7fe7dea-5fed-43d9-8ebf-5e2e2d07ff8f)

# After:

![Screenshot from 2024-08-09 10-28-33](https://github.com/user-attachments/assets/092cb742-b931-40e9-8621-6a3bd93890ff)

