### PR TITLE
Update some food spawners w/ entity tables

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_ingredients.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_ingredients.yml
@@ -1,0 +1,91 @@
+#Spawners
+- type: entity
+  id: RandomIngredient
+  name: random ingredient spawner
+  suffix: Non-Plant
+  parent: MarkerBase
+  placement:
+    mode: PlaceFree
+  components:
+  - type: Transform
+    anchored: false
+  - type: Sprite
+    layers:
+      - state: green
+      - sprite: Objects/Consumable/Food/ingredients.rsi
+        state: cheesewheel
+  - type: EntityTableSpawner
+    table: !type:NestedSelector
+      tableId: IngredientTable
+      prob: 0.80
+
+#Tables
+- type: entityTable
+  id: IngredientTable
+  table: !type:GroupSelector
+    children:
+    #Common
+    - !type:GroupSelector
+      weight: 10
+      children:
+      - id: ReagentContainerOliveoil
+      - id: ReagentContainerMayo
+      - id: FoodButter
+        amount: !type:RangeNumberSelector
+          range: 1, 2
+      - id: FoodContainerEgg
+      - id: FoodCondimentBottleEnzyme
+      - id: DrinkSodaWaterBottleFull
+      - id: FoodShakerSalt
+      - id: FoodShakerPepper
+      - !type:GroupSelector
+        children:
+        - id: ReagentContainerFlour
+        - id: ReagentContainerCornmeal
+        - id: ReagentContainerRice
+        - id: ReagentContainerSugar
+        - !type:GroupSelector
+          children:
+          - id: ReagentContainerFlourSmall
+          - id: ReagentContainerCornmealSmall
+          - id: ReagentContainerRiceSmall
+          - id: ReagentContainerSugarSmall
+      - !type:GroupSelector
+        children:
+        - id: DrinkMilkCarton
+        - id: DrinkSoyMilkCarton
+        - id: DrinkOatMilkCarton
+        - id: DrinkMilkCarton
+      - !type:GroupSelector
+        children:
+        - id: FoodCheese
+        - id: FoodChevre
+        - id: FoodTofu
+        - !type:GroupSelector
+          children:
+          - id: FoodCheeseSlice
+            amount: !type:RangeNumberSelector
+              range: 1, 5
+          - id: FoodChevreSlice
+            amount: !type:RangeNumberSelector
+              range: 1, 5
+          - id: FoodTofuSlice
+            amount: !type:RangeNumberSelector
+              range: 1, 5
+      - !type:GroupSelector
+        children:
+        - id: FoodCondimentBottleColdsauce
+        - id: FoodCondimentBottleVinegar
+        - id: FoodCondimentBottleHotsauce
+        - id: FoodCondimentBottleKetchup
+        - id: FoodCondimentBottleBBQ
+        - id: FoodCondimentBottleKetchup
+        - id: FoodCondimentBottleKetchup
+    #Rare
+    - !type:GroupSelector
+      weight: 0.5
+      children:
+      - id: FoodCannabisButter
+        amount: !type:RangeNumberSelector
+          range: 1, 2
+      - id: EggBoxBroken

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_meat.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_meat.yml
@@ -1,0 +1,147 @@
+#Spawners
+- type: entity
+  id: RandomMeat
+  name: random meat spawner
+  parent: MarkerBase
+  placement:
+    mode: PlaceFree
+  components:
+  - type: Transform
+    anchored: false
+  - type: Sprite
+    layers:
+      - state: green
+      - sprite: Objects/Consumable/Food/meat.rsi
+        state: plain
+  - type: EntityTableSpawner
+    table: !type:NestedSelector
+      tableId: MeatTable
+      prob: 0.85
+
+#Tables
+- type: entityTable
+  id: MeatTable
+  table: !type:GroupSelector
+    children:
+    #Meat
+    - !type:GroupSelector
+      weight: 10
+      children:
+      - id: FoodMeat
+    #Medium-Rare
+    - !type:GroupSelector
+      weight: 7.5
+      children:
+      - id: FoodMeatFish
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodMeatBacon
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodMeatChicken
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodMeatDuck
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodMeatCrab
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodMeatWheat
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodMeatSalami
+        amount: !type:RangeNumberSelector
+          range: 1, 2
+      - id: FoodMeatMeatball
+        amount: !type:RangeNumberSelector
+          range: 1, 8
+      - !type:GroupSelector
+        children:
+        - id: FoodMeatCutlet
+          amount: !type:RangeNumberSelector
+            range: 1, 4
+        - id: FoodMeatChickenCutlet
+          amount: !type:RangeNumberSelector
+            range: 1, 4
+        - id: FoodMeatDuckCutlet
+          amount: !type:RangeNumberSelector
+            range: 1, 4
+        - id: FoodMeatSalamiSlice
+          amount: !type:RangeNumberSelector
+            range: 1, 4
+    #Rotten
+    - !type:GroupSelector
+      weight: 2
+      children:
+      - id: FoodMeatRotten
+        weight: 2
+        amount: !type:RangeNumberSelector
+          range: 1, 6
+      - id: FoodMeatRat
+        amount: !type:RangeNumberSelector
+          range: 1, 6
+      - id: FoodMeatSnake
+        amount: !type:RangeNumberSelector
+          range: 1, 6
+    #Rare
+    - !type:GroupSelector
+      children:
+      - !type:GroupSelector
+        weight: 0.5
+        children:
+        - id: FoodMeatHuman
+          amount: !type:RangeNumberSelector
+            range: 1, 3
+        - id: FoodMeatLizard
+          amount: !type:RangeNumberSelector
+            range: 1, 3
+        - id: FoodMeatPlant
+          amount: !type:RangeNumberSelector
+            range: 1, 3
+        - id: FoodMeatSpider
+          amount: !type:RangeNumberSelector
+            range: 1, 3
+        - id: FoodMeatSlime
+          amount: !type:RangeNumberSelector
+            range: 1, 3
+        - !type:GroupSelector
+          children:
+          - id: FoodMeatLizardCutlet
+            amount: !type:RangeNumberSelector
+              range: 1, 2
+          - id: FoodMeatSpiderCutlet
+            amount: !type:RangeNumberSelector
+              range: 1, 2
+          - id: FoodMeatXenoCutlet
+            amount: !type:RangeNumberSelector
+              range: 1, 2
+          - id: FoodMeatSpider
+            amount: !type:RangeNumberSelector
+              range: 1, 2
+          - id: FoodMeatSlime
+            amount: !type:RangeNumberSelector
+              range: 1, 2
+      - id: FoodMeatBear
+        amount: !type:RangeNumberSelector
+          range: 1, 4
+      - id: FoodMeatPenguin
+        amount: !type:RangeNumberSelector
+          range: 1, 4
+      - id: FoodMeatSpiderLeg
+        amount: !type:RangeNumberSelector
+          range: 1, 4
+      - id: FoodMeatXeno
+        amount: !type:RangeNumberSelector
+          range: 1, 4
+      - !type:GroupSelector
+        children:
+          - id: FoodMeatBearCutlet
+            amount: !type:RangeNumberSelector
+              range: 1, 4
+          - id: FoodMeatPenguinCutlet
+            amount: !type:RangeNumberSelector
+              range: 1, 4
+          - id: FoodMeatXenoCutlet
+            amount: !type:RangeNumberSelector
+              range: 1, 4

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_produce.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/food_produce.yml
@@ -1,3 +1,4 @@
+#Spawners
 - type: entity
   id: RandomProduce
   name: random produce spawner
@@ -10,53 +11,152 @@
       - state: green
       - sprite: Objects/Specific/Hydroponics/onion_red.rsi
         state: produce
-  - type: RandomSpawner
-    prototypes:
-      - WheatBushel
-      - OatBushel
-      - Sugarcane
-      - Nettle
-      - FoodBanana
-      - FoodCarrot
-      - FoodCabbage
-      - FoodGarlic
-      - FoodLemon
-      - FoodLime
-      - FoodOrange
-      - FoodPineapple
-      - FoodPotato
-      - FoodTomato
-      - FoodEggplant
-      - FoodApple
-      - FoodCocoaPod
-      - FoodCorn
-      - FoodOnion
-      - FoodOnionRed
-      - FoodMushroom
-      - FoodChiliPepper
-      - FoodChillyPepper
-      - FoodAloe
-      - FoodPoppy
-      - FoodLingzhi
-      - FoodAmbrosiaVulgaris
-      - RiceBushel
-      - FoodSoybeans
-      - FoodKoibean
-      - FoodWatermelon
-      - FoodGrape
-      - FoodBerries
-      - FoodBungo
-      - FoodPeaPod
-      - FoodPumpkin
-      - CottonBol
-    chance: 0.8
-    offset: 0.0
+  - type: EntityTableSpawner
+    table: !type:NestedSelector
+      tableId: ProduceTable
+      prob: 0.8
+
+#Tables
+- type: entityTable
+  id: ProduceTable
+  table: !type:GroupSelector
+    children:
+    #Common
+    - !type:GroupSelector
+      weight: 100
+      children:
+      - id: WheatBushel
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: OatBushel
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: Sugarcane
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: Nettle
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodBanana
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodCarrot
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodCabbage
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodGarlic
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodLemon
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodLime
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodOrange
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodPineapple
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodPotato
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodTomato
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodEggplant
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodApple
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodCocoaPod
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodCorn
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodOnion
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodOnionRed
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodMushroom
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodChiliPepper
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodChillyPepper
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodAloe
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodPoppy
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodLingzhi
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodAmbrosiaVulgaris
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: RiceBushel
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodSoybeans
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodKoibean
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodWatermelon
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodGrape
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodBerries
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodBungo
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodPeaPod
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodPumpkin
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: CottonBol
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodCocoaBeans
+        amount: !type:RangeNumberSelector
+          range: 1, 5
     #rare
-    rarePrototypes:
-      - FoodBlueTomato
-      - FoodBloodTomato
-      - FoodAmbrosiaDeus
-      - FoodGalaxythistle
-      - FoodFlyAmanita
-      - DeathNettle
-    rareChance: 0.01
+    - !type:GroupSelector
+      children:
+      - id: FoodBlueTomato
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodBloodTomato
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodAmbrosiaDeus
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodGalaxythistle
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: FoodFlyAmanita
+        amount: !type:RangeNumberSelector
+          range: 1, 5
+      - id: DeathNettle
+        amount: !type:RangeNumberSelector
+          range: 1, 5


### PR DESCRIPTION
## About the PR
- Changes `food_produce` spawner to use entity table
- Adds `food_meat` and `food_ingredient` spawners to compliment the produce spawner

## Why / Balance
Updates to newer system and rounds out kitchen mapping 

## Technical details
n/a
## Media
n/a

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
n/a