### PR TITLE
Throw the book at em! The space law book now does 1 blunt projectile damage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -385,6 +385,10 @@
     damage:
       types:
         Blunt: 1
+  - type: DamageOtherOnHit # so you can throw the book at 'em
+    damage:
+      types:
+        Blunt: 1
 
 - type: entity
   parent: BookBase

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -33,6 +33,16 @@
     backgroundImagePath: "/Textures/Interface/Paper/paper_background_book.svg.96dpi.png"
     backgroundPatchMargin: 23.0, 16.0, 14.0, 15.0
     contentMargin: 20.0, 20.0, 20.0, 20.0
+  - type: MeleeWeapon  # This was originally a feature exclusive to the law book but maintainers decided it should apply to all books for consistency. I frankly disagree but :P
+    soundHit:
+      collection: Punch
+    damage:
+      types:
+        Blunt: 1
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 1
 
 - type: entity
   id: BookSpaceEncyclopedia
@@ -379,16 +389,6 @@
     openOnActivation: true
     guides:
     - SpaceLaw
-  - type: MeleeWeapon # so you can beat stupid cadets
-    soundHit:
-      collection: Punch
-    damage:
-      types:
-        Blunt: 1
-  - type: DamageOtherOnHit # so you can throw the book at 'em
-    damage:
-      types:
-        Blunt: 1
 
 - type: entity
   parent: BookBase


### PR DESCRIPTION
## About the PR
added one projectile damage to the space law book, so you can literally throw the book at someone in addition to just hitting people with it.

## Why / Balance
Funny, and it already does one blunt, just not as a projectile, so I felt like it was a missed opportunity

## Media

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- tweak: Books now do one blunt damage when thrown as a projectile..