### PR TITLE
remove thief figurine objective

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/figurines.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/figurines.yml
@@ -17,8 +17,6 @@
   - type: Tag
     tags:
     - Figurine
-  - type: StealTarget
-    stealGroup: Figurines
   - type: UseDelay
     delay: 10
   - type: Speech

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -63,7 +63,6 @@
     StampStealCollectionObjective: 1
     DoorRemoteStealCollectionObjective: 1
     TechnologyDiskStealCollectionObjective: 1        #rnd
-    FigurineStealCollectionObjective: 0.3          #service
     IDCardsStealCollectionObjective: 1
     LAMPStealCollectionObjective: 2 #only for moth
 

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -87,13 +87,6 @@
 # Thief Collection
 
 - type: stealTargetGroup
-  id: Figurines
-  name: steal-target-groups-figurines
-  sprite:
-    sprite: Objects/Fun/figurines.rsi
-    state: figurine_spawner
-
-- type: stealTargetGroup
   id: HeadCloak
   name: steal-target-groups-heads-cloaks
   sprite:

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -59,8 +59,6 @@
   components:
   - type: StealCondition
     stealGroup: Figurines
-    minCollectionSize: 10
-    maxCollectionSize: 18 #will be limited to the number of figures on the station anyway.
   - type: Objective
     difficulty: 0.25
 

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -55,15 +55,6 @@
 
 - type: entity
   parent: BaseThiefStealCollectionObjective
-  id: FigurineStealCollectionObjective
-  components:
-  - type: StealCondition
-    stealGroup: Figurines
-  - type: Objective
-    difficulty: 0.25
-
-- type: entity
-  parent: BaseThiefStealCollectionObjective
   id: HeadCloakStealCollectionObjective
   components:
   - type: StealCondition


### PR DESCRIPTION
## About the PR
15-18 -> 0

## Why / Balance
there are 2 issues the insane number had:
- before thieving beacon was a thing youd also **have** to make yourself a bag of holding because its physically impossible to hold them all, not even accounting for any other objectives you might have
- **its not stealing**, you just order 10 grand of figurines at cargo and they either metagame you as a thief or dont give a shit. bonus points if you work for cargo then you are literally just buying yourself a treat. this is not stealing
- no map has 15 figurines mapped and the objective shouldnt rely on a certain map being rolled that has them placed willy nilly

i have no idea how this has been a thing for so long

**Changelog**
:cl:
- remove: Removed the thief figurines objective.
