### PR TITLE
Added LV power cables to Marathon library

### DIFF
--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -10999,7 +10999,7 @@ entities:
       pos: -20.5,-5.5
       parent: 30
     - type: Door
-      secondsUntilStateChange: -21585.09
+      secondsUntilStateChange: -21816.006
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -30210,6 +30210,51 @@ entities:
     components:
     - type: Transform
       pos: -2.5,-33.5
+      parent: 30
+  - uid: 20722
+    components:
+    - type: Transform
+      pos: -62.5,-60.5
+      parent: 30
+  - uid: 20723
+    components:
+    - type: Transform
+      pos: -62.5,-61.5
+      parent: 30
+  - uid: 20724
+    components:
+    - type: Transform
+      pos: -62.5,-62.5
+      parent: 30
+  - uid: 20725
+    components:
+    - type: Transform
+      pos: -62.5,-63.5
+      parent: 30
+  - uid: 20726
+    components:
+    - type: Transform
+      pos: -62.5,-64.5
+      parent: 30
+  - uid: 20727
+    components:
+    - type: Transform
+      pos: -61.5,-64.5
+      parent: 30
+  - uid: 20728
+    components:
+    - type: Transform
+      pos: -63.5,-64.5
+      parent: 30
+  - uid: 20729
+    components:
+    - type: Transform
+      pos: -64.5,-64.5
+      parent: 30
+  - uid: 20730
+    components:
+    - type: Transform
+      pos: -60.5,-64.5
       parent: 30
   - uid: 21007
     components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added LV power cables to Marathon's library to provide power at roundstart

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes #31126 

## Media
No subfloor:
![image](https://github.com/user-attachments/assets/d162d2ca-fec9-46fd-8dbf-15d850608411)

Subfloor:
![image](https://github.com/user-attachments/assets/d0ffaf24-b49a-4e1b-af5a-b4763ec923bf)
_The LV cable comes straight down from the left airlock, splitting left and right at the first table_
## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
