### PR TITLE
APCs are now usable by multiple entities at the same time, with no jank!

### DIFF
--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -25,6 +25,7 @@ namespace Content.Client.Power.APC.UI
             RobustXamlLoader.Load(this);
 
             BreakerButton.OnPressed += _ => OnBreaker?.Invoke();
+
         }
 
         public void SetEntity(EntityUid entity)
@@ -38,7 +39,8 @@ namespace Content.Client.Power.APC.UI
 
             if (BreakerButton != null)
             {
-                if(castState.HasAccess == false)
+                //                     Below is commented out as part of HasAccess removal.
+                /*if(castState.HasAccess == false)
                 {
                     BreakerButton.Disabled = true;
                     BreakerButton.ToolTip = Loc.GetString("apc-component-insufficient-access");
@@ -48,7 +50,8 @@ namespace Content.Client.Power.APC.UI
                     BreakerButton.Disabled = false;
                     BreakerButton.ToolTip = null;
                     BreakerButton.Pressed = castState.MainBreaker;
-                }
+                }*/
+                BreakerButton.Pressed = castState.MainBreaker;
             }
 
             if (PowerLabel != null)

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -74,9 +74,11 @@ public sealed class ApcSystem : EntitySystem
     //Update the HasAccess var for UI to read
     private void OnBoundUiOpen(EntityUid uid, ApcComponent component, BoundUIOpenedEvent args)
     {
-        // TODO: this should be per-player not stored on the apc
-        component.HasAccess = _accessReader.IsAllowed(args.Actor, uid);
-        UpdateApcState(uid, component);
+        // TODO: this should be per-player not stored on the apc                        maybe remove before merge.
+        //component.HasAccess = _accessReader.IsAllowed(args.Actor, uid);           !!REMOVE BEFORE MERGE!!
+        component.HasAccess = true;
+        //UpdateApcState(uid, component);                                           !!REMOVE BEFORE MERGE!!
+        UpdateUIState(uid, component);
     }
 
     private void OnToggleMainBreaker(EntityUid uid, ApcComponent component, ApcToggleMainBreakerMessage args)
@@ -90,6 +92,7 @@ public sealed class ApcSystem : EntitySystem
             return;
         }
 
+        //component.HasAccess = _accessReader.IsAllowed(args.Actor, uid);           !!REMOVE BEFORE MERGE!!
         if (_accessReader.IsAllowed(args.Actor, uid))
         {
             ApcToggleBreaker(uid, component);

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -74,18 +74,17 @@ public sealed class ApcSystem : EntitySystem
     //Update the HasAccess var for UI to read
     private void OnBoundUiOpen(EntityUid uid, ApcComponent component, BoundUIOpenedEvent args)
     {
-        // TODO: this should be per-player not stored on the apc                        maybe remove before merge.
-        //component.HasAccess = _accessReader.IsAllowed(args.Actor, uid);           Maybe un-comment this.
-        component.HasAccess = true;                 // This can likely be changed with the above line again, though it will re-inroduce unnecessary jank.
-        //UpdateApcState(uid, component);                                           !!REMOVE BEFORE MERGE!!
-        UpdateUIState(uid, component);
+        // TODO: this should be per-player not stored on the apc                        //maybe remove before merge.
+        //component.HasAccess = _accessReader.IsAllowed(args.Actor, uid);           //Maybe un-comment this.
+        //component.HasAccess = true;                 // This can likely be changed with the above line again, though it will re-inroduce unnecessary jank without singleUser:true
+        UpdateApcState(uid, component);                                           //!!REMOVE (one of these) BEFORE MERGE!!
     }
 
     private void OnToggleMainBreaker(EntityUid uid, ApcComponent component, ApcToggleMainBreakerMessage args)
     {
         var attemptEv = new ApcToggleMainBreakerAttemptEvent();
         RaiseLocalEvent(uid, ref attemptEv);
-        if (attemptEv.Cancelled)
+        if (attemptEv.Cancelled)                        // this is for EMPed APCs
         {
             _popup.PopupCursor(Loc.GetString("apc-component-on-toggle-cancel"),
                 args.Actor, PopupType.Medium);
@@ -93,7 +92,7 @@ public sealed class ApcSystem : EntitySystem
         }
 
         //component.HasAccess = _accessReader.IsAllowed(args.Actor, uid);           !!REMOVE BEFORE MERGE!!
-        if (_accessReader.IsAllowed(args.Actor, uid))
+        if (_accessReader.IsAllowed(args.Actor, uid))       // this is the check for ID permissions
         {
             ApcToggleBreaker(uid, component);
         }
@@ -168,7 +167,7 @@ public sealed class ApcSystem : EntitySystem
         // TODO: Fix ContentHelpers or make a new one coz this is cooked.
         var charge = ContentHelpers.RoundToNearestLevels(battery.CurrentStorage / battery.Capacity, 1.0, 100 / ChargeAccuracy) / 100f * ChargeAccuracy;
 
-        var state = new ApcBoundInterfaceState(apc.MainBreakerEnabled, apc.HasAccess,
+        var state = new ApcBoundInterfaceState(apc.MainBreakerEnabled,/* apc.HasAccess,*/
             (int) MathF.Ceiling(battery.CurrentSupply), apc.LastExternalState,
             charge);
 

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -74,10 +74,10 @@ public sealed class ApcSystem : EntitySystem
     //Update the HasAccess var for UI to read
     private void OnBoundUiOpen(EntityUid uid, ApcComponent component, BoundUIOpenedEvent args)
     {
-        // TODO: this should be per-player not stored on the apc                        //maybe remove before merge.
-        //component.HasAccess = _accessReader.IsAllowed(args.Actor, uid);           //Maybe un-comment this.
+        // TODO: this should be per-player not stored on the apc                        //maybe remove before merge, if maints think this is solved
+        //component.HasAccess = _accessReader.IsAllowed(args.Actor, uid);           //All instances of HasAccess have been commented.
         //component.HasAccess = true;                 // This can likely be changed with the above line again, though it will re-inroduce unnecessary jank without singleUser:true
-        UpdateApcState(uid, component);                                           //!!REMOVE (one of these) BEFORE MERGE!!
+        UpdateApcState(uid, component);
     }
 
     private void OnToggleMainBreaker(EntityUid uid, ApcComponent component, ApcToggleMainBreakerMessage args)
@@ -91,7 +91,6 @@ public sealed class ApcSystem : EntitySystem
             return;
         }
 
-        //component.HasAccess = _accessReader.IsAllowed(args.Actor, uid);           !!REMOVE BEFORE MERGE!!
         if (_accessReader.IsAllowed(args.Actor, uid))       // this is the check for ID permissions
         {
             ApcToggleBreaker(uid, component);

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -75,8 +75,8 @@ public sealed class ApcSystem : EntitySystem
     private void OnBoundUiOpen(EntityUid uid, ApcComponent component, BoundUIOpenedEvent args)
     {
         // TODO: this should be per-player not stored on the apc                        maybe remove before merge.
-        //component.HasAccess = _accessReader.IsAllowed(args.Actor, uid);           !!REMOVE BEFORE MERGE!!
-        component.HasAccess = true;
+        //component.HasAccess = _accessReader.IsAllowed(args.Actor, uid);           Maybe un-comment this.
+        component.HasAccess = true;                 // This can likely be changed with the above line again, though it will re-inroduce unnecessary jank.
         //UpdateApcState(uid, component);                                           !!REMOVE BEFORE MERGE!!
         UpdateUIState(uid, component);
     }

--- a/Content.Shared/APC/SharedApc.cs
+++ b/Content.Shared/APC/SharedApc.cs
@@ -178,15 +178,15 @@ namespace Content.Shared.APC
     public sealed class ApcBoundInterfaceState : BoundUserInterfaceState, IEquatable<ApcBoundInterfaceState>
     {
         public readonly bool MainBreaker;
-        public readonly bool HasAccess;
+        //public readonly bool HasAccess;                                       All instances of HasAccess have been commented
         public readonly int Power;
         public readonly ApcExternalPowerState ApcExternalPower;
         public readonly float Charge;
 
-        public ApcBoundInterfaceState(bool mainBreaker, bool hasAccess, int power, ApcExternalPowerState apcExternalPower, float charge)
+        public ApcBoundInterfaceState(bool mainBreaker,/* bool hasAccess,*/ int power, ApcExternalPowerState apcExternalPower, float charge)
         {
             MainBreaker = mainBreaker;
-            HasAccess = hasAccess;
+            //HasAccess = hasAccess;
             Power = power;
             ApcExternalPower = apcExternalPower;
             Charge = charge;
@@ -197,7 +197,7 @@ namespace Content.Shared.APC
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return MainBreaker == other.MainBreaker &&
-                   HasAccess == other.HasAccess &&
+                   /*HasAccess == other.HasAccess &&*/
                    Power == other.Power &&
                    ApcExternalPower == other.ApcExternalPower &&
                    MathHelper.CloseTo(Charge, other.Charge);
@@ -210,7 +210,7 @@ namespace Content.Shared.APC
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(MainBreaker, HasAccess, Power, (int) ApcExternalPower, Charge);
+            return HashCode.Combine(MainBreaker,/* HasAccess,*/ Power, (int) ApcExternalPower, Charge);
         }
     }
 

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -91,7 +91,7 @@
         type: ApcBoundUserInterface
   - type: ActivatableUI
     inHandsOnly: false
-    singleUser: true
+    singleUser: false
     key: enum.ApcUiKey.Key
   - type: Construction
     graph: APC


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
- APCs can now be used by multiple users, including the AI, at the same time.
- The Toggle button on APCs no longer gets disabled.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
#32312 exposed a bit of detail where the AI was capable of preventing people from physically toggling APCs, regardless of access. At the very least, the AI will have to fight for it now, as multiple users can fight over the toggle switch if they have the right access.
Those unable to toggle the breaker before are still unable, the button will just tell them "insufficient access" instead of being disabled.

## Technical details
<!-- Summary of code changes for easier review. -->
The code had 2 different methods by which access was determined, one was tied to disabling the button - that method is entirely removed. Technically, this doesn't solve the TODO in ApcSystem.cs ("this should be per-player not stored on the apc"), so I've left that comment in - maints can remove it if they want.
This does mean it's now the server's responsibility to reject button toggles, so people can spam the button. I have no way to test if this makes the implemented solution non-viable.
If the removed HasAccess method is desirable to be returned for whatever reason, that can be done - but be warned it causes a lot of jank, and would need singleUser within apc.yml to be made true again.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Removes HasAccess arguments and variables from APCs entirely. Not certain this will break anything, but it doesn't have a replacement.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: APCs can now be interacted with by multiple users, preventing AI from completely stalling out control.
