### PR TITLE
Aghost speed up

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -92,6 +92,8 @@
   - type: Loadout
     prototypes: [ MobAghostGear ]
   - type: BypassInteractionChecks
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 50
 
 - type: entity
   id: ActionAGhostShowSolar

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -93,7 +93,7 @@
     prototypes: [ MobAghostGear ]
   - type: BypassInteractionChecks
   - type: MovementSpeedModifier
-    baseWalkSpeed : 50
+    baseWalkSpeed : 30
 
 - type: entity
   id: ActionAGhostShowSolar


### PR DESCRIPTION
## About the PR
Sprint speed (default): unchanged
Walking speed (when shift key is pressed): Speed increased to 50

## Why / Balance
Aghost never wants to slow down, on the contrary, it wants to move faster to construe more space, or cover distance for mapping faster

## Media

https://github.com/user-attachments/assets/8cdff536-fdca-4b0c-b15e-abdfaf4aaa61

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
