### PR TITLE
some securiby contra fixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
@@ -30,7 +30,7 @@
     state: whistle
 
 - type: entity
-  parent: [BaseWhistle, BaseRestrictedContraband]
+  parent: BaseWhistle
   id: SecurityWhistle
   description: Sound of it make you feel fear.
   components:
@@ -42,7 +42,7 @@
     distance: 5
 
 - type: entity
-  parent: BaseWhistle
+  parent: [BaseWhistle, BaseMinorContraband]
   id: SyndicateWhistle
   name: trench whistle
   description: A whistle used by Syndicate commanders to draw attention. Avanti!

--- a/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
@@ -30,7 +30,7 @@
     state: whistle
 
 - type: entity
-  parent: BaseWhistle
+  parent: [BaseWhistle, BaseRestrictedContraband]
   id: SecurityWhistle
   description: Sound of it make you feel fear.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -2,7 +2,7 @@
   name: handcuffs
   description: Used to detain criminals and other assholes.
   id: Handcuffs
-  parent: [BaseItem, BaseRestrictedContraband]
+  parent: [BaseItem, BaseSecurityCommandContraband]
   components:
   - type: Item
     size: Small

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -76,7 +76,7 @@
 
 - type: entity
   name: seclite
-  parent: FlashlightLantern
+  parent: [FlashlightLantern, BaseRestrictedContraband]
   id: FlashlightSeclite
   description: A robust flashlight used by security.
   components:


### PR DESCRIPTION
## About the PR
Seclite: allowed -> security
Trench whistle: allowed -> minor contra
Handcuffs: security -> security;command

## Why / Balance
handcuffs are mapped in bridge pretty often. Other items are used only by security and have functionality that is not supposed to be available to everyone (seclite has damage, whistle is used to stop people for a search/something else)

## Technical details

## Media
![image](https://github.com/user-attachments/assets/29b1fdf1-2473-4cf6-911c-40a0a6466850)
![image](https://github.com/user-attachments/assets/b8f9ba65-d32e-4c0d-addc-d3b414100871)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl:
- tweak: Seclite is now restricted to security.
- tweak: Handcuffs are now restricted to security and command.
- tweak: Trench whistle is now minor contraband.