### PR TITLE
Change minibomb to be explosion resistant and start timer on damage

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/TimerStartBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/TimerStartBehavior.cs
@@ -1,0 +1,10 @@
+﻿namespace Content.Server.Destructible.Thresholds.Behaviors;
+
+[DataDefinition]
+public sealed partial class TimerStartBehavior : IThresholdBehavior
+{
+    public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
+    {
+        system.TriggerSystem.StartTimer(owner, cause);
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -106,6 +106,21 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Grenades/syndgrenade.rsi
+  - type: ExplosionResistance
+    damageCoefficient: 0.1
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:TimerStartBehavior
+    - trigger:
+        !type:DamageTrigger
+        damage: 20
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
   - type: OnUseTimerTrigger
     delay: 5
   - type: ExplodeOnTrigger

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -117,8 +117,9 @@
       - !type:TimerStartBehavior
     - trigger:
         !type:DamageTrigger
-        damage: 20
+        damage: 45
       behaviors:
+      - !type:TriggerBehavior
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: OnUseTimerTrigger


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Prevents C4+Minibomb combo from being instant and impossible to do anything about without excessive paranoia. Same idea as #32423, but done from the other end. Mutually exclusive with it, unless maintainers will want to go for maximum fun.

For even more fun, see #32428 that makes the container fly into a random direction before the second explosion.

## Why / Balance
See #32423, but without the note about nukies. Instagib throwable shouldn't be near impossible to counterplay *in an RP game full of distractions lasting 5+ seconds*. This isn't a twitch shooter.

## Technical details
Creates a new damage threshold behavior that works on explosives and causes them to start counting down. In combination with extreme explosive resistance, this allows for a bomb that's not deleted and is counting down, after being triggered by another explosive. Current version of this PR only does this to minibomb, though. So no funny business with C4, unless someone requests that. Also it will just disappear without exploding if damaged too much. Gotta be careful!

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: Minibomb is now explosion resistant and will start counting down if damaged by a C4
