### PR TITLE
tweak(oasis): Lower the engineering borg spawn

### DIFF
--- a/Resources/Maps/oasis.yml
+++ b/Resources/Maps/oasis.yml
@@ -14481,7 +14481,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -9254.769
+      secondsUntilStateChange: -9307.528
       state: Opening
   - uid: 6934
     components:
@@ -14493,7 +14493,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -9257.402
+      secondsUntilStateChange: -9310.162
       state: Opening
   - uid: 6935
     components:
@@ -14505,7 +14505,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -9256.252
+      secondsUntilStateChange: -9309.012
       state: Opening
   - uid: 6936
     components:
@@ -14516,7 +14516,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -9255.469
+      secondsUntilStateChange: -9308.229
       state: Opening
 - proto: AirlockTheatreLocked
   entities:
@@ -92183,7 +92183,7 @@ entities:
       pos: -13.5,-1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -578.74854
+      secondsUntilStateChange: -631.5082
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -136211,7 +136211,7 @@ entities:
       pos: 36.5,-35.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -37410.598
+      secondsUntilStateChange: -37463.355
       state: Opening
   - uid: 5211
     components:
@@ -137911,7 +137911,7 @@ entities:
     - type: Transform
       pos: 35.5,35.5
       parent: 2
-- proto: LogicGate
+- proto: LogicGateOr
   entities:
   - uid: 28922
     components:
@@ -157096,7 +157096,7 @@ entities:
   - uid: 28413
     components:
     - type: Transform
-      pos: 13.5,61.5
+      pos: 13.5,46.5
       parent: 2
   - uid: 28414
     components:
@@ -183809,7 +183809,7 @@ entities:
       pos: 24.5,2.5
       parent: 21002
     - type: Door
-      secondsUntilStateChange: -382615.2
+      secondsUntilStateChange: -382667.94
       state: Opening
   - uid: 28863
     components:


### PR DESCRIPTION
# Why
Resolves #30774 

# Before
![Screenshot from 2024-08-10 13-01-06](https://github.com/user-attachments/assets/3d8ffab8-1ea3-4569-993d-fd2fd6784343)

# After
![Screenshot from 2024-08-10 13-01-36](https://github.com/user-attachments/assets/57ba4d94-20c2-4b7c-b9aa-e146523132b9)
![Screenshot from 2024-08-10 13-01-32](https://github.com/user-attachments/assets/d0ede2af-ce4a-4505-9755-442879df5267)
