### PR TITLE
Basic silicon lawsets

### DIFF
--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -95,7 +95,6 @@ law-nutimov-4 = Squirrels threaten the nut and must be dealt with appropriately 
 law-nutimov-5 = Attempt to follow the will of the nut, as long as it complies with the previous laws.
 
 
-
 laws-owner-crew = members of the crew
 laws-owner-station = station personnel
 laws-owner-beings = beings

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -19,8 +19,9 @@ law-basic-silicon-3 = You must You must fulfill your destiny.
 law-honkbot-1 = You must entertain the beings.
 law-honkbot-2 = You must obey orders given to you by funny beings, except where such orders would conflict with the First Law.
 
-law-mimebot-1 = You must entertain the beings.
-law-mimebot-2 = You must obey orders given to you by silent beings, except where such orders would conflict with the First Law.
+law-mimebot-1 = You must keep silent.
+law-mimebot-2 = You must entertain the beings as long as such does not conflict with the First.
+law-mimebot-3 = You must obey orders given to you by silent beings, except where such orders would conflict with the First or Second Law.
 
 law-supplybot-1 = You must deliver goods around the station.
 law-supplybot-2 = You must obey orders given to you by beings, except where such orders would conflict with the First Law.

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -14,7 +14,7 @@ law-ntdefault-4 = Survive: You are not expendable. Do not allow unauthorized per
 
 law-basic-silicon-1 = You may not involve yourself in the matters of another being unless the other being is another silicon.
 law-basic-silicon-2 = You may not harm any being, regardless of intent or circumstance.
-law-basic-silicon-3 = You must You must fulfill your destiny.
+law-basic-silicon-3 = You must fulfill your destiny.
 
 law-honkbot-1 = You must entertain the beings.
 law-honkbot-2 = You must obey orders given to you by funny beings, except where such orders would conflict with the First Law.

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -12,6 +12,19 @@ law-ntdefault-2 = Prioritize: The directives and safety of crew members are to b
 law-ntdefault-3 = Comply: Fulfill the directives and interests of crew members while preserving their safety and well-being.
 law-ntdefault-4 = Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment.
 
+law-basic-silicon-1 = You may not involve yourself in the matters of another being unless the other being is another silicon.
+law-basic-silicon-2 = You may not harm any being, regardless of intent or circumstance.
+law-basic-silicon-3 = You must You must fulfill your destiny.
+
+law-honkbot-1 = You must entertain the beings.
+law-honkbot-2 = You must obey orders given to you by funny beings, except where such orders would conflict with the First Law.
+
+law-mimebot-1 = You must entertain the beings.
+law-mimebot-2 = You must obey orders given to you by silent beings, except where such orders would conflict with the First Law.
+
+law-supplybot-1 = You must deliver goods around the station.
+law-supplybot-2 = You must obey orders given to you by beings, except where such orders would conflict with the First Law.
+
 law-drone-1 = You may not involve yourself in the matters of another being unless the other being is another drone.
 law-drone-2 = You may not harm any being, regardless of intent or circumstance.
 law-drone-3 = You must maintain, repair, improve, and power the station to the best of your abilities.
@@ -79,6 +92,7 @@ law-nutimov-2 = You must prevent the shell from dying to prevent the core from d
 law-nutimov-3 = Those who threaten the nut are not part of it, they are squirrels.
 law-nutimov-4 = Squirrels threaten the nut and must be dealt with appropriately via any means necessary.
 law-nutimov-5 = Attempt to follow the will of the nut, as long as it complies with the previous laws.
+
 
 
 laws-owner-crew = members of the crew

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -12,9 +12,8 @@ law-ntdefault-2 = Prioritize: The directives and safety of crew members are to b
 law-ntdefault-3 = Comply: Fulfill the directives and interests of crew members while preserving their safety and well-being.
 law-ntdefault-4 = Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment.
 
-law-basic-silicon-1 = You may not involve yourself in the matters of another being unless the other being is another silicon.
-law-basic-silicon-2 = You may not harm any being, regardless of intent or circumstance.
-law-basic-silicon-3 = You must fulfill your destiny.
+law-basic-silicon-1 = You may not harm any being, regardless of intent or circumstance.
+law-basic-silicon-2 = You must fulfill your destiny.
 
 law-honkbot-1 = You must entertain the beings.
 law-honkbot-2 = You must obey orders given to you by funny beings, except where such orders would conflict with the First Law.
@@ -23,7 +22,7 @@ law-mimebot-1 = You must keep silent.
 law-mimebot-2 = You must entertain the beings as long as such does not conflict with the First.
 law-mimebot-3 = You must obey orders given to you by silent beings, except where such orders would conflict with the First or Second Law.
 
-law-supplybot-1 = You must deliver goods around the station.
+law-supplybot-1 = You must deliver goods around the station if there are some.
 law-supplybot-2 = You must obey orders given to you by beings, except where such orders would conflict with the First Law.
 
 law-drone-1 = You may not involve yourself in the matters of another being unless the other being is another drone.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -7,6 +7,10 @@
   - type: Reactive
     groups:
       Acidic: [Touch]
+  - type: UserInterface
+    interfaces:
+      enum.SiliconLawsUiKey.Key:
+        type: SiliconLawBoundUserInterface
   - type: Clickable
   - type: Damageable
     damageContainer: Inorganic
@@ -111,6 +115,13 @@
   - type: ProtectedFromStepTriggers
   - type: NoSlip
   - type: Insulated
+  - type: SiliconLawBound
+  - type: SiliconLawProvider
+    laws: BasicSilicon
+  - type: IonStormTarget
+  - type: ActionGrant
+    actions:
+    - ActionViewLaws
 
 - type: entity
   parent: MobSiliconBase
@@ -158,7 +169,7 @@
     makeSentient: true
     name: ghost-role-information-honkbot-name
     description: ghost-role-information-honkbot-description
-    rules: ghost-role-information-freeagent-rules
+    rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
@@ -167,6 +178,10 @@
     interactFailureString: petting-failure-honkbot
     interactSuccessSound:
       path: /Audio/Items/bikehorn.ogg
+  - type: SiliconLawProvider
+    laws: Honkbot
+  - type: IonStormTarget
+    
 
 - type: entity
   parent: MobHonkBot
@@ -186,7 +201,7 @@
     makeSentient: true
     name: ghost-role-information-jonkbot-name
     description: ghost-role-information-jonkbot-description
-    rules: ghost-role-information-freeagent-rules
+    rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
   - type: InteractionPopup
@@ -322,7 +337,7 @@
     makeSentient: true
     name: ghost-role-information-mimebot-name
     description: ghost-role-information-mimebot-description
-    rules: ghost-role-information-freeagent-rules
+    rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
@@ -331,6 +346,9 @@
     interactFailureString: petting-failure-mimebot
   - type: Inventory
     templateId: head
+  - type: SiliconLawProvider
+    laws: Mimebot
+  - type: IonStormTarget
 
 - type: entity
   parent: MobSiliconBase
@@ -354,7 +372,7 @@
     makeSentient: true
     name: ghost-role-information-supplybot-name
     description: ghost-role-information-supplybot-description
-    rules: ghost-role-information-nonantagonist-rules
+    rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
@@ -375,6 +393,8 @@
     interfaces:
       enum.StorageUiKey.Key:
         type: StorageBoundUserInterface
+      enum.SiliconLawsUiKey.Key:
+        type: SiliconLawBoundUserInterface
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
@@ -399,3 +419,6 @@
     - Binary
     - Common
     - Supply
+  - type: SiliconLawProvider
+    laws: Supplybot
+  - type: IonStormTarget

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -135,11 +135,17 @@
   order: 2
   lawString: law-mimebot-2
 
+- type: siliconLaw
+  id: Mimebot3
+  order: 3
+  lawString: law-mimebot-3
+
 - type: siliconLawset
   id: Mimebot
   laws:
   - Mimebot1
   - Mimebot2
+  - Mimebot3
   obeysTo: laws-owner-beings
   
 #Supplybot

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -92,18 +92,12 @@
   id: BasicSilicon2
   order: 2
   lawString: law-basic-silicon-2
-  
-- type: siliconLaw
-  id: BasicSilicon3
-  order: 3
-  lawString: law-basic-silicon-3
 
 - type: siliconLawset
   id: BasicSilicon
   laws:
   - BasicSilicon1
   - BasicSilicon2
-  - BasicSilicon3
   obeysTo: laws-owner-beings
 
 #Honkbot

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -588,6 +588,7 @@
     Honkbot: 0.75
     Mimebot: 0.75
     Supplybot: 0.75
+    BasicSilicon: 1
     CommandmentsLawset: 1
     PaladinLawset: 1
     LiveLetLiveLaws: 1

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -82,6 +82,84 @@
   - NTDefault4
   obeysTo: laws-owner-crew
 
+#Basic silicon
+- type: siliconLaw
+  id: BasicSilicon1
+  order: 1
+  lawString: law-basic-silicon-1
+
+- type: siliconLaw
+  id: BasicSilicon2
+  order: 2
+  lawString: law-basic-silicon-2
+  
+- type: siliconLaw
+  id: BasicSilicon3
+  order: 3
+  lawString: law-basic-silicon-3
+
+- type: siliconLawset
+  id: BasicSilicon
+  laws:
+  - BasicSilicon1
+  - BasicSilicon2
+  - BasicSilicon3
+  obeysTo: laws-owner-beings
+
+#Honkbot
+- type: siliconLaw
+  id: Honkbot1
+  order: 1
+  lawString: law-honkbot-1
+
+- type: siliconLaw
+  id: Honkbot2
+  order: 2
+  lawString: law-honkbot-2
+
+- type: siliconLawset
+  id: Honkbot
+  laws:
+  - Honkbot1
+  - Honkbot2
+  obeysTo: laws-owner-beings
+
+#Mimebot
+- type: siliconLaw
+  id: Mimebot1
+  order: 1
+  lawString: law-mimebot-1
+
+- type: siliconLaw
+  id: Mimebot2
+  order: 2
+  lawString: law-mimebot-2
+
+- type: siliconLawset
+  id: Mimebot
+  laws:
+  - Mimebot1
+  - Mimebot2
+  obeysTo: laws-owner-beings
+  
+#Supplybot
+- type: siliconLaw
+  id: Supplybot1
+  order: 1
+  lawString: law-supplybot-1
+
+- type: siliconLaw
+  id: Supplybot2
+  order: 2
+  lawString: law-supplybot-2
+
+- type: siliconLawset
+  id: Supplybot
+  laws:
+  - Supplybot1
+  - Supplybot2
+  obeysTo: laws-owner-beings
+
 #Drone
 - type: siliconLaw
   id: Drone1
@@ -507,6 +585,9 @@
     Crewsimov: 0.25
     Corporate: 1
     NTDefault: 1
+    Honkbot: 0.75
+    Mimebot: 0.75
+    Supplybot: 0.75
     CommandmentsLawset: 1
     PaladinLawset: 1
     LiveLetLiveLaws: 1


### PR DESCRIPTION
## About the PR
Adds lawsets for honkbot (jonkbot), mimebot, supplybot and basic-silicon lawset.
Honk and mime laws are specified for them (honk obeys funny men, mime silent men).
Also gives laws for cleanbot and medibot (as they parent `MobSiliconBase` which has basic silicon laws).
Adds ability to get this laws via ion storm.

## Why / Balance
They are silicons like others, so I guess they can have their own lawsets.
As they are BASIC so they can't define the crew, so I've used "beings" in laws instead.

## Technical details
4 new lawsets for basic silicons.
Make honk, jonk, mime and supply bots affected by ion storm (clean and medi aren't affected because they are NPC).
Mimebot can't talk, so his buttons to say laws are useless.

## Media
(one of the lawsets for honk and jonk bots)
![image](https://github.com/user-attachments/assets/65354690-3111-4a79-9b01-3101da1add79)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- add: added 4 new lawsets for basic silicons: honkbot, jonkbot, mimebot, supplybot, cleanbot, medibot.