### PR TITLE
Inaprovaline metabolizes slower for better use as a stabilizing medicine

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -416,6 +416,7 @@
   color: "#731024"
   metabolisms:
     Medicine:
+      metabolismRate: 0.1 # Smaller doses stabilize critical people for longer. Gives it a specific usecase as to not be entirely outclassed by dex+
       effects:
       - !type:HealthChange
         conditions:
@@ -424,7 +425,7 @@
           mobstate: Critical
         damage:
           types:
-            Asphyxiation: -5
+            Asphyxiation: -2
       - !type:ModifyBleedAmount
         amount: -0.25
 


### PR DESCRIPTION
## About the PR
Inaprovaline now metabolizes slower at 0.1u/s.
It also heals slower as well at 2/s, but still does so at a rate greater than someone in a critical state asphyxiates.

## Why / Balance
Currently inaprovaline is more or less entirely outclassed by dexalin+, and really doesn't have a unique scenario to use in. With these changes, it will be extremely helpful for keeping a gasping patient alive, but not so useful for treating asphyxiation outright.
Epinephrine is often not seen early in a round due to having a somewhat complex recipe compared to other meds, so I think having inaprovaline as a medicine purely for keeping a critical patient alive while you tend to someone else will work out pretty well.

## Media
https://github.com/user-attachments/assets/6fea8dda-8ceb-486d-a35f-2a0bdc1a068f

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Inaprovaline now heals slower, but lingers in the bloodstream for much longer, making it much more useful for stabilizing critical patients for an extended duration rather than outright treating damage.