### PR TITLE
New publish workflow for Robust.Cdn

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,21 +41,10 @@ jobs:
     - name: Package client
       run: dotnet run --project Content.Packaging client --no-wipe-release
 
-    - name: Upload build artifact
-      id: artifact-upload-step
-      uses: actions/upload-artifact@v4
-      with:
-        name: build
-        path: release/*.zip
-        compression-level: 0
-        retention-days: 0
-
     - name: Publish version
-      run: Tools/publish_github_artifact.py
+      run: Tools/publish_multi_request.py
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-        ARTIFACT_ID: ${{ steps.artifact-upload-step.outputs.artifact-id }}
         GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}
 
     - name: Publish changelog (Discord)
@@ -68,8 +57,3 @@ jobs:
       run: Tools/actions_changelog_rss.py
       env:
         CHANGELOG_RSS_KEY: ${{ secrets.CHANGELOG_RSS_KEY }}
-
-    - uses: geekyeggo/delete-artifact@v5
-      if: always()
-      with:
-        name: build

--- a/Tools/publish_multi_request.py
+++ b/Tools/publish_multi_request.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import requests
+import os
+import subprocess
+from typing import Iterable
+
+PUBLISH_TOKEN = os.environ["PUBLISH_TOKEN"]
+VERSION = os.environ["GITHUB_SHA"]
+
+RELEASE_DIR = "release"
+
+#
+# CONFIGURATION PARAMETERS
+# Forks should change these to publish to their own infrastructure.
+#
+ROBUST_CDN_URL = "https://wizards.cdn.spacestation14.com/"
+FORK_ID = "wizards"
+
+def main():
+    session = requests.Session()
+    session.headers = {
+        "Authorization": f"Bearer {PUBLISH_TOKEN}",
+    }
+
+    print(f"Starting publish on Robust.Cdn for version {VERSION}")
+
+    data = {
+        "version": VERSION,
+        "engineVersion": get_engine_version(),
+    }
+    headers = {
+        "Content-Type": "application/json"
+    }
+    resp = session.post(f"{ROBUST_CDN_URL}fork/{FORK_ID}/publish/start", json=data, headers=headers)
+    resp.raise_for_status()
+    print("Publish successfully started, adding files...")
+
+    for file in get_files_to_publish():
+        print(f"Publishing {file}")
+        with open(file, "rb") as f:
+            headers = {
+                "Content-Type": "application/octet-stream",
+                "Robust-Cdn-Publish-File": os.path.basename(file),
+                "Robust-Cdn-Publish-Version": VERSION
+            }
+            resp = session.post(f"{ROBUST_CDN_URL}fork/{FORK_ID}/publish/file", data=f, headers=headers)
+
+        resp.raise_for_status()
+
+    print("Successfully pushed files, finishing publish...")
+
+    data = {
+        "version": VERSION
+    }
+    headers = {
+        "Content-Type": "application/json"
+    }
+    resp = session.post(f"{ROBUST_CDN_URL}fork/{FORK_ID}/publish/finish", json=data, headers=headers)
+    resp.raise_for_status()
+
+    print("SUCCESS!")
+
+
+def get_files_to_publish() -> Iterable[str]:
+    for file in os.listdir(RELEASE_DIR):
+        yield os.path.join(RELEASE_DIR, file)
+
+
+def get_engine_version() -> str:
+    proc = subprocess.run(["git", "describe","--tags", "--abbrev=0"], stdout=subprocess.PIPE, cwd="RobustToolbox", check=True, encoding="UTF-8")
+    tag = proc.stdout.strip()
+    assert tag.startswith("v")
+    return tag[1:] # Cut off v prefix.
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This uses multiple API requests to directly send the publish to the CDN server, no more GitHub artifacts.

Faster, less moving parts.

Needs Robust.Cdn 2.2.0
