### PR TITLE
fix the admin verbs trying to kill players by filling their lungs with plasma

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -736,11 +736,11 @@ public sealed partial class AdminVerbSystem
         }
     }
 
-    private void RefillEquippedTanks(EntityUid target, Gas plasma)
+    private void RefillEquippedTanks(EntityUid target, Gas gasType)
     {
         foreach (var held in _inventorySystem.GetHandOrInventoryEntities(target))
         {
-            RefillGasTank(held, Gas.Plasma);
+            RefillGasTank(held, gasType);
         }
     }
 


### PR DESCRIPTION
## About the PR
reported on discord
![grafik](https://github.com/user-attachments/assets/7657d4be-48a4-4263-aa34-fd744ffd3af2)


## Why / Balance
bugfix

## Technical details
it was set to always use plasma

## Requirements

- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:ADMIN:
- fix: The tricks verb for refilling someone's air tank with O2/N2 no longer fills the the tank with plasma.
