### PR TITLE
Fix recycler eating materials (Salvage mains rejoice)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -85,6 +85,7 @@
         volume: -3
     cutOffSound: false
   - type: MaterialStorage
+    insertOnInteract: false
   - type: Conveyor
   - type: Rotatable
   - type: Repairable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When you clicked on a recycler it would store the materials in a storage that was impossible to access. Not quite sure why the storage is even on the grinder but it is being used to do something important looking (not quite sure what its doing😆).


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/b09c22da-c5be-4b31-b677-79416c06ee1e

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Beck Thompson
- fix: Recycler no longer allows basic materials to be inserted into it.