### PR TITLE
fix infinite banana bug

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/ChemicalPuddleArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/ChemicalPuddleArtifactSystem.cs
@@ -18,7 +18,7 @@ public sealed class ChemicalPuddleArtifactSystem : EntitySystem
     /// The key for the node data entry containing
     /// the chemicals that the puddle is made of.
     /// </summary>
-    public const string NodeDataChemicalList = "nodeDataSpawnAmount";
+    public const string NodeDataChemicalList = "nodeDataChemicalList";
 
     /// <inheritdoc/>
     public override void Initialize()


### PR DESCRIPTION
## About the PR
Prevents this from happening:


https://github.com/user-attachments/assets/87f9e8cc-8ca3-471d-8e47-7ab2b3f59648



## Why / Balance
bugfix

## Technical details
SpawnArtifact has a maxSpawns DataField exactly to avoid this, but if a node has the ChemicalPuddleArtifact effect as well the node data saving the previously spawned amount gets overwritten with a list since it uses the same key string (which seems to be an unintentional copy paste error).

## Media
I did not test this since I do not know how to create a custom artifact using VV, but it seems pretty obvious this was the cause for the bug.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
nah
