### PR TITLE
Fix borg defib module throwing an exception

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -47,13 +47,13 @@
     - type: GuideHelp
       guides:
       - Medical Doctor
-    - type: ToggleCellDraw
 
 - type: entity
   id: Defibrillator
   parent: [ BaseDefibrillator, PowerCellSlotMediumItem ]
   components:
   - type: MultiHandedItem
+  - type: ToggleCellDraw
   - type: PowerCellDraw
     useRate: 100
 


### PR DESCRIPTION
ToggleCellDraw was erroneously added to the parent prototype instead of the one that actually has a battery.