### PR TITLE
add button to print logprobe logs

### DIFF
--- a/Content.Client/CartridgeLoader/Cartridges/LogProbeUi.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/LogProbeUi.cs
@@ -13,16 +13,16 @@ public sealed partial class LogProbeUi : UIFragment
         return _fragment!;
     }
 
-    public override void Setup(BoundUserInterface userInterface, EntityUid? fragmentOwner)
+    public override void Setup(BoundUserInterface ui, EntityUid? fragmentOwner)
     {
         _fragment = new LogProbeUiFragment();
     }
 
     public override void UpdateState(BoundUserInterfaceState state)
     {
-        if (state is not LogProbeUiState logProbeUiState)
+        if (state is not LogProbeUiState cast)
             return;
 
-        _fragment?.UpdateState(logProbeUiState.PulledLogs);
+        _fragment?.UpdateState(cast.EntityName, cast.PulledLogs);
     }
 }

--- a/Content.Client/CartridgeLoader/Cartridges/LogProbeUi.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/LogProbeUi.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Client.UserInterface.Fragments;
+using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
 using Robust.Client.UserInterface;
 
@@ -16,6 +17,13 @@ public sealed partial class LogProbeUi : UIFragment
     public override void Setup(BoundUserInterface ui, EntityUid? fragmentOwner)
     {
         _fragment = new LogProbeUiFragment();
+
+        _fragment.OnPrintPressed += () =>
+        {
+            var ev = new LogProbePrintMessage();
+            var message = new CartridgeUiMessage(ev);
+            ui.SendMessage(message);
+        };
     }
 
     public override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/CartridgeLoader/Cartridges/LogProbeUiFragment.xaml
+++ b/Content.Client/CartridgeLoader/Cartridges/LogProbeUiFragment.xaml
@@ -19,6 +19,7 @@
         <BoxContainer Orientation="Vertical" Name="ProbedDeviceContainer"/>
     </ScrollContainer>
     <BoxContainer Orientation="Horizontal" Margin="4 8">
+        <Button Name="PrintButton" HorizontalAlignment="Left" Text="{Loc 'log-probe-print-button'}" Disabled="True"/>
         <BoxContainer HorizontalExpand="True"/>
         <Label Name="EntityName" Align="Right"/>
     </BoxContainer>

--- a/Content.Client/CartridgeLoader/Cartridges/LogProbeUiFragment.xaml
+++ b/Content.Client/CartridgeLoader/Cartridges/LogProbeUiFragment.xaml
@@ -18,4 +18,8 @@
     <ScrollContainer VerticalExpand="True" HScrollEnabled="True">
         <BoxContainer Orientation="Vertical" Name="ProbedDeviceContainer"/>
     </ScrollContainer>
+    <BoxContainer Orientation="Horizontal" Margin="4 8">
+        <BoxContainer HorizontalExpand="True"/>
+        <Label Name="EntityName" Align="Right"/>
+    </BoxContainer>
 </cartridges:LogProbeUiFragment>

--- a/Content.Client/CartridgeLoader/Cartridges/LogProbeUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/LogProbeUiFragment.xaml.cs
@@ -8,19 +8,24 @@ namespace Content.Client.CartridgeLoader.Cartridges;
 [GenerateTypedNameReferences]
 public sealed partial class LogProbeUiFragment : BoxContainer
 {
+    /// <summary>
+    /// Action invoked when the print button gets pressed.
+    /// </summary>
+    public Action? OnPrintPressed;
+
     public LogProbeUiFragment()
     {
         RobustXamlLoader.Load(this);
+
+        PrintButton.OnPressed += _ => OnPrintPressed?.Invoke();
     }
 
     public void UpdateState(string name, List<PulledAccessLog> logs)
     {
         EntityName.Text = name;
+        PrintButton.Disabled = string.IsNullOrEmpty(name);
 
         ProbedDeviceContainer.RemoveAllChildren();
-
-        //Reverse the list so the oldest entries appear at the bottom
-        logs.Reverse();
 
         var count =  1;
         foreach (var log in logs)

--- a/Content.Client/CartridgeLoader/Cartridges/LogProbeUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/LogProbeUiFragment.xaml.cs
@@ -13,8 +13,10 @@ public sealed partial class LogProbeUiFragment : BoxContainer
         RobustXamlLoader.Load(this);
     }
 
-    public void UpdateState(List<PulledAccessLog> logs)
+    public void UpdateState(string name, List<PulledAccessLog> logs)
     {
+        EntityName.Text = name;
+
         ProbedDeviceContainer.RemoveAllChildren();
 
         //Reverse the list so the oldest entries appear at the bottom

--- a/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
+++ b/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
@@ -421,6 +421,7 @@ public sealed class CartridgeLoaderSystem : SharedCartridgeLoaderSystem
     private void OnUiMessage(EntityUid uid, CartridgeLoaderComponent component, CartridgeUiMessage args)
     {
         var cartridgeEvent = args.MessageEvent;
+        cartridgeEvent.User = args.Actor;
         cartridgeEvent.LoaderUid = GetNetEntity(uid);
 
         RelayEvent(component, cartridgeEvent, true);

--- a/Content.Server/CartridgeLoader/Cartridges/LogProbeCartridgeComponent.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/LogProbeCartridgeComponent.cs
@@ -8,6 +8,12 @@ namespace Content.Server.CartridgeLoader.Cartridges;
 public sealed partial class LogProbeCartridgeComponent : Component
 {
     /// <summary>
+    /// The name of the scanned entity, sent to clients when they open the UI.
+    /// </summary>
+    [DataField]
+    public string EntityName = string.Empty;
+
+    /// <summary>
     /// The list of pulled access logs
     /// </summary>
     [DataField, ViewVariables]

--- a/Content.Server/CartridgeLoader/Cartridges/LogProbeCartridgeComponent.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/LogProbeCartridgeComponent.cs
@@ -1,10 +1,13 @@
 ﻿using Content.Shared.CartridgeLoader.Cartridges;
+﻿using Content.Shared.Paper;
 using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.CartridgeLoader.Cartridges;
 
-[RegisterComponent]
-[Access(typeof(LogProbeCartridgeSystem))]
+[RegisterComponent, Access(typeof(LogProbeCartridgeSystem))]
+[AutoGenerateComponentPause]
 public sealed partial class LogProbeCartridgeComponent : Component
 {
     /// <summary>
@@ -24,4 +27,25 @@ public sealed partial class LogProbeCartridgeComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public SoundSpecifier SoundScan = new SoundPathSpecifier("/Audio/Machines/scan_finish.ogg");
+
+    /// <summary>
+    /// Paper to spawn when printing logs.
+    /// </summary>
+    [DataField]
+    public EntProtoId<PaperComponent> PaperPrototype = "PaperAccessLogs";
+
+    [DataField]
+    public SoundSpecifier PrintSound = new SoundPathSpecifier("/Audio/Machines/diagnoser_printing.ogg");
+
+    /// <summary>
+    /// How long you have to wait before printing logs again.
+    /// </summary>
+    [DataField]
+    public TimeSpan PrintCooldown = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// When anyone is allowed to spawn another printout.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    public TimeSpan NextPrintAllowed = TimeSpan.Zero;
 }

--- a/Content.Server/CartridgeLoader/Cartridges/LogProbeCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/LogProbeCartridgeSystem.cs
@@ -1,25 +1,40 @@
 using Content.Shared.Access.Components;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Audio;
 using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
+using Content.Shared.Database;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Labels.EntitySystems;
+using Content.Shared.Paper;
 using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
+using System.Text;
 
 namespace Content.Server.CartridgeLoader.Cartridges;
 
 public sealed class LogProbeCartridgeSystem : EntitySystem
 {
+    [Dependency] private readonly CartridgeLoaderSystem _cartridge = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly CartridgeLoaderSystem? _cartridgeLoaderSystem = default!;
-    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
-    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedLabelSystem _label = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly PaperSystem _paper = default!;
 
     public override void Initialize()
     {
         base.Initialize();
+
         SubscribeLocalEvent<LogProbeCartridgeComponent, CartridgeUiReadyEvent>(OnUiReady);
         SubscribeLocalEvent<LogProbeCartridgeComponent, CartridgeAfterInteractEvent>(AfterInteract);
+        SubscribeLocalEvent<LogProbeCartridgeComponent, CartridgeMessageEvent>(OnMessage);
     }
 
     /// <summary>
@@ -37,8 +52,8 @@ public sealed class LogProbeCartridgeSystem : EntitySystem
             return;
 
         //Play scanning sound with slightly randomized pitch
-        _audioSystem.PlayEntity(ent.Comp.SoundScan, args.InteractEvent.User, target, AudioHelpers.WithVariation(0.25f, _random));
-        _popupSystem.PopupCursor(Loc.GetString("log-probe-scan", ("device", target)), args.InteractEvent.User);
+        _audio.PlayEntity(ent.Comp.SoundScan, args.InteractEvent.User, target, AudioHelpers.WithVariation(0.25f, _random));
+        _popup.PopupCursor(Loc.GetString("log-probe-scan", ("device", target)), args.InteractEvent.User);
 
         ent.Comp.EntityName = Name(target);
         ent.Comp.PulledAccessLogs.Clear();
@@ -53,6 +68,9 @@ public sealed class LogProbeCartridgeSystem : EntitySystem
             ent.Comp.PulledAccessLogs.Add(log);
         }
 
+        // Reverse the list so the oldest is at the bottom
+        ent.Comp.PulledAccessLogs.Reverse();
+
         UpdateUiState(ent, args.Loader);
     }
 
@@ -64,9 +82,49 @@ public sealed class LogProbeCartridgeSystem : EntitySystem
         UpdateUiState(ent, args.Loader);
     }
 
+    private void OnMessage(Entity<LogProbeCartridgeComponent> ent, ref CartridgeMessageEvent args)
+    {
+        if (args is LogProbePrintMessage cast)
+            PrintLogs(ent, cast.User);
+    }
+
+    private void PrintLogs(Entity<LogProbeCartridgeComponent> ent, EntityUid user)
+    {
+        if (string.IsNullOrEmpty(ent.Comp.EntityName))
+            return;
+
+        if (_timing.CurTime < ent.Comp.NextPrintAllowed)
+            return;
+
+        ent.Comp.NextPrintAllowed = _timing.CurTime + ent.Comp.PrintCooldown;
+
+        var paper = Spawn(ent.Comp.PaperPrototype, _transform.GetMapCoordinates(user));
+        _label.Label(paper, ent.Comp.EntityName); // label it for easy identification
+
+        _audio.PlayEntity(ent.Comp.PrintSound, user, paper);
+        _hands.PickupOrDrop(user, paper, checkActionBlocker: false);
+
+        // generate the actual printout text
+        var builder = new StringBuilder();
+        builder.AppendLine(Loc.GetString("log-probe-printout-device", ("name", ent.Comp.EntityName)));
+        builder.AppendLine(Loc.GetString("log-probe-printout-header"));
+        var number = 1;
+        foreach (var log in ent.Comp.PulledAccessLogs)
+        {
+            var time = TimeSpan.FromSeconds(Math.Truncate(log.Time.TotalSeconds)).ToString();
+            builder.AppendLine(Loc.GetString("log-probe-printout-entry", ("number", number), ("time", time), ("accessor", log.Accessor)));
+            number++;
+        }
+
+        var paperComp = Comp<PaperComponent>(paper);
+        _paper.SetContent((paper, paperComp), builder.ToString());
+
+        _adminLogger.Add(LogType.EntitySpawn, LogImpact.Low, $"{ToPrettyString(user):user} printed out LogProbe logs ({paper}) of {ent.Comp.EntityName}");
+    }
+
     private void UpdateUiState(Entity<LogProbeCartridgeComponent> ent, EntityUid loaderUid)
     {
         var state = new LogProbeUiState(ent.Comp.EntityName, ent.Comp.PulledAccessLogs);
-        _cartridgeLoaderSystem?.UpdateCartridgeUiState(loaderUid, state);
+        _cartridge.UpdateCartridgeUiState(loaderUid, state);
     }
 }

--- a/Content.Server/CartridgeLoader/Cartridges/LogProbeCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/LogProbeCartridgeSystem.cs
@@ -40,6 +40,7 @@ public sealed class LogProbeCartridgeSystem : EntitySystem
         _audioSystem.PlayEntity(ent.Comp.SoundScan, args.InteractEvent.User, target, AudioHelpers.WithVariation(0.25f, _random));
         _popupSystem.PopupCursor(Loc.GetString("log-probe-scan", ("device", target)), args.InteractEvent.User);
 
+        ent.Comp.EntityName = Name(target);
         ent.Comp.PulledAccessLogs.Clear();
 
         foreach (var accessRecord in accessReaderComponent.AccessLog)
@@ -65,7 +66,7 @@ public sealed class LogProbeCartridgeSystem : EntitySystem
 
     private void UpdateUiState(Entity<LogProbeCartridgeComponent> ent, EntityUid loaderUid)
     {
-        var state = new LogProbeUiState(ent.Comp.PulledAccessLogs);
+        var state = new LogProbeUiState(ent.Comp.EntityName, ent.Comp.PulledAccessLogs);
         _cartridgeLoaderSystem?.UpdateCartridgeUiState(loaderUid, state);
     }
 }

--- a/Content.Shared/CartridgeLoader/CartridgeUiMessage.cs
+++ b/Content.Shared/CartridgeLoader/CartridgeUiMessage.cs
@@ -16,6 +16,7 @@ public sealed class CartridgeUiMessage : BoundUserInterfaceMessage
 [Serializable, NetSerializable]
 public abstract class CartridgeMessageEvent : EntityEventArgs
 {
+    [NonSerialized]
     public EntityUid User;
     public NetEntity LoaderUid;
 }

--- a/Content.Shared/CartridgeLoader/CartridgeUiMessage.cs
+++ b/Content.Shared/CartridgeLoader/CartridgeUiMessage.cs
@@ -16,5 +16,6 @@ public sealed class CartridgeUiMessage : BoundUserInterfaceMessage
 [Serializable, NetSerializable]
 public abstract class CartridgeMessageEvent : EntityEventArgs
 {
+    public EntityUid User;
     public NetEntity LoaderUid;
 }

--- a/Content.Shared/CartridgeLoader/Cartridges/LogProbePrintMessage.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/LogProbePrintMessage.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.CartridgeLoader.Cartridges;
+
+[Serializable, NetSerializable]
+public sealed class LogProbePrintMessage : CartridgeMessageEvent;

--- a/Content.Shared/CartridgeLoader/Cartridges/LogProbeUiState.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/LogProbeUiState.cs
@@ -6,12 +6,18 @@ namespace Content.Shared.CartridgeLoader.Cartridges;
 public sealed class LogProbeUiState : BoundUserInterfaceState
 {
     /// <summary>
+    /// The name of the scanned entity.
+    /// </summary>
+    public string EntityName;
+
+    /// <summary>
     /// The list of probed network devices
     /// </summary>
     public List<PulledAccessLog> PulledLogs;
 
-    public LogProbeUiState(List<PulledAccessLog> pulledLogs)
+    public LogProbeUiState(string entityName, List<PulledAccessLog> pulledLogs)
     {
+        EntityName = entityName;
         PulledLogs = pulledLogs;
     }
 }

--- a/Resources/Locale/en-US/cartridge-loader/cartridges.ftl
+++ b/Resources/Locale/en-US/cartridge-loader/cartridges.ftl
@@ -19,3 +19,7 @@ log-probe-scan = Downloaded logs from {$device}!
 log-probe-label-time = Time
 log-probe-label-accessor = Accessed by
 log-probe-label-number = #
+log-probe-print-button = Print Logs
+log-probe-printout-device = Scanned Device: {$name}
+log-probe-printout-header = Latest logs:
+log-probe-printout-entry = #{$number} / {$time} / {$accessor}

--- a/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
@@ -57,3 +57,13 @@
   - type: GuideHelp
     guides:
     - Forensics
+
+- type: entity
+  parent: ForensicReportPaper
+  id: PaperAccessLogs
+  name: access logs
+  description: A printout from the detective's trusty LogProbe.
+  components:
+  - type: PaperVisuals
+    headerImagePath: null
+    headerMargin: 0.0, 0.0, 0.0, 0.0


### PR DESCRIPTION
## About the PR
- title
- add the name of the scanned entity to the program and printout

## Why / Balance
so you dont need to get a whole extra pda to keep logs visible...
also could be used as supporting evidence in a trial :trollface:

## Technical details
added `User` to CartridgeUiMessage so cartridges can use it

printing has an admin log so if someone makes 200 paper entities for an entire round they can be bwoinked

log reversing moved from client to server, to save work and since server needs it reversed too

## Media
button and entity name
![06:30:58](https://github.com/user-attachments/assets/820f8040-4e24-4294-a438-db86d9ea090f)

the printout
![06:31:15](https://github.com/user-attachments/assets/9dbbed62-126f-497c-9346-29ff69687790)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: LogProbe's access logs can now be printed out.
