### PR TITLE
fix viewing nav slowing shuttle down

### DIFF
--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -314,6 +314,9 @@ public sealed class MoverController : SharedMoverController
             var linearInput = Vector2.Zero;
             var brakeInput = 0f;
             var angularInput = 0f;
+            var linearCount = 0;
+            var brakeCount = 0;
+            var angularCount = 0;
 
             foreach (var (pilotUid, pilot, _, consoleXform) in pilots)
             {
@@ -322,24 +325,27 @@ public sealed class MoverController : SharedMoverController
                 if (brakes > 0f)
                 {
                     brakeInput += brakes;
+                    brakeCount++;
                 }
 
                 if (strafe.Length() > 0f)
                 {
                     var offsetRotation = consoleXform.LocalRotation;
                     linearInput += offsetRotation.RotateVec(strafe);
+                    linearCount++;
                 }
 
                 if (rotation != 0f)
                 {
                     angularInput += rotation;
+                    angularCount++;
                 }
             }
 
-            var count = pilots.Count;
-            linearInput /= count;
-            angularInput /= count;
-            brakeInput /= count;
+            // Don't slow down the shuttle if there's someone just looking at the console
+            linearInput /= Math.Max(1, linearCount);
+            angularInput /= Math.Max(1, angularCount);
+            brakeInput /= Math.Max(1, brakeCount);
 
             // Handle shuttle movement
             if (brakeInput > 0f)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title, fixes the fact that a person simply viewing the shuttle nav console without any input would cause it to slow down

## Why / Balance
just looking shouldn't make the shuttle slow down

## Media
tested, works

## Technical Details
made it actually count people with nonzero input and take into account 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Multiple people using one shuttle console will no longer cause the shuttle to slow down.