### PR TITLE
Add MinHealth Construction Condition

### DIFF
--- a/Content.Server/Construction/Conditions/MinHealth.cs
+++ b/Content.Server/Construction/Conditions/MinHealth.cs
@@ -18,12 +18,13 @@ namespace Content.Server.Construction.Conditions;
 public sealed partial class MinHealth : IGraphCondition
 {
     /// <summary>
-    /// If ByProportion is true, Threshold is a value less than or equal to 1, but more than 0.
-    /// Else, Threshold is any positive value with at most 2 decimal points of percision.
+    /// If ByProportion is true, Threshold is a value less than or equal to 1, but more than 0,
+    /// which is compared to the percent of health remaining in the structure.
+    /// Else, Threshold is any positive value with at most 2 decimal points of percision,
+    /// which is compared to the current health of the structure.
     /// </summary>
     [DataField]
     public FixedPoint2 Threshold = 1;
-
     [DataField]
     public bool ByProportion = false;
 

--- a/Content.Server/Construction/Conditions/MinHealth.cs
+++ b/Content.Server/Construction/Conditions/MinHealth.cs
@@ -1,0 +1,91 @@
+using Content.Server.Destructible;
+using Content.Shared.Construction;
+using Content.Shared.Damage;
+using Content.Shared.Examine;
+using Content.Shared.FixedPoint;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Content.Server.Construction.Conditions;
+
+/// <summary>
+/// Requires that the structure has at least some amount of health
+/// </summary>
+[DataDefinition]
+public sealed partial class MinHealth : IGraphCondition
+{
+    /// <summary>
+    /// If ByProportion is true, Threshold is a value less than or equal to 1, but more than 0.
+    /// Else, Threshold is any positive value with at most 2 decimal points of percision.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 Threshold = 1;
+
+    [DataField]
+    public bool ByProportion = false;
+
+    [DataField]
+    public bool IncludeEquals = true;
+
+    public bool Condition(EntityUid uid, IEntityManager entMan)
+    {
+        if (!entMan.TryGetComponent(uid, out DestructibleComponent? destructibleComp) ||
+            !entMan.TryGetComponent(uid, out DamageableComponent? damageComp))
+        {
+            return false;
+        }
+
+        var destructionSys = entMan.System<DestructibleSystem>();
+        var maxHealth = destructionSys.DestroyedAt(uid, destructibleComp);
+        var curHealth = maxHealth - damageComp.TotalDamage;
+        var proportionHealth = curHealth / maxHealth;
+
+        if (IncludeEquals)
+        {
+            if (ByProportion)
+            {
+                return proportionHealth >= Threshold;
+            }
+            else
+            {
+                return curHealth >= Threshold;
+            }
+        }
+        else
+        {
+            if (ByProportion)
+            {
+                return proportionHealth > Threshold;
+            }
+            else
+            {
+                return curHealth > Threshold;
+            }
+        }
+    }
+
+    public bool DoExamine(ExaminedEvent args)
+    {
+        var entMan = IoCManager.Resolve<IEntityManager>();
+        var entity = args.Examined;
+
+        if (Condition(entity, entMan))
+        {
+            return false;
+        }
+        args.PushMarkup(Loc.GetString("construction-examine-condition-low-health"));
+
+        return true;
+    }
+
+    public IEnumerable<ConstructionGuideEntry> GenerateGuideEntry()
+    {
+        yield return new ConstructionGuideEntry()
+        {
+            Localization = "construction-step-condition-low-health"
+        };
+    }
+}

--- a/Resources/Locale/en-US/construction/conditions/min-health.ftl
+++ b/Resources/Locale/en-US/construction/conditions/min-health.ftl
@@ -1,0 +1,2 @@
+construction-examine-condition-low-health = First, repair it.
+construction-step-condition-low-health = It must be repaired.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Created a new IGraphCondition: MinHealth.
It is true if the structure's health is either above a specified flat value OR
above a specified percentage.

A structure's health is the amount of damage it can take before being destroyed.
A structure's max health is the amount of damage it can take before being destroyed, assuming it currently has no damage.
A structure's health percent is it's (health /  max health)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.
If you're unsure whether your PR will require media, ask a maintainer.
-->
https://github.com/user-attachments/assets/28e4976c-44e1-43b3-bae7-1663c47585b9
## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## YMLs changed for testing purposes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

The construction node for deconstructing a railing was adjusted to this for the purposes of testing:
    - node: railing
      entity: Railing
      edges:
        - to: start
          completed:
            - !type:SpawnPrototype
              prototype: PartRodMetal1
              amount: 1
            - !type:DeleteEntity
          steps:
            - tool: Cutting
              doAfter: 0.5
            - tool: Screwing
              doAfter: 0.25
          conditions:
            - !type:MinHealth
              threshold: 0.9
              byProportion: true