### PR TITLE
Fix DoDrop to DropNextTo in container cases

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -126,13 +126,22 @@ public abstract partial class SharedHandsSystem
         var userXform = Transform(uid);
         var isInContainer = ContainerSystem.IsEntityOrParentInContainer(uid, xform: userXform);
 
+        // if the user is in a container, drop the item inside the container
+        if (isInContainer) {
+            TransformSystem.DropNextTo((entity, itemXform), (uid, userXform));
+            return true;
+        }
+        
+        // drop the item with heavy calculations from their hands and place it at the calculated interaction range position
+        // The DoDrop is handle if there's no drop target
         DoDrop(uid, hand, doDropInteraction: doDropInteraction, handsComp);
 
-        // drop the item inside the container if the user is in a container
-        if (targetDropLocation == null || isInContainer)
+        // if there's no drop location stop here
+        if (targetDropLocation == null) {
             return true;
-
-        // otherwise, remove the item from their hands and place it at the calculated interaction range position
+        }
+        
+        // otherwise, also move dropped item and rotate it properly according to grid/map
         var (itemPos, itemRot) = TransformSystem.GetWorldPositionRotation(entity);
         var origin = new MapCoordinates(itemPos, itemXform.MapID);
         var target = TransformSystem.ToMapCoordinates(targetDropLocation.Value);

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -137,9 +137,8 @@ public abstract partial class SharedHandsSystem
         DoDrop(uid, hand, doDropInteraction: doDropInteraction, handsComp);
 
         // if there's no drop location stop here
-        if (targetDropLocation == null) {
+        if (targetDropLocation == null)
             return true;
-        }
         
         // otherwise, also move dropped item and rotate it properly according to grid/map
         var (itemPos, itemRot) = TransformSystem.GetWorldPositionRotation(entity);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Fix issue https://github.com/space-wizards/space-station-14/issues/30261 that's points to PR https://github.com/space-wizards/space-station-14/pull/30223 .
`DoDrop` heavy to calculate (hands positions, mouse positions, moving, raises moveevents and so on).
Implemented that if player's in container then `DropNextTo` used, that's much faster and without redundunt actions.
As much as possible, we should avoid using `DoDrop`.
<!-- What did you change in this PR? -->

## Technical details
Uses `DropNextTo` for drop logic if action's have been in container.
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
no cl, just sped
