### PR TITLE
Fix the salvage magnet lying about what ore is on the asteroid

### DIFF
--- a/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiomeMarkerLayer.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiomeMarkerLayer.cs
@@ -4,7 +4,6 @@ using Content.Shared.Parallax.Biomes;
 using Content.Shared.Parallax.Biomes.Markers;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;
-using Content.Shared.Random.Helpers;
 using Robust.Shared.Map;
 using Robust.Shared.Utility;
 
@@ -15,7 +14,7 @@ public sealed partial class DungeonJob
     /// <summary>
     /// <see cref="BiomeMarkerLayerDunGen"/>
     /// </summary>
-    private async Task PostGen(BiomeMarkerLayerDunGen dunGen, DungeonData data, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
+    private async Task PostGen(BiomeMarkerLayerDunGen dunGen, DungeonData data, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random, int seed)
     {
         // If we're adding biome then disable it and just use for markers.
         if (_entManager.EnsureComponent(_gridUid, out BiomeComponent biomeComp))
@@ -24,16 +23,15 @@ public sealed partial class DungeonJob
         }
 
         var biomeSystem = _entManager.System<BiomeSystem>();
-        var weightedRandom = _prototype.Index(dunGen.MarkerTemplate);
         var xformQuery = _entManager.GetEntityQuery<TransformComponent>();
         var templates = new Dictionary<string, int>();
 
-        for (var i = 0; i < dunGen.Count; i++)
+        var genTemplates = dunGen.GetMarkers(_prototype, seed);
+        foreach (var gen in genTemplates)
         {
-            var template = weightedRandom.Pick(random);
-            var count = templates.GetOrNew(template);
+            var count = templates.GetOrNew(gen);
             count++;
-            templates[template] = count;
+            templates[gen] = count;
         }
 
         foreach (var (template, count) in templates)

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.cs
@@ -192,7 +192,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
                 await PostGen(cabling, data, dungeons[^1], reservedTiles, random);
                 break;
             case BiomeMarkerLayerDunGen markerPost:
-                await PostGen(markerPost, data, dungeons[^1], reservedTiles, random);
+                await PostGen(markerPost, data, dungeons[^1], reservedTiles, random, seed);
                 break;
             case BiomeDunGen biome:
                 await PostGen(biome, data, dungeons[^1], reservedTiles, random);

--- a/Content.Shared/Procedural/PostGeneration/BiomeMarkerLayerDunGen.cs
+++ b/Content.Shared/Procedural/PostGeneration/BiomeMarkerLayerDunGen.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Random;
+using Content.Shared.Random.Helpers;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Procedural.PostGeneration;
@@ -16,4 +17,13 @@ public sealed partial class BiomeMarkerLayerDunGen : IDunGenLayer
 
     [DataField(required: true)]
     public ProtoId<WeightedRandomPrototype> MarkerTemplate;
+
+    public IEnumerable<string> GetMarkers(IPrototypeManager prototypeManager, int seed)
+    {
+        var rand = new System.Random(seed);
+        for (var i = 0; i < Count; i++)
+        {
+            yield return prototypeManager.Index(MarkerTemplate).Pick(rand);
+        }
+    }
 }

--- a/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
@@ -1,8 +1,6 @@
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;
-using Content.Shared.Random.Helpers;
 using Content.Shared.Salvage.Magnet;
-using Content.Shared.Store;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
@@ -40,12 +38,13 @@ public abstract partial class SharedSalvageSystem
                         rand.Next();
                         break;
                     case BiomeMarkerLayerDunGen marker:
-                        for (var i = 0; i < marker.Count; i++)
+
+                        var genTemplates = marker.GetMarkers(_proto, seed);
+                        foreach (var gen in genTemplates)
                         {
-                            var proto = _proto.Index(marker.MarkerTemplate).Pick(rand);
-                            var layerCount = layers.GetOrNew(proto);
+                            var layerCount = layers.GetOrNew(gen);
                             layerCount++;
-                            layers[proto] = layerCount;
+                            layers[gen] = layerCount;
                         }
                         break;
                 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
gaslit by a magnet? you may be entitled to compensation.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
changes BiomeMarkerLayerDunGen to use the seed directly when selecting layers.
this means that you can actually know which markers it'll pick ahead of time, which we need for the salvage magnet.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: The salvage magnet now accurately reports what ores an asteroid contains.