### PR TITLE
Disables vox talksounds until someone fixes them

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -21,9 +21,16 @@
     proto: vox
   - type: Vocal
     sounds:
-      Male: UnisexVox
-      Female: UnisexVox
-      Unsexed: UnisexVox
+      Male: MaleReptilian
+      Female: MaleReptilian
+      Unsexed: MaleReptilian
+# These are currently disabled because they are too grating (read: they are giving some people actual headaches.)
+# Reptilian sounds are being used as a placeholder in the interm. 
+#  - type: Vocal
+#    sounds:
+#      Male: UnisexVox
+#      Female: UnisexVox
+#      Unsexed: UnisexVox
   - type: Butcherable
     butcheringType: Spike
     spawned:


### PR DESCRIPTION
## About the PR
Comments out the vox talk sounds and replaces them with the reptilian ones (they were the best analog I could think of.) No audio files have been removed or changed.

## Why / Balance
This sound is so grating that it causes some players *psychical pain* in the form of headaches, along with just generally hurting people's want to play them / be around them. Even though I've gotten kind of used to them personally, the fact that this sound alone actively prevents people from playing the game is terrible.

This change is strictly intended to be temporary. Someone can re-enable the vox sounds later when they are made less harsh.

## Technical details
N/A

## Media
N/A

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
:cl:
- remove: Temporarily replaced vox talk sounds with reptilian ones, until they are made less grating.
