### PR TITLE
Fix raditation collectors gaslighting you

### DIFF
--- a/Content.Server/Singularity/EntitySystems/RadiationCollectorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/RadiationCollectorSystem.cs
@@ -103,7 +103,7 @@ public sealed class RadiationCollectorSystem : EntitySystem
 
             if (gas.Byproduct != null)
             {
-                gasTankComponent.Air.AdjustMoles((int) gas.Byproduct, delta * gas.MolarRatio);
+                gasTankComponent.Air.AdjustMoles((int)gas.Byproduct, delta * gas.MolarRatio);
             }
         }
 
@@ -204,13 +204,14 @@ public sealed class RadiationCollectorSystem : EntitySystem
         if (!Resolve(uid, ref appearance, false))
             return;
 
+        // gas canisters can fill tanks up to 10 atm, so we set the warning level thresholds 1/3 and 2/3 of that
         if (gasTank == null || gasTank.Air.Pressure < 10)
             _appearance.SetData(uid, RadiationCollectorVisuals.PressureState, 0, appearance);
 
-        else if (gasTank.Air.Pressure < Atmospherics.OneAtmosphere)
+        else if (gasTank.Air.Pressure < 3.33f * Atmospherics.OneAtmosphere)
             _appearance.SetData(uid, RadiationCollectorVisuals.PressureState, 1, appearance);
 
-        else if (gasTank.Air.Pressure < 3f * Atmospherics.OneAtmosphere)
+        else if (gasTank.Air.Pressure < 6.66f * Atmospherics.OneAtmosphere)
             _appearance.SetData(uid, RadiationCollectorVisuals.PressureState, 2, appearance);
 
         else


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
## About the PR
See https://forum.spacestation14.com/t/radiation-collectors-gaslight-you-about-how-full-they-are/11192
The yellow light means half full according to the examination text, but it only showed up below 30% before.

## Why / Balance
common noob trap

## Technical details
Adjusted the numbers.
The examination text is automatically taken from RadiationCollectorVisuals.PressureState, so it actually is half full now when it says so.

## Media
![grafik](https://github.com/user-attachments/assets/a1a90703-3174-4430-97d9-01c4b571c103)

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed the radiation collector warning light thresholds.