### PR TITLE
Fix justice helm crafting

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -1,6 +1,26 @@
 #These are intentionally all very mediocre as locational damage does not exist yet. Without it, armor values will stack in a way that makes it really god damn hard to determine how effective something is, along with making players extremely tanky.
 #When it DOES exist, the values here should be totally reworked - probably just port them from SS13.
 
+- type: entity
+  parent: [ClothingHeadBase, BaseRestrictedContraband]
+  id: ClothingHeadHelmetBase
+  abstract: true
+  components:
+  - type: Armor #Values seem to let the user survive one extra hit if attacked consistently.
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.9
+        Heat: 0.9
+  - type: Tag
+    tags:
+    - WhitelistChameleon
+  - type: HideLayerClothing
+    slots:
+    - HeadTop
+    - HeadSide
+
 #Basic Helmet (Security Helmet)
 - type: entity
   parent: [ClothingHeadBase, BaseRestrictedContraband]
@@ -12,25 +32,14 @@
     sprite: Clothing/Head/Helmets/security.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/security.rsi
-  - type: Armor #Values seem to let the user survive one extra hit if attacked consistently.
-    modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
   - type: Tag
     tags:
     - WhitelistChameleon
     - SecurityHelmet
-  - type: HideLayerClothing
-    slots:
-    - HeadTop
-    - HeadSide
 
 #Mercenary Helmet
 - type: entity
-  parent: [ ClothingHeadHelmetBasic, BaseRestrictedContraband ]
+  parent: [ ClothingHeadHelmetBase, BaseRestrictedContraband ]
   id: ClothingHeadHelmetMerc
   name: mercenary helmet
   description: The combat helmet is commonly used by mercenaries, is strong, light and smells like gunpowder and the jungle.
@@ -302,7 +311,7 @@
 #ERT HELMETS
 #ERT Leader Helmet
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetBasic ]
+  parent: [ BaseCentcommContraband, ClothingHeadHelmetBase ]
   id: ClothingHeadHelmetERTLeader
   name: ERT leader helmet
   description: An in-atmosphere helmet worn by the leader of a Nanotrasen Emergency Response Team. Has blue highlights.
@@ -314,7 +323,7 @@
 
 #ERT Security Helmet
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetBasic ]
+  parent: [ BaseCentcommContraband, ClothingHeadHelmetBase ]
   id: ClothingHeadHelmetERTSecurity
   name: ERT security helmet
   description: An in-atmosphere helmet worn by security members of the Nanotrasen Emergency Response Team. Has red highlights.
@@ -326,7 +335,7 @@
 
 #ERT Medic Helmet
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetBasic ]
+  parent: [ BaseCentcommContraband, ClothingHeadHelmetBase ]
   id: ClothingHeadHelmetERTMedic
   name: ERT medic helmet
   description: An in-atmosphere helmet worn by medical members of the Nanotrasen Emergency Response Team. Has white highlights.
@@ -338,7 +347,7 @@
 
 #ERT Engineer Helmet
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetBasic ]
+  parent: [ BaseCentcommContraband, ClothingHeadHelmetBase ]
   id: ClothingHeadHelmetERTEngineer
   name: ERT engineer helmet
   description: An in-atmosphere helmet worn by engineering members of the Nanotrasen Emergency Response Team. Has orange highlights.
@@ -350,7 +359,7 @@
 
 #ERT Janitor Helmet
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetBasic ]
+  parent: [ BaseCentcommContraband, ClothingHeadHelmetBase ]
   id: ClothingHeadHelmetERTJanitor
   name: ERT janitor helmet
   description: An in-atmosphere helmet worn by janitorial members of the Nanotrasen Emergency Response Team. Has dark purple highlights.
@@ -361,7 +370,7 @@
     sprite: Clothing/Head/Helmets/ert_janitor.rsi
 
 - type: entity
-  parent: [ BaseSyndicateContraband, ClothingHeadHelmetBasic ]
+  parent: [ BaseSyndicateContraband, ClothingHeadHelmetBase ]
   id: ClothingHeadHelmetRaid
   name: syndicate raid helmet
   description: An armored helmet for use with the syndicate raid suit. Very stylish.
@@ -380,7 +389,7 @@
 
 #Bone Helmet
 - type: entity
-  parent: ClothingHeadHelmetBasic
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetBone
   name: bone helmet
   description: Cool-looking helmet made of skull of your enemies.
@@ -394,7 +403,7 @@
     node: helmet
 
 - type: entity
-  parent: ClothingHeadHelmetBasic
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetPodWars
   name: ironclad II helmet
   description: An ironclad II helmet, a relic of the pod wars.
@@ -406,7 +415,7 @@
 
 #Justice Helmet
 - type: entity
-  parent: ClothingHeadHelmetBasic
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetJustice
   name: justice helm
   description: Advanced security gear. Protects the station from ne'er-do-wells.
@@ -430,6 +439,8 @@
       path: /Audio/Items/flashlight_on.ogg
     soundDeactivate:
       path: /Audio/Items/flashlight_off.ogg
+    soundFailToActivate:
+      path: /Audio/Machines/button.ogg
   - type: ItemToggleActiveSound
     activeSound:
       path: /Audio/Effects/Vehicle/policesiren.ogg
@@ -470,9 +481,6 @@
   - type: Construction
     graph: HelmetJustice
     node: helmet
-  - type: Tag
-    tags:
-    - WhitelistChameleon
 
 - type: entity
   parent: ClothingHeadHelmetJustice


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR fixes the justice helm from being craftable with incorrect helmets. I also added a failToActivate sound that I forgot to add before.

Fixes #31964

## Technical details
<!-- Summary of code changes for easier review. -->

This simply adds an abstract parent ClothingHeadHelmetBase that the helmets can inherit from, instead of everyone inheriting from the security helmet.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: The Justice Helm can now only be crafted using a security helmet.
