### PR TITLE
tweak(shuttle_infiltrator): Replace NukeCodePaper with BoxFolderNuclearCodes

### DIFF
--- a/Resources/Maps/Shuttles/infiltrator.yml
+++ b/Resources/Maps/Shuttles/infiltrator.yml
@@ -3733,7 +3733,7 @@ entities:
     - type: Transform
       pos: -2.5,-12.5
       parent: 1
-- proto: NukeCodePaper
+- proto: BoxFolderNuclearCodes
   entities:
   - uid: 510
     components:


### PR DESCRIPTION
# Why

Requested in https://github.com/space-wizards/space-station-14/pull/31272

Requires https://github.com/space-wizards/space-station-14/pull/31272

Resolves #31216

:cl:
- fix: Nukie shuttle now spawns with the nuclear authentication code folder. This fixes the issue where the nuclear codes would only ever have the codes for the nuclear operatives nuke and not the stations.