### PR TITLE
AI now "can" use media console

### DIFF
--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -309,9 +309,6 @@ public sealed class NewsSystem : SharedNewsSystem
 
     private bool CanUse(EntityUid user, EntityUid console)
     {
-        // This shouldn't technically be possible because of BUI but don't trust client.
-        if (!_interaction.InRangeUnobstructed(console, user))
-            return false;
 
         if (TryComp<AccessReaderComponent>(console, out var accessReaderComponent))
         {


### PR DESCRIPTION
## About the PR
Lets AI to use console that is far away from his core.

## Why / Balance
Currently AI is able to use media console that is NEAR his core (so basically AI never get in such situation)

## Technical details
Deletes some code that don't allow to use console. Comment in the code: "This shouldn't technically be possible because of BUI but don't trust client"

## Media
![image](https://github.com/user-attachments/assets/697c93f8-8197-4101-a072-aa06076e18bc)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Now AI is able to use news manager console that is far away from its core.

