### PR TITLE
Eject mech pilot alert

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -211,8 +211,11 @@ public sealed partial class MechSystem : SharedMechSystem
                         return;
                     }
 
-                    var doAfterEventArgs = new DoAfterArgs(EntityManager, args.User, component.ExitDelay,
-                        new MechExitEvent(), uid, target: uid);
+                    var doAfterEventArgs = new DoAfterArgs(EntityManager, args.User, component.ExitDelay, new MechExitEvent(), uid, target: uid)
+                    {
+                        BreakOnMove = true,
+                    };
+                    _popup.PopupEntity(Loc.GetString("mech-eject-pilot-alert", ("item", uid), ("user", args.User)), uid, PopupType.Large);
 
                     _doAfter.TryStartDoAfter(doAfterEventArgs);
                 }

--- a/Resources/Locale/en-US/mech/mech.ftl
+++ b/Resources/Locale/en-US/mech/mech.ftl
@@ -17,3 +17,5 @@ mech-energy-missing = Energy: MISSING
 mech-slot-display = Open Slots: {$amount}
 
 mech-no-enter = You cannot pilot this.
+
+mech-eject-pilot-alert = {$user} eject out the pilot {$item}!

--- a/Resources/Locale/en-US/mech/mech.ftl
+++ b/Resources/Locale/en-US/mech/mech.ftl
@@ -18,4 +18,4 @@ mech-slot-display = Open Slots: {$amount}
 
 mech-no-enter = You cannot pilot this.
 
-mech-eject-pilot-alert = {$user} eject out the pilot {$item}!
+mech-eject-pilot-alert = {$user} ejects the pilot of the {$item}!

--- a/Resources/Locale/en-US/mech/mech.ftl
+++ b/Resources/Locale/en-US/mech/mech.ftl
@@ -18,4 +18,4 @@ mech-slot-display = Open Slots: {$amount}
 
 mech-no-enter = You cannot pilot this.
 
-mech-eject-pilot-alert = {$user} ejects the pilot of the {$item}!
+mech-eject-pilot-alert = {$user} is pulling the pilot out of the {$item}!


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Mech pilots receive a warning before they are ejected from the mech.

Also addition, in order to throw the pilot out of the mech, you need to not move.

## Why / Balance
Mech pilot must understand that at this moment he may be thrown out of the mech.

## Media
![изображение](https://github.com/user-attachments/assets/be96b80b-5b5b-4eb7-8bd9-96c7357a7ee4)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes


**Changelog**
:cl:
- tweak: Mech pilots receive a warning before they are ejected from the mech.
- fix: Now, when removing the pilot of the mech, you need to not move.
