### PR TITLE
Update chapel.yml

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -20,6 +20,7 @@
     BoxCandle: 2
     BoxCandleSmall: 2
     Urn: 5
+    Bible: 1
   emaggedInventory:
     ClothingOuterArmorCult: 1
     ClothingHeadHelmetCult: 1


### PR DESCRIPTION
## About the PR
Added a bible to the piety vending machine. I'm bad at git so if things explode I plead the 5th

## Why / Balance
Thief can have steal bible objective, and without a chaplain , there is no way to get a bible; this gives them a way to get it and for the poor chaplain who got slipped by the clown and lost his bible to not lose purpose in life. 

## Technical details
N/A

## Media
N/A

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
N/A

**Changelog**
:cl:
- add: You can now find a spare bible in the PietyVend