### PR TITLE
Device-list limiting

### DIFF
--- a/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/DeviceNetworkComponent.cs
@@ -103,6 +103,13 @@ namespace Content.Server.DeviceNetwork.Components
         public bool SendBroadcastAttemptEvent = false;
 
         /// <summary>
+        ///     Whether this device's address can be saved to device-lists
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("savableAddress")]
+        public bool SavableAddress = true;
+
+        /// <summary>
         ///     A list of device-lists that this device is on.
         /// </summary>
         [DataField]

--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -106,6 +106,13 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!targetUid.HasValue || !Resolve(targetUid.Value, ref device, false))
             return;
 
+        //This checks if the device is marked as having a savable address,
+        //to avoid adding pdas and whatnot to air alarms. This flag is true
+        //by default, so this will only prevent devices from being added to
+        //network configurator lists if manually set to false in the prototype
+        if (!device.SavableAddress)
+            return;
+
         var address = device.Address;
         if (string.IsNullOrEmpty(address))
         {

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -47,6 +47,7 @@
   - type: DeviceNetwork
     deviceNetId: Wireless
     transmitFrequencyId: SuitSensor
+    savableAddress: false
   - type: WirelessNetworkConnection
     range: 1200
   - type: StationLimitedNetwork

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -244,6 +244,7 @@
     deviceNetId: Wireless
     receiveFrequencyId: CyborgControl
     transmitFrequencyId: RoboticsConsole
+    savableAddress: false
   - type: OnUseTimerTrigger
     delay: 10
     examinable: false

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -67,6 +67,7 @@
     deviceNetId: Wireless
     receiveFrequencyId: PDA
     prefix: device-address-prefix-console
+    savableAddress: false
   - type: WirelessNetworkConnection
     range: 500
   - type: CartridgeLoader

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -63,10 +63,6 @@
     softness: 5
     autoRot: true
   - type: Ringer
-  - type: DeviceNetwork
-    deviceNetId: Wireless
-    receiveFrequencyId: PDA
-    prefix: device-address-prefix-console
   - type: WirelessNetworkConnection
     range: 500
   - type: CartridgeLoader

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -63,6 +63,10 @@
     softness: 5
     autoRot: true
   - type: Ringer
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: PDA
+    prefix: device-address-prefix-console
   - type: WirelessNetworkConnection
     range: 500
   - type: CartridgeLoader


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I added a system to make certain items unable to be added to network configurators
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes https://github.com/space-wizards/space-station-14/issues/30178#issue-2420000358
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
There's a new Datafield in the DeviceNetwork component, called `SavableAddress`. This field is true by default.

In `TryAddNetworkDevice()`, a new check is added at the top for if SavableAddress is true for the device. If it's false, the function returns immeadiately, without adding the device to the list.

Because the SavableAddress field is true by default, this change will only affect an item if the field is set to false manually in its prototype. And because the check is only in the network configurator code, other connections still work, such as borgs to robotics consoles and suit sensors to crew monitoring consoles.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Suit sensors, borgs, and PDAs can no longer be saved to device-lists.
