### PR TITLE
Made the Armory Gun Safe a craftable object

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -156,7 +156,7 @@
         prob: 0.5
 
 - type: entity
-  parent: [GunSafe, BaseRestrictedContraband]
+  parent: [GunSafeBaseSecure, BaseRestrictedContraband]
   id: GunSafeDisabler
   name: disabler safe
   components:
@@ -166,7 +166,7 @@
       amount: 5
 
 - type: entity
-  parent: [GunSafe, BaseRestrictedContraband]
+  parent: [GunSafeBaseSecure, BaseRestrictedContraband]
   id: GunSafePistolMk58
   name: mk58 safe
   components:
@@ -178,7 +178,7 @@
       amount: 8
 
 - type: entity
-  parent: [GunSafe, BaseRestrictedContraband]
+  parent: [GunSafeBaseSecure, BaseRestrictedContraband]
   id: GunSafeRifleLecter
   name: lecter safe
   components:
@@ -190,7 +190,7 @@
       amount: 4
 
 - type: entity
-  parent: [GunSafe, BaseRestrictedContraband]
+  parent: [GunSafeBaseSecure, BaseRestrictedContraband]
   id: GunSafeSubMachineGunDrozd
   name: drozd safe
   components:
@@ -202,7 +202,7 @@
       amount: 4
 
 - type: entity
-  parent: [GunSafe, BaseRestrictedContraband]
+  parent: [GunSafeBaseSecure, BaseRestrictedContraband]
   id: GunSafeShotgunEnforcer
   name: enforcer safe
   components:
@@ -214,7 +214,7 @@
       amount: 4
 
 - type: entity
-  parent: [GunSafe, BaseRestrictedContraband]
+  parent: [GunSafeBaseSecure, BaseRestrictedContraband]
   id: GunSafeShotgunKammerer
   name: kammerer safe
   components:
@@ -228,7 +228,7 @@
 - type: entity
   id: GunSafeSubMachineGunWt550
   suffix: Wt550
-  parent: [GunSafe, BaseRestrictedContraband]
+  parent: [GunSafeBaseSecure, BaseRestrictedContraband]
   name: wt550 safe
   components:
   - type: StorageFill
@@ -239,7 +239,7 @@
       amount: 4
 
 - type: entity
-  parent: GunSafe
+  parent: GunSafeBaseSecure
   id: GunSafeLaserCarbine
   name: laser safe
   components:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -350,7 +350,7 @@
     access: [["Security"]]
 
 - type: entity
-  id: GunSafe
+  id: GunSafeBase
   parent: LockerBaseSecure
   name: gun safe
   components:
@@ -360,12 +360,20 @@
     stateDoorOpen: shotguncase_open
     stateDoorClosed: shotguncase_door
   - type: AccessReader
-    access: [["Armory"]]
   - type: Construction
-    graph: GunSafe
+    graph: GunSafeBase
     node: done
     containers:
     - entity_storage
+  - type: StaticPrice
+    price: 335
+
+- type: entity
+  id: GunSafeBaseSecure
+  parent: GunSafeBase
+  components:
+  - type: AccessReader
+    access: [["Armory"]]
 
 # Detective
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -361,6 +361,11 @@
     stateDoorClosed: shotguncase_door
   - type: AccessReader
     access: [["Armory"]]
+  - type: Construction
+    graph: GunSafe
+    node: done
+    containers:
+    - entity_storage
 
 # Detective
 - type: entity

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/tallbox.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/tallbox.yml
@@ -62,6 +62,47 @@
       - !type:DeleteEntity
 
 - type: constructionGraph
+  id: GunSafe
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: done
+      steps:
+      - material: Steel
+        amount: 10
+      - material: Cable
+        amount: 5
+        doAfter: 5
+      - material: Plasteel
+        amount: 10
+        doAfter: 10
+  - node: done
+    entity: GunSafe
+    edges:
+    - to: start
+      steps:
+      - tool: Screwing
+        doAfter: 5
+      conditions:
+      - !type:StorageWelded
+        welded: false
+      - !type:Locked
+        locked: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 10
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 5
+      - !type:SpawnPrototype
+        prototype: SheetPlasteel1
+        amount: 10
+      - !type:EmptyAllContainers
+      - !type:DeleteEntity
+
+- type: constructionGraph
   id: ClosetWall
   start: start
   graph:

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/tallbox.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/tallbox.yml
@@ -62,7 +62,7 @@
       - !type:DeleteEntity
 
 - type: constructionGraph
-  id: GunSafe
+  id: GunSafeBase
   start: start
   graph:
   - node: start
@@ -78,7 +78,7 @@
         amount: 10
         doAfter: 10
   - node: done
-    entity: GunSafe
+    entity: GunSafeBase
     edges:
     - to: start
       steps:

--- a/Resources/Prototypes/Recipes/Crafting/tallbox.yml
+++ b/Resources/Prototypes/Recipes/Crafting/tallbox.yml
@@ -21,9 +21,9 @@
   objectType: Structure
 
 - type: construction
-  id: GunSafe
+  id: GunSafeBase
   name: gun safe
-  graph: GunSafe
+  graph: GunSafeBase
   startNode: start
   targetNode: done
   category: construction-category-storage

--- a/Resources/Prototypes/Recipes/Crafting/tallbox.yml
+++ b/Resources/Prototypes/Recipes/Crafting/tallbox.yml
@@ -21,6 +21,17 @@
   objectType: Structure
 
 - type: construction
+  id: GunSafe
+  name: gun safe
+  graph: GunSafe
+  startNode: start
+  targetNode: done
+  category: construction-category-storage
+  description: A durable gun safe that can be locked.
+  icon: { sprite: Structures/Storage/closet.rsi, state: shotguncase }
+  objectType: Structure
+
+- type: construction
   id: ClosetWall
   name: wall closet
   graph: ClosetWall


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changed Gun Safes to be craftable with 10 steel, 5 LV cables, and 10 plasteel. Takes longer to construct than regular closets/lockers.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
If something breaks a safe or if new weapons are unlocked in science, it is impossible for the Warden/HoS to create a new safe to hold these weapons.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
YML only changes. 

Create entity "GunSafeBase" that has no default access, and can be constructed with 10 steel, 5 LV cable, and 10 plasteel. It has a price of 335 spesos (280 for 10 plasteel, 50 for 10 steel, and 5 for the 5 LV cables). 

Create entity "GunSafeBaseSecure" with "GunSafeBase" as a parent. This has an access level of "Armory"

Changed filled gun safes to inherit from "GunSafeBaseSecure," so that they still spawn requiring Armory access 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
![image](https://github.com/user-attachments/assets/1736d498-0fa2-45d7-98e3-cbe9e9ffbffe)
![image](https://github.com/user-attachments/assets/06e72453-b4fb-40ea-abc9-acbeb912ed1b)
![image](https://github.com/user-attachments/assets/35bfb6f3-50e3-4976-b9f6-8fe7de6b3b86)
![image](https://github.com/user-attachments/assets/ba6d9c94-c213-446a-a19f-3ab90b683a4b)
![image](https://github.com/user-attachments/assets/31dcd3cf-88ac-476c-8fda-f7cf5e839428)
![image](https://github.com/user-attachments/assets/a16d7301-b54a-43dd-867d-c51bfea277a0)

![image](https://github.com/user-attachments/assets/2c022c09-aada-4a2a-b12c-7684733f7fa9)
![image](https://github.com/user-attachments/assets/1d6d44f4-de05-4e29-83e0-7ae0c83d18b0)
![image](https://github.com/user-attachments/assets/18a2b1cc-b7f8-493f-9fde-01fb2bf155d9)
![image](https://github.com/user-attachments/assets/e97b1af1-b890-4bad-b57f-afa7966b0c6d)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
Renamed entity "GunSafe" to "GunSafeBase" that has no default access, and can be constructed, with a cost of 335 spesos (280 for 10 plasteel, 50 for 10 steel, and 5 for the 5 LV cables). 

Create entity "GunSafeBaseSecure" with "GunSafeBase" as a parent. This has access level of "Armory"

Changed filled gun safes to inherit from "GunSafeBaseSecure" vs "GunSafe"

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl: Allen
- add: Made Gun Safes a craftable object (10 steel, 5 lv cable, 10 plasteel)
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl: Allen
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
