### PR TITLE
Add an option for hiding vote counts to customvote

### DIFF
--- a/Content.Client/Voting/UI/VotePopup.xaml.cs
+++ b/Content.Client/Voting/UI/VotePopup.xaml.cs
@@ -55,7 +55,9 @@ namespace Content.Client.Voting.UI
             for (var i = 0; i < _voteButtons.Length; i++)
             {
                 var entry = _vote.Entries[i];
-                _voteButtons[i].Text = Loc.GetString("ui-vote-button", ("text", entry.Text), ("votes", entry.Votes));
+                _voteButtons[i].Text = _vote.ShowVotes
+                    ? Loc.GetString("ui-vote-button", ("text", entry.Text), ("votes", entry.Votes))
+                    : entry.Text; // There is no need to use Loc.GetString here because no formatting is needed.
 
                 if (_vote.OurVote == i)
                     _voteButtons[i].Pressed = true;

--- a/Content.Client/Voting/VoteManager.cs
+++ b/Content.Client/Voting/VoteManager.cs
@@ -155,7 +155,7 @@ namespace Content.Client.Voting
                 {
                     Entries = message.Options
                         .Select(c => new VoteEntry(c.name))
-                        .ToArray()
+                        .ToArray(),
                 };
 
                 existingVote = vote;
@@ -182,6 +182,7 @@ namespace Content.Client.Voting
             // It can't hurt to just re-set this stuff since I'm lazy and the server is sending it anyways, so...
             existingVote.Initiator = message.VoteInitiator;
             existingVote.Title = message.VoteTitle;
+            existingVote.ShowVotes = message.ShowVotes;
             existingVote.StartTime = _gameTiming.RealServerToLocal(message.StartTime);
             existingVote.EndTime = _gameTiming.RealServerToLocal(message.EndTime);
 
@@ -245,6 +246,7 @@ namespace Content.Client.Voting
             public string Initiator = "";
             public int? OurVote;
             public int Id;
+            public bool ShowVotes;
 
             public ActiveVote(int voteId)
             {

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -57,7 +57,7 @@ namespace Content.Server.Voting.Managers
 
             var ghostVotePercentageRequirement = _cfg.GetCVar(CCVars.VoteRestartGhostPercentage);
             var ghostCount = 0;
-            
+
             foreach (var player in _playerManager.Sessions)
             {
                 _playerManager.UpdateState(player);
@@ -174,7 +174,8 @@ namespace Content.Server.Voting.Managers
                 Title = Loc.GetString("ui-vote-gamemode-title"),
                 Duration = alone
                     ? TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerAlone))
-                    : TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerPreset))
+                    : TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerPreset)),
+                ShowVotes = false,
             };
 
             if (alone)
@@ -220,7 +221,8 @@ namespace Content.Server.Voting.Managers
                 Title = Loc.GetString("ui-vote-map-title"),
                 Duration = alone
                     ? TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerAlone))
-                    : TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerMap))
+                    : TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerMap)),
+                ShowVotes = false,
             };
 
             if (alone)

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -209,7 +209,7 @@ namespace Content.Server.Voting.Managers
             var start = _timing.RealTime;
             var end = start + options.Duration;
             var reg = new VoteReg(id, entries, options.Title, options.InitiatorText,
-                options.InitiatorPlayer, start, end);
+                options.InitiatorPlayer, start, end, options.ShowVotes);
 
             var handle = new VoteHandle(this, reg);
 
@@ -251,6 +251,7 @@ namespace Content.Server.Voting.Managers
                 msg.VoteInitiator = v.InitiatorText;
                 msg.StartTime = v.StartTime;
                 msg.EndTime = v.EndTime;
+                msg.ShowVotes = v.ShowVotes;
             }
 
             if (v.CastVotes.TryGetValue(player, out var cast))
@@ -270,7 +271,7 @@ namespace Content.Server.Voting.Managers
             for (var i = 0; i < msg.Options.Length; i++)
             {
                 ref var entry = ref v.Entries[i];
-                msg.Options[i] = ((ushort) entry.Votes, entry.Text);
+                msg.Options[i] = (v.ShowVotes ? (ushort) entry.Votes : (ushort)0, entry.Text);
             }
 
             player.Channel.SendMessage(msg);
@@ -441,6 +442,7 @@ namespace Content.Server.Voting.Managers
             public readonly string InitiatorText;
             public readonly TimeSpan StartTime;
             public readonly TimeSpan EndTime;
+            public readonly bool ShowVotes;
             public readonly HashSet<ICommonSession> VotesDirty = new();
 
             public bool Cancelled;
@@ -452,7 +454,7 @@ namespace Content.Server.Voting.Managers
             public ICommonSession? Initiator { get; }
 
             public VoteReg(int id, VoteEntry[] entries, string title, string initiatorText,
-                ICommonSession? initiator, TimeSpan start, TimeSpan end)
+                ICommonSession? initiator, TimeSpan start, TimeSpan end, bool showVotes)
             {
                 Id = id;
                 Entries = entries;
@@ -461,6 +463,7 @@ namespace Content.Server.Voting.Managers
                 Initiator = initiator;
                 StartTime = start;
                 EndTime = end;
+                ShowVotes = showVotes;
             }
         }
 

--- a/Content.Server/Voting/VoteOptions.cs
+++ b/Content.Server/Voting/VoteOptions.cs
@@ -34,6 +34,11 @@ namespace Content.Server.Voting
         public TimeSpan? InitiatorTimeout { get; set; }
 
         /// <summary>
+        /// Show the current number of votes in each of the options while the vote is ongoing.
+        /// </summary>
+        public bool ShowVotes { get; set; } = true;
+
+        /// <summary>
         ///     The options of the vote. Each entry is a tuple of the player-shown text,
         ///     and a data object that can be used to keep track of options later.
         /// </summary>

--- a/Content.Shared/Voting/MsgVoteData.cs
+++ b/Content.Shared/Voting/MsgVoteData.cs
@@ -17,6 +17,7 @@ namespace Content.Shared.Voting
         public (ushort votes, string name)[] Options = default!;
         public bool IsYourVoteDirty;
         public byte? YourVote;
+        public bool ShowVotes;
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
         {
@@ -43,6 +44,8 @@ namespace Content.Shared.Voting
             {
                 YourVote = buffer.ReadBoolean() ? buffer.ReadByte() : null;
             }
+
+            ShowVotes = buffer.ReadBoolean();
         }
 
         public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
@@ -75,6 +78,7 @@ namespace Content.Shared.Voting
                     buffer.Write(YourVote.Value);
                 }
             }
+            buffer.Write(ShowVotes);
         }
 
         public override NetDeliveryMethod DeliveryMethod => NetDeliveryMethod.ReliableOrdered;

--- a/Resources/Locale/en-US/administration/commands/custom-vote-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/custom-vote-command.ftl
@@ -1,4 +1,7 @@
 custom-vote-webhook-name = Custom Vote Held
+custom-vote-webhook-description =
+    Title: { $title }
+    Show Votes: { $showVotes }
 custom-vote-webhook-footer = server: { $serverName }, round: { $roundId } { $runLevel }
 custom-vote-webhook-cancelled = **Vote cancelled**
 custom-vote-webhook-option-pending = TBD

--- a/Resources/Locale/en-US/voting/ui/vote-popup.ftl
+++ b/Resources/Locale/en-US/voting/ui/vote-popup.ftl
@@ -1,2 +1,3 @@
 ui-vote-created = { $initiator } has called a vote:
 ui-vote-button  = { $text } ({ $votes })
+ui-vote-button-hidden-votes = { $text }

--- a/Resources/Locale/en-US/voting/vote-commands.ftl
+++ b/Resources/Locale/en-US/voting/vote-commands.ftl
@@ -11,10 +11,11 @@ cmd-createvote-arg-vote-type = <vote type>
 ## 'customvote' command
 
 cmd-customvote-desc = Creates a custom vote
-cmd-customvote-help = Usage: customvote <title> <option1> <option2> [option3...]
+cmd-customvote-help = Usage: customvote <title> <show-votes> <option1> <option2> [option3...]
 cmd-customvote-on-finished-tie = Tie between {$ties}!
 cmd-customvote-on-finished-win = {$winner} wins!
 cmd-customvote-arg-title = <title>
+cmd-customvote-arg-showvotes = <show-votes>
 cmd-customvote-arg-option-n = <option{ $n }>
 
 ## 'vote' command


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Add a flag to customvote to not show the current vote count to players. In
addition, this PR also disables showing the vote count for map and gamemode
votes.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
In my experience showing the vote count tends to lead to players "dogpiling" on
two options because they think those are the only options that have any hope of
winning OR they try to force a tie. This PR will hopefully increase the verity
of vote results.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This PR mainly consists of a new field on `VoteOptions` called `ShowVotes`. We
then need to ensure that this field is not lost at any point from the creation
to when the vote is presented to the user.

## Requirements
<!--
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/user-attachments/assets/999af8b0-2622-42a8-ad0e-61e98621bfc9)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
The `customvote` command gained an additional parameter. There should be no other breaking changes.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl: Aquif
ADMIN:
- tweak: The customvote command now requires a additional boolean parameter to determine if the vote count should be shown to players.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
