### PR TITLE
prevent friendly fire for dragon/carp

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -25,6 +25,7 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Systems;
+using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Systems;
 using Content.Shared.Nutrition.AnimalHusbandry;
 using Content.Shared.Nutrition.Components;
@@ -218,6 +219,7 @@ public sealed partial class ZombieSystem
 
         _faction.ClearFactions(target, dirty: false);
         _faction.AddFaction(target, "Zombie");
+        EnsureComp<NoFriendlyFireComponent>(target); // prevent shitters biting other zombies
 
         //gives it the funny "Zombie ___" name.
         _nameMod.RefreshNameModifiers(target);

--- a/Content.Shared/NPC/Components/NoFriendlyFireComponent.cs
+++ b/Content.Shared/NPC/Components/NoFriendlyFireComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.NPC.Components;
+
+/// <summary>
+/// Prevents this mob from doing melee damage to friendly mobs.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class NoFriendlyFireComponent : Component;

--- a/Content.Shared/NPC/Systems/NoFriendlyFireSystem.cs
+++ b/Content.Shared/NPC/Systems/NoFriendlyFireSystem.cs
@@ -1,0 +1,32 @@
+using Content.Shared.NPC.Components;
+using Content.Shared.Weapons.Melee.Events;
+
+namespace Content.Shared.NPC.Systems;
+
+public sealed class NoFriendlyFireSystem : EntitySystem
+{
+    [Dependency] private readonly NpcFactionSystem _faction = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<NoFriendlyFireComponent, MeleeHitEvent>(OnMeleeHit);
+    }
+
+    private void OnMeleeHit(Entity<NoFriendlyFireComponent> ent, ref MeleeHitEvent args)
+    {
+        if (!TryComp<NpcFactionMemberComponent>(ent, out var faction))
+            return;
+
+        var factionEnt = (ent.Owner, faction);
+        foreach (var hit in args.HitEntities)
+        {
+            if (_faction.IsEntityFriendly(factionEnt, hit))
+            {
+                args.BonusDamage = -args.BaseDamage;
+                return; // prevent healing by swinging multiple friendlies or something
+            }
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -13,6 +13,7 @@
       blackboard:
         NavSmash: !type:Bool
           true
+    - type: NoFriendlyFire # don't let fish hurt their dragon, and dont let sentient fish bypass FactionClothing
     - type: NpcFactionMember
       factions:
       - Dragon

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -31,6 +31,7 @@
   - type: NpcFactionMember
     factions:
     - Dragon
+  - type: NoFriendlyFire # don't let dragon accidentally hit the fish when fighting
   - type: Speech
     speechVerb: LargeMob
   - type: CombatMode

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -31,7 +31,6 @@
   - type: NpcFactionMember
     factions:
     - Dragon
-  - type: NoFriendlyFire # don't let dragon accidentally hit the fish when fighting
   - type: Speech
     speechVerb: LargeMob
   - type: CombatMode

--- a/Resources/Prototypes/Entities/Structures/Specific/dragon.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/dragon.yml
@@ -45,3 +45,6 @@
   - type: EmitSoundOnSpawn
     sound:
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg
+  - type: NpcFactionMember
+    factions:
+    - Dragon # prevent shitter carp from destroying rifts


### PR DESCRIPTION
## About the PR
dragon/carp cant hurt eachother or the rifts
also applies for people wearing carp hardsuit, sentient carp cant bypass FactionClothing. if someone is wearing it and tries to kill the dragon, the carp cant fight but the dragon can

## Why / Balance
theres no reason carp should be able to kill their dragon or rifts
dragon can hurt anyone so they can be the boss

## Technical details
moved the zombie FF logic into NoFriendlyFireSystem, made zombie system add NoFriendlyFireComponent
carp + dragon + rift has this component

the logic of it is slightly different, zombie code could potentially heal all targets hit if you hit multiple friendlies ??? idk but i prevented it by returning after zeroing the damage so total damage would never go negative

## Media
it work

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Dragons and Carp can no longer hurt eachother.