### PR TITLE
Make the explosions throw the container/item they originated from

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -488,9 +488,12 @@ public sealed partial class ExplosionSystem
             && physics.BodyType == BodyType.Dynamic)
         {
             var pos = _transformSystem.GetWorldPosition(xform);
+            var dir = pos - epicenter.Position;
+            if (dir.IsLengthZero())
+                dir = _robustRandom.NextVector2().Normalized();
             _throwingSystem.TryThrow(
                 uid,
-                 pos - epicenter.Position,
+                dir,
                 physics,
                 xform,
                 _projectileQuery,


### PR DESCRIPTION
## About the PR
Makes the containers containing an explosive (and maybe the explosive itself if it's multitrigger? didn't test) fly away from the epicenter in a random direction.

## Why / Balance
Container bombs leave a weirdly still container at the exact spot things detonated. Also if something manages to explode second time, it will happen in an entirely different spot than the first explosion.

## Technical details
In explosion throw direction processing code, adds a check for null vector. Generates a random one of normalized magnitude if it is null.

## Media
Tested with another edit that makes minibomb not go off right away:

https://github.com/user-attachments/assets/f36482fb-81bd-4fb2-9891-486bdd04534c

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: Explosives throw a container they are in