### PR TITLE
Fix build and lint

### DIFF
--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPressurePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPressurePumpSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Database;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
+using Content.Shared.Power;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPressurePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPressurePumpSystem.cs
@@ -2,7 +2,6 @@ using Content.Server.Administration.Logs;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Binary.Components;
 using Content.Server.Atmos.Piping.Components;
-using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.Power.Components;

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.DeviceNetwork;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
+using Content.Shared.Power;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
@@ -6,7 +6,6 @@ using Content.Server.Atmos.Piping.Components;
 using Content.Server.DeviceNetwork;
 using Content.Server.DeviceNetwork.Components;
 using Content.Server.DeviceNetwork.Systems;
-using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.Power.Components;

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3136,7 +3136,7 @@
       Alive:
         Base: ferret
       Critical:
-        Base:
+        Base: ferret_dead
       Dead:
         Base: ferret_dead
   - type: Butcherable
@@ -3344,7 +3344,7 @@
       Alive:
         Base: pig
       Critical:
-        Base:
+        Base: dead
       Dead:
         Base: dead
   - type: Butcherable

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -149,8 +149,6 @@
             !type:DamageTrigger
             damage: 100
           behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
             - !type:TriggerBehavior
     - type: Gun
       fireRate: 2

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -150,6 +150,8 @@
             damage: 100
           behaviors:
             - !type:TriggerBehavior
+            - !type:DoActsBehavior
+              acts: [ "Destruction" ]
     - type: Gun
       fireRate: 2
       selectedMode: FullAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -149,9 +149,9 @@
             !type:DamageTrigger
             damage: 100
           behaviors:
-            - !type:TriggerBehavior
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
+            - !type:TriggerBehavior
     - type: Gun
       fireRate: 2
       selectedMode: FullAuto


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
ferret and pigs were missing state declarations in their yml for their crit states from https://github.com/space-wizards/space-station-14/pull/32175 so they go invisible

gas pump and whatever had their namespace changed which causes master to no longer build successfully after https://github.com/space-wizards/space-station-14/pull/28995