### PR TITLE
Adds flavors to a bunch of things without them

### DIFF
--- a/Resources/Locale/en-US/flavors/flavor-profiles.ftl
+++ b/Resources/Locale/en-US/flavors/flavor-profiles.ftl
@@ -50,6 +50,7 @@ flavor-base-horrible = horrible
 # lmao
 flavor-base-terrible = terrible
 flavor-base-mindful = mindful
+flavor-base-chewy = chewy
 
 # Complex flavors. Put a flavor here when you want something that's more
 # specific.
@@ -173,6 +174,8 @@ flavor-complex-violets = like violets
 flavor-complex-pyrotton = like a burning mouth
 flavor-complex-mothballs = like mothballs
 flavor-complex-paint-thinner = like paint thinner
+flavor-complex-paper = like mushy pulp
+flavor-complex-compressed-meat = like compressed meat
 
 # Drink-specific flavors.
 

--- a/Resources/Prototypes/Entities/Clothing/base_clothing.yml
+++ b/Resources/Prototypes/Entities/Clothing/base_clothing.yml
@@ -11,6 +11,9 @@
       - WhitelistChameleon
   - type: StaticPrice
     price: 10
+  - type: FlavorProfile #yes not every peice of clothing is edible, but this way every edible piece of clothing should have the flavor without me having to track down what specific clothing can and cannot be eaten.
+    flavors:
+    - fiber
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1743,6 +1743,9 @@
         Asphyxiation: 4
         Slash: 7
         Blunt: 3
+  - type: FlavorProfile
+    flavors:
+    - meaty
 
 - type: entity
   parent: MobMouse

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -347,6 +347,11 @@
     bloodReagent: InsectBlood
     bloodMaxVolume: 20
   - type: Food
+  - type: FlavorProfile
+    flavors:
+    - horrible
+    - terrible
+    - chewy
   - type: Hunger
     baseDecayRate: 0.25
   - type: Extractable
@@ -957,6 +962,9 @@
     requiresSpecialDigestion: true
     # Wooly prevents eating wool deleting the goat so its fine
     requireDead: false
+  - type: FlavorProfile
+    flavors:
+    - fiber
   - type: Butcherable
     spawned:
     - id: FoodMeat
@@ -1635,6 +1643,9 @@
       Dead:
         Base: splat-0
   - type: Food
+  - type: FlavorProfile
+    flavors:
+    - meaty
   - type: Thirst
     startingThirst: 25  # spawn with Okay thirst state
     thresholds:
@@ -1743,9 +1754,6 @@
         Asphyxiation: 4
         Slash: 7
         Blunt: 3
-  - type: FlavorProfile
-    flavors:
-    - meaty
 
 - type: entity
   parent: MobMouse
@@ -3182,6 +3190,9 @@
       Dead:
         Base: splat-0
   - type: Food
+  - type: FlavorProfile
+    flavors:
+    - meaty
   - type: Hunger
     baseDecayRate: 0.3
   - type: Extractable

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -585,6 +585,10 @@
     - Hamster
     - VimPilot
     - ChefPilot
+  - type: FlavorProfile
+    flavors:
+    - meaty
+    - sadness
 
 - type: entity
   name: Shiva

--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -23,6 +23,10 @@
   - type: Crayon
     capacity: 15
   - type: Food
+  - type: FlavorProfile
+    flavors:
+    - chewy
+    - bitter
   - type: SolutionContainerManager
     solutions:
       food:

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -117,6 +117,9 @@
   - type: Appearance
   - type: Food
     requiresSpecialDigestion: true
+  - type: FlavorProfile
+    flavors:
+    - fiber
   - type: SolutionContainerManager
     solutions:
       food:
@@ -405,6 +408,9 @@
   - type: Appearance
   - type: Food
     requiresSpecialDigestion: true
+  - type: FlavorProfile
+    flavors:
+    - fiber
   - type: SolutionContainerManager
     solutions:
       food:

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -65,7 +65,7 @@
     forceFeedDelay: 7
   - type: FlavorProfile
     flavors:
-      - paper
+    - paper
   - type: BadFood
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -63,6 +63,9 @@
     solution: food
     delay: 7
     forceFeedDelay: 7
+  - type: FlavorProfile
+    flavors:
+      - paper
   - type: BadFood
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -15,6 +15,11 @@
           Quantity: 10
   - type: Food
     solution: cube
+  - type: FlavorProfile
+    flavors:
+    - chewy
+    - horrible
+    - compressed-meat
   - type: RefillableSolution
     solution: cube
   - type: Sprite
@@ -161,7 +166,7 @@
       plushie:
         maxVol: 11 # needs room for water
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: Nutriment #contains nutriment like other dehydrated animals, but isn't edible? Who is grinding dehydrated carp to eat them??
           Quantity: 10
   - type: RefillableSolution
     solution: plushie
@@ -205,7 +210,7 @@
     sound:
       path: /Audio/Effects/bite.ogg
 
-- type: entity
+- type: entity #why is this all redefined down here as a parent of base object instead of just being parented to monkeycube?? TODO: Fix this shit
   parent: BaseItem
   id: SyndicateSponge
   name: monkey cube
@@ -223,6 +228,11 @@
           Quantity: 10
   - type: Food
     solution: cube
+  - type: FlavorProfile
+    flavors:
+    - chewy
+    - horrible
+    - compressed-meat
   - type: RefillableSolution
     solution: cube
   - type: Sprite

--- a/Resources/Prototypes/Flavors/flavors.yml
+++ b/Resources/Prototypes/Flavors/flavors.yml
@@ -180,6 +180,11 @@
   description: flavor-base-mindful
 
 - type: flavor
+  id: chewy
+  flavorType: Base
+  description: flavor-base-chewy
+
+- type: flavor
   id: mustard
   flavorType: Complex
   description: flavor-complex-mustard
@@ -1113,3 +1118,13 @@
   id: cherry
   flavorType: Complex
   description: flavor-complex-cherry
+
+- type: flavor
+  id: paper
+  flavorType: Complex
+  description: flavor-complex-paper
+
+- type: flavor
+  id: compressed-meat
+  flavorType: Complex
+  description: flavor-complex-compressed-meat

--- a/Resources/Prototypes/Flavors/flavors.yml
+++ b/Resources/Prototypes/Flavors/flavors.yml
@@ -1128,3 +1128,4 @@
   id: compressed-meat
   flavorType: Complex
   description: flavor-complex-compressed-meat
+  


### PR DESCRIPTION
## About the PR
Added flavor profiles to an array of things that were previously "indescribable"
the following have been flavored
- mice
- hamsters (hamlet included)
- cockroaches
- paper
- monkey cubes (and other dehydrated creatures)
- crayons
- clothing
- cloth/cotton
- sheep wool (as in literally eating it off a live sheep)

## Why / Balance
"Tastes indescribable" is boring.

## Technical details
Just yml changes. I added a few new flavors, including "chewy" which may be useful for other things.

## Media
![2024-08-31_16-09](https://github.com/user-attachments/assets/6be443e5-6539-4618-9e37-dd10f6b5db48)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None (probably)

**Changelog**
:cl:
- add: Added flavors to an array of previously indescribable things.
