### PR TITLE
VIM have Passenger Access.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -300,3 +300,4 @@
     containers:
       mech-battery-slot:
       - PowerCellHigh
+ 

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -300,3 +300,6 @@
     containers:
       mech-battery-slot:
       - PowerCellHigh
+  - type: Tag
+    tags:
+        - DoorBumpOpener

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -300,6 +300,6 @@
     containers:
       mech-battery-slot:
       - PowerCellHigh
-  - type: Tag
+  - type: Access
     tags:
-        - DoorBumpOpener
+    - Maintenance

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -288,6 +288,9 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
     baseSprintSpeed: 3.6
+  - type: Access
+    tags:
+    - Maintenance
   # TOOD: buzz / chime actions
   # TODO: builtin flashlight
 
@@ -300,6 +303,3 @@
     containers:
       mech-battery-slot:
       - PowerCellHigh
-  - type: Access
-    tags:
-    - Maintenance

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -300,4 +300,3 @@
     containers:
       mech-battery-slot:
       - PowerCellHigh
- 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The VIM mech now has the same access as a passenger.

## Why / Balance
Currently its possible to get stuck inside doors if not moving fast enough.
It is still possible to get stuck behind Fire Doors.

## Technical details
Added to MechVim in mechs.yml
```
- type: Access
    tags:
    - Maintenance
```

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
[output2.webm](https://github.com/user-attachments/assets/d340d376-ca49-4835-89c1-ed3d9cdb4c9a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: VIM mech now can open maintenance doors!

