### PR TITLE
Aghost can see jobs icons and mindshield

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -86,6 +86,8 @@
   - type: SolutionScanner
   - type: IgnoreUIRange
   - type: ShowAntagIcons
+  - type: ShowJobIcons
+  - type: ShowMindShieldIcons
   - type: Inventory
     templateId: aghost
   - type: Loadout


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The ShowJobIcons and ShowMindShieldIcons components have been added to the aghost.

## Why / Balance
It is quite useful for the administration to see what position a particular character holds, as well as to monitor the presence of a Mindshield from one or another employee of the station.

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](![изображение_2024-08-15_150637964](https://github.com/user-attachments/assets/649a9774-ba7b-4d65-b331-0311133a9d5f)). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

![screenshot](https://github.com/user-attachments/assets/9c9a75e4-539b-4941-aaf7-149e42a41370)