### PR TITLE
reach update :3

### DIFF
--- a/Resources/Maps/reach.yml
+++ b/Resources/Maps/reach.yml
@@ -1899,7 +1899,7 @@ entities:
   - uid: 80
     components:
     - type: Transform
-      pos: 1.5,9.5
+      pos: -0.5,10.5
       parent: 2
 - proto: BarSignTheLightbulb
   entities:
@@ -7544,8 +7544,8 @@ entities:
       pos: 7.5,-13.5
       parent: 2
     - type: GasMixer
-      inletTwoConcentration: 0.78
-      inletOneConcentration: 0.22
+      inletTwoConcentration: 0.22000003
+      inletOneConcentration: 0.78
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasPassiveVent
@@ -12187,11 +12187,6 @@ entities:
     - type: Transform
       pos: 2.5,6.5
       parent: 2
-  - uid: 1739
-    components:
-    - type: Transform
-      pos: -0.5,10.5
-      parent: 2
   - uid: 1949
     components:
     - type: Transform
@@ -14360,12 +14355,6 @@ entities:
     components:
     - type: Transform
       pos: 16.5,-4.5
-      parent: 2
-  - uid: 2081
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,10.5
       parent: 2
   - uid: 2082
     components:


### PR DESCRIPTION
## About the PR
- Battery recharger between sci and cargo got replaced with autolathe that was moved from cargo
- Gas mixer in atmos got fixed, it had oxygen set to 78% and nitrogen to 22%, changed to 22% and 78%

## Why / Balance
- Cargo already has a battery charger outside VERY close to sci; also, autolathe is usually mapped for science anyway
- idk if that is a thing in the game yet but roundstart atmos setup that would burn your lungs IRL is probably not the best thing

## Technical details

## Media
![image](https://github.com/user-attachments/assets/6a8fd152-6288-4866-ae74-a77c84aae1c0)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
