### PR TITLE
MMI borg roletime tracking

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSystem.MMI.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.MMI.cs
@@ -84,14 +84,12 @@ public sealed partial class BorgSystem
 
         if (component.LinkedMMI is not { } linked)
             return;
-        var oldJob = component.OldJob;
         RemComp(uid, component);
 
         if (_mind.TryGetMind(linked, out var mindId, out var mind))
         {
             _mind.TransferTo(mindId, uid, true, mind: mind);
-
-            EnsureComp<JobComponent>(mindId).Prototype = oldJob;
+            EnsureComp<JobComponent>(mindId).Prototype = component.OldJob;
         }
 
         _appearance.SetData(linked, MMIVisuals.BrainPresent, false);

--- a/Content.Server/Silicons/Borgs/BorgSystem.MMI.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.MMI.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Mind.Components;
+using Content.Shared.Roles.Jobs;
 using Content.Shared.Silicons.Borgs.Components;
 using Robust.Shared.Containers;
 
@@ -43,6 +44,9 @@ public sealed partial class BorgSystem
         if (_mind.TryGetMind(ent, out var mindId, out var mind))
             _mind.TransferTo(mindId, uid, true, mind: mind);
 
+        EnsureComp<JobComponent>(mindId);
+        Comp<JobComponent>(mindId).Prototype = "Borg";
+
         _appearance.SetData(uid, MMIVisuals.BrainPresent, true);
     }
 
@@ -76,6 +80,10 @@ public sealed partial class BorgSystem
 
         if (_mind.TryGetMind(linked, out var mindId, out var mind))
             _mind.TransferTo(mindId, uid, true, mind: mind);
+
+        //If it ever becomes possible to put the brain back in a body, then there needs to be a way to recover the old job prototype
+        if (TryComp<JobComponent>(mindId, out var job))
+            job.Prototype = null;
 
         _appearance.SetData(linked, MMIVisuals.BrainPresent, false);
     }

--- a/Content.Shared/Silicons/Borgs/Components/MMILinkedComponent.cs
+++ b/Content.Shared/Silicons/Borgs/Components/MMILinkedComponent.cs
@@ -1,4 +1,6 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared.Roles;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Silicons.Borgs.Components;
 
@@ -15,4 +17,9 @@ public sealed partial class MMILinkedComponent : Component
     /// </summary>
     [DataField("linkedMMI"), AutoNetworkedField]
     public EntityUid? LinkedMMI;
+
+    /// <summary>
+    /// The job this entity had before being borged.
+    /// </summary>
+    public ProtoId<JobPrototype>? OldJob;
 }


### PR DESCRIPTION
## About the PR
Brains put into an MMI now count as Borg for purposes of playtime tracking. 

Note: due to an unrelated issue, MMI brains (unlike positronic brains) will not track borg playtime while outside of a borg. 

## Why / Balance
Not only was MMI borg playtime not tracked, it actually counted as the mob's original job
Fixes #31760

## Technical details
JobComponent.Prototype is changed to Borg upon being inserted into an MMI. The old job prototype is saved on MMILinkedComponent, and restored if the brain is taken out of the MMI. This doesn't currently matter, since the brain will be dead and not tracking playtime, but it will be needed by potential future features like brain cloning or transplantation

Issue: Brains still count as "dead" while in an MMI so they only start tracking playtime after inserted into a borg. this is inconsistent with Positronic Brains, which start tracking as soon as they are possessed, regardless of body. I'm not fixing that here yet, because I'm not actually sure which of the two behaviors is "correct", and it can be handled on its own

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Errant
- fix: Organic brains turned into a borg now count borg playtime.