### PR TITLE
Returned functionality to industrial reagent grinders

### DIFF
--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -258,9 +258,24 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
         }
 
         // if the item we inserted has reagents, add it in.
-        if (_solutionContainer.TryGetDrainableSolution(item, out _, out var drainableSolution))
+
+        if (reclaimerComponent.OnlyReclaimDrainable)
         {
-            totalChemicals.AddSolution(drainableSolution, _prototype);
+            // Are we a recycler? Only use drainable solutions.
+            if (_solutionContainer.TryGetDrainableSolution(item, out _, out var drainableSolution))
+            {
+                totalChemicals.AddSolution(drainableSolution, _prototype);
+            }
+        }
+        else
+        {
+            // Are we an industrial reagent grinder? Use any solutions it has.
+            if (TryComp<SolutionContainerManagerComponent>(item, out var solutionContainer)){
+                foreach (var (_, soln) in _solutionContainer.EnumerateSolutions((item, solutionContainer)))
+                {
+                    totalChemicals.AddSolution(soln.Comp.Solution, _prototype);
+                }
+            }
         }
 
         if (!_solutionContainer.TryGetSolution(reclaimer, reclaimerComponent.SolutionContainerId, out var outputSolution) ||

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -261,7 +261,7 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
 
         if (reclaimerComponent.OnlyReclaimDrainable)
         {
-            // Are we a recycler? Only use drainable solutions.
+            // Are we a recycler? Only use drainable solution.
             if (_solutionContainer.TryGetDrainableSolution(item, out _, out var drainableSolution))
             {
                 totalChemicals.AddSolution(drainableSolution, _prototype);
@@ -269,12 +269,10 @@ public sealed class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
         }
         else
         {
-            // Are we an industrial reagent grinder? Use any solutions it has.
-            if (TryComp<SolutionContainerManagerComponent>(item, out var solutionContainer)){
-                foreach (var (_, soln) in _solutionContainer.EnumerateSolutions((item, solutionContainer)))
-                {
-                    totalChemicals.AddSolution(soln.Comp.Solution, _prototype);
-                }
+            // Are we an industrial reagent grinder? Use extractable solution.
+            if (_solutionContainer.TryGetExtractableSolution(item, out _, out var extractableSolution))
+            {
+                totalChemicals.AddSolution(extractableSolution, _prototype);
             }
         }
 

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.Capabilities.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.Capabilities.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Chemistry.Components;
+using Content.Shared.Kitchen.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.Reaction;
 using Content.Shared.FixedPoint;
@@ -32,6 +33,17 @@ public abstract partial class SharedSolutionContainerSystem
         }
 
         return TryGetSolution((entity.Owner, entity.Comp2), entity.Comp1.Solution, out soln, out solution);
+    }
+
+    public bool TryGetExtractableSolution(Entity<ExtractableComponent?, SolutionContainerManagerComponent?> entity, [NotNullWhen(true)] out Entity<SolutionComponent>? soln, [NotNullWhen(true)] out Solution? solution)
+    {
+        if (!Resolve(entity, ref entity.Comp1, logMissing: false))
+        {
+            (soln, solution) = (default!, null);
+            return false;
+        }
+
+        return TryGetSolution((entity.Owner, entity.Comp2), entity.Comp1.GrindableSolution, out soln, out solution);
     }
 
     public bool TryGetDumpableSolution(Entity<DumpableSolutionComponent?, SolutionContainerManagerComponent?> entity, [NotNullWhen(true)] out Entity<SolutionComponent>? soln, [NotNullWhen(true)] out Solution? solution)

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -70,6 +70,13 @@ public sealed partial class MaterialReclaimerComponent : Component
     public string? SolutionContainerId;
 
     /// <summary>
+    /// If the reclaimer should attempt to reclaim all solutions or just drainable ones
+    /// Difference between Recycler and Industrial Reagent Grinder
+    /// </summary>
+    [DataField]
+    public bool OnlyReclaimDrainable = true;
+
+    /// <summary>
     /// a whitelist for what entities can be inserted into this reclaimer
     /// </summary>
     [DataField]

--- a/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
@@ -75,6 +75,8 @@
       tags:
       - HighRiskItem #ian meat
     efficiency: 0.9
+    onlyReclaimDrainable: false
+    solutionContainerId: output
   - type: Sprite
     sprite: Structures/Machines/recycling.rsi
     layers:


### PR DESCRIPTION
The nerf to recyclers that limits them to only extract materials from drainable solutions broke industrial reagent grinders, as discovered in issue #31441. I fixed it.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Restored the functionality of industrial reagent grinders while leaving the recycler untouched.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It was bugged to be less than useless. It was actually detrimental to attempt to use it because it would eat your plants and not give anything back.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added a new property to MaterialReclaimerComponents, "onlyDrainableSolutions" which is true by default. This allows for a branch during the MaterialReclaimerSystem's SpawnChemicalsFromComposition function, which in the case that this is true, follows the logic to only extract drainable solutions. In the case that this is set to false, as it now is with the Industrial Reagent Grinder, extracts only extractable solutions. I also defined the solutionContainerId property for the industrial reagent grinder, as this was added in the nerf update but was not added to the industrial reagent grinder, the only object in the game that uses the MaterialReclaimer component and has a solution container.

Added a new function to try and get the extractable solution of an entity specifically to support the MaterialReclaimer's code and mirror the other solution capability functions.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

https://github.com/user-attachments/assets/cf680875-21f6-4452-b894-06ca7b85e303



## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Restored functionality to the Industrial Reagent Grinder
