### PR TITLE
Allows you to buckle transfer person from bed to bed

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -269,6 +269,10 @@ public abstract partial class SharedBuckleSystem
 
         if (buckleComp.Buckled)
         {
+            // allows you to try and buckle them to a different chair or bed
+            if (TryUnbuckle(buckleUid, user, buckleComp))
+                return true;
+
             if (_netManager.IsClient || popup || user == null)
                 return false;
 

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -267,12 +267,8 @@ public abstract partial class SharedBuckleSystem
             return false;
         }
 
-        if (buckleComp.Buckled)
+        if (buckleComp.Buckled && !TryUnbuckle(buckleUid, user, buckleComp))
         {
-            // allows you to try and buckle them to a different chair or bed
-            if (TryUnbuckle(buckleUid, user, buckleComp))
-                return true;
-
             if (_netManager.IsClient || popup || user == null)
                 return false;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the ability to buckle someone to a different bed even if they're already strapped to another bed

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Paramedic brings someone in on a roller bed, has to awkwardly drag the person off the bed so they flop over on the floor, then buckle them to the next bed

After this PR they can just drag the person onto the new bed

## Technical details
<!-- Summary of code changes for easier review. -->
Tries to unbuckle the target if they're already buckled into something. It does kind of look and sound weird because you're unbuckling them and buckling them in the same frame.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2aa59932-3918-4041-bab0-e8ebf4c4fb58

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: You can now transfer someone from a rollerbed to a bed directly.