### PR TITLE
Change Phalanximine to be more complex, increase Arithrazine damage

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -124,9 +124,7 @@
           types:
             Radiation: -3
           groups:
-            Brute: 0.5
-      - !type:ChemVomit
-        probability: 0.1
+            Brute: 1.5
 
 - type: reagent
   id: Bicaridine
@@ -564,14 +562,23 @@
         damage:
           types:
             Cellular: -0.3
-            Radiation: 0.3
+            Radiation: 0.15
+            Caustic: 0.15
       - !type:HealthChange
         conditions:
-          - !type:ReagentThreshold
-            min: 10
+        - !type:ReagentThreshold
+          min: 11
         damage:
           types:
             Radiation: 0.2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Arithrazine
+          min: 1
+        damage:
+          types:
+            Caustic: 0.3
 
 - type: reagent
   id: PolypyryliumOligomers
@@ -977,6 +984,21 @@
         - !type:ReagentThreshold
           min: 30
         probability: 0.02
+      - !type:ChemVomit
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Arithrazine
+          min: 1
+        probability: 0.1
+      - !type:PopupMessage
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Arithrazine
+          min: 1
+        type: Local
+        visualType: Medium
+        messages: [ "generic-reagent-effect-nauseous" ]
+        probability: 0.2
 
 - type: reagent
   id: Lacerinol

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -125,6 +125,8 @@
             Radiation: -3
           groups:
             Brute: 0.5
+      - !type:ChemVomit
+        probability: 0.1
 
 - type: reagent
   id: Bicaridine
@@ -556,14 +558,20 @@
         min: 4
   metabolisms:
     Medicine:
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
           types:
-            Cellular: -1
-            Radiation: 1
-      - !type:ChemVomit
-        probability: 0.05
+            Cellular: -0.3
+            Radiation: 0.3
+      - !type:HealthChange
+        conditions:
+          - !type:ReagentThreshold
+            min: 10
+        damage:
+          types:
+            Radiation: 0.2
 
 - type: reagent
   id: PolypyryliumOligomers


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR changes Phalanximine to be a more interesting medicine to use in treatment, by making it easy to use for small doses but being more demanding when healing higher amounts. 

- Metabolism rate is set to 0.1 (was 0.5). 
- Healing is reduced to 0.3 Cellular per tick (was 1)
- Damage is reduced to 0.15 Radiation per tick (was 1), 0.15 Caustic per tick
- Phalanx now has an OD threshold of 11u, after which it deals 0.2 Caustic per tick.
- Phalanx now has a negative reaction with Arithrazine, dealing 0.3 Caustic if both are in the system at the same time.
- Vomiting has been removed from Phalanx.

- Arithrazine has had its Brute damage increased from 0.5 to 1.5 per tick. 

- Sigynate now has a negative reaction with Arithrazine, with a 10% vomit chance per tick if both are in the system at the same time.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Phalanx has been a pretty tame drug to administer for a damage type that is one of the rarest in the game. Cellular is most commonly found in small amounts after a a slime attack, with some more build-up seen with eating brains. The PR #32136 intends to introduce a higher burst of Cellular that is most likely to be found in singular alive crew. 

The combined changes to Phalanx makes it easy to administer for small doses, but requires a longer treatment process for higher amounts of damage. 5u will heal 15 Cellular, so a doctor can administer 10u for a safe 30 Cellular heal. If a doctor has to heal higher amounts of Cellular the patient will be required to wait for the duration of the first injection before another can be made. Vomiting was removed due to the higher likelihood of it triggering over a longer duration, which makes it much harder to dose it and would require constant doctor supervision. 

The changes to Arithrazine is to make it less of a "inject a whole syringe no matter what" drug; a full syringe would deal 15 Brute damage, which since it's spread out over the damage category means it can be healed by a single brute pack (or just walked off via passive healing). This PR changes this to 45 damage for a full syringe, which should make it more appealing to pair with Bicardine or simply using more careful dosing. 

To prevent the post-Phalanx treatment to be a simple syringe of Arithrazine and Sigynate combined, there's now a vomit chance if the two are metabolised together. Considering the rarity of Caustic and Radiation it should be fairly uncommon to need to treat both at the same time, and even then the effectiveness of the drugs means you don't need a lot, making them be out of your system fast.

## Technical details
<!-- Summary of code changes for easier review. -->

Yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Phalanximine now has an overdose threshold and works slower, along with other minor tweaks.
- tweak: Arithrazine now deals increased damage during treatment.
