### PR TITLE
add map and grid prototypes

### DIFF
--- a/Resources/Prototypes/Entities/Maps/atmos.yml
+++ b/Resources/Prototypes/Entities/Maps/atmos.yml
@@ -1,0 +1,48 @@
+# 20C air mix planet atmosphere
+- type: entity
+  parent: Map
+  id: MapAtmos
+  components:
+  - type: MapAtmosphere
+    space: False
+    mixture:
+      volume: 2500
+      immutable: True
+      temperature: 293.15
+      moles:
+      - 21.824879
+      - 82.10312
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+
+# -25C air mix planet atmosphere
+- type: entity
+  parent: MapAtmos
+  id: MapAtmosCold
+  components:
+  - type: MapAtmosphere
+    mixture:
+      volume: 2500
+      immutable: True
+      temperature: 248.15
+      moles:
+      - 21.824879
+      - 82.10312
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0

--- a/Resources/Prototypes/Entities/Maps/grid.yml
+++ b/Resources/Prototypes/Entities/Maps/grid.yml
@@ -1,0 +1,42 @@
+# Prototype for a map's grid entity
+# The parent should be the Map entity
+# For the station's main grid you add BecomesStation with the station ID.
+# You must set GridAtmosphere yourself, it doesn't like composition.
+- type: entity
+  parent: BaseMapEntity
+  id: MapGrid
+  name: grid
+  components:
+  - type: MapGrid
+  - type: Physics
+    bodyStatus: InAir
+    angularDamping: 0.05
+    linearDamping: 0.05
+    fixedRotation: False
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures: {}
+  - type: Shuttle
+    angularDamping: 0.05
+    linearDamping: 0.05
+  - type: SpreaderGrid
+  - type: Gravity
+    gravityShakeSound: !type:SoundPathSpecifier
+      path: /Audio/Effects/alert.ogg
+  - type: DecalGrid
+  - type: GasTileOverlay
+  - type: RadiationGridResistance
+  - type: GridPathfinding
+  - type: NavMap # Required for nav maps to work on this grid, even for mapped shuttles you shouldn't prevent players building navmaps just because
+
+# A grid that has extremely high dampening, so it can't be moved
+- type: entity
+  parent: MapGrid
+  id: MapGridAnchored
+  components:
+  - type: Physics
+    angularDamping: 10000
+    linearDamping: 10000
+  - type: Shuttle
+    angularDamping: 10000
+    linearDamping: 10000

--- a/Resources/Prototypes/Entities/Maps/map.yml
+++ b/Resources/Prototypes/Entities/Maps/map.yml
@@ -1,0 +1,24 @@
+# Components the map itself and grids have in common
+- type: entity
+  abstract: true
+  categories: [ HideSpawnMenu ]
+  id: BaseMapEntity
+  components:
+  - type: Broadphase
+  - type: OccluderTree
+
+# Prototype for a station's map entity
+# Set the station's name with MetaData, this is visible on a shuttle console when FTLing
+# Add your map's custom parallax to this entity with Parallax
+- type: entity
+  parent: BaseMapEntity
+  id: Map
+  name: station
+  components:
+  - type: Transform
+  - type: Map
+    mapPaused: True
+  - type: PhysicsMap
+  - type: GridTree
+  - type: MovedGrids
+  - type: LoadedMap


### PR DESCRIPTION
## About the PR
adds `Map`, `MapAtmos`, `MapAtmosCold`, `MapGrid`, `MapGridAnchored` prototypes
anchored only used downstream right now but could be useful for station anchor pr

## Why / Balance
resolves #30999

## Media
shittle works

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun