### PR TITLE
Move mining roid and magnet pulls closer

### DIFF
--- a/Content.Server/Salvage/Magnet/SalvageMagnetComponent.cs
+++ b/Content.Server/Salvage/Magnet/SalvageMagnetComponent.cs
@@ -3,5 +3,16 @@ namespace Content.Server.Salvage.Magnet;
 [RegisterComponent]
 public sealed partial class SalvageMagnetComponent : Component
 {
+    /// <summary>
+    /// The max distance at which the magnet will pull in wrecks.
+    /// Scales from 50% to 100%.
+    /// </summary>
+    [DataField]
+    public float MagnetSpawnDistance = 128f;
 
+    /// <summary>
+    /// How far offset to either side will the magnet wreck spawn.
+    /// </summary>
+    [DataField]
+    public float LateralOffset = 32f;
 }

--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -338,7 +338,7 @@ public sealed partial class SalvageSystem
             worldAngle = _random.NextAngle();
         }
 
-        if (!TryGetSalvagePlacementLocation(mapId, attachedBounds, bounds!.Value, worldAngle, out var spawnLocation, out var spawnAngle))
+        if (!TryGetSalvagePlacementLocation(magnet, mapId, attachedBounds, bounds!.Value, worldAngle, out var spawnLocation, out var spawnAngle))
         {
             Report(magnet.Owner, MagnetChannel, "salvage-system-announcement-spawn-no-debris-available");
             _mapManager.DeleteMap(salvMapXform.MapID);
@@ -390,22 +390,19 @@ public sealed partial class SalvageSystem
         RaiseLocalEvent(ref active);
     }
 
-    private bool TryGetSalvagePlacementLocation(MapId mapId, Box2Rotated attachedBounds, Box2 bounds, Angle worldAngle, out MapCoordinates coords, out Angle angle)
+    private bool TryGetSalvagePlacementLocation(Entity<SalvageMagnetComponent> magnet, MapId mapId, Box2Rotated attachedBounds, Box2 bounds, Angle worldAngle, out MapCoordinates coords, out Angle angle)
     {
-        // Grid intersection only does AABB atm.
         var attachedAABB = attachedBounds.CalcBoundingBox();
-
-        var minDistance = (attachedAABB.Height < attachedAABB.Width ? attachedAABB.Width : attachedAABB.Height) / 2f;
-        var minActualDistance = bounds.Height < bounds.Width ? minDistance + bounds.Width / 2f : minDistance + bounds.Height / 2f;
-
-        var attachedCenter = attachedAABB.Center;
-        var fraction = 0.25f;
+        var magnetPos = _transform.GetWorldPosition(magnet) + worldAngle.ToVec() * bounds.MaxDimension;
+        var origin = attachedAABB.ClosestPoint(magnetPos);
+        var fraction = 0.50f;
 
         // Thanks 20kdc
         for (var i = 0; i < 20; i++)
         {
-            var randomPos = attachedCenter +
-                            worldAngle.ToVec() * (minActualDistance * fraction);
+            var randomPos = origin +
+                            worldAngle.ToVec() * (magnet.Comp.MagnetSpawnDistance * fraction) +
+                            (worldAngle + Math.PI / 2).ToVec() * _random.NextFloat(-magnet.Comp.LateralOffset, magnet.Comp.LateralOffset);
             var finalCoords = new MapCoordinates(randomPos, mapId);
 
             angle = _random.NextAngle();
@@ -417,7 +414,7 @@ public sealed partial class SalvageSystem
             if (_mapManager.FindGridsIntersecting(finalCoords.MapId, box2Rot).Any())
             {
                 // Bump it further and further just in case.
-                fraction += 0.25f;
+                fraction += 0.1f;
                 continue;
             }
 

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -73,8 +73,8 @@
           - /Maps/Ruins/whiteship_ancient.yml
           - /Maps/Ruins/whiteship_bluespacejumper.yml
         vgroid: !type:DungeonSpawnGroup
-          minimumDistance: 400
-          maximumDistance: 450
+          minimumDistance: 300
+          maximumDistance: 350
           nameDataset: names_borer
           stationGrid: false
           addComponents:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Moves the mining asteroid distance from 400-450 down to 300-350.

Adjusts magnet pulls so they spawn at a more consistent distance that is closer to the station. The previous range was hard to calculate but now its about 64-128.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
#### Mining Asteroid
Having the mining asteroid be so far away that you cannot even see it on a mass scanner half the time makes any kind of non-shuttle traversal impossible. You should be fully capable of reaching it with just a jetpack and knowledge of its location. 

#### Magnet Pulls
The magnet has a weird consistency issue where the distance it pulls things in can vary wildly while also being dependent on the size of the map. This isn't an ideal solution as it means that magnet pulls, which are meant to be trivially accessible and low-tech, can spawn 250 meters out from the station. Moving it closer means that you can reach them by just running to them or with the gentle assistance of a fire extinguisher or a stack of rods.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Moved the mining asteroid slightly closer to the station.
- tweak: Things pulled in by the salvage magnet should spawn closer to the station at a more consistent distance.
