### PR TITLE
remove Wall tag from asteroids

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -10,6 +10,8 @@
   name: asteroid rock
   description: A rocky asteroid.
   components:
+  - type: Tag
+    tags: [] # rewrite Wall tag
   - type: Transform
     noRot: true
   - type: IconSmooth
@@ -664,6 +666,8 @@
   name: rock
   suffix: planetmap
   components:
+    - type: Tag
+      tags: [] # rewrite Wall tag
     - type: Transform
       noRot: true
     - type: SoundOnGather


### PR DESCRIPTION
mostly for tilewalls command, which counted asteroids as walls and placed plating underneath (which is bad i.e. on omega) fixes #26854 

:cl:
- tweak: You can no longer build wallmount structures on any type of asteroids.