### PR TITLE
Make context menu uses spritetree

### DIFF
--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -126,11 +126,6 @@
     bodyType: Static
   - type: Fixtures
     fixtures:
-      # Context / examine fixture
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.25
       slipFixture:
         shape:
           !type:PhysShapeAabb

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
@@ -8,11 +8,6 @@
     bodyType: Static
   - type: Fixtures
     fixtures:
-      # This exists for examine.
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.25
       light:
         shape:
           !type:PhysShapeCircle


### PR DESCRIPTION
Rather than doing goofy hacks we just use what sprites are near the mouse.

Fixes https://github.com/space-wizards/space-station-14/issues/31756