### PR TITLE
Changes to "Burst" firemode; Drozd, WT550 and C20-r

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -157,7 +157,7 @@ public sealed partial class GunSystem : SharedGunSystem
 
         var useKey = gun.UseKey ? EngineKeyFunctions.Use : EngineKeyFunctions.UseSecondary;
 
-        if (_inputSystem.CmdStates.GetState(useKey) != BoundKeyState.Down)
+        if (_inputSystem.CmdStates.GetState(useKey) != BoundKeyState.Down && !gun.BurstActivated)
         {
             if (gun.ShotCounter != 0)
                 EntityManager.RaisePredictiveEvent(new RequestStopShootEvent { Gun = GetNetEntity(gunUid) });

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.AutoFire.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.AutoFire.cs
@@ -1,4 +1,6 @@
+using Content.Shared.Damage;
 using Content.Shared.Weapons.Ranged.Components;
+using Robust.Shared.Map;
 
 namespace Content.Server.Weapons.Ranged.Systems;
 
@@ -13,17 +15,28 @@ public sealed partial class GunSystem
          */
 
         // Automatic firing without stopping if the AutoShootGunComponent component is exist and enabled
-        var query = EntityQueryEnumerator<AutoShootGunComponent, GunComponent>();
+        var query = EntityQueryEnumerator<GunComponent>();
 
-        while (query.MoveNext(out var uid, out var autoShoot, out var gun))
+        while (query.MoveNext(out var uid, out var gun))
         {
-            if (!autoShoot.Enabled)
-                continue;
-
             if (gun.NextFire > Timing.CurTime)
                 continue;
 
-            AttemptShoot(uid, gun);
+            if (TryComp(uid, out AutoShootGunComponent? autoShoot))
+            {
+                if (!autoShoot.Enabled)
+                    continue;
+
+                AttemptShoot(uid, gun);
+            }
+            else if (gun.BurstActivated)
+            {
+                var parent = _transform.GetParentUid(uid);
+                if (HasComp<DamageableComponent>(parent))
+                    AttemptShoot(parent, uid, gun, gun.ShootCoordinates ?? new EntityCoordinates(uid, gun.DefaultDirection));
+                else
+                    AttemptShoot(uid, gun);
+            }
         }
     }
 }

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -164,10 +164,10 @@ public sealed partial class GunComponent : Component
     public float BurstCooldown = 0.25f;
 
     /// <summary>
-    /// How much faster the gun will fire when in burst mode. Multiplicative.
+    /// The fire rate of the weapon in burst fire mode.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float BurstFireRateModifier = 1f;
+    public float BurstFireRate = 8f;
 
     /// <summary>
     /// Whether the burst fire mode has been activated.

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio;
@@ -157,6 +158,30 @@ public sealed partial class GunComponent : Component
     public int ShotsPerBurstModified = 3;
 
     /// <summary>
+    /// How long time must pass between burstfire shots.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float BurstCooldown = 0.25f;
+
+    /// <summary>
+    /// How much faster the gun will fire when in burst mode. Multiplicative.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float BurstFireRateModifier = 1f;
+
+    /// <summary>
+    /// Whether the burst fire mode has been activated.
+    /// </summary>
+    [AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public bool BurstActivated = false;
+
+    /// <summary>
+    /// The burst fire bullet count.
+    /// </summary>
+    [AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public int BurstShotsCount = 0;
+
+    /// <summary>
     /// Used for tracking semi-auto / burst
     /// </summary>
     [ViewVariables]
@@ -232,6 +257,12 @@ public sealed partial class GunComponent : Component
     /// </summary>
     [DataField]
     public bool ClumsyProof = false;
+
+    /// <summary>
+    /// Firing direction for an item not being held (e.g. shuttle cannons, thrown guns still firing).
+    /// </summary>
+    [DataField]
+    public Vector2 DefaultDirection = new Vector2(0, -1);
 }
 
 [Flags]

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -218,7 +218,7 @@ public abstract partial class SharedGunSystem : EntitySystem
     /// </summary>
     public void AttemptShoot(EntityUid gunUid, GunComponent gun)
     {
-        var coordinates = new EntityCoordinates(gunUid, new Vector2(0, -1));
+        var coordinates = new EntityCoordinates(gunUid, gun.DefaultDirection);
         gun.ShootCoordinates = coordinates;
         AttemptShoot(gunUid, gunUid, gun);
         gun.ShotCounter = 0;
@@ -258,6 +258,9 @@ public abstract partial class SharedGunSystem : EntitySystem
 
         var fireRate = TimeSpan.FromSeconds(1f / gun.FireRateModified);
 
+        if (gun.SelectedMode == SelectiveFire.Burst || gun.BurstActivated)
+            fireRate = fireRate / gun.BurstFireRateModifier;
+
         // First shot
         // Previously we checked shotcounter but in some cases all the bullets got dumped at once
         // curTime - fireRate is insufficient because if you time it just right you can get a 3rd shot out slightly quicker.
@@ -278,18 +281,24 @@ public abstract partial class SharedGunSystem : EntitySystem
 
         // Get how many shots we're actually allowed to make, due to clip size or otherwise.
         // Don't do this in the loop so we still reset NextFire.
-        switch (gun.SelectedMode)
+        if (!gun.BurstActivated)
         {
-            case SelectiveFire.SemiAuto:
-                shots = Math.Min(shots, 1 - gun.ShotCounter);
-                break;
-            case SelectiveFire.Burst:
-                shots = Math.Min(shots, gun.ShotsPerBurstModified - gun.ShotCounter);
-                break;
-            case SelectiveFire.FullAuto:
-                break;
-            default:
-                throw new ArgumentOutOfRangeException($"No implemented shooting behavior for {gun.SelectedMode}!");
+            switch (gun.SelectedMode)
+            {
+                case SelectiveFire.SemiAuto:
+                    shots = Math.Min(shots, 1 - gun.ShotCounter);
+                    break;
+                case SelectiveFire.Burst:
+                    shots = Math.Min(shots, gun.ShotsPerBurstModified - gun.ShotCounter);
+                    break;
+                case SelectiveFire.FullAuto:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException($"No implemented shooting behavior for {gun.SelectedMode}!");
+            }
+        } else
+        {
+            shots = Math.Min(shots, gun.ShotsPerBurstModified - gun.ShotCounter);
         }
 
         var attemptEv = new AttemptShootEvent(user, null);
@@ -301,7 +310,8 @@ public abstract partial class SharedGunSystem : EntitySystem
             {
                 PopupSystem.PopupClient(attemptEv.Message, gunUid, user);
             }
-
+            gun.BurstActivated = false;
+            gun.BurstShotsCount = 0;
             gun.NextFire = TimeSpan.FromSeconds(Math.Max(lastFire.TotalSeconds + SafetyNextFire, gun.NextFire.TotalSeconds));
             return;
         }
@@ -328,6 +338,10 @@ public abstract partial class SharedGunSystem : EntitySystem
             var emptyGunShotEvent = new OnEmptyGunShotEvent();
             RaiseLocalEvent(gunUid, ref emptyGunShotEvent);
 
+            gun.BurstActivated = false;
+            gun.BurstShotsCount = 0;
+            gun.NextFire += TimeSpan.FromSeconds(gun.BurstCooldown);
+
             // Play empty gun sounds if relevant
             // If they're firing an existing clip then don't play anything.
             if (shots > 0)
@@ -345,6 +359,22 @@ public abstract partial class SharedGunSystem : EntitySystem
             }
 
             return;
+        }
+
+        // Handle burstfire
+        if (gun.SelectedMode == SelectiveFire.Burst)
+        {
+            gun.BurstActivated = true;
+        }
+        if (gun.BurstActivated)
+        {
+            gun.BurstShotsCount += shots;
+            if (gun.BurstShotsCount >= gun.ShotsPerBurstModified)
+            {
+                gun.NextFire += TimeSpan.FromSeconds(gun.BurstCooldown);
+                gun.BurstActivated = false;
+                gun.BurstShotsCount = 0;
+            }
         }
 
         // Shoot confirmed - sounds also played here in case it's invalid (e.g. cartridge already spent).

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -259,7 +259,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         var fireRate = TimeSpan.FromSeconds(1f / gun.FireRateModified);
 
         if (gun.SelectedMode == SelectiveFire.Burst || gun.BurstActivated)
-            fireRate = fireRate / gun.BurstFireRateModifier;
+            fireRate = TimeSpan.FromSeconds(1f / gun.BurstFireRate);
 
         // First shot
         // Previously we checked shotcounter but in some cases all the bullets got dumped at once

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -19,6 +19,7 @@
     minAngle: 2
     maxAngle: 16
     fireRate: 8
+    burstFireRate: 8
     angleIncrease: 3
     angleDecay: 16
     selectedMode: FullAuto
@@ -142,6 +143,7 @@
       minAngle: 21
       maxAngle: 32
       fireRate: 12
+      burstFireRate: 12
       selectedMode: Burst
       soundGunshot:
         path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
@@ -254,7 +256,7 @@
     selectedMode: FullAuto
     shotsPerBurst: 5
     burstCooldown: 0.2
-    burstFireRateModifier: 1.273
+    burstFireRate: 7
     availableModes:
     - SemiAuto
     - Burst

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -27,6 +27,7 @@
     - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/smg.ogg
+    defaultDirection: 1, 0
   - type: ChamberMagazineAmmoProvider
     soundRack:
       path: /Audio/Weapons/Guns/Cock/smg_cock.ogg
@@ -140,12 +141,14 @@
     - type: Gun
       minAngle: 21
       maxAngle: 32
-      fireRate: 6
-      selectedMode: FullAuto
+      fireRate: 12
+      selectedMode: Burst
       soundGunshot:
         path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
       availableModes:
-        - FullAuto
+        - Burst
+      shotsPerBurst: 3
+      burstCooldown: 0.25
     - type: ItemSlots
       slots:
         gun_magazine:
@@ -250,6 +253,8 @@
     angleDecay: 6
     selectedMode: FullAuto
     shotsPerBurst: 5
+    burstCooldown: 0.2
+    burstFireRateModifier: 1.273
     availableModes:
     - SemiAuto
     - Burst


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This PR makes changes to the Burst firemode of guns, with major changes to Drozd and minor changes to WT550 and C20-r. The burst firemode was underutilized due to being largely unnecessary; no guns were balanced around it, and since you had to continuously hold the mouse button down to fire, you had free control to stop firing mid-burst. This PR aims to change that.

General changes:
- Burst firemode now fires the entire burst after pulling the trigger, even if the trigger is let go. The gun continues to fire even if the gun is let go until either the burst is over or all ammo is used up. 
- A delay has been introduced between bursts. This keeps burst mode from being used as full-auto by timing clicks/holding the trigger.
- Guns now have the ability to fire faster when toggled into burst mode.

Drozd changes (major):
- Drozd has been changed into a burst-only firemode SMG.
  - 3 bullets per burst, fired over 0.25 seconds. There is a burst delay of 0.25 seconds. This results in 6 shots per second, which is the same DPS as the previous version. 

WT550 changes (minor):
- WT550 is still an auto/semi/burst firemode toggle. 
- The burst mode has the same 5 bullets per burst but buffed to fire them over 0.714 seconds, with a burst delay of 0.2 seconds. This results in 5.5 shots per second, which is the same DPS as the full-auto mode. 

C20-r changes (minor):
- C20-r is still an auto/semi/burst firemode toggle.
- The burst mode has the same 5 bullets per burst and does not have a buffed firing speed, with a burst delay of 0.25 seconds. This results in a slightly lower DPS. However, due to each SMG mag containing 30 bullets and the C20-r's ability to auto-eject its mag, it becomes a lot more controllable to hotswap to a new mag with a bullet still in the chamber, which skips having to bolt the gun. Therefore it becomes much easier to reload faster if managed correctly.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

The Drozd, AKMS and Lecters were raised as currently being very similar with no real stand-out features in between them. The Drozd is supposed to have slightly higher DPS by sacrificing accuracy, but this is largely not felt in gameplay and hasn't created much distinction between the weapons. 

Changing the Drozd into a burst-fire only SMG pushes it into a much more unique niche, while perserving the strong DPS and higher spread. The choice to change the Drozd was due to the spread; being able to burst 3 bullets very rapidly with full accuracy down a hallway while cornerpeeking could be very punishing for the other side, but with spread you're encouraged to engage in the mid-range instead where it becomes harder to disengage.

The WT550 change makes the burst fire an optional mode for those that feel it suits them better; it's not much faster than full-auto (5.5 vs 7 firerate) and the delay keeps the DPS in check.

The C20-r change could have followed the same reasoning if not for the very strong assistance it provides for reloading. It becomes a lot harder to lose the final chamber bullet and the speedier reload this results in can make for frighteningly little downtime.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

To make for comfortable prediction the client is supposed to send shoot commands to the server. These are sent when the mouse button is held down and the server just checks if enough time has passed for the next shot to happen.
Since bursts are supposed to continue no matter what the client's input is the server might need to take responsibility for firing the bullets itself via its own update loop. `BurstEnabled` ensures this.
This is really only noticeable if the client experiences packet loss (e.g. a lag spike). 

Since the ship cannons also uses the gun system there has been a `DefaultDirection` property added that makes any thrown guns actively shooting fire in the direction of the sprite's muzzle.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
Video link ([youtube](https://www.youtube.com/watch?v=LCns95cXJB8)):
[![Video link](https://img.youtube.com/vi/LCns95cXJB8/0.jpg)](https://www.youtube.com/watch?v=LCns95cXJB8)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: WT550 and C20-r's "burst" firemodes are now actual bursts.
- tweak: Drozd is now a burst-only weapon (DPS remains unchanged!).
