### PR TITLE
Change `Resave` Permission Requirement to Host

### DIFF
--- a/Content.Server/Maps/ResaveCommand.cs
+++ b/Content.Server/Maps/ResaveCommand.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Maps;
 /// <summary>
 /// Loads every map and resaves it into the data folder.
 /// </summary>
-[AdminCommand(AdminFlags.Mapping)]
+[AdminCommand(AdminFlags.Host)]
 public sealed class ResaveCommand : LocalizedCommands
 {
     [Dependency] private readonly IEntityManager _entManager = default!;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changes the admin flag on the `resave` command to be host, not mapping.

## Why / Balance
Due to the nature of the resave command (and its capability to make watchdog angry to the point of causing a server restart), it should be locked behind a non-standard permission. The `mapping` permission is given out to admins (to my understanding fairly regularly), while the mapping permission is incredibly valuable for admins, resave shouldn't be included in that list due to its potency and the nature of the command.

## Technical details
The admin flag for the resave command now checks for host, not mapping.

## Media
N/A

## Requirements

- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
You are more than free to nuke this CL, I'm unsure if you deem this change CL worthy, but I wished to write one just incase.

:cl:
ADMIN:
- tweak: The resave command is no longer usable with the mapping permission, instead it requires host permissions.
