### PR TITLE
Makes the rat king's cheeseEm order more convenient to use

### DIFF
--- a/Resources/Prototypes/NPCs/mob.yml
+++ b/Resources/Prototypes/NPCs/mob.yml
@@ -17,6 +17,9 @@
           task: RatServantCombatCompound
     - tasks:
         - !type:HTNCompoundTask
+          task: FollowCompound
+    - tasks:
+        - !type:HTNCompoundTask
           task: IdleCompound
 
 - type: htnCompound


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
When using the cheeseEm order as the rat king, makes the rats follow you instead of idling when there is no one to attack.

## Why / Balance
The person you are gonna point at is logically gonna be close to you and the rats only attack ordered targets which are close to them, this prevents moments when the rats are not gonna do anything because the fight moved since you gave the order.
Also now the cheeseEm order is visually identical to the follow order so now you dont have to give away that you are gonna send your rats on someone by your character screaming "CheeseEm!", which i think is a nice bonus in my opinion

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: PopGamer46
- tweak: The rat king's rats now follow you instead of idling when there is no one to attack during the CheeseEm order
