### PR TITLE
Fix OOC not re-enabling if restartroundnow is used

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -122,6 +122,7 @@ public sealed partial class ChatSystem : SharedChatSystem
                     _configurationManager.SetCVar(CCVars.OocEnabled, false);
                 break;
             case GameRunLevel.PostRound:
+            case GameRunLevel.PreRoundLobby:
                 if (!_configurationManager.GetCVar(CCVars.OocEnableDuringRound))
                     _configurationManager.SetCVar(CCVars.OocEnabled, true);
                 break;


### PR DESCRIPTION
The ChatSystem code for re-enabling OOC only ran during PostRound, which gets skipped over when doing restartroundnow. Now it does this on PreRoundLobby too.
