### PR TITLE
Disabler SMG no longer fits in boots

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -458,7 +458,6 @@
   - type: Tag
     tags:
       - Taser
-      - Sidearm
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/disabler_smg.rsi
     layers:


### PR DESCRIPTION
## About the PR
The disabler SMG can no longer be stored in combat boots, jackboots, etc.

## Why / Balance
Why can you store the 2x4 item in boots? Because someone didn't know what the "sidearm" tag meant.

## Media
I set up nohboard just for this

https://github.com/user-attachments/assets/7bb697ac-04e0-4cbb-8fda-28cf43ddea88

## Requirements

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Disabler SMGs no longer fit in combat boots
