### PR TITLE
Make space scanning T1 technology

### DIFF
--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -18,6 +18,20 @@
   - ClothingMaskWeldingGas
 
 - type: technology
+  id: SpaceScanning
+  name: research-technology-space-scanning
+  icon:
+    sprite: Objects/Tools/handheld_mass_scanner.rsi
+    state: icon
+  discipline: Industrial
+  tier: 1
+  cost: 5000
+  recipeUnlocks:
+  - RadarConsoleCircuitboard
+  - HandHeldMassScanner
+  - BorgModuleGPS
+
+- type: technology
   id: AdvancedPowercells
   name: research-technology-advanced-powercells
   icon:
@@ -108,20 +122,6 @@
   - MechEquipmentGrabber
 
 # Tier 2
-
-- type: technology
-  id: SpaceScanning
-  name: research-technology-space-scanning
-  icon:
-    sprite: Objects/Tools/handheld_mass_scanner.rsi
-    state: icon
-  discipline: Industrial
-  tier: 2
-  cost: 7500
-  recipeUnlocks:
-  - RadarConsoleCircuitboard
-  - HandHeldMassScanner
-  - BorgModuleGPS
 
 - type: technology
   id: Shuttlecraft


### PR DESCRIPTION
## About the PR
The space scanning technology, and thus the handheld mass scanner and borg GPS module, are now T1 technology.

## Why / Balance
Mass scanner consoles are roundstart, and handheld mass scanners can often be found easily by salvage, so there's not much point in gating them behind T2 industrial.

## Media
![image](https://github.com/user-attachments/assets/5e73ccee-7ff6-4675-b289-df25c1c40611)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Space scanning technology is now T1 industrial, this includes cyborg GPS modules and handheld mass scanners.
