### PR TITLE
make laid power cables more visible

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -46,7 +46,7 @@
   - type: RCDDeconstructable
     cost: 2
     delay: 0
-    fx: EffectRCDConstruct0  
+    fx: EffectRCDConstruct0
 
 - type: entity
   parent: CableBase
@@ -56,6 +56,7 @@
   components:
   - type: Sprite
     sprite: Structures/Power/Cables/hv_cable.rsi
+    offset: 0.1, -0.1
     state: hvcable_0
     drawdepth: ThickWire
   - type: Icon
@@ -107,6 +108,7 @@
   - type: Sprite
     color: Yellow
     sprite: Structures/Power/Cables/mv_cable.rsi
+    offset: -0.1, 0.1
     state: mvcable_0
   - type: Icon
     color: Yellow
@@ -151,6 +153,7 @@
   - type: Sprite
     color: Green
     sprite: Structures/Power/Cables/lv_cable.rsi
+    offset: -0.1, 0.1
     state: lvcable_0
   - type: Icon
     color: Green


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I offset cable sprites

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Adds a lot of visibility. Neither cables nor pipes are now obscured by the other or by catwalks when laid down together.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
old: either cables or pipes are obscured, depending on which became first. new: both are clearly visible.

![old-new](https://github.com/user-attachments/assets/766afae1-7ec0-4e0a-8952-776d8c6dacb2)

new

![image](https://github.com/user-attachments/assets/08f3d3e4-eb9b-4f3a-8216-80f07c736bb0)

![image](https://github.com/user-attachments/assets/cc02afb9-98e1-4890-b966-51b96ee390f6)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
tweak: Power cables on the ground are now offset and do not obscure each other or pipes beneath.