### PR TITLE
Devmap crew monitor fix

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/SingletonDeviceNetServerSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/SingletonDeviceNetServerSystem.cs
@@ -63,7 +63,7 @@ public sealed class SingletonDeviceNetServerSystem : EntitySystem
 
             last = (uid, server, device);
 
-            if (!server.Active)
+            if (!server.Active || string.IsNullOrEmpty(device.Address))
                 continue;
 
             address = device.Address;


### PR DESCRIPTION
## About the PR
Crew Monitor Servers on Dev now work
Replacement crew monitor servers (on any map) now work

## Why / Balance
Fixes #29787
Fixes #31657

## Technical details

Crew Monitors do not auto-connect to the device network when spawned, because only one of them must be active on a station to make sure every suit sensor is connecting to the same server. When a suit sensor detects that it is not connected to a server, it starts an attempt to connect to or activate one. 
On live maps, this check finds the Crew Monitor Server, finds it to be unavailable (~~possibly due to power not being available yet?~~ apparently the other maps are saved with the crew monitor having those variables set to False. Mapping trickery or something. Anyway, my fix makes them work regardless of how they were saved), disconnects it and reports failure. A few seconds later the check is triggered again and finds the server to be Available this time so it connects, which gives the server a random Address.

However, on the Devmap (or when trying to spawn a new crew monitor server on ANY map during the round), the server will immediately report as active and available. So the game just takes it's Address, which is unfortunately the default empty string. The empty address is given to the suit sensor system which either ignores it or tries to use it and gets no response. Either way, it will check for crew monitor servers again a few seconds later, getting the empty Address again. And this repeats until the end of time.

An Empty String for Address now also treated as a server failure, triggering a reconnect and giving it a random address.

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- fix: Replacement Crew Monitor Servers, as well as the Crew Monitor Server on the dev map, now work properly.
