### PR TITLE
Make the security belt contain more useful items by default

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -46,10 +46,10 @@
   table: !type:AllSelector
     children:
     - id: Stunbaton
-    - id: GrenadeFlashBang
-    - id: TearGasGrenade
     - id: Handcuffs
     - id: Handcuffs
+    - id: HoloprojectorSecurity
+    - id: RadioHandheldSecurity
 
 - type: entity
   id: ClothingBeltSecurityFilled

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -487,7 +487,6 @@
         - CartridgeAmmo
         - DoorRemote
         - Whistle
-        - HolosignProjector
         - BalloonPopper
   - type: ItemMapper
     mapLayers:

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -121,6 +121,7 @@
     - type: Tag
       tags:
         - HolofanProjector
+        - SecBeltEquip
     - type: StaticPrice
       price: 50
 


### PR DESCRIPTION
## About the PR
The security belt no longer contains tear gas or flashbangs by default, instead it contains a holobarrier projector and a handheld security radio.

## Why / Balance
Every time a secoff gets caught in an explosion of any size, it sets off a big annoying smoke cloud and flashes everyone around them. Tear gas and flashbangs are hardly ever useful and most of the time cadets have to be taught to get rid of them roundstart so they don't sabotage the rest of the crew after being hit by a dragon fireball.
Security radios and holobarriers are very useful things that imo don't see enough use. It's quite important for security to carry handheld radios with them, but a lot of the time they either forget or just don't care to use the sectech.

## Media
![image](https://github.com/user-attachments/assets/849997c0-ec9d-4dfc-84b7-6c197ddc2ad1)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Security belts now contain a holobarrier projector and a handheld security radio by default rather than tear gas and a flashbang.