### PR TITLE
Fixes the projectile list in AmmoShotEvent when firing something with a ProjectileSpreadComponent

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -292,7 +292,7 @@ public sealed partial class GunSystem : SharedGunSystem
                 {
                     var newuid = Spawn(ammoSpreadComp.Proto, fromEnt);
                     ShootOrThrow(newuid, angles[i].ToVec(), gunVelocity, gun, gunUid, user);
-                    shotProjectiles.Add(ammoEnt);
+                    shotProjectiles.Add(newuid);
                 }
             }
             else


### PR DESCRIPTION

## About the PR
When firing a projectile with a `ProjectileSpreadComponent` the game spawns the extra projectiles correctly, but it only (repeatedly) adds the original projectile to `FiredProjectiles` in the AmmoShotEvent. So we can't modify those extra projectiles if we need to.

## Why / Balance
Bug. And it broke a few things in RMC14.

## Technical details
Changed one line of code.

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
No player-facing changes, since I'm pretty sure this only actually *broke* stuff downstream.
