### PR TITLE
Fixs suffocation alerts not appearing.

### DIFF
--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -290,7 +290,7 @@ public sealed class RespiratorSystem : EntitySystem
             var organs = _bodySystem.GetBodyOrganEntityComps<LungComponent>((ent, null));
             foreach (var entity in organs)
             {
-                _alertsSystem.ShowAlert(entity.Owner, entity.Comp1.Alert);
+                _alertsSystem.ShowAlert(ent, entity.Comp1.Alert);
             }
         }
 
@@ -306,7 +306,7 @@ public sealed class RespiratorSystem : EntitySystem
         var organs = _bodySystem.GetBodyOrganEntityComps<LungComponent>((ent, null));
         foreach (var entity in organs)
         {
-            _alertsSystem.ClearAlert(entity.Owner, entity.Comp1.Alert);
+            _alertsSystem.ClearAlert(ent, entity.Comp1.Alert);
         }
 
         _damageableSys.TryChangeDamage(ent, ent.Comp.DamageRecovery);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Reported [here](https://ptb.discord.com/channels/310555209753690112/1273890676731416597) and confirmed by me. A recent refactoring PR I did missed a detail about the way the variables where being used here. I've corrected it and confirmed that the suffocation alerts work properly again.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed suffocation alerts not appearing.