### PR TITLE
Add conducting gloves to the maintenance loot table

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -242,6 +242,8 @@
           weight: 0.5
         - id: ClothingHandsGlovesColorYellow
           weight: 1
+        - id: ClothingHandsGlovesConducting
+          weight: 1
       # Uncommon Group
     - !type:GroupSelector
       weight: 23

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -243,7 +243,7 @@
         - id: ClothingHandsGlovesColorYellow
           weight: 1
         - id: ClothingHandsGlovesConducting
-          weight: 1
+          weight: 0.1
       # Uncommon Group
     - !type:GroupSelector
       weight: 23


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds a chance for conducting gloves in the maintenance loot table.

Compared to insulated gloves, it is 1/10 of the chance, and 1/5 of the chance of fingerless insulated gloves.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

It's funny to imagine a tider going through maintenance to powergame, put on the closest insuls and die the next time he tries to hack into someplace he's not allowed to.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

no cl since people will learn either way.
