### PR TITLE
medical lockers no longer have belts in them.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -50,7 +50,6 @@
       - id: ClothingHandsGlovesLatex
       - id: ClothingHeadsetMedical
       - id: ClothingEyesHudMedical
-      - id: ClothingBeltMedicalFilled
       - id: ClothingHeadHatSurgcapGreen
         prob: 0.1
         orGroup: Surgcaps
@@ -84,7 +83,6 @@
       - id: ClothingHandsGlovesLatex
       - id: ClothingHeadsetMedical
       - id: ClothingEyesHudMedical
-      - id: ClothingBeltMedicalFilled
       - id: ClothingHeadHatSurgcapGreen
         prob: 0.1
         orGroup: Surgcaps

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -50,7 +50,7 @@
       - id: ClothingHandsGlovesLatex
       - id: ClothingHeadsetMedical
       - id: ClothingEyesHudMedical
-      - id: ClothingBeltMedical
+      - id: ClothingBeltMedicalFilled
       - id: ClothingHeadHatSurgcapGreen
         prob: 0.1
         orGroup: Surgcaps
@@ -84,7 +84,7 @@
       - id: ClothingHandsGlovesLatex
       - id: ClothingHeadsetMedical
       - id: ClothingEyesHudMedical
-      - id: ClothingBeltMedical
+      - id: ClothingBeltMedicalFilled
       - id: ClothingHeadHatSurgcapGreen
         prob: 0.1
         orGroup: Surgcaps

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
@@ -6,6 +6,7 @@
     ClothingBackpackSatchelMedical: 4
     ClothingUniformJumpsuitMedicalDoctor: 4
     ClothingUniformJumpskirtMedicalDoctor: 4
+    ClothingBeltMedical: 4
     ClothingHeadHatBeretMedic: 4
     ClothingHeadNurseHat: 4
     ClothingOuterCoatLab: 4


### PR DESCRIPTION
## About the PR
Removed the empty belts from medical lockers. Empty belts are now in the medidrobe.

## Why / Balance
fixes #31469 

## Technical details


## Media

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl:
- tweak: medibelts are found in the medidrobe instead of in lockers.