### PR TITLE
Use archived gas mixture in gas exchange comparison

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -1,9 +1,9 @@
+using System.Linq;
+using System.Runtime.CompilerServices;
 using Content.Server.Atmos.Reactions;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Reactions;
 using Robust.Shared.Prototypes;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
 
 namespace Content.Server.Atmos.EntitySystems
@@ -298,6 +298,7 @@ namespace Content.Server.Atmos.EntitySystems
         public GasCompareResult CompareExchange(GasMixture sample, GasMixture otherSample)
         {
             var moles = 0f;
+
             for(var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
             {
                 var gasMoles = sample.Moles[i];

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -282,7 +282,7 @@ namespace Content.Server.Atmos.EntitySystems
         }
 
         /// <summary>
-        ///     Compares two gas mixtures to see if they are within acceptable ranges for group processing to be enabled.
+        ///     Compares two TileAtmospheres to see if they are within acceptable ranges for group processing to be enabled.
         /// </summary>
         public GasCompareResult CompareExchange(TileAtmosphere sample, TileAtmosphere otherSample, bool useArchived = false)
         {

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Gases.cs
@@ -284,48 +284,21 @@ namespace Content.Server.Atmos.EntitySystems
         /// <summary>
         ///     Compares two TileAtmospheres to see if they are within acceptable ranges for group processing to be enabled.
         /// </summary>
-        public GasCompareResult CompareExchange(TileAtmosphere sample, TileAtmosphere otherSample, bool useArchived)
+        public GasCompareResult CompareExchange(TileAtmosphere sample, TileAtmosphere otherSample)
         {
-            if (!useArchived && sample.Air != null && otherSample.Air != null)
-            {
-                return CompareExchange(sample.Air, otherSample.Air);
-            }
+            if (sample.AirArchived == null || otherSample.AirArchived == null)
+                return GasCompareResult.NoExchange;
 
-            float[] samples = sample.MolesArchived;
-            float[] otherSamples = otherSample.MolesArchived;
-
-            var moles = 0f;
-            float sampleMoles, otherSampleMoles;
-
-            for(var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
-            {
-                sampleMoles = samples[i];
-                otherSampleMoles = otherSamples[i];
-
-                var delta = MathF.Abs(sampleMoles - otherSampleMoles);
-                if (delta > Atmospherics.MinimumMolesDeltaToMove && (delta > sampleMoles * Atmospherics.MinimumAirRatioToMove))
-                    return (GasCompareResult)i; // We can move gases!
-                moles += sampleMoles;
-            }
-
-            if (moles > Atmospherics.MinimumMolesDeltaToMove)
-            {
-                var tempDelta = MathF.Abs(sample.Temperature - otherSample.Temperature);
-                if (tempDelta > Atmospherics.MinimumTemperatureDeltaToSuspend)
-                    return GasCompareResult.TemperatureExchange; // There can be temperature exchange.
-            }
-
-            // No exchange at all!
-            return GasCompareResult.NoExchange;
+            return CompareExchange(sample.AirArchived, otherSample.AirArchived);
         }
 
         /// <summary>
-        ///     Compares two GasMixtures to see if they are within acceptable ranges for group processing to be enabled.
+        ///     Compares two gas mixtures to see if they are within acceptable ranges for group processing to be enabled.
         /// </summary>
         public GasCompareResult CompareExchange(GasMixture sample, GasMixture otherSample)
         {
             var moles = 0f;
-            for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+            for(var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
             {
                 var gasMoles = sample.Moles[i];
                 var delta = MathF.Abs(gasMoles - otherSample.Moles[i]);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
@@ -270,7 +270,7 @@ public sealed partial class AtmosphereSystem
     {
         DebugTools.AssertNotNull(tile.Air);
         DebugTools.Assert(tile.Air?.Immutable == false);
-        Array.Clear(tile.MolesArchived);
+        tile.AirArchived = null;
         tile.ArchivedCycle = 0;
 
         var count = 0;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -54,7 +54,7 @@ namespace Content.Server.Atmos.EntitySystems
                     }
 
                     shouldShareAir = true;
-                } else if (CompareExchange(tile, enemyTile, true) != GasCompareResult.NoExchange)
+                } else if (CompareExchange(tile, enemyTile) != GasCompareResult.NoExchange)
                 {
                     AddActiveTile(gridAtmosphere, enemyTile);
                     if (ExcitedGroups)
@@ -117,9 +117,8 @@ namespace Content.Server.Atmos.EntitySystems
         private void Archive(TileAtmosphere tile, int fireCount)
         {
             if (tile.Air != null)
-                tile.Air.Moles.AsSpan().CopyTo(tile.MolesArchived.AsSpan());
+                tile.AirArchived = tile.Air.Clone();
 
-            tile.TemperatureArchived = tile.Temperature;
             tile.ArchivedCycle = fireCount;
         }
 
@@ -184,10 +183,10 @@ namespace Content.Server.Atmos.EntitySystems
         /// </summary>
         public float GetHeatCapacityArchived(TileAtmosphere tile)
         {
-            if (tile.Air == null)
+            if (tile.AirArchived == null)
                 return tile.HeatCapacity;
 
-            return GetHeatCapacityCalculation(tile.MolesArchived!, tile.Space);
+            return GetHeatCapacity(tile.AirArchived);
         }
 
         /// <summary>
@@ -195,10 +194,11 @@ namespace Content.Server.Atmos.EntitySystems
         /// </summary>
         public float Share(TileAtmosphere tileReceiver, TileAtmosphere tileSharer, int atmosAdjacentTurfs)
         {
-            if (tileReceiver.Air is not {} receiver || tileSharer.Air is not {} sharer)
+            if (tileReceiver.Air is not {} receiver || tileSharer.Air is not {} sharer ||
+                    tileReceiver.AirArchived == null || tileSharer.AirArchived == null)
                 return 0f;
 
-            var temperatureDelta = tileReceiver.TemperatureArchived - tileSharer.TemperatureArchived;
+            var temperatureDelta = tileReceiver.AirArchived.Temperature - tileSharer.AirArchived.Temperature;
             var absTemperatureDelta = Math.Abs(temperatureDelta);
             var oldHeatCapacity = 0f;
             var oldSharerHeatCapacity = 0f;
@@ -249,12 +249,12 @@ namespace Content.Server.Atmos.EntitySystems
                 // Transfer of thermal energy (via changed heat capacity) between self and sharer.
                 if (!receiver.Immutable && newHeatCapacity > Atmospherics.MinimumHeatCapacity)
                 {
-                    receiver.Temperature = ((oldHeatCapacity * receiver.Temperature) - (heatCapacityToSharer * tileReceiver.TemperatureArchived) + (heatCapacitySharerToThis * tileSharer.TemperatureArchived)) / newHeatCapacity;
+                    receiver.Temperature = ((oldHeatCapacity * receiver.Temperature) - (heatCapacityToSharer * tileReceiver.AirArchived.Temperature) + (heatCapacitySharerToThis * tileSharer.AirArchived.Temperature)) / newHeatCapacity;
                 }
 
                 if (!sharer.Immutable && newSharerHeatCapacity > Atmospherics.MinimumHeatCapacity)
                 {
-                    sharer.Temperature = ((oldSharerHeatCapacity * sharer.Temperature) - (heatCapacitySharerToThis * tileSharer.TemperatureArchived) + (heatCapacityToSharer * tileReceiver.TemperatureArchived)) / newSharerHeatCapacity;
+                    sharer.Temperature = ((oldSharerHeatCapacity * sharer.Temperature) - (heatCapacitySharerToThis * tileSharer.AirArchived.Temperature) + (heatCapacityToSharer * tileReceiver.AirArchived.Temperature)) / newSharerHeatCapacity;
                 }
 
                 // Thermal energy of the system (self and sharer) is unchanged.
@@ -273,7 +273,7 @@ namespace Content.Server.Atmos.EntitySystems
             var moles = receiver.TotalMoles;
             var theirMoles = sharer.TotalMoles;
 
-            return (tileReceiver.TemperatureArchived * (moles + movedMoles)) - (tileSharer.TemperatureArchived * (theirMoles - movedMoles)) * Atmospherics.R / receiver.Volume;
+            return (tileReceiver.AirArchived.Temperature * (moles + movedMoles)) - (tileSharer.AirArchived.Temperature * (theirMoles - movedMoles)) * Atmospherics.R / receiver.Volume;
         }
 
         /// <summary>
@@ -281,10 +281,11 @@ namespace Content.Server.Atmos.EntitySystems
         /// </summary>
         public float TemperatureShare(TileAtmosphere tileReceiver, TileAtmosphere tileSharer, float conductionCoefficient)
         {
-            if (tileReceiver.Air is not { } receiver || tileSharer.Air is not { } sharer)
+            if (tileReceiver.Air is not { } receiver || tileSharer.Air is not { } sharer ||
+                    tileReceiver.AirArchived == null || tileSharer.AirArchived == null)
                 return 0f;
 
-            var temperatureDelta = tileReceiver.TemperatureArchived - tileSharer.TemperatureArchived;
+            var temperatureDelta = tileReceiver.AirArchived.Temperature - tileSharer.AirArchived.Temperature;
             if (MathF.Abs(temperatureDelta) > Atmospherics.MinimumTemperatureDeltaToConsider)
             {
                 var heatCapacity = GetHeatCapacityArchived(tileReceiver);
@@ -310,10 +311,10 @@ namespace Content.Server.Atmos.EntitySystems
         /// </summary>
         public float TemperatureShare(TileAtmosphere tileReceiver, float conductionCoefficient, float sharerTemperature, float sharerHeatCapacity)
         {
-            if (tileReceiver.Air is not {} receiver)
+            if (tileReceiver.Air is not {} receiver || tileReceiver.AirArchived == null)
                 return 0;
 
-            var temperatureDelta = tileReceiver.TemperatureArchived - sharerTemperature;
+            var temperatureDelta = tileReceiver.AirArchived.Temperature - sharerTemperature;
             if (MathF.Abs(temperatureDelta) > Atmospherics.MinimumTemperatureDeltaToConsider)
             {
                 var heatCapacity = GetHeatCapacityArchived(tileReceiver);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -117,7 +117,7 @@ namespace Content.Server.Atmos.EntitySystems
         private void Archive(TileAtmosphere tile, int fireCount)
         {
             if (tile.Air != null)
-                tile.AirArchived.CopyFrom(tile.Air);
+                tile.AirArchived = new GasMixture(tile.Air);
 
             tile.ArchivedCycle = fireCount;
         }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -54,7 +54,7 @@ namespace Content.Server.Atmos.EntitySystems
                     }
 
                     shouldShareAir = true;
-                } else if (CompareExchange(tile.Air, enemyTile.Air) != GasCompareResult.NoExchange)
+                } else if (CompareExchange(tile, enemyTile, true) != GasCompareResult.NoExchange)
                 {
                     AddActiveTile(gridAtmosphere, enemyTile);
                     if (ExcitedGroups)

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -117,7 +117,7 @@ namespace Content.Server.Atmos.EntitySystems
         private void Archive(TileAtmosphere tile, int fireCount)
         {
             if (tile.Air != null)
-                tile.AirArchived = tile.Air.Clone();
+                tile.AirArchived.CopyFrom(tile.Air);
 
             tile.ArchivedCycle = fireCount;
         }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -355,7 +355,7 @@ namespace Content.Server.Atmos.EntitySystems
                         continue;
 
                     DebugTools.Assert(otherTile2.AdjacentBits.IsFlagSet(direction.GetOpposite()));
-                    if (otherTile2.Air != null && CompareExchange(otherTile2, tile, true) == GasCompareResult.NoExchange)
+                    if (otherTile2.Air != null && CompareExchange(otherTile2, tile) == GasCompareResult.NoExchange)
                         continue;
 
                     AddActiveTile(gridAtmosphere, otherTile2);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Monstermos.cs
@@ -355,7 +355,7 @@ namespace Content.Server.Atmos.EntitySystems
                         continue;
 
                     DebugTools.Assert(otherTile2.AdjacentBits.IsFlagSet(direction.GetOpposite()));
-                    if (otherTile2.Air != null && CompareExchange(otherTile2.Air, tile.Air) == GasCompareResult.NoExchange)
+                    if (otherTile2.Air != null && CompareExchange(otherTile2, tile, true) == GasCompareResult.NoExchange)
                         continue;
 
                     AddActiveTile(gridAtmosphere, otherTile2);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -231,7 +231,7 @@ namespace Content.Server.Atmos.EntitySystems
             tile.MapAtmosphere = false;
             atmos.MapTiles.Remove(tile);
             tile.Air = null;
-            Array.Clear(tile.MolesArchived);
+            tile.AirArchived = null;
             tile.ArchivedCycle = 0;
             tile.LastShare = 0f;
             tile.Space = false;
@@ -261,7 +261,7 @@ namespace Content.Server.Atmos.EntitySystems
                     return;
 
                 tile.Air = null;
-                Array.Clear(tile.MolesArchived);
+                tile.AirArchived = null;
                 tile.ArchivedCycle = 0;
                 tile.LastShare = 0f;
                 tile.Hotspot = new Hotspot();

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Superconductivity.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Superconductivity.cs
@@ -131,7 +131,10 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void TemperatureShareMutualSolid(TileAtmosphere tile, TileAtmosphere other, float conductionCoefficient)
         {
-            var deltaTemperature = (tile.TemperatureArchived - other.TemperatureArchived);
+            if (tile.AirArchived == null || other.AirArchived == null)
+                return;
+
+            var deltaTemperature = (tile.AirArchived.Temperature - other.AirArchived.Temperature);
             if (MathF.Abs(deltaTemperature) > Atmospherics.MinimumTemperatureDeltaToConsider
                 && tile.HeatCapacity != 0f && other.HeatCapacity != 0f)
             {
@@ -145,11 +148,14 @@ namespace Content.Server.Atmos.EntitySystems
 
         public void RadiateToSpace(TileAtmosphere tile)
         {
+            if (tile.AirArchived == null)
+                return;
+
             // Considering 0ºC as the break even point for radiation in and out.
             if (tile.Temperature > Atmospherics.T0C)
             {
                 // Hardcoded space temperature.
-                var deltaTemperature = (tile.TemperatureArchived - Atmospherics.TCMB);
+                var deltaTemperature = (tile.AirArchived.Temperature - Atmospherics.TCMB);
                 if ((tile.HeatCapacity > 0) && (MathF.Abs(deltaTemperature) > Atmospherics.MinimumTemperatureDeltaToConsider))
                 {
                     var heat = tile.ThermalConductivity * deltaTemperature * (tile.HeatCapacity *

--- a/Content.Server/Atmos/TileAtmosphere.cs
+++ b/Content.Server/Atmos/TileAtmosphere.cs
@@ -23,9 +23,6 @@ namespace Content.Server.Atmos
         public float Temperature { get; set; } = Atmospherics.T20C;
 
         [ViewVariables]
-        public float TemperatureArchived { get; set; } = Atmospherics.T20C;
-
-        [ViewVariables]
         public TileAtmosphere? PressureSpecificTarget { get; set; }
 
         /// <summary>
@@ -93,11 +90,15 @@ namespace Content.Server.Atmos
         [Access(typeof(AtmosphereSystem), Other = AccessPermissions.ReadExecute)] // FIXME Friends
         public GasMixture? Air { get; set; }
 
+        /// <summary>
+        /// Like Air, but a copy stored each atmos tick before tile processing takes place. This lets us update Air
+        /// in-place without affecting the results based on update order.
+        /// </summary>
+        [ViewVariables]
+        public GasMixture? AirArchived;
+
         [DataField("lastShare")]
         public float LastShare;
-
-        [ViewVariables]
-        public readonly float[] MolesArchived = new float[Atmospherics.AdjustedNumberOfGases];
 
         GasMixture IGasMixtureHolder.Air
         {
@@ -139,6 +140,7 @@ namespace Content.Server.Atmos
             GridIndex = gridIndex;
             GridIndices = gridIndices;
             Air = mixture;
+            AirArchived = Air != null ? Air.Clone() : null;
             Space = space;
 
             if(immutable)
@@ -153,7 +155,7 @@ namespace Content.Server.Atmos
             NoGridTile = other.NoGridTile;
             MapAtmosphere = other.MapAtmosphere;
             Air = other.Air?.Clone();
-            Array.Copy(other.MolesArchived, MolesArchived, MolesArchived.Length);
+            AirArchived = Air != null ? Air.Clone() : null;
         }
 
         public TileAtmosphere()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
CompareExchange() now allows using archives gases instead of current ones.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #32053

## Technical details
<!-- Summary of code changes for easier review. -->
A flag was added to CompareExchange to let it pick the current air or the archived air value for comparisons. The 2 calls to it were updated to match the new function signature. The function's 2 main arguments were also changed to the parent of both the current and archived air values.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
No visible changes

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- In `TileAtmosphere`, `TemperatureArchived` and `MolesArchived` have been rolled into `AirArchived`. Use `AirArchived.Temperature` and `AirArchived.Moles` to access these fields, respectively.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fix error in gas exchange processing order.