### PR TITLE
development build ghostrole lottery changes

### DIFF
--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Ghost.Roles.Raffles;
 using Content.Server.Ghost.Roles.UI;
 using Content.Server.Mind.Commands;
 using Content.Shared.Administration;
+using Content.Shared.CCVar;
 using Content.Shared.Database;
 using Content.Shared.Follower;
 using Content.Shared.GameTicking;
@@ -20,6 +21,7 @@ using Content.Shared.Roles;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Console;
 using Robust.Shared.Enums;
 using Robust.Shared.Player;
@@ -37,6 +39,7 @@ namespace Content.Server.Ghost.Roles
     [UsedImplicitly]
     public sealed class GhostRoleSystem : EntitySystem
     {
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly EuiManager _euiManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
@@ -356,7 +359,8 @@ namespace Content.Server.Ghost.Roles
 
             var raffle = ent.Comp;
             raffle.Identifier = ghostRole.Identifier;
-            raffle.Countdown = TimeSpan.FromSeconds(settings.InitialDuration);
+            var countdown = _cfg.GetCVar(CCVars.GhostQuickLottery)? 1 : settings.InitialDuration;
+            raffle.Countdown = TimeSpan.FromSeconds(countdown);
             raffle.CumulativeTime = TimeSpan.FromSeconds(settings.InitialDuration);
             // we copy these settings into the component because they would be cumbersome to access otherwise
             raffle.JoinExtendsDurationBy = TimeSpan.FromSeconds(settings.JoinExtendsDurationBy);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2035,6 +2035,12 @@ namespace Content.Shared.CCVar
             CVarDef.Create("ghost.role_time", 3f, CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
+        /// If ghost role lotteries should be made near-instanteous.
+        /// </summary>
+        public static readonly CVarDef<bool> GhostQuickLottery =
+            CVarDef.Create("ghost.quick_lottery", false, CVar.SERVERONLY);
+
+        /// <summary>
         /// Whether or not to kill the player's mob on ghosting, when it is in a critical health state.
         /// </summary>
         public static readonly CVarDef<bool> GhostKillCrit =

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -5,6 +5,10 @@ lobbyenabled = false
 map = "Dev"
 role_timers = false
 
+[ghost]
+role_time = 0.5
+quick_lottery = true
+
 [gateway]
 generator_enabled = false
 


### PR DESCRIPTION
## About the PR
Development build now sets the delay before you can click the Request button  on a ghostrole to 0.5 seconds (from 3)

A new cvar can reduce the duration of all lotteries to 1 second. The development server build automatically sets this to true

No changes to the live build's default settings 

## Why / Balance
Annoying to occasionally run into a 30 sec wait because I forgot to change the settings when all I want to do is quickly test something. Also annoying to keep changing the settings

## Media

https://github.com/user-attachments/assets/a24b7751-3755-494c-814a-5db355827f18

## Requirements

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase