### PR TITLE
Fix to let borgs buckle people

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
@@ -43,7 +43,7 @@ public abstract partial class SharedBuckleSystem
         }
         else
         {
-            var doAfterArgs = new DoAfterArgs(EntityManager, args.User, component.BuckleDoafterTime, new BuckleDoAfterEvent(), args.User, args.Dragged, uid)
+            var doAfterArgs = new DoAfterArgs(EntityManager, args.User, component.BuckleDoafterTime, new BuckleDoAfterEvent(), args.Dragged, args.Dragged, uid)
             {
                 BreakOnMove = true,
                 BreakOnDamage = true,


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes https://github.com/space-wizards/space-station-14/issues/30898

Changes it so the event is raised on the target and not the user. Now the event will check that the target has the buckle component and not the user. Thank you @Hreno for letting me know where the problem is.


https://github.com/user-attachments/assets/a7106245-39ca-4d54-b290-e443ee6b314d

