### PR TITLE
Force stop pulling when fall asleep

### DIFF
--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -188,7 +188,7 @@ public sealed class PullingSystem : EntitySystem
 
         if (EntityManager.TryGetComponent(args.BlockingEntity, out PullableComponent? comp))
         {
-            StopPulling(args.BlockingEntity, comp);
+            TryStopPull(args.BlockingEntity, comp);
         }
     }
 

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -188,7 +188,7 @@ public sealed class PullingSystem : EntitySystem
 
         if (EntityManager.TryGetComponent(args.BlockingEntity, out PullableComponent? comp))
         {
-            TryStopPull(args.BlockingEntity, comp, uid);
+            StopPulling(args.BlockingEntity, comp);
         }
     }
 


### PR DESCRIPTION
## About the PR
![изображение](https://github.com/user-attachments/assets/674d1af2-92fe-4c93-b16f-3b8a81629c12)

## Why / Balance
it's a bug

## Technical details
`TryStopPull` requires consciousness while sleeping person is unconscious.

## Media
https://github.com/user-attachments/assets/57547efb-e5d8-460b-afbd-df4127f777a5

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl: yuitop
- fix: break pull when fall asleep
