### PR TITLE
Add an acid cleanade for traitor janitors

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/cleaning.ftl
+++ b/Resources/Locale/en-US/reagents/meta/cleaning.ftl
@@ -4,6 +4,9 @@ reagent-desc-bleach = Heavy duty cleaner that can clean tiles the same as Space 
 reagent-name-space-cleaner = space cleaner
 reagent-desc-space-cleaner = This is able to clean almost all surfaces of almost anything that may dirty them. The janitor is likely to appreciate refills.
 
+reagent-name-universal-solvent = universal solvent
+reagent-desc-universal-solvent = A heavy duty cleaner outlawed in most places due to safety concerns. Exceptionally effective at dissolving skin, scales, and fuzz. Visually identical to space cleaner.
+
 reagent-name-soap = soap
 reagent-desc-soap = I wouldn't clean my mouth out with this if I were you.
 

--- a/Resources/Locale/en-US/reagents/universalsolvent.ftl
+++ b/Resources/Locale/en-US/reagents/universalsolvent.ftl
@@ -1,0 +1,2 @@
+universalsolvent-effect-skin = You feel your skin searing off!
+universalsolvent-effect-organs = You feel your organs dissolving!

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -287,6 +287,9 @@ uplink-chimp-upgrade-kit-desc = Insert this chip into a standard C.H.I.M.P. hand
 uplink-proximity-mine-name = Proximity Mine
 uplink-proximity-mine-desc = A mine disguised as a wet floor sign.
 
+uplink-heavy-cleanade-name = Heavy Duty Cleanade
+uplink-heavy-cleanade-desc = An outwardly normal cleaning grenade filled with an extremely corrosive chemical which is visually identical to regular space cleaner foam. Best used for "cleaning" crowded medical facilities.
+
 uplink-disposable-turret-name = Disposable Ballistic Turret
 uplink-disposable-turret-desc = Looks and functions like a normal electrical toolbox. Upon hitting the toolbox it will transform into a ballistic turret, theoretically shooting at anyone except members of the syndicate. Can be turned back into a toolbox using a screwdriver and repaired using a wrench.
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1713,14 +1713,13 @@
   description: uplink-heavy-cleanade-desc
   productEntity: CleanerGrenadeAcid
   cost:
-    Telecrystal: 4
+    Telecrystal: 6
   categories:
   - UplinkJob
   conditions:
   - !type:BuyerJobCondition
     whitelist:
     - Janitor
-    - Chemist # They're already war criminals, they can have the mustard gas bomb.
 
 - type: listing
   id: UplinkSyndicateSpongeBox

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1708,6 +1708,21 @@
       - SurplusBundle
 
 - type: listing
+  id: uplinkHeavyCleanade
+  name: uplink-heavy-cleanade-name
+  description: uplink-heavy-cleanade-desc
+  productEntity: CleanerGrenadeAcid
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkJob
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist:
+    - Janitor
+    - Chemist # They're already war criminals, they can have the mustard gas bomb.
+
+- type: listing
   id: UplinkSyndicateSpongeBox
   name: uplink-syndicate-sponge-box-name
   description: uplink-syndicate-sponge-box-desc

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -413,8 +413,8 @@
   suffix: Acid
   components:
   - type: SmokeOnTrigger
-    duration: 30 # Spends longer dissolving people who don't or can't get out of the cloud
-    spreadAmount: 75 # It's technically better at cleaning
+    duration: 20 # Spends longer dissolving people who don't or can't get out of the cloud
+    spreadAmount: 50
     smokePrototype: Foam
     solution:
       reagents:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -408,6 +408,20 @@
         Quantity: 30
 
 - type: entity
+  parent: CleanerGrenade
+  id: CleanerGrenadeAcid
+  suffix: Acid
+  components:
+  - type: SmokeOnTrigger
+    duration: 30 # Spends longer dissolving people who don't or can't get out of the cloud
+    spreadAmount: 75 # It's technically better at cleaning
+    smokePrototype: Foam
+    solution:
+      reagents:
+      - ReagentId: UniversalSolvent
+        Quantity: 30
+
+- type: entity
   parent: SmokeGrenade
   id: TearGasGrenade
   name: tear gas grenade

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -60,7 +60,7 @@
         ignoreResistances: false
         damage:
           types:
-            Caustic: 6 # High skin contact damage to remain effective against internals users.
+            Caustic: 4 # High skin contact damage to remain effective against internals users.
       - !type:PopupMessage
         type: Local
         visualType: LargeCaution
@@ -76,7 +76,7 @@
       - !type:HealthChange
         damage:
           types:
-            Caustic: 9 # 3 damage per unit
+            Caustic: 6 # 2 damage per unit
       - !type:PopupMessage
         type: Local
         visualType: LargeCaution

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -39,6 +39,54 @@
     - !type:CleanDecalsReaction {}
 
 - type: reagent
+  id: UniversalSolvent
+  name: reagent-name-universal-solvent
+  desc: reagent-desc-universal-solvent
+  physicalDesc: reagent-physical-desc-strong-smelling
+  flavor:
+  color: "#c8ff69" # Everyone is accustomed to this color being the safe foam, so... >:D
+  recognizable: false
+  boilingPoint: 147.0
+  meltingPoint: -11.0
+  tileReactions:
+    - !type:CleanTileReaction {} # It still cleans, just the scope of what it cleans is... larger...
+    - !type:CleanDecalsReaction {}
+  reactiveEffects:
+    Acidic:
+      methods: [ Touch ]
+      effects:
+      - !type:HealthChange
+        scaleByQuantity: true
+        ignoreResistances: false
+        damage:
+          types:
+            Caustic: 6 # High skin contact damage to remain effective against internals users.
+      - !type:PopupMessage
+        type: Local
+        visualType: LargeCaution
+        messages: [ "universalsolvent-effect-skin" ]
+        probability: 0.33
+      - !type:Emote
+        emote: Scream
+        probability: 0.5
+  metabolisms:
+    Poison:
+      metabolismRate : 3.00
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Caustic: 9 # 3 damage per unit
+      - !type:PopupMessage
+        type: Local
+        visualType: LargeCaution
+        messages: [ "universalsolvent-effect-organs" ]
+        probability: 0.33
+      - !type:Emote
+        emote: Scream
+        probability: 0.3
+
+- type: reagent
   id: SoapReagent
   name: reagent-name-soap
   desc: reagent-desc-soap

--- a/Resources/Prototypes/Recipes/Reactions/cleaning.yml
+++ b/Resources/Prototypes/Recipes/Reactions/cleaning.yml
@@ -30,6 +30,18 @@
     SpaceCleaner: 2
 
 - type: reaction
+  id: UniversalSolvent
+  reactants:
+    FluorosulfuricAcid:
+      amount: 1
+    Bleach:
+      amount: 1
+    Vestine:
+      amount: 4
+  products:
+    UniversalSolvent: 6
+
+- type: reaction
   id: SpaceLube
   impact: Medium
   reactants:

--- a/Resources/Prototypes/Recipes/Reactions/cleaning.yml
+++ b/Resources/Prototypes/Recipes/Reactions/cleaning.yml
@@ -30,7 +30,7 @@
     SpaceCleaner: 2
 
 - type: reaction
-  id: UniversalSolvent
+  id: UniversalSolvent # Chemists are already war criminals, they can have the mustard gas chemical.
   reactants:
     FluorosulfuricAcid:
       amount: 1


### PR DESCRIPTION
## About the PR
Adds a "heavy duty cleanade" that can be purchased for 4 tc by syndicate janitors and chemists. It is visually identical to regular cleanades with no immediate way to differentiate them. The foam it creates lasts a bit longer than regular cleanade foam, and does high caustic damage to anyone caught within.
Also adds Universal Solvent, a powerful acid with especially high skin contact damage compared to other acids. It can be made with vestine, bleach, and fluorosulfuric acid.

## Why / Balance
Had an idea for an acid cleanade, thought it would be a fun addition for janitor syndies. Give people some fear when the janitor comes in to clean up the crowded medical with a cleanade.
## Media
https://github.com/user-attachments/assets/fc8ebb41-3f95-462a-8174-73836c8da594

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- add: Added acid-filled cleaning grenades for traitor janitors.
