### PR TITLE
Ninja throwing star ability fix

### DIFF
--- a/Content.Server/Ninja/Systems/NinjaGlovesSystem.cs
+++ b/Content.Server/Ninja/Systems/NinjaGlovesSystem.cs
@@ -49,6 +49,7 @@ public sealed class NinjaGlovesSystem : SharedNinjaGlovesSystem
         {
             var ev = new NinjaBatteryChangedEvent(battery.Value, suit);
             RaiseLocalEvent(user, ref ev);
+            RaiseLocalEvent(suit, ref ev);
         }
     }
 }

--- a/Content.Server/Ninja/Systems/NinjaSuitSystem.cs
+++ b/Content.Server/Ninja/Systems/NinjaSuitSystem.cs
@@ -37,6 +37,16 @@ public sealed class NinjaSuitSystem : SharedNinjaSuitSystem
         base.NinjaEquipped(ent, user);
 
         _ninja.SetSuitPowerAlert(user);
+
+        // raise event to let ninja components get starting battery
+        _ninja.GetNinjaBattery(user.Owner, out var uid, out var _);
+
+        if (uid is not {} battery_uid)
+            return;
+
+        var ev = new NinjaBatteryChangedEvent(battery_uid, ent.Owner);
+        RaiseLocalEvent(ent, ref ev);
+        RaiseLocalEvent(user, ref ev);
     }
 
     // TODO: if/when battery is in shared, put this there too


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixed the bug when activating ninja throwing star ability wouldn't spawn a throwing star.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
fixes #31594

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Throwing star ability has reference to current battery which only changes on `NinjaBatteryChangedEvent` raised. `NinjaBatteryChangedEvent` is only called when ninja gloves are activated or suit battery is upgraded which means there was no way to get reference to starting battery. Raising `NinjaBatteryChangedEvent` on ninja suit equip fixes the problem.

Also, raise `NinjaBatteryChangedEvent` for both suit and ninja in `EnableGloves` because `NinjaBatteryChangedEvent` description says so.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
https://github.com/user-attachments/assets/7a1d9885-83a7-4dcb-8396-52839e1b14de

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
🆑 yuitop

- fix: space ninja throwing star ability now spawns a throwing star

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->