### PR TITLE
Lower shuttle event weights

### DIFF
--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -5,19 +5,19 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: UnknownShuttleCargoLost
-    - id: UnknownShuttleTravelingCuisine
     - id: UnknownShuttleDisasterEvacPod
     - id: UnknownShuttleHonki
+    - id: UnknownShuttleTravelingCuisine
 
 - type: entityTable
   id: UnknownShuttlesFreelanceTable
-  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+  table: !type:AllSelector
     children:
     - id: UnknownShuttleSyndieEvacPod
 
 - type: entityTable
   id: UnknownShuttlesHostileTable
-  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+  table: !type:AllSelector
     children:
     - id: LoneOpsSpawn
 
@@ -32,7 +32,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    weight: 5
+    weight: 2
     reoccurrenceDelay: 30
     duration: 1
   - type: RuleGrids
@@ -64,7 +64,7 @@
   id: UnknownShuttleHonki
   components:
   - type: StationEvent
-    weight: 2
+    weight: 1
   - type: LoadMapRule
     preloadedGrid: Honki
 
@@ -73,6 +73,6 @@
   id: UnknownShuttleSyndieEvacPod
   components:
   - type: StationEvent
-    weight: 2
+    weight: 1
   - type: LoadMapRule
     preloadedGrid: SyndieEvacPod

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -47,17 +47,19 @@
 
 - type: entity
   parent: BaseUnknownShuttleRule
-  id: UnknownShuttleTravelingCuisine
-  components:
-  - type: LoadMapRule
-    preloadedGrid: TravelingCuisine
-
-- type: entity
-  parent: BaseUnknownShuttleRule
   id: UnknownShuttleDisasterEvacPod
   components:
   - type: LoadMapRule
     preloadedGrid: DisasterEvacPod
+
+- type: entity
+  parent: BaseUnknownShuttleRule
+  id: UnknownShuttleTravelingCuisine
+  components:
+  - type: StationEvent
+    weight: 1
+  - type: LoadMapRule
+    preloadedGrid: TravelingCuisine
 
 - type: entity
   parent: BaseUnknownShuttleRule


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Most shuttles have been lowered from 5 weight down to 2, with the clown, travelling chef, and syndicate shuttles being at 1 weight. This means there is a total of 7 weight for any shuttle event to occur, and is slightly less than half as common (in theory)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Most shifts they happen anywhere from 1-3 times, and sometimes I've even seen ALL shuttles occur on longer shifts or on survival. This makes it an actually rare event, and hopefully feel more worth it to take.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Ubaser
- tweak: Shuttle events are now rarer.

