### PR TITLE
Mobs with `CanEscapeInventoryComponent` now have a grace period after escaping (or being dropped while escaping)

### DIFF
--- a/Content.Server/Resist/CanEscapeInventoryComponent.cs
+++ b/Content.Server/Resist/CanEscapeInventoryComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.DoAfter;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Resist;
 
@@ -12,11 +13,17 @@ public sealed partial class CanEscapeInventoryComponent : Component
     public float BaseResistTime = 5f;
 
     /// <summary>
-    /// Penalty time for when you are let go during resisting.
-    /// No one can pick you up during this time.
+    ///     Initial amount of time when you cannot be picked up when dropped while escaping
     /// </summary>
-    [DataField("penaltyTimer")]
-    public float PenaltyTimer = 0f;
+    [DataField("basePenaltyTime")]
+    public float BasePenaltyTime = 1.0f;
+
+    /// <summary>
+    /// Penalty time for when you are let go during resisting.
+    /// No one can pick you up before current time reaches this value.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan PenaltyTimer = TimeSpan.MaxValue;
 
     public bool IsEscaping => DoAfter != null;
 

--- a/Content.Server/Resist/CanEscapeInventoryComponent.cs
+++ b/Content.Server/Resist/CanEscapeInventoryComponent.cs
@@ -11,6 +11,13 @@ public sealed partial class CanEscapeInventoryComponent : Component
     [DataField("baseResistTime")]
     public float BaseResistTime = 5f;
 
+    /// <summary>
+    /// Penalty time for when you are let go during resisting.
+    /// No one can pick you up during this time.
+    /// </summary>
+    [DataField("penaltyTimer")]
+    public float PenaltyTimer = 0f;
+
     public bool IsEscaping => DoAfter != null;
 
     [DataField("doAfter")]

--- a/Content.Server/Resist/CanEscapeInventoryComponent.cs
+++ b/Content.Server/Resist/CanEscapeInventoryComponent.cs
@@ -23,7 +23,8 @@ public sealed partial class CanEscapeInventoryComponent : Component
     /// No one can pick you up before current time reaches this value.
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
-    public TimeSpan PenaltyTimer = TimeSpan.MaxValue;
+    [AutoPausedField]
+    public TimeSpan PenaltyTimer = TimeSpan.Zero;
 
     public bool IsEscaping => DoAfter != null;
 

--- a/Content.Server/Resist/CanEscapeInventoryComponent.cs
+++ b/Content.Server/Resist/CanEscapeInventoryComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Resist;
 
-[RegisterComponent]
+[RegisterComponent, AutoGenerateComponentPause]
 public sealed partial class CanEscapeInventoryComponent : Component
 {
     /// <summary>

--- a/Content.Server/Resist/CanEscapeInventoryComponent.cs
+++ b/Content.Server/Resist/CanEscapeInventoryComponent.cs
@@ -9,13 +9,13 @@ public sealed partial class CanEscapeInventoryComponent : Component
     /// <summary>
     /// Base doafter length for uncontested breakouts.
     /// </summary>
-    [DataField("baseResistTime")]
+    [DataField]
     public float BaseResistTime = 5f;
 
     /// <summary>
     ///     Initial amount of time when you cannot be picked up when dropped while escaping
     /// </summary>
-    [DataField("basePenaltyTime")]
+    [DataField]
     public float BasePenaltyTime = 1.0f;
 
     /// <summary>

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -110,10 +110,7 @@ public sealed class EscapeInventorySystem : EntitySystem
             return;
         // so we are being dropped while we are escaping.
         _doAfterSystem.Cancel(component.DoAfter);
-        /*
-         * TODO: Set this to 1 or something lower on PR approval, this is just for demoing
-         */
-        component.PenaltyTimer = 5f;
+        component.PenaltyTimer = 1f;
         RemComp<ItemComponent>(uid);
     }
 }

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -3,7 +3,6 @@ using Content.Shared.Storage.Components;
 using Content.Shared.ActionBlocker;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands.EntitySystems;
-using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Item;
@@ -40,7 +39,8 @@ public sealed class EscapeInventorySystem : EntitySystem
             if (comp.PenaltyTimer <= 0)
                 continue;
             comp.PenaltyTimer -= frameTime;
-            if (comp.PenaltyTimer <= 0) {
+            if (comp.PenaltyTimer <= 0)
+            {
                 // make the item able to be picked up again
                 AddComp<ItemComponent>(uid);
             }

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -40,9 +40,7 @@ public sealed class EscapeInventorySystem : EntitySystem
         ref GettingPickedUpAttemptEvent args)
     {
         if (_timing.CurTime < component.PenaltyTimer)
-        {
             args.Cancel();
-        }
     }
     private void OnRelayMovement(EntityUid uid, CanEscapeInventoryComponent component, ref MoveInputEvent args)
     {

--- a/Content.Server/Resist/EscapeInventorySystem.cs
+++ b/Content.Server/Resist/EscapeInventorySystem.cs
@@ -21,6 +21,11 @@ public sealed class EscapeInventorySystem : EntitySystem
     [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
 
+    /// <summary>
+    ///     Initial amount of time when you cannot be picked up when dropped while escaping
+    /// </summary>
+    private const float BasePenaltyTime = 1.0f;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -110,7 +115,7 @@ public sealed class EscapeInventorySystem : EntitySystem
             return;
         // so we are being dropped while we are escaping.
         _doAfterSystem.Cancel(component.DoAfter);
-        component.PenaltyTimer = 1f;
+        component.PenaltyTimer = BasePenaltyTime;
         RemComp<ItemComponent>(uid);
     }
 }

--- a/Content.Shared/Resist/CanEscapeInventoryComponent.cs
+++ b/Content.Shared/Resist/CanEscapeInventoryComponent.cs
@@ -1,9 +1,10 @@
 using Content.Shared.DoAfter;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
-namespace Content.Server.Resist;
+namespace Content.Shared.Resist;
 
-[RegisterComponent, AutoGenerateComponentPause]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
 public sealed partial class CanEscapeInventoryComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Resist/EscapeInventorySystem.cs
+++ b/Content.Shared/Resist/EscapeInventorySystem.cs
@@ -83,8 +83,8 @@ public sealed class EscapeInventorySystem : EntitySystem
         if (!_doAfterSystem.TryStartDoAfter(doAfterEventArgs, out component.DoAfter))
             return;
 
-        _popupSystem.PopupPredicted(Loc.GetString("escape-inventory-component-start-resisting"), user, user);
-        _popupSystem.PopupPredicted(Loc.GetString("escape-inventory-component-start-resisting-target"), container, container);
+        _popupSystem.PopupEntity(Loc.GetString("escape-inventory-component-start-resisting"), user, user);
+        _popupSystem.PopupEntity(Loc.GetString("escape-inventory-component-start-resisting-target"), container, container);
     }
 
     private void OnEscape(EntityUid uid, CanEscapeInventoryComponent component, EscapeInventoryEvent args)

--- a/Content.Shared/Resist/EscapeInventorySystem.cs
+++ b/Content.Shared/Resist/EscapeInventorySystem.cs
@@ -1,4 +1,3 @@
-using Content.Server.Popups;
 using Content.Shared.Storage.Components;
 using Content.Shared.ActionBlocker;
 using Content.Shared.DoAfter;
@@ -7,17 +6,18 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Item;
 using Content.Shared.Movement.Events;
+using Content.Shared.Popups;
 using Content.Shared.Resist;
 using Content.Shared.Storage;
 using Robust.Shared.Timing;
 using Robust.Shared.Containers;
 
-namespace Content.Server.Resist;
+namespace Content.Shared.Resist;
 
 public sealed class EscapeInventorySystem : EntitySystem
 {
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
-    [Dependency] private readonly PopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;

--- a/Content.Shared/Resist/EscapeInventorySystem.cs
+++ b/Content.Shared/Resist/EscapeInventorySystem.cs
@@ -52,7 +52,7 @@ public sealed class EscapeInventorySystem : EntitySystem
         // Make sure there's nothing stopped the removal (like being glued)
         if (!_containerSystem.CanRemove(uid, container))
         {
-            _popupSystem.PopupPredicted(Loc.GetString("escape-inventory-component-failed-resisting"), uid, uid);
+            _popupSystem.PopupEntity(Loc.GetString("escape-inventory-component-failed-resisting"), uid, uid);
             return;
         }
 

--- a/Content.Shared/Resist/EscapeInventorySystem.cs
+++ b/Content.Shared/Resist/EscapeInventorySystem.cs
@@ -7,7 +7,6 @@ using Content.Shared.Inventory;
 using Content.Shared.Item;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
-using Content.Shared.Resist;
 using Content.Shared.Storage;
 using Robust.Shared.Timing;
 using Robust.Shared.Containers;
@@ -53,7 +52,7 @@ public sealed class EscapeInventorySystem : EntitySystem
         // Make sure there's nothing stopped the removal (like being glued)
         if (!_containerSystem.CanRemove(uid, container))
         {
-            _popupSystem.PopupEntity(Loc.GetString("escape-inventory-component-failed-resisting"), uid, uid);
+            _popupSystem.PopupPredicted(Loc.GetString("escape-inventory-component-failed-resisting"), uid, uid);
             return;
         }
 
@@ -84,8 +83,8 @@ public sealed class EscapeInventorySystem : EntitySystem
         if (!_doAfterSystem.TryStartDoAfter(doAfterEventArgs, out component.DoAfter))
             return;
 
-        _popupSystem.PopupEntity(Loc.GetString("escape-inventory-component-start-resisting"), user, user);
-        _popupSystem.PopupEntity(Loc.GetString("escape-inventory-component-start-resisting-target"), container, container);
+        _popupSystem.PopupPredicted(Loc.GetString("escape-inventory-component-start-resisting"), user, user);
+        _popupSystem.PopupPredicted(Loc.GetString("escape-inventory-component-start-resisting-target"), container, container);
     }
 
     private void OnEscape(EntityUid uid, CanEscapeInventoryComponent component, EscapeInventoryEvent args)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I made mobs that are small enough to be in a players hands have a small period of time in which they cannot be picked up which takes effect if they were dropped after escaping or being dropped while escaping.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This basically prevents players from dropping a mouse and then quickly picking them up again in order to effectively cancel the mouse's escape doAfter.
Also prevents AI Monkeys from trapping you in an infinite escape loop.

Also because this happened to me recently (as of making this PR) and I essentially made this PR out of spite.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
CanEscapeInventoryComponent and EscapeInventorySystem have been moved from Server to Shared, and made predictable.

In the component, added a `PenaltyTimer` TimeSpan.
In the system, Added a `GettingPickedUpEvent` Local Event Subscription that checks if `PenaltyTimer` is passed by `curTime`, changed `OnDropped()` so that it sets the `PenaltyTimer` when dropped WHILE a doAfter is in progress, changed `DoEscape()` to apply the grace period on success (because AI MONKEYS ARE A PAIN IN THE ASS)
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
(penalty time is way larger than it should be for demoing purposes but its still gonna be 1 second)

https://github.com/user-attachments/assets/f74e261e-0f0c-4f24-b103-f6e099188c20


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl:
- tweak: Mice, Mothroaches, etc., can no longer be picked up for a brief moment after escaping from your inventory or dropping them during.
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
