### PR TITLE
Show ID Job and Identity when examining players and PDAs

### DIFF
--- a/Resources/Locale/en-US/examine/examine-system.ftl
+++ b/Resources/Locale/en-US/examine/examine-system.ftl
@@ -9,3 +9,5 @@ examine-verb-name = Basic
 examinable-anchored = It is [color=darkgreen]anchored[/color] to the floor.
 
 examinable-unanchored = It is [color=darkred]unanchored[/color] from the floor.
+
+examinable-impersonating-id-name = as {$idname}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When examining players, the job and identity from their worn ID card are now visible next to their name. If the ID card's name differs from their true name, then it will be displayed separately (unless the player hides their true identity with a mask, or you are too far away to be able to read the name on the ID).

You can now also examine PDA's to see the name and job of the ID card inserted into them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Makes it much easier to see which job someone is, and makes it more obvious when someone is wearing someone else's ID.

## Technical details
<!-- Summary of code changes for easier review. -->
Changes done in `ExamineSystem.cs` as it seemed the only place where you can modify examine popup titles. Please correct me if that is not the case.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![2024-09-13 02_36_10-Space Station 14](https://github.com/user-attachments/assets/57e920be-a0d5-4d5a-82f2-88c17aa98e79)
![2024-09-13 02_38_35-Space Station 14](https://github.com/user-attachments/assets/509a3eff-f404-4d94-b927-8ce6eccedd2f)

https://github.com/user-attachments/assets/70e66548-b999-4af3-9af1-61976521498d


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: ID Jobs and names are now more visible when examining
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
