### PR TITLE
ERT chaplains can now use bibles

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -170,6 +170,7 @@
     - type: Loadout
       prototypes: [ ERTChaplainGear ]
       roleLoadout: [ RoleSurvivalExtended ]
+    - type: BibleUser
 
 - type: entity
   id: RandomHumanoidSpawnerERTChaplainEVA
@@ -196,6 +197,7 @@
     - type: Loadout
       prototypes: [ ERTChaplainGearEVA ]
       roleLoadout: [ RoleSurvivalEVA ]
+    - type: BibleUser
 
 ## ERT Janitor
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
added the bibleuser component to the ert chaplains you can spawn with the entity spawn panel

## Why / Balance
saw someone in the discord bug channel showing it [sizzling their hands](https://discord.com/channels/310555209753690112/1271499228589457490/1271499228589457490), pretty sure this fixes it (i am sorry if this somehow bsod's someone's computer)

## Media
Before: 


https://github.com/user-attachments/assets/e4e9ecff-6bb3-4964-ac14-c534da7c02d3



After:

https://github.com/user-attachments/assets/6dc2946e-69ad-4734-abe0-b97a8a46d12b




## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: ERT Chaplains now have blessings to use their bible.
