### PR TITLE
added the ability for pigs to feed themselves

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3377,6 +3377,11 @@
   - type: NpcFactionMember
     factions:
     - Passive
+  - type: HTN
+    rootTask:
+      task: RuminantCompound
+  - type: Body
+    prototype: AnimalHemocyanin
 
 - type: entity
   name: diona nymph


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
pigs can now look for food themselves and eat it (like cows)

## Why / Balance
This makes it easier to set up pig farms.

## Technical details
HTN of ruminants has been added to pigs

## Media
![svin213](https://github.com/user-attachments/assets/fa609172-a166-4a03-a502-ceac2978b539)
![svin21](https://github.com/user-attachments/assets/949905a6-e03d-4864-9d91-b974d8a757c6)
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

