### PR TITLE
More ItemTogglePointLight fixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1268,6 +1268,7 @@
         right:
           - state: inhand-right-blade
             shader: unshaded
+    - type: ItemTogglePointLight
     - type: DisarmMalus
       malus: 0
     - type: StaminaDamageOnHit

--- a/Resources/Prototypes/Entities/Objects/Misc/arabianlamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/arabianlamp.yml
@@ -14,9 +14,9 @@
   - type: EntityStorage
     capacity: 1 # Its smol.
     itemCanStoreMobs: false #  just leaving this here explicitly since I know at some point someone will want to use this to hold a mob. This also prevents it from becoming His Grace.
-  # - type: StorageFill 
-    # contents: 
-      # - id: PuddleSparkle # Ha! Cute. Unfortunately it despawns before the container is likely to open. 
+  # - type: StorageFill
+    # contents:
+      # - id: PuddleSparkle # Ha! Cute. Unfortunately it despawns before the container is likely to open.
   - type: ContainerContainer
     containers:
       entity_storage: !type:Container
@@ -64,7 +64,7 @@
   - type: Sprite
     sprite: Objects/Misc/arabianlamp.rsi
     layers:
-    - state: lamp 
+    - state: lamp
       map: [ "enum.StorageVisualLayers.Base" ]
     - state: lamptop
       map: ["enum.StorageVisualLayers.Door"]
@@ -130,6 +130,7 @@
     netsync: false
     radius: 5
     color: orange
+  - type: ItemTogglePointLight
   - type: StaticPrice
     price: 1500
   - type: Prayable

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -87,6 +87,7 @@
     netsync: false
     radius: 1.1 #smallest possible
     color: orange
+  - type: ItemTogglePointLight
 
 - type: entity
   name: cheap lighter
@@ -205,6 +206,7 @@
     netsync: false
     radius: 1.2 #slightly stronger than the other lighters
     color: orange
+  - type: ItemTogglePointLight
   - type: UseDelay
   - type: IgnitionSource
     ignited: false

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -95,6 +95,7 @@
     radius: 1.5
     color: orange
     netsync: false
+  - type: ItemTogglePointLight
   - type: Appearance
   - type: RequiresEyeProtection
   - type: PhysicalComposition


### PR DESCRIPTION
## About the PR
Fixes the toggleable point lights for toy swords, lighters, welders and the arabian lamp.

## Why / Balance
bugfix

## Technical details
Same as #31478 and #31619
@metalgearsloth you overlooked these in #31312, that should mabye have been a breaking changes entry
I think I found all of them now though.

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed toggleable pointlights for the toy sword, lighters, welders and arabian lamp.