### PR TITLE
Budget insuls leaves behind frayed insulative fibers instead of insulative fibers

### DIFF
--- a/Resources/Locale/en-US/forensics/fibers.ftl
+++ b/Resources/Locale/en-US/forensics/fibers.ftl
@@ -2,6 +2,7 @@ forensic-fibers = {LOC($material)} fibers
 forensic-fibers-colored = {LOC($color)} {LOC($material)} fibers
 
 fibers-insulative = insulative
+fibers-insulative-frayed = frayed insulative
 fibers-synthetic = synthetic
 fibers-leather = leather
 fibers-durathread = durathread

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -335,6 +335,9 @@
       - 3
       - 3.5
       - 4
+  - type: Fiber
+    fiberMaterial: fibers-insulative-frayed
+    fiberColor: fibers-yellow
 
 # Conductive Insulated Gloves
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Budget insuls now leave behind yellow frayed insulative fibers instead of insulative fibers upon examination by the Forensic Scanner.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Currently, insulated fibers are produced by both budget and regular insulated gloves. This commonly leads to security and the detective gaining very little headway in terms of narrowing down which department (greytide or engineering) did the crime.

With this change, insulated gloves and budget insulated gloves leave behind different fibers. This can aid security a little bit more in closing a case. It's important to recognize that gloves/fibers in forensic gameplay are not supposed to pinpoint the criminal, but narrow it down a decent amount and provide a point to trace between different points when solving a case. 

I believe this change makes fibers evidence a little bit stronger, while not tipping the scale entirely on Security's side.

Furthermore, this suggestion was noted in (the now unfortunately closed) PR #30603, where SlamBamActionman stated:

> The issue with yellow insulated fibers being too common could be solved by giving budget insuls their own category instead.

_Small note: in real life insulative equipment most commonly fails because a sharp metallic object punctures and penetrates the gloves, causing contact with skin. But "punctured insulated fibers" is weird. I could not find any info on any product recalls for insulated gloves (involving manufacturing defects), so enjoy frayed fibers instead._

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
FTL and YAML editing lmao
Added `fibers-insulative-frayed = frayed insulative` in fibers.ftl
Added `fiberMaterial: fibers-insulative-frayed` component to budget insuls in colored.yml

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
![Content Client_PlVWe8e6qY](https://github.com/user-attachments/assets/443da091-b110-485f-9057-73b7c945e377)


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Budget insulated gloves now leave behind yellow frayed insulative fibers instead of yellow insulative fibers.


