### PR TITLE
lower frezon/n2o sale prices, make frezon take more trit

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -233,7 +233,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     1 mol of Tritium is required per X mol of oxygen.
         /// </summary>
-        public const float FrezonProductionTritRatio = 50.0f;
+        public const float FrezonProductionTritRatio = 8.0f;
 
         /// <summary>
         ///     1 / X of the tritium is converted into Frezon each tick

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -86,7 +86,7 @@
   molarMass: 44
   color: 8F00FF
   reagent: NitrousOxide
-  pricePerMole: 1
+  pricePerMole: 0.1
 
 - type: gas
   id: 8
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 3
+  pricePerMole: 0.3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixes #32404 (note that the amount of money portrayed in that shift is a pretty significant outlier owed to atmos and cargo having good luck and being competent), effectively reverts #25608

reduces frezon prices back to what they were before, agreed upon by me and notafet

increases tritium:oxygen ratio from 1:50 to 1:8

## Why / Balance
frezon and n2o let atmos make cargo way too much money, this should keep it to reasonable figures

note that those figures have been used before and they worked well

the increase of the trit:oxygen ratio will cause atmos to actually have to buy plasma canisters from cargo, and will slow down frezon production due to an oxygen bottleneck; additionally, plasma canisters cost a lot and this will deduct much of the frezon profits

i did some approximate basic calculations, and in an ideal case (unlikely to ever be reached), atmos could at most make ~50k per shift with those values if they act perfectly, their burn chamber is unrealistically efficient, and the station doesn't need any air; real figures are likely to be closer to 20-30k per shift with cargo's cooperation

## Media
untested

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Atmos gas sell prices significantly lowered.
- tweak: Frezon now consumes significantly more tritium to produce.