### PR TITLE
Goliath rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -49,12 +49,12 @@
       Dead:
         Base: goliath_dead
   - type: MovementSpeedModifier
-    baseWalkSpeed : 2.50
-    baseSprintSpeed : 2.50
+    baseWalkSpeed : 2.00
+    baseSprintSpeed : 2.00
   - type: MobThresholds
     thresholds:
       0: Alive
-      300: Dead
+      250: Dead
   - type: MeleeWeapon
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
@@ -63,7 +63,7 @@
     animation: WeaponArcPunch
     damage:
       types:
-        Slash: 15
+        Slash: 10
         Piercing: 10
   - type: NpcFactionMember
     factions:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

- Adjusted Goliath death threshold from 300 to 250.  The Goliath now has less health
- Adjusted Goliath move speed from 2.50 to 2.00.  The Goliath is now slightly slower
- Adjusted Slash damage from 15 to 10.  The Goliath now does 10 Slash and 10 Pierce per melee hit.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The goliath provides a new and different combat challenge for salvage players, however **given the quantity of them found within vgroids, they are slightly overtuned**.  Their very fast ranged AoE stun has few counterplay options in cramped areas and presents a threat that encourages players to avoid them, which is good.  These adjustments to health, movement speed, and damage will lower the skill floor slightly so that salvage players will be slightly less punished when encountering these mobs, while preserving their status as a dangerous threat that should ideally be avoided unless the player is sufficiently equipped.


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [ X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X ]this PR does not require an ingame showcase

## Breaking changes
<!--
None
-->

**Changelog**
<!--
Slightly reduced goliath health, movement speed, and melee damage.
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- tweak: Goliath movespeed adjusted from 2.50 to 2.00
- tweak: Goliath health reduced by 16.667%
- tweak: Goliath melee damage reduced from 15 slash 10 pierce to 10 slash 10 pierce
-->
