### PR TITLE
prevent using holo inside containers

### DIFF
--- a/Content.Server/Guardian/GuardianSystem.cs
+++ b/Content.Server/Guardian/GuardianSystem.cs
@@ -80,6 +80,12 @@ namespace Content.Server.Guardian
             if (args.Handled)
                 return;
 
+            if (_container.IsEntityInContainer(uid))
+            {
+                _popupSystem.PopupEntity(Loc.GetString("guardian-inside-container"), uid, uid);
+                return;
+            }
+
             if (component.HostedGuardian != null)
                 ToggleGuardian(uid, component);
 

--- a/Resources/Locale/en-US/guardian/guardian.ftl
+++ b/Resources/Locale/en-US/guardian/guardian.ftl
@@ -10,6 +10,7 @@ guardian-activator-empty-examine = [color=#ba1919]The injector is spent.[/color]
 guardian-activator-invalid-target = Only humans can be injected!
 guardian-no-soul = Your guardian has no soul.
 guardian-available = Your guardian now has a soul.
+guardian-inside-container = There's no room to release your guardian!
 
 ## Guardian entity specific
 


### PR DESCRIPTION
## About the PR
title

## Why / Balance
so someone cant use a holo inside a locker (okay...) or a disposals loop (downright evil, impossible to damage)

## Technical details
its shrimple really

## Media
![01:19:01](https://github.com/user-attachments/assets/aa6e771f-3a58-46ff-9e4a-66ddec1891d4)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Holoparasites can no longer be summoned from inside containers.
