### PR TITLE
Emote for cyborgs

### DIFF
--- a/Resources/Prototypes/Actions/borgs.yml
+++ b/Resources/Prototypes/Actions/borgs.yml
@@ -17,7 +17,7 @@
   description: Beep Bepep
   components:
   - type: InstantAction
-    useDelay: 10
+    useDelay: 5
     icon: Interface/Emotes/beep.png
     event: !type:ScreamActionEvent
     checkCanInteract: false

--- a/Resources/Prototypes/Actions/borgs.yml
+++ b/Resources/Prototypes/Actions/borgs.yml
@@ -10,3 +10,14 @@
       state: state-laws
     event: !type:ToggleLawsScreenEvent
     useDelay: 0.5
+
+- type: entity
+  id: ActionBeep
+  name: Beep
+  description: Beep Bepep
+  components:
+  - type: InstantAction
+    useDelay: 10
+    icon: Interface/Emotes/beep.png
+    event: !type:ScreamActionEvent
+    checkCanInteract: false

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -149,6 +149,9 @@
   - type: Vocal
     sounds:
       Unsexed: UnisexSilicon
+    screamId: Beep
+    wilhelmProbability: 0
+    screamAction: ActionBeep
   - type: UnblockableSpeech
   - type: FootstepModifier
     footstepSoundCollection:


### PR DESCRIPTION
## About the PR
Removes screaming action for cyborgs, replaces it with beep action (i think the beep sound is the best)

## Why / Balance
Screaming don't work for cyborgs.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Replaces scream action with beep action for cyborgs.