### PR TITLE
Revert "Tweaking things that restrict freedom (#31095)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/misc.yml
@@ -8,6 +8,8 @@
     sprite: Clothing/Eyes/Misc/blindfold.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Misc/blindfold.rsi
+    equipDelay: 3
+    unequipDelay: 3
   - type: Blindfold
   - type: Construction
     graph: Blindfold

--- a/Resources/Prototypes/Entities/Clothing/Eyes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/misc.yml
@@ -8,8 +8,6 @@
     sprite: Clothing/Eyes/Misc/blindfold.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Misc/blindfold.rsi
-    equipDelay: 5
-    unequipDelay: 5
   - type: Blindfold
   - type: Construction
     graph: Blindfold

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -315,6 +315,8 @@
     sprite: Clothing/Mask/muzzle.rsi
   - type: Clothing
     sprite: Clothing/Mask/muzzle.rsi
+    equipDelay: 3
+    unequipDelay: 3
   - type: IngestionBlocker
   - type: AddAccentClothing
     accent: ReplacementAccent

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -315,8 +315,6 @@
     sprite: Clothing/Mask/muzzle.rsi
   - type: Clothing
     sprite: Clothing/Mask/muzzle.rsi
-    equipDelay: 5
-    unequipDelay: 5
   - type: IngestionBlocker
   - type: AddAccentClothing
     accent: ReplacementAccent

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -762,6 +762,7 @@
       - BoxShotgunIncendiary
       - BoxShotgunUranium
       - BoxShellTranquilizer
+      - ClothingBackpackElectropack
       - ExplosivePayload
       - FlashPayload
       - GrenadeBlast
@@ -807,7 +808,6 @@
       - WeaponLaserCannon
       - WeaponLaserCarbine
       - WeaponXrayCannon
-      - ClothingBackpackElectropack
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -762,8 +762,6 @@
       - BoxShotgunIncendiary
       - BoxShotgunUranium
       - BoxShellTranquilizer
-      - ClothingBackpackElectropack
-      - ClothingOuterStraightjacket
       - ExplosivePayload
       - FlashPayload
       - GrenadeBlast
@@ -809,6 +807,7 @@
       - WeaponLaserCannon
       - WeaponLaserCarbine
       - WeaponXrayCannon
+      - ClothingBackpackElectropack
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -710,11 +710,3 @@
      Plastic: 1000
      Plasma: 500
      Glass: 500
-
-- type: latheRecipe
-  id: ClothingOuterStraightjacket
-  result: ClothingOuterStraightjacket
-  completetime: 4
-  materials:
-    Steel: 200
-    Cloth: 500

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -126,7 +126,6 @@
   cost: 5000
   recipeUnlocks:
   - ClothingBackpackElectropack
-  - ClothingOuterStraightjacket
 
 # Tier 2
 


### PR DESCRIPTION
#31095 got accidentally merged while still in maintainer discussion.
Reverts making the straitjacket printable, as the general maintainer agreement was that this should not be possible and having one per map is enough.
We keep the equip/unequip delay for the muzzle and blindfold, but reduce the number a little to 3 seconds.

**Changelog**
:cl:
- remove: Made the straitjacked non-printable again.

