### PR TITLE
add material composition to some salv treasure

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/treasure.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/treasure.yml
@@ -83,6 +83,11 @@
     - state: cpu_super
   - type: Item
     size: Tiny
+  - type: PhysicalComposition
+    materialComposition: # big mats if you don't sell it
+      Steel: 500
+      Glass: 1000
+      Silver: 300
   - type: StaticPrice
     price: 750
 
@@ -150,6 +155,9 @@
     state: coin_iron
   - type: Item
     size: Tiny
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 300
   - type: StaticPrice
     price: 75
 
@@ -159,6 +167,10 @@
   components:
   - type: Sprite
     state: coin_silver
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 100 # coins are fake on the inside
+      Silver: 200
   - type: StaticPrice
     price: 125
 
@@ -168,6 +180,10 @@
   components:
   - type: Sprite
     state: coin_gold
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 100
+      Gold: 200
   - type: StaticPrice
     price: 175
 
@@ -177,6 +193,10 @@
   components:
   - type: Sprite
     state: coin_adamantine
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 400
+      Diamond: 25 # very hard gamble
   - type: StaticPrice
     price: 250
 
@@ -186,6 +206,10 @@
   components:
   - type: Sprite
     state: coin_diamond
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 200
+      Diamond: 50 # you can gamble recycling it or sell for guaranteed money
   - type: StaticPrice
     price: 500
 

--- a/Resources/Prototypes/Entities/Objects/Misc/treasure.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/treasure.yml
@@ -172,7 +172,7 @@
       Steel: 100 # coins are fake on the inside
       Silver: 200
   - type: StaticPrice
-    price: 125
+    price: 135
 
 - type: entity
   parent: TreasureCoinIron
@@ -196,7 +196,7 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 400
-      Diamond: 25 # very hard gamble
+      Diamond: 5
   - type: StaticPrice
     price: 250
 
@@ -208,8 +208,8 @@
     state: coin_diamond
   - type: PhysicalComposition
     materialComposition:
-      Steel: 200
-      Diamond: 50 # you can gamble recycling it or sell for guaranteed money
+      Steel: 300
+      Diamond: 15
   - type: StaticPrice
     price: 500
 


### PR DESCRIPTION
## About the PR
iron made of steel
silver and gold coins have a steel core and silver/gold coating because no zinc
diamond and adamantine coins have less than 1 diamond so recycler doesn't give you anything :trollface:

## Why / Balance
if you are low on specific mats you can choose to recycle valuable treasure, essentially buying them at a steep price.

**Changelog**
:cl:
- tweak: Coins and Supercharged CPUs can now be recycled for rarer materials.
