### PR TITLE
Immovable Rod Spawn Addition: Lizard Plushie

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: ImmovableRod
   name: immovable rod
   description: You can sense that it's hungry. That's usually a bad sign.
@@ -175,5 +175,17 @@
   - type: Sprite
     sprite: Objects/Weapons/Melee/debug.rsi
     state: icon
+    rotation: 225
+    noRot: false
+
+- type: entity
+  parent: ImmovableRodKeepTilesStill
+  id: ImmovableRodWeh
+  name: immovable weh
+  description: WEH!
+  components:
+  - type: Sprite
+    sprite: Objects/Fun/toys.rsi
+    state: plushie_lizard
     rotation: 225
     noRot: false

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -187,5 +187,4 @@
   - type: Sprite
     sprite: Objects/Fun/toys.rsi
     state: plushie_lizard
-    rotation: 225
     noRot: false

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -211,29 +211,29 @@
   - type: ImmovableRodRule
     rodPrototypes:
     - id: ImmovableRodKeepTilesStill
-      prob: 0.95
+      prob: 0.94
       orGroup: rodProto
     - id: ImmovableRodMop
-      prob: 0.0072
+      prob: 0.0075
       orGroup: rodProto
     - id: ImmovableRodShark
-      prob: 0.0072
+      prob: 0.0075
       orGroup: rodProto
     - id: ImmovableRodClown
-      prob: 0.0072
+      prob: 0.0075
       orGroup: rodProto
     - id: ImmovableRodBanana
-      prob: 0.0072
+      prob: 0.0075
       orGroup: rodProto
     - id: ImmovableRodHammer
-      prob: 0.0072
+      prob: 0.0075
       orGroup: rodProto
     - id: ImmovableRodThrongler
-      prob: 0.0072
+      prob: 0.0075
       orGroup: rodProto
     - id: ImmovableRodGibstick
-      prob: 0.0072
+      prob: 0.0075
       orGroup: rodProto
     - id: ImmovableRodWeh
-      prob: 0.0072
+      prob: 0.0075
       orGroup: rodProto

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -234,3 +234,6 @@
     - id: ImmovableRodGibstick
       prob: 0.0072
       orGroup: rodProto
+    - id: ImmovableRodWeh
+      prob: 0.0072
+      orGroup: rodProto


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a chance for the Immovable Rod to spawn as a lizard plushie.

## Why / Balance
Adds a little more fun variety to Immovable Rod spawns!

## Technical details
Added new ImmovableRod type in immovable_rod.yml, as well as relevant probability adjustments/inclusions in meteorswarms.yml

## Media
![immovableweh](https://github.com/user-attachments/assets/1604cac1-049f-45cf-b9a6-c24031dd79a0)

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**

:cl:
- new: Added a new immovable rod chance spawn, the immovable weh!

