### PR TITLE
Fix powered machines working unpowered if the panel is open.

### DIFF
--- a/Content.Client/Power/ActivatableUIRequiresPowerSystem.cs
+++ b/Content.Client/Power/ActivatableUIRequiresPowerSystem.cs
@@ -18,9 +18,6 @@ public sealed class ActivatableUIRequiresPowerSystem : SharedActivatableUIRequir
             return;
         }
 
-        if (TryComp<WiresPanelComponent>(ent.Owner, out var panel) && panel.Open)
-            return;
-
         _popup.PopupClient(Loc.GetString("base-computer-ui-component-not-powered", ("machine", ent.Owner)), args.User, args.User);
         args.Cancel();
     }

--- a/Content.Server/Power/EntitySystems/ActivatableUIRequiresPowerSystem.cs
+++ b/Content.Server/Power/EntitySystems/ActivatableUIRequiresPowerSystem.cs
@@ -1,9 +1,7 @@
-using Content.Server.Power.Components;
 using Content.Shared.Power;
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.UserInterface;
-using Content.Shared.Wires;
 using ActivatableUISystem = Content.Shared.UserInterface.ActivatableUISystem;
 
 namespace Content.Server.Power.EntitySystems;
@@ -25,9 +23,6 @@ public sealed class ActivatableUIRequiresPowerSystem : SharedActivatableUIRequir
         {
             return;
         }
-
-        if (TryComp<WiresPanelComponent>(ent.Owner, out var panel) && panel.Open)
-            return;
 
         args.Cancel();
     }


### PR DESCRIPTION
So for some reason, ActivatableUIRequiresPower just... skipped the power check if the wire panel is open.

This makes no fucking sense for so many reasons I am going to just remove this code no more question asked.

Also, the code was copy pasted between client and server. Hilarious.

:cl:
- fix: Fixed some powered machines working when unpowered if the panel is open.