### PR TITLE
Fix energy sword visuals

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -22,6 +22,7 @@
   - type: ItemToggleHot
   - type: ItemToggleSize
     activatedSize: Huge
+  - type: ItemTogglePointLight
   - type: ItemToggleMeleeWeapon
     activatedSoundOnHit:
       path: /Audio/Weapons/eblade1.ogg


### PR DESCRIPTION
## About the PR
See title. They currently don't show the glowing laser blade when toggled on.
This was overlooked in #31312

## Why / Balance
bugfix

## Technical details
In #31312 the light toggle was split off from ItemToggleComponent into the new ItemTogglePointLightComponent
We add the missing component.

## Media
![Screenshot (256)](https://github.com/user-attachments/assets/c47f030c-8a07-467d-97a7-28981b992139)

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed energy sword visuals.
