### PR TITLE
Ghosts now take the appearance of the dead character's last appearance

### DIFF
--- a/Content.Client/Ghost/GhostSystem.cs
+++ b/Content.Client/Ghost/GhostSystem.cs
@@ -1,6 +1,7 @@
 using Content.Client.Movement.Systems;
 using Content.Shared.Actions;
 using Content.Shared.Ghost;
+using Content.Shared.Rotation;
 using Robust.Client.Console;
 using Robust.Client.GameObjects;
 using Robust.Client.Player;
@@ -71,7 +72,18 @@ namespace Content.Client.Ghost
         private void OnStartup(EntityUid uid, GhostComponent component, ComponentStartup args)
         {
             if (TryComp(uid, out SpriteComponent? sprite))
+            {
                 sprite.Visible = GhostVisibility || uid == _playerManager.LocalEntity;
+
+                var localEnt = _playerManager.LocalSession?.AttachedEntity;
+
+                if (localEnt != null && TryComp(localEnt, out SpriteComponent? otherSprite))
+                {
+                    sprite.CopyFrom(otherSprite);
+                    sprite.Color = Color.White.WithAlpha(0.5f); // ghostly opacity
+                    sprite.Rotation = Angle.Zero; // set upright for dead characters
+                }
+            }
         }
 
         private void OnToggleLighting(EntityUid uid, EyeComponent component, ToggleLightingActionEvent args)


### PR DESCRIPTION
## Why / Balance
cool little thing

## Technical details
observer ghosts remain the same

## Media

https://github.com/user-attachments/assets/47581ad5-5908-4b85-badd-a0f78aea30e7



## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
none
-->

:cl:
- tweak: Ghosts now take the form of the dead character.
