### PR TITLE
Increase (SUPER)PACMAN ramp rate/tolerance

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
@@ -182,6 +182,9 @@
         - output_mv
       sprite: Structures/Power/Generation/portable_generator.rsi
       state: portgen0
+    - type: PowerSupplier
+      supplyRampRate: 5000
+      supplyRampTolerance: 1500
 
 - type: entity
   name: S.U.P.E.R.P.A.C.M.A.N.-type portable generator
@@ -235,6 +238,9 @@
         - output_mv
       sprite: Structures/Power/Generation/portable_generator.rsi
       state: portgen1
+    - type: PowerSupplier
+      supplyRampRate: 7500
+      supplyRampTolerance: 2500
 
 - type: entity
   name: J.R.P.A.C.M.A.N.-type portable generator


### PR DESCRIPTION
All PACMANs used to use the same ramping parameters, this meant a SUPERPACMAN (50 kW) took literally a 100 seconds to get up to its full output level. Ouch.

PACMAN has been raised to 5000 W/s with 1500 W tolerance, SUPERPACMAN to 7500 W/s with 2500 W tolerance

:cl:
- tweak: PACMAN and SUPERPACMAN now ramp their power output significantly faster.