### PR TITLE
Blunt damage will do stamina damage on wide attacks

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -658,6 +658,12 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
             if (damageResult != null && damageResult.GetTotal() > FixedPoint2.Zero)
             {
+                // If the target has stamina and is taking blunt damage, they should also take stamina damage based on their blunt to stamina factor
+                if (damageResult.DamageDict.TryGetValue("Blunt", out var bluntDamage))
+                {
+                    _stamina.TakeStaminaDamage(entity, (bluntDamage * component.BluntStaminaDamageFactor).Float(), visual: false, source: user, with: meleeUid == user ? null : meleeUid);
+                }
+
                 appliedDamage += damageResult;
 
                 if (meleeUid == user)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added stamina damage to right click wide arc attacks that do blunt damage

## Why / Balance
Think it was a bug that blunt didn't do stamina on wide attacks, it's reported as a bug in https://github.com/space-wizards/space-station-14/issues/31693

Buffing wide against single is maybe kinda bad, but I think blunt should still do stamina in wide to keep blunt x pierce x cut balanced, and because it's unintuitive that it don't. Wide x single should be balanced in other ways.

This might be relevant to the new medical as it changes code dealing with damage. 

## Technical details
Just added a few lines checking for blunt damage and applying stamina damage to wide attacks, pretty similar to what single attacks had. in shared melee weapons system

## Media

https://github.com/user-attachments/assets/df35ad5c-e4d1-4ebe-8999-ebe9edfb5543

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: wide attacks that deal blunt damage will now deal stamina damage.
