### PR TITLE
Add failure logging to DiscordWebhook.cs

### DIFF
--- a/Content.Server/Discord/DiscordWebhook.cs
+++ b/Content.Server/Discord/DiscordWebhook.cs
@@ -68,7 +68,11 @@ public sealed class DiscordWebhook : IPostInjectInit
     public async Task<HttpResponseMessage> CreateMessage(WebhookIdentifier identifier, WebhookPayload payload)
     {
         var url = $"{GetUrl(identifier)}?wait=true";
-        return await _http.PostAsJsonAsync(url, payload, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+        var response = await _http.PostAsJsonAsync(url, payload, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+
+        LogResponse(response, "Create");
+
+        return response;
     }
 
     /// <summary>
@@ -80,7 +84,11 @@ public sealed class DiscordWebhook : IPostInjectInit
     public async Task<HttpResponseMessage> DeleteMessage(WebhookIdentifier identifier, ulong messageId)
     {
         var url = $"{GetUrl(identifier)}/messages/{messageId}";
-        return await _http.DeleteAsync(url);
+        var response = await _http.DeleteAsync(url);
+
+        LogResponse(response, "Delete");
+
+        return response; ;
     }
 
     /// <summary>
@@ -93,11 +101,40 @@ public sealed class DiscordWebhook : IPostInjectInit
     public async Task<HttpResponseMessage> EditMessage(WebhookIdentifier identifier, ulong messageId, WebhookPayload payload)
     {
         var url = $"{GetUrl(identifier)}/messages/{messageId}";
-        return await _http.PatchAsJsonAsync(url, payload, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+        var response = await _http.PatchAsJsonAsync(url, payload, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+
+        LogResponse(response, "Edit");
+
+        return response;
     }
 
     void IPostInjectInit.PostInject()
     {
         _sawmill = _log.GetSawmill("DISCORD");
     }
+
+    /// <summary>
+    ///     Logs detailed information about the HTTP response received from a Discord webhook request.
+    ///     If the response status code is non-2XX it logs the status code, relevant rate limit headers.
+    /// </summary>
+    /// <param name="response">The HTTP response received from the Discord API.</param>
+    /// <param name="methodName">The name (constant) of the method that initiated the webhook request (e.g., "Create", "Edit", "Delete").</param>
+    private void LogResponse(HttpResponseMessage response, string methodName)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            _sawmill.Error($"Failed to {methodName} message. Status code: {response.StatusCode}.");
+
+            if (response.Headers.TryGetValues("Retry-After", out var retryAfter))
+                _sawmill.Error($"Retry-After: {string.Join(", ", retryAfter)}");
+
+            if (response.Headers.TryGetValues("X-RateLimit-Global", out var globalRateLimit))
+                _sawmill.Error($"X-RateLimit-Global: {string.Join(", ", globalRateLimit)}");
+
+            if (response.Headers.TryGetValues("X-RateLimit-Scope", out var rateLimitScope))
+                _sawmill.Error($"X-RateLimit-Scope: {string.Join(", ", rateLimitScope)}");
+        }
+    }
+
+
 }


### PR DESCRIPTION



<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Add a new function that logs errors with discord webhook's http requests.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Added as a response to issue #30248. Also created for a Open Source Software course, any review is appreciated but this does not need to be accepted.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Create, Delete, and Edit functions were modified slightly to call the log function but return the same information as before.

The log function logs the error code, caller method using a simple constant (could be better), and attempts to log headers mentioned in issue #30248.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
Nothing of note.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
No obvious breaking changes. Testing was not as extensive as I would have liked.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Added Discord webhook error logging!

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
