### PR TITLE
fix(UseDelaySystem): Use safe method to index into dictionary

### DIFF
--- a/Content.Shared/Timing/UseDelaySystem.cs
+++ b/Content.Shared/Timing/UseDelaySystem.cs
@@ -125,7 +125,9 @@ public sealed class UseDelaySystem : EntitySystem
     /// </summary>
     public UseDelayInfo GetLastEndingDelay(Entity<UseDelayComponent> ent)
     {
-        var last = ent.Comp.Delays[DefaultId];
+        if (!ent.Comp.Delays.TryGetValue(DefaultId, out var last))
+            return new UseDelayInfo(TimeSpan.Zero);
+
         foreach (var entry in ent.Comp.Delays)
         {
             if (entry.Value.EndTime > last.EndTime)


### PR DESCRIPTION
# Why
Resolves #31134 

I don't code in C# so this might be shit. ~~Sue me~~ Take me out to dinner and lets have a good time.

# Before

[Screencast from 08-17-2024 04:48:51 PM.webm](https://github.com/user-attachments/assets/cca8d554-36ce-4dc8-ac27-dbb8910cbc97)


# After 

[Screencast from 08-17-2024 04:35:45 PM.webm](https://github.com/user-attachments/assets/6951e534-8423-4640-98c9-d0ab4372bf26)
