### PR TITLE
Shuttle event rule changes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -698,7 +698,7 @@
     - type: GhostRole
       name: ghost-role-information-clown-troupe-name
       description: ghost-role-information-clown-troupe-description
-      rules: ghost-role-information-nonantagonist-rules
+      rules: ghost-role-information-freeagent-rules
       raffle:
         settings: short
     - type: Loadout
@@ -750,7 +750,7 @@
     - type: GhostRole
       name: ghost-role-information-traveling-chef-name
       description: ghost-role-information-traveling-chef-description
-      rules: ghost-role-information-nonantagonist-rules
+      rules: ghost-role-information-freeagent-rules
       raffle:
         settings: short
     - type: Loadout
@@ -875,7 +875,7 @@
     - type: GhostRole
       name: ghost-role-information-syndie-disaster-victim-name
       description: ghost-role-information-syndie-disaster-victim-description
-      rules: ghost-role-information-nonantagonist-rules
+      rules: ghost-role-information-freeagent-rules
       raffle:
         settings: short
     - type: Loadout

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -5,19 +5,19 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: UnknownShuttleCargoLost
-    - id: UnknownShuttleTravelingCuisine
     - id: UnknownShuttleDisasterEvacPod
     - id: UnknownShuttleHonki
+    - id: UnknownShuttleTravelingCuisine
 
 - type: entityTable
   id: UnknownShuttlesFreelanceTable
-  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+  table: !type:AllSelector
     children:
     - id: UnknownShuttleSyndieEvacPod
 
 - type: entityTable
   id: UnknownShuttlesHostileTable
-  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+  table: !type:AllSelector
     children:
     - id: LoneOpsSpawn
 
@@ -32,7 +32,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    weight: 5
+    weight: 2
     reoccurrenceDelay: 30
     duration: 1
   - type: RuleGrids
@@ -47,13 +47,6 @@
 
 - type: entity
   parent: BaseUnknownShuttleRule
-  id: UnknownShuttleTravelingCuisine
-  components:
-  - type: LoadMapRule
-    preloadedGrid: TravelingCuisine
-
-- type: entity
-  parent: BaseUnknownShuttleRule
   id: UnknownShuttleDisasterEvacPod
   components:
   - type: LoadMapRule
@@ -61,10 +54,19 @@
 
 - type: entity
   parent: BaseUnknownShuttleRule
+  id: UnknownShuttleTravelingCuisine
+  components:
+  - type: StationEvent
+    weight: 1
+  - type: LoadMapRule
+    preloadedGrid: TravelingCuisine
+
+- type: entity
+  parent: BaseUnknownShuttleRule
   id: UnknownShuttleHonki
   components:
   - type: StationEvent
-    weight: 2
+    weight: 1
   - type: LoadMapRule
     preloadedGrid: Honki
 
@@ -73,6 +75,6 @@
   id: UnknownShuttleSyndieEvacPod
   components:
   - type: StationEvent
-    weight: 2
+    weight: 1
   - type: LoadMapRule
     preloadedGrid: SyndieEvacPod


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Requires #31780.
The shuttles that have lower weights (at 1) now are free agents. This includes the travelling chef, clown shuttle, and syndicate agents.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Treat the following discussion assuming that the PR above is merged.

Quite often these ghost roles were yet another way of getting back into the round but it was rather boring, they often wandered around as passengers. Since they were always non-antagonists, it was guaranteed that security would metagame. In regards to the syndicate shuttle, security would get free blood-red keys as the passengers weren't allowed to fight back and it makes more sense if the "syndicates" were properly "syndicate-aligned". The clowns are free-agents now so that they can truly cause chaos using the stuff they are given without limits and can now be seen as an omen (which is really really funny imo). The chefs are now allowed to kidnap and cook human burgers in their shuttle selling it as "exotic food" and can now legally protect their shuttle from invaders. Even if all of these roles decide to be antagonistic, altogether they aren't actually that powerful since their loot is no better than an average crew member.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Ubaser
- tweak: Some shuttle ghost roles are now free agents.