### PR TITLE
Fix mains wire light

### DIFF
--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -151,19 +151,17 @@ public sealed class WiresSystem : SharedWiresSystem
             for (var i = 0; i < enumeratedList.Count; i++)
             {
                 (int id, Wire d) = enumeratedList[i];
+                d.Id = i;
 
                 if (d.Action != null)
                 {
                     var actionType = d.Action.GetType();
-                    if (types.ContainsKey(actionType))
+                    if (!types.TryAdd(actionType, 1))
                         types[actionType] += 1;
-                    else
-                        types.Add(actionType, 1);
 
                     if (!d.Action.AddWire(d, types[actionType]))
                         d.Action = null;
                 }
-                d.Id = i;
 
                 data.Add(id, new WireLayout.WireData(d.Letter, d.Color, i));
                 wires.WiresList[i] = wireSet[id];


### PR DESCRIPTION
No idea how long this was broken; mains wire relies upon this id being accurate which means it needs doing before the calls.

:cl:
- fix: Fix mains light on wires not being lit.
