### PR TITLE
remove(NukeopsRuleComponent): Remove a trap from the component file

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -96,36 +96,6 @@ public sealed partial class NukeopsRuleComponent : Component
     public SoundSpecifier GreetSoundNotification = new SoundPathSpecifier("/Audio/Ambience/Antag/nukeops_start.ogg");
 }
 
-/// <summary>
-/// Stores the presets for each operative type
-/// Ie Commander, Agent and Operative
-/// </summary>
-[DataDefinition, Serializable]
-public sealed partial class NukeopSpawnPreset
-{
-
-    [DataField]
-    public ProtoId<AntagPrototype> AntagRoleProto = "Nukeops";
-
-    /// <summary>
-    /// The equipment set this operative will be given when spawned
-    /// </summary>
-    [DataField]
-    public ProtoId<StartingGearPrototype> GearProto = "SyndicateOperativeGearFull";
-
-    /// <summary>
-    /// The name prefix, ie "Agent"
-    /// </summary>
-    [DataField]
-    public LocId NamePrefix = "nukeops-role-operator";
-
-    /// <summary>
-    /// The entity name suffix will be chosen from this list randomly
-    /// </summary>
-    [DataField]
-    public ProtoId<DatasetPrototype> NameList = "SyndicateNamesNormal";
-}
-
 public enum WinType : byte
 {
     /// <summary>


### PR DESCRIPTION
# Why

This code is completely unused.
Annoying to grep for something and hit a dead end here.
# Before 

![Screenshot from 2024-08-14 21-43-12](https://github.com/user-attachments/assets/2330c904-d1fa-4cd0-bc31-6c3c8741e25c)


[Screencast from 08-14-2024 09:42:09 PM.webm](https://github.com/user-attachments/assets/bb0efac9-e482-4194-bf67-59ab9c2f991d)


# After

![Screenshot from 2024-08-14 21-37-46](https://github.com/user-attachments/assets/5286f6ef-b2e4-4441-8ce1-962c98bd715d)

[Screencast from 08-14-2024 09:38:59 PM.webm](https://github.com/user-attachments/assets/0079b3ed-c17a-463b-87a5-29237b444c1b)
