### PR TITLE
QSI Fixes

### DIFF
--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -170,21 +170,7 @@ public sealed class SwapTeleporterSystem : EntitySystem
         _container.TryGetOuterContainer(teleEnt, Transform(teleEnt), out var cont);
         _container.TryGetOuterContainer(otherTeleEnt, Transform(otherTeleEnt), out var otherCont);
 
-        if (otherCont != null && !_container.CanInsert(teleEnt, otherCont) ||
-            cont != null && !_container.CanInsert(otherTeleEnt, cont))
-        {
-            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-fail",
-                ("entity", Identity.Entity(linkedEnt, EntityManager))),
-                teleEnt,
-                teleEnt,
-                PopupType.MediumCaution);
-            return;
-        }
-
-
-        // Prevents teleporting to the polymorph zone or the cryosleep zone.
-        // Don't unlink because it might be temporary (polymorph). Let them figure it out and unlink it themselves.
-        if (_map.IsPaused(Transform(teleEnt).MapID) || _map.IsPaused(Transform(otherTeleEnt).MapID))
+        if (!CanTeleport(teleEnt,otherTeleEnt)) // Logic moved upon request
         {
             _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-fail",
                 ("entity", Identity.Entity(linkedEnt, EntityManager))),
@@ -201,6 +187,8 @@ public sealed class SwapTeleporterSystem : EntitySystem
             PopupType.MediumCaution);
 
         // break pulls before teleport so we dont break shit
+        // Ideally this situation would be well-handled by the physics engine, but until it is this needs to handle it
+        // https://github.com/space-wizards/space-station-14/issues/31214
         if (TryComp<PullableComponent>(teleEnt, out var pullable) && pullable.BeingPulled)
         {
             _pulling.TryStopPull(teleEnt, pullable);
@@ -224,6 +212,27 @@ public sealed class SwapTeleporterSystem : EntitySystem
         }
 
         _transform.SwapPositions(teleEnt, otherTeleEnt);
+    }
+
+    public bool CanTeleport(EntityUid teleEnt, EntityUid otherTeleEnt)
+    {
+        _container.TryGetOuterContainer(teleEnt, Transform(teleEnt), out var cont);
+        _container.TryGetOuterContainer(otherTeleEnt, Transform(otherTeleEnt), out var otherCont);
+
+        // Checks if the objects can actually be swapped with respect to containers
+
+        bool containerBlocked = otherCont != null && !_container.CanInsert(teleEnt, otherCont) ||
+            cont != null && !_container.CanInsert(otherTeleEnt, cont);
+
+        // Prevents teleporting to the polymorph zone or the cryosleep zone.
+
+        bool pausedMap = _map.IsPaused(Transform(teleEnt).MapID) || _map.IsPaused(Transform(otherTeleEnt).MapID);
+
+        // Room for more logic in case more situations come up in the future
+
+        // Bring it all together
+
+        return !(containerBlocked || pausedMap);
     }
 
     /// <remarks>

--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -157,6 +157,13 @@ public sealed class SwapTeleporterSystem : EntitySystem
             return;
         }
 
+        // can't predict if either entity doesn't exist on the client / is outside of PVS
+        if (_netMan.IsClient)
+        {
+            if (!Exists(uid) || Transform(uid).MapID == MapId.Nullspace || !Exists(linkedEnt) || Transform(linkedEnt).MapID == MapId.Nullspace)
+                return;
+        }
+
         var teleEnt = GetTeleportingEntity((uid, xform));
         var otherTeleEnt = GetTeleportingEntity((linkedEnt, Transform(linkedEnt)));
 
@@ -214,13 +221,6 @@ public sealed class SwapTeleporterSystem : EntitySystem
             && TryComp<PullableComponent>(otherPullerComp.Pulling, out var otherSubjectPulling))
         {
             _pulling.TryStopPull(otherPullerComp.Pulling.Value, otherSubjectPulling);
-        }
-
-        // can't predict if the target doesn't exist on the client / is outside of PVS
-        if (_netMan.IsClient)
-        {
-            if (!Exists(otherTeleEnt) || Transform(otherTeleEnt).MapID == MapId.Nullspace)
-                return;
         }
 
         _transform.SwapPositions(teleEnt, otherTeleEnt);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixed a number of the major breaking bugs that made the QSI almost unusable without encountering some kind of glitch or exploit

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It's a fun item! When used for anything but short-range teleporting it left client-side artifacts due to improper client-side predictions, and had a lot of other incidental breaking interactions #27432 #28507

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds logic to check if the teleporting entities exist client-side, and if they don't stop, trying to predict the outcome and wait for the server to send the proper data. This logic was copied from Portals.
Adds logic to ensure neither end is on a paused map, and if it is the teleport fails. This prevents teleporting to/from polymorph/cryosleep hell.
Adds logic to cause teleporting entities to stop pulling/being pulled. This prevents "teleporter accidents" where dragging a heavy object while using the QSI would cause you to only travel about half the intended distance as the physics engine tried to resolve maintaining the pull constraint after teleporting.

There are some lingering debug assertions that fail when dragging players and teleporting. I have tested these changes with release clients and the tools client, they do print exceptions to the console but still act as expected. I've attached 
[an example of the error](https://github.com/user-attachments/files/16652427/QSI.Dragged.Teleport.Error.txt) for ease of verification on if it is or is not important enough to change before pulling, or if it should be left as an open issue. It seems clients may not be properly predicting that they should drop the target. I attempted a fix by not immediately quitting the prediction as soon as we found one or both sides to be in nullspace, but that introduced a different bug where now the client was predicting (inaccurately) that the player should be UNABLE to pull the entity, but only while the QSI was in hand, until the other entity was once again in-view. I opted for silently ignored errors over client-facing instability.

Additionally, it would appear the while the QSI is on a paused map, such as the polymorph map, it "stocks up" the queued sounds from attempted teleports, and plays them all at once when it returns. This is a purely cosmetic bug, it does not actually proceed with the teleporting, but this may be easily fixable. I've been focusing on the actual teleport logic.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

https://github.com/user-attachments/assets/0ed78092-e1f6-452a-8537-b506d42d86b9



## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Drags-His-Tail
- fix: The Quantum Spin Inverter no longer leaves hallucinations for distant teleports, causes teleporter accidents when carrying heavy objects, or sends users to hell/summons flesh golems if the other side is polymorphed or in cryosleep.
