### PR TITLE
norot added to grille + grille fix devmap

### DIFF
--- a/Resources/Maps/Test/dev_map.yml
+++ b/Resources/Maps/Test/dev_map.yml
@@ -3642,7 +3642,6 @@ entities:
   - uid: 108
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,23.5
       parent: 179
   - uid: 986

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -4,6 +4,8 @@
   name: grille
   description: A flimsy framework of iron rods.
   components:
+    - type: Transform
+      noRot: True
     - type: MeleeSound
       soundGroups:
         Brute:

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -5,7 +5,7 @@
   description: A flimsy framework of iron rods.
   components:
     - type: Transform
-      noRot: True
+      noRot: true
     - type: MeleeSound
       soundGroups:
         Brute:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Grille noRot fix 


## Why / Balance
  #31943 Emisse asked 
 
## Technical details
Changed the .yml file for grille and devmap


## Requirements
TODO: remove rotated grilles from all the maps in rotation

- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

 ## Breaking changes

**Changelog**

:cl:
- fix: Fixed Grilles being rotatable

