### PR TITLE
Fixed throngler name inconsistencies

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -56,7 +56,7 @@
 - type: entity
   parent: BasePlushie
   id: PlushieThrongler
-  name: The Throngler plushie
+  name: throngler plushie
   description: A stuffed toy to remind cargo techs of what they can no longer have.
   components:
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -161,7 +161,7 @@
   - type: DisarmMalus
 
 - type: entity
-  name: Throngler
+  name: throngler
   parent: [ BaseSword, BaseMajorContraband ]
   id: Throngler
   description: Why would you make this?


### PR DESCRIPTION
## About the PR
Changed the names of the throngler items to follow the same naming convention as the rest of the items.
E.g. "The Throngler plushie" is now named "throngler plushie" instead.

## Why / Balance
Fixes #31607
It looked ugly in the spawning menu and I wanted to try doing a PR for the first time.

## Media
![image](https://github.com/user-attachments/assets/4adaa5f1-99bd-4b56-b887-c5259c221290)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
I don't think this needs a changelog.
