### PR TITLE
Make guidebook remember where you left off

### DIFF
--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
@@ -23,7 +23,7 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler
 
     private readonly ISawmill _sawmill;
 
-    public ProtoId<GuideEntryPrototype> _lastEntry;
+    public ProtoId<GuideEntryPrototype> LastEntry;
 
     public GuidebookWindow()
     {
@@ -93,7 +93,7 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler
             _sawmill.Error($"Failed to parse contents of guide document {entry.Id}.");
         }
 
-        _lastEntry = entry.Id;
+        LastEntry = entry.Id;
     }
 
     public void UpdateGuides(

--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
@@ -23,6 +23,8 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler
 
     private readonly ISawmill _sawmill;
 
+    public ProtoId<GuideEntryPrototype> _lastEntry;
+
     public GuidebookWindow()
     {
         RobustXamlLoader.Load(this);
@@ -90,6 +92,8 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler
 
             _sawmill.Error($"Failed to parse contents of guide document {entry.Id}.");
         }
+
+        _lastEntry = entry.Id;
     }
 
     public void UpdateGuides(

--- a/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
+++ b/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
@@ -197,7 +197,7 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
 
         if (selected == null)
         {
-            if (_lastEntry != null && guides.ContainsKey((ProtoId<GuideEntryPrototype>)_lastEntry))
+            if (_lastEntry is { } lastEntry && guides.ContainsKey(lastEntry))
             {
                 selected = _lastEntry;
             }

--- a/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
+++ b/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
@@ -30,7 +30,7 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
 
     private GuidebookWindow? _guideWindow;
     private MenuButton? GuidebookButton => UIManager.GetActiveUIWidgetOrNull<MenuBar.Widgets.GameTopMenuBar>()?.GuidebookButton;
-    private ProtoId<GuideEntryPrototype> _lastEntry;
+    private ProtoId<GuideEntryPrototype>? _lastEntry;
 
     public void OnStateEntered(LobbyState state)
     {
@@ -194,15 +194,18 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
                 RecursivelyAddChildren(guide, guides);
             }
         }
-        if (guides.ContainsKey(_lastEntry))
-        {
-            selected ??= _lastEntry;
-        }
-        else
-        {
-            selected ??= _configuration.GetCVar(CCVars.DefaultGuide);
-        }
 
+        if (selected == null)
+        {
+            if (_lastEntry != null && guides.ContainsKey((ProtoId<GuideEntryPrototype>)_lastEntry))
+            {
+                selected = _lastEntry;
+            }
+            else
+            {
+                selected = _configuration.GetCVar(CCVars.DefaultGuide);
+            }
+        }
         _guideWindow.UpdateGuides(guides, rootEntries, forceRoot, selected);
 
         // Expand up to depth-2.

--- a/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
+++ b/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
@@ -30,6 +30,7 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
 
     private GuidebookWindow? _guideWindow;
     private MenuButton? GuidebookButton => UIManager.GetActiveUIWidgetOrNull<MenuBar.Widgets.GameTopMenuBar>()?.GuidebookButton;
+    private ProtoId<GuideEntryPrototype> _lastEntry;
 
     public void OnStateEntered(LobbyState state)
     {
@@ -142,7 +143,10 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
             GuidebookButton.Pressed = false;
 
         if (_guideWindow != null)
+        {
             _guideWindow.ReturnContainer.Visible = false;
+            _lastEntry = _guideWindow._lastEntry;
+        }
     }
 
     private void OnWindowOpen()
@@ -191,6 +195,10 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
             {
                 RecursivelyAddChildren(guide, guides);
             }
+        }
+        if (guides.ContainsKey(_lastEntry))
+        {
+            selected = _lastEntry;
         }
 
         _guideWindow.UpdateGuides(guides, rootEntries, forceRoot, selected);

--- a/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
+++ b/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
@@ -145,7 +145,7 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
         if (_guideWindow != null)
         {
             _guideWindow.ReturnContainer.Visible = false;
-            _lastEntry = _guideWindow._lastEntry;
+            _lastEntry = _guideWindow.LastEntry;
         }
     }
 
@@ -180,8 +180,6 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
         if (GuidebookButton != null)
             GuidebookButton.SetClickPressed(!_guideWindow.IsOpen);
 
-        selected ??= _configuration.GetCVar(CCVars.DefaultGuide);
-
         if (guides == null)
         {
             guides = _prototypeManager.EnumeratePrototypes<GuideEntryPrototype>()
@@ -198,7 +196,11 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
         }
         if (guides.ContainsKey(_lastEntry))
         {
-            selected = _lastEntry;
+            selected ??= _lastEntry;
+        }
+        else
+        {
+            selected ??= _configuration.GetCVar(CCVars.DefaultGuide);
         }
 
         _guideWindow.UpdateGuides(guides, rootEntries, forceRoot, selected);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Re-opening the guidebook after closing it will now display the last read entry instead of defaulting to the top of the list.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Not having to constantly navigate back to the page you were reading should make it much more convenient to reference stuff like chemical/recipe tables.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a `_lastEntry` variable to the guidebook window and UI controller. The window updates `_lastEntry` whenever selecting a new page, and it gets sent to the controller upon closing the window. 
When opening the guidebook the controller checks if the current guide list contains that entry, and then passes that entry in as `selected`.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

https://github.com/user-attachments/assets/80db5586-f667-4c11-8be0-06ea9781b380

Plays nice with trainee books as well, defaulting to the front page if it doesn't contain the last read entry. 

https://github.com/user-attachments/assets/a211d239-ed86-4417-8ce1-697261ed82ee




## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: The guidebook now remembers where you left off when re-opened.
