### PR TITLE
Seed vend restock price increase (Fix test fails)

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -174,7 +174,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockSeedsFilled
-  cost: 3470
+  cost: 3600
   category: cargoproduct-category-name-hydroponics
   group: market
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Increase the price of the seed restock from 3470 -> 3600.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
#25092 seems to have made the price exactly the sell price which makes the tests mad. The tester seems to think its somehow worth a little more than I see in game as well which is odd... This should fix it either way!

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Beck Thompson
- tweak: Slightly increased the price of the seed restock.