### PR TITLE
add new salv loot into the vgroid procgen

### DIFF
--- a/Content.Server/Procedural/DungeonJob/DungeonJob.EntityTableDunGen.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.EntityTableDunGen.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Content.Server.Ghost.Roles.Components;
+using Content.Server.NPC.Systems;
+using Content.Shared.EntityTable;
+using Content.Shared.Physics;
+using Content.Shared.Procedural;
+using Content.Shared.Procedural.DungeonLayers;
+using Robust.Shared.Collections;
+
+namespace Content.Server.Procedural.DungeonJob;
+
+public sealed partial class DungeonJob
+{
+    private async Task PostGen(
+        EntityTableDunGen gen,
+        Dungeon dungeon,
+        Random random)
+    {
+        var availableRooms = new ValueList<DungeonRoom>();
+        availableRooms.AddRange(dungeon.Rooms);
+        var availableTiles = new ValueList<Vector2i>(dungeon.AllTiles);
+
+        var count = random.Next(gen.MinCount, gen.MaxCount + 1);
+        var npcs = _entManager.System<NPCSystem>();
+
+        for (var i = 0; i < count; i++)
+        {
+            while (availableTiles.Count > 0)
+            {
+                var tile = availableTiles.RemoveSwap(random.Next(availableTiles.Count));
+
+                if (!_anchorable.TileFree(_grid,
+                        tile,
+                        (int) CollisionGroup.MachineLayer,
+                        (int) CollisionGroup.MachineLayer))
+                {
+                    continue;
+                }
+
+                var entities = _entManager.System<EntityTableSystem>().GetSpawns(gen.Table, random).ToList();
+                foreach (var ent in entities)
+                {
+                    var uid = _entManager.SpawnAtPosition(ent, _maps.GridTileToLocal(_gridUid, _grid, tile));
+                    _entManager.RemoveComponent<GhostRoleComponent>(uid);
+                    _entManager.RemoveComponent<GhostTakeoverAvailableComponent>(uid);
+                    npcs.SleepNPC(uid);
+                }
+
+                break;
+            }
+
+            await SuspendDungeon();
+
+            if (!ValidateResume())
+                return;
+        }
+    }
+}

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.cs
@@ -239,6 +239,9 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
             case MobsDunGen mob:
                 await PostGen(mob, dungeons[^1], random);
                 break;
+            case EntityTableDunGen entityTable:
+                await PostGen(entityTable, dungeons[^1], random);
+                break;
             case NoiseDistanceDunGen distance:
                 dungeons.Add(await GenerateNoiseDistanceDunGen(position, distance, reservedTiles, seed, random));
                 break;

--- a/Content.Shared/Procedural/DungeonLayers/EntityTableDunGen.cs
+++ b/Content.Shared/Procedural/DungeonLayers/EntityTableDunGen.cs
@@ -1,0 +1,21 @@
+using Content.Shared.EntityTable.EntitySelectors;
+
+namespace Content.Shared.Procedural.DungeonLayers;
+
+
+/// <summary>
+/// Spawns entities inside of the dungeon randomly.
+/// </summary>
+public sealed partial class EntityTableDunGen : IDunGenLayer
+{
+    // Counts separate to config to avoid some duplication.
+
+    [DataField]
+    public int MinCount = 1;
+
+    [DataField]
+    public int MaxCount = 1;
+
+    [DataField(required: true)]
+    public EntityTableSelector Table;
+}

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -121,6 +121,54 @@
       tableId: SalvageScrapSpawnerValuable
       prob: 0.75
 
+- type: entityTable
+  id: SalvageTreasureSpawnerCommon
+  table: !type:GroupSelector
+    children:
+    # 80% chance of some treasure
+    - !type:GroupSelector
+      weight: 80
+      children:
+      - !type:NestedSelector
+        tableId: SalvageTreasureCommon
+        weight: 60
+      - !type:NestedSelector
+        tableId: SalvageTreasureUncommon
+        weight: 30
+      - !type:NestedSelector
+        tableId: SalvageTreasureRare
+        weight: 9
+      - !type:NestedSelector
+        tableId: SalvageTreasureLegendary
+        weight: 1
+    # 10% chance of low-level equipment
+    - !type:GroupSelector
+      weight: 10
+      children:
+      - !type:NestedSelector
+        tableId: SalvageEquipmentCommon
+        weight: 60
+      - !type:NestedSelector
+        tableId: SalvageEquipmentUncommon
+        weight: 40
+    # 5% chance of moderate scrap
+    - !type:GroupSelector
+      weight: 5
+      children:
+      - !type:NestedSelector
+        tableId: SalvageScrapLowValue
+        weight: 60
+      - !type:NestedSelector
+        tableId: SalvageScrapHighValue
+        weight: 30
+      - !type:NestedSelector
+        tableId: SalvageScrapLarge
+        weight: 10
+    # 5% chance of maintenance fluff
+    - !type:NestedSelector
+      tableId: MaintFluffTable
+      weight: 5
+
 - type: entity
   parent: MarkerBase
   id: SalvageSpawnerTreasure
@@ -134,52 +182,62 @@
       state: diamond
   - type: EntityTableSpawner
     offset: 0.4
-    table: !type:GroupSelector
+    table: !type:NestedSelector
+      tableId: SalvageTreasureSpawnerCommon
       prob: 0.75
+
+- type: entityTable
+  id: SalvageTreasureSpawnerValuable
+  table: !type:GroupSelector
+    children:
+    # 80% chance of some treasure
+    - !type:GroupSelector
+      weight: 80
       children:
-      # 80% chance of some treasure
-      - !type:GroupSelector
-        weight: 80
-        children:
-        - !type:NestedSelector
-          tableId: SalvageTreasureCommon
-          weight: 60
-        - !type:NestedSelector
-          tableId: SalvageTreasureUncommon
-          weight: 30
-        - !type:NestedSelector
-          tableId: SalvageTreasureRare
-          weight: 9
-        - !type:NestedSelector
-          tableId: SalvageTreasureLegendary
-          weight: 1
-      # 10% chance of low-level equipment
-      - !type:GroupSelector
-        weight: 10
-        children:
-        - !type:NestedSelector
-          tableId: SalvageEquipmentCommon
-          weight: 60
-        - !type:NestedSelector
-          tableId: SalvageEquipmentUncommon
-          weight: 40
-      # 5% chance of moderate scrap
-      - !type:GroupSelector
-        weight: 5
-        children:
-        - !type:NestedSelector
-          tableId: SalvageScrapLowValue
-          weight: 60
-        - !type:NestedSelector
-          tableId: SalvageScrapHighValue
-          weight: 30
-        - !type:NestedSelector
-          tableId: SalvageScrapLarge
-          weight: 10
-      # 5% chance of maintenance fluff
       - !type:NestedSelector
-        tableId: MaintFluffTable
+        tableId: SalvageTreasureCommon
+        weight: 45
+      - !type:NestedSelector
+        tableId: SalvageTreasureUncommon
+        weight: 35
+      - !type:NestedSelector
+        tableId: SalvageTreasureRare
+        weight: 15
+      - !type:NestedSelector
+        tableId: SalvageTreasureLegendary
         weight: 5
+    # 10% chance of low-level equipment
+    - !type:GroupSelector
+      weight: 10
+      children:
+      - !type:NestedSelector
+        tableId: SalvageEquipmentCommon
+        weight: 50
+      - !type:NestedSelector
+        tableId: SalvageEquipmentUncommon
+        weight: 40
+      - !type:NestedSelector
+        tableId: SalvageEquipmentUncommon
+        weight: 10
+    # 5% chance of moderate scrap
+    - !type:GroupSelector
+      weight: 5
+      children:
+      - !type:NestedSelector
+        tableId: SalvageScrapLowValue
+        weight: 30
+      - !type:NestedSelector
+        tableId: SalvageScrapHighValue
+        weight: 45
+      - !type:NestedSelector
+        tableId: SalvageScrapLarge
+        weight: 25
+    # 5% chance of maintenance fluff
+    - !type:NestedSelector
+      tableId: MaintFluffTable
+      weight: 5
+      rolls: !type:RangeNumberSelector
+        range: 1, 2
 
 - type: entity
   parent: MarkerBase
@@ -194,57 +252,51 @@
       state: diamond
   - type: EntityTableSpawner
     offset: 0.4
-    table: !type:GroupSelector
+    table: !type:NestedSelector
+      tableId: SalvageTreasureSpawnerValuable
       prob: 0.75
+
+- type: entityTable
+  id: SalvageEquipmentSpawnerCommon
+  table: !type:GroupSelector
+    children:
+    # 80% chance of equipment item
+    - !type:GroupSelector
+      weight: 80
       children:
-      # 80% chance of some treasure
-      - !type:GroupSelector
-        weight: 80
-        children:
-        - !type:NestedSelector
-          tableId: SalvageTreasureCommon
-          weight: 45
-        - !type:NestedSelector
-          tableId: SalvageTreasureUncommon
-          weight: 35
-        - !type:NestedSelector
-          tableId: SalvageTreasureRare
-          weight: 15
-        - !type:NestedSelector
-          tableId: SalvageTreasureLegendary
-          weight: 5
-      # 10% chance of low-level equipment
-      - !type:GroupSelector
-        weight: 10
-        children:
-        - !type:NestedSelector
-          tableId: SalvageEquipmentCommon
-          weight: 50
-        - !type:NestedSelector
-          tableId: SalvageEquipmentUncommon
-          weight: 40
-        - !type:NestedSelector
-          tableId: SalvageEquipmentUncommon
-          weight: 10
-      # 5% chance of moderate scrap
-      - !type:GroupSelector
+      - !type:NestedSelector
+        tableId: SalvageEquipmentCommon
+        weight: 60
+      - !type:NestedSelector
+        tableId: SalvageEquipmentUncommon
+        weight: 30
+      - !type:NestedSelector
+        tableId: SalvageEquipmentRare
+        weight: 9
+      - !type:NestedSelector
+        tableId: SalvageEquipmentLegendary
+        weight: 1
+    # 15% chance of decent-ish treasure
+    - !type:GroupSelector
+      weight: 15
+      children:
+      - !type:NestedSelector
+        tableId: SalvageTreasureCommon
+        weight: 75
+      - !type:NestedSelector
+        tableId: SalvageTreasureUncommon
+        weight: 20
+      - !type:NestedSelector
+        tableId: SalvageTreasureRare
         weight: 5
-        children:
-        - !type:NestedSelector
-          tableId: SalvageScrapLowValue
-          weight: 30
-        - !type:NestedSelector
-          tableId: SalvageScrapHighValue
-          weight: 45
-        - !type:NestedSelector
-          tableId: SalvageScrapLarge
-          weight: 25
-      # 5% chance of maintenance fluff
+    # 5% chance of decent maintenance loot
+    - !type:GroupSelector
+      weight: 5
+      children:
+      - !type:NestedSelector
+        tableId: MaintToolsTable
       - !type:NestedSelector
         tableId: MaintFluffTable
-        weight: 5
-        rolls: !type:RangeNumberSelector
-          range: 1, 2
 
 - type: entity
   parent: MarkerBase
@@ -259,46 +311,57 @@
       state: walkietalkie
   - type: EntityTableSpawner
     offset: 0.4
-    table: !type:GroupSelector
+    table: !type:NestedSelector
+      tableId: SalvageEquipmentSpawnerCommon
       prob: 0.75
+
+- type: entityTable
+  id: SalvageEquipmentSpawnerValuable
+  table: !type:GroupSelector
+    children:
+    # 80% chance of equipment item
+    - !type:GroupSelector
+      weight: 80
       children:
-      # 80% chance of equipment item
-      - !type:GroupSelector
-        weight: 80
-        children:
-        - !type:NestedSelector
-          tableId: SalvageEquipmentCommon
-          weight: 60
-        - !type:NestedSelector
-          tableId: SalvageEquipmentUncommon
-          weight: 30
-        - !type:NestedSelector
-          tableId: SalvageEquipmentRare
-          weight: 9
-        - !type:NestedSelector
-          tableId: SalvageEquipmentLegendary
-          weight: 1
-      # 15% chance of decent-ish treasure
-      - !type:GroupSelector
+      - !type:NestedSelector
+        tableId: SalvageEquipmentCommon
+        weight: 45
+      - !type:NestedSelector
+        tableId: SalvageEquipmentUncommon
+        weight: 35
+      - !type:NestedSelector
+        tableId: SalvageEquipmentRare
         weight: 15
-        children:
-        - !type:NestedSelector
-          tableId: SalvageTreasureCommon
-          weight: 75
-        - !type:NestedSelector
-          tableId: SalvageTreasureUncommon
-          weight: 20
-        - !type:NestedSelector
-          tableId: SalvageTreasureRare
-          weight: 5
-      # 5% chance of decent maintenance loot
-      - !type:GroupSelector
+      - !type:NestedSelector
+        tableId: SalvageEquipmentLegendary
         weight: 5
-        children:
-        - !type:NestedSelector
-          tableId: MaintToolsTable
-        - !type:NestedSelector
-          tableId: MaintFluffTable
+    # 14% chance of decent-ish treasure
+    - !type:GroupSelector
+      weight: 14
+      children:
+      - !type:NestedSelector
+        tableId: SalvageTreasureCommon
+        weight: 60
+      - !type:NestedSelector
+        tableId: SalvageTreasureUncommon
+        weight: 30
+      - !type:NestedSelector
+        tableId: SalvageTreasureRare
+        weight: 10
+    # 5% chance of decent maintenance loot
+    - !type:GroupSelector
+      weight: 5
+      children:
+      - !type:NestedSelector
+        tableId: MaintToolsTable
+      - !type:NestedSelector
+        tableId: MaintFluffTable
+    # 1% chance of syndie maintenance loot
+    - !type:GroupSelector
+      weight: 1
+      children:
+      - !type:NestedSelector
+        tableId: SyndieMaintLoot
 
 - type: entity
   parent: MarkerBase
@@ -313,52 +376,9 @@
       state: walkietalkie
   - type: EntityTableSpawner
     offset: 0.4
-    table: !type:GroupSelector
+    table: !type:NestedSelector
+      tableId: SalvageEquipmentSpawnerValuable
       prob: 0.75
-      children:
-      # 80% chance of equipment item
-      - !type:GroupSelector
-        weight: 80
-        children:
-        - !type:NestedSelector
-          tableId: SalvageEquipmentCommon
-          weight: 45
-        - !type:NestedSelector
-          tableId: SalvageEquipmentUncommon
-          weight: 35
-        - !type:NestedSelector
-          tableId: SalvageEquipmentRare
-          weight: 15
-        - !type:NestedSelector
-          tableId: SalvageEquipmentLegendary
-          weight: 5
-      # 14% chance of decent-ish treasure
-      - !type:GroupSelector
-        weight: 14
-        children:
-        - !type:NestedSelector
-          tableId: SalvageTreasureCommon
-          weight: 60
-        - !type:NestedSelector
-          tableId: SalvageTreasureUncommon
-          weight: 30
-        - !type:NestedSelector
-          tableId: SalvageTreasureRare
-          weight: 10
-      # 5% chance of decent maintenance loot
-      - !type:GroupSelector
-        weight: 5
-        children:
-        - !type:NestedSelector
-          tableId: MaintToolsTable
-        - !type:NestedSelector
-          tableId: MaintFluffTable
-      # 1% chance of syndie maintenance loot
-      - !type:GroupSelector
-        weight: 1
-        children:
-        - !type:NestedSelector
-          tableId: SyndieMaintLoot
 
 - type: entity
   name: Salvage Canister Spawner

--- a/Resources/Prototypes/Procedural/vgroid.yml
+++ b/Resources/Prototypes/Procedural/vgroid.yml
@@ -141,9 +141,39 @@
   layers:
   - !type:ExteriorDunGen
     proto: Experiment
+  - !type:EntityTableDunGen
+    minCount: 25
+    maxCount: 40
+    table: !type:NestedSelector
+      tableId: SalvageScrapSpawnerCommon
+  - !type:EntityTableDunGen
+    minCount: 30
+    maxCount: 40
+    table: !type:NestedSelector
+      tableId: SalvageScrapSpawnerValuable
+  - !type:EntityTableDunGen
+    minCount: 15
+    maxCount: 25
+    table: !type:NestedSelector
+      tableId: SalvageTreasureSpawnerCommon
+  - !type:EntityTableDunGen
+    minCount: 15
+    maxCount: 25
+    table: !type:NestedSelector
+      tableId: SalvageEquipmentSpawnerCommon
+  - !type:EntityTableDunGen
+    minCount: 15
+    maxCount: 20
+    table: !type:NestedSelector
+      tableId: SalvageTreasureSpawnerValuable
+  - !type:EntityTableDunGen
+    minCount: 15
+    maxCount: 20
+    table: !type:NestedSelector
+      tableId: SalvageEquipmentSpawnerValuable
   - !type:MobsDunGen
-    minCount: 5
-    maxCount: 8
+    minCount: 8
+    maxCount: 15
     groups:
     - id: MobGoliath
       amount: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
adds all the recently added salvage spawners into the vgroid dungeon procgen. This means that the dungeons will now be filled with various scrap, equipment, and treasure items.

slightly increases the number of goliaths per dungeon.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The goal is to offload some of the loot population off of mapping the dungeon presets and just let procgen fill out some random junk for salvagers to use. Furthermore, this makes the vgroid a bit more lucrative as an option seeing as it now fills up with a ton of scrap and potential weapons, upgrades, and high-value sellables.

the goliath increase makes it a little more intimidating. :)

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
![image](https://github.com/user-attachments/assets/fbc1f854-9258-4c7a-8805-2da9a051d4c1)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: The mining asteroid dungeons now spawn with more equipment, scrap, and treasure in them.