### PR TITLE
Fix Doctors Delight metabolism Rate

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -867,6 +867,7 @@
   metamorphicChangeColor: false
   metabolisms:
     Drink:
+      metabolismRate: 0.25
       effects:
       - !type:SatiateThirst
         factor: 2
@@ -876,6 +877,7 @@
         reagent: Ethanol
         amount: 0.05
     Medicine:
+      metabolismRate: 0.25
       effects:
       - !type:HealthChange
         damage:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Doctors Delight now metabolizes 0.25 units per second for both the medicine and drink aspect, which results in it using 0.5 per second as opposed to previously using 1 per second.

## Why / Balance
It currently using 1 per second is likely an unintentional sideeffect of it having both the medicine metabolism and the drink metabolism.

## Technical details
N/A

## Media
This PR does not require an ingame showcase.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: BramvanZijp
- fix: Fixed an issue that caused Doctors Delight to metabolize twice the normal speed, which also halved its effectiveness.
