### PR TITLE
Most papers are no longer trash

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -28,7 +28,6 @@
   - type: Tag
     tags:
     - Document
-    - Trash
     - Paper
   - type: Appearance
   - type: FaxableObject
@@ -81,6 +80,11 @@
   id: PaperScrap
   description: 'A crumpled up piece of white paper.'
   components:
+  - type: Tag
+    tags:
+    - Document
+    - Trash
+    - Paper
   - type: Sprite
     layers:
     - state: scrap
@@ -178,6 +182,11 @@
       visible: false
   - type: PaperLabelType
     paperType: Invoice
+  - type: Tag
+    tags:
+    - Document
+    - Trash
+    - Paper
   - type: PaperVisuals
     backgroundImagePath: "/Textures/Interface/Paper/paper_background_default.svg.96dpi.png"
     contentImagePath: "/Textures/Interface/Paper/paper_content_lined.svg.96dpi.png"
@@ -207,6 +216,11 @@
       visible: false
   - type: PaperLabelType
     paperType: Bounty
+  - type: Tag
+    tags:
+    - Document
+    - Trash
+    - Paper
   - type: PaperVisuals
     backgroundImagePath: "/Textures/Interface/Paper/paper_background_default.svg.96dpi.png"
     contentImagePath: "/Textures/Interface/Paper/paper_content_lined.svg.96dpi.png"


### PR DESCRIPTION
## About the PR
Most papers are no longer tagged as "Trash" this way, janitors won't pick them up with their bag. Cargo invoice/bounty papers are still trash because you can just print another bounty and lets be real, invoices are never read anyway.

## Why / Balance
It was very annoying to have janitors taking documents I am working on as they are trying to do their job. And by very annoying I mean it has proven to be a major setback multiple times and I'm actually really annoyed by it. So I fixed it.

## Technical details


## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- tweak: Most papers are no longer considered trash.