### PR TITLE
add checks to reset buttons in construction menu on close

### DIFF
--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -95,19 +95,17 @@ namespace Content.Client.Construction.UI
 
             _placementManager.PlacementChanged += OnPlacementChanged;
 
-            _constructionView.OnClose += () => _uiManager.GetActiveUIWidget<GameTopMenuBar>().CraftingButton.Pressed = false;
+            _constructionView.OnClose += () =>
+            {
+                if (_constructionView.BuildButtonPressed) BuildButtonToggled(false);
+                if (_constructionView.EraseButtonPressed) EraseButtonToggled(false);
+                _uiManager.GetActiveUIWidget<GameTopMenuBar>().CraftingButton.Pressed = false;
+            };
             _constructionView.ClearAllGhosts += (_, _) => _constructionSystem?.ClearAllGhosts();
             _constructionView.PopulateRecipes += OnViewPopulateRecipes;
             _constructionView.RecipeSelected += OnViewRecipeSelected;
             _constructionView.BuildButtonToggled += (_, b) => BuildButtonToggled(b);
-            _constructionView.EraseButtonToggled += (_, b) =>
-            {
-                if (_constructionSystem is null) return;
-                if (b) _placementManager.Clear();
-                _placementManager.ToggleEraserHijacked(new ConstructionPlacementHijack(_constructionSystem, null));
-                _constructionView.EraseButtonPressed = b;
-            };
-
+            _constructionView.EraseButtonToggled += (_, b) => EraseButtonToggled(b);
             _constructionView.RecipeFavorited += (_, _) => OnViewFavoriteRecipe();
 
             PopulateCategories();
@@ -305,6 +303,14 @@ namespace Content.Client.Construction.UI
                 TooltipEnabled = true,
                 TooltipText = recipe.Description
             };
+        }
+
+        private void EraseButtonToggled(bool pressed)
+        {
+            if (_constructionSystem is null) return;
+            if (pressed) _placementManager.Clear();
+            _placementManager.ToggleEraserHijacked(new ConstructionPlacementHijack(_constructionSystem, null));
+            _constructionView.EraseButtonPressed = pressed;
         }
 
         private void BuildButtonToggled(bool pressed)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed an issue where closing the construction menu while erase or build mode is active leaves those functions toggled and keeps certain top menu functions and interactions disabled.

## Why / Balance
The issue is that with erase mode active in particular, there is no indication that erase mode is still active as the window is gone and the top menu button has toggled off. This leads to confusion as you are unable to perform certain interactions and shortcuts with no indication as to what is calling it.

## Technical details
I wanted to get some feedback on this as the implementation may be poor or the issue may be intentional and just in need of some tweaking. I moved the code handling EraseButtonToggled to its own function similar to BuildButtonToggled and then added checks for both to reset them upon closing the window.

## Media
https://github.com/user-attachments/assets/a53a90b9-aec2-48ff-9145-6d3c9dbb4217


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No breaking changes to note.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Build and erase modes no longer remain active upon closing the construction menu.
-->
