### PR TITLE
Dialog windows now grab the keyboard focus

### DIFF
--- a/Content.Client/UserInterface/Controls/DialogWindow.xaml.cs
+++ b/Content.Client/UserInterface/Controls/DialogWindow.xaml.cs
@@ -87,6 +87,8 @@ public sealed partial class DialogWindow : FancyWindow
             Prompts.AddChild(box);
         }
 
+        _promptLines[0].Item2.GrabKeyboardFocus();
+
         OkButton.OnPressed += _ => Confirm();
 
         CancelButton.OnPressed += _ =>

--- a/Content.Client/UserInterface/Controls/DialogWindow.xaml.cs
+++ b/Content.Client/UserInterface/Controls/DialogWindow.xaml.cs
@@ -87,6 +87,7 @@ public sealed partial class DialogWindow : FancyWindow
             Prompts.AddChild(box);
         }
 
+        // Grab keyboard focus for the first dialog entry
         _promptLines[0].Item2.GrabKeyboardFocus();
 
         OkButton.OnPressed += _ => Confirm();


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
I made the first edit line in the dialog window grab the keyboard focus.

## Why / Balance
Fixes #28260.

## Technical details
``DialogWindow`` class constructor now gets the first line and calls the ``GrabKeyboardFocus`` method on it.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
https://github.com/user-attachments/assets/112200d4-7bc1-4e7a-a246-600b311fd2e0

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The first editable line in the dialog window now grabs the keyboard focus once it's open.