### PR TITLE
Fix a spelling mistake in the DonutVend's advertisments

### DIFF
--- a/Resources/Locale/en-US/advertisements/vending/donut.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/donut.ftl
@@ -1,5 +1,5 @@
 ﻿advertisement-donut-1 = Each of us is a little cop!
-advertisement-donut-2 = Hope you're hunger!
+advertisement-donut-2 = Hope you're hungry!
 advertisement-donut-3 = Over 1 million donuts sold!
 advertisement-donut-4 = We pride ourselves in the consistency of our products!
 advertisement-donut-5 = Sweet, sugary and delicious!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
For probably a year or so, this spelling mistake has existed. And for about a few months or so, nobody went and fixed it.
So, here I am, fixing another two letters.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
a 2 character change really shouldn't need one