### PR TITLE
remove hardcoded item toggle verb

### DIFF
--- a/Content.Shared/Item/ItemToggle/Components/ToggleVerbComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ToggleVerbComponent.cs
@@ -15,4 +15,10 @@ public sealed partial class ToggleVerbComponent : Component
     /// </summary>
     [DataField(required: true)]
     public LocId Text = string.Empty;
+
+    /// <summary>
+    /// If this is true then mobs that can't do complex interactions (mice, etc) can't get the verb.
+    /// </summary>
+    [DataField]
+    public bool Complex = true;
 }

--- a/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Popups;
 using Content.Shared.Temperature;
 using Content.Shared.Toggleable;
-using Content.Shared.Verbs;
 using Content.Shared.Wieldable;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -37,7 +36,6 @@ public sealed class ItemToggleSystem : EntitySystem
         SubscribeLocalEvent<ItemToggleComponent, ItemUnwieldedEvent>(TurnOffOnUnwielded);
         SubscribeLocalEvent<ItemToggleComponent, ItemWieldedEvent>(TurnOnOnWielded);
         SubscribeLocalEvent<ItemToggleComponent, UseInHandEvent>(OnUseInHand);
-        SubscribeLocalEvent<ItemToggleComponent, GetVerbsEvent<ActivationVerb>>(OnActivateVerb);
         SubscribeLocalEvent<ItemToggleComponent, ActivateInWorldEvent>(OnActivate);
 
         SubscribeLocalEvent<ItemToggleHotComponent, IsHotEvent>(OnIsHotEvent);
@@ -67,23 +65,6 @@ public sealed class ItemToggleSystem : EntitySystem
         args.Handled = true;
 
         Toggle((ent, ent.Comp), args.User, predicted: ent.Comp.Predictable);
-    }
-
-    private void OnActivateVerb(Entity<ItemToggleComponent> ent, ref GetVerbsEvent<ActivationVerb> args)
-    {
-        if (!args.CanAccess || !args.CanInteract)
-            return;
-
-        var user = args.User;
-
-        args.Verbs.Add(new ActivationVerb()
-        {
-            Text = !ent.Comp.Activated ? Loc.GetString("item-toggle-activate") : Loc.GetString("item-toggle-deactivate"),
-            Act = () =>
-            {
-                Toggle((ent.Owner, ent.Comp), user, predicted: ent.Comp.Predictable);
-            }
-        });
     }
 
     private void OnActivate(Entity<ItemToggleComponent> ent, ref ActivateInWorldEvent args)

--- a/Content.Shared/Item/ItemToggle/ToggleVerbSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ToggleVerbSystem.cs
@@ -23,6 +23,9 @@ public sealed class ToggleVerbSystem : EntitySystem
         if (!args.CanAccess || !args.CanInteract)
             return;
 
+        if (ent.Comp.Complex && !args.CanComplexInteract)
+            return;
+
         var name = Identity.Entity(ent, EntityManager);
         var user = args.User;
         args.Verbs.Add(new ActivationVerb()

--- a/Resources/Locale/en-US/items/toggle.ftl
+++ b/Resources/Locale/en-US/items/toggle.ftl
@@ -1,2 +1,0 @@
-item-toggle-activate = Activate
-item-toggle-deactivate = Deactivate


### PR DESCRIPTION
## About the PR
title, add `ToggleVerb` if its really needed

`ToggleVerb` now also requires complex interaction by default, you can disable this with `complex: false`.

## Why / Balance
this had a lot of borg exploits, mice toggling eswords, etc
`ToggleVerb` already existed i dont know why sloth did this

(also the activate/deactivate text was misleading, if something else toggles it, you wont activate an already active item (do nothing), youll deactivate it because it toggles it at time of verb use)

fixes #31895

## Technical details
yoink


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
add `- type: ToggleVerb` if you want a toggle verb
added `complex: false` if you want mice to be able to toggle it

**Changelog**
:cl:
- fix: Fixed borgs and other things having an unintentional toggle verb.