### PR TITLE
fix paper staying on fire forever

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -35,9 +35,7 @@
   - type: PaperVisuals
   - type: Flammable
     fireSpread: true
-    canResistFire: false
     alwaysCombustible: true
-    canExtinguish: false # Mwahaha! Let the world burn because of one piece of paper!
     damage:
       types:
         Heat: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
what it says on the tin
fixes https://github.com/DeltaV-Station/Delta-v/issues/1325 and https://github.com/space-wizards/space-station-14/issues/32081

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Paper being able to stay on fire forever, even in vacuum, is just stupid. I think the intention here was that documents being set on fire will always turn to ash but it clearly doesn't work anyways and maybe with a proper FlammableSystem refactor this could be brought back.


## Technical details
<!-- Summary of code changes for easier review. -->
removes two lines of yaml, canResistFire already defaults to false and canExtinguish to true

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
no

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Paper will no longer stay on fire indefinitely.

