### PR TITLE
Fix being able to use chameleon projector on medibot

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
@@ -18,6 +18,7 @@
       - InsideEntityStorage # no clark kent going in phone booth and becoming superman
       - MindContainer # no
       - Pda # PDAs currently make you invisible /!\
+      - HTN # for medibot
     polymorph:
       entity: ChameleonDisguise
 


### PR DESCRIPTION

:cl:
- fix: You can no longer disguise yourself as any NPC entity (e.g. medibot)
