### PR TITLE
Damaged by contact fix

### DIFF
--- a/Content.Shared/Damage/Systems/DamageContactsSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageContactsSystem.cs
@@ -42,11 +42,11 @@ public sealed class DamageContactsSystem : EntitySystem
     {
         var otherUid = args.OtherEntity;
 
-        if (!TryComp<PhysicsComponent>(uid, out var body))
+        if (!TryComp<PhysicsComponent>(otherUid, out var body))
             return;
 
         var damageQuery = GetEntityQuery<DamageContactsComponent>();
-        foreach (var ent in _physics.GetContactingEntities(uid, body))
+        foreach (var ent in _physics.GetContactingEntities(otherUid, body))
         {
             if (ent == uid)
                 continue;


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
`DamagedByContactComponent` was removed when moving from one entity with `DamageContactsComponent` to another, which is why tendons could not dealing damage.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Tendons (and other entities with a `DamageContactsComponent`) must deal damage when an entity is on them

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Now in the method `OnEntityExit` component `DamagedByContactComponent` is removed only when an `OtherEntity` does not find any contacting entity that has a `DamageContactsComponent`.

```cs
var otherUid = args.OtherEntity;

if (!TryComp<PhysicsComponent>(otherUid, out var body)) // uid -> otherUid
    return;

var damageQuery = GetEntityQuery<DamageContactsComponent>();
foreach (var ent in _physics.GetContactingEntities(otherUid, body)) // uid -> otherUid
{
    if (ent == uid)
        continue;

    if (damageQuery.HasComponent(ent))
        return;
}

RemComp<DamagedByContactComponent>(otherUid);
```
## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

no cl
