### PR TITLE
fix missing circuitboard recipes

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -542,6 +542,7 @@
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
   id: MiniGravityGeneratorCircuitboard
+  result: MiniGravityGeneratorCircuitboard
 
 - type: latheRecipe
   parent: BaseCircuitboardRecipe

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -166,6 +166,7 @@
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
   id: ChemMasterMachineCircuitboard
+  result: ChemMasterMachineCircuitboard
 
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
@@ -431,6 +432,7 @@
 - type: latheRecipe
   parent: BaseCircuitboardRecipe
   id: MicrowaveMachineCircuitboard
+  result: MicrowaveMachineCircuitboard
 
 - type: latheRecipe
   parent: BaseCircuitboardRecipe


### PR DESCRIPTION
## About the PR
Fixes this:
![grafik](https://github.com/user-attachments/assets/c7991c84-79b5-4ad6-966a-4136fc767f7f)
chemmaster and microwave are missing

## Why / Balance
bugfix

## Technical details
delta goofed in #31524 :trollface: 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
nah
