### PR TITLE
add atmos stuff for mapping vox boxes

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
@@ -36,7 +36,7 @@ public sealed partial class AtmosphereSystem
            return;
        }
 
-       var mixtures = new GasMixture[7];
+       var mixtures = new GasMixture[8];
        for (var i = 0; i < mixtures.Length; i++)
            mixtures[i] = new GasMixture(Atmospherics.CellVolume) { Temperature = Atmospherics.T20C };
 
@@ -64,6 +64,9 @@ public sealed partial class AtmosphereSystem
        mixtures[6].AdjustMoles(Gas.Oxygen, Atmospherics.OxygenMolesStandard);
        mixtures[6].AdjustMoles(Gas.Nitrogen, Atmospherics.NitrogenMolesStandard);
        mixtures[6].Temperature = 235f; // Little colder than an actual freezer but gives a grace period to get e.g. themomachines set up, should keep warm for a few door openings
+
+       // 7: Nitrogen (101kpa) for vox rooms
+       mixtures[7].AdjustMoles(Gas.Nitrogen, Atmospherics.MolesCellStandard);
 
        foreach (var arg in args)
        {

--- a/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
@@ -11,8 +11,8 @@ namespace Content.Server.Atmos.Monitor.Components;
 [RegisterComponent]
 public sealed partial class AirAlarmComponent : Component
 {
-    [ViewVariables] public AirAlarmMode CurrentMode { get; set; } = AirAlarmMode.Filtering;
-    [ViewVariables] public bool AutoMode { get; set; } = true;
+    [DataField] public AirAlarmMode CurrentMode { get; set; } = AirAlarmMode.Filtering;
+    [DataField] public bool AutoMode { get; set; } = true;
 
     // Remember to null this afterwards.
     [ViewVariables] public IAirAlarmModeUpdate? CurrentModeUpdater { get; set; }

--- a/Content.Server/Atmos/Piping/Trinary/Components/GasFilterComponent.cs
+++ b/Content.Server/Atmos/Piping/Trinary/Components/GasFilterComponent.cs
@@ -5,31 +5,25 @@ namespace Content.Server.Atmos.Piping.Trinary.Components
     [RegisterComponent]
     public sealed partial class GasFilterComponent : Component
     {
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("enabled")]
-        public bool Enabled { get; set; } = true;
+        [DataField]
+        public bool Enabled = true;
 
-        [ViewVariables(VVAccess.ReadWrite)]
         [DataField("inlet")]
-        public string InletName { get; set; } = "inlet";
+        public string InletName = "inlet";
 
-        [ViewVariables(VVAccess.ReadWrite)]
         [DataField("filter")]
-        public string FilterName { get; set; } = "filter";
+        public string FilterName = "filter";
 
-        [ViewVariables(VVAccess.ReadWrite)]
         [DataField("outlet")]
-        public string OutletName { get; set; } = "outlet";
+        public string OutletName = "outlet";
 
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
+        public float TransferRate = Atmospherics.MaxTransferRate;
 
-        [DataField("transferRate")]
-        public float TransferRate { get; set; } = Atmospherics.MaxTransferRate;
+        [DataField]
+        public float MaxTransferRate = Atmospherics.MaxTransferRate;
 
-        [DataField("maxTransferRate")]
-        public float MaxTransferRate { get; set; } = Atmospherics.MaxTransferRate;
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        public Gas? FilteredGas { get; set; }
+        [DataField]
+        public Gas? FilteredGas;
     }
 }

--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentScrubberComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentScrubberComponent.cs
@@ -9,26 +9,25 @@ namespace Content.Server.Atmos.Piping.Unary.Components
     [Access(typeof(GasVentScrubberSystem))]
     public sealed partial class GasVentScrubberComponent : Component
     {
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public bool Enabled { get; set; } = false;
 
-        [ViewVariables]
+        [DataField]
         public bool IsDirty { get; set; } = false;
 
-        [ViewVariables(VVAccess.ReadWrite)]
         [DataField("outlet")]
         public string OutletName { get; set; } = "pipe";
 
-        [ViewVariables]
-        public readonly HashSet<Gas> FilterGases = new(GasVentScrubberData.DefaultFilterGases);
+        [DataField]
+        public HashSet<Gas> FilterGases = new(GasVentScrubberData.DefaultFilterGases);
 
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public ScrubberPumpDirection PumpDirection { get; set; } = ScrubberPumpDirection.Scrubbing;
 
         /// <summary>
         ///     Target volume to transfer. If <see cref="WideNet"/> is enabled, actual transfer rate will be much higher.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public float TransferRate
         {
             get => _transferRate;
@@ -37,18 +36,17 @@ namespace Content.Server.Atmos.Piping.Unary.Components
 
         private float _transferRate = Atmospherics.MaxTransferRate;
 
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("maxTransferRate")]
+        [DataField]
         public float MaxTransferRate = Atmospherics.MaxTransferRate;
 
         /// <summary>
         ///     As pressure difference approaches this number, the effective volume rate may be smaller than <see
         ///     cref="TransferRate"/>
         /// </summary>
-        [DataField("maxPressure")]
+        [DataField]
         public float MaxPressure = Atmospherics.MaxOutputPressure;
 
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public bool WideNet { get; set; } = false;
 
         public GasVentScrubberData ToAirAlarmData()

--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -89,3 +89,17 @@
   id: danger # just any gas you don't want at all
   upperBound: !type:AlarmThresholdSetting
     threshold: 0.0001
+
+- type: alarmThreshold
+  id: voxOxygen
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 0.02 # 2%
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.5 # 1%
+
+- type: alarmThreshold
+  id: voxNitrogen
+  lowerBound: !type:AlarmThresholdSetting
+    threshold: 0.8 # danger below 80% nitrogen
+  lowerWarnAround: !type:AlarmThresholdSetting
+    threshold: 1.125 # warning below 90%

--- a/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
+++ b/Resources/Prototypes/Entities/Markers/atmos_blocker.yml
@@ -99,3 +99,12 @@
           state: freeze
     - type: AtmosFixMarker
       mode: 6
+
+- type: entity
+  parent: AtmosFixNitrogenMarker
+  id: AtmosFixVoxMarker
+  suffix: Vox Atmosphere
+  description: "Nitrogen @ 101 kPa, 20C"
+  components:
+  - type: AtmosFixMarker
+    mode: 7

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
@@ -1,0 +1,50 @@
+- type: entity
+  abstract: true
+  parent: AirSensorBase
+  id: AirSensorVoxBase
+  suffix: Vox Atmosphere
+  components:
+  - type: AtmosMonitor
+    gasThresholdPrototypes:
+      Oxygen: voxOxygen
+      Nitrogen: voxNitrogen
+      CarbonDioxide: stationCO2
+      Plasma: stationPlasma
+      Tritium: stationTritium
+      WaterVapor: stationWaterVapor
+      Ammonia: stationAmmonia
+      NitrousOxide: stationNO
+      Frezon: danger
+
+- type: entity
+  parent: [AirSensorVoxBase, AirSensor]
+  id: AirSensorVox
+
+- type: entity
+  parent: [AirSensorVoxBase, GasVentPump]
+  id: GasVentPumpVox
+
+- type: entity
+  parent: [AirSensorVoxBase, GasVentScrubber]
+  id: GasVentScrubberVox
+  components:
+  - type: GasVentScrubber
+    wideNet: true # Air alarm with auto mode overrides filters with hardcoded defaults so default to widenet
+    filterGases:
+    - Oxygen # filter out oxygen as well as regular harmful gases
+    - CarbonDioxide
+    - Plasma
+    - Tritium
+    - WaterVapor
+    - Ammonia
+    - NitrousOxide
+    - Frezon
+
+# use this to prevent overriding filters with hardcoded defaults
+- type: entity
+  parent: AirAlarm
+  id: AirAlarmVox
+  suffix: Vox Atmosphere, auto mode disabled
+  components:
+  - type: AirAlarm
+    autoMode: false


### PR DESCRIPTION
## About the PR
- add atmos fix vox box marker for 101kpa nitrogen
- add `[Vox Atmosphere]` suffixed scrubber, vent, air alarm
- gas filters can save their filtered gas so you can have it filter nitrogen roundstart

## Why / Balance
for mapping and persistence

## Technical details
- added datafield to a lot of fields for persistence mapping and prototypes
- because air alarm shitcode has the filter list for each mode hardcoded, auto mode has to be disabled for vox air alarm. since it cant set wide filtering with the air alarms, vox scrubbers have widenet enabled by default

## Media
scrubber filters nitrogen out
![04:30:23](https://github.com/user-attachments/assets/79492ae7-bef2-43d2-985d-4eadb749cbb7)

air alarm vox thresholds are real
![04:31:34](https://github.com/user-attachments/assets/5ea318f2-9206-4787-87db-7fe703eba0b0)
(now widenet and manual)
![04:31:21](https://github.com/user-attachments/assets/51afa888-5fe7-4eca-91c9-094e924d844c)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun