### PR TITLE
fix mice and revs being able to toggle suit pieces

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -57,7 +57,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
 
     private void OnGetVerbs(EntityUid uid, ToggleableClothingComponent component, GetVerbsEvent<EquipmentVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract || component.ClothingUid == null || component.Container == null)
+        if (!args.CanAccess || !args.CanInteract || args.Hands == null || component.ClothingUid == null || component.Container == null)
             return;
 
         var text = component.VerbText ?? (component.ActionEntity == null ? null : Name(component.ActionEntity.Value));


### PR DESCRIPTION
## About the PR
Bug reported on Discord by RoseD:
https://discord.com/channels/310555209753690112/1273836446297358437

## Why / Balance
bugfix

## Technical details
It now checks if the mob has hands before showing the verb.

## Media
Human:
![Screenshot (246)](https://github.com/user-attachments/assets/cc42b399-4c13-4efe-8249-6b6b518f3e99)

Mouse:
![Screenshot (247)](https://github.com/user-attachments/assets/00e05a4a-a771-499b-8a81-423d0a906f7e)

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: Mobs without hands can no longer toggle other players' suit pieces.
