### PR TITLE
Fix cauterization spam from space damage

### DIFF
--- a/Content.Server/Body/Components/BloodstreamComponent.cs
+++ b/Content.Server/Body/Components/BloodstreamComponent.cs
@@ -111,6 +111,13 @@ namespace Content.Server.Body.Components
         [DataField]
         public SoundSpecifier BloodHealedSound = new SoundPathSpecifier("/Audio/Effects/lightburn.ogg");
 
+        /// <summary>
+        /// The minimum amount damage reduction needed to play the healing sound/popup.
+        /// This prevents tiny amounts of heat damage from spamming the sound, e.g. spacing.
+        /// </summary>
+        [DataField]
+        public float BloodHealedSoundThreshold = -0.1f;
+
         // TODO probably damage bleed thresholds.
 
         /// <summary>

--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -241,7 +241,7 @@ public sealed class BloodstreamSystem : EntitySystem
         }
 
         // Heat damage will cauterize, causing the bleed rate to be reduced.
-        else if (totalFloat < 0 && oldBleedAmount > 0)
+        else if (totalFloat <= ent.Comp.BloodHealedSoundThreshold && oldBleedAmount > 0)
         {
             // Magically, this damage has healed some bleeding, likely
             // because it's burn damage that cauterized their wounds.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR sets a small threshold for playing the cauterization sound/popup. (You still receive the tiny amount of bloodloss reduction.)

Fixes #31827

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Tiny amounts of heat damage do almost nothing stop your bleeding and can cause a lot of spam of the noise/popup. Instead of providing useful feedback to the player, it's annoying and can cover up more useful sounds or popups.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/d467a040-9a4c-472f-b8a9-1dc55fe3dad7

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Very small amounts of heat damage no longer play the cauterization sound (e.g. spacing)
