### PR TITLE
Cook-able cutlets for kebabs/tacos

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -1512,6 +1512,10 @@
         sprite: 
           sprite: Objects/Consumable/Food/skewer.rsi
           state: skewer-meat
+  - type: Construction
+    graph: Cutlet
+    node: start
+    defaultTarget: cutlet
 
 - type: entity
   name: raw bear cutlet
@@ -1547,6 +1551,10 @@
         name: food-sequence-burger-content-bear
       taco:
         name: food-sequence-content-bear
+  - type: Construction
+    graph: BearCutlet
+    node: start
+    defaultTarget: bear cutlet
 
 - type: entity
   name: raw penguin cutlet
@@ -1580,6 +1588,10 @@
         name: food-sequence-burger-content-penguin
       taco:
         name: food-sequence-content-penguin
+  - type: Construction
+    graph: PenguinCutlet
+    node: start
+    defaultTarget: penguin cutlet
 
 - type: entity
   name: raw chicken cutlet
@@ -1618,6 +1630,10 @@
         sprite: 
           sprite: Objects/Consumable/Food/skewer.rsi
           state: skewer-meat
+  - type: Construction
+    graph: ChickenCutlet
+    node: start
+    defaultTarget: chicken cutlet
 
 - type: entity
   name: raw duck cutlet
@@ -1656,6 +1672,10 @@
         sprite: 
           sprite: Objects/Consumable/Food/skewer.rsi
           state: skewer-meat
+  - type: Construction
+    graph: DuckCutlet
+    node: start
+    defaultTarget: duck cutlet
 
 - type: entity
   name: raw lizard cutlet
@@ -1697,6 +1717,10 @@
         sprite: 
           sprite: Objects/Consumable/Food/skewer.rsi
           state: skewer-tail
+  - type: Construction
+    graph: LizardCutlet
+    node: start
+    defaultTarget: lizard cutlet
 
 - type: entity
   name: raw spider cutlet
@@ -1728,6 +1752,10 @@
         name: food-sequence-burger-content-spider
       taco:
         name: food-sequence-content-spider
+  - type: Construction
+    graph: SpiderCutlet
+    node: start
+    defaultTarget: spider cutlet
 
 - type: entity
   name: raw xeno cutlet
@@ -1761,6 +1789,10 @@
         name: food-sequence-content-xeno
       taco:
         name: food-sequence-content-xeno
+  - type: Construction
+    graph: XenoCutlet
+    node: start
+    defaultTarget: xeno cutlet
 
 - type: entity
   name: raw killer tomato cutlet
@@ -1850,6 +1882,9 @@
         sprite:
           sprite: Objects/Consumable/Food/meat.rsi
           state: cutlet-cooked
+  - type: Construction
+    graph: Cutlet
+    node: cutlet
 
 - type: entity
   name: bear cutlet
@@ -1884,6 +1919,9 @@
         name: food-sequence-burger-content-bear
       taco:
         name: food-sequence-content-bear
+  - type: Construction
+    graph: BearCutlet
+    node: bear cutlet
 
 - type: entity
   name: penguin cutlet
@@ -1916,6 +1954,9 @@
         name: food-sequence-burger-content-penguin
       taco:
         name: food-sequence-content-penguin
+  - type: Construction
+    graph: PenguinCutlet
+    node: penguin cutlet
 
 - type: entity
   name: chicken cutlet
@@ -1953,6 +1994,9 @@
         sprite: 
           sprite: Objects/Consumable/Food/skewer.rsi
           state: skewer-meat
+  - type: Construction
+    graph: ChickenCutlet
+    node: chicken cutlet
 
 - type: entity
   name: duck cutlet
@@ -1990,6 +2034,9 @@
         sprite: 
           sprite: Objects/Consumable/Food/skewer.rsi
           state: skewer-meat
+  - type: Construction
+    graph: DuckCutlet
+    node: duck cutlet
 
 - type: entity
   name: lizard cutlet
@@ -2028,6 +2075,9 @@
         sprite: 
           sprite: Objects/Consumable/Food/skewer.rsi
           state: skewer-tail-cooked
+  - type: Construction
+    graph: LizardCutlet
+    node: lizard cutlet
 
 - type: entity
   name: spider cutlet
@@ -2057,6 +2107,9 @@
     entries:
       burger:
         name: food-sequence-burger-content-spider
+  - type: Construction
+    graph: SpiderCutlet
+    node: spider cutlet
 
 - type: entity
   name: xeno cutlet
@@ -2086,3 +2139,6 @@
     entries:
       burger:
         name: food-sequence-content-xeno
+  - type: Construction
+    graph: XenoCutlet
+    node: xeno cutlet

--- a/Resources/Prototypes/Recipes/Construction/Graphs/food/steak.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/food/steak.yml
@@ -173,3 +173,125 @@
       - minTemperature: 345
   - node: bacon
     entity: FoodMeatBaconCooked
+
+# cutlets
+
+- type: constructionGraph
+  id: Cutlet
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: cutlet
+      completed:
+      - !type:PlaySound
+        sound: /Audio/Effects/sizzle.ogg
+      steps:
+      - minTemperature: 335
+  - node: cutlet
+    entity: FoodMeatCutletCooked
+
+- type: constructionGraph
+  id: BearCutlet
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: bear cutlet
+      completed:
+      - !type:PlaySound
+        sound: /Audio/Effects/sizzle.ogg
+      steps:
+      - minTemperature: 345
+  - node: bear cutlet
+    entity: FoodMeatBearCutletCooked
+
+- type: constructionGraph
+  id: PenguinCutlet
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: penguin cutlet
+      completed:
+      - !type:PlaySound
+        sound: /Audio/Effects/sizzle.ogg
+      steps:
+      - minTemperature: 345
+  - node: penguin cutlet
+    entity: FoodMeatPenguinCutletCooked
+
+- type: constructionGraph
+  id: ChickenCutlet
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: chicken cutlet
+      completed:
+      - !type:PlaySound
+        sound: /Audio/Effects/sizzle.ogg
+      steps:
+      - minTemperature: 345
+  - node: chicken cutlet
+    entity: FoodMeatChickenCutletCooked
+
+- type: constructionGraph
+  id: DuckCutlet
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: duck cutlet
+      completed:
+      - !type:PlaySound
+        sound: /Audio/Effects/sizzle.ogg
+      steps:
+      - minTemperature: 335
+  - node: duck cutlet
+    entity: FoodMeatDuckCutletCooked
+
+- type: constructionGraph
+  id: LizardCutlet
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: lizard cutlet
+      completed:
+      - !type:PlaySound
+        sound: /Audio/Effects/sizzle.ogg
+      steps:
+      - minTemperature: 345
+  - node: lizard cutlet
+    entity: FoodMeatLizardCutletCooked
+
+- type: constructionGraph
+  id: SpiderCutlet
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: spider cutlet
+      completed:
+      - !type:PlaySound
+        sound: /Audio/Effects/sizzle.ogg
+      steps:
+      - minTemperature: 345
+  - node: spider cutlet
+    entity: FoodMeatSpiderCutletCooked
+
+- type: constructionGraph
+  id: XenoCutlet
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: xeno cutlet
+      completed:
+      - !type:PlaySound
+        sound: /Audio/Effects/sizzle.ogg
+      steps:
+      - minTemperature: 345
+  - node: xeno cutlet
+    entity: FoodMeatXenoCutletCooked


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This PR adds temperature-based construction graphs for the raw meat cutlets.

Partially resolves #30989, I think there are still some steaks that need cook-able versions like spider meat.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Now that we moved to sequential kebab/taco recipes, we want to be able to use cooked cutlets in their construction.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Raw meat cutlets can be cooked on a grill
