### PR TITLE
make svalinn t2

### DIFF
--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -175,6 +175,18 @@
   technologyPrerequisites:
   - SalvageWeapons
 
+- type: technology
+  id: ExperimentalBatteryAmmo
+  name: research-technology-experimental-battery-ammo
+  icon:
+    sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
+    state: icon
+  discipline: Arsenal
+  tier: 2
+  cost: 15000
+  recipeUnlocks:
+  - WeaponLaserSvalinn
+
 # Tier 3
 
 - type: technology
@@ -189,18 +201,6 @@
   recipeUnlocks:
   - WeaponAdvancedLaser
   - PortableRecharger
-
-- type: technology
-  id: ExperimentalBatteryAmmo
-  name: research-technology-experimental-battery-ammo
-  icon:
-    sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
-    state: icon
-  discipline: Arsenal
-  tier: 3
-  cost: 15000
-  recipeUnlocks:
-  - WeaponLaserSvalinn
 
 - type: technology
   id: AdvancedShuttleWeapon


### PR DESCRIPTION
## About the PR
title
no points change only tier

## Why / Balance
its just outclassed by advanced laser which is an actual t3, if you want to make 10 batteries you can also just make 10 lasers

maybe it will be seen outside of warops now

**Changelog**
:cl:
- tweak: Svalinn laser pistol is now a Tier 2 tech instead of Tier 3.
