### PR TITLE
Remove whitelist from shelves

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/shelfs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/shelfs.yml
@@ -323,12 +323,6 @@
     - 0,0,5,1
     - 0,3,5,4
     maxItemSize: Normal
-    whitelist:
-      tags:
-        - DrinkGlass
-        - DrinkBottle
-        - DrinkCan
-        - Beer
   - type: Construction
     graph: Shelf
     node: ShelfBar
@@ -377,24 +371,6 @@
     - 0,0,5,1
     - 0,3,5,4
     maxItemSize: Normal
-    whitelist:
-      tags:
-        - DrinkBottle
-        - DrinkCan
-        - DrinkCup
-        - DrinkGlass
-        - BoxCardboard
-        - MonkeyCube
-        - Enzyme
-        - Mayo
-        - Packet
-        - Cleaver
-        - Knife
-        - KitchenKnife
-        - RollingPin
-        - Ingredient
-        - Trash
-        - Plastic
   - type: Construction
     graph: Shelf
     node: ShelfKitchen
@@ -449,11 +425,6 @@
     - 0,0,5,1
     - 0,3,5,4
     maxItemSize: Normal
-    whitelist:
-      tags:
-        - ChemDispensable
-        - GlassBeaker
-        - Bottle
   - type: Construction
     graph: Shelf
     node: ShelfChemistry


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
I thought we weren't doing WL on most storage because, why wouldn't I be able to put other items in there? 

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- tweak: Department specific shelves no longer restrict the items that can be placed in them.
