### PR TITLE
fix SpawnAndDeleteAllEntitiesInTheSameSpot heisentest

### DIFF
--- a/Content.Shared/Power/Generator/ActiveGeneratorRevvingComponent.cs
+++ b/Content.Shared/Power/Generator/ActiveGeneratorRevvingComponent.cs
@@ -3,8 +3,8 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Power.Generator;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class ActiveGeneratorRevvingComponent: Component
+public sealed partial class ActiveGeneratorRevvingComponent : Component
 {
-    [DataField, ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public TimeSpan CurrentTime = TimeSpan.Zero;
 }

--- a/Content.Shared/Power/Generator/ActiveGeneratorRevvingComponent.cs
+++ b/Content.Shared/Power/Generator/ActiveGeneratorRevvingComponent.cs
@@ -5,6 +5,6 @@ namespace Content.Shared.Power.Generator;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ActiveGeneratorRevvingComponent : Component
 {
-    [DataField, AutoNetworkedField]
+    [DataField, ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
     public TimeSpan CurrentTime = TimeSpan.Zero;
 }

--- a/Content.Shared/Power/Generator/ActiveGeneratorRevvingSystem.cs
+++ b/Content.Shared/Power/Generator/ActiveGeneratorRevvingSystem.cs
@@ -1,6 +1,6 @@
 namespace Content.Shared.Power.Generator;
 
-public sealed class ActiveGeneratorRevvingSystem: EntitySystem
+public sealed class ActiveGeneratorRevvingSystem : EntitySystem
 {
     public override void Initialize()
     {
@@ -25,7 +25,7 @@ public sealed class ActiveGeneratorRevvingSystem: EntitySystem
     /// <param name="component">ActiveGeneratorRevvingComponent of the generator entity.</param>
     public void StartAutoRevving(EntityUid uid, ActiveGeneratorRevvingComponent? component = null)
     {
-        if (Resolve(uid, ref component))
+        if (Resolve(uid, ref component, false))
         {
             // reset the revving
             component.CurrentTime = TimeSpan.FromSeconds(0);


### PR DESCRIPTION
## About the PR
Fixes the SpawnAndDeleteAllEntitiesInTheSameSpot heisentest (at least partially)
See this stack trace:
```
2024-09-20T14:49:43.6921463Z  SERVER: 19.242s [ERRO] system.active_generator_revving: Can't resolve "Content.Shared.Power.Generator.ActiveGeneratorRevvingComponent" on entity S.U.P.E.R.P.A.C.M.A.N.-type portable generator (4049/n4049, PortableGeneratorSuperPacman)!
2024-09-20T14:49:43.6923839Z     at System.Environment.get_StackTrace()
2024-09-20T14:49:43.6926721Z     at Content.Shared.Power.Generator.ActiveGeneratorRevvingSystem.StartAutoRevving(EntityUid uid, ActiveGeneratorRevvingComponent component) in /home/runner/work/space-station-14/space-station-14/Content.Shared/Power/Generator/ActiveGeneratorRevvingSystem.cs:line 28
2024-09-20T14:49:43.6931724Z     at Content.Server.Power.Generator.GeneratorSignalControlSystem.OnSignalReceived(EntityUid uid, GeneratorSignalControlComponent component, SignalReceivedEvent args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Power/Generator/GeneratorSignalControlSystem.cs:line 28
2024-09-20T14:49:43.6936876Z     at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass54_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 272
2024-09-20T14:49:43.6941355Z     at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass67_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 460
2024-09-20T14:49:43.6945691Z     at Robust.Shared.GameObjects.EntityEventBus.EntDispatch(EntityUid euid, Type eventType, Unit& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 633
2024-09-20T14:49:43.6949860Z     at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEventCore(EntityUid uid, Unit& unitRef, Type type, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 240
2024-09-20T14:49:43.6954449Z     at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 218
2024-09-20T14:49:43.6958838Z     at Robust.Shared.GameObjects.EntitySystem.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystem.cs:line 170
2024-09-20T14:49:43.6963436Z     at Content.Server.DeviceLinking.Systems.DeviceLinkSystem.InvokeDirect(Entity`1 source, Entity`1 sink, String sourcePort, String sinkPort, NetworkPayload data) in /home/runner/work/space-station-14/space-station-14/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs:line 86
2024-09-20T14:49:43.6968244Z     at Content.Server.DeviceLinking.Systems.DeviceLinkSystem.InvokePort(EntityUid uid, String port, NetworkPayload data, DeviceLinkSourceComponent sourceComponent) in /home/runner/work/space-station-14/space-station-14/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs:line 58
2024-09-20T14:49:43.6972585Z     at Content.Server.Anomaly.Effects.TechAnomalySystem.Update(Single frameTime) in /home/runner/work/space-station-14/space-station-14/Content.Server/Anomaly/Effects/TechAnomalySystem.cs:line 42
2024-09-20T14:49:43.6976492Z     at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 265
2024-09-20T14:49:43.6980633Z     at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 196
2024-09-20T14:49:43.6984540Z     at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 704
2024-09-20T14:49:43.6988015Z     at Robust.UnitTesting.RobustIntegrationTest.IntegrationGameLoop.SingleThreadRunUntilEmpty() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 1098
2024-09-20T14:49:43.6991651Z     at Robust.UnitTesting.RobustIntegrationTest.IntegrationGameLoop.Run() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 1085
2024-09-20T14:49:43.6995388Z     at Robust.UnitTesting.RobustIntegrationTest.ServerIntegrationInstance._serverMain() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 656
2024-09-20T14:49:43.6998073Z     at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
2024-09-20T14:49:43.6999417Z  DisposeAsync: Dirty return of pair 4 started
2024-09-20T14:49:43.7000131Z  DisposeAsync: Test gave back pair 4 in 19060.5156 ms
2024-09-20T14:49:43.7000826Z  DisposeAsync: Disposed pair 4 in 0.243 ms
2024-09-20T14:49:43.7001269Z 
2024-09-20T14:49:43.7001287Z 
2024-09-20T14:53:47.6822574Z 
2024-09-20T14:53:47.6870801Z Failed!  - Failed:     1, Passed:   361, Skipped:     0, Total:   362, Duration: 7 m 1 s - Content.IntegrationTests.dll (net8.0)
```

What happened was that the new tech anomaly randomly triggered a signal sink on the portable generator, which is currently broken and throws an error if the that sink is activated.

TODO: Add a test spawning every entity with signal sinks and trigger them.

## Why / Balance
bugfix

## Technical details
The resolve needed `logMissing = false` because it does not expect the ActiveGeneratorRevvingComponent to exist.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
no cl no fun
