### PR TITLE
fix selfunremoveable component being bypassed by hand pickup verb

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
@@ -184,7 +184,9 @@ public abstract partial class SharedHandsSystem : EntitySystem
             if (!ContainerSystem.CanRemove(entity, container))
                 return false;
 
-            if (!_inventory.CanUnequip(uid, entity, container.ID, out _))
+            if (_inventory.TryGetSlotEntity(uid, container.ID, out var slotEnt) &&
+                slotEnt == entity &&
+                !_inventory.CanUnequip(uid, entity, container.ID, out _))
                 return false;
         }
 

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Pickup.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Clothing.Components;
 using Content.Shared.Database;
 using Content.Shared.Hands.Components;
 using Content.Shared.Item;
@@ -177,6 +178,15 @@ public abstract partial class SharedHandsSystem : EntitySystem
 
         if (checkActionBlocker && !_actionBlocker.CanPickup(uid, entity))
             return false;
+
+        if (ContainerSystem.TryGetContainingContainer((entity, null, null), out var container))
+        {
+            if (!ContainerSystem.CanRemove(entity, container))
+                return false;
+
+            if (!_inventory.CanUnequip(uid, entity, container.ID, out _))
+                return false;
+        }
 
         // check can insert (including raising attempt events).
         return ContainerSystem.CanInsert(entity, handContainer);

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
+using Content.Shared.Inventory;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Containers;
@@ -17,6 +18,7 @@ public abstract partial class SharedHandsSystem
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] protected readonly SharedContainerSystem ContainerSystem = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
     [Dependency] private readonly SharedVirtualItemSystem _virtualSystem = default!;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
kinda a lackluster fix but container events are super fuckin lame.

stops being able to use a verb to bypass inventory removal attempt events.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun