### PR TITLE
give guides field for antags

### DIFF
--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -4,6 +4,7 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-thief-objective
+  guides: [ Thieves ]
 
 - type: startingGear
   id: ThiefGear

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -12,6 +12,7 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-syndicate-agent-sleeper-objective
+  guides: [ Traitors ]
 
 # Syndicate Operative Outfit - Monkey
 - type: startingGear


### PR DESCRIPTION
give default traitor guidebook for sleeper traitor
give guidebook for thief, was added in #31075 but not in antag prototype