### PR TITLE
Energy Shotgun Buff I

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1018,10 +1018,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 10
-    soundHit:
-      collection: WeakHit
-    forceSound: true
+        Heat: 13
 
 - type: entity
   name: wide laser barrage
@@ -1031,7 +1028,7 @@
   components:
   - type: ProjectileSpread
     proto: BulletLaser
-    count: 5 #50 heat damage if you hit all your shots, but wide spread
+    count: 5 #65 heat damage if you hit all your shots, but wide spread
     spread: 30 
 
 - type: entity
@@ -1052,8 +1049,8 @@
   parent: BulletLaser
   components:
   - type: ProjectileSpread
-    proto: BulletLaser
-    count: 3 #45 heat damage if you hit all your shots, but narrower spread
+    proto: BulletLaserHeavy
+    count: 4 #60 heat damage if you hit all your shots, but narrower spread
     spread: 10
 
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Buffs the energy shotgun:
-Wide fire's projectiles now deal 13 damage instead of 10
-Narrow fire now fires 4 projectiles, which CORRECTLY deal 15 damage instead of the incorrect 10(forgot to change something on the spread proto)
Other changes:
-Sound is no longer weakHit and no longer forced
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The numerical changes were requested by maintainers. This PR addresses 2/4 maintainer requests. The requests being as follows:
-Add visuals for firing modes (just on the icon is fine) (GOING TO BE HANDLED IN DIFFERENT PR)
-Rename the two laser modes to be distinct (HANDLED IN ORIGINAL PR)
-Bump laser pellet damage from 10 to 13 (HANDLED IN THIS PR)
-Add a laser pellet to the concentrated laser mode (HANDLED IN THIS PR)

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
don't think this needs a CL if it gets merged before the next server push, please inform me if this is not the case.