### PR TITLE
Add trash tag to chopsticks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/chopsticks.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/chopsticks.yml
@@ -13,6 +13,9 @@
   - type: Utensil
     types:
     - Fork
+  - type: Tag
+    tags:
+    - Trash
 
 - type: entity
   parent: BaseItem
@@ -28,3 +31,6 @@
   - type: Sprite
     sprite: Objects/Misc/chopstick.rsi
     state: paired
+  - type: Tag
+    tags:
+    - Trash


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This adds the Trash tag to the chopsticks and paired chopsticks.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This allows the janitor to clean up the chopsticks that seem to inevitably cover the floor near the ramen vending machine.
They are single-use utensils like the plastic utensils (which have the trash tag), so it makes logical sense too.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

no cl needed
