### PR TITLE
Add more gas tanks to suit lockers.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -69,6 +69,9 @@
     - id: ClothingMaskGasCaptain
     - id: JetpackCaptainFilled
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled
+    - id: DoubleEmergencyOxygenTank
+    - id: DoubleEmergencyNitrogenTank
 
 # No laser locker, used when the antique laser is placed in the special display crate
 - type: entity
@@ -172,6 +175,9 @@
     - id: ClothingShoesBootsMagAdv
     - id: JetpackVoidFilled
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled
+    - id: DoubleEmergencyOxygenTank
+    - id: DoubleEmergencyNitrogenTank
 
 # No hardsuit locker
 - type: entity
@@ -227,6 +233,9 @@
     - id: ClothingMaskBreathMedical
     - id: ClothingOuterHardsuitMedical
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled
+    - id: DoubleEmergencyOxygenTank
+    - id: DoubleEmergencyNitrogenTank
 
 # No hardsuit locker
 - type: entity
@@ -277,6 +286,9 @@
     - id: ClothingMaskBreath
     - id: ClothingOuterHardsuitRd
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled
+    - id: DoubleEmergencyOxygenTank
+    - id: DoubleEmergencyNitrogenTank
 
 # No hardsuit locker
 - type: entity
@@ -336,6 +348,9 @@
     - id: ClothingOuterHardsuitSecurityRed
     - id: JetpackSecurityFilled
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled
+    - id: DoubleEmergencyOxygenTank
+    - id: DoubleEmergencyNitrogenTank
 
 # No hardsuit locker
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -70,8 +70,8 @@
     - id: JetpackCaptainFilled
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
-    - id: DoubleEmergencyOxygenTank
-    - id: DoubleEmergencyNitrogenTank
+    - id: DoubleEmergencyOxygenTankFilled
+    - id: DoubleEmergencyNitrogenTankFilled
 
 # No laser locker, used when the antique laser is placed in the special display crate
 - type: entity
@@ -176,8 +176,8 @@
     - id: JetpackVoidFilled
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
-    - id: DoubleEmergencyOxygenTank
-    - id: DoubleEmergencyNitrogenTank
+    - id: DoubleEmergencyOxygenTankFilled
+    - id: DoubleEmergencyNitrogenTankFilled
 
 # No hardsuit locker
 - type: entity
@@ -234,8 +234,8 @@
     - id: ClothingOuterHardsuitMedical
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
-    - id: DoubleEmergencyOxygenTank
-    - id: DoubleEmergencyNitrogenTank
+    - id: DoubleEmergencyOxygenTankFilled
+    - id: DoubleEmergencyNitrogenTankFilled
 
 # No hardsuit locker
 - type: entity
@@ -287,8 +287,8 @@
     - id: ClothingOuterHardsuitRd
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
-    - id: DoubleEmergencyOxygenTank
-    - id: DoubleEmergencyNitrogenTank
+    - id: DoubleEmergencyOxygenTankFilled
+    - id: DoubleEmergencyNitrogenTankFilled
 
 # No hardsuit locker
 - type: entity
@@ -349,8 +349,8 @@
     - id: JetpackSecurityFilled
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
-    - id: DoubleEmergencyOxygenTank
-    - id: DoubleEmergencyNitrogenTank
+    - id: DoubleEmergencyOxygenTankFilled
+    - id: DoubleEmergencyNitrogenTankFilled
 
 # No hardsuit locker
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -8,6 +8,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitEVA
         - id: ClothingHeadHelmetEVA
         - id: ClothingMaskBreath
@@ -21,6 +22,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitEVA
         - id: ClothingHeadHelmetEVALarge
         - id: ClothingMaskBreath
@@ -34,6 +36,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterSuitEmergency
         - id: ClothingMaskBreath
 
@@ -46,6 +49,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitEVAPrisoner
         - id: ClothingHeadHelmetEVALarge
         - id: ClothingMaskBreath
@@ -59,6 +63,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitSyndicate
         - id: ClothingHeadHelmetSyndicate
         - id: ClothingMaskGasSyndicate
@@ -72,6 +77,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitPirateEVA
         - id: ClothingMaskGas
 
@@ -98,6 +104,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitBasic
         - id: ClothingMaskBreath
 
@@ -110,6 +117,9 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
+        - id: ExtendedEmergencyOxygenTank
+        - id: ExtendedEmergencyNitrogenTank
         - id: ClothingShoesBootsMag
         - id: ClothingOuterHardsuitEngineering
         - id: ClothingMaskBreath
@@ -125,6 +135,9 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
+        - id: ExtendedEmergencyOxygenTank
+        - id: ExtendedEmergencyNitrogenTank
         - id: ClothingOuterHardsuitAtmos
         - id: ClothingMaskBreath
   - type: AccessReader
@@ -139,6 +152,9 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
+        - id: ExtendedEmergencyOxygenTank
+        - id: ExtendedEmergencyNitrogenTank
         - id: ClothingOuterHardsuitSecurity
         - id: ClothingMaskBreath
   - type: AccessReader
@@ -205,6 +221,9 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
+        - id: ExtendedEmergencyOxygenTank
+        - id: ExtendedEmergencyNitrogenTank
         - id: ClothingOuterHardsuitWarden
         - id: ClothingMaskBreath
   - type: AccessReader
@@ -245,6 +264,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitSyndie
         - id: ClothingShoesBootsMagSyndie
         - id: ClothingMaskGasSyndicate
@@ -258,6 +278,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitPirateCap
         - id: ClothingMaskGas
 
@@ -270,5 +291,6 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitWizard
         - id: ClothingMaskBreath

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -118,8 +118,8 @@
     contents:
         - id: OxygenTankFilled
         - id: NitrogenTankFilled
-        - id: ExtendedEmergencyOxygenTank
-        - id: ExtendedEmergencyNitrogenTank
+        - id: ExtendedEmergencyOxygenTankFilled
+        - id: ExtendedEmergencyNitrogenTankFilled
         - id: ClothingShoesBootsMag
         - id: ClothingOuterHardsuitEngineering
         - id: ClothingMaskBreath
@@ -136,8 +136,8 @@
     contents:
         - id: OxygenTankFilled
         - id: NitrogenTankFilled
-        - id: ExtendedEmergencyOxygenTank
-        - id: ExtendedEmergencyNitrogenTank
+        - id: ExtendedEmergencyOxygenTankFilled
+        - id: ExtendedEmergencyNitrogenTankFilled
         - id: ClothingOuterHardsuitAtmos
         - id: ClothingMaskBreath
   - type: AccessReader
@@ -153,8 +153,8 @@
     contents:
         - id: OxygenTankFilled
         - id: NitrogenTankFilled
-        - id: ExtendedEmergencyOxygenTank
-        - id: ExtendedEmergencyNitrogenTank
+        - id: ExtendedEmergencyOxygenTankFilled
+        - id: ExtendedEmergencyNitrogenTankFilled
         - id: ClothingOuterHardsuitSecurity
         - id: ClothingMaskBreath
   - type: AccessReader
@@ -222,8 +222,8 @@
     contents:
         - id: OxygenTankFilled
         - id: NitrogenTankFilled
-        - id: ExtendedEmergencyOxygenTank
-        - id: ExtendedEmergencyNitrogenTank
+        - id: ExtendedEmergencyOxygenTankFilled
+        - id: ExtendedEmergencyNitrogenTankFilled
         - id: ClothingOuterHardsuitWarden
         - id: ClothingMaskBreath
   - type: AccessReader


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a nitrogen tank to all suit lockers.
Adds extended oxygen and nitrogen tanks to engi, atmos, and security suit lockers.
Adds double extended emergency oxygen and nitrogen tanks to command suit lockers. 

## Why / Balance
The nitrogen should be self explanetory, theres plenty of species which use nitrogen now and they should be considered.
As for the extended for engi atmos and sec, they will need to use space semi-often, engi and atmos need it regularly, while security will need it for extended periods of time while their backslot is clear for a weapon
Heads also need space surprisingly often, with a lot of them having better things to put on their back, and them having to go to EVA in some maps or scrounge through maints in ones that dont have them mapped to get better pocket tanks feels wrong. I feel like they should get these roundstart, especially since some maps have them mapped while all of them can have them spawn in maints.

## Media
Unneccesary

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: BramvanZijp
- add: Engineering, Atmos and Security Hardsuit lockers now come with Extended Emergency Tanks, while heads of staff get double emergency tanks in their lockers.
- tweak: Suit lockers now also come with nitrogen tanks instead of just oxygen.
