### PR TITLE
Stop VIM from getting stuck in doors.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -267,6 +267,9 @@
       path: /Audio/Mecha/mechmove03.ogg
       params:
         volume: -10
+  - type: Tag
+    tags:
+        - DoorBumpOpener
   - type: Mech
     baseState: vim
     openState: vim-open
@@ -300,3 +303,4 @@
     containers:
       mech-battery-slot:
       - PowerCellHigh
+ 

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -303,4 +303,3 @@
     containers:
       mech-battery-slot:
       - PowerCellHigh
- 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the tag -DoorBumpOpener to the VIM mech, this way the VIM can actually traverse the station without getting stuck inside doors.

## Why / Balance
Currently its possible to get stuck inside doors if not moving fast enough. 

Possible consequences:
Monkeys are the highest risk for mischief with a VIM since it will allow them access as if they were a borg. Not sure if there is a simple method of limiting that at this time; however, it should not pose a major risk due to the lack of VIMs in most rounds. The lack of interaction while in a VIM is also detrimental to, so any pilots trying to get into mischief have to leave the VIM to actually interact with the environment again.


## Technical details
Added the tag -DoorBumpOpener to the VIM mech.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
No breaking changes.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added -DoorBumpOpener tag to the VIM mech.
-->
