### PR TITLE
Fix creator prefix for Cog

### DIFF
--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -12,7 +12,7 @@
           mapNameTemplate: '{0} Cog {1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
-            prefixCreator: '14'
+            prefixCreator: 'R4' # R4407/Goon. GS isn't as cool sounding.
         - type: StationEmergencyShuttle
           emergencyShuttlePath: /Maps/Shuttles/emergency_wode.yml
         - type: StationJobs


### PR DESCRIPTION
Now uses the same one as Atlas.
