### PR TITLE
Mining Rebalance

### DIFF
--- a/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
+++ b/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
@@ -63,7 +63,7 @@ public sealed class SalvageMagnetBoundUserInterface : BoundUserInterface
             switch (offer)
             {
                 case AsteroidOffering asteroid:
-                    option.Title = Loc.GetString($"dungeon-config-proto-{asteroid.DungeonConfig.ID}");
+                    option.Title = Loc.GetString($"dungeon-config-proto-{asteroid.Id}");
                     var layerKeys = asteroid.MarkerLayers.Keys.ToList();
                     layerKeys.Sort();
 

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -623,14 +623,14 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
             var groupSize = rand.Next(layerProto.MinGroupSize, layerProto.MaxGroupSize + 1);
 
             // While we have remaining tiles keep iterating
-            while (groupSize >= 0 && remainingTiles.Count > 0)
+            while (groupSize > 0 && remainingTiles.Count > 0)
             {
                 var startNode = rand.PickAndTake(remainingTiles);
                 frontier.Clear();
                 frontier.Add(startNode);
 
                 // This essentially may lead to a vein being split in multiple areas but the count matters more than position.
-                while (frontier.Count > 0 && groupSize >= 0)
+                while (frontier.Count > 0 && groupSize > 0)
                 {
                     // Need to pick a random index so we don't just get straight lines of ores.
                     var frontierIndex = rand.Next(frontier.Count);
@@ -643,9 +643,6 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
                     {
                         for (var y = -1; y <= 1; y++)
                         {
-                            if (x != 0 && y != 0)
-                                continue;
-
                             var neighbor = new Vector2i(node.X + x, node.Y + y);
 
                             if (frontier.Contains(neighbor) || !remainingTiles.Contains(neighbor))

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.OreDunGen.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.OreDunGen.cs
@@ -88,14 +88,14 @@ public sealed partial class DungeonJob
             var groupSize = random.Next(gen.MinGroupSize, gen.MaxGroupSize + 1);
 
             // While we have remaining tiles keep iterating
-            while (groupSize >= 0 && availableTiles.Count > 0)
+            while (groupSize > 0 && availableTiles.Count > 0)
             {
                 var startNode = random.PickAndTake(availableTiles);
                 frontier.Clear();
                 frontier.Add(startNode);
 
                 // This essentially may lead to a vein being split in multiple areas but the count matters more than position.
-                while (frontier.Count > 0 && groupSize >= 0)
+                while (frontier.Count > 0 && groupSize > 0)
                 {
                     // Need to pick a random index so we don't just get straight lines of ores.
                     var frontierIndex = random.Next(frontier.Count);
@@ -108,9 +108,6 @@ public sealed partial class DungeonJob
                     {
                         for (var y = -1; y <= 1; y++)
                         {
-                            if (x != 0 && y != 0)
-                                continue;
-
                             var neighbor = new Vector2i(node.X + x, node.Y + y);
 
                             if (frontier.Contains(neighbor) || !availableTiles.Contains(neighbor))
@@ -142,7 +139,7 @@ public sealed partial class DungeonJob
 
             if (groupSize > 0)
             {
-                _sawmill.Warning($"Found remaining group size for ore veins!");
+                _sawmill.Warning($"Found remaining group size for ore veins of {gen.Replacement ?? "null"}!");
             }
         }
     }

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.cs
@@ -44,7 +44,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<TransformComponent> _xformQuery;
 
-    private readonly DungeonConfigPrototype _gen;
+    private readonly DungeonConfig _gen;
     private readonly int _seed;
     private readonly Vector2i _position;
 
@@ -65,7 +65,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
         EntityLookupSystem lookup,
         TileSystem tile,
         SharedTransformSystem transform,
-        DungeonConfigPrototype gen,
+        DungeonConfig gen,
         MapGridComponent grid,
         EntityUid gridUid,
         int seed,
@@ -102,7 +102,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
     /// <param name="reserve">Should we reserve tiles even if the config doesn't specify.</param>
     private async Task<List<Dungeon>> GetDungeons(
         Vector2i position,
-        DungeonConfigPrototype config,
+        DungeonConfig config,
         DungeonData data,
         List<IDunGenLayer> layers,
         HashSet<Vector2i> reservedTiles,
@@ -139,7 +139,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
 
     protected override async Task<List<Dungeon>?> Process()
     {
-        _sawmill.Info($"Generating dungeon {_gen.ID} with seed {_seed} on {_entManager.ToPrettyString(_gridUid)}");
+        _sawmill.Info($"Generating dungeon {_gen} with seed {_seed} on {_entManager.ToPrettyString(_gridUid)}");
         _grid.CanSplit = false;
         var random = new Random(_seed);
         var position = (_position + random.NextPolarVector2(_gen.MinOffset, _gen.MaxOffset)).Floored();
@@ -177,7 +177,7 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
         int seed,
         Random random)
     {
-        _sawmill.Debug($"Doing postgen {layer.GetType()} for {_gen.ID} with seed {_seed}");
+        _sawmill.Debug($"Doing postgen {layer.GetType()} for {_gen} with seed {_seed}");
 
         // If there's a way to just call the methods directly for the love of god tell me.
         // Some of these don't care about reservedtiles because they only operate on dungeon tiles (which should

--- a/Content.Server/Procedural/DungeonSystem.cs
+++ b/Content.Server/Procedural/DungeonSystem.cs
@@ -183,7 +183,7 @@ public sealed partial class DungeonSystem : SharedDungeonSystem
         return mapId;
     }
 
-    public void GenerateDungeon(DungeonConfigPrototype gen,
+    public void GenerateDungeon(DungeonConfig gen,
         EntityUid gridUid,
         MapGridComponent grid,
         Vector2i position,
@@ -214,7 +214,7 @@ public sealed partial class DungeonSystem : SharedDungeonSystem
     }
 
     public async Task<List<Dungeon>> GenerateDungeonAsync(
-        DungeonConfigPrototype gen,
+        DungeonConfig gen,
         EntityUid gridUid,
         MapGridComponent grid,
         Vector2i position,

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -175,7 +175,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         var dungeonOffset = new Vector2(0f, dungeonOffsetDistance);
         dungeonOffset = dungeonRotation.RotateVec(dungeonOffset);
         var dungeonMod = _prototypeManager.Index<SalvageDungeonModPrototype>(mission.Dungeon);
-        var dungeonConfig = _prototypeManager.Index<DungeonConfigPrototype>(dungeonMod.Proto);
+        var dungeonConfig = _prototypeManager.Index(dungeonMod.Proto);
         var dungeons = await WaitAsyncTask(_dungeon.GenerateDungeonAsync(dungeonConfig, mapUid, grid, (Vector2i) dungeonOffset,
             _missionParams.Seed));
 

--- a/Content.Shared/Destructible/Thresholds/MinMax.cs
+++ b/Content.Shared/Destructible/Thresholds/MinMax.cs
@@ -17,7 +17,12 @@ public partial struct MinMax
         Max = max;
     }
 
-    public int Next(IRobustRandom random)
+    public readonly int Next(IRobustRandom random)
+    {
+        return random.Next(Min, Max + 1);
+    }
+
+    public readonly int Next(System.Random random)
     {
         return random.Next(Min, Max + 1);
     }

--- a/Content.Shared/Procedural/DungeonConfig.cs
+++ b/Content.Shared/Procedural/DungeonConfig.cs
@@ -1,14 +1,10 @@
-using Content.Shared.Procedural.PostGeneration;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Procedural;
 
-[Prototype]
-public sealed partial class DungeonConfigPrototype : IPrototype
+[Virtual, DataDefinition]
+public partial class DungeonConfig
 {
-    [IdDataField]
-    public string ID { get; private set; } = default!;
-
     /// <summary>
     /// <see cref="Data"/>
     /// </summary>
@@ -18,7 +14,7 @@ public sealed partial class DungeonConfigPrototype : IPrototype
     /// <summary>
     /// The secret sauce, procedural generation layers that get run.
     /// </summary>
-    [DataField(required: true)]
+    [DataField]
     public List<IDunGenLayer> Layers = new();
 
     /// <summary>
@@ -50,4 +46,11 @@ public sealed partial class DungeonConfigPrototype : IPrototype
     /// </summary>
     [DataField]
     public int MaxOffset;
+}
+
+[Prototype]
+public sealed class DungeonConfigPrototype : DungeonConfig, IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
 }

--- a/Content.Shared/Procedural/DungeonGenerators/PrototypeDunGen.cs
+++ b/Content.Shared/Procedural/DungeonGenerators/PrototypeDunGen.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Procedural.DungeonGenerators;
 
 /// <summary>
-/// Runs another <see cref="DungeonConfigPrototype"/>.
+/// Runs another <see cref="DungeonConfig"/>.
 /// Used for storing data on 1 system.
 /// </summary>
 public sealed partial class PrototypeDunGen : IDunGenLayer

--- a/Content.Shared/Procedural/DungeonLayers/OreDunGen.cs
+++ b/Content.Shared/Procedural/DungeonLayers/OreDunGen.cs
@@ -8,7 +8,8 @@ namespace Content.Shared.Procedural.DungeonLayers;
 /// <remarks>
 /// Generates on top of existing entities for sanity reasons moreso than performance.
 /// </remarks>
-public sealed partial class OreDunGen : IDunGenLayer
+[Virtual]
+public partial class OreDunGen : IDunGenLayer
 {
     /// <summary>
     /// If the vein generation should occur on top of existing entities what are we replacing.

--- a/Content.Shared/Procedural/DungeonLayers/OreDunGenPrototype.cs
+++ b/Content.Shared/Procedural/DungeonLayers/OreDunGenPrototype.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Procedural.DungeonLayers;
+
+[Prototype]
+public sealed partial class OreDunGenPrototype : OreDunGen, IPrototype
+{
+    [IdDataField]
+    public string ID { set; get; } = default!;
+}

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageDungeonModPrototype.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageDungeonModPrototype.cs
@@ -23,6 +23,6 @@ public sealed partial class SalvageDungeonModPrototype : IPrototype, IBiomeSpeci
     /// <summary>
     /// The config to use for spawning the dungeon.
     /// </summary>
-    [DataField("proto", customTypeSerializer: typeof(PrototypeIdSerializer<DungeonConfigPrototype>), required: true)]
-    public string Proto = string.Empty;
+    [DataField(required: true)]
+    public ProtoId<DungeonConfigPrototype> Proto = string.Empty;
 }

--- a/Content.Shared/Salvage/Magnet/AsteroidOffering.cs
+++ b/Content.Shared/Salvage/Magnet/AsteroidOffering.cs
@@ -7,7 +7,9 @@ namespace Content.Shared.Salvage.Magnet;
 /// </summary>
 public record struct AsteroidOffering : ISalvageMagnetOffering
 {
-    public DungeonConfigPrototype DungeonConfig;
+    public string Id;
+
+    public DungeonConfig DungeonConfig;
 
     /// <summary>
     /// Calculated marker layers for the asteroid.

--- a/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
@@ -1,8 +1,9 @@
+using Content.Shared.Destructible.Thresholds;
 using Content.Shared.Procedural;
-using Content.Shared.Procedural.PostGeneration;
+using Content.Shared.Procedural.DungeonLayers;
+using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Salvage.Magnet;
-using Content.Shared.Store;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
@@ -20,6 +21,10 @@ public abstract partial class SharedSalvageSystem
         "SwissCheeseAsteroid"
     };
 
+    private readonly ProtoId<WeightedRandomPrototype> _asteroidOreWeights = "AsteroidOre";
+
+    private readonly MinMax _asteroidOreCount = new(5, 7);
+
     public ISalvageMagnetOffering GetSalvageOffering(int seed)
     {
         var rand = new System.Random(seed);
@@ -27,33 +32,40 @@ public abstract partial class SharedSalvageSystem
         // Asteroid seed
         if (seed % 2 == 0)
         {
-            var config = _asteroidConfigs[rand.Next(_asteroidConfigs.Count)];
-            var configProto = _proto.Index(config);
+            var configId = _asteroidConfigs[rand.Next(_asteroidConfigs.Count)];
+            var configProto =_proto.Index(configId);
             var layers = new Dictionary<string, int>();
 
-            // If we ever add more random layers will need to Next on these.
-            foreach (var layer in configProto.Layers)
+            var data = new DungeonData();
+            data.Apply(configProto.Data);
+
+            var config = new DungeonConfig()
             {
-                switch (layer)
-                {
-                    case BiomeDunGen:
-                        rand.Next();
-                        break;
-                    case BiomeMarkerLayerDunGen marker:
-                        for (var i = 0; i < marker.Count; i++)
-                        {
-                            var proto = _proto.Index(marker.MarkerTemplate).Pick(rand);
-                            var layerCount = layers.GetOrNew(proto);
-                            layerCount++;
-                            layers[proto] = layerCount;
-                        }
-                        break;
-                }
+                Data = data,
+                Layers = new(configProto.Layers),
+                MaxCount = configProto.MaxCount,
+                MaxOffset = configProto.MaxOffset,
+                MinCount = configProto.MinCount,
+                MinOffset = configProto.MinOffset,
+                ReserveTiles = configProto.ReserveTiles
+            };
+
+            var count = _asteroidOreCount.Next(rand);
+            var weightedProto = _proto.Index(_asteroidOreWeights);
+            for (var i = 0; i < count; i++)
+            {
+                var ore = weightedProto.Pick(rand);
+                config.Layers.Add(_proto.Index<OreDunGenPrototype>(ore));
+
+                var layerCount = layers.GetOrNew(ore);
+                layerCount++;
+                layers[ore] = layerCount;
             }
 
             return new AsteroidOffering
             {
-                DungeonConfig = configProto,
+                Id = configId,
+                DungeonConfig = config,
                 MarkerLayers = layers,
             };
         }

--- a/Resources/Locale/en-US/salvage/salvage-magnet.ftl
+++ b/Resources/Locale/en-US/salvage/salvage-magnet.ftl
@@ -18,6 +18,7 @@ salvage-magnet-resources = {$resource ->
     [OrePlasma] Plasma
     [OreUranium] Uranium
     [OreArtifactFragment] Artifact fragments
+    [OreBananium] Bananium
     *[other] {$resource}
 }
 

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -48,7 +48,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawGold: 500
+      RawGold: 100
   - type: Extractable
     grindableSolutionName: goldore
   - type: SolutionContainerManager
@@ -79,7 +79,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawDiamond: 500
+      RawDiamond: 100
   - type: Extractable
     grindableSolutionName: diamondore
   - type: SolutionContainerManager
@@ -110,7 +110,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawIron: 500
+      RawIron: 100
   - type: Extractable
     grindableSolutionName: ironore
   - type: SolutionContainerManager
@@ -141,7 +141,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawPlasma: 500
+      RawPlasma: 100
   - type: PointLight
     radius: 1.2
     energy: 0.6
@@ -177,7 +177,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSilver: 500
+      RawSilver: 100
   - type: Extractable
     grindableSolutionName: silverore
   - type: SolutionContainerManager
@@ -208,7 +208,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawQuartz: 500
+      RawQuartz: 100
   - type: Extractable
     grindableSolutionName: quartzore
   - type: SolutionContainerManager
@@ -239,7 +239,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawUranium: 500
+      RawUranium: 100
   - type: PointLight
     radius: 1.2
     energy: 0.8
@@ -278,7 +278,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawBananium: 500
+      RawBananium: 100
   - type: PointLight
     radius: 1.2
     energy: 1
@@ -334,7 +334,7 @@
           Quantity: 0.1
   - type: PhysicalComposition
     materialComposition:
-      Coal: 500
+      Coal: 100
 
 - type: entity
   parent: Coal
@@ -357,7 +357,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSalt: 500
+      RawSalt: 100
   - type: Extractable
     grindableSolutionName: saltore
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Procedural/Magnet/asteroid.yml
+++ b/Resources/Prototypes/Procedural/Magnet/asteroid.yml
@@ -1,24 +1,10 @@
-- type: weightedRandom
-  id: AsteroidOre
-  weights:
-    OreIron: 1.0
-    OreQuartz: 1.0
-    OreCoal: 1.0
-    OreSalt: 1.0
-    OreGold: 0.25
-    OreDiamond: 0.05
-    OreSilver: 0.25
-    OrePlasma: 0.15
-    OreUranium: 0.15
-    OreArtifactFragment: 0.15
-
 # Large asteroids, typically 1
 - type: dungeonConfig
   id: BlobAsteroid
   # Floor generation
   layers:
   - !type:NoiseDunGen
-    tileCap: 1500
+    tileCap: 1000
     capStd: 32
     iterations: 3
     layers:
@@ -35,10 +21,6 @@
   - !type:BiomeDunGen
     biomeTemplate: Asteroid
 
-  # Generate ore veins
-  - !type:BiomeMarkerLayerDunGen
-    markerTemplate: AsteroidOre
-
 # Multiple smaller asteroids
 # This is a pain so we generate fewer tiles
 - type: dungeonConfig
@@ -46,7 +28,7 @@
   # Floor generation
   layers:
   - !type:NoiseDunGen
-    tileCap: 1000
+    tileCap: 750
     capStd: 32
     layers:
       - tile: FloorAsteroidSand
@@ -62,17 +44,13 @@
   - !type:BiomeDunGen
     biomeTemplate: Asteroid
 
-  # Generate ore veins
-  - !type:BiomeMarkerLayerDunGen
-    markerTemplate: AsteroidOre
-
 # Long and spindly, less smooth than blob
 - type: dungeonConfig
   id: SpindlyAsteroid
   # Floor generation
   layers:
   - !type:NoiseDunGen
-    tileCap: 1500
+    tileCap: 1000
     capStd: 32
     layers:
       - tile: FloorAsteroidSand
@@ -89,17 +67,13 @@
   - !type:BiomeDunGen
     biomeTemplate: Asteroid
 
-  # Generate ore veins
-  - !type:BiomeMarkerLayerDunGen
-    markerTemplate: AsteroidOre
-
 # Lots of holes in it
 - type: dungeonConfig
   id: SwissCheeseAsteroid
   # Floor generation
   layers:
   - !type:NoiseDunGen
-    tileCap: 1500
+    tileCap: 1000
     capStd: 32
     layers:
       - tile: FloorAsteroidSand
@@ -114,7 +88,3 @@
   # Generate biome
   - !type:BiomeDunGen
     biomeTemplate: Asteroid
-
-  # Generate ore veins
-  - !type:BiomeMarkerLayerDunGen
-    markerTemplate: AsteroidOre

--- a/Resources/Prototypes/Procedural/Magnet/asteroid_ore_gens.yml
+++ b/Resources/Prototypes/Procedural/Magnet/asteroid_ore_gens.yml
@@ -1,0 +1,95 @@
+- type: weightedRandom
+  id: AsteroidOre
+  weights:
+    OreIron: 1.0
+    OreQuartz: 1.0
+    OreCoal: 0.33
+    OreSalt: 0.25
+    OreGold: 0.25
+    OreSilver: 0.25
+    OrePlasma: 0.15
+    OreUranium: 0.15
+    OreArtifactFragment: 0.10
+    OreBananium: 0.10
+
+- type: oreDunGen
+  id: OreIron
+  replacement: AsteroidRock
+  entity: AsteroidRockTin
+  count: 5
+  minGroupSize: 5
+  maxGroupSize: 7
+
+- type: oreDunGen
+  id: OreQuartz
+  replacement: AsteroidRock
+  entity: AsteroidRockQuartz
+  count: 5
+  minGroupSize: 5
+  maxGroupSize: 7
+
+- type: oreDunGen
+  id: OreCoal
+  replacement: AsteroidRock
+  entity: AsteroidRockCoal
+  count: 3
+  minGroupSize: 5
+  maxGroupSize: 7
+
+- type: oreDunGen
+  id: OreSalt
+  replacement: AsteroidRock
+  entity: AsteroidRockSalt
+  count: 3
+  minGroupSize: 5
+  maxGroupSize: 7
+
+- type: oreDunGen
+  id: OreGold
+  replacement: AsteroidRock
+  entity: AsteroidRockGold
+  count: 4
+  minGroupSize: 4
+  maxGroupSize: 6
+
+- type: oreDunGen
+  id: OreSilver
+  replacement: AsteroidRock
+  entity: AsteroidRockSilver
+  count: 4
+  minGroupSize: 4
+  maxGroupSize: 6
+
+- type: oreDunGen
+  id: OrePlasma
+  replacement: AsteroidRock
+  entity: AsteroidRockPlasma
+  count: 4
+  minGroupSize: 3
+  maxGroupSize: 6
+
+- type: oreDunGen
+  id: OreUranium
+  replacement: AsteroidRock
+  entity: AsteroidRockUranium
+  count: 4
+  minGroupSize: 3
+  maxGroupSize: 6
+
+- type: oreDunGen
+  id: OreBananium
+  replacement: AsteroidRock
+  entity: AsteroidRockBananium
+  count: 6
+  minGroupSize: 3
+  maxGroupSize: 6
+
+- type: oreDunGen
+  id: OreArtifactFragment
+  replacement: AsteroidRock
+  entity: AsteroidRockArtifactFragment
+  count: 5
+  minGroupSize: 1
+  maxGroupSize: 2
+
+

--- a/Resources/Prototypes/Procedural/biome_ore_templates.yml
+++ b/Resources/Prototypes/Procedural/biome_ore_templates.yml
@@ -96,7 +96,7 @@
     WallRockChromite: WallRockChromitePlasma
     WallRockSand: WallRockSandPlasma
     WallRockSnow: WallRockSnowPlasma
-  count: 12
+  maxCount: 12
   minGroupSize: 4
   maxGroupSize: 8
   radius: 4
@@ -111,7 +111,7 @@
     WallRockChromite: WallRockChromiteUranium
     WallRockSand: WallRockSandUranium
     WallRockSnow: WallRockSnowUranium
-  count: 15
+  maxCount: 15
   minGroupSize: 4
   maxGroupSize: 8
   radius: 4

--- a/Resources/Prototypes/Procedural/biome_ore_templates.yml
+++ b/Resources/Prototypes/Procedural/biome_ore_templates.yml
@@ -10,7 +10,7 @@
     WallRockSnow: WallRockSnowTin
   maxCount: 30
   minGroupSize: 10
-  maxGroupSize: 20
+  maxGroupSize: 15
   radius: 4
 
 - type: biomeMarkerLayer
@@ -23,7 +23,7 @@
     WallRockSnow: WallRockSnowQuartz
   maxCount: 30
   minGroupSize: 10
-  maxGroupSize: 20
+  maxGroupSize: 15
   radius: 4
 
 - type: biomeMarkerLayer
@@ -36,8 +36,8 @@
     WallRockSand: WallRockSandCoal
     WallRockSnow: WallRockSnowCoal
   maxCount: 30
-  minGroupSize: 10
-  maxGroupSize: 20
+  minGroupSize: 8
+  maxGroupSize: 12
   radius: 4
 
 - type: biomeMarkerLayer
@@ -50,8 +50,8 @@
     WallRockSand: WallRockSandSalt
     WallRockSnow: WallRockSnowSalt
   maxCount: 30
-  minGroupSize: 10
-  maxGroupSize: 20
+  minGroupSize: 8
+  maxGroupSize: 12
   radius: 4
 
 # Medium value
@@ -65,7 +65,7 @@
     WallRockChromite: WallRockChromiteGold
     WallRockSand: WallRockSandGold
     WallRockSnow: WallRockSnowGold
-  maxCount: 30
+  maxCount: 20
   minGroupSize: 5
   maxGroupSize: 10
   radius: 4
@@ -80,7 +80,7 @@
     WallRockChromite: WallRockChromiteSilver
     WallRockSand: WallRockSandSilver
     WallRockSnow: WallRockSnowSilver
-  maxCount: 30
+  maxCount: 20
   minGroupSize: 5
   maxGroupSize: 10
   radius: 4
@@ -96,9 +96,9 @@
     WallRockChromite: WallRockChromitePlasma
     WallRockSand: WallRockSandPlasma
     WallRockSnow: WallRockSnowPlasma
-  maxCount: 12
-  minGroupSize: 5
-  maxGroupSize: 10
+  count: 12
+  minGroupSize: 4
+  maxGroupSize: 8
   radius: 4
 
 # Uranium
@@ -111,23 +111,9 @@
     WallRockChromite: WallRockChromiteUranium
     WallRockSand: WallRockSandUranium
     WallRockSnow: WallRockSnowUranium
-  maxCount: 12
-  minGroupSize: 5
-  maxGroupSize: 10
-  radius: 4
-
-- type: biomeMarkerLayer
-  id: OreBananium
-  entityMask:
-    AsteroidRock: AsteroidRockBananium
-    WallRock: WallRockBananium
-    WallRockBasalt: WallRockBasaltBananium
-    WallRockChromite: WallRockChromiteBananium
-    WallRockSand: WallRockSandBananium
-    WallRockSnow: WallRockSnowBananium
-  maxCount: 12
-  minGroupSize: 5
-  maxGroupSize: 10
+  count: 15
+  minGroupSize: 4
+  maxGroupSize: 8
   radius: 4
 
 - type: biomeMarkerLayer

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -172,13 +172,6 @@
       proto: OreUranium
 
 - type: salvageLoot
-  id: OreBananium
-  guaranteed: true
-  loots:
-    - !type:BiomeMarkerLoot
-      proto: OreBananium
-
-- type: salvageLoot
   id: OreDiamond
   guaranteed: true
   loots:

--- a/Resources/Prototypes/Procedural/vgroid.yml
+++ b/Resources/Prototypes/Procedural/vgroid.yml
@@ -26,62 +26,56 @@
       replacement: IronRock
       entity: IronRockIron
       count: 50
-      minGroupSize: 20
-      maxGroupSize: 30
+      minGroupSize: 10
+      maxGroupSize: 15
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockCoal
       count: 50
-      minGroupSize: 20
-      maxGroupSize: 30
+      minGroupSize: 8
+      maxGroupSize: 12
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockQuartz
       count: 50
-      minGroupSize: 20
-      maxGroupSize: 30
+      minGroupSize: 10
+      maxGroupSize: 15
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockSalt
       count: 50
-      minGroupSize: 20
-      maxGroupSize: 30
+      minGroupSize: 8
+      maxGroupSize: 12
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockGold
-      count: 50
-      minGroupSize: 10
-      maxGroupSize: 20
+      count: 40
+      minGroupSize: 8
+      maxGroupSize: 12
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockSilver
-      count: 50
-      minGroupSize: 10
-      maxGroupSize: 20
+      count: 40
+      minGroupSize: 8
+      maxGroupSize: 12
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockPlasma
-      count: 50
-      minGroupSize: 10
-      maxGroupSize: 20
+      count: 35
+      minGroupSize: 4
+      maxGroupSize: 8
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockUranium
-      count: 50
-      minGroupSize: 10
-      maxGroupSize: 20
-    - !type:OreDunGen
-      replacement: IronRock
-      entity: IronRockBananium
-      count: 50
-      minGroupSize: 10
-      maxGroupSize: 20
+      count: 35
+      minGroupSize: 4
+      maxGroupSize: 8
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockArtifactFragment
-      count: 50
-      minGroupSize: 2
-      maxGroupSize: 4
+      count: 25
+      minGroupSize: 1
+      maxGroupSize: 3
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockDiamond

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -18,7 +18,7 @@
   id: OreCoal
   oreEntity: Coal1
   minOreYield: 1
-  maxOreYield: 45
+  maxOreYield: 5
 
 # Medium yields
 - type: ore

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -6,19 +6,19 @@
   id: OreSteel
   oreEntity: SteelOre1
   minOreYield: 1
-  maxOreYield: 4
+  maxOreYield: 5
 
 - type: ore
   id: OreSpaceQuartz
   oreEntity: SpaceQuartz1
   minOreYield: 1
-  maxOreYield: 4
+  maxOreYield: 5
 
 - type: ore
   id: OreCoal
   oreEntity: Coal1
   minOreYield: 1
-  maxOreYield: 4
+  maxOreYield: 45
 
 # Medium yields
 - type: ore

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -6,19 +6,19 @@
   id: OreSteel
   oreEntity: SteelOre1
   minOreYield: 1
-  maxOreYield: 5
+  maxOreYield: 4
 
 - type: ore
   id: OreSpaceQuartz
   oreEntity: SpaceQuartz1
   minOreYield: 1
-  maxOreYield: 5
+  maxOreYield: 4
 
 - type: ore
   id: OreCoal
   oreEntity: Coal1
   minOreYield: 1
-  maxOreYield: 5
+  maxOreYield: 4
 
 # Medium yields
 - type: ore
@@ -56,7 +56,7 @@
   id: OreBananium
   oreEntity: BananiumOre1
   minOreYield: 1
-  maxOreYield: 3
+  maxOreYield: 2
 
 - type: ore
   id: OreDiamond
@@ -83,8 +83,8 @@
 - type: ore
   id: OreArtifactFragment
   oreEntity: ArtifactFragment1
-  minOreYield: 2
-  maxOreYield: 4
+  minOreYield: 1
+  maxOreYield: 3
 
 - type: weightedRandomOre
   id: RandomOreDistributionStandard


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

### Magnet Asteroid Generation
Magnets asteroids had the general issue of feeling super empty. I partially reduced the total number of tiles so that they are a bit more compact and the other changes to ore amounts should hopefully make them feel a bit more full.

### Material Values
The main goal of this was twofold:
- for vgroid/expeds, decrease the overall amount of material as well as the density of ore as to encourage exploring more of the area.
- for magnets, increase the amount of ore to make the generation feel less empty as well as decrease the ore amounts themselves to make it multiple trips necessary.

The way i addressed this was by reducing the amount of refined materials a single piece of ores gives you (5 -> 1) as well as adjusting the amount of ore being spawned as needed. This should ideally give a more balanced amount of materials.

#### VGroid/Expeds
(expedition planets have the same values)

| Ore | Old Avg. Amount (ore chunks) | New Avg. Amount (ore chunks) | Old Avg. Amount (sheets) | New Avg. Amount (sheets) |
| -------- | -- | -- | -- | -- | 
| Iron | 3,750 | 1,875 | 18,750  | 1,875 | 
| Quartz | 3,750 | 1,875 | 18,750 | 1,875 |
| Coal | 3,750 | 1,500 | 18,750 | 1,500 |
| Salt | 1,875 | 1,000 | 9,375 | 1,000 |
| Gold | 1,500 | 800 | 7,500 | 800 |
| Silver | 1,500 | 800 | 7,500 | 800 |
| Plasma | 1,500 | 315 | 7,500 | 315 |
| Uranium | 1,500 | 315 | 7,500 | 315 |
| Bananium | 1,500 | 0 (magnet-only) | 7,500 | 0 (magnet-only) |
| Artifact Fragments | n/a | n/a | 450 | 100 |
| Diamond | 33.75 | 33.75 | 168.75 | 33.75 |

#### Magnet Asteroids
Magnets randomly populate ores 5 to 7 times.
A single population is displayed as "poor" in the UI.

| Ore | Old Avg. Amount (ore chunks) | New Avg. Amount (ore chunks) | Old Avg. Amount per 1 Population (sheets) | New Avg. Amount per 1 Population (sheets) |
| -------- | ------- | -- | -- | -- |
| Iron | 45 | 90 | 225 | 90 | 
| Quartz | 45 | 90 | 225 | 90 |
| Coal | 45 | 54 | 225  | 54 |
| Salt | 22.5 | 27 | 112.5 | 27 |
| Gold | 11.25 | 36 | 56.25 | 36 |
| Silver | 11.25 | 36 | 56.25 | 36 |
| Plasma | 11.25 | 27 | 56.25 | 27 |
| Uranium | 11.25 | 27 | 56.25 | 27 |
| Bananium | 11.25 | 40.5 | 56.25 | 40.5 |
| Artifact Fragments | n/a | n/a | 4.5 | 15 |
| Diamond | 2.25 | 0 (vgroid/exped-only) | 11.25 | 0 (vgroid/exped-only) |

## Why / Balance
Material supply is currently very out of wack. The overall amounts of every material are way too high, which makes meaningful economic gameplay (read: #30869) impossible due to the sheer volume you can acquire. On the other hand, the veins are so infrequent and dense in places that actually finding the ore becomes difficult. 

this isn't necessarily the most refined approach at this. My goal was just to reduce the pure amounts of all the materials to a level where it made sense. The VGroid should not be an infinite material generator and the magnet should be a easy-to-acquire reliable source of specific materials.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Changed DungeonConfigPrototype to have an intermediate class so i can modify it directly before generation instead of having to do stuff manually.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Reduced the amount of ore on the mining asteroid and expeditions.
- tweak: Increased the amount of ore on magnet asteroids.
- tweak: Each piece of ore now only has enough material to create 1 sheet.
- fix: The salvage magnet now accurately reports the contents of asteroids.