### PR TITLE
fix Gatherable magic number

### DIFF
--- a/Content.Server/Gatherable/GatherableSystem.cs
+++ b/Content.Server/Gatherable/GatherableSystem.cs
@@ -78,8 +78,11 @@ public sealed partial class GatherableSystem : EntitySystem
             }
             var getLoot = _proto.Index(table);
             var spawnLoot = getLoot.GetSpawns(_random);
-            var spawnPos = pos.Offset(_random.NextVector2(component.GatherOffset));
-            Spawn(spawnLoot[0], spawnPos);
+            foreach (var loot in spawnLoot)
+            {
+                var spawnPos = pos.Offset(_random.NextVector2(component.GatherOffset));
+                Spawn(loot, spawnPos);
+            }
         }
     }
 }


### PR DESCRIPTION
bugfix[0]

why the hell does Gatherable only use the first element of the table and not all that are generated?