### PR TITLE
Fix medical PDA toggling light when scanning

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -121,7 +121,6 @@
   components:
   - type: ItemToggle
     onUse: false
-  - type: ItemTogglePointLight
   - type: HealthAnalyzer
     scanDelay: 1
     scanningEndSound:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR removes the ItemTogglePointLight component from medical PDAs.

Fixes #31696 

## Technical details
<!-- Summary of code changes for easier review. -->

We have a situation where we want two independent toggle states, that of the light and that of the analyzer.

The UnpoweredFlashlight was already handling the light toggling, so having the generic ItemTogglePointLight was causing the light to be toggled when the health analyzer activated/deactivated.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

See a video of the original bug behavior here: #32086

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed medical PDAs sometimes toggling their lights while scanning
