### PR TITLE
Fix CS0642 - Possible mistaken empty statement

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -106,7 +106,7 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnExamined(EntityUid uid, GasTankComponent component, ExaminedEvent args)
         {
-            using(args.PushGroup(nameof(GasTankComponent)));
+            using var _ = args.PushGroup(nameof(GasTankComponent));
             if (args.IsInDetailsRange)
                 args.PushMarkup(Loc.GetString("comp-gas-tank-examine", ("pressure", Math.Round(component.Air?.Pressure ?? 0))));
             if (component.IsConnected)
@@ -348,7 +348,7 @@ namespace Content.Server.Atmos.EntitySystems
                 if (component.Integrity <= 0)
                 {
                     var environment = _atmosphereSystem.GetContainingMixture(owner, false, true);
-                    if(environment != null)
+                    if (environment != null)
                         _atmosphereSystem.Merge(environment, component.Air);
 
                     _audioSys.PlayPvs(component.RuptureSound, Transform(owner).Coordinates, AudioParams.Default.WithVariation(0.125f));


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This took me a minute to disambiguate so I'll recount the tale here.

This is the original statement:
```c#
using(args.PushGroup(nameof(GasTankComponent)));
if (args.IsInDetailsRange)
   ...
```

This statement throws a warning on the ending semicolon: `CS0642 Possible mistaken empty statement`. What it's trying to tell us is that the above statement actually **becomes**:

```c#
using(args.PushGroup(nameof(GasTankComponent)));
{
    // empty using block!
}
if (args.IsInDetailsRange)
   ...
```

What the code is actually trying _to do_ is use a [variant of the using statement](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/using) that creates an implied `using` scope that is equal to the (rest of) the function scope (i.e. the `Dispose()` is called just before the function returns). That variant of the `using` statement **must explicitly assign to a variable** or else the using statement is actually treated like a `using` statement with a single-line code block following it (i.e. the example in the code example above).

So we need to explicitly assign to something, but we don't actually need the result of `PushGroup` so we can just assign to the discard value.

This properly sets the scope of the `using` statement to the whole function and clears the warning.

I think C# probably has a bit too much syntax these days, but maybe I'm just old.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

