### PR TITLE
plant bags automatically insert gathered spaceshrooms

### DIFF
--- a/Content.Shared/Gatherable/Events.cs
+++ b/Content.Shared/Gatherable/Events.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Inventory;
+
+namespace Content.Shared.Gatherable;
+
+/// <summary>
+/// Relayed to the user's equipped items when an item has been gathered.
+/// </summary>
+public record struct ItemGatheredEvent(EntityUid Item, EntityUid User) : IInventoryRelayEvent
+{
+    public SlotFlags TargetSlots => SlotFlags.WITHOUT_POCKET;
+}

--- a/Content.Shared/Gatherable/GatherablePickupComponent.cs
+++ b/Content.Shared/Gatherable/GatherablePickupComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Gatherable;
+
+[RegisterComponent, NetworkedComponent, Access(typeof(GatherablePickupSystem))]
+public sealed partial class GatherablePickupComponent : Component
+{
+    /// <summary>
+    /// Whether something was gathered in this tick.
+    /// Reset every tick to avoid multiple items spamming pickup sounds.
+    /// </summary>
+    public bool Gathered;
+}

--- a/Content.Shared/Gatherable/GatherablePickupSystem.cs
+++ b/Content.Shared/Gatherable/GatherablePickupSystem.cs
@@ -1,0 +1,57 @@
+using Content.Shared.Inventory;
+using Content.Shared.Storage.EntitySystems;
+
+namespace Content.Shared.Gatherable;
+
+/// <summary>
+/// Tries to automatically insert gathered items into a storage.
+/// Does nothing if it can't be inserted.
+/// </summary>
+public sealed class GatherablePickupSystem : EntitySystem
+{
+    [Dependency] private readonly SharedStorageSystem _storage = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GatherablePickupComponent, InventoryRelayedEvent<ItemGatheredEvent>>(OnGathered);
+    }
+
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<GatherablePickupComponent>();
+        while (query.MoveNext(out var comp))
+        {
+            comp.Gathered = false; // reset it for the next tick to play a sound
+        }
+    }
+
+    private void OnGathered(Entity<GatherablePickupComponent> ent, ref InventoryRelayedEvent<ItemGatheredEvent> args)
+    {
+        if (!_storage.HasSpace(ent.Owner))
+            return;
+
+        var item = args.Args.Item;
+
+        var xform = Transform(ent);
+        var finalCoords = xform.Coordinates;
+        var moverCoords = _transform.GetMoverCoordinates(ent, xform);
+
+        var itemXform = Transform(item);
+        var itemMap = _transform.GetMapCoordinates(item, xform: itemXform);
+        var itemCoords = _transform.ToCoordinates(moverCoords.EntityId, itemMap);
+
+        if (!_storage.Insert(ent, item, out var stacked, playSound: !ent.Comp.Gathered))
+            return;
+
+        ent.Comp.Gathered = true;
+
+        var rot = itemXform.LocalRotation;
+        if (stacked is {} stackedUid)
+            _storage.PlayPickupAnimation(stackedUid, itemCoords, finalCoords, rot);
+        else
+            _storage.PlayPickupAnimation(item, itemCoords, finalCoords, rot);
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -139,3 +139,4 @@
         - Produce
         - Seed
   - type: Dumpable
+  - type: GatherablePickup # for space shrooms

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -5,6 +5,7 @@
   description: A robust bag for salvage specialists and miners alike to carry large amounts of ore. Magnetises any nearby ores when attached to a belt.
   components:
   - type: MagnetPickup
+  - type: GatherablePickup
   - type: Sprite
     sprite: Objects/Specific/Mining/ore_bag.rsi
     state: icon


### PR DESCRIPTION
## About the PR
title
added support for ore bag but mining has its own thing instead of Gatherable so it doesn't do anything right now

## Why / Balance
plant bag makes you better at looting maints :trollface:

for ore bag it would be a solution to #26259 by having it always insert ore into the miners bag, IF IT USED GATHERABLE!!!

## Technical details
added `ItemGatheredEvent` raised for every loot item that gets spawned
added `GatherablePickupComponent` that inserts gathered items

## Media
it work trust

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun