### PR TITLE
Radiation blocker values for directional plasma and uranium windows

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
@@ -97,6 +97,8 @@
         acts: [ "Destruction" ]
   - type: StaticPrice
     price: 50
+  - type: RadiationBlocker
+    resistance: 1
 
 - type: entity
   parent: PlasmaWindow

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -82,6 +82,8 @@
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks_directional.rsi
+  - type: RadiationBlocker
+    resistance: 2
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
@@ -100,6 +100,8 @@
         acts: [ "Destruction" ]
   - type: StaticPrice
     price: 110
+  - type: RadiationBlocker
+    resistance: 2.5
 
 - type: entity
   parent: ReinforcedUraniumWindow

--- a/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
@@ -95,6 +95,8 @@
         acts: [ "Destruction" ]
   - type: StaticPrice
     price: 100
+  - type: RadiationBlocker
+    resistance: 1.5
 
 - type: entity
   parent: UraniumWindow


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds missing radiation blocker values for directional plasma and uranium windows.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Fixes #31972.

The radiation blocker values were determined by material cost; two glass units are required for a full window, one glass for directional. Thus values are halved.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

yml changes only
- plasma.yml
- rplasma.yml
- ruranium.yml
- uranium.yml

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

![image](https://github.com/user-attachments/assets/f6ac8436-32bd-4aa3-b0bd-16727058982a)


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: added missing missing resistance values for directional plasma and uranium windows