### PR TITLE
Fix disposal units flushing too soon after power-on

### DIFF
--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -322,7 +322,7 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
 
         if (component.Engaged)
         {
-            // Run ManualEngage to reclaculate a new flush time
+            // Run ManualEngage to recalculate a new flush time
             ManualEngage(uid, component);
         }
     }

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -320,9 +320,10 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
             return;
         }
 
-        if (component.Engaged && !TryFlush(uid, component))
+        if (component.Engaged)
         {
-            QueueAutomaticEngage(uid, component);
+            // Run ManualEngage to reclaculate a new flush time
+            ManualEngage(uid, component);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fix disposal units flushing immediately on power-on.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

When a disposal unit was powered on while engaged, the unit would flush immediately, skipping the actual wait time for the flush to occur. Combined with having a power-toggle button on the UI, ProGamers(TM) could use this to flush items real fast:

https://github.com/user-attachments/assets/4602bbcb-8aea-4355-b834-91a6688cd363

Pretty clear this is unintended behaviour. Now, when the unit is powered on while engaged, will time the flush from the point of power-on. 

## Technical details 
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
