### PR TITLE
Add briefcase damage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
@@ -12,6 +12,10 @@
   - type: Tag
     tags:
     - Briefcase
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 8
 
 - type: entity
   parent: BriefcaseBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

The briefcase can now be used to deal 8 blunt damage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bonk

## Technical details
<!-- Summary of code changes for easier review. -->

``` 
- type: MeleeWeapon
    damage:
      types:
        Blunt: 8
```

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Briefcases can now be used as melee weapons.
