### PR TITLE
Enable worldgen by default in non-wizden config

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2134,7 +2134,7 @@ namespace Content.Shared.CCVar
         ///     Whether or not world generation is enabled.
         /// </summary>
         public static readonly CVarDef<bool> WorldgenEnabled =
-            CVarDef.Create("worldgen.enabled", false, CVar.SERVERONLY);
+            CVarDef.Create("worldgen.enabled", true, CVar.SERVERONLY);
 
         /// <summary>
         ///     The worldgen config to use.

--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -38,6 +38,3 @@ see_own_notes = true
 deadmin_on_join = true
 new_player_threshold = 600
 alert.min_players_sharing_connection = 2
-
-[worldgen]
-enabled = true


### PR DESCRIPTION
If somebody can explain to me WHY this isn't enabled by default, that would be epic. Otherwise we're merging this
