### PR TITLE
Convert bookshelves from StorageFill to EntityTables

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -25,7 +25,7 @@
       - id: BookTheBookOfControl
     # Handwritten books
     - !type:GroupSelector
-      amount: !type:RangeNumberSelector
+      rolls: !type:RangeNumberSelector
         range: 0, 2
       children:
       - id: BookAurora

--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -1,129 +1,70 @@
+- type: entityTable
+  id: BookshelfEntityTable
+  table: !type:AllSelector
+    children:
+    # Randomly generated books
+    - id: BookRandomStory
+      amount: !type:RangeNumberSelector
+        range: 0, 4
+    # Guidebooks
+    - !type:GroupSelector
+      children:
+      - id: BookBartendersManual
+      - id: BookChemicalCompendium
+      - id: BookEngineersHandbook
+      - id: BookHowToCookForFortySpaceman
+      - id: BookHowToKeepStationClean
+      - id: BookHowToRockAndStone
+      - id: BookHowToSurvive
+      - id: BookLeafLoversSecret
+      - id: BookMedicalReferenceBook
+      - id: BookScientistsGuidebook
+      - id: BookSecurity
+      - id: BookSpaceEncyclopedia
+      - id: BookSpaceLaw
+      - id: BookTheBookOfControl
+    # Handwritten books
+    - !type:GroupSelector
+      amount: !type:RangeNumberSelector
+        range: 0, 2
+      children:
+      - id: BookAurora
+      - id: BookCafe
+      - id: BookEarth
+      - id: BookFeather
+      - id: BookIanAntarctica
+      - id: BookIanArctic
+      - id: BookIanCity
+      - id: BookIanDesert
+      - id: BookIanLostWolfPup
+      - id: BookIanMountain
+      - id: BookIanOcean
+      - id: BookIanRanch
+      - id: BookInspiration
+      - id: BookJourney
+      - id: BookMap
+      - id: BookMedicalOfficer
+      - id: BookMorgue
+      - id: BookNames
+      - id: BookNarsieLegend
+      - id: BookPossum
+      - id: BookRufus
+      - id: BookSlothClownMMD
+      - id: BookSlothClownPranks
+      - id: BookSlothClownSSS
+      - id: BookStruck
+      - id: BookSun
+      - id: BookTemple
+      - id: BookTruth
+      - id: BookWatched
+      - id: BookWorld
+
 - type: entity
   id: BookshelfFilled
   parent: Bookshelf
   suffix: random filled
   components:
-  - type: StorageFill
-    contents:
-      - id: BookRandomStory
-        prob: 0.6
-        amount: 2
-        maxAmount: 6
-      - id: BookSpaceEncyclopedia
-        orGroup: BookPool
-      - id: BookTheBookOfControl
-        orGroup: BookPool
-      - id: BookBartendersManual
-        orGroup: BookPool
-      - id: BookHowToCookForFortySpaceman
-        orGroup: BookPool
-      - id: BookLeafLoversSecret
-        orGroup: BookPool
-      - id: BookEngineersHandbook
-        orGroup: BookPool
-      - id: BookScientistsGuidebook
-        orGroup: BookPool
-      - id: BookSecurity
-        orGroup: BookPool
-      - id: BookHowToKeepStationClean
-        orGroup: BookPool
-      - id: BookHowToRockAndStone
-        orGroup: BookPool
-      - id: BookMedicalReferenceBook
-        orGroup: BookPool
-      - id: BookHowToSurvive
-        orGroup: BookPool
-      - id: BookChemicalCompendium
-        orGroup: BookPool
-      - id: BookSpaceLaw
-        orGroup: BookPool
-      - id: BookNarsieLegend
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookTruth
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookWorld
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookIanAntarctica
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookSlothClownSSS
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookSlothClownPranks
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookSlothClownMMD
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookStruck
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookSun
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookPossum
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookCafe
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookFeather
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookIanLostWolfPup
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookIanRanch
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookIanOcean
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookIanMountain
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookIanCity
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookIanArctic
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookIanDesert
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookNames
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookEarth
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookAurora
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookTemple
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookWatched
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookMedicalOfficer
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookMorgue
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookRufus
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookMap
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookJourney
-        prob: 0.1
-        orGroup: BookAuthor
-      - id: BookInspiration
-        prob: 0.1
-        orGroup: BookAuthor
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: BookshelfEntityTable


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Bookshelves now use EntityTables instead of StorageFill.

Filled bookshelves have anywhere from one book guaranteed to seven books total.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
EntityTables are just more sane to work with. I hate orGroups with a passion.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Having probabilities for every single book in the authored section felt a bit obtuse to work with so I just got rid of it.

- Random book amount has gone from 2-6 (prob 0.6) to 0-4 (prob 1.0)
- Guidebook amount and probability unchanged
- Authored book amount went from 0-1 (prob ???) to 0-2 (prob 1.0)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->


https://github.com/user-attachments/assets/f2c0159d-63ba-458b-9c12-1bbc14d6a2ab



## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
