### PR TITLE
make epinephrine adrenaline

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -359,6 +359,10 @@
         key: KnockedDown
         time: 0.75
         type: Remove
+      - !type:GenericStatusEffect
+        key: Adrenaline # Guess what epinephrine is...
+        component: IgnoreSlowOnDamage
+        time: 5 # lingers less than hivemind reagent to give it a niche
 
 - type: reagent
   id: Hyronalin


### PR DESCRIPTION
## About the PR
epinephrine gives you the adrenaline status, linger for 5 seconds after it wears off (compared to hivemind juice which is 2 minutes)

## Why / Balance
![03:28:37](https://github.com/user-attachments/assets/b1cede55-11a5-4f94-af09-e125748aca73)

makes it more useful in an emergency, if you are close to crit you want to get to safety and avoiding a slowdown helps that
it lingers for less time to give hivemind juice a niche

**Changelog**
:cl:
- tweak: Epinephrine now adds Adrenaline, because it is.
