### PR TITLE
Increase gas canister volumes (take 2)

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -24,7 +24,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: LiquidOxygenCanister
-  cost: 2500
+  cost: 5000
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -44,7 +44,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: LiquidNitrogenCanister
-  cost: 2500
+  cost: 5000
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -54,7 +54,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
-  cost: 2200 # Until someone fixes it co2 can be used to oneshot people so it's more expensive
+  cost: 3500 # Until someone fixes it co2 can be used to oneshot people so it's more expensive
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -64,7 +64,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: LiquidCarbonDioxideCanister
-  cost: 4000
+  cost: 10000
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -86,7 +86,7 @@
 #    sprite: Structures/Storage/canister.rsi
 #    state: water_vapor
 #  product: WaterVaporCanister
-#  cost: 2600
+#  cost: 17000
 #  category: cargoproduct-category-name-atmospherics
 #  group: market
 
@@ -96,7 +96,7 @@
     sprite: Structures/Storage/canister.rsi
     state: orange
   product: PlasmaCanister
-  cost: 4000
+  cost: 40000
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -108,6 +108,6 @@
 #    sprite: Structures/Storage/canister.rsi
 #    state: green
 #  product: TritiumCanister
-#  cost: 15500
+#  cost: 146000
 #  category: cargoproduct-category-name-atmospherics
 #  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
@@ -83,13 +83,13 @@
       prob: 0.001
       orGroup: Canister
     - id: FrezonCanister
-      prob: 0.001
+      prob: 0.0001
       orGroup: Canister
     - id: NitrogenCanister
       prob: 0.001
       orGroup: Canister
     - id: NitrousOxideCanister
-      prob: 0.001
+      prob: 0.0001
       orGroup: Canister
     - id: OxygenCanister
       prob: 0.001
@@ -98,7 +98,7 @@
       prob: 0.001
       orGroup: Canister
     - id: TritiumCanister
-      prob: 0.001
+      prob: 0.0001
       orGroup: Canister
     - id: WaterVaporCanister
       prob: 0.001

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -115,7 +115,7 @@
         - state: yellow
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 10000
         moles: # List of gasses for easy reference
           - 0 # oxygen
           - 0 # nitrogen
@@ -151,7 +151,7 @@
           acts: [ "Destruction" ]
         - !type:DumpCanisterBehavior
 
-# Filled canisters, contain 1871.71051 moles each
+# Filled canisters, contain 18717.1051 moles each
 
 - type: entity
   parent: GasCanister
@@ -164,10 +164,10 @@
       - state: grey
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 10000
       moles:
-        - 393.0592071 # oxygen 21%
-        - 1478.6513029 # nitrogen 79%
+        - 3930.592071 # oxygen 21%
+        - 14786.513029 # nitrogen 79%
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -204,9 +204,9 @@
       - state: blue
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 10000
       moles:
-        - 1871.71051 # oxygen
+        - 18717.1051 # oxygen
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -240,9 +240,9 @@
   components:
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 10000
       moles:
-        - 18710.71051 # oxygen
+        - 187107.1051 # oxygen
       temperature: 72
   - type: AccessReader
     access: [["Atmospherics"]]
@@ -258,10 +258,10 @@
         - state: red
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 10000
         moles:
           - 0 # oxygen
-          - 1871.71051 # nitrogen
+          - 18717.1051 # nitrogen
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -295,10 +295,10 @@
   components:
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 10000
       moles:
         - 0 # oxygen
-        - 18710.71051 # nitrogen
+        - 187107.1051 # nitrogen
       temperature: 72
   - type: AccessReader
     access: [["Atmospherics"]]
@@ -314,11 +314,11 @@
         - state: black
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 10000
         moles:
           - 0 # oxygen
           - 0 # nitrogen
-          - 1871.71051 # CO2
+          - 18717.1051 # CO2
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -354,11 +354,11 @@
   components:
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 10000
       moles:
         - 0 # oxygen
         - 0 # nitrogen
-        - 18710.71051 # CO2
+        - 187107.1051 # CO2
       temperature: 72
   - type: AccessReader
     access: [["Atmospherics"]]
@@ -374,12 +374,12 @@
         - state: orange
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 10000
         moles:
           - 0 # oxygen
           - 0 # nitrogen
           - 0 # carbon dioxide
-          - 1871.71051 # plasma
+          - 18717.1051 # plasma
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -418,13 +418,13 @@
         - state: green
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 10000
         moles:
           - 0 # oxygen
           - 0 # nitrogen
           - 0 # CO2
           - 0 # Plasma
-          - 1871.71051 # Tritium
+          - 18717.1051 # Tritium
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -463,14 +463,14 @@
         - state: water_vapor
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 10000
         moles:
           - 0 # oxygen
           - 0 # nitrogen
           - 0 # CO2
           - 0 # Plasma
           - 0 # Tritium
-          - 1871.71051 # Water vapor
+          - 18717.1051 # Water vapor
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -507,7 +507,7 @@
         - state: greenys
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 10000
         moles:
           - 0 # oxygen
           - 0 # nitrogen
@@ -515,7 +515,7 @@
           - 0 # Plasma
           - 0 # Tritium
           - 0 #  Water vapor
-          - 1871.71051 # Ammonia
+          - 18717.1051 # Ammonia
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -554,7 +554,7 @@
         - state: redws
     - type: GasCanister
       gasMixture:
-        volume: 1000
+        volume: 10000
         moles:
           - 0 # oxygen
           - 0 # nitrogen
@@ -563,7 +563,7 @@
           - 0 # Tritium
           - 0 #  Water vapor
           - 0 # Ammonia
-          - 1871.71051 # N2O
+          - 18717.1051 # N2O
         temperature: 293.15
     - type: Destructible
       thresholds:
@@ -600,7 +600,7 @@
     - state: frezon
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 10000
       moles:
       - 0 # oxygen
       - 0 # nitrogen
@@ -610,7 +610,7 @@
       - 0 # Water vapor
       - 0 # Ammonia
       - 0 # N2O
-      - 1871.71051 # Frezon
+      - 18717.1051 # Frezon
       temperature: 293.15
   - type: Destructible
     thresholds:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Previously gas canisters didn't hold enough gas to suitably pressurize any meaningful amount of tiles. This has led to them being mostly ignored for use in fixing spacings, as well as not fulfilling their intended uses aboard shuttles and evac shuttles.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

To make gas canisters useful.
This will likely have some strange balance implications due to how this will interact with the more dangerous gases, but I think making them useful for the main distro gases is more important, and we can come up with ways to hinder their misuse to accompany this change.

What follows is [a discord blurb](https://discord.com/channels/310555209753690112/1008709214006427689/1256275687652720661)
> I did some back of the napkin canister exploration today, here are my findings, and a recommendation based on some things you mentioned the other day.
>
>A tile at common temp takes a little over 100 mols of 78/22 air mix to reach 101kpa. 
>
>current canisters hold 1871.71 (weird number) mols at that temp by default. This is the relevant metric I think despite the ability to change temp to augment that because a hotter or colder mix will also quickly make it unsuitable for repressurizing areas due to temperature damage.
>
>canisters at common temp can *almost* repressurize 18 tiles to 101kpa but quickly falls off at anything higher than that.
>
>We could bump this up and make canisters more useful. Ideally I think canisters should be able to pressurize *most* rooms on their own. For that I think we likely need *at least* a 4x increase in mols & volume (here they are tightly coupled due to restricting temp).
>
>I've added a quick visual of how large these multiples would *feel* in game.
![image](https://github.com/user-attachments/assets/1e12e4aa-b3ad-4ba4-be32-bcb11be6eac0)
![image](https://github.com/user-attachments/assets/8ada8048-3087-4619-811a-dcac9b7751aa)
> Something I did not explore is how this would effect canister bombs, but Im not sure those are even something we want long term, and this is far more important imo.
> Something I found that doesn't work in the current context is using canisters as station pressure banks. Unfortunately pipenets are orders of magnitude larger than canisters. For context Oasis' pipenet (admittedly a very large station, but thats where you would want a volume buffer the most due to the longer time to repressurize the pipenet and larger number of rooms/tiles) is 3460x larger than a canister.
> So if we wanted pressure banks, they would need to be new, probably immobile at least when pressurized, entities.
> Canisters should work as decent pressure banks for shuttles though with my proposed changes. Higher multiples preferred however for that application, especially as the pipenets currently start empty of gas and so any connected canister on a shuttle grid will initially fill the pipenet and require changing nearly immediately.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: gas canisters now hold much larger volumes of gas. 