### PR TITLE
Fix cadet pda

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -115,11 +115,11 @@
     speechVerb: Robotic
 
 - type: entity
+  parent: BasePDA
   id: BaseSecurityPDA
   abstract: true
   components:
   - type: CartridgeLoader
-    uiKey: enum.PdaUiKey.Key
     preinstalled:
     - CrewManifestCartridge
     - NotekeeperCartridge
@@ -184,7 +184,7 @@
     - Medical Doctor
 
 - type: entity
-  parent: BasePDA
+  parent: BaseSecurityPDA
   id: SecurityCadetPDA
   name: security cadet PDA
   description: Why isn't it red?
@@ -445,7 +445,7 @@
     state: pda-library
 
 - type: entity
-  parent: [BaseSecurityPDA, BasePDA]
+  parent: BaseSecurityPDA
   id: LawyerPDA
   name: lawyer PDA
   description: For lawyers to poach dubious clients.
@@ -488,7 +488,7 @@
     state: pda-janitor
 
 - type: entity
-  parent: [BaseSecurityPDA, BasePDA]
+  parent: BaseSecurityPDA
   id: CaptainPDA
   name: captain PDA
   description: Surprisingly no different from your PDA.
@@ -663,7 +663,7 @@
     state: pda-science
 
 - type: entity
-  parent: [BaseSecurityPDA, BasePDA]
+  parent: BaseSecurityPDA
   id: HoSPDA
   name: head of security PDA
   description: Whosoever bears this PDA is the law.
@@ -678,7 +678,7 @@
     state: pda-hos
 
 - type: entity
-  parent: [BaseSecurityPDA, BasePDA]
+  parent: BaseSecurityPDA
   id: WardenPDA
   name: warden PDA
   description: The OS appears to have been jailbroken.
@@ -693,7 +693,7 @@
     state: pda-warden
 
 - type: entity
-  parent: [BaseSecurityPDA, BasePDA]
+  parent: BaseSecurityPDA
   id: SecurityPDA
   name: security PDA
   description: Red to hide the stains of passenger blood.
@@ -707,7 +707,7 @@
     state: pda-security
 
 - type: entity
-  parent: [BaseSecurityPDA, BasePDA]
+  parent: BaseSecurityPDA
   id: CentcomPDA
   name: CentComm PDA
   description: Light green sign of walking bureaucracy.
@@ -847,7 +847,7 @@
           - Cartridge
 
 - type: entity
-  parent: [BaseSecurityPDA, BasePDA]
+  parent: BaseSecurityPDA
   id: ERTLeaderPDA
   name: ERT Leader PDA
   suffix: Leader
@@ -995,7 +995,7 @@
     state: pda-boxer
 
 - type: entity
-  parent: [BaseSecurityPDA, BasePDA]
+  parent: BaseSecurityPDA
   id: DetectivePDA
   name: detective PDA
   description: Smells like rain... pouring down the rooftops...
@@ -1095,7 +1095,7 @@
     state: pda-seniorphysician
 
 - type: entity
-  parent: [BaseSecurityPDA, BasePDA]
+  parent: BaseSecurityPDA
   id: SeniorOfficerPDA
   name: senior officer PDA
   description: Beaten, battered and broken, but just barely useable.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
fixes #32393 
set parent of BaseSecurityPDA to BasePDA and change some double parenting

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix + cleanup

## Technical details
<!-- Summary of code changes for easier review. -->
explained in about

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
no

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
no

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Cadet PDA now has wanted list cartridge preinstalled.