### PR TITLE
decouple ItemToggle from PowerCellDraw

### DIFF
--- a/Content.Server/PowerCell/PowerCellSystem.Draw.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.Draw.cs
@@ -14,11 +14,11 @@ public sealed partial class PowerCellSystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
-        var query = EntityQueryEnumerator<PowerCellDrawComponent, PowerCellSlotComponent, ItemToggleComponent>();
+        var query = EntityQueryEnumerator<PowerCellDrawComponent, PowerCellSlotComponent>();
 
-        while (query.MoveNext(out var uid, out var comp, out var slot, out var toggle))
+        while (query.MoveNext(out var uid, out var comp, out var slot))
         {
-            if (!comp.Enabled || !toggle.Activated)
+            if (!comp.Enabled || !Toggle.IsActivated(uid))
                 continue;
 
             if (Timing.CurTime < comp.NextUpdateTime)
@@ -32,7 +32,7 @@ public sealed partial class PowerCellSystem
             if (_battery.TryUseCharge(batteryEnt.Value, comp.DrawRate, battery))
                 continue;
 
-            Toggle.TryDeactivate((uid, toggle));
+            Toggle.TryDeactivate(uid, predicted: false);
 
             var ev = new PowerCellSlotEmptyEvent();
             RaiseLocalEvent(uid, ref ev);

--- a/Content.Server/PowerCell/PowerCellSystem.Draw.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.Draw.cs
@@ -1,5 +1,4 @@
 using Content.Server.Power.Components;
-using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.PowerCell;
 using Content.Shared.PowerCell.Components;
 
@@ -18,7 +17,7 @@ public sealed partial class PowerCellSystem
 
         while (query.MoveNext(out var uid, out var comp, out var slot))
         {
-            if (!comp.Enabled || !Toggle.IsActivated(uid))
+            if (!comp.Enabled)
                 continue;
 
             if (Timing.CurTime < comp.NextUpdateTime)
@@ -31,8 +30,6 @@ public sealed partial class PowerCellSystem
 
             if (_battery.TryUseCharge(batteryEnt.Value, comp.DrawRate, battery))
                 continue;
-
-            Toggle.TryDeactivate(uid, predicted: false);
 
             var ev = new PowerCellSlotEmptyEvent();
             RaiseLocalEvent(uid, ref ev);
@@ -60,7 +57,10 @@ public sealed partial class PowerCellSystem
         var canUse = !args.Ejected && HasActivatableCharge(uid, component);
 
         if (!canDraw)
-            Toggle.TryDeactivate(uid);
+        {
+            var ev = new PowerCellSlotEmptyEvent();
+            RaiseLocalEvent(uid, ref ev);
+        }
 
         if (canUse != component.CanUse || canDraw != component.CanDraw)
         {

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -282,6 +282,7 @@ public sealed partial class BorgSystem : SharedBorgSystem
     {
         Popup.PopupEntity(Loc.GetString("borg-mind-added", ("name", Identity.Name(uid, EntityManager))), uid);
         Toggle.TryActivate(uid);
+        _powerCell.SetDrawEnabled(uid, _mobState.IsAlive(uid));
         _appearance.SetData(uid, BorgVisuals.HasPlayer, true);
     }
 
@@ -292,6 +293,7 @@ public sealed partial class BorgSystem : SharedBorgSystem
     {
         Popup.PopupEntity(Loc.GetString("borg-mind-removed", ("name", Identity.Name(uid, EntityManager))), uid);
         Toggle.TryDeactivate(uid);
+        _powerCell.SetDrawEnabled(uid, false);
         _appearance.SetData(uid, BorgVisuals.HasPlayer, false);
     }
 

--- a/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
@@ -23,7 +23,7 @@ public sealed class ItemToggleSystem : EntitySystem
     [Dependency] private readonly SharedPointLightSystem _light = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
-    private EntityQuery _query;
+    private EntityQuery<ItemToggleComponent> _query;
 
     public override void Initialize()
     {

--- a/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
@@ -23,9 +23,13 @@ public sealed class ItemToggleSystem : EntitySystem
     [Dependency] private readonly SharedPointLightSystem _light = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
+    private EntityQuery _query;
+
     public override void Initialize()
     {
         base.Initialize();
+
+        _query = GetEntityQuery<ItemToggleComponent>();
 
         SubscribeLocalEvent<ItemToggleComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<ItemToggleComponent, MapInitEvent>(OnMapInit);
@@ -69,7 +73,7 @@ public sealed class ItemToggleSystem : EntitySystem
     /// <returns>Same as <see cref="TrySetActive"/></returns>
     public bool Toggle(Entity<ItemToggleComponent?> ent, EntityUid? user = null, bool predicted = true)
     {
-        if (!Resolve(ent, ref ent.Comp))
+        if (!_query.Resolve(ent, ref ent.Comp, false))
             return false;
 
         return TrySetActive(ent, !ent.Comp.Activated, user, predicted);
@@ -92,7 +96,7 @@ public sealed class ItemToggleSystem : EntitySystem
     /// </summary>
     public bool TryActivate(Entity<ItemToggleComponent?> ent, EntityUid? user = null, bool predicted = true)
     {
-        if (!Resolve(ent, ref ent.Comp))
+        if (!_query.Resolve(ent, ref ent.Comp, false))
             return false;
 
         var uid = ent.Owner;
@@ -135,7 +139,7 @@ public sealed class ItemToggleSystem : EntitySystem
     /// </summary>
     public bool TryDeactivate(Entity<ItemToggleComponent?> ent, EntityUid? user = null, bool predicted = true)
     {
-        if (!Resolve(ent, ref ent.Comp))
+        if (!_query.Resolve(ent, ref ent.Comp, false))
             return false;
 
         var uid = ent.Owner;
@@ -230,7 +234,7 @@ public sealed class ItemToggleSystem : EntitySystem
 
     public bool IsActivated(Entity<ItemToggleComponent?> ent)
     {
-        if (!Resolve(ent, ref ent.Comp, false))
+        if (!_query.Resolve(ent, ref ent.Comp, false))
             return true; // assume always activated if no component
 
         return ent.Comp.Activated;

--- a/Content.Shared/PowerCell/Components/ToggleCellDrawComponent.cs
+++ b/Content.Shared/PowerCell/Components/ToggleCellDrawComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.PowerCell.Components;
+
+/// <summary>
+/// Integrate PowerCellDraw and ItemToggle.
+/// Make toggling this item require power, and deactivates the item when power runs out.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ToggleCellDrawComponent : Component;

--- a/Content.Shared/PowerCell/PowerCellDrawComponent.cs
+++ b/Content.Shared/PowerCell/PowerCellDrawComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.PowerCell;
 /// </summary>
 /// <remarks>
 /// With ActivatableUI it will activate and deactivate when the ui is opened and closed, drawing power inbetween.
-/// Requires <see cref="ItemToggleComponent"/> to work.
+/// If it has <see cref="ItemToggleComponent"/> it must also be toggled to work.
 /// </remarks>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class PowerCellDrawComponent : Component

--- a/Content.Shared/PowerCell/PowerCellDrawComponent.cs
+++ b/Content.Shared/PowerCell/PowerCellDrawComponent.cs
@@ -8,7 +8,6 @@ namespace Content.Shared.PowerCell;
 /// </summary>
 /// <remarks>
 /// With ActivatableUI it will activate and deactivate when the ui is opened and closed, drawing power inbetween.
-/// If it has <see cref="ItemToggleComponent"/> it must also be toggled to work.
 /// </remarks>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class PowerCellDrawComponent : Component
@@ -30,9 +29,8 @@ public sealed partial class PowerCellDrawComponent : Component
     #endregion
 
     /// <summary>
-    /// Whether drawing is enabled, regardless of ItemToggle.
+    /// Whether drawing is enabled.
     /// Having no cell will still disable it.
-    /// Only use this if you really don't want it to use power for some time.
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool Enabled = true;

--- a/Content.Shared/PowerCell/SharedPowerCellSystem.cs
+++ b/Content.Shared/PowerCell/SharedPowerCellSystem.cs
@@ -1,6 +1,4 @@
 using Content.Shared.Containers.ItemSlots;
-using Content.Shared.Item.ItemToggle;
-using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.PowerCell.Components;
 using Content.Shared.Rejuvenate;
 using Robust.Shared.Containers;
@@ -13,7 +11,6 @@ public abstract class SharedPowerCellSystem : EntitySystem
     [Dependency] protected readonly IGameTiming Timing = default!;
     [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-    [Dependency] protected readonly ItemToggleSystem Toggle = default!;
 
     public override void Initialize()
     {
@@ -23,9 +20,6 @@ public abstract class SharedPowerCellSystem : EntitySystem
         SubscribeLocalEvent<PowerCellSlotComponent, EntInsertedIntoContainerMessage>(OnCellInserted);
         SubscribeLocalEvent<PowerCellSlotComponent, EntRemovedFromContainerMessage>(OnCellRemoved);
         SubscribeLocalEvent<PowerCellSlotComponent, ContainerIsInsertingAttemptEvent>(OnCellInsertAttempt);
-
-        SubscribeLocalEvent<PowerCellDrawComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
-        SubscribeLocalEvent<PowerCellDrawComponent, ItemToggledEvent>(OnToggled);
     }
 
     private void OnRejuvenate(EntityUid uid, PowerCellSlotComponent component, RejuvenateEvent args)
@@ -70,16 +64,13 @@ public abstract class SharedPowerCellSystem : EntitySystem
         RaiseLocalEvent(uid, new PowerCellChangedEvent(true), false);
     }
 
-    private void OnActivateAttempt(Entity<PowerCellDrawComponent> ent, ref ItemToggleActivateAttemptEvent args)
+    /// <summary>
+    /// Makes the draw logic update in the next tick.
+    /// </summary>
+    public void QueueUpdate(Entity<PowerCellDrawComponent?> ent)
     {
-        if (!HasDrawCharge(ent, ent.Comp, user: args.User)
-            || !HasActivatableCharge(ent, ent.Comp, user: args.User))
-            args.Cancelled = true;
-    }
-
-    private void OnToggled(Entity<PowerCellDrawComponent> ent, ref ItemToggledEvent args)
-    {
-        ent.Comp.NextUpdateTime = Timing.CurTime;
+        if (Resolve(ent, ref ent.Comp))
+            ent.Comp.NextUpdateTime = Timing.CurTime;
     }
 
     public void SetDrawEnabled(Entity<PowerCellDrawComponent?> ent, bool enabled)

--- a/Content.Shared/PowerCell/SharedPowerCellSystem.cs
+++ b/Content.Shared/PowerCell/SharedPowerCellSystem.cs
@@ -16,10 +16,17 @@ public abstract class SharedPowerCellSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<PowerCellDrawComponent, MapInitEvent>(OnMapInit);
+
         SubscribeLocalEvent<PowerCellSlotComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<PowerCellSlotComponent, EntInsertedIntoContainerMessage>(OnCellInserted);
         SubscribeLocalEvent<PowerCellSlotComponent, EntRemovedFromContainerMessage>(OnCellRemoved);
         SubscribeLocalEvent<PowerCellSlotComponent, ContainerIsInsertingAttemptEvent>(OnCellInsertAttempt);
+    }
+
+    private void OnMapInit(Entity<PowerCellDrawComponent> ent, ref MapInitEvent args)
+    {
+        QueueUpdate((ent, ent.Comp));
     }
 
     private void OnRejuvenate(EntityUid uid, PowerCellSlotComponent component, RejuvenateEvent args)

--- a/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
+++ b/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
@@ -24,7 +24,7 @@ public sealed class ToggleCellDrawSystem : EntitySystem
 
     private void OnMapInit(Entity<ToggleCellDrawComponent> ent, ref MapInitEvent args)
     {
-        _cell.SetDrawEnabled(uid, _toggle.IsActivated(ent.Owner));
+        _cell.SetDrawEnabled(ent.Owner, _toggle.IsActivated(ent.Owner));
     }
 
     private void OnActivateAttempt(Entity<ToggleCellDrawComponent> ent, ref ItemToggleActivateAttemptEvent args)

--- a/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
+++ b/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
@@ -1,0 +1,43 @@
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.PowerCell.Components;
+
+namespace Content.Shared.PowerCell;
+
+/// <summary>
+/// Handles events to integrate PowerCellDraw with ItemToggle
+/// </summary>
+public sealed class ToggleCellDrawSystem : EntitySystem
+{
+    [Dependency] private readonly ItemToggleSystem _toggle = default!;
+    [Dependency] private readonly SharedPowerCellSystem _cell = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ToggleCellDrawComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
+        SubscribeLocalEvent<ToggleCellDrawComponent, ItemToggledEvent>(OnToggled);
+        SubscribeLocalEvent<ToggleCellDrawComponent, PowerCellSlotEmptyEvent>(OnEmpty);
+    }
+
+    private void OnActivateAttempt(Entity<ToggleCellDrawComponent> ent, ref ItemToggleActivateAttemptEvent args)
+    {
+        if (!_cell.HasDrawCharge(ent, ent.Comp, user: args.User)
+            || !_cell.HasActivatableCharge(ent, ent.Comp, user: args.User))
+            args.Cancelled = true;
+    }
+
+    private void OnToggled(Entity<ToggleCellDrawComponent> ent, ref ItemToggledEvent args)
+    {
+        var uid = ent.Owner;
+        var draw = Comp<PowerCellDrawComponent>(uid);
+        _cell.QueueUpdate((uid, draw));
+        _cell.SetDrawEnabled((uid, draw), args.Activated);
+    }
+
+    private void OnEmpty(Entity<ToggleCellDrawComponent> ent, ref PowerCellSlotEmptyEvent args)
+    {
+        _toggle.TryDeactivate(ent.Owner);
+    }
+}

--- a/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
+++ b/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
@@ -23,8 +23,8 @@ public sealed class ToggleCellDrawSystem : EntitySystem
 
     private void OnActivateAttempt(Entity<ToggleCellDrawComponent> ent, ref ItemToggleActivateAttemptEvent args)
     {
-        if (!_cell.HasDrawCharge(ent, ent.Comp, user: args.User)
-            || !_cell.HasActivatableCharge(ent, ent.Comp, user: args.User))
+        if (!_cell.HasDrawCharge(ent, user: args.User)
+            || !_cell.HasActivatableCharge(ent user: args.User))
             args.Cancelled = true;
     }
 

--- a/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
+++ b/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
@@ -24,7 +24,7 @@ public sealed class ToggleCellDrawSystem : EntitySystem
     private void OnActivateAttempt(Entity<ToggleCellDrawComponent> ent, ref ItemToggleActivateAttemptEvent args)
     {
         if (!_cell.HasDrawCharge(ent, user: args.User)
-            || !_cell.HasActivatableCharge(ent user: args.User))
+            || !_cell.HasActivatableCharge(ent, user: args.User))
             args.Cancelled = true;
     }
 

--- a/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
+++ b/Content.Shared/PowerCell/ToggleCellDrawSystem.cs
@@ -16,9 +16,15 @@ public sealed class ToggleCellDrawSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<ToggleCellDrawComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<ToggleCellDrawComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
         SubscribeLocalEvent<ToggleCellDrawComponent, ItemToggledEvent>(OnToggled);
         SubscribeLocalEvent<ToggleCellDrawComponent, PowerCellSlotEmptyEvent>(OnEmpty);
+    }
+
+    private void OnMapInit(Entity<ToggleCellDrawComponent> ent, ref MapInitEvent args)
+    {
+        _cell.SetDrawEnabled(uid, _toggle.IsActivated(ent.Owner));
     }
 
     private void OnActivateAttempt(Entity<ToggleCellDrawComponent> ent, ref ItemToggleActivateAttemptEvent args)

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -160,6 +160,7 @@
       lastVisibility: 0.1
   - type: PowerCellDraw
     drawRate: 1.8 # 200 seconds on the default cell
+  - type: ToggleCellDraw
   # throwing star ability
   - type: ItemCreator
     action: ActionCreateThrowingStar

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -116,6 +116,7 @@
     price: 500
   - type: PowerCellDraw
     drawRate: 4
+  - type: ToggleCellDraw
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -126,6 +126,7 @@
   # TODO: or just have sentient speedboots be fast idk
   - type: PowerCellDraw
     drawRate: 0.6
+  # no ToggleCellDraw since dont want to lose access when power is gone
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
@@ -9,3 +9,4 @@
   - type: PowerCellDraw
     drawRate: 0
     useRate: 20
+  - type: ToggleCellDraw

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -47,6 +47,7 @@
   components:
   - type: PowerCellDraw
     drawRate: 1.2 #Calculated for 5 minutes on a small cell
+  - type: ToggleCellDraw
   - type: ActivatableUIRequiresPowerCell
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -68,6 +68,7 @@
   - type: PowerCellDraw
     drawRate: 1
     useRate: 0
+  - type: ToggleCellDraw
 
 - type: entity
   id: AnomalyLocatorEmpty
@@ -101,6 +102,7 @@
   - type: PowerCellDraw
     drawRate: 1
     useRate: 0
+  - type: ToggleCellDraw
 
 - type: entity
   id: AnomalyLocatorWideEmpty

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -26,6 +26,7 @@
           False: { visible: false }
   - type: PowerCellDraw
     drawRate: 1.5
+  - type: ToggleCellDraw
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
     inHandsOnly: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -169,6 +169,7 @@
     - type: ItemToggle
       onUse: false
     - type: PowerCellDraw
+    - type: ToggleCellDraw
     - type: Sprite
       sprite: Objects/Weapons/Guns/Launchers/tether_gun.rsi
       layers:
@@ -216,6 +217,7 @@
     - type: ItemToggle
       onUse: false
     - type: PowerCellDraw
+    - type: ToggleCellDraw
     - type: Sprite
       sprite: Objects/Weapons/Guns/Launchers/force_gun.rsi
       layers:


### PR DESCRIPTION
## About the PR
idk why i did this but now it actually works without it

## Why / Balance
fixes #31377 

## Technical details
(uid, toggle) -> uid
added ToggleCellDraw which everything but borg has (borg uses ItemToggle for toggling access, so it would lose access if power ran out)

## Media

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed borgs losing access when they run out of power.