### PR TITLE
Packed Engi Solar Controller

### DIFF
--- a/Resources/Maps/packed.yml
+++ b/Resources/Maps/packed.yml
@@ -7547,7 +7547,7 @@ entities:
       pos: 24.5,-39.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -3925.5847
+      secondsUntilStateChange: -4254.259
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -9984,6 +9984,11 @@ entities:
       parent: 2
 - proto: Autolathe
   entities:
+  - uid: 474
+    components:
+    - type: Transform
+      pos: 51.5,18.5
+      parent: 2
   - uid: 942
     components:
     - type: Transform
@@ -64286,11 +64291,6 @@ entities:
       parent: 2
 - proto: Protolathe
   entities:
-  - uid: 474
-    components:
-    - type: Transform
-      pos: 51.5,18.5
-      parent: 2
   - uid: 5305
     components:
     - type: Transform
@@ -84954,12 +84954,6 @@ entities:
       parent: 2
 - proto: WindoorSecureAtmosphericsLocked
   entities:
-  - uid: 4152
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 23.5,-23.5
-      parent: 2
   - uid: 5127
     components:
     - type: Transform
@@ -84971,12 +84965,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,-23.5
-      parent: 2
-  - uid: 11763
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 23.5,-24.5
       parent: 2
 - proto: WindoorSecureCargoLocked
   entities:
@@ -85060,6 +85048,12 @@ entities:
       parent: 2
 - proto: WindoorSecureEngineeringLocked
   entities:
+  - uid: 4152
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-23.5
+      parent: 2
   - uid: 5858
     components:
     - type: Transform
@@ -85071,6 +85065,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,-15.5
+      parent: 2
+  - uid: 11763
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-24.5
       parent: 2
 - proto: WindoorSecureHeadOfPersonnelLocked
   entities:

--- a/Resources/Maps/packed.yml
+++ b/Resources/Maps/packed.yml
@@ -7547,7 +7547,7 @@ entities:
       pos: 24.5,-39.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -3878.2183
+      secondsUntilStateChange: -3925.5847
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -34748,11 +34748,6 @@ entities:
     - type: Transform
       pos: 28.5,48.5
       parent: 2
-  - uid: 11749
-    components:
-    - type: Transform
-      pos: 21.5,-23.5
-      parent: 2
   - uid: 13443
     components:
     - type: Transform
@@ -35056,6 +35051,11 @@ entities:
     components:
     - type: Transform
       pos: 70.5,46.5
+      parent: 2
+  - uid: 11749
+    components:
+    - type: Transform
+      pos: 21.5,-23.5
       parent: 2
 - proto: ComputerStationRecords
   entities:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Replaces the alerts console in Engineering with a solar controller.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes some things with #31024. There was a solar controller there before the update and it's much more useful than an alerts console that does nothing. Atmos still has the alerts console by its' front desk so not exactly losing much either.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

