### PR TITLE
Add flash reaction effect

### DIFF
--- a/Content.Server/EntityEffects/Effects/FlashReactionEffect.cs
+++ b/Content.Server/EntityEffects/Effects/FlashReactionEffect.cs
@@ -1,0 +1,82 @@
+using Content.Shared.EntityEffects;
+using Content.Server.Flash;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.EntityEffects.Effects;
+
+[DataDefinition]
+public sealed partial class FlashReactionEffect : EntityEffect
+{
+    /// <summary>
+    ///     Flash range per unit of reagent.
+    /// </summary>
+    [DataField]
+    public float RangePerUnit = 0.2f;
+
+    /// <summary>
+    ///     Maximum flash range.
+    /// </summary>
+    [DataField]
+    public float MaxRange = 10f;
+
+    /// <summary>
+    ///     How much to entities are slowed down.
+    /// </summary>
+    [DataField]
+    public float SlowTo = 0.5f;
+
+    /// <summary>
+    ///     The time entities will be flashed in seconds.
+    ///     The default is chosen to be better than the hand flash so it is worth using it for grenades etc.
+    /// </summary>
+    [DataField]
+    public float Duration = 4f;
+
+    /// <summary>
+    ///     The prototype ID used for the visual effect.
+    /// </summary>
+    [DataField]
+    public EntProtoId? FlashEffectPrototype = "ReactionFlash";
+
+    /// <summary>
+    ///     The sound the flash creates.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? Sound = new SoundPathSpecifier("/Audio/Weapons/flash.ogg");
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => Loc.GetString("reagent-effect-guidebook-flash-reaction-effect", ("chance", Probability));
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        var transform = args.EntityManager.GetComponent<TransformComponent>(args.TargetEntity);
+        var transformSystem = args.EntityManager.System<SharedTransformSystem>();
+
+        var range = 1f;
+
+        if (args is EntityEffectReagentArgs reagentArgs)
+            range = MathF.Min((float)(reagentArgs.Quantity * RangePerUnit), MaxRange);
+
+        args.EntityManager.System<FlashSystem>().FlashArea(
+            args.TargetEntity,
+            null,
+            range,
+            Duration * 1000,
+            slowTo: SlowTo,
+            sound: Sound);
+
+        if (FlashEffectPrototype == null)
+            return;
+
+        var uid = args.EntityManager.SpawnEntity(FlashEffectPrototype, transformSystem.GetMapCoordinates(transform));
+        transformSystem.AttachToGridOrMap(uid);
+
+        if (!args.EntityManager.TryGetComponent<PointLightComponent>(uid, out var pointLightComp))
+            return;
+        var pointLightSystem = args.EntityManager.System<SharedPointLightSystem>();
+        // PointLights with a radius lower than 1.1 are too small to be visible, so this is hardcoded
+        pointLightSystem.SetRadius(uid, MathF.Max(1.1f, range), pointLightComp);
+    }
+}

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -37,6 +37,12 @@ reagent-effect-guidebook-emp-reaction-effect =
         *[other] cause
     } an electromagnetic pulse
 
+reagent-effect-guidebook-flash-reaction-effect =
+    { $chance ->
+        [1] Causes
+        *[other] cause
+    } a blinding flash
+
 reagent-effect-guidebook-foam-area-reaction-effect =
     { $chance ->
         [1] Creates

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -222,3 +222,16 @@
       state: metal_foam-north
     - map: [ "enum.EdgeLayer.West" ]
       state: metal_foam-west
+
+- type: entity
+  id: ReactionFlash
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: PointLight
+    enabled: true
+    radius: 2
+    energy: 8
+  - type: LightFade
+    duration: 0.5
+  - type: TimedDespawn
+    lifetime: 0.5

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -81,7 +81,7 @@
       amount: 1
     Sulfur:
       amount: 1
-    Oxygen: 
+    Oxygen:
       amount: 2
   products:
     SulfuricAcid: 3
@@ -204,6 +204,20 @@
       maxRange: 6
       energyConsumption: 12500
       duration: 15
+
+- type: reaction
+  id: Flash
+  impact: High
+  priority: 20
+  reactants:
+    Aluminium:
+      amount: 1
+    Potassium:
+      amount: 1
+    Sulfur:
+      amount: 1
+  effects:
+    - !type:FlashReactionEffect
 
 - type: reaction
   id: TableSalt
@@ -501,3 +515,4 @@
       amount: 1
   products:
     Tazinide: 1
+


### PR DESCRIPTION
## About the PR
Adds the flash reaction effect from SS13 (see [tg wiki](https://tgstation13.org/wiki/Guide_to_chemistry)).
1 aluminium
1 potassium
1 sulfur
The range scales with the reagent amount.

## Why / Balance
Chemistry needs a few more fun reactions that are non-lethal.

## Technical details
Adds a new entity effect that calls FlashArea.
It also spawns a disappearing pointlight prototype similar to that used by the flashbang for better visual feedback.
The pointlight is scaled in size according to the flash range.

## Media

https://github.com/user-attachments/assets/14b6b1e1-1a08-4681-9509-287bde6725bb

(I accidentally had the dropper in draw mode, but you still see what happens)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- add: Mix 1u aluminium, 1u potassium and 1u sulfur for a flash reaction effect. The radius scales with the reagent amount.
