### PR TITLE
Set Salamander Max Pop to 80

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/salamander.toml
+++ b/Resources/ConfigPresets/WizardsDen/salamander.toml
@@ -3,7 +3,6 @@
 [game]
 desc = "Official English Space Station 14 servers. Medium roleplay ruleset. you must be whitelisted by playing on other Wizard's Den servers if there are more than 15 online players."
 hostname = "[EN] Wizard's Den Salamander [US West RP]"
-soft_max_players = 130
 
 [server]
 rules_file = "MRPRuleset"


### PR DESCRIPTION
## About the PR
Sets Salamander's max population to 80.
(Or rather, just removes it's set population config so it defaults to the Wizard's Den default like how the other servers are set up.)

## Why / Balance
There was a consensus at some point that the game just doesn't _function_ at higher populations than 80, alongside admin sanity being heavily degraded.

All the other servers were adjusted to fit this consensus, but Salamander was left out due to a brief oversight I believe and no one ever bothered to set it properly since it wasn't reaching 80 for the longest while.

I don't think the majority of the playerbase genuinely enjoy this either, but I suppose I haven't asked about.

There's also a comment to be made about how higher population generally leads to lower roleplay, but that's not the focus here.

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] This PR does not require an ingame showcase.

**Changelog**
Doesn't fit here, don't think.