### PR TITLE
Spaceshroom grilling

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/spaceshroom.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spaceshroom.yml
@@ -76,6 +76,28 @@
     weightedRandomId: RandomFillSpaceshroom
   - type: StaticPrice
     price: 20
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 1
+        mask:
+        - ItemMask
+        restitution: 0.3
+        friction: 0.2
+  - type: Construction
+    graph: CookedSpaceshroom
+    node: start
+    defaultTarget: cooked spaceshroom
+  - type: AtmosExposed
+  - type: Temperature
+    currentTemperature: 290
+  - type: InternalTemperature
+    thickness: 0.02
+    area: 0.02
+    conductivity: 0.43
 
 - type: weightedRandomFillSolution
   id: RandomFillSpaceshroom
@@ -126,3 +148,6 @@
   - type: Produce
   - type: StaticPrice
     price: 40
+  - type: Construction
+    graph: CookedSpaceshroom
+    node: cooked spaceshroom

--- a/Resources/Prototypes/Recipes/Construction/Graphs/food/spaceshroom.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/food/spaceshroom.yml
@@ -1,0 +1,16 @@
+- type: constructionGraph
+  id: CookedSpaceshroom
+  start: start
+  graph:
+
+  - node: start
+    edges:
+    - to: cooked spaceshroom
+      completed:
+      - !type:PlaySound
+        sound: /Audio/Effects/sizzle.ogg
+      steps:
+      - minTemperature: 375 # little bit above boiling, shrooms need to lose all moisture to be good
+
+  - node: cooked spaceshroom
+    entity: FoodSpaceshroomCooked

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1834,14 +1834,6 @@
     FoodBreadBaguetteSlice: 1
 
 - type: microwaveMealRecipe
-  id: RecipeCookedSpaceshroom
-  name: cooked spaceshroom recipe
-  result: FoodSpaceshroomCooked
-  time: 5
-  solids:
-    FoodSpaceshroom: 1
-
-- type: microwaveMealRecipe
   id: RecipeCannabisButter
   name: cannabis butter recipe
   result: FoodCannabisButter


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changes spaceshroom cooking to be temperature based instead of the microwave timer. They can now be cooked both in the microwave and on the grill. 

## Why / Balance
There is a maints room in cog that features a grill with spaceshrooms on top of it, urging the player to cook them. This was impossible before.
/
The cooked item is identical to the previous recipe and it roughly takes the same amount of time to cook. It's possible to cook them in batches, but this shouldn't be a problem as they provide the same amount of nutrients as steaks.

## Media

https://github.com/user-attachments/assets/b460589d-8ac9-4665-af83-f3d8196de2b1



## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Spaceshrooms can now be cooked on the electric grill.
