### PR TITLE
Test parallelization stuff.

### DIFF
--- a/Content.IntegrationTests/AssemblyInfo.cs
+++ b/Content.IntegrationTests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿[assembly: Parallelizable(ParallelScope.Children)]
+
+// I don't know why this parallelism limit was originally put here.
+// I *do* know that I tried removing it, and ran into the following .NET runtime problem:
+// https://github.com/dotnet/runtime/issues/107197
+// So we can't really parallelize integration tests harder either until the runtime fixes that,
+// *or* we fix serv3 to not spam expression trees.
+[assembly: LevelOfParallelism(3)]

--- a/Content.IntegrationTests/PoolManager.cs
+++ b/Content.IntegrationTests/PoolManager.cs
@@ -23,8 +23,6 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.UnitTesting;
 
-[assembly: LevelOfParallelism(3)]
-
 namespace Content.IntegrationTests;
 
 /// <summary>

--- a/Content.IntegrationTests/PoolManagerTestEventHandler.cs
+++ b/Content.IntegrationTests/PoolManagerTestEventHandler.cs
@@ -1,7 +1,4 @@
-﻿
-[assembly: Parallelizable(ParallelScope.Children)]
-
-namespace Content.IntegrationTests;
+﻿namespace Content.IntegrationTests;
 
 [SetUpFixture]
 public sealed class PoolManagerTestEventHandler

--- a/Content.Tests/AssemblyInfo.cs
+++ b/Content.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.Fixtures)]


### PR DESCRIPTION
This is the content analogue of https://github.com/space-wizards/RobustToolbox/pull/5412

Made Content.Tests run tests parallelized, which doesn't really seem to matter much.

I tried to make Content.IntegrationTest more aggressively parallelized but ran into https://github.com/dotnet/runtime/issues/107197 so we need to shelve that. Added a comment explaining as such.
