### PR TITLE
add(AdminGhost): Add a multitool to the admin ghost backpack

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -178,6 +178,7 @@
     - GasAnalyzer
     - trayScanner
     - AccessConfiguratorUniversal
+    - Multitool
 
 #Gladiator with spear
 - type: startingGear


### PR DESCRIPTION
# Why
Less work for making mapping changes

[Screencast from 08-14-2024 08:37:31 AM.webm](https://github.com/user-attachments/assets/54df695d-7946-448f-8a43-fa551fcbda8d)
