### PR TITLE
Fix bone and ironclad helmet contraband status

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -2,7 +2,7 @@
 #When it DOES exist, the values here should be totally reworked - probably just port them from SS13.
 
 - type: entity
-  parent: [ClothingHeadBase, BaseRestrictedContraband]
+  parent: ClothingHeadBase
   id: ClothingHeadHelmetBase
   abstract: true
   components:
@@ -415,7 +415,7 @@
 
 #Justice Helmet
 - type: entity
-  parent: ClothingHeadHelmetBase
+  parent: [ClothingHeadHelmetBase, BaseRestrictedContraband]
   id: ClothingHeadHelmetJustice
   name: justice helm
   description: Advanced security gear. Protects the station from ne'er-do-wells.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR removes the contraband status from the bone helmet and ironclad II helmets.

I thought I borked the contraband status in my justice helm crafting fix PR, but it turns out this was an existing issue.

Related to #31047

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The ironclad armor isn't considered contraband, so it is weird that the helmet is.
The bone helmet seems to be map loot, so it is weird to be security locked.

I think both of these mistakenly had the status through inheritance.

## Technical details
<!-- Summary of code changes for easier review. -->

I removed the contraband status from the base helmet, to allow non-contraband helmets to inherit it. All other helmets already had their correct contraband parentage but these two.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl:
- fix: The bone helmet and ironclad II helmet are no longer security restricted.
