### PR TITLE
Fix Speedloader Partial Reload

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -130,7 +130,7 @@ public partial class SharedGunSystem
                 return false;
             }
 
-            for (var i = Math.Min(ev.Ammo.Count - 1, component.Capacity - 1); i >= 0; i--)
+            for (var i = 0; i < component.Capacity; i++)
             {
                 var index = (component.CurrentIndex + i) % component.Capacity;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This fixes two bugs that caused partial reloads with Speedloaders to break in many many ways. Partial reloads will now function as expected. Upstreaming from RMC downstream.

## Why / Balance
Fixes two bugs related to Revolvers that seem to have gone unreported on here for a long time. Currently Speedloaders will not handle partial reloads well, as they will not even attempt to look at more slots than are missing rounds, and often times these are not the ones that are hovered. This causes the Speedloader to unsuccessfully reload the missing slots, but it also still consumes ammo. 

Furthermore, attempting to reload with a partially filled Speedloader would insert the rounds into the farthest possible chambers, as for some reason it was inserting them in reverse. This also fixes that.

## Technical details
The i index here just tells how many slots in the Revolver the loop will look at, so I removed the Math.Min involving the amount of ammo to be loaded, as it is entirely irrelevant to how many chambers the Revolver has. There is already a Break condition present for when there isn't enough ammo that handles this correctly. Also changes the i-- behavior to i++ because by trying to reload the Revolver in reverse it put the ammo in only the farthest of slots compared to where your current index is.

## Media
https://github.com/user-attachments/assets/a62bb86e-ac5d-41e1-becf-8e07abfc5625

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed Revolvers not correctly reloading from Speedloaders when the Revolver is partially loaded.
- fix: Speedloaders will now prioritize loading the active and upcoming chambers in a Revolver when the Speedloader is only partially filled, rather than the ones farthest away.
