### PR TITLE
Toolbox turrets deploy on throw, randomized toolbox turrets, entityPrototype for uplink store and toolboxes

### DIFF
--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -6,6 +6,7 @@ using Content.Server.Stack;
 using Content.Server.Store.Components;
 using Content.Shared.Actions;
 using Content.Shared.Database;
+using Content.Shared.EntityTable;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Mind;
@@ -31,6 +32,7 @@ public sealed partial class StoreSystem
     [Dependency] private readonly StackSystem _stack = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly EntityTableSystem _entityTable = default!;
 
     private void InitializeUi()
     {
@@ -193,6 +195,31 @@ public sealed partial class StoreSystem
                 while (childEnumerator.MoveNext(out var child))
                 {
                     component.BoughtEntities.Add(child);
+                }
+            }
+        }
+
+        // pick an option from the entity table and spawn it
+        if (listing.ProductEntityTable != null)
+        {
+            var products = _entityTable.GetSpawns(listing.ProductEntityTable);
+
+            foreach (var proto in products)
+            {
+                var product = Spawn(proto, Transform(buyer).Coordinates);
+                _hands.PickupOrDrop(buyer, product);
+
+                HandleRefundComp(uid, component, product);
+
+                var xForm = Transform(product);
+
+                if (xForm.ChildCount > 0)
+                {
+                    var childEnumerator = xForm.ChildEnumerator;
+                    while (childEnumerator.MoveNext(out var child))
+                    {
+                        component.BoughtEntities.Add(child);
+                    }
                 }
             }
         }

--- a/Content.Shared/Store/ListingPrototype.cs
+++ b/Content.Shared/Store/ListingPrototype.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.FixedPoint;
 using Content.Shared.Store.Components;
 using Content.Shared.StoreDiscount.Components;
@@ -29,6 +30,7 @@ public partial class ListingData : IEquatable<ListingData>
         other.Icon,
         other.Priority,
         other.ProductEntity,
+        other.ProductEntityTable,
         other.ProductAction,
         other.ProductUpgradeId,
         other.ProductActionEntity,
@@ -53,6 +55,7 @@ public partial class ListingData : IEquatable<ListingData>
         SpriteSpecifier? icon,
         int priority,
         EntProtoId? productEntity,
+        EntityTableSelector? productEntityTable,
         EntProtoId? productAction,
         ProtoId<ListingPrototype>? productUpgradeId,
         EntityUid? productActionEntity,
@@ -73,6 +76,7 @@ public partial class ListingData : IEquatable<ListingData>
         Icon = icon;
         Priority = priority;
         ProductEntity = productEntity;
+        ProductEntityTable = productEntityTable;
         ProductAction = productAction;
         ProductUpgradeId = productUpgradeId;
         ProductActionEntity = productActionEntity;
@@ -146,6 +150,12 @@ public partial class ListingData : IEquatable<ListingData>
     /// </summary>
     [DataField]
     public EntProtoId? ProductEntity;
+
+    /// <summary>
+    /// The entity table that is picked from when the listing is purchased.
+    /// </summary>
+    [DataField]
+    public EntityTableSelector? ProductEntityTable;
 
     /// <summary>
     /// The action that is given when the listing is purchased.
@@ -277,6 +287,7 @@ public sealed partial class ListingDataWithCostModifiers : ListingData
             listingData.Icon,
             listingData.Priority,
             listingData.ProductEntity,
+            listingData.ProductEntityTable,
             listingData.ProductAction,
             listingData.ProductUpgradeId,
             listingData.ProductActionEntity,

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -288,7 +288,7 @@ uplink-proximity-mine-name = Proximity Mine
 uplink-proximity-mine-desc = A mine disguised as a wet floor sign.
 
 uplink-disposable-turret-name = Disposable Ballistic Turret
-uplink-disposable-turret-desc = Looks and functions like a normal electrical toolbox. Upon hitting the toolbox it will transform into a ballistic turret, theoretically shooting at anyone except members of the syndicate. Can be turned back into a toolbox using a screwdriver and repaired using a wrench.
+uplink-disposable-turret-desc = Looks and functions like a normal toolbox. Upon hitting the toolbox it will transform into a ballistic turret, theoretically shooting at anyone except members of the syndicate. Can be turned back into a toolbox using a screwdriver and repaired using a wrench.
 
 uplink-cluster-banana-peel-name = Cluster Banana
 uplink-cluster-banana-peel-desc = Splits into 6 explosive banana peels after being thrown, the peels detonate automatically after 20 seconds if nobody slips on them.

--- a/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/toolboxes.yml
@@ -1,109 +1,125 @@
-- type: entity
-  id: ToolboxEmergencyFilled
-  name: emergency toolbox
-  parent: ToolboxEmergency
-  suffix: Filled
-  components:
-  - type: StorageFill
-    contents:
-      - id: CrowbarRed
-      - id: RadioHandheld
-      - id: WelderMini
-      - id: FireExtinguisherMini
-      # Random lighting item orGroup
-      - id: FlashlightLantern
-        orGroup: LightingItem
-      - id: Flare
-        orGroup: LightingItem
-      - id: GlowstickBase
-        orGroup: LightingItem
-      # Low-chance items
-      - id: FoodSnackChocolate
-        prob: 0.15
-      - id: HarmonicaInstrument
-        prob: 0.15
- 
-- type: entity
-  id: ToolboxElectricalFilled
-  name: electrical toolbox
-  suffix: Filled
-  parent: ToolboxElectrical
-  components:
-  - type: StorageFill
-    contents:
-      - id: Screwdriver
-      - id: CrowbarOrange
-      - id: Wirecutter
-      - id: CableApcStack10
-      - id: CableMVStack10
-      - id: trayScanner
-        prob: 0.9
-      - id: ClothingHandsGlovesColorYellow
-        prob: 0.05
-        orGroup: GlovesOrWires
-      - id: CableHVStack10
-        orGroup: GlovesOrWires
-
-- type: entity
-  id: ToolboxElectricalTurretFilled
-  name: electrical toolbox
-  suffix: Syndicate, Turret, Filled
-  parent: ToolboxElectricalTurret
-  components:
-  - type: StorageFill
-    contents:
-      - id: Screwdriver
-      - id: CrowbarOrange
-      - id: Wirecutter
-      - id: CableApcStack10
-      - id: CableMVStack10
-      - id: trayScanner
-        prob: 0.9
-      - id: ClothingHandsGlovesColorYellow
-        prob: 0.05
-        orGroup: GlovesOrWires
-      - id: CableHVStack10
-        orGroup: GlovesOrWires
-
-- type: entity
-  id: ToolboxArtisticFilled
-  name: artistic toolbox
-  suffix: Filled
-  parent: ToolboxArtistic
-  components:
-  - type: StorageFill
-    contents:
+- type: entityTable
+  id: ToolboxArtisticFilledEntityTable
+  table: !type:AllSelector
+    children:
     - id: CrayonBox
     - id: Paper
-      amount: 3
+      amount: !type:ConstantNumberSelector
+        value: 3
     - id: Pen
     - id: MysteryFigureBox
-      prob: 0.5
-    - id: MysteryFigureBox
-      prob: 0.5
+      amount: !type:RangeNumberSelector
+        range: 0, 2
     - id: BookRandom
-      amount: 2 
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: CrayonMime
     - id: CrayonRainbow
 
 - type: entity
-  id: ToolboxMechanicalFilled
-  name: mechanical toolbox
+  parent: ToolboxArtistic
+  id: ToolboxArtisticFilled
   suffix: Filled
-  parent: ToolboxMechanical
   components:
-  - type: StorageFill
-    contents:
-      - id: CrowbarOrange
-      - id: Wrench
-      - id: Welder
-      - id: Wirecutter
-      - id: Screwdriver
-        prob: 0.5
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: ToolboxArtisticFilledEntityTable
+
+- type: entityTable
+  id: ToolboxEmergencyFilledEntityTable
+  table: !type:AllSelector
+    children:
+    - id: CrowbarRed
+    - id: RadioHandheld
+    - id: WelderMini
+    - id: FireExtinguisherMini
+    - !type:GroupSelector
+      children:
       - id: FlashlightLantern
-        prob: 0.7
-      - id: ClothingHeadHatHardhatBlue
-        prob: 0.5
+      - id: Flare
+      - id: GlowstickBase
+    - id: FoodSnackChocolate
+      prob: 0.15
+    - id: HarmonicaInstrument
+      prob: 0.15
+
+- type: entity
+  parent: ToolboxEmergency
+  id: ToolboxEmergencyFilled
+  suffix: Filled
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: ToolboxEmergencyFilledEntityTable
+
+- type: entity
+  parent: [ ToolboxEmergencyFilled, ToolboxTurret ]
+  id: ToolboxEmergencyTurretFilled
+  suffix: Syndicate, Turret, Filled
+
+- type: entityTable
+  id: ToolboxElectricalFilledEntityTable
+  table: !type:AllSelector
+    children:
+    - id: Screwdriver
+    - id: CrowbarOrange
+    - id: Wirecutter
+    - id: CableApcStack10
+    - id: CableMVStack10
+    - id: trayScanner
+      prob: 0.9
+    - !type:GroupSelector
+      children:
+      - id: ClothingHandsGlovesColorYellow
+      - id: CableHVStack10
+        weight: 20
+
+- type: entity
+  parent: ToolboxElectrical
+  id: ToolboxElectricalFilled
+  suffix: Filled
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: ToolboxElectricalFilledEntityTable
+
+- type: entity
+  parent: [ ToolboxElectricalFilled, ToolboxTurret ]
+  id: ToolboxElectricalTurretFilled
+  suffix: Syndicate, Turret, Filled
+
+- type: entityTable
+  id: ToolboxMechanicalFilledEntityTable
+  table: !type:AllSelector
+    children:
+    - id: CrowbarOrange
+    - id: Wrench
+    - id: Welder
+    - id: Wirecutter
+    - id: Screwdriver
+      prob: 0.5
+    - id: FlashlightLantern
+      prob: 0.7
+    - id: ClothingHeadHatHardhatBlue
+      prob: 0.5
+
+- type: entity
+  parent: ToolboxMechanical
+  id: ToolboxMechanicalFilled
+  suffix: Filled
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: ToolboxMechanicalFilledEntityTable
+
+- type: entity
+  parent: [ ToolboxMechanicalFilled, ToolboxTurret ]
+  id: ToolboxMechanicalTurretFilled
+  suffix: Syndicate, Turret, Filled
 
 - type: entity
   parent: ToolboxSyndicate

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -107,11 +107,21 @@
   categories:
   - UplinkWeaponry
 
+- type: entityTable
+  id: ToolBoxTurretFilledUplinkEntityTable
+  table: !type:GroupSelector
+    children:
+    - id: ToolboxElectricalTurretFilled
+    - id: ToolboxEmergencyTurretFilled
+    - id: ToolboxMechanicalTurretFilled
+
 - type: listing
   id: UplinkDisposableTurret
   name: uplink-disposable-turret-name
   description: uplink-disposable-turret-desc
   productEntity: ToolboxElectricalTurretFilled
+  productEntityTable: !type:NestedSelector
+    tableId: ToolBoxTurretFilledUplinkEntityTable
   discountCategory: usualDiscounts
   discountDownTo:
     Telecrystal: 3

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -70,35 +70,54 @@
     sprite: Objects/Tools/Toolboxes/toolbox_yellow.rsi
 
 - type: entity
-  name: electrical toolbox
-  suffix: Syndicate, Turret
-  parent: ToolboxElectrical
-  id: ToolboxElectricalTurret
-  description: A toolbox typically stocked with electrical gear.
+  abstract: true
+  id: ToolboxTurret
   components:
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
     thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 100
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-      - trigger:
-          !type:DamageTrigger
-          damage: 1
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              WeaponTurretSyndicateDisposable:
-                min: 1
-                max: 1
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 1
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          WeaponTurretSyndicateDisposable:
+            min: 1
+            max: 1
+  - type: DamageOnLand
+    damage:
+      types:
+        Blunt: 1
   - type: StaticPrice
     price: 1350
+
+- type: entity
+  parent: [ ToolboxEmergency, ToolboxTurret ]
+  id: ToolboxEmergencyTurret
+  suffix: Syndicate, Turret
+
+- type: entity
+  parent: [ ToolboxMechanical, ToolboxTurret ]
+  id: ToolboxMechanicalTurret
+  suffix: Syndicate, Turret
+
+- type: entity
+  parent: [ ToolboxElectrical, ToolboxTurret ]
+  id: ToolboxElectricalTurret
+  suffix: Syndicate, Turret
 
 - type: entity
   name: artistic toolbox


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Toolbox turrets will now deploy themselves when you throw them
- The toolbox that you get when purchasing the turret will now be randomized to prevent metagaming that yellow toolboxes are bad
- The potential varieties are the emergency toolbox, mechanical toolbox, and the electrical toolbox. They will be filled with their normal contents.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Toolbox turrets feel clunky and horrible to use. You have to place the box on the ground, switch to a weapon, awkwardly wait for your swap attack cooldown, and then swing at the toolbox. Sometimes the attack is overridden by the act of storing the item inside the toolbox, and overall you don't feel like you have much control over where you're deploying the toolbox. Throwing it to deploy it just feels better.

Randomizing which toolbox you get from the store will prevent security members from sussing you out just because you're walking around with a yellow toolbox.

## Technical details
<!-- Summary of code changes for easier review. -->
- Toolbox storageFill converted to use EntityTables and EntityTableContainerFills for reusability
- Uplinks now support the use of EntityTables to randomize the item that someone receives when purchasing something

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The disposable ballistic toolbox turret will now be randomized in appearance when purchased.
- tweak: You can now throw to deploy ballistic toolbox turrets.