### PR TITLE
Fix cooking sizzle noise

### DIFF
--- a/Content.Server/Construction/Completions/PlaySound.cs
+++ b/Content.Server/Construction/Completions/PlaySound.cs
@@ -22,8 +22,9 @@ namespace Content.Server.Construction.Completions
         public void PerformAction(EntityUid uid, EntityUid? userUid, IEntityManager entityManager)
         {
             var scale = (float) IoCManager.Resolve<IRobustRandom>().NextGaussian(1, Variation);
-            entityManager.EntitySysManager.GetEntitySystem<SharedAudioSystem>()
-                .PlayPvs(Sound, uid, AudioParams.WithPitchScale(scale));
+            if (entityManager.TryGetComponent<TransformComponent>(uid, out var xform))
+                entityManager.EntitySysManager.GetEntitySystem<SharedAudioSystem>()
+                .PlayPvs(Sound, xform.Coordinates, AudioParams.WithPitchScale(scale));
         }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

I noticed the sizzle noise when cooking meat wasn't playing. This PR fixes that.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

We were trying to play a sound based on an entity about to be deleted (raw meat -> cooked meat). This uses the same solution from PlaySoundBehavior for DestructibleSystem where we use the current location rather than the entity which might be deleted soon.

Since construction graphs regularly replace one entity with another (and don't tend to move while being constructed), it made sense to use this new behavior in all cases, but I could also create a new IGraphAction for this case if that is better.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

https://github.com/user-attachments/assets/9257236c-b81b-4f54-891b-c3a0baf8217c

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

cl not needed