### PR TITLE
Energy Shotgun Change 2 - Narrow Nerf + instances from NoSpawn --> categories: [ HideSpawnMenu ] + self recharge removed + 1 more shot + normal recharge speed

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -740,15 +740,15 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletLaserSpread
-    fireCost: 150
+    fireCost: 100
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: BulletLaserSpread
-      fireCost: 150
+      fireCost: 100
     - proto: BulletLaserSpreadNarrow
-      fireCost: 150
+      fireCost: 100
     - proto: BulletDisablerSmgSpread
-      fireCost: 150
+      fireCost: 100
   - type: Item
     size: Large
     shape:
@@ -762,5 +762,5 @@
     stealGroup: WeaponEnergyShotgun
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Battery
-    maxCharge: 1050
-    startingCharge: 1050
+    maxCharge: 800
+    startingCharge: 800

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -745,7 +745,7 @@
     fireModes:
     - proto: BulletLaserSpread
       fireCost: 150
-    - proto: BulletLaserHeavySpread
+    - proto: BulletLaserSpreadNarrow
       fireCost: 150
     - proto: BulletDisablerSmgSpread
       fireCost: 150

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -764,6 +764,3 @@
   - type: Battery
     maxCharge: 1050
     startingCharge: 1050
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 25 #takes 42 seconds to fully recharge, the answer to life, the universe and everything

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1023,7 +1023,7 @@
 - type: entity
   name: wide laser barrage
   id: BulletLaserSpread
-  noSpawn: true
+  categories: [ HideSpawnMenu ]
   parent: BulletLaser
   components:
   - type: ProjectileSpread
@@ -1032,31 +1032,20 @@
     spread: 30 
 
 - type: entity
-  name : heavy laser bolt
-  id: BulletLaserHeavy
-  parent: BulletLaser
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: Projectile
-    damage:
-      types:
-        Heat: 15
-
-- type: entity
   name: narrow laser barrage
-  id: BulletLaserHeavySpread
-  noSpawn: true
+  id: BulletLaserSpreadNarrow
+  categories: [ HideSpawnMenu ]
   parent: BulletLaser
   components:
   - type: ProjectileSpread
-    proto: BulletLaserHeavy
-    count: 4 #60 heat damage if you hit all your shots, but narrower spread
+    proto: BulletLaser
+    count: 4 #52 heat damage if you hit all your shots, but narrower spread
     spread: 10
 
 - type: entity
   name: disabling laser barrage
   id: BulletDisablerSmgSpread
-  noSpawn: true
+  categories: [ HideSpawnMenu ]
   parent: BulletDisablerSmg
   components:
   - type: ProjectileSpread

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -195,7 +195,6 @@
 ## hos
 
 - type: entity
-  noSpawn: true
   parent: BaseTraitorStealObjective
   id: EnergyShotgunStealObjective
   components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Nerfs the Narrow Fire Mode from 60 dmg over 4 projectiles to 52 damage over 4 projectiles.
Makes the energy shotgun no longer self recharge
Changes uses of noSpawn to categories: [ HideSpawnMenu ]
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Miscommunication between me and Slam, as well as a bug that was in the release version of the shotgun lead to the narrow fire mode being stronger than intended by the maintainers.
The shotgun was basically a game changer during nuclear operative rounds, depending on which side got it. With the self recharge removed, it should no longer remove the concept of attrition from nukie rounds. If this turns out to make the weapon too weak, I'll change it.
 https://github.com/space-wizards/RobustToolbox/pull/5364 for the noSpawn instance changes
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Energy Shotgun's narrow fire mode's projectiles now deal 13 heat dmg each, for a total of 52. The energy shotgun additionally no longer self recharges and has received some minor buffs.