### PR TITLE
New Color for Command Radio

### DIFF
--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -18,7 +18,7 @@
   name: chat-radio-command
   keycode: 'c'
   frequency: 1353
-  color: "#fcdf03"
+  color: "#436be0"
 
 - type: radioChannel
   id: Engineering


### PR DESCRIPTION
## About the PR
Changes color of command radio channel from yellow to blue.

## Why / Balance
From a colorblind accessibility standpoint, the current command radio color is incredibly similar to common at a glance for some people (including myself). This makes playing command a bit more difficult as I have to more frequently check for command related radio messages and often end up missing them entirely.

Only issue remaining that should be added to this PR (or fixed later I suppose) is the color used for this chat section when typing, which is independent from radio_channels.yml and I can't find where it's controlled.
![image](https://github.com/user-attachments/assets/6ecf9f16-aff5-4b08-816c-616fea47083b)

## Media
**New color**
![image](https://github.com/user-attachments/assets/b7f6cb14-a226-4cc3-9801-512a09fe3078)
**Old Color (and compared to common)**
![image](https://github.com/user-attachments/assets/7eeb36bb-6aac-448e-97a0-3f5a38f42960)
Command headset and encryption key aren't yellow anyways so it still fits theme wise.
![image](https://github.com/user-attachments/assets/8e817b27-ca47-44b9-9311-870699bf9eb9)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Changed command radio color from yellow to blue.