### PR TITLE
Ore Processors can now produce Reinforced Glass

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -33,8 +33,8 @@
   result: SheetRGlass1
   completetime: 0
   materials:
-    Glass: 100
-    Steel: 50
+    RawQuartz: 100
+    RawIron: 50
     Coal: 15
 
 - type: latheRecipe


### PR DESCRIPTION
## About the PR
Fixes an issue where the ore processor's reinforced glass recipe called for Steel and Glass instead of raw iron and raw quartz.

## Why / Balance
Bug fix.

## Technical details
<!-- Summary of code changes for easier review. -->
YML changes.

## Media
![image](https://github.com/user-attachments/assets/c21fdc5e-b2e0-44a5-874d-23ed1b100c6c)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed a bug where ore processors could not produce reinforced glass