### PR TITLE
Diona hydration can prevent ignition by damage

### DIFF
--- a/Content.Server/Damage/Components/IgniteOnHeatDamageComponent.cs
+++ b/Content.Server/Damage/Components/IgniteOnHeatDamageComponent.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 
 namespace Content.Server.Damage.Components;
@@ -6,10 +5,22 @@ namespace Content.Server.Damage.Components;
 [RegisterComponent]
 public sealed partial class IgniteOnHeatDamageComponent : Component
 {
-    [DataField("fireStacks")]
+    [DataField]
     public float FireStacks = 1f;
 
     // The minimum amount of damage taken to apply fire stacks
-    [DataField("threshold")]
+    [DataField]
     public FixedPoint2 Threshold = 15;
+
+    /// <summary>
+    /// If you're properly hydrated, you won't ignite on hit
+    /// Your hydration will decrease by the amount of damage you take multiplied by
+    /// <see cref="IgniteOnHeatDamageComponent.DehydrationMultiplier"/>
+    /// And you will then ignite when completely dehydrated.
+    /// </summary>
+    [DataField]
+    public bool PreventedByHydration;
+
+    [DataField]
+    public float DehydrationMultiplier = 1f;
 }

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -95,6 +95,8 @@
   - type: IgniteOnHeatDamage
     fireStacks: 1
     threshold: 12
+    preventedByHydration: true
+    dehydrationMultiplier: 2
   - type: GibAction
     actionPrototype: DionaGibAction
     allowedStates:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Diona have a significant downside of lighting on fire when faced with any laser weapons. This makes them one of the weakest species in the game (besides the lack of shoes).

This PR reduces that downside a bit by making it so that heat damage will reduce their thirst level, and if their thirst ever reaches zero, they will ignite on any subsequent damage they've taken.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Being a Diona is suffering

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
My comments are quite straightforward as well as the code

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

This video is a showcase what a 4x dehydration multiplier looks like. The PR has it set to 2x.

https://private-user-images.githubusercontent.com/58439124/335835870-82ff06ac-43ac-4460-8cfe-7ae41101844f.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjM3Njk5MjIsIm5iZiI6MTcyMzc2OTYyMiwicGF0aCI6Ii81ODQzOTEyNC8zMzU4MzU4NzAtODJmZjA2YWMtNDNhYy00NDYwLThjZmUtN2FlNDExMDE4NDRmLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA4MTYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwODE2VDAwNTM0MlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTBjYzkyYzlhZTQyYjMyZGJlMGQ1YzAzMDFkZmUzYTlkYzZiZDY4NDE3ZjA3ZGIxZDQ1ODlmN2FhMTRjMWU1NjYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.WTlCpWHWg7EPzl-nk5_L_M8UvwxAbMZupPNipHEap7w

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Heat damage will cause Diona to lose hydration. Upon max dehydration, Diona will ignite on damage.