### PR TITLE
make flare recipe roundstart instead of blueprint

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -217,7 +217,6 @@
   id: SalvageEquipmentRare
   table: !type:GroupSelector
     children:
-    - id: BlueprintFlare
     - id: FultonBeacon
     - id: Fulton
       amount: !type:RangeNumberSelector

--- a/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
@@ -37,13 +37,3 @@
   - type: Blueprint
     providedRecipes:
     - SeismicCharge
-
-- type: entity
-  parent: BaseBlueprint
-  id: BlueprintFlare
-  name: flare blueprint
-  description: A blueprint with a schematic of a flare. It can be inserted into an autolathe.
-  components:
-  - type: Blueprint
-    providedRecipes:
-    - Flare

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -198,7 +198,7 @@
       - ClothingHeadHatWelding
       - WetFloorSign
       - ClothingHeadHatCone
-
+      - Flare
   - type: EmagLatheRecipes
     emagStaticRecipes:
       - BoxLethalshot

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -434,3 +434,6 @@ OverlordCircuitBoard: null
 
 # 2024-09-08
 HatBase: null
+
+# 2024-09-19
+BlueprintFlare: null


### PR DESCRIPTION
## About the PR
flare recipe is unlocked roundstart instead of being a blueprint

## Why / Balance
- every single person on the station starts with a flare. if that isn't roundstart i don't know what is
- floodlight and probably even the spationaut helmet light outclass it
- if you want to use it still and need more, just go to disposals where many people throw their flares away
  this means you basically dont need a recipe at all for flares
- a flare blueprint and seismic blueprint are so wildly different in value, it just shouldnt take up loot pool space

## Technical details
no

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
migrated incase someone mapped it, no breaking changes

**Changelog**
:cl:
- remove: Removed the flare blueprint from salvage, it's now unlocked roundstart in autolathes.
