### PR TITLE
AI now uses the criminal console instead of the station console to view records.

### DIFF
--- a/Content.Shared/CriminalRecords/Components/CriminalRecordsConsoleComponent.cs
+++ b/Content.Shared/CriminalRecords/Components/CriminalRecordsConsoleComponent.cs
@@ -1,6 +1,7 @@
 using Content.Shared.CriminalRecords.Systems;
 using Content.Shared.Radio;
 using Content.Shared.StationRecords;
+using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.CriminalRecords.Components;
@@ -8,7 +9,7 @@ namespace Content.Shared.CriminalRecords.Components;
 /// <summary>
 /// A component for Criminal Record Console storing an active station record key and a currently applied filter
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(SharedCriminalRecordsConsoleSystem))]
 public sealed partial class CriminalRecordsConsoleComponent : Component
 {
@@ -22,24 +23,24 @@ public sealed partial class CriminalRecordsConsoleComponent : Component
     /// Server then sends a state with just the records, not the listing or filter, and the client updates just that.
     /// I don't know if it's possible to have multiple bui states right now.
     /// </remarks>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public uint? ActiveKey;
 
     /// <summary>
     /// Currently applied filter.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public StationRecordsFilter? Filter;
 
     /// <summary>
     /// Channel to send messages to when someone's status gets changed.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public ProtoId<RadioChannelPrototype> SecurityChannel = "Security";
 
     /// <summary>
     /// Max length of arrest and crime history strings.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public uint MaxStringLength = 256;
 }

--- a/Resources/Prototypes/Actions/station_ai.yml
+++ b/Resources/Prototypes/Actions/station_ai.yml
@@ -66,3 +66,16 @@
       state: state_laws
     event: !type:ToggleLawsScreenEvent
     useDelay: 0.5
+
+- type: entity
+  id: ActionAIShowCriminalRecords
+  name: Criminal Records Interface
+  description: View a criminal records Interface.
+  components:
+  - type: InstantAction
+    icon: { sprite: Interface/Actions/actions_ai.rsi, state: station_records }
+    iconOn: Interface/Actions/actions_ai.rsi/station_records.png
+    keywords: [ "AI", "console", "interface" ]
+    priority: -8
+    event: !type:ToggleIntrinsicUIEvent { key: enum.CriminalRecordsConsoleKey.Key }
+    

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -42,8 +42,8 @@
         type: RadarConsoleBoundUserInterface
       enum.CrewMonitoringUIKey.Key:
         type: CrewMonitoringBoundUserInterface
-      enum.GeneralStationRecordConsoleKey.Key:
-        type: GeneralStationRecordConsoleBoundUserInterface
+      enum.CriminalRecordsConsoleKey.Key:
+        type: CriminalRecordsConsoleBoundUserInterface
       enum.SiliconLawsUiKey.Key:
         type: SiliconLawBoundUserInterface
       enum.CommunicationsConsoleUiKey.Key:
@@ -54,12 +54,12 @@
         toggleAction: ActionAGhostShowRadar
       enum.CrewMonitoringUIKey.Key:
         toggleAction: ActionAGhostShowCrewMonitoring
-      enum.GeneralStationRecordConsoleKey.Key:
-        toggleAction: ActionAGhostShowStationRecords
+      enum.CriminalRecordsConsoleKey.Key:
+        toggleAction: ActionAIShowCriminalRecords
       enum.CommunicationsConsoleUiKey.Key:
         toggleAction: ActionAGhostShowCommunications
   - type: CrewMonitoringConsole
-  - type: GeneralStationRecordConsole
+  - type: CriminalRecordsConsole
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: CrewMonitor


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes the AI Station Records action instead be the Criminal Records console.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The station records is useless and just an inferior version of the criminal records console. AI had essentially no use with it anyways. Now you can at least set criminals as wanted when sec asks you to without flying across the map.
Additionally when AI was using the sec console it would constantly get overwriten by whoever else was using it at the time in case several criminals had to be marked and it was annoying, though I guess a rare occurance.

## Technical details
<!-- Summary of code changes for easier review. -->
Made the CriminalRecordsConsole component networked.
Added a new action for AI to seperate aghost's station records and ai's criminal records. (Since Aghost is supposed to be able to delete the records, which AI couldnt do anyways)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/15fbb929-d439-4ffb-b294-044985cba12f)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: AI now uses a criminal console instead of the station records console.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
