### PR TITLE
Disable resizing of lobby character editor

### DIFF
--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -14,7 +14,7 @@
                  Stretch="KeepAspectCovered" />
     <BoxContainer Name="MainContainer" VerticalExpand="True" HorizontalExpand="True" Orientation="Horizontal"
                   Margin="10 10 10 10" SeparationOverride="2">
-        <SplitContainer State="Auto" HorizontalExpand="True">
+        <SplitContainer State="Auto" ResizeMode="NotResizable" HorizontalExpand="True">
             <!-- LHS Controls -->
             <BoxContainer Name="LeftSide" Orientation="Vertical" SeparationOverride="4" HorizontalExpand="True">
                 <Control Name="DefaultState" VerticalExpand="True">


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Real trivial bugfix. When attempting to close the character editor, I misclicked and accidentally resized the character editor.

Once the editor has been resized, the container remembers the sizes until application restart, and when the user attempts to manually restore the size, it makes a mess of the main lobby screen.

There's no need for these controls to be user-resizable anyway, so just disable that. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Old behaviour; character editor remembers a bad size and is broken whenever you open it:
![2024-09-19_21-45](https://github.com/user-attachments/assets/67f4e28d-301d-4b8a-997c-8e84d34833ea)

Lobby after you attempt to resize the character editor back to what it was previously:
![2024-09-19_21-45_1](https://github.com/user-attachments/assets/247b2cf0-9675-4728-8efe-dc82f238c741)

Bonus, stops this "resizable" mouse cursor from appearing, even though the panel couldn't be resized:

![2024-09-19_21-51](https://github.com/user-attachments/assets/cc767c15-eb7e-4fed-8dfe-e49f82b090a2)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
