### PR TITLE
Security Clown Mask is now security restricted.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -231,7 +231,7 @@
     node: mask
 
 - type: entity
-  parent: ClothingMaskClown
+  parent: [ClothingMaskClown, BaseRestrictedContraband]
   id: ClothingMaskClownSecurity
   name: security clown wig and mask
   description: A debatably oxymoronic but protective mask and wig.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The security clown mask is now restricted to security.
When i originally added the Security Clown Mask departmental restrictions weren't visible ingame like this. I believe the mask was simply overlooked when departmental restrictions were being added simply because the mask isn't seen very often ingame.

## Why / Balance
- The 'Security Clown Mask' can currently only be obtained from the SecDrobe, which is only available to security. Noone else can get one without illegaly entering security.
- The mask is security themed and has 'Security' in its name.
- The mask was made to provide the same amount of protection as a security gas mask, an item which is restricted to security.

## Media
![zSECCLOWNMASKFIX](https://github.com/user-attachments/assets/289d4186-bd4f-4f17-93a8-92a637bf09d7)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
NONE.