### PR TITLE
Toggleable clothing system refactor

### DIFF
--- a/Content.Client/Clothing/UI/ToggleableClothingBoundUserInterface.cs
+++ b/Content.Client/Clothing/UI/ToggleableClothingBoundUserInterface.cs
@@ -1,0 +1,39 @@
+using Content.Shared.Clothing.Components;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+using Robust.Client.UserInterface;
+
+namespace Content.Client.Clothing.UI;
+
+public sealed class ToggleableClothingBoundUserInterface : BoundUserInterface
+{
+    [Dependency] private readonly IClyde _displayManager = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
+
+    private IEntityManager _entityManager;
+    private ToggleableClothingRadialMenu? _menu;
+
+    public ToggleableClothingBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
+    {
+        IoCManager.InjectDependencies(this);
+        _entityManager = IoCManager.Resolve<IEntityManager>();
+    }
+
+    protected override void Open()
+    {
+        base.Open();
+
+        _menu = this.CreateWindow<ToggleableClothingRadialMenu>();
+        _menu.SetEntity(Owner);
+        _menu.SendToggleClothingMessageAction += SendToggleableClothingMessage;
+
+        var vpSize = _displayManager.ScreenSize;
+        _menu.OpenCenteredAt(_inputManager.MouseScreenPosition.Position / vpSize);
+    }
+
+    private void SendToggleableClothingMessage(EntityUid uid)
+    {
+        var message = new ToggleableClothingUiMessage(_entityManager.GetNetEntity(uid));
+        SendPredictedMessage(message);
+    }
+}

--- a/Content.Client/Clothing/UI/ToggleableClothingRadialMenu.xaml
+++ b/Content.Client/Clothing/UI/ToggleableClothingRadialMenu.xaml
@@ -1,0 +1,13 @@
+<ui:RadialMenu xmlns="https://spacestation14.io"
+                xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
+                BackButtonStyleClass="RadialMenuBackButton"
+                CloseButtonStyleClass="RadialMenuCloseButton"
+                VerticalExpand="True"
+                HorizontalExpand="True"
+                MinSize="450 450">
+
+    <!-- Main -->
+    <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" Radius="64" ReserveSpaceForHiddenChildren="False">
+    </ui:RadialContainer>
+
+</ui:RadialMenu>

--- a/Content.Client/Clothing/UI/ToggleableClothingRadialMenu.xaml.cs
+++ b/Content.Client/Clothing/UI/ToggleableClothingRadialMenu.xaml.cs
@@ -1,0 +1,102 @@
+using Content.Client.UserInterface.Controls;
+using Content.Shared.Clothing.Components;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.XAML;
+using System.Numerics;
+
+namespace Content.Client.Clothing.UI;
+
+public sealed partial class ToggleableClothingRadialMenu : RadialMenu
+{
+    [Dependency] private readonly EntityManager _entityManager = default!;
+
+    public event Action<EntityUid>? SendToggleClothingMessageAction;
+
+    public EntityUid Entity { get; set; }
+
+    public ToggleableClothingRadialMenu()
+    {
+        IoCManager.InjectDependencies(this);
+        RobustXamlLoader.Load(this);
+    }
+
+    public void SetEntity(EntityUid uid)
+    {
+        Entity = uid;
+        RefreshUI();
+    }
+
+    public void RefreshUI()
+    {
+        var main = FindControl<RadialContainer>("Main");
+
+        if (!_entityManager.TryGetComponent<ToggleableClothingComponent>(Entity, out var clothing))
+            return;
+
+        var clothingContainer = clothing.Container;
+
+        if (clothingContainer == null)
+            return;
+
+        foreach(var attached in clothing.ClothingUids)
+        {
+            // Change tooltip text if attached clothing is toggle/untoggled
+            var tooltipText = Loc.GetString("toggleable-clothing-attach-tooltip");
+
+            if (clothingContainer.Contains(attached.Key))
+                tooltipText = Loc.GetString("toggleable-clothing-unattach-tooltip");
+
+            var button = new ToggleableClothingRadialMenuButton()
+            {
+                StyleClasses = { "RadialMenuButton" },
+                SetSize = new Vector2(64, 64),
+                ToolTip = tooltipText,
+                AttachedClothingId = attached.Key
+            };
+
+            var entProtoView = new EntityPrototypeView()
+            {
+                SetSize = new Vector2(48, 48),
+                VerticalAlignment = VAlignment.Center,
+                HorizontalAlignment = HAlignment.Center,
+                Stretch = SpriteView.StretchMode.Fill
+            };
+
+            entProtoView.SetEntity(attached.Key);
+
+            button.AddChild(entProtoView);
+            main.AddChild(button);
+        }
+
+        AddToggleableClothingMenuButtonOnClickAction(main);
+    }
+
+    private void AddToggleableClothingMenuButtonOnClickAction(Control control)
+    {
+        var mainControl = control as RadialContainer;
+
+        if (mainControl == null)
+            return;
+
+        foreach (var child in mainControl.Children)
+        {
+            var castChild = child as ToggleableClothingRadialMenuButton;
+
+            if (castChild == null)
+                return;
+
+            castChild.OnButtonDown += _ =>
+            {
+                SendToggleClothingMessageAction?.Invoke(castChild.AttachedClothingId);
+                mainControl.DisposeAllChildren();
+                RefreshUI();
+            };
+        }
+    }
+}
+
+public sealed class ToggleableClothingRadialMenuButton : RadialMenuTextureButton
+{
+    public EntityUid AttachedClothingId { get; set; }
+}

--- a/Content.Client/Clothing/UI/ToggleableClothingRadialMenu.xaml.cs
+++ b/Content.Client/Clothing/UI/ToggleableClothingRadialMenu.xaml.cs
@@ -42,10 +42,10 @@ public sealed partial class ToggleableClothingRadialMenu : RadialMenu
         foreach(var attached in clothing.ClothingUids)
         {
             // Change tooltip text if attached clothing is toggle/untoggled
-            var tooltipText = Loc.GetString("toggleable-clothing-attach-tooltip");
+            var tooltipText = Loc.GetString("toggleable-clothing-unattach-tooltip");
 
             if (clothingContainer.Contains(attached.Key))
-                tooltipText = Loc.GetString("toggleable-clothing-unattach-tooltip");
+                tooltipText = Loc.GetString("toggleable-clothing-attach-tooltip");
 
             var button = new ToggleableClothingRadialMenuButton()
             {

--- a/Content.Client/Content.Client.csproj
+++ b/Content.Client/Content.Client.csproj
@@ -25,4 +25,9 @@
   </ItemGroup>
   <Import Project="..\RobustToolbox\MSBuild\Robust.Properties.targets" />
   <Import Project="..\RobustToolbox\MSBuild\XamlIL.targets" />
+  <ItemGroup>
+    <EmbeddedResource Update="Clothing\UI\ToggleableClothingRadialMenu.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/Content.Client/Content.Client.csproj
+++ b/Content.Client/Content.Client.csproj
@@ -25,9 +25,4 @@
   </ItemGroup>
   <Import Project="..\RobustToolbox\MSBuild\Robust.Properties.targets" />
   <Import Project="..\RobustToolbox\MSBuild\XamlIL.targets" />
-  <ItemGroup>
-    <EmbeddedResource Update="Clothing\UI\ToggleableClothingRadialMenu.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
 </Project>

--- a/Content.Shared/Clothing/Components/AttachedClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/AttachedClothingComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Clothing.EntitySystems;
+using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Clothing.Components;
@@ -13,9 +14,20 @@ namespace Content.Shared.Clothing.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class AttachedClothingComponent : Component
 {
+    public const string DefaultClothingContainerId = "replaced-clothing";
+
     /// <summary>
     ///     The Id of the piece of clothing that this entity belongs to.
     /// </summary>
     [DataField, AutoNetworkedField]
     public EntityUid AttachedUid;
+
+    /// <summary>
+    ///     Container ID for clothing that will be replaced with this one
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string ClothingContainerId = DefaultClothingContainerId;
+
+    [ViewVariables, NonSerialized]
+    public ContainerSlot? ClothingContainer;
 }

--- a/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
@@ -3,6 +3,7 @@ using Content.Shared.Inventory;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Clothing.Components;
@@ -35,7 +36,7 @@ public sealed partial class ToggleableClothingComponent : Component
     ///     Dictionary of clothing uids and slots
     /// </summary>
     [DataField, AutoNetworkedField]
-    public Dictionary<EntityUid, string> ClothingUids = default!;
+    public Dictionary<EntityUid, string> ClothingUids = new();
 
     /// <summary>
     ///     The inventory slot flags required for this component to function.
@@ -65,8 +66,25 @@ public sealed partial class ToggleableClothingComponent : Component
     public string? VerbText;
 
     /// <summary>
-    ///     If true it will block unequip of this entity until all toggleable clothing are removed
+    ///     If true it will block unequip of this entity until all attached clothing are removed
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool BlockUnequipWhenToggle = false;
+}
+
+[Serializable, NetSerializable]
+public enum ToggleClothingUiKey : byte
+{
+    Key
+}
+
+[Serializable, NetSerializable]
+public sealed class ToggleableClothingUiMessage : BoundUserInterfaceMessage
+{
+    public NetEntity AttachedClothingUid;
+
+    public ToggleableClothingUiMessage(NetEntity attachedClothingUid)
+    {
+        AttachedClothingUid = attachedClothingUid;
+    }
 }

--- a/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
@@ -26,17 +26,16 @@ public sealed partial class ToggleableClothingComponent : Component
     public EntityUid? ActionEntity;
 
     /// <summary>
-    ///     Default clothing entity prototype to spawn into the clothing container.
+    ///     Dictionary of inventory slots and entity prototypes to spawn into the clothing container.
     /// </summary>
     [DataField(required: true), AutoNetworkedField]
-    public EntProtoId ClothingPrototype = default!;
+    public Dictionary<string, EntProtoId> ClothingPrototypes = default!;
 
     /// <summary>
-    ///     The inventory slot that the clothing is equipped to.
+    ///     Dictionary of clothing uids and slots
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
     [DataField, AutoNetworkedField]
-    public string Slot = "head";
+    public Dictionary<EntityUid, string> ClothingUids = default!;
 
     /// <summary>
     ///     The inventory slot flags required for this component to function.
@@ -51,14 +50,7 @@ public sealed partial class ToggleableClothingComponent : Component
     public string ContainerId = DefaultClothingContainerId;
 
     [ViewVariables]
-    public ContainerSlot? Container;
-
-    /// <summary>
-    ///     The Id of the piece of clothing that belongs to this component. Required for map-saving if the clothing is
-    ///     currently not inside of the container.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public EntityUid? ClothingUid;
+    public Container? Container;
 
     /// <summary>
     ///     Time it takes for this clothing to be toggled via the stripping menu verbs. Null prevents the verb from even showing up.
@@ -71,4 +63,10 @@ public sealed partial class ToggleableClothingComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public string? VerbText;
+
+    /// <summary>
+    ///     If true it will block unequip of this entity until all toggleable clothing are removed
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool BlockUnequipWhenToggle = false;
 }

--- a/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
@@ -69,7 +69,13 @@ public sealed partial class ToggleableClothingComponent : Component
     ///     If true it will block unequip of this entity until all attached clothing are removed
     /// </summary>
     [DataField, AutoNetworkedField]
-    public bool BlockUnequipWhenToggle = false;
+    public bool BlockUnequipWhenAttached = false;
+
+    /// <summary>
+    ///     If true all attached will replace already equipped clothing on equip attempt
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool ReplaceCurrentClothing = false;
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/clothing/components/toggleable-clothing-component.ftl
+++ b/Resources/Locale/en-US/clothing/components/toggleable-clothing-component.ftl
@@ -1,3 +1,6 @@
 toggle-clothing-verb-text = Toggle {CAPITALIZE($entity)}
 
 toggleable-clothing-remove-first = You have to unequip {$entity} first.
+toggleable-clothing-remove-all-attached-first = You have to unequip all toggled clothings first.
+toggleable-clothing-attach-tooltip = Equip
+toggleable-clothing-unattach-tooltip = Unequip

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -153,13 +153,14 @@
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/goliathcloak.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodGoliathCloak
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodGoliathCloak
     requiredSlot:
     - neck
     slot: head
   - type: ContainerContainer
     containers:
-      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-clothing: !type:Container {}
 
 - type: entity
   parent: ClothingNeckBase
@@ -179,13 +180,14 @@
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/moth.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodMoth
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodMoth
     requiredSlot:
     - neck
     slot: head
   - type: ContainerContainer
     containers:
-      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-clothing: !type:Container {}
   - type: TypingIndicatorClothing
     proto: moth
 

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -157,7 +157,10 @@
       head: ClothingHeadHatHoodGoliathCloak
     requiredSlot:
     - neck
-    slot: head
+  - type: UserInterface
+    interfaces:
+      enum.ToggleClothingUiKey.Key:
+        type: ToggleableClothingBoundUserInterface
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:Container {}
@@ -184,7 +187,10 @@
       head: ClothingHeadHatHoodMoth
     requiredSlot:
     - neck
-    slot: head
+  - type: UserInterface
+    interfaces:
+      enum.ToggleClothingUiKey.Key:
+        type: ToggleableClothingBoundUserInterface
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:Container {}

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -91,11 +91,12 @@
   id: ClothingOuterStorageToggleableBase
   components:
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterDefault
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterDefault
     slot: head
   - type: ContainerContainer
     containers:
-      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-clothing: !type:Container {}
       storagebase: !type:Container
         ents: []
 
@@ -125,10 +126,9 @@
         Heat: 0.90
         Radiation: 0.25
   - type: ToggleableClothing
-    slot: head
   - type: ContainerContainer
     containers:
-      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-clothing: !type:Container {}
   - type: GroupExamine
   - type: Tag
     tags:
@@ -174,11 +174,11 @@
   abstract: True
   components:
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterDefault
-    slot: head
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterDefault
   - type: ContainerContainer
     containers:
-      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-clothing: !type:Container {}
       storagebase: !type:Container
         ents: []
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -94,6 +94,10 @@
     clothingPrototypes: 
       head: ClothingHeadHatHoodWinterDefault
     slot: head
+  - type: UserInterface
+    interfaces:
+      enum.ToggleClothingUiKey.Key:
+        type: ToggleableClothingBoundUserInterface
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:Container {}
@@ -129,6 +133,10 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:Container {}
+  - type: UserInterface
+    interfaces:
+      enum.ToggleClothingUiKey.Key:
+        type: ToggleableClothingBoundUserInterface
   - type: GroupExamine
   - type: Tag
     tags:
@@ -181,6 +189,10 @@
       toggleable-clothing: !type:Container {}
       storagebase: !type:Container
         ents: []
+  - type: UserInterface
+    interfaces:
+      enum.ToggleClothingUiKey.Key:
+        type: ToggleableClothingBoundUserInterface
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -111,7 +111,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/jensencoat.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodChaplainHood
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodChaplainHood
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -26,7 +26,8 @@
     sprintModifier: 0.80
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitBasic
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitBasic
 
 #Atmospherics Hardsuit
 - type: entity
@@ -61,7 +62,10 @@
     sprintModifier: 0.7
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitAtmos
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitAtmos
+      gloves: ClothingHandsGlovesColorYellow
+      shoes: ClothingShoesBootsMag
 
 #Engineering Hardsuit
 - type: entity
@@ -93,7 +97,8 @@
     sprintModifier: 0.7
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitEngineering
+    clothingPrototypes:
+      head: ClothingHeadHelmetHardsuitEngineering
 
 #Spationaut Hardsuit
 - type: entity
@@ -122,7 +127,8 @@
     sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitSpatio
+    clothingPrototypes:
+      head: ClothingHeadHelmetHardsuitSpatio
 
 #Salvage Hardsuit
 - type: entity
@@ -153,7 +159,8 @@
     sprintModifier: 0.75
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitSalvage
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitSalvage
 
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCargoContraband]
@@ -184,7 +191,8 @@
   - type: TemperatureProtection
     coefficient: 0.001
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitMaxim
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitMaxim
 
 #Security Hardsuit
 - type: entity
@@ -214,7 +222,8 @@
     sprintModifier: 0.75
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitSecurity
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitSecurity
 
 #Brigmedic Hardsuit
 - type: entity
@@ -241,7 +250,8 @@
     sprintModifier: 0.65
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitBrigmedic
 
 #Warden's Hardsuit
 - type: entity
@@ -271,7 +281,8 @@
     sprintModifier: 0.7
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitWarden
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitWarden
 
 #Captain's Hardsuit
 - type: entity
@@ -303,7 +314,8 @@
     sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitCap
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitCap
 
 #Chief Engineer's Hardsuit
 - type: entity
@@ -337,7 +349,8 @@
     sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitEngineeringWhite
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitEngineeringWhite
 
 #Chief Medical Officer's Hardsuit
 - type: entity
@@ -362,7 +375,8 @@
     sprintModifier: 0.95
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitMedical
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitMedical
 
 #Research Director's Hardsuit
 - type: entity
@@ -402,7 +416,8 @@
     - WhitelistChameleon
     - HighRiskItem
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitRd
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitRd
   - type: StaticPrice
     price: 750
   - type: StealTarget
@@ -437,7 +452,8 @@
     sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitSecurityRed
 
 #Luxury Mining Hardsuit
 - type: entity
@@ -468,7 +484,8 @@
     sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitLuxury
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitLuxury
 
 #ANTAG HARDSUITS
 #Blood-red Hardsuit
@@ -503,7 +520,8 @@
     sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitSyndie
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitSyndie
   - type: Tag
     tags:
     - MonkeyWearable
@@ -522,7 +540,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/syndiemedic.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitSyndieMedic
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitSyndieMedic
   - type: Tag
     tags:
     - Hardsuit
@@ -564,7 +583,8 @@
     sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitSyndieElite
 
 #Syndicate Commander Hardsuit
 - type: entity
@@ -596,7 +616,8 @@
     sprintModifier: 1.0
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitSyndieCommander
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
@@ -628,7 +649,8 @@
     sprintModifier: 0.65
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitCybersun
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitCybersun
 
 #Wizard Hardsuit
 - type: entity
@@ -660,7 +682,8 @@
     sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitWizard
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitWizard
 
 #Ling Space Suit
 - type: entity
@@ -690,7 +713,8 @@
     sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitLing
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitLing
 
 #Pirate EVA Suit (Deep Space EVA Suit)
 #Despite visually appearing like a softsuit, it functions exactly like a hardsuit would (parents off of base hardsuit, has resistances and toggleable clothing, etc.) so it goes here.
@@ -720,7 +744,8 @@
     sprintModifier: 0.6
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitPirateEVA
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitPirateEVA
   - type: StaticPrice
     price: 0
 
@@ -753,7 +778,8 @@
     sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitPirateCap
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitPirateCap
   - type: StaticPrice
     price: 0
 
@@ -770,7 +796,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertleader.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitERTLeader
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitERTLeader
 
 #ERT Chaplain Hardsuit
 - type: entity
@@ -784,7 +811,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertchaplain.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitERTChaplain
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitERTChaplain
 
 #ERT Engineer Hardsuit
 - type: entity
@@ -798,7 +826,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertengineer.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitERTEngineer
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitERTEngineer
 
 #ERT Medic Hardsuit
 - type: entity
@@ -812,7 +841,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertmedical.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitERTMedical
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitERTMedical
 
 #ERT Security Hardsuit
 - type: entity
@@ -826,7 +856,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertsecurity.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitERTSecurity
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitERTSecurity
   - type: Tag
     tags:
     - Hardsuit
@@ -844,7 +875,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertjanitor.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitERTJanitor
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitERTJanitor
 
 #Deathsquad
 - type: entity
@@ -880,7 +912,8 @@
     sprintModifier: 1.0
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitDeathsquad
 
 #CBURN Hardsuit
 - type: entity
@@ -916,7 +949,8 @@
     sprintModifier: 1.0
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetCBURN
+    clothingPrototypes: 
+      head: ClothingHeadHelmetCBURN
 
 #MISC. HARDSUITS
 #Clown Hardsuit
@@ -950,7 +984,8 @@
     graph: ClownHardsuit
     node: clownHardsuit
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitClown
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitClown
 
 #Mime Hardsuit
 - type: entity
@@ -967,7 +1002,8 @@
     graph: MimeHardsuit
     node: mimeHardsuit
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitMime
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitMime
 
 #Santa's Hardsuit
 - type: entity
@@ -997,4 +1033,5 @@
     sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitSanta
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitSanta

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -64,8 +64,6 @@
   - type: ToggleableClothing
     clothingPrototypes: 
       head: ClothingHeadHelmetHardsuitAtmos
-      gloves: ClothingHandsGlovesColorYellow
-      shoes: ClothingShoesBootsMag
 
 #Engineering Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -105,7 +105,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/chaplain_hoodie.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodChaplainHood
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodChaplainHood
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -50,11 +50,11 @@
   - type: TemperatureProtection
     coefficient: 0.5
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetEVALarge
-    slot: head
+    clothingPrototypes: 
+      head: ClothingHeadHelmetEVALarge
   - type: ContainerContainer
     containers:
-      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-clothing: !type:Container {}
 
 #Prisoner EVA
 - type: entity
@@ -120,8 +120,8 @@
   - type: StealTarget
     stealGroup: ClothingOuterHardsuitVoidParamed
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetVoidParamed
-    slot: head
+    clothingPrototypes: 
+      head: ClothingHeadHelmetVoidParamed
   - type: ContainerContainer
     containers:
-      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-clothing: !type:Container {}

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -34,7 +34,7 @@
 
 #Emergency EVA
 - type: entity
-  parent: ClothingOuterEVASuitBase
+  parent: [ ClothingOuterEVASuitBase, ClothingOuterBaseToggleable ]
   id: ClothingOuterSuitEmergency
   name: emergency EVA suit
   description: An emergency EVA suit with a built-in helmet. It's horribly slow and lacking in temperature protection, but enough to buy you time from the harsh vacuum of space.
@@ -52,9 +52,6 @@
   - type: ToggleableClothing
     clothingPrototypes: 
       head: ClothingHeadHelmetEVALarge
-  - type: ContainerContainer
-    containers:
-      toggleable-clothing: !type:Container {}
 
 #Prisoner EVA
 - type: entity
@@ -92,7 +89,7 @@
 #Paramedic Voidsuit
 #Despite having resistances and looking like a hardsuit, this parents off the EVA suit so it goes here.
 - type: entity
-  parent: ClothingOuterEVASuitBase
+  parent: [ ClothingOuterEVASuitBase, ClothingOuterBaseToggleable ]
   id: ClothingOuterHardsuitVoidParamed
   name: paramedic void suit
   description: A void suit made for paramedics.
@@ -122,6 +119,3 @@
   - type: ToggleableClothing
     clothingPrototypes: 
       head: ClothingHeadHelmetVoidParamed
-  - type: ContainerContainer
-    containers:
-      toggleable-clothing: !type:Container {}

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -118,11 +118,11 @@
     sprite: Clothing/OuterClothing/Suits/rad.rsi
   - type: GroupExamine
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodRad
-    slot: head
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodRad
   - type: ContainerContainer
     containers:
-      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-clothing: !type:Container {}
   - type: ClothingRequiredStepTriggerImmune
     slots: WITHOUT_POCKET
 
@@ -249,10 +249,11 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/iansuit.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodIan
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodIan
   - type: ContainerContainer
     containers:
-      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-clothing: !type:Container {}
   - type: Construction
     graph: ClothingOuterSuitIan
     node: suit
@@ -273,10 +274,11 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/carpsuit.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodCarp
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodCarp
   - type: ContainerContainer
     containers:
-      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-clothing: !type:Container {}
 
 - type: entity
   parent: ClothingOuterSuitCarp
@@ -289,4 +291,5 @@
   - type: TemperatureProtection
     coefficient: 0.01
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitCarp
+    clothingPrototypes: 
+      head: ClothingHeadHelmetHardsuitCarp

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -102,7 +102,7 @@
     slots: WITHOUT_POCKET
 
 - type: entity
-  parent: [ClothingOuterBaseLarge, GeigerCounterClothing, AllowSuitStorageClothing]
+  parent: [ ClothingOuterBaseLarge, GeigerCounterClothing, AllowSuitStorageClothing, ClothingOuterBaseToggleable ]
   id: ClothingOuterSuitRad
   name: radiation suit
   description: "A suit that protects against radiation. The label reads, 'Made with lead. Please do not consume insulation.'"
@@ -120,9 +120,6 @@
   - type: ToggleableClothing
     clothingPrototypes: 
       head: ClothingHeadHatHoodRad
-  - type: ContainerContainer
-    containers:
-      toggleable-clothing: !type:Container {}
   - type: ClothingRequiredStepTriggerImmune
     slots: WITHOUT_POCKET
 
@@ -237,7 +234,7 @@
     slots: WITHOUT_POCKET
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: [ ClothingOuterBase, ClothingOuterBaseToggleable ]
   id: ClothingOuterSuitIan
   name: ian suit
   description: Who's a good boy?
@@ -251,9 +248,6 @@
   - type: ToggleableClothing
     clothingPrototypes: 
       head: ClothingHeadHatHoodIan
-  - type: ContainerContainer
-    containers:
-      toggleable-clothing: !type:Container {}
   - type: Construction
     graph: ClothingOuterSuitIan
     node: suit
@@ -261,7 +255,7 @@
     slots: WITHOUT_POCKET
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: [ ClothingOuterBase, ClothingOuterBaseToggleable ]
   id: ClothingOuterSuitCarp
   name: carp suit
   description: A special suit that makes you look just like a space carp, if your eyesight is bad.
@@ -276,9 +270,6 @@
   - type: ToggleableClothing
     clothingPrototypes: 
       head: ClothingHeadHatHoodCarp
-  - type: ContainerContainer
-    containers:
-      toggleable-clothing: !type:Container {}
 
 - type: entity
   parent: ClothingOuterSuitCarp

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -41,11 +41,11 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterDefault
-    slot: head
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterDefault
   - type: ContainerContainer
     containers:
-      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-clothing: !type:Container {}
       storagebase: !type:Container
         ents: []
 
@@ -70,7 +70,8 @@
       outerClothing:
       - state: ATMOS-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterEngineer
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterEngineer
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -93,7 +94,8 @@
       outerClothing:
       - state: BAR-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterBartender
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterBartender
 
 - type: entity
   parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
@@ -116,7 +118,8 @@
       outerClothing:
       - state: CAP-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterCaptain
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterCaptain
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -139,7 +142,8 @@
       outerClothing:
       - state: CARGO-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterCargo
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterCargo
 
 - type: entity
   parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
@@ -162,7 +166,8 @@
       outerClothing:
       - state: CE-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterCE
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterCE
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -185,7 +190,8 @@
       outerClothing:
       - state: CENTCOM-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterCentcom
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterCentcom
 
 - type: entity
   parent: ClothingOuterWinterCoat
@@ -237,7 +243,8 @@
         Caustic: 0.75
     priceMultiplier: 0.15
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterChem
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterChem
 
 - type: entity
   parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
@@ -267,7 +274,8 @@
         Caustic: 0.75
     priceMultiplier: 0.15
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterCMO
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterCMO
 
 - type: entity
   parent: ClothingOuterWinterCoat
@@ -300,7 +308,8 @@
       outerClothing:
       - state: ENGI-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterEngineer
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterEngineer
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -330,7 +339,8 @@
         Caustic: 0.9
     priceMultiplier: 0.15
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterSci
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterSci
 
 - type: entity
   parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
@@ -353,7 +363,8 @@
       outerClothing:
       - state: HOP-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterHOP
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterHOP
 
 
 ##########################################################
@@ -368,7 +379,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/WinterCoats/coathosarmored.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterHOS
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterHOS
 ##########################################################
 
 - type: entity
@@ -393,7 +405,8 @@
       outerClothing:
       - state: HOS-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterHOS
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterHOS
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -416,7 +429,8 @@
       outerClothing:
       - state: HYDRO-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterHydro
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterHydro
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -446,7 +460,8 @@
         Caustic: 0.9
     priceMultiplier: 0.15
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterJani
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterJani
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -476,7 +491,8 @@
         Caustic: 0.9
     priceMultiplier: 0.15
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterMed
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterMed
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -499,7 +515,8 @@
       outerClothing:
       - state: MIME-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterMime
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterMime
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -522,7 +539,8 @@
       outerClothing:
       - state: MINER-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterMiner
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterMiner
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -552,7 +570,8 @@
         Caustic: 0.9
     priceMultiplier: 0.15
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterPara
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterPara
 
 - type: entity
   parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
@@ -575,7 +594,8 @@
       outerClothing:
       - state: QM-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterQM
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterQM
 
 
 - type: entity
@@ -606,7 +626,8 @@
         Caustic: 0.9
     priceMultiplier: 0.15
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterRD
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterRD
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -629,7 +650,8 @@
       outerClothing:
       - state: ROBO-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterRobo
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterRobo
 
 
 - type: entity
@@ -660,7 +682,8 @@
         Caustic: 0.9
     priceMultiplier: 0.15
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterSci
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterSci
 
 - type: entity
   parent: [ClothingOuterWinterCoatToggleable, BaseRestrictedContraband]
@@ -683,7 +706,8 @@
       outerClothing:
       - state: SEC-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterSec
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterSec
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -713,7 +737,8 @@
         Caustic: 0.9
     priceMultiplier: 0.15
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterSci
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterSci
 
 ################################################################
 - type: entity
@@ -727,7 +752,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/WinterCoats/coatwardenarmored.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterWarden
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterWarden
 ################################################################
 
 - type: entity
@@ -752,7 +778,8 @@
       outerClothing:
       - state: WARD-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterWarden
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterWarden
 
 - type: entity
   parent: [ClothingOuterWinterCoatToggleable, BaseSyndicateContraband]
@@ -776,7 +803,8 @@
       outerClothing:
       - state: SYNDIECAP-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterSyndie
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterSyndie
 
 ##############################################################
 - type: entity
@@ -790,7 +818,8 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/WinterCoats/syndicate/coatsyndiecaparmored.rsi
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterSyndie
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterSyndie
 ##############################################################
 
 - type: entity
@@ -815,7 +844,8 @@
       outerClothing:
       - state: SYNDIE-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterSyndie
+    clothingPrototypes:
+      head: ClothingHeadHatHoodWinterSyndie
 
 - type: entity
   parent: ClothingOuterWinterCoat
@@ -865,7 +895,8 @@
         - ReagentId: Fiber
           Quantity: 20
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterWeb
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterWeb
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -896,7 +927,8 @@
         color: "#1d1d1d"
       - state: winterbits-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterColorBlack
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterColorBlack
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -927,7 +959,8 @@
         color: "#9C0DE1"
       - state: winterbits-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterColorPurple
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterColorPurple
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -958,7 +991,8 @@
         color: "#940000"
       - state: winterbits-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterColorRed
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterColorRed
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -989,7 +1023,8 @@
         color: "#0089EF"
       - state: winterbits-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterColorBlue
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterColorBlue
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -1020,7 +1055,8 @@
         color: "#723A02"
       - state: winterbits-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterColorBrown
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterColorBrown
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -1051,7 +1087,8 @@
         color: "#999999"
       - state: winterbits-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterColorGray
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterColorGray
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -1082,7 +1119,8 @@
         color: "#5ABF2F"
       - state: winterbits-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterColorGreen
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterColorGreen
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -1113,7 +1151,8 @@
         color: "#C09F72"
       - state: winterbits-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterColorLightBrown
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterColorLightBrown
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -1144,7 +1183,8 @@
         color: "#EF8100"
       - state: winterbits-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterColorOrange
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterColorOrange
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -1175,7 +1215,8 @@
         color: "#EAE8E8"
       - state: winterbits-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterColorWhite
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterColorWhite
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -1206,4 +1247,5 @@
         color: "#EBE216"
       - state: winterbits-equipped-OUTERCLOTHING
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterColorYellow
+    clothingPrototypes: 
+      head: ClothingHeadHatHoodWinterColorYellow

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -35,7 +35,7 @@
     price: 50
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: [ ClothingOuterWinterCoat, ClothingOuterBaseToggleable ]
   id: ClothingOuterWinterCoatToggleable
   name: winter coat with hood
   categories: [ HideSpawnMenu ]
@@ -43,11 +43,6 @@
   - type: ToggleableClothing
     clothingPrototypes: 
       head: ClothingHeadHatHoodWinterDefault
-  - type: ContainerContainer
-    containers:
-      toggleable-clothing: !type:Container {}
-      storagebase: !type:Container
-        ents: []
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable


### PR DESCRIPTION
## About the PR
- Toggleable clothing now can work with multiple clothings.
- Toggleable clothing now have ui (if more than one attached clothing)
- Toggleable clothing unequip now can be blocked if any attached clothing is equipped
- Attached clothing now have option to replace already worn clothings keeping them in container

## Why / Balance
Toggleable clothing now is very limited with only one attached clothing whats not allow to make something more cool like modsuits.

## Technical details
Most ToggleableClothingSystem methods were change to work with multiple attached clothings. ToggleableClothing component now have two Dictionaries instead of Slot, ClothingUid and Prototype fields. ContainerSlot was replaced with Container to contain multiple clothings. 

AttachedClothingComponent got container for replaceable clothing.

I really need review to understand how to make everything of this better.

## Media

(Atmos Hardsuit was changed just for tests)

https://github.com/user-attachments/assets/e0f8e423-6437-4117-a779-144f2c44698d


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
ToggleableClothingComponent was changed to work with multiple clothings so prototypes with it need to changed from this:
  - type: ToggleableClothing
    clothingPrototype: prototypeName
to this:
  - type: ToggleableClothing
    clothingPrototypes: 
      slotName: prototypeName
