### PR TITLE
Disable Revolutionary's Pending a Rules and Mechanics Rework

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -7,4 +7,4 @@
     Zombieteors: 0.01
     Survival: 0.09
     KesslerSyndrome: 0.01
-    Revolutionary: 0.05
+    Revolutionary: 0.00

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -3,7 +3,7 @@
   weights:
     Nukeops: 0.20
     Traitor: 0.60
-    Zombie: 0.04
+    Zombie: 0.09
     Zombieteors: 0.01
     Survival: 0.09
     KesslerSyndrome: 0.01

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,8 +2,8 @@
   id: Secret
   weights:
     Nukeops: 0.20
-    Traitor: 0.60
-    Zombie: 0.09
+    Traitor: 0.65
+    Zombie: 0.04
     Zombieteors: 0.01
     Survival: 0.09
     KesslerSyndrome: 0.01


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Revs has been reduced to a weight of 0.00 to stop it from rolling while discussion take place on how to improve the gamemode

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I have observed quite a few conversation about revs and one of the standout points that I saw was

1. "Revs doesn't work well with the rules and I feel like I'm skirting the lines of the rules when fighting revs."

2. "The mechanics feel half baked and aren't encouraging exile or even finding a way to convert the heads themselves."

3. "A way to remove mindshields should be possible alongside directing the gamemode to properly follow it's own mechanics."

The primary issues with revs is apparent with revs just turning into TDM with a label, there is not attempt at exiling nor is there any fun in security being extremely paranoid and shooting anyone that moves, I and many others believe that revs is in need of a rules rewrite and a mechanic rework so the gamemode can actually be enjoyable for all parties involved. It isn't fun when the rules prevent you from discerning what to do during revs or even how to handle expedited execution which got removed in the latest rule rewrite.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

🆑 
- remove: Removed revolutionary's pending a rules rewrite and mechanic rework.
