### PR TITLE
now you need hands to rotate stuff

### DIFF
--- a/Content.Server/Rotatable/RotatableSystem.cs
+++ b/Content.Server/Rotatable/RotatableSystem.cs
@@ -37,7 +37,7 @@ namespace Content.Server.Rotatable
 
         private void AddFlipVerb(EntityUid uid, FlippableComponent component, GetVerbsEvent<Verb> args)
         {
-            if (!args.CanAccess || !args.CanInteract)
+            if (!args.CanAccess || !args.CanInteract || args.Hands is null)
                 return;
 
             // Check if the object is anchored.
@@ -60,7 +60,8 @@ namespace Content.Server.Rotatable
         {
             if (!args.CanAccess
                 || !args.CanInteract
-                || Transform(uid).NoLocalRotation) // Good ol prototype inheritance, eh?
+                || Transform(uid).NoLocalRotation
+                || args.Hands is null) // Good ol prototype inheritance, eh?
                 return;
 
             // Check if the object is anchored, and whether we are still allowed to rotate it.

--- a/Content.Server/Rotatable/RotatableSystem.cs
+++ b/Content.Server/Rotatable/RotatableSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Popups;
 using Content.Shared.ActionBlocker;
+using Content.Shared.Hands.Components;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
 using Content.Shared.Rotatable;
@@ -127,6 +128,9 @@ namespace Content.Server.Rotatable
             if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
                 return false;
 
+            if (!HasComp<HandsComponent>(player))
+                return false;
+
             // Check if the object is anchored, and whether we are still allowed to rotate it.
             if (!rotatableComp.RotateWhileAnchored && EntityManager.TryGetComponent(entity, out PhysicsComponent? physics) &&
                 physics.BodyType == BodyType.Static)
@@ -150,6 +154,9 @@ namespace Content.Server.Rotatable
             if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
                 return false;
 
+            if (!HasComp<HandsComponent>(player))
+                return false;
+
             // Check if the object is anchored, and whether we are still allowed to rotate it.
             if (!rotatableComp.RotateWhileAnchored && EntityManager.TryGetComponent(entity, out PhysicsComponent? physics) &&
                 physics.BodyType == BodyType.Static)
@@ -171,6 +178,9 @@ namespace Content.Server.Rotatable
                 return false;
 
             if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
+                return false;
+
+            if (!HasComp<HandsComponent>(player))
                 return false;
 
             // Check if the object is anchored.


### PR DESCRIPTION
## About the PR
title

## Why / Balance
mice shouldn't be able to rotate computers methinks
borgs can still rotate stuff (tested)

## Technical details

## Media

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**
:cl:
- fix: Now you need hands in order to rotate things.

