### PR TITLE
Makes NPCs wait out the idleTime instead of finding a new spot every time they go idle

### DIFF
--- a/Resources/Prototypes/NPCs/idle.yml
+++ b/Resources/Prototypes/NPCs/idle.yml
@@ -2,6 +2,14 @@
 - type: htnCompound
   id: IdleCompound
   branches:
+    - tasks:
+        - !type:HTNPrimitiveTask
+          operator: !type:WaitOperator
+            key: IdleTime
+          preconditions:
+            - !type:KeyExistsPrecondition
+              key: IdleTime
+
     # Pick a new spot and wait there.
     - preconditions:
         - !type:BuckledPrecondition


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Like with the IdleSpinCompound makes the IdleCompound wait if there is already idletime, this prevents NPCs from finding a new idling spot when they switch from one idle task to another idle task, like for example with how when the rat king orders the rat servants to CheeseEm from Stay all of them find a new idling spot even when they were already idling.

## Why / Balance
The rat servants finding a new idling spot every time you order them to do something is i think a bit annoying and awkward, plus consistency of the IdleCompound with the IdleSpinCompound is good.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Changelog probably not needed
