### PR TITLE
Fix news management console access checks

### DIFF
--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -132,14 +132,14 @@ public sealed class NewsSystem : SharedNewsSystem
         if (!ent.Comp.PublishEnabled)
             return;
 
+        ent.Comp.PublishEnabled = false;
+        ent.Comp.NextPublish = _timing.CurTime + TimeSpan.FromSeconds(ent.Comp.PublishCooldown);
+
         if (!TryGetArticles(ent, out var articles))
             return;
 
         if (!CanUse(msg.Actor, ent.Owner))
             return;
-
-        ent.Comp.PublishEnabled = false;
-        ent.Comp.NextPublish = _timing.CurTime + TimeSpan.FromSeconds(ent.Comp.PublishCooldown);
 
         string? authorName = null;
         if (_idCardSystem.TryFindIdCard(msg.Actor, out var idCard))

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -96,7 +96,7 @@ public sealed class NewsSystem : SharedNewsSystem
             return;
 
         var article = articles[msg.ArticleNum];
-        if (CanUse(msg.Actor, ent.Owner))
+        if (CanUse(msg.Actor, ent))
         {
             _adminLogger.Add(
                 LogType.Chat, LogImpact.Medium,

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -96,7 +96,7 @@ public sealed class NewsSystem : SharedNewsSystem
             return;
 
         var article = articles[msg.ArticleNum];
-        if (CanUse(msg.Actor, ent))
+        if (CanUse(msg.Actor, ent.Owner))
         {
             _adminLogger.Add(
                 LogType.Chat, LogImpact.Medium,
@@ -132,14 +132,14 @@ public sealed class NewsSystem : SharedNewsSystem
         if (!ent.Comp.PublishEnabled)
             return;
 
-        ent.Comp.PublishEnabled = false;
-        ent.Comp.NextPublish = _timing.CurTime + TimeSpan.FromSeconds(ent.Comp.PublishCooldown);
-
         if (!TryGetArticles(ent, out var articles))
             return;
 
         if (!CanUse(msg.Actor, ent.Owner))
             return;
+
+        ent.Comp.PublishEnabled = false;
+        ent.Comp.NextPublish = _timing.CurTime + TimeSpan.FromSeconds(ent.Comp.PublishCooldown);
 
         string? authorName = null;
         if (_idCardSystem.TryFindIdCard(msg.Actor, out var idCard))

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -96,7 +96,7 @@ public sealed class NewsSystem : SharedNewsSystem
             return;
 
         var article = articles[msg.ArticleNum];
-        if (CanUse(msg.Actor, ent))
+        if (CanUse(msg.Actor, ent.Owner))
         {
             _adminLogger.Add(
                 LogType.Chat, LogImpact.Medium,

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -1,11 +1,14 @@
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
+using Content.Server.Access.Systems;
 using Content.Server.Administration.Logs;
 using Content.Server.CartridgeLoader;
 using Content.Server.CartridgeLoader.Cartridges;
+using Content.Server.Chat.Managers;
 using Content.Server.GameTicking;
-using System.Diagnostics.CodeAnalysis;
-using Content.Server.Access.Systems;
+using Content.Server.Interaction;
+using Content.Server.MassMedia.Components;
 using Content.Server.Popups;
+using Content.Server.Station.Systems;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.CartridgeLoader;
@@ -13,20 +16,18 @@ using Content.Shared.CartridgeLoader.Cartridges;
 using Content.Shared.Database;
 using Content.Shared.MassMedia.Components;
 using Content.Shared.MassMedia.Systems;
-using Robust.Server.GameObjects;
-using Content.Server.MassMedia.Components;
-using Robust.Shared.Timing;
-using Content.Server.Station.Systems;
 using Content.Shared.Popups;
-using Content.Shared.StationRecords;
+using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
-using Content.Server.Chat.Managers;
+using Robust.Shared.Timing;
 
 namespace Content.Server.MassMedia.Systems;
 
 public sealed class NewsSystem : SharedNewsSystem
 {
+    [Dependency] private readonly AccessReaderSystem _accessReaderSystem = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly InteractionSystem _interaction = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
     [Dependency] private readonly CartridgeLoaderSystem _cartridgeLoaderSystem = default!;
@@ -95,7 +96,7 @@ public sealed class NewsSystem : SharedNewsSystem
             return;
 
         var article = articles[msg.ArticleNum];
-        if (CheckDeleteAccess(article, ent, msg.Actor))
+        if (CanUse(msg.Actor, ent))
         {
             _adminLogger.Add(
                 LogType.Chat, LogImpact.Medium,
@@ -137,7 +138,7 @@ public sealed class NewsSystem : SharedNewsSystem
         if (!TryGetArticles(ent, out var articles))
             return;
 
-        if (!_accessReader.FindStationRecordKeys(msg.Actor, out _))
+        if (!CanUse(msg.Actor, ent.Owner))
             return;
 
         string? authorName = null;
@@ -305,21 +306,17 @@ public sealed class NewsSystem : SharedNewsSystem
         }
     }
 
-    private bool CheckDeleteAccess(NewsArticle articleToDelete, EntityUid device, EntityUid user)
+    private bool CanUse(EntityUid user, EntityUid console)
     {
-        if (TryComp<AccessReaderComponent>(device, out var accessReader) &&
-            _accessReader.IsAllowed(user, device, accessReader))
-            return true;
+        // This shouldn't technically be possible because of BUI but don't trust client.
+        if (!_interaction.InRangeUnobstructed(console, user))
+            return false;
 
-        if (articleToDelete.AuthorStationRecordKeyIds == null || articleToDelete.AuthorStationRecordKeyIds.Count == 0)
-            return true;
-
-        return _accessReader.FindStationRecordKeys(user, out var recordKeys)
-               && StationRecordsToNetEntities(recordKeys).Intersect(articleToDelete.AuthorStationRecordKeyIds).Any();
+        if (TryComp<AccessReaderComponent>(console, out var accessReaderComponent))
+        {
+            return _accessReaderSystem.IsAllowed(user, console, accessReaderComponent);
+        }
+        return true;
     }
 
-    private ICollection<(NetEntity, uint)> StationRecordsToNetEntities(IEnumerable<StationRecordKey> records)
-    {
-        return records.Select(record => (GetNetEntity(record.OriginStation), record.Id)).ToList();
-    }
 }

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1025,7 +1025,7 @@
   - type: DeviceNetworkRequiresPower
   - type: NewsWriter
   - type: AccessReader
-    access: [[ "Command" ]]
+    access: [[ "Service" ]]
   - type: ActivatableUI
     key: enum.NewsWriterUiKey.Key
   - type: ActivatableUIRequiresVision


### PR DESCRIPTION
## About the PR
- Fix news management console using the manifest instead of access reader for access checks
- Fix AccessReader configuration of news management console checking for Command access instead of something applicable

## Why / Balance
It was very broken, even with a stolen Captain ID you could not use it if you didn't start as Reporter or ranking command member round start.

## Technical details
- Copied `CanUse` method from communications console and used that for access checks instead

## Media

https://github.com/user-attachments/assets/9b20ddb0-40b5-466c-bdaf-d1d52f1d7f77


## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**

:cl:
- fix: News management console now checks for Service ID card access instead of the manifest