### PR TITLE
Add freebsd-x64 server packaging target

### DIFF
--- a/Content.Packaging/ServerPackaging.cs
+++ b/Content.Packaging/ServerPackaging.cs
@@ -22,6 +22,7 @@ public static class ServerPackaging
         new PlatformReg("win-x86", "Windows", false),
         new PlatformReg("linux-x86", "Linux", false),
         new PlatformReg("linux-arm", "Linux", false),
+        new PlatformReg("freebsd-x64", "FreeBSD", false),
     };
 
     private static List<string> PlatformRids => Platforms


### PR DESCRIPTION
## About the PR
Adds freebsd-x64 (FreeBSD amd64) as a valid server packaging target.

## Why / Balance
Over the course of several PR's the SS14 server builds and runs on FreeBSD. So add it to the non-default list of targets so that other people can start building it, too.

## Media
N/A

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase