### PR TITLE
Fix Station AI being affected by Bureaucratic Event

### DIFF
--- a/Content.Server/StationEvents/Components/BureaucraticErrorRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/BureaucraticErrorRuleComponent.cs
@@ -11,5 +11,5 @@ public sealed partial class BureaucraticErrorRuleComponent : Component
     /// The jobs that are ignored by this rule and won't have their slots changed.
     /// </summary>
     [DataField]
-    public HashSet<ProtoId<JobPrototype>> IgnoredJobs = new();
+    public List<ProtoId<JobPrototype>> IgnoredJobs = new();
 }

--- a/Content.Server/StationEvents/Components/BureaucraticErrorRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/BureaucraticErrorRuleComponent.cs
@@ -1,9 +1,15 @@
-﻿using Content.Server.StationEvents.Events;
+using Content.Server.StationEvents.Events;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.StationEvents.Components;
 
 [RegisterComponent, Access(typeof(BureaucraticErrorRule))]
 public sealed partial class BureaucraticErrorRuleComponent : Component
 {
-
+    /// <summary>
+    /// The jobs that are ignored by this rule and won't have their slots changed.
+    /// </summary>
+    [DataField]
+    public HashSet<ProtoId<JobPrototype>> IgnoredJobs = new();
 }

--- a/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
+++ b/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
@@ -14,9 +14,6 @@ public sealed class BureaucraticErrorRule : StationEventSystem<BureaucraticError
 {
     [Dependency] private readonly StationJobsSystem _stationJobs = default!;
 
-    [ValidatePrototypeId<JobPrototype>]
-    public const string IgnoreRuleJob = "StationAi";
-
     protected override void Started(EntityUid uid, BureaucraticErrorRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         base.Started(uid, component, gameRule, args);
@@ -26,7 +23,8 @@ public sealed class BureaucraticErrorRule : StationEventSystem<BureaucraticError
 
         var jobList = _stationJobs.GetJobs(chosenStation.Value).Keys.ToList();
 
-        jobList.Remove(IgnoreRuleJob);
+        foreach(var job in component.IgnoredJobs)
+            jobList.Remove(job);
 
         if (jobList.Count == 0)
             return;

--- a/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
+++ b/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
@@ -1,9 +1,9 @@
 using System.Linq;
-using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Server.StationEvents.Components;
 ﻿using Content.Shared.GameTicking.Components;
+using Content.Shared.Roles;
 using JetBrains.Annotations;
 using Robust.Shared.Random;
 
@@ -14,6 +14,9 @@ public sealed class BureaucraticErrorRule : StationEventSystem<BureaucraticError
 {
     [Dependency] private readonly StationJobsSystem _stationJobs = default!;
 
+    [ValidatePrototypeId<JobPrototype>]
+    public const string IgnoreRuleJob = "StationAi";
+
     protected override void Started(EntityUid uid, BureaucraticErrorRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         base.Started(uid, component, gameRule, args);
@@ -22,6 +25,8 @@ public sealed class BureaucraticErrorRule : StationEventSystem<BureaucraticError
             return;
 
         var jobList = _stationJobs.GetJobs(chosenStation.Value).Keys.ToList();
+
+        jobList.Remove(IgnoreRuleJob);
 
         if (jobList.Count == 0)
             return;

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -124,6 +124,8 @@
     weight: 3
     duration: 1
   - type: BureaucraticErrorRule
+    ignoredJobs:
+    - StationAi
 
 - type: entity
   id: ClericalError


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR makes it so that the StationAI can't be included in the BureaucraticEvent which scrambles the number of roles available on the station.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

There's only one AI on the station. Admin told me it was a headache. I fix.

## Technical details
<!-- Summary of code changes for easier review. -->

Just removes the station AI prototype from the job list in the event, by giving the component a list.

(Also I removed `using Content.Server.GameTicking.Rules.Components;` because it wasn't being used)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: The Station AI job is no longer affected by the Bureaucratic Event event.
