### PR TITLE
Capacitor Crafting Change

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/clothing/medsec_hud.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/clothing/medsec_hud.yml
@@ -27,17 +27,8 @@
                 sprite: Objects/Devices/communication.rsi
                 state: walkietalkie
               doAfter: 5
-            - tag: CapacitorStockPart
-              name: capacitor
-              icon:
-                sprite: Objects/Misc/stock_parts.rsi
-                state: capacitor
-              doAfter: 5
-            - tag: CapacitorStockPart
-              name: capacitor
-              icon:
-                sprite: Objects/Misc/stock_parts.rsi
-                state: capacitor
+            - material: Capacitor
+              amount: 2
               doAfter: 5
     - node: medsecHud
       entity: ClothingEyesHudMedSec

--- a/Resources/Prototypes/Recipes/Construction/Graphs/tools/logic_gate.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/tools/logic_gate.yml
@@ -46,11 +46,8 @@
         doAfter: 1
     - to: memory_cell
       steps:
-      - tag: CapacitorStockPart
-        icon:
-          sprite: Objects/Misc/stock_parts.rsi
-          state: capacitor
-        name: a capacitor
+      - material: Capacitor
+        amount: 1
       - material: Cable
         amount: 2
         doAfter: 1

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_substation.yml
@@ -57,12 +57,8 @@
             sprite: "Objects/Power/power_cells.rsi"
             state: "medium"
           doAfter: 0.5
-        - tag: CapacitorStockPart
-          name: a capacitor
-          store: capacitor
-          icon:
-            sprite: "Objects/Misc/stock_parts.rsi"
-            state: "capacitor"
+        - material: Capacitor
+          amount: 1
           doAfter: 0.5
       - to: frame
         completed:

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/potato.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/potato.yml
@@ -60,15 +60,7 @@
             - material: Cable
               amount: 2
               doAfter: 1
-            - tag: CapacitorStockPart
-              name: capacitor
-              icon:
-                sprite: Objects/Misc/stock_parts.rsi
-                state: capacitor
-            - tag: CapacitorStockPart
-              name: capacitor
-              icon:
-                sprite: Objects/Misc/stock_parts.rsi
-                state: capacitor
+            - material: Capacitor
+              amount: 2
     - node: potatoaichip
       entity: PotatoAIChip

--- a/Resources/Prototypes/Stacks/science_stacks.yml
+++ b/Resources/Prototypes/Stacks/science_stacks.yml
@@ -7,6 +7,7 @@
 - type: stack
   id: Capacitor
   name: capacitor
+  icon: { sprite: /Textures/Objects/Misc/stock_parts.rsi, state: capacitor }
   spawn: CapacitorStockPart
   maxCount: 10
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
changes how you use capacitors while crafting (basically just makes stacks of them be useable without it eating it all)
(also sorry if this is a bandaid fix or this bricks someones pc)

## Why / Balance
so that you dont use up a whole stack while crafting, or need to split for medsec hud.

## Technical details
adds a sprite/icon to capacitors in the stack file, and changes them from being tags or whatever to material instead in a crafting recipe (works with stacks!! yippeee!!)

## Media
![image](https://github.com/user-attachments/assets/2f0273da-2b52-4baa-86a8-78d0da7387b5) 
![image](https://github.com/user-attachments/assets/e31dcc64-a5ed-4d45-a6bf-e0c8bc8615d2)


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: You can now craft items with stacks of capacitors without it eating it all!

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
