### PR TITLE
Ensure speech bubble cap is always respected

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -467,8 +467,9 @@ public sealed class ChatUIController : UIController
 
         if (existing.Count > SpeechBubbleCap)
         {
-            // Get the oldest to start fading fast.
-            var last = existing[0];
+            // Get the next speech bubble to fade
+            // Any speech bubbles before it are already fading
+            var last = existing[^(SpeechBubbleCap + 1)];
             last.FadeNow();
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
If messages are sent very quickly, the standard limit of 4 speech bubbles per mob can be overrun. This PR fixes the bug that causes that.

## Why / Balance
This is a bug.

## Technical details
Normally, when a mob has more than 4 speech bubbles over it, the last one is quickly faded out to prevent too many speech bubbles from stacking up on the screen. However, if another message is sent before the last message is done fading out, this logic mistakenly tries to fade the same bubble twice, leading to more than 4 speech bubbles being on the screen at once.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
### Before:
https://github.com/user-attachments/assets/b222bd46-a6f0-452f-b613-994ba8157769
### After:
https://github.com/user-attachments/assets/3f6f198a-c255-4a90-8e2b-a13cfd7aa97a


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed bug with speech bubble limits