### PR TITLE
Ashen hud item status slot fix

### DIFF
--- a/Content.Client/UserInterface/Systems/Inventory/Controls/ItemStatusPanel.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/Controls/ItemStatusPanel.xaml.cs
@@ -38,6 +38,7 @@ public sealed partial class ItemStatusPanel : Control
         StyleBox.Margin cutOut;
         StyleBox.Margin flat;
         Thickness contentMargin;
+        Thickness patchMargin;
 
         switch (location)
         {
@@ -61,15 +62,19 @@ public sealed partial class ItemStatusPanel : Control
 
         Contents.Margin = contentMargin;
 
+        //Important to note for patchMargin!
+        //Because of hand ui flipping, left and right instead correspond to outside and inside respectively.
+        patchMargin = MarginFromThemeColor("_itemstatus_patch_margin");
+
         var panel = (StyleBoxTexture) Panel.PanelOverride!;
         panel.Texture = texture;
-        panel.SetPatchMargin(flat, 4);
-        panel.SetPatchMargin(cutOut, 7);
+        panel.SetPatchMargin(flat, patchMargin.Right);
+        panel.SetPatchMargin(cutOut, patchMargin.Left);
 
         var panelHighlight = (StyleBoxTexture) HighlightPanel.PanelOverride!;
         panelHighlight.Texture = textureHighlight;
-        panelHighlight.SetPatchMargin(flat, 4);
-        panelHighlight.SetPatchMargin(cutOut, 7);
+        panelHighlight.SetPatchMargin(flat, patchMargin.Left);
+        panelHighlight.SetPatchMargin(cutOut, patchMargin.Right);
 
         _side = location;
     }

--- a/Content.Client/UserInterface/Systems/Inventory/Controls/ItemStatusPanel.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/Controls/ItemStatusPanel.xaml.cs
@@ -68,13 +68,17 @@ public sealed partial class ItemStatusPanel : Control
 
         var panel = (StyleBoxTexture) Panel.PanelOverride!;
         panel.Texture = texture;
-        panel.SetPatchMargin(flat, patchMargin.Right);
         panel.SetPatchMargin(cutOut, patchMargin.Left);
+        panel.SetPatchMargin(flat, patchMargin.Right);
+        panel.SetPatchMargin(StyleBox.Margin.Top, patchMargin.Top);
+        panel.SetPatchMargin(StyleBox.Margin.Bottom, patchMargin.Bottom);
 
         var panelHighlight = (StyleBoxTexture) HighlightPanel.PanelOverride!;
         panelHighlight.Texture = textureHighlight;
-        panelHighlight.SetPatchMargin(flat, patchMargin.Left);
-        panelHighlight.SetPatchMargin(cutOut, patchMargin.Right);
+        panelHighlight.SetPatchMargin(cutOut, patchMargin.Left);
+        panelHighlight.SetPatchMargin(flat, patchMargin.Right);
+        panelHighlight.SetPatchMargin(StyleBox.Margin.Top, patchMargin.Top);
+        panelHighlight.SetPatchMargin(StyleBox.Margin.Bottom, patchMargin.Bottom);
 
         _side = location;
     }

--- a/Resources/Prototypes/themes.yml
+++ b/Resources/Prototypes/themes.yml
@@ -14,6 +14,7 @@
     disabledFore: "#5A5A5A"
     _itemstatus_content_margin_right: "#06060404"
     _itemstatus_content_margin_left: "#04060604"
+    _itemstatus_patch_margin: "#07000400"
 - type: uiTheme
   id: SS14PlasmafireTheme
   path: /Textures/Interface/Plasmafire/
@@ -30,6 +31,7 @@
     disabledFore: "#FFF5EE"
     _itemstatus_content_margin_right: "#06060404"
     _itemstatus_content_margin_left: "#04060604"
+    _itemstatus_patch_margin: "#07000400"
 - type: uiTheme
   id: SS14SlimecoreTheme
   path: /Textures/Interface/Slimecore/
@@ -46,6 +48,7 @@
     disabledFore: "#FFF5EE"
     _itemstatus_content_margin_right: "#06060404"
     _itemstatus_content_margin_left: "#04060604"
+    _itemstatus_patch_margin: "#07000400"
 - type: uiTheme
   id: SS14ClockworkTheme
   path: /Textures/Interface/Clockwork/
@@ -62,6 +65,7 @@
     disabledFore: "#FFF5EE"
     _itemstatus_content_margin_right: "#06060404"
     _itemstatus_content_margin_left: "#04060604"
+    _itemstatus_patch_margin: "#07000400"
 - type: uiTheme
   id: SS14RetroTheme
   path: /Textures/Interface/Retro/
@@ -78,6 +82,7 @@
     disabledFore: "#FFF5EE"
     _itemstatus_content_margin_right: "#06060404"
     _itemstatus_content_margin_left: "#04060604"
+    _itemstatus_patch_margin: "#07000400"
 - type: uiTheme
   id: SS14MinimalistTheme
   path: /Textures/Interface/Minimalist/
@@ -94,6 +99,7 @@
     disabledFore: "#5A5A5A"
     _itemstatus_content_margin_right: "#06060604"
     _itemstatus_content_margin_left: "#06060604"
+    _itemstatus_patch_margin: "#07000400"
 - type: uiTheme
   id: SS14AshenTheme
   path: /Textures/Interface/Ashen/
@@ -110,3 +116,4 @@
     disabledFore: "#FFF5EE"
     _itemstatus_content_margin_right: "#06060604"
     _itemstatus_content_margin_left: "#06060604"
+    _itemstatus_patch_margin: "#07000500"

--- a/Resources/Prototypes/themes.yml
+++ b/Resources/Prototypes/themes.yml
@@ -14,7 +14,7 @@
     disabledFore: "#5A5A5A"
     _itemstatus_content_margin_right: "#06060404"
     _itemstatus_content_margin_left: "#04060604"
-    _itemstatus_patch_margin: "#07000400"
+    _itemstatus_patch_margin: "#07060404"
 - type: uiTheme
   id: SS14PlasmafireTheme
   path: /Textures/Interface/Plasmafire/
@@ -31,7 +31,7 @@
     disabledFore: "#FFF5EE"
     _itemstatus_content_margin_right: "#06060404"
     _itemstatus_content_margin_left: "#04060604"
-    _itemstatus_patch_margin: "#07000400"
+    _itemstatus_patch_margin: "#07060404"
 - type: uiTheme
   id: SS14SlimecoreTheme
   path: /Textures/Interface/Slimecore/
@@ -48,7 +48,7 @@
     disabledFore: "#FFF5EE"
     _itemstatus_content_margin_right: "#06060404"
     _itemstatus_content_margin_left: "#04060604"
-    _itemstatus_patch_margin: "#07000400"
+    _itemstatus_patch_margin: "#07060404"
 - type: uiTheme
   id: SS14ClockworkTheme
   path: /Textures/Interface/Clockwork/
@@ -65,7 +65,7 @@
     disabledFore: "#FFF5EE"
     _itemstatus_content_margin_right: "#06060404"
     _itemstatus_content_margin_left: "#04060604"
-    _itemstatus_patch_margin: "#07000400"
+    _itemstatus_patch_margin: "#07060404"
 - type: uiTheme
   id: SS14RetroTheme
   path: /Textures/Interface/Retro/
@@ -82,7 +82,7 @@
     disabledFore: "#FFF5EE"
     _itemstatus_content_margin_right: "#06060404"
     _itemstatus_content_margin_left: "#04060604"
-    _itemstatus_patch_margin: "#07000400"
+    _itemstatus_patch_margin: "#07060404"
 - type: uiTheme
   id: SS14MinimalistTheme
   path: /Textures/Interface/Minimalist/
@@ -99,7 +99,7 @@
     disabledFore: "#5A5A5A"
     _itemstatus_content_margin_right: "#06060604"
     _itemstatus_content_margin_left: "#06060604"
-    _itemstatus_patch_margin: "#07000400"
+    _itemstatus_patch_margin: "#07060404"
 - type: uiTheme
   id: SS14AshenTheme
   path: /Textures/Interface/Ashen/
@@ -116,4 +116,4 @@
     disabledFore: "#FFF5EE"
     _itemstatus_content_margin_right: "#06060604"
     _itemstatus_content_margin_left: "#06060604"
-    _itemstatus_patch_margin: "#07000500"
+    _itemstatus_patch_margin: "#07060505"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I added a new system to determine the margins copied when expanding hand slots, preventing stray pixels that appeared in the Ashen hud.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Fixes https://github.com/space-wizards/space-station-14/issues/30642 and makes future similar issues quick to fix.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
It reuses a system labeled as "the worst code I've ever programmed", courtesy of PJB. This uses a color entry in a theme's definition in themes.yaml to store the thickness of margins for hand item status slots. The original stores the margins for content inside the slots, the new field stores the padding margins for what part of the base slot image should be repeated when expanding when creating the hotbar UI.

All themes except the Ashen theme use the original padding margin values, with Ashen being tweaked to prevent the large corners from being partially repeated, resulting in the pixels mentioned in the above issue.

The content margin field is split into left and right, but this is unnecessary for padding margins, which automatically get flipped horizontally based on which status slot is being rendered. I also rearranged the order of padding margin being set, because it didn't line up with the order of declaration and instantiation for flat and cutOut and that bugged me.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
We're looking at the borders of the item status slots here
Ashen hud before fix:
![Screenshot_20240824_211608](https://github.com/user-attachments/assets/11468524-f84a-4c9c-a4c5-ba97aaf88d45)
Ashen hud after fix:
![Screenshot_20240824_204659](https://github.com/user-attachments/assets/ee629f0b-330d-4417-a58c-804e7daa2d5e)
Default hud after fix (just to show that other themes still work):
![Screenshot_20240824_204731](https://github.com/user-attachments/assets/61f91dd1-5f29-4c01-8222-7ba8640aa904)


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
