### PR TITLE
Fix contraband never getting added to vend inventory

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineContrabandWireAction.cs
+++ b/Content.Server/VendingMachines/VendingMachineContrabandWireAction.cs
@@ -7,10 +7,19 @@ namespace Content.Server.VendingMachines;
 [DataDefinition]
 public sealed partial class VendingMachineContrabandWireAction : BaseToggleWireAction
 {
+    private VendingMachineSystem _vendingMachineSystem = default!;
+
     public override Color Color { get; set; } = Color.Green;
     public override string Name { get; set; } = "wire-name-vending-contraband";
     public override object? StatusKey { get; } = ContrabandWireKey.StatusKey;
     public override object? TimeoutKey { get; } = ContrabandWireKey.TimeoutKey;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _vendingMachineSystem = EntityManager.System<VendingMachineSystem>();
+    }
 
     public override StatusLightState? GetLightState(Wire wire)
     {
@@ -28,7 +37,7 @@ public sealed partial class VendingMachineContrabandWireAction : BaseToggleWireA
     {
         if (EntityManager.TryGetComponent(owner, out VendingMachineComponent? vending))
         {
-            vending.Contraband = !setting;
+            _vendingMachineSystem.SetContraband(owner, !vending.Contraband, vending);
         }
     }
 

--- a/Content.Server/VendingMachines/VendingMachineContrabandWireAction.cs
+++ b/Content.Server/VendingMachines/VendingMachineContrabandWireAction.cs
@@ -5,35 +5,40 @@ using Content.Shared.Wires;
 namespace Content.Server.VendingMachines;
 
 [DataDefinition]
-public sealed partial class VendingMachineContrabandWireAction : BaseToggleWireAction
+public sealed partial class VendingMachineContrabandWireAction : ComponentWireAction<VendingMachineComponent>
 {
+    private VendingMachineSystem _vendingMachineSystem = default!;
+
     public override Color Color { get; set; } = Color.Green;
     public override string Name { get; set; } = "wire-name-vending-contraband";
     public override object? StatusKey { get; } = ContrabandWireKey.StatusKey;
-    public override object? TimeoutKey { get; } = ContrabandWireKey.TimeoutKey;
+    // TODO probably gonna need this for the pulse action? delete otherwise
+    //public override object? TimeoutKey { get; } = ContrabandWireKey.TimeoutKey;
 
-    public override StatusLightState? GetLightState(Wire wire)
+    public override void Initialize()
     {
-        if (EntityManager.TryGetComponent(wire.Owner, out VendingMachineComponent? vending))
-        {
-            return vending.Contraband
-                ? StatusLightState.BlinkingSlow
-                : StatusLightState.On;
-        }
+        base.Initialize();
 
-        return StatusLightState.Off;
+        _vendingMachineSystem = EntityManager.System<VendingMachineSystem>();
     }
 
-    public override void ToggleValue(EntityUid owner, bool setting)
+    public override StatusLightState? GetLightState(Wire wire, VendingMachineComponent component)
+        => component.Contraband ? StatusLightState.BlinkingSlow : StatusLightState.On;
+
+    public override bool Cut(EntityUid user, Wire wire, VendingMachineComponent component)
     {
-        if (EntityManager.TryGetComponent(owner, out VendingMachineComponent? vending))
-        {
-            vending.Contraband = !setting;
-        }
+        _vendingMachineSystem.SetContraband(wire.Owner, true, component);
+        return true;
     }
 
-    public override bool GetValue(EntityUid owner)
+    public override bool Mend(EntityUid user, Wire wire, VendingMachineComponent component)
     {
-        return EntityManager.TryGetComponent(owner, out VendingMachineComponent? vending) && !vending.Contraband;
+        _vendingMachineSystem.SetContraband(wire.Owner, false, component);
+        return true;
+    }
+
+    public override void Pulse(EntityUid user, Wire wire, VendingMachineComponent component)
+    {
+        throw new NotImplementedException(); // TODO
     }
 }

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -192,6 +192,18 @@ namespace Content.Server.VendingMachines
             component.CanShoot = canShoot;
         }
 
+        /// <summary>
+        /// Sets the <see cref="VendingMachineComponent.Contraband"/> property of the vending machine.
+        /// </summary>
+        public void SetContraband(EntityUid uid, bool contraband, VendingMachineComponent? component = null)
+        {
+            if (!Resolve(uid, ref component))
+                return;
+
+            component.Contraband = contraband;
+            Dirty(uid, component);
+        }
+
         public void Deny(EntityUid uid, VendingMachineComponent? vendComponent = null)
         {
             if (!Resolve(uid, ref vendComponent))

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -192,6 +192,15 @@ namespace Content.Server.VendingMachines
             component.CanShoot = canShoot;
         }
 
+        public void SetContraband(EntityUid uid, bool contraband, VendingMachineComponent? component = null)
+        {
+            if (!Resolve(uid, ref component))
+                return;
+
+            component.Contraband = contraband;
+            Dirty(uid, component);
+        }
+
         public void Deny(EntityUid uid, VendingMachineComponent? vendComponent = null)
         {
             if (!Resolve(uid, ref vendComponent))

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -192,15 +192,6 @@ namespace Content.Server.VendingMachines
             component.CanShoot = canShoot;
         }
 
-        public void SetContraband(EntityUid uid, bool contraband, VendingMachineComponent? component = null)
-        {
-            if (!Resolve(uid, ref component))
-                return;
-
-            component.Contraband = contraband;
-            Dirty(uid, component);
-        }
-
         public void Deny(EntityUid uid, VendingMachineComponent? vendComponent = null)
         {
             if (!Resolve(uid, ref vendComponent))

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -41,6 +41,7 @@ namespace Content.Shared.VendingMachines
         [DataField, AutoNetworkedField]
         public Dictionary<string, VendingMachineInventoryEntry> ContrabandInventory = new();
 
+        [DataField, AutoNetworkedField]
         public bool Contraband;
 
         public bool Ejecting;

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -41,7 +41,6 @@ namespace Content.Shared.VendingMachines
         [DataField, AutoNetworkedField]
         public Dictionary<string, VendingMachineInventoryEntry> ContrabandInventory = new();
 
-        [DataField, AutoNetworkedField]
         public bool Contraband;
 
         public bool Ejecting;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes #32421

## Technical details
The old code updated the server component, but not the client component. To ensure the values stay synced, instead of setting the component directly in the action, the action now calls a setter on the system, similarly to how CanShoot is set.

Other actions were not affected by this bug probably because all of them are event based. Emagging is event based and runs through a completely different pipeline which updates both components. But building the vend inventory happens in the shared system, and uses the client side component for it, leading to this bug.

## Media
https://github.com/user-attachments/assets/61c73c75-26d7-47d2-a052-1947eb97c7f7


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Vending machines can be hacked again.
