### PR TITLE
Navmap Warp

### DIFF
--- a/Content.Shared/Maps/NavMapWarpComponent.cs
+++ b/Content.Shared/Maps/NavMapWarpComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.Maps;
+
+/// <summary>
+/// This enables an entity to teleport with any navMap by pressing a key over the map screen
+/// </summary>
+[RegisterComponent]
+public sealed partial class NavMapWarpComponent : Component
+{
+
+}

--- a/Content.Shared/Pinpointer/MapWarpRequest.cs
+++ b/Content.Shared/Pinpointer/MapWarpRequest.cs
@@ -1,0 +1,17 @@
+using System.Numerics;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Pinpointer;
+
+[Serializable, NetSerializable]
+public sealed class MapWarpRequest: EntityEventArgs
+{
+    public readonly NetEntity Uid;
+    public readonly Vector2 Target;
+
+    public MapWarpRequest(NetEntity uid, Vector2 target)
+    {
+        Target = target;
+        Uid = uid;
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -91,6 +91,7 @@
   - type: Loadout
     prototypes: [ MobAghostGear ]
   - type: BypassInteractionChecks
+  - type: NavMapWarp
 
 - type: entity
   id: ActionAGhostShowSolar

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -311,6 +311,7 @@
     - state: ai_camera
       shader: unshaded
       map: ["base"]
+  - type: NavMapWarp
 
 # Borgs
 - type: entity


### PR DESCRIPTION
## About the PR
Specific entities can now teleport using a navmap (or any navmap-inheritors such as the Crew Monitor)
Simply Alt-Click (Alternate Activate Item In World) on the map screen, and you are teleported to that location

## Why / Balance
The AI Eye and aghosts can now get around the station more easily and quickly. A case could be made that regular ghosts should also be given some sort of navmap and this power, but currently only aghosts and AI Eyes are allowed.

## Technical details
Upon the specified input, client calculates the global coordiantes at the cursor, gets the player's current entity, and sends a network event to the server. Server checks for the required component that allows warp, replaces the provided UI with it's Eye target if there was one, then teleports the entity to the specified location. There are no collision checks due to everything that is expected to use this being incorporeal

There is also no limit to where this can go, by scrolling the map away from the station any arbitrary distance can theoretically be reached. I don't know why anyone would do that. This creates a "stuck" state since there is no Crew Monitor available offgrid, but an AI's Go Home ability or GhostWarp can bring the player back to the station.

## Media

https://github.com/user-attachments/assets/0752a807-b410-402c-a6ba-3c14ac3a8a24

## Requirements

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Errant
- add: The AI Eye can now teleport to any location on the station by Alt-Clicking on the Crew Monitor map.