### PR TITLE
Add pickaxes to Engi-Vend for easier meteor repair

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -10,3 +10,4 @@
     ClothingHandsGlovesColorYellow: 6
     BoxInflatable: 2
     ClothingHeadHatCone: 4
+    Pickaxe: 2


### PR DESCRIPTION
## About the PR
This PR adds 2 pickaxes to the engi-vend inventory to better equip engineers to respond to meteor strikes.
## Why / Balance
The recent frequency of meteor strikes makes it necessary for engineering to find mining tools to remove unwanted rubble, however getting said tools from QM can be iffy and takes time. Providing engineering with a few pickaxes lets them fix holes faster and lets whoever got their work blown up get back to the game.

## Technical details
Added 2 pickaxes to the end of engivend.yml

## Media

https://github.com/user-attachments/assets/5742aeda-7e19-4e59-a8cd-bfbfbc48ec32


## Requirements
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.
- [X ] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [ X] I have added screenshots/videos to this PR showcasing its changes ingame


**Changelog**
:cl:
- add: Added Pickaxe to Engi-Vend for meteor repair technicians!
