### PR TITLE
fix cargo order scams, fix internals crate desc

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
@@ -34,7 +34,7 @@
     sprite: Clothing/Mask/breath.rsi
     state: icon
   product: CrateEmergencyInternalsLarge
-  cost: 2000
+  cost: 1200
   category: cargoproduct-category-name-emergency
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -44,7 +44,7 @@
     sprite: Objects/Tools/cable-coils.rsi
     state: coilall-30
   product: CrateEngineeringCableBulk
-  cost: 750
+  cost: 600
   category: cargoproduct-category-name-engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
@@ -38,7 +38,7 @@
   id: CrateEmergencyInternals
   parent: CrateInternals
   name: internals crate
-  description: Master your life energy and control your breathing with three breath masks, three emergency oxygen tanks and three large air tanks.
+  description: Master your life energy and control your breathing with 3 breath masks, emergency suits and large air tanks.
   components:
   - type: StorageFill
     contents:
@@ -57,7 +57,7 @@
   id: CrateEmergencyInternalsLarge
   parent: CrateInternals
   name: internals crate (large)
-  description: Master your life energy and control your breathing with six breath masks, six emergency oxygen tanks and six large air tanks.
+  description: Master your life energy and control your breathing with 6 breath masks, emergency suits and large air tanks.
   components:
     - type: StorageFill
       contents:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixes #32349 and fixes bulk cable crate being a scam, because:
- the normal internals crate costs $600 and provides 3 of each thing inside
- the large internal crate costs $2k, ~3.33x the normal one, yet only provides 2x the items
- normal cable crates provide 3 stacks of their respective cable for $300 each ($100 per stack)
- bulk cable crate provides 2 stacks of every cable for $750, or $250 for 2 ($125 per stack)

also fixes the internals crates' descriptions to mention that they contain 3 emergency suits, not 3 emergency air tanks

## Why / Balance
isn't intended to be balance, fixes prices making some of the orders being unviable and being noob traps

## Media
untested

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
shouldn't need a CL
