### PR TITLE
Change the syndicate charge to start a timer on signal

### DIFF
--- a/Content.Server/Explosion/Components/TimerStartOnSignalComponent.cs
+++ b/Content.Server/Explosion/Components/TimerStartOnSignalComponent.cs
@@ -1,0 +1,15 @@
+using Content.Shared.DeviceLinking;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.Explosion.Components
+{
+    /// <summary>
+    /// Sends a trigger when signal is received.
+    /// </summary>
+    [RegisterComponent]
+    public sealed partial class TimerStartOnSignalComponent : Component
+    {
+        [DataField("port", customTypeSerializer: typeof(PrototypeIdSerializer<SinkPortPrototype>))]
+        public string Port = "Timer";
+    }
+}

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.Signal.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.Signal.cs
@@ -11,6 +11,9 @@ namespace Content.Server.Explosion.EntitySystems
         {
             SubscribeLocalEvent<TriggerOnSignalComponent,SignalReceivedEvent>(OnSignalReceived);
             SubscribeLocalEvent<TriggerOnSignalComponent,ComponentInit>(OnInit);
+
+            SubscribeLocalEvent<TimerStartOnSignalComponent,SignalReceivedEvent>(OnTimerSignalReceived);
+            SubscribeLocalEvent<TimerStartOnSignalComponent,ComponentInit>(OnTimerSignalInit);
         }
 
         private void OnSignalReceived(EntityUid uid, TriggerOnSignalComponent component, ref SignalReceivedEvent args)
@@ -21,6 +24,18 @@ namespace Content.Server.Explosion.EntitySystems
             Trigger(uid, args.Trigger);
         }
         private void OnInit(EntityUid uid, TriggerOnSignalComponent component, ComponentInit args)
+        {
+            _signalSystem.EnsureSinkPorts(uid, component.Port);
+        }
+
+        private void OnTimerSignalReceived(EntityUid uid, TimerStartOnSignalComponent component, ref SignalReceivedEvent args)
+        {
+            if (args.Port != component.Port)
+                return;
+
+            StartTimer(uid, args.Trigger);
+        }
+        private void OnTimerSignalInit(EntityUid uid, TimerStartOnSignalComponent component, ComponentInit args)
         {
             _signalSystem.EnsureSinkPorts(uid, component.Port);
         }

--- a/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
@@ -28,6 +28,9 @@ signal-port-description-doorbolt = Bolts door when HIGH.
 signal-port-name-trigger = Trigger
 signal-port-description-trigger = Triggers some mechanism on the device.
 
+signal-port-name-timer = Timer
+signal-port-description-timer = Starts the timer countdown of the device.
+
 signal-port-name-order-sender = Order sender
 signal-port-description-order-sender = Cargo console order sender
 

--- a/Resources/Prototypes/DeviceLinking/sink_ports.yml
+++ b/Resources/Prototypes/DeviceLinking/sink_ports.yml
@@ -49,6 +49,11 @@
   description: signal-port-description-trigger
 
 - type: sinkPort
+  id: Timer
+  name: signal-port-name-timer
+  description: signal-port-description-timer
+
+- type: sinkPort
   id: OrderReceiver
   name: signal-port-name-order-receiver
   description: signal-port-description-order-receiver

--- a/Resources/Prototypes/DeviceLinking/source_ports.yml
+++ b/Resources/Prototypes/DeviceLinking/source_ports.yml
@@ -2,13 +2,13 @@
   id: Pressed
   name: signal-port-name-pressed
   description: signal-port-description-pressed
-  defaultLinks: [ Toggle, Trigger ]
+  defaultLinks: [ Toggle, Trigger, Timer ]
 
 - type: sourcePort
   id: On
   name: signal-port-name-on-transmitter
   description: signal-port-description-on-transmitter
-  defaultLinks: [ On, Open, Forward, Trigger ]
+  defaultLinks: [ On, Open, Forward, Trigger, Timer ]
 
 - type: sourcePort
   id: Off
@@ -25,13 +25,13 @@
   id: Left
   name: signal-port-name-left
   description: signal-port-description-left
-  defaultLinks: [ On, Open, Forward, Trigger ]
+  defaultLinks: [ On, Open, Forward, Trigger, Timer ]
 
 - type: sourcePort
   id: Right
   name: signal-port-name-right
   description: signal-port-description-right
-  defaultLinks: [ On, Open, Reverse, Trigger ]
+  defaultLinks: [ On, Open, Reverse, Trigger, Timer ]
 
 - type: sourcePort
   id: Middle
@@ -76,7 +76,7 @@
   id: Timer
   name: signal-port-name-timer-trigger
   description: signal-port-description-timer-trigger
-  defaultLinks: [ AutoClose, On, Open, Forward, Trigger ]
+  defaultLinks: [ AutoClose, On, Open, Forward, Trigger, Timer ]
 
 - type: sourcePort
   id: Start
@@ -94,7 +94,7 @@
   id: OutputHigh
   name: signal-port-name-logic-output-high
   description: signal-port-description-logic-output-high
-  defaultLinks: [ On, Open, Forward, Trigger ]
+  defaultLinks: [ On, Open, Forward, Trigger, Timer ]
 
 - type: sourcePort
   id: OutputLow

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -54,10 +54,10 @@
     beepSound: /Audio/Machines/Nuke/general_beep.ogg
     startOnStick: true
     canToggleStartOnStick: true
-  - type: TriggerOnSignal
+  - type: TimerStartOnSignal
   - type: DeviceLinkSink
     ports:
-      - Trigger
+      - Timer
   - type: Explosive # Powerful explosion in a very small radius. Doesn't break underplating.
     explosionType: DemolitionCharge
     totalIntensity: 60


### PR DESCRIPTION
## About the PR
Made the charge start the timer countdown, rather than getting detonated instantly

Mutually exclusive with #32429 that instead changes minibomb to start the timer, but keeps C4 instant. For maximum fun, consider them non-exclusive.

## Why / Balance
Minibomb + C4 can not be dodged, predicted or counterplayed by any way other than extreme paranoia towards anyone being nearby. If the instant detonation succeeds, which depends on item dropping skills of the player and the target being in the right spot (e.g. distracted by roleplaying and typing), the target will be not just killed but completely gibbed. This shouldn't be something that any traitor can do with a minibomb after spending just extra 2 TC. At this point just give them a one-time-use throwable instagib Throngler for 8 TC. Same deal.

It affects the instant C4 strategy of nukies, but pre-cooking the C4 sounds pretty doable. Does make it less of an instant grenade though.

Alternative to this PR would be to give the minibomb way more explosive resistance, make it start a timer when damaged by an explosion, and just completely break without explosion if it gets damaged to destruction. Rather than the current behavior of deleting itself explosively.

## Technical details
Feels like shitcode, basically copy-paste of the existing `TriggerOnSignalComponent` code, but with `StartTimer` instead of `Trigger`. Unsure if I got the `EntityUid user` right for that method though. Also added new localisation strings, woo!

## Media
It's visually minimal but can attach a recording later.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Syndicate C4 now starts a countdown on signal, rather than exploding instantly.