### PR TITLE
Disable Arrivals message for Cryosleep

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using Content.Server.Administration.Managers;
 using Content.Server.GameTicking.Events;
 using Content.Server.Ghost;
+using Content.Server.Shuttles.Components;
 using Content.Server.Spawners.Components;
 using Content.Server.Speech.Components;
 using Content.Server.Station.Components;
@@ -274,9 +275,11 @@ namespace Content.Server.GameTicking
                     Loc.GetString("job-greet-station-name", ("stationName", metaData.EntityName)));
             }
 
+
             // Arrivals is unable to do this during spawning as no actor is attached yet.
             // We also want this message last.
-            if (!silent && lateJoin && _arrivals.Enabled)
+            // Arrival System adds a PendingClockInComponent, while the Cryosleep System does not.
+            if (!silent && lateJoin && HasComp(mob, typeof(PendingClockInComponent)))
             {
                 var arrival = _arrivals.NextShuttleArrival();
                 if (arrival == null)

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -299,6 +299,7 @@ namespace Content.Server.GameTicking
                 player,
                 jobId,
                 lateJoin,
+                silent,
                 PlayersJoinedRoundNormally,
                 station,
                 character);
@@ -497,6 +498,7 @@ namespace Content.Server.GameTicking
         public ICommonSession Player { get; }
         public string? JobId { get; }
         public bool LateJoin { get; }
+        public bool Silent { get; }
         public EntityUid Station { get; }
         public HumanoidCharacterProfile Profile { get; }
 
@@ -507,6 +509,7 @@ namespace Content.Server.GameTicking
             ICommonSession player,
             string? jobId,
             bool lateJoin,
+            bool silent,
             int joinOrder,
             EntityUid station,
             HumanoidCharacterProfile profile)
@@ -515,6 +518,7 @@ namespace Content.Server.GameTicking
             Player = player;
             JobId = jobId;
             LateJoin = lateJoin;
+            Silent = silent;
             Station = station;
             Profile = profile;
             JoinOrder = joinOrder;

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -318,7 +318,7 @@ namespace Content.Server.GameTicking
         }
 
         /// <summary>
-        /// Makes a player join into the game and spawn on a staiton.
+        /// Makes a player join into the game and spawn on a station.
         /// </summary>
         /// <param name="player">The player joining</param>
         /// <param name="station">The station they're spawning on</param>

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -275,24 +275,6 @@ namespace Content.Server.GameTicking
                     Loc.GetString("job-greet-station-name", ("stationName", metaData.EntityName)));
             }
 
-
-            // Arrivals is unable to do this during spawning as no actor is attached yet.
-            // We also want this message last.
-            // Arrival System adds a PendingClockInComponent, while the Cryosleep System does not.
-            if (!silent && lateJoin && HasComp(mob, typeof(PendingClockInComponent)))
-            {
-                var arrival = _arrivals.NextShuttleArrival();
-                if (arrival == null)
-                {
-                    _chatManager.DispatchServerMessage(player, Loc.GetString("latejoin-arrivals-direction"));
-                }
-                else
-                {
-                    _chatManager.DispatchServerMessage(player,
-                        Loc.GetString("latejoin-arrivals-direction-time", ("time", $"{arrival:mm\\:ss}")));
-                }
-            }
-
             // We raise this event directed to the mob, but also broadcast it so game rules can do something now.
             PlayersJoinedRoundNormally++;
             var aev = new PlayerSpawnCompleteEvent(mob,

--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -103,6 +103,8 @@ public sealed class ArrivalsSystem : EntitySystem
         SubscribeLocalEvent<ArrivalsShuttleComponent, FTLStartedEvent>(OnArrivalsFTL);
         SubscribeLocalEvent<ArrivalsShuttleComponent, FTLCompletedEvent>(OnArrivalsDocked);
 
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(SendDirections);
+
         _pendingQuery = GetEntityQuery<PendingClockInComponent>();
         _blacklistQuery = GetEntityQuery<ArrivalsBlacklistComponent>();
         _mobQuery = GetEntityQuery<MobStateComponent>();
@@ -375,6 +377,20 @@ public sealed class ArrivalsSystem : EntitySystem
         // If you're forced to spawn, you're invincible until you leave wherever you were forced to spawn.
         if (ArrivalsGodmode)
             EnsureComp<GodmodeComponent>(ev.SpawnResult.Value);
+    }
+
+    private void SendDirections(PlayerSpawnCompleteEvent ev)
+    {
+        if (!Enabled || !ev.LateJoin || ev.Silent || !_pendingQuery.HasComp(ev.Mob))
+            return;
+
+        var arrival = NextShuttleArrival();
+
+        var message = arrival is not null
+            ? Loc.GetString("latejoin-arrivals-direction-time", ("time", $"{arrival:mm\\:ss}"))
+            : Loc.GetString("latejoin-arrivals-direction");
+
+        _chat.DispatchServerMessage(ev.Player, message);
     }
 
     private bool TryTeleportToMapSpawn(EntityUid player, EntityUid stationId, TransformComponent? transform = null)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This PR fixes an issue where players arriving via Cryosleep would still receive the message about an arrivals shuttle, even though they are already on the station. 

An additional check is now implemented to verify that the player is not arriving through the arrivals system before displaying the message.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

The previous behavior was confusing, particularly for new players, as it incorrectly suggested that the arrivals shuttle was still incoming when they had already arrived on the station. 

This fix helps prevent that confusion and ensures a more consistent player experience.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This update moves the logic of the arrivals message into the arrivals system by using the `PlayerSpawnCompleteEvent`.

To make the change, a new field was added to the event called `silent`, which while adding complexity, may prove useful to other end-users of the event.

The actual check itself is pretty similar except now it also checks for the `PendingClockInComponent` before displaying the message, as a way to verify that the play has actually been initiated by the arrivals system and not the cryosleep.

<details><summary>Previous implementation</summary>

The update now checks if the player has the `PendingClockInComponent` before displaying the arrival shuttle message. 

This component was originally designed to prevent players in the arrivals area from getting playtime by idling. 

Since only players arriving via the arrivals system have this component, this check distinguishes between Arrivals and Cryosleep (or any other non-arrivals methods).

Additionally, the previous `_arrivals.Enabled` check is no longer needed, as the `PendingClockInComponent` implies that it has been enabled.

</details>

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

<details><summary>Cryosleep</summary>

![image](https://github.com/user-attachments/assets/8f571c02-8f7b-43e0-af3c-650a97e63d6b)

</details>

<details><summary>Arrivals</summary>

![image](https://github.com/user-attachments/assets/150c6e59-37ef-4d5b-8d6b-4cf4620c7252)

</details>

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

No breaking change.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: 
- fix: Cryosleep no longer gives arrival shuttle directions.
