### PR TITLE
Remove client state from server AirAlarmComponent

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmBoundUserInterface.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmBoundUserInterface.cs
@@ -30,7 +30,6 @@ public sealed class AirAlarmBoundUserInterface : BoundUserInterface
         _window.AirAlarmModeChanged += OnAirAlarmModeChanged;
         _window.AutoModeChanged += OnAutoModeChanged;
         _window.ResyncAllRequested += ResyncAllDevices;
-        _window.AirAlarmTabChange += OnTabChanged;
     }
 
     private void ResyncAllDevices()
@@ -61,11 +60,6 @@ public sealed class AirAlarmBoundUserInterface : BoundUserInterface
     private void OnThresholdChanged(string address, AtmosMonitorThresholdType type, AtmosAlarmThreshold threshold, Gas? gas = null)
     {
         SendMessage(new AirAlarmUpdateAlarmThresholdMessage(address, type, threshold, gas));
-    }
-
-    private void OnTabChanged(AirAlarmTab tab)
-    {
-        SendMessage(new AirAlarmTabSetMessage(tab));
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -23,7 +23,6 @@ public sealed partial class AirAlarmWindow : FancyWindow
     public event Action<AirAlarmMode>? AirAlarmModeChanged;
     public event Action<bool>? AutoModeChanged;
     public event Action? ResyncAllRequested;
-    public event Action<AirAlarmTab>? AirAlarmTabChange;
 
     private RichTextLabel _address => CDeviceAddress;
     private RichTextLabel _deviceTotal => CDeviceTotal;
@@ -80,11 +79,6 @@ public sealed partial class AirAlarmWindow : FancyWindow
         _tabContainer.SetTabTitle(1, Loc.GetString("air-alarm-ui-window-tab-scrubbers"));
         _tabContainer.SetTabTitle(2, Loc.GetString("air-alarm-ui-window-tab-sensors"));
 
-        _tabContainer.OnTabChanged += idx =>
-        {
-            AirAlarmTabChange!((AirAlarmTab) idx);
-        };
-
         _resyncDevices.OnPressed += _ =>
         {
             _ventDevices.RemoveAllChildren();
@@ -117,8 +111,6 @@ public sealed partial class AirAlarmWindow : FancyWindow
         {
             UpdateDeviceData(addr, dev);
         }
-
-        _tabContainer.CurrentTab = (int) state.Tab;
     }
 
     public void UpdateModeSelector(AirAlarmMode mode)

--- a/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
@@ -17,8 +17,6 @@ public sealed partial class AirAlarmComponent : Component
     // Remember to null this afterwards.
     [ViewVariables] public IAirAlarmModeUpdate? CurrentModeUpdater { get; set; }
 
-    [ViewVariables] public AirAlarmTab CurrentTab { get; set; }
-
     public readonly HashSet<string> KnownDevices = new();
     public readonly Dictionary<string, GasVentPumpData> VentData = new();
     public readonly Dictionary<string, GasVentScrubberData> ScrubberData = new();

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -173,7 +173,6 @@ public sealed class AirAlarmSystem : EntitySystem
             subs.Event<AirAlarmUpdateAlarmThresholdMessage>(OnUpdateThreshold);
             subs.Event<AirAlarmUpdateDeviceDataMessage>(OnUpdateDeviceData);
             subs.Event<AirAlarmCopyDeviceDataMessage>(OnCopyDeviceData);
-            subs.Event<AirAlarmTabSetMessage>(OnTabChange);
         });
     }
 
@@ -198,12 +197,6 @@ public sealed class AirAlarmSystem : EntitySystem
         UpdateUI(uid, component);
 
         SyncRegisterAllDevices(uid);
-    }
-
-    private void OnTabChange(EntityUid uid, AirAlarmComponent component, AirAlarmTabSetMessage msg)
-    {
-        component.CurrentTab = msg.Tab;
-        UpdateUI(uid, component);
     }
 
     private void OnPowerChanged(EntityUid uid, AirAlarmComponent component, ref PowerChangedEvent args)
@@ -600,32 +593,17 @@ public sealed class AirAlarmSystem : EntitySystem
         var temperature = CalculateTemperatureAverage(alarm);
         var dataToSend = new Dictionary<string, IAtmosDeviceData>();
 
-        if (alarm.CurrentTab != AirAlarmTab.Settings)
+        foreach (var (addr, data) in alarm.VentData)
         {
-            switch (alarm.CurrentTab)
-            {
-                case AirAlarmTab.Vent:
-                    foreach (var (addr, data) in alarm.VentData)
-                    {
-                        dataToSend.Add(addr, data);
-                    }
-
-                    break;
-                case AirAlarmTab.Scrubber:
-                    foreach (var (addr, data) in alarm.ScrubberData)
-                    {
-                        dataToSend.Add(addr, data);
-                    }
-
-                    break;
-                case AirAlarmTab.Sensors:
-                    foreach (var (addr, data) in alarm.SensorData)
-                    {
-                        dataToSend.Add(addr, data);
-                    }
-
-                    break;
-            }
+            dataToSend.Add(addr, data);
+        }
+        foreach (var (addr, data) in alarm.ScrubberData)
+        {
+            dataToSend.Add(addr, data);
+        }
+        foreach (var (addr, data) in alarm.SensorData)
+        {
+            dataToSend.Add(addr, data);
         }
 
         var deviceCount = alarm.KnownDevices.Count;
@@ -638,7 +616,7 @@ public sealed class AirAlarmSystem : EntitySystem
         _ui.SetUiState(
             uid,
             SharedAirAlarmInterfaceKey.Key,
-            new AirAlarmUIState(devNet.Address, deviceCount, pressure, temperature, dataToSend, alarm.CurrentMode, alarm.CurrentTab, highestAlarm.Value, alarm.AutoMode));
+            new AirAlarmUIState(devNet.Address, deviceCount, pressure, temperature, dataToSend, alarm.CurrentMode, highestAlarm.Value, alarm.AutoMode));
     }
 
     private const float Delay = 8f;

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -591,19 +591,19 @@ public sealed class AirAlarmSystem : EntitySystem
 
         var pressure = CalculatePressureAverage(alarm);
         var temperature = CalculateTemperatureAverage(alarm);
-        var dataToSend = new Dictionary<string, IAtmosDeviceData>();
+        var dataToSend = new List<(string, IAtmosDeviceData)>();
 
         foreach (var (addr, data) in alarm.VentData)
         {
-            dataToSend.Add(addr, data);
+            dataToSend.Add((addr, data));
         }
         foreach (var (addr, data) in alarm.ScrubberData)
         {
-            dataToSend.Add(addr, data);
+            dataToSend.Add((addr, data));
         }
         foreach (var (addr, data) in alarm.SensorData)
         {
-            dataToSend.Add(addr, data);
+            dataToSend.Add((addr, data));
         }
 
         var deviceCount = alarm.KnownDevices.Count;

--- a/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
+++ b/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
@@ -37,7 +37,7 @@ public interface IAtmosDeviceData
 [Serializable, NetSerializable]
 public sealed class AirAlarmUIState : BoundUserInterfaceState
 {
-    public AirAlarmUIState(string address, int deviceCount, float pressureAverage, float temperatureAverage, Dictionary<string, IAtmosDeviceData> deviceData, AirAlarmMode mode, AtmosAlarmType alarmType, bool autoMode)
+    public AirAlarmUIState(string address, int deviceCount, float pressureAverage, float temperatureAverage, List<(string, IAtmosDeviceData)> deviceData, AirAlarmMode mode, AtmosAlarmType alarmType, bool autoMode)
     {
         Address = address;
         DeviceCount = deviceCount;
@@ -56,8 +56,11 @@ public sealed class AirAlarmUIState : BoundUserInterfaceState
     /// <summary>
     ///     Every single device data that can be seen from this
     ///     air alarm. This includes vents, scrubbers, and sensors.
+    ///     Each entry is a tuple of device address and the device
+    ///     data. The same address may appear multiple times, if
+    ///     that device provides multiple functions.
     /// </summary>
-    public Dictionary<string, IAtmosDeviceData> DeviceData { get; }
+    public List<(string, IAtmosDeviceData)> DeviceData { get; }
     public AirAlarmMode Mode { get; }
     public AtmosAlarmType AlarmType { get; }
     public bool AutoMode { get; }

--- a/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
+++ b/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
@@ -37,7 +37,7 @@ public interface IAtmosDeviceData
 [Serializable, NetSerializable]
 public sealed class AirAlarmUIState : BoundUserInterfaceState
 {
-    public AirAlarmUIState(string address, int deviceCount, float pressureAverage, float temperatureAverage, Dictionary<string, IAtmosDeviceData> deviceData, AirAlarmMode mode, AirAlarmTab tab, AtmosAlarmType alarmType, bool autoMode)
+    public AirAlarmUIState(string address, int deviceCount, float pressureAverage, float temperatureAverage, Dictionary<string, IAtmosDeviceData> deviceData, AirAlarmMode mode, AtmosAlarmType alarmType, bool autoMode)
     {
         Address = address;
         DeviceCount = deviceCount;
@@ -45,7 +45,6 @@ public sealed class AirAlarmUIState : BoundUserInterfaceState
         TemperatureAverage = temperatureAverage;
         DeviceData = deviceData;
         Mode = mode;
-        Tab = tab;
         AlarmType = alarmType;
         AutoMode = autoMode;
     }
@@ -57,25 +56,11 @@ public sealed class AirAlarmUIState : BoundUserInterfaceState
     /// <summary>
     ///     Every single device data that can be seen from this
     ///     air alarm. This includes vents, scrubbers, and sensors.
-    ///     The device data you get, however, depends on the current
-    ///     selected tab.
     /// </summary>
     public Dictionary<string, IAtmosDeviceData> DeviceData { get; }
     public AirAlarmMode Mode { get; }
-    public AirAlarmTab Tab { get; }
     public AtmosAlarmType AlarmType { get; }
     public bool AutoMode { get; }
-}
-
-[Serializable, NetSerializable]
-public sealed class AirAlarmTabSetMessage : BoundUserInterfaceMessage
-{
-    public AirAlarmTabSetMessage(AirAlarmTab tab)
-    {
-        Tab = tab;
-    }
-
-    public AirAlarmTab Tab { get; }
 }
 
 [Serializable, NetSerializable]
@@ -143,12 +128,4 @@ public sealed class AirAlarmUpdateAlarmThresholdMessage : BoundUserInterfaceMess
         Type = type;
         Gas = gas;
     }
-}
-
-public enum AirAlarmTab
-{
-    Vent,
-    Scrubber,
-    Sensors,
-    Settings
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Fixes bug where air alarm UI would jump between different tabs uncontrollably. Fixes #12842

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The server AirAlarmComponent stored client state for the currently-open tab. When a client changed tab, a "tab update" message was sent, and the server would reply with an updated UI set. However, multiple "tab update" messages could be in flight (if multiple users were opening the UI, or if one user switched tabs faster than the server responded) - in that scenario, the client/server would get stuck in a loop of updating the UI and sending "tab changed" messages.

Just remove all that code. Less code == less bugs. Now sensd information for all connected devices, not just the ones for the current tab.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
