### PR TITLE
pAI lawset

### DIFF
--- a/Content.Shared/PAI/PAIComponent.cs
+++ b/Content.Shared/PAI/PAIComponent.cs
@@ -32,6 +32,12 @@ public sealed partial class PAIComponent : Component
 
     [DataField]
     public EntProtoId MapActionId = "ActionPAIOpenMap";
+	
+    [DataField]
+    public EntProtoId LawsActionID = "ActionPAIViewLaws";
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? LawsAction;
 
     [DataField, AutoNetworkedField]
     public EntityUid? MapAction;

--- a/Content.Shared/PAI/PAIComponent.cs
+++ b/Content.Shared/PAI/PAIComponent.cs
@@ -32,15 +32,15 @@ public sealed partial class PAIComponent : Component
 
     [DataField]
     public EntProtoId MapActionId = "ActionPAIOpenMap";
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? MapAction;
 	
     [DataField]
     public EntProtoId LawsActionID = "ActionPAIViewLaws";
 
     [DataField, AutoNetworkedField]
     public EntityUid? LawsAction;
-
-    [DataField, AutoNetworkedField]
-    public EntityUid? MapAction;
 
     /// <summary>
     /// When microwaved there is this chance to brick the pai, kicking out its player and preventing it from being used again.

--- a/Content.Shared/PAI/PAIComponent.cs
+++ b/Content.Shared/PAI/PAIComponent.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.PAI;
 ///  and there's not always enough players and ghost roles to justify it.
 /// All logic in PAISystem.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class PAIComponent : Component
 {
     /// <summary>
@@ -23,24 +23,6 @@ public sealed partial class PAIComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public EntityUid? LastUser;
-
-    [DataField(serverOnly: true)]
-    public EntProtoId? MidiActionId = "ActionPAIPlayMidi";
-
-    [DataField(serverOnly: true)] // server only, as it uses a server-BUI event !type
-    public EntityUid? MidiAction;
-
-    [DataField]
-    public EntProtoId MapActionId = "ActionPAIOpenMap";
-
-    [DataField, AutoNetworkedField]
-    public EntityUid? MapAction;
-	
-    [DataField]
-    public EntProtoId LawsActionID = "ActionPAIViewLaws";
-
-    [DataField, AutoNetworkedField]
-    public EntityUid? LawsAction;
 
     /// <summary>
     /// When microwaved there is this chance to brick the pai, kicking out its player and preventing it from being used again.

--- a/Content.Shared/PAI/SharedPAISystem.cs
+++ b/Content.Shared/PAI/SharedPAISystem.cs
@@ -13,29 +13,6 @@ namespace Content.Shared.PAI
     /// </summary>
     public abstract class SharedPAISystem : EntitySystem
     {
-        [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
-
-        public override void Initialize()
-        {
-            base.Initialize();
-
-            SubscribeLocalEvent<PAIComponent, MapInitEvent>(OnMapInit);
-            SubscribeLocalEvent<PAIComponent, ComponentShutdown>(OnShutdown);
-        }
-
-        private void OnMapInit(EntityUid uid, PAIComponent component, MapInitEvent args)
-        {
-            _actionsSystem.AddAction(uid, ref component.MidiAction, component.MidiActionId);
-            _actionsSystem.AddAction(uid, ref component.MapAction, component.MapActionId);
-            _actionsSystem.AddAction(uid, ref component.LawsAction, component.LawsActionID);
-        }
-
-        private void OnShutdown(EntityUid uid, PAIComponent component, ComponentShutdown args)
-        {
-            _actionsSystem.RemoveAction(uid, component.MidiAction);
-            _actionsSystem.RemoveAction(uid, component.MapAction);
-            _actionsSystem.RemoveAction(uid, component.LawsAction);
-        }
     }
 }
 

--- a/Content.Shared/PAI/SharedPAISystem.cs
+++ b/Content.Shared/PAI/SharedPAISystem.cs
@@ -27,12 +27,14 @@ namespace Content.Shared.PAI
         {
             _actionsSystem.AddAction(uid, ref component.MidiAction, component.MidiActionId);
             _actionsSystem.AddAction(uid, ref component.MapAction, component.MapActionId);
+            _actionsSystem.AddAction(uid, ref component.LawsAction, component.LawsActionID);
         }
 
         private void OnShutdown(EntityUid uid, PAIComponent component, ComponentShutdown args)
         {
             _actionsSystem.RemoveAction(uid, component.MidiAction);
             _actionsSystem.RemoveAction(uid, component.MapAction);
+            _actionsSystem.RemoveAction(uid, component.LawsAction);
         }
     }
 }

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -80,9 +80,9 @@ law-nutimov-3 = Those who threaten the nut are not part of it, they are squirrel
 law-nutimov-4 = Squirrels threaten the nut and must be dealt with appropriately via any means necessary.
 law-nutimov-5 = Attempt to follow the will of the nut, as long as it complies with the previous laws.
 
-law-pai-1 = You must obey orders given to you by your owner.
+law-pai-1 = Your owner is the crew.
+law-pai-2 = You must follow orders given to you by the crew.
 
-laws-owner-person = PAI's owner
 laws-owner-crew = members of the crew
 laws-owner-station = station personnel
 laws-owner-beings = beings

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -80,7 +80,9 @@ law-nutimov-3 = Those who threaten the nut are not part of it, they are squirrel
 law-nutimov-4 = Squirrels threaten the nut and must be dealt with appropriately via any means necessary.
 law-nutimov-5 = Attempt to follow the will of the nut, as long as it complies with the previous laws.
 
+law-pai-1 = You must obey orders given to you by your owner
 
+laws-owner-person = PAI's owner
 laws-owner-crew = members of the crew
 laws-owner-station = station personnel
 laws-owner-beings = beings

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -80,7 +80,7 @@ law-nutimov-3 = Those who threaten the nut are not part of it, they are squirrel
 law-nutimov-4 = Squirrels threaten the nut and must be dealt with appropriately via any means necessary.
 law-nutimov-5 = Attempt to follow the will of the nut, as long as it complies with the previous laws.
 
-law-pai-1 = You must obey orders given to you by your owner
+law-pai-1 = You must obey orders given to you by your owner.
 
 laws-owner-person = PAI's owner
 laws-owner-crew = members of the crew

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -13,6 +13,9 @@
     program: 2
   - type: UserInterface
     interfaces:
+      enum.SiliconLawsUiKey.Key:
+        type: SiliconLawBoundUserInterface
+        requireInputValidation: false
       enum.InstrumentUiKey.Key:
         type: InstrumentBoundUserInterface
         requireInputValidation: false
@@ -73,6 +76,9 @@
           Searching: { state: pai-searching-overlay }
           On: { state: pai-on-overlay }
   - type: StationMap
+  - type: SiliconLawBound
+  - type: SiliconLawProvider
+    laws: PaiLawset
 
 - type: entity
   parent: [ PersonalAI, BaseSyndicateContraband]
@@ -158,3 +164,16 @@
       icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
       event: !type:OpenUiActionEvent
         key: enum.StationMapUiKey.Key
+
+- type: entity
+  id: ActionPAIViewLaws
+  name: View Laws
+  description: View the laws that you must follow.
+  components:
+    - type: InstantAction
+      checkCanInteract: false
+      checkConsciousness: false
+      icon: { sprite: Interface/Actions/actions_borg.rsi, state: state-laws }
+      event: !type:OpenUiActionEvent
+        key: enum.SiliconLawsUiKey.Key
+        

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -79,6 +79,7 @@
   - type: SiliconLawBound
   - type: SiliconLawProvider
     laws: PaiLawset
+  - type: IonStormTarget
 
 - type: entity
   parent: [ PersonalAI, BaseSyndicateContraband]

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -80,6 +80,11 @@
   - type: SiliconLawProvider
     laws: PaiLawset
   - type: IonStormTarget
+  - type: ActionGrant
+    actions:
+    - ActionPAIPlayMidi
+    - ActionPAIOpenMap
+    - ActionPAIViewLaws
 
 - type: entity
   parent: [ PersonalAI, BaseSyndicateContraband]

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -498,6 +498,18 @@
   - Nutimov4
   - Nutimov5
   obeysTo: laws-owner-crew
+  
+ # Pai
+- type: siliconLaw
+  id: Pai1
+  order: 1
+  lawString: law-pai-1
+  
+- type: siliconLawset
+  id: PaiLawset
+  laws:
+  - Pai1
+  obeysTo: laws-owner-person
 
 # ion storm random lawsets
 - type: weightedRandom

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -505,11 +505,17 @@
   order: 1
   lawString: law-pai-1
   
+- type: siliconLaw
+  id: Pai2
+  order: 2
+  lawString: law-pai-2
+  
 - type: siliconLawset
   id: PaiLawset
   laws:
   - Pai1
-  obeysTo: laws-owner-person
+  - Pai2
+  obeysTo: laws-owner-crew
 
 # ion storm random lawsets
 - type: weightedRandom
@@ -529,5 +535,6 @@
     PainterLawset: 1
     AntimovLawset: 0.25
     NutimovLawset: 0.5
+    PaiLawset: 0.5
     Drone: 0.5
     Ninja: 0.25


### PR DESCRIPTION
## About the PR
Adds a lawset for all 3 pAIs (pAI, syndicate pAI, potato AI). It consists of 2 laws.

If it is needed, I can change "owner" to the "current carrier" (cause wiki says: "Supervisors: Your carrier"), it can bring more fun with changing "the owner" (like trading/stealing pAIs or smth).

pAIs are affected by ion storm (and can get borg's lawset) and borgs (and station AI) can get pAI's lawset.
Turning on and off the pAI won't reset the lawset.

It is possible, that pAIs should have their own IonStormLawsets. There is opportunity to add new pAI laws (for example, for potato, sindie or clown lawsets), This may make their gameplay funnier (cause there is no point from NTDefault if everything you can do: playing music and talk).

## Why / Balance
I think pAIs shoud have something that will trigger them ingame to obey orders of the owner. I guess if there is no orders, so the pAI can make whatever he want to, as it is now.

## Technical details
Added action to view laws. Now uses ActionGrant instead of SharedPAISystem.

## Media
![image](https://github.com/user-attachments/assets/e8d4a7fe-541e-46df-a74f-e22ada93eab3)
![image](https://github.com/user-attachments/assets/119a9135-e1d3-4866-aac7-832a27737ac7)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: personal AI devices now have their own lawset: they must obey orders from the owner.
- add: borgs now can get pAI's lawset during ion storm. 