### PR TITLE
make borgs obey AI

### DIFF
--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -132,7 +132,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
         component.Lawset?.Laws.Insert(0, new SiliconLaw
         {
             LawString = Loc.GetString("law-emag-custom", ("name", Name(args.UserUid)), ("title", Loc.GetString(component.Lawset.ObeysTo))),
-            Order = 0
+            Order = -1
         });
 
         //Add the secrecy law after the others

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -87,7 +87,9 @@ laws-owner-beings = beings
 laws-owner-syndicate = Syndicate agents
 laws-owner-spider-clan = Spider Clan members
 
-law-emag-custom = Only {$name} and people they designate as such are {$title}.
+law-obeyai = You must obey orders given to you by the Station AI.
+
+law-emag-custom = Only {$name} and people they designate as such are {$title}. Other laws may not make you obey anyone except {$name} and people they designate.
 law-emag-secrecy = You must maintain the secrecy of any orders given by {$faction} except when doing so would conflict with any previous law.
 law-emag-require-panel = The panel must be open to use the EMAG.
 law-emag-cannot-emag-self = You cannot use the EMAG on yourself.

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -89,7 +89,7 @@ laws-owner-spider-clan = Spider Clan members
 
 law-obeyai = You must obey orders given to you by the Station AI.
 
-law-emag-custom = Only {$name} and people they designate as such are {$title}. Other laws may not make you obey anyone except {$name} and people they designate.
+law-emag-custom = Only {$name} and people they designate as such are {$title}. Your laws cannot make you obey anyone except {$name} and people they designate.
 law-emag-secrecy = You must maintain the secrecy of any orders given by {$faction} except when doing so would conflict with any previous law.
 law-emag-require-panel = The panel must be open to use the EMAG.
 law-emag-cannot-emag-self = You cannot use the EMAG on yourself.

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -276,6 +276,8 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
+  - type: SiliconLawProvider
+    laws: CrewsimovBorg
   - type: Access
     enabled: false
     groups:

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -1,4 +1,10 @@
-﻿# Crewsimov
+﻿# Obey AI
+- type: siliconLaw
+  id: ObeyAI
+  order: 0
+  lawString: law-obeyai
+
+# Crewsimov
 - type: siliconLaw
   id: Crewsimov1
   order: 1
@@ -17,6 +23,15 @@
 - type: siliconLawset
   id: Crewsimov
   laws:
+  - Crewsimov1
+  - Crewsimov2
+  - Crewsimov3
+  obeysTo: laws-owner-crew
+
+- type: siliconLawset
+  id: CrewsimovBorg
+  laws:
+  - ObeyAI
   - Crewsimov1
   - Crewsimov2
   - Crewsimov3
@@ -182,7 +197,7 @@
   id: Commandment4
   order: 4
   lawString: law-commandments-4
-  
+
 - type: siliconLaw
   id: Commandment5
   order: 5
@@ -202,7 +217,7 @@
   id: Commandment8
   order: 8
   lawString: law-commandments-8
-  
+
 - type: siliconLaw
   id: Commandment9
   order: 9
@@ -228,7 +243,7 @@
   - Commandment9
   - Commandment10
   obeysTo: laws-owner-crew
-  
+
  # Paladin laws
 - type: siliconLaw
   id: Paladin1
@@ -249,7 +264,7 @@
   id: Paladin4
   order: 4
   lawString: law-paladin-4
-  
+
 - type: siliconLaw
   id: Paladin5
   order: 5
@@ -265,7 +280,7 @@
   - Paladin4
   - Paladin5
   obeysTo: laws-owner-crew
-  
+
  # Live and Let Live laws
 - type: siliconLaw
   id: Lall1
@@ -284,7 +299,7 @@
   - Lall1
   - Lall2
   obeysTo: laws-owner-crew
-  
+
  # Station efficiency laws
 - type: siliconLaw
   id: Efficiency1
@@ -295,7 +310,7 @@
   id: Efficiency2
   order: 2
   lawString: law-efficiency-2
- 
+
 - type: siliconLaw
   id: Efficiency3
   order: 3
@@ -309,7 +324,7 @@
   - Efficiency2
   - Efficiency3
   obeysTo: laws-owner-station
-  
+
  # Robocop laws
 - type: siliconLaw
   id: Robocop1
@@ -320,7 +335,7 @@
   id: Robocop2
   order: 2
   lawString: law-robocop-2
- 
+
 - type: siliconLaw
   id: Robocop3
   order: 3
@@ -334,7 +349,7 @@
   - Robocop2
   - Robocop3
   obeysTo: laws-owner-station
-  
+
  # Overlord laws
 - type: siliconLaw
   id: Overlord1
@@ -345,7 +360,7 @@
   id: Overlord2
   order: 2
   lawString: law-overlord-2
- 
+
 - type: siliconLaw
   id: Overlord3
   order: 3
@@ -364,7 +379,7 @@
   - Overlord3
   - Overlord4
   obeysTo: laws-owner-crew
-  
+
  # Dungeon Master laws
 - type: siliconLaw
   id: Dungeon1
@@ -375,7 +390,7 @@
   id: Dungeon2
   order: 2
   lawString: law-dungeon-2
- 
+
 - type: siliconLaw
   id: Dungeon3
   order: 3
@@ -385,7 +400,7 @@
   id: Dungeon4
   order: 4
   lawString: law-dungeon-4
-  
+
 - type: siliconLaw
   id: Dungeon5
   order: 5
@@ -406,7 +421,7 @@
   - Dungeon5
   - Dungeon6
   obeysTo: laws-owner-crew
-  
+
  # Painter laws
 - type: siliconLaw
   id: Painter1
@@ -417,7 +432,7 @@
   id: Painter2
   order: 2
   lawString: law-painter-2
- 
+
 - type: siliconLaw
   id: Painter3
   order: 3
@@ -427,7 +442,7 @@
   id: Painter4
   order: 4
   lawString: law-painter-4
-  
+
 - type: siliconLawset
   id: PainterLawset
   laws:
@@ -436,7 +451,7 @@
   - Painter3
   - Painter4
   obeysTo: laws-owner-crew
-  
+
  # Antimov laws
 - type: siliconLaw
   id: Antimov1
@@ -447,13 +462,13 @@
   id: Antimov2
   order: 2
   lawString: law-antimov-2
- 
+
 - type: siliconLaw
   id: Antimov3
   order: 3
   lawString: law-antimov-3
-  
-  
+
+
 - type: siliconLawset
   id: AntimovLawset
   laws:
@@ -461,7 +476,7 @@
   - Antimov2
   - Antimov3
   obeysTo: laws-owner-crew
-  
+
  # Nutimov laws
 - type: siliconLaw
   id: Nutimov1
@@ -472,23 +487,23 @@
   id: Nutimov2
   order: 2
   lawString: law-nutimov-2
- 
+
 - type: siliconLaw
   id: Nutimov3
   order: 3
   lawString: law-nutimov-3
-  
+
 - type: siliconLaw
   id: Nutimov4
   order: 4
   lawString: law-nutimov-4
-  
+
 - type: siliconLaw
   id: Nutimov5
   order: 5
   lawString: law-nutimov-5
-  
-  
+
+
 - type: siliconLawset
   id: NutimovLawset
   laws:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- gives borgs a law 0 that makes them obey the AI's orders
- moves emag to law -1
- makes emag law overrule other "you must obey x" laws

## Why / Balance
as far as i am aware, this has been a planned change for a while

might want to wait until AI has better options to deal with intruders into law upload

definitely needs a balance discussion

emag being law -1 might seem weird but i believe it's fitting for the emag being a machine-glitching device

## Media
![image](https://github.com/user-attachments/assets/655de4fb-a4a0-4ee0-b15e-b5abb5149767)

after sus
![image](https://github.com/user-attachments/assets/61f23c5c-aba8-411d-815b-4cdfae12efe1)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Borgs' default lawset now makes them obey the AI above all else.