### PR TITLE
Crew Monitor filter

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
@@ -15,6 +15,9 @@
                     </PanelContainer>
                 </controls:StripeBack>
 
+                <LineEdit Name="SearchLineEdit" HorizontalExpand="True"
+                          PlaceHolder="{Loc crew-monitor-filter-line-placeholder}" />
+
                 <ScrollContainer Name="SensorScroller"
                                  VerticalExpand="True"
                                  SetWidth="520"

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -156,6 +156,11 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
         // Populate departments
         foreach (var sensor in departmentSensors)
         {
+            if (!string.IsNullOrEmpty(SearchLineEdit.Text)
+                && !sensor.Name.ToUpper().Contains(SearchLineEdit.Text.ToUpper())
+                && !sensor.Job.ToUpper().Contains(SearchLineEdit.Text.ToUpper()))
+                continue;
+
             var coordinates = _entManager.GetCoordinates(sensor.Coordinates);
 
             // Add a button that will hold a username and other details

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -157,8 +157,8 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
         foreach (var sensor in departmentSensors)
         {
             if (!string.IsNullOrEmpty(SearchLineEdit.Text)
-                && !sensor.Name.ToUpper().Contains(SearchLineEdit.Text.ToUpper())
-                && !sensor.Job.ToUpper().Contains(SearchLineEdit.Text.ToUpper()))
+                && !sensor.Name.Contains(SearchLineEdit.Text, StringComparison.CurrentCultureIgnoreCase)
+                && !sensor.Job.Contains(SearchLineEdit.Text, StringComparison.CurrentCultureIgnoreCase))
                 continue;
 
             var coordinates = _entManager.GetCoordinates(sensor.Coordinates);

--- a/Resources/Locale/en-US/medical/components/crew-monitoring-component.ftl
+++ b/Resources/Locale/en-US/medical/components/crew-monitoring-component.ftl
@@ -2,6 +2,8 @@
 
 crew-monitoring-user-interface-title = Crew Monitoring Console
 
+crew-monitor-filter-line-placeholder = Filter
+
 crew-monitoring-user-interface-name = Name
 crew-monitoring-user-interface-job = Job
 crew-monitoring-user-interface-status = Status


### PR DESCRIPTION
## About the PR
The crew monitor now has a filter, that looks in both Name and Job

## Why / Balance
QOL change, particularly for AI (once it's crew monitor gets fixed)

## Media

https://github.com/user-attachments/assets/6ab98dcc-f32a-41c0-9412-e00811be0bff

## Requirements

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Errant
- add: Crew monitor list can now be filtered by name and job.
