### PR TITLE
add gps to salvage jumpsuit

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -83,12 +83,13 @@
   parent: ClothingUniformBase
   id: ClothingUniformJumpsuitSalvageSpecialist
   name: salvage specialist's jumpsuit
-  description: It's a snappy jumpsuit with a sturdy set of overalls. It's very dirty.
+  description: It's a snappy jumpsuit with a sturdy set of overalls and integrated GPS. It's very dirty.
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpsuit/salvage.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/salvage.rsi
+  - type: HandheldGPS
 
 - type: entity
   parent: [ClothingUniformBase, BaseCommandContraband]


### PR DESCRIPTION
## About the PR
title

didnt remove gps from the locker or vendor so you can choose to wear something else

## Why / Balance
getting lost in space because you forgot a gps basically round removes you for an extremely small mistake, it has put a bad taste in so many new salvagers mouths that they probably never played the role again

now if you get stuck without a gps you can use your jumpsuit to get saved

## Media
![10:18:18](https://github.com/user-attachments/assets/c4c2270f-3e50-4006-b3d1-5bd01b5a1aaa)

will be a lot nicer with #31814

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Salvage jumpsuits now have an integrated GPS.
