### PR TITLE
change ShowHealthBars and ShowHealthIcons to use protoId

### DIFF
--- a/Content.Client/Commands/ShowHealthBarsCommand.cs
+++ b/Content.Client/Commands/ShowHealthBarsCommand.cs
@@ -1,6 +1,8 @@
+using Content.Shared.Damage.Prototypes;
 using Content.Shared.Overlays;
 using Robust.Client.Player;
 using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
 using System.Linq;
 
 namespace Content.Client.Commands;
@@ -34,7 +36,7 @@ public sealed class ShowHealthBarsCommand : LocalizedCommands
         {
             var showHealthBarsComponent = new ShowHealthBarsComponent
             {
-                DamageContainers = args.ToList(),
+                DamageContainers = args.Select(arg => new ProtoId<DamageContainerPrototype>(arg)).ToList(),
                 HealthStatusIcon = null,
                 NetSyncEnabled = false
             };

--- a/Content.Shared/Overlays/ShowHealthBarsComponent.cs
+++ b/Content.Shared/Overlays/ShowHealthBarsComponent.cs
@@ -2,7 +2,6 @@ using Content.Shared.Damage.Prototypes;
 using Content.Shared.StatusIcon;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 
 namespace Content.Shared.Overlays;
 
@@ -15,8 +14,11 @@ public sealed partial class ShowHealthBarsComponent : Component
     /// <summary>
     /// Displays health bars of the damage containers.
     /// </summary>
-    [DataField("damageContainers", customTypeSerializer: typeof(PrototypeIdListSerializer<DamageContainerPrototype>))]
-    public List<string> DamageContainers = new();
+    [DataField]
+    public List<ProtoId<DamageContainerPrototype>> DamageContainers = new()
+    {
+        "Biological"
+    };
 
     [DataField]
     public ProtoId<HealthIconPrototype>? HealthStatusIcon = "HealthIconFine";

--- a/Content.Shared/Overlays/ShowHealthIconsComponent.cs
+++ b/Content.Shared/Overlays/ShowHealthIconsComponent.cs
@@ -1,6 +1,6 @@
 using Content.Shared.Damage.Prototypes;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Overlays;
 
@@ -13,6 +13,9 @@ public sealed partial class ShowHealthIconsComponent : Component
     /// <summary>
     /// Displays health status icons of the damage containers.
     /// </summary>
-    [DataField("damageContainers", customTypeSerializer: typeof(PrototypeIdListSerializer<DamageContainerPrototype>))]
-    public List<string> DamageContainers = new();
+    [DataField]
+    public List<ProtoId<DamageContainerPrototype>> DamageContainers = new()
+    {
+        "Biological"
+    };
 }

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -13,11 +13,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ShowHealthBars
-    damageContainers:
-    - Biological
   - type: ShowHealthIcons
-    damageContainers:
-    - Biological
 
 - type: entity
   parent: ClothingEyesBase
@@ -223,8 +219,6 @@
     sprite: Clothing/Eyes/Hud/syndagent.rsi
   - type: ShowSyndicateIcons
   - type: ShowHealthBars
-    damageContainers:
-    - Biological
 
 - type: entity
   parent: [ClothingEyesGlassesSunglasses, ShowSecurityIcons]

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -391,8 +391,6 @@
     - type: Construction
       node: syndicatemedical
     - type: ShowHealthBars
-      damageContainers:
-      - Biological
     - type: InteractionPopup
       interactSuccessString: petting-success-syndicate-cyborg
       interactFailureString: petting-failure-syndicate-cyborg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
use protoId 

## Why / Balance
qol for working with the fucking overlays

## Technical details
<!-- Summary of code changes for easier review. -->
Changes the ShowHealthBarsComponent and ShowHealthIconsComponent to use ProtoId and default to Biological (you can set it to anything else in yaml still, like with the diagnostic hud), changes the ShowHealthBarsCommand to work with ProtoId, yaml cleanup 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->