### PR TITLE
Make tricordrazine cheaper to produce

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -247,7 +247,7 @@
       amount: 1
     Iron:
       amount: 1
-    Potassium:
+    Iodine:
       amount: 1
   products:
     Tricordrazine: 3

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -243,12 +243,14 @@
 - type: reaction
   id: Tricordrazine
   reactants:
-    Inaprovaline:
+    Copper:
       amount: 1
-    Dylovene:
+    Iron:
+      amount: 1
+    Potassium:
       amount: 1
   products:
-    Tricordrazine: 2
+    Tricordrazine: 3
 
 - type: reaction
   id: HeartbreakerToxin


### PR DESCRIPTION
## About the PR
Tricordrazine is now cheaper to produce, requiring less commonly used ingredients instead of being a mix of dylovene/inaprovaline
```
- type: reaction
  id: Tricordrazine
  reactants:
    Copper:
      amount: 1
    Iron:
      amount: 1
    Potassium:
      amount: 1
  products:
    Tricordrazine: 3
```
    
## Why / Balance
Tricordrazine is a neat chemical to use on not-so-damaged patients, but the recipe for it calls for carbon, oxygen, and sugar, which are all important ingredients in medicines such as bicaridine (and by extension all advanced brutes), dexalin+, dermaline, bruizine, sigynate, etc.
Iron, copper, and potassium all are only used in one significant medicine: dex+, leporazine, and dylovene respectively. They're much more abundant in supply as well.
It's also quite annoying when you're trying to revive someone in a critical state from poisoning, and your inaprovaline mixes with your dylovene to make something entirely useless for the situation at hand.

## Media
https://github.com/user-attachments/assets/ee7b9f28-2663-4935-9a19-8b02dd32bf9c


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Tricordrazine is now mixed using copper, iron, and potassium rather than dylovene and inaprovaline.
