### PR TITLE
AI loses vision when cameras lose power.

### DIFF
--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
@@ -203,7 +203,7 @@ public sealed class SurveillanceCameraMonitorSystem : EntitySystem
     }
 
     // This is to ensure that there's no delay in ensuring that a camera is deactivated.
-    private void OnSurveillanceCameraDeactivate(EntityUid uid, SurveillanceCameraMonitorComponent monitor, SurveillanceCameraDeactivateEvent args)
+    private void OnSurveillanceCameraDeactivate(EntityUid uid, SurveillanceCameraMonitorComponent monitor, ref SurveillanceCameraDeactivateEvent args)
     {
         DisconnectCamera(uid, false, monitor);
     }

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSystem.cs
@@ -65,9 +65,6 @@ public sealed class SurveillanceCameraSystem : EntitySystem
 
         SubscribeLocalEvent<SurveillanceCameraComponent, EmpPulseEvent>(OnEmpPulse);
         SubscribeLocalEvent<SurveillanceCameraComponent, EmpDisabledRemoved>(OnEmpDisabledRemoved);
-
-        SubscribeLocalEvent<SurveillanceCameraComponent, SurveillanceCameraActivateEvent>(OnSurveillanceCameraActivate);
-        SubscribeLocalEvent<SurveillanceCameraComponent, SurveillanceCameraDeactivateEvent>(OnSurveillanceCameraDeactivate);
     }
 
     private void OnPacketReceived(EntityUid uid, SurveillanceCameraComponent component, DeviceNetworkPacketEvent args)
@@ -408,18 +405,6 @@ public sealed class SurveillanceCameraSystem : EntitySystem
         }
 
         _appearance.SetData(uid, SurveillanceCameraVisualsKey.Key, key, appearance);
-    }
-
-    private void OnSurveillanceCameraActivate(EntityUid camera, SurveillanceCameraComponent component, ref SurveillanceCameraActivateEvent args)
-    {
-        if (TryComp(args.Camera, out StationAiVisionComponent? aiVision))
-            _stationAI.SetVisionEnabled((camera, aiVision), true);
-    }
-
-    private void OnSurveillanceCameraDeactivate(EntityUid camera, SurveillanceCameraComponent component, ref SurveillanceCameraDeactivateEvent args)
-    {
-        if (TryComp(args.Camera, out StationAiVisionComponent? aiVision))
-            _stationAI.SetVisionEnabled((camera, aiVision), false);
     }
 
     private void OnEmpPulse(EntityUid uid, SurveillanceCameraComponent component, ref EmpPulseEvent args)


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

The AI will now properly lose vision granted by cameras when those cameras lose power.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

![ai-power](https://github.com/user-attachments/assets/12f13bf7-8877-49e2-82e1-f5642b0b5009)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The AI will now properly lose vision granted by cameras when those cameras lose power