### PR TITLE
Salvage Melee Nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -395,11 +395,11 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 25
-        Structural: 30
+        Blunt: 10
+        Structural: 10
   # Short lifespan
   - type: TimedDespawn
-    lifetime: 0.4
+    lifetime: 0.170 #the cost of infinite ammo. goes about 4~ tiles
   - type: GatheringProjectile
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -395,7 +395,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 10
+        Blunt: 15
         Structural: 10
   # Short lifespan
   - type: TimedDespawn

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -395,11 +395,11 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 15
-        Structural: 10
+        Blunt: 25
+        Structural: 30
   # Short lifespan
   - type: TimedDespawn
-    lifetime: 0.170 #the cost of infinite ammo. goes about 4~ tiles
+    lifetime: 0.4
   - type: GatheringProjectile
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -132,6 +132,7 @@
     count: 1
   - type: MeleeWeapon
     wideAnimationRotation: -135
+    attackRate: 1.5
     damage:
       types:
         Blunt: 7

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -131,12 +131,11 @@
     capacity: 1
     count: 1
   - type: MeleeWeapon
-    attackRate: 1.5
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 10
-        Slash: 5
+        Blunt: 7
+        Slash: 3
     soundHit:
       collection: MetalThud
   - type: Wieldable
@@ -145,7 +144,7 @@
       types:
         Blunt: 2.5
         Slash: 2.5
-        Structural: 30
+        Structural: 10
   - type: GunRequiresWield
   - type: Item
     size: Ginormous
@@ -167,7 +166,7 @@
     attackRate: 2
     damage:
       types:
-        Slash: 15
+        Slash: 10
   - type: Tag
     tags:
     - Knife
@@ -177,7 +176,7 @@
   parent: [ WeaponCrusher, BaseSecurityCargoContraband]
   id: WeaponCrusherGlaive
   name: crusher glaive
-  description: An early design of the proto-kinetic accelerator, in glaive form.
+  description: An improved version of the proto-kinetic crusher. Heals the user significantly more.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Melee/crusher_glaive.rsi


### PR DESCRIPTION
## About the PR
Reels in the salvage crusher weapons. The changes are as follows:

- The crusher now does 15 damage when wielded. You can 2-shot carp with it.
- The crusher now has a more accurate description.
- The crusher dagger now only does 10 damage.

## Why / Balance
The current salvage weapons are hilariously overtuned. There's currently almost never any reason to use any weapon for salvage outside of these. This should open up more design space for upgrades/sidegrades, & generally reel them in more to where these weapons probably should be. My thought process for each weapon is as follows:

- The crusher just generally had really weirdly high damage. I feel iffy on keeping the faster attack speed, but can recognize that it's probably to make up for the fact that the weapon has no wideswing. In testing against carp, the crusher was difficult to use, but very rewarding when I could land hits the enemy.
- The crusher dagger had the same DPS as the *energy sword.* I don't think I really need to elaborate beyond that.

## Media
N/A

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Salvage Weapon Nerfer
- tweak: Nerfed the Crusher, Crusher Glaive, and Crusher Dagger.
