### PR TITLE
Run actions on press

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -121,7 +121,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
             var boundKey = hotbarKeys[i];
             builder = builder.Bind(boundKey, new PointerInputCmdHandler((in PointerInputCmdArgs args) =>
             {
-                if (args.State != BoundKeyState.Up)
+                if (args.State != BoundKeyState.Down)
                     return false;
 
                 TriggerAction(boundId);


### PR DESCRIPTION
I know UI generally want to do stuff on key-up not key-down. With that being said the delay on release for these is noticeable as they're being compared to verbs / in-game keybinds. e.g.
ActivateInWorld / UseInHand / any in-world interactions are on-press. This is especially noticeable if you have the same event on action + verb.

:cl:
- tweak: Actions now activate on key-down, not key-up.
