### PR TITLE
fix(mapping): Actually open the mapping editor when the mapping command is used

### DIFF
--- a/Content.Client/Commands/MappingClientSideSetupCommand.cs
+++ b/Content.Client/Commands/MappingClientSideSetupCommand.cs
@@ -26,6 +26,7 @@ internal sealed class MappingClientSideSetupCommand : LocalizedCommands
             _entitySystemManager.GetEntitySystem<MarkerSystem>().MarkersVisible = true;
             _lightManager.Enabled = false;
             shell.ExecuteCommand("showsubfloorforever");
+            shell.ExecuteCommand("scene MappingState");
             _entitySystemManager.GetEntitySystem<ActionsSystem>().LoadActionAssignments("/mapping_actions.yml", false);
         }
     }

--- a/Content.Client/Commands/MappingClientSideSetupCommand.cs
+++ b/Content.Client/Commands/MappingClientSideSetupCommand.cs
@@ -27,7 +27,6 @@ internal sealed class MappingClientSideSetupCommand : LocalizedCommands
             _lightManager.Enabled = false;
             shell.ExecuteCommand("showsubfloorforever");
             shell.ExecuteCommand("scene MappingState");
-            _entitySystemManager.GetEntitySystem<ActionsSystem>().LoadActionAssignments("/mapping_actions.yml", false);
         }
     }
 }


### PR DESCRIPTION
# why

It's supposed to be this way

``_entitySystemManager.GetEntitySystem<ActionsSystem>().LoadActionAssignments("/mapping_actions.yml", false);`` 
Never even did anything