### PR TITLE
Improvements to hand labeler UI

### DIFF
--- a/Content.Client/Labels/UI/HandLabelerBoundUserInterface.cs
+++ b/Content.Client/Labels/UI/HandLabelerBoundUserInterface.cs
@@ -26,6 +26,11 @@ namespace Content.Client.Labels.UI
 
             _window = this.CreateWindow<HandLabelerWindow>();
 
+            if (_entManager.TryGetComponent(Owner, out HandLabelerComponent? labeler))
+            {
+                _window.SetMaxLabelLength(labeler!.MaxLabelChars);
+            }
+
             _window.OnLabelChanged += OnLabelChanged;
             Reload();
         }

--- a/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
+++ b/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
@@ -21,7 +21,7 @@ namespace Content.Client.Labels.UI
         {
             RobustXamlLoader.Load(this);
 
-            LabelLineEdit.OnTextEntered += e =>
+            LabelLineEdit.OnTextChanged += e =>
             {
                 _label = e.Text;
                 OnLabelChanged?.Invoke(_label);
@@ -33,6 +33,10 @@ namespace Content.Client.Labels.UI
                 _focused = false;
                 LabelLineEdit.Text = _label;
             };
+
+            // Give the editor keybard focus, since that's the only
+            // thing the user will want to be doing with this UI
+            LabelLineEdit.GrabKeyboardFocus();
         }
 
         public void SetCurrentLabel(string label)
@@ -43,6 +47,11 @@ namespace Content.Client.Labels.UI
             _label = label;
             if (!_focused)
                 LabelLineEdit.Text = label;
+        }
+
+        public void SetMaxLabelLength(int maxLength)
+        {
+            LabelLineEdit.IsValid = s => s.Length <= maxLength;
         }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Improves a couple of minor usability issues with the hand labeler UI:

Line edit did not have focus when UI was opened; so, users had to open the UI, then click on the line edit. If they're opening the UI, the only thing they can do is type text, so give the line edit focus to save them a click.

Line edit required user to press enter to set the text, but no feedback was given. If you typed text without pressing enter, then attempted to apply a label, the item would be labeled with the old text and your entered text would be reset to the old text. Now, it updates the label whenever the user changes the text; no need to press enter.

Line edit allowed you to enter a label which was longer than the maximum label length; when applying a label, your text would be silently truncated. Now, the line edit does not update if you attempt to insert text which would hit the maximum label length limit.


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Improved UI/usability.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
