### PR TITLE
Fix cartesian explosion in pref loading

### DIFF
--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -52,7 +52,7 @@ namespace Content.Server.Database
                     .ThenInclude(h => h.Loadouts)
                     .ThenInclude(l => l.Groups)
                     .ThenInclude(group => group.Loadouts)
-                .AsSingleQuery()
+                .AsSplitQuery()
                 .SingleOrDefaultAsync(p => p.UserId == userId.UserId, cancel);
 
             if (prefs is null)


### PR DESCRIPTION
Lol .AsSingleQuery().

Some people's preferences wouldn't load on Lizard. Turns out the entire preferences set is loaded with a morbillion joins in a single query and one person had 240,000 (!!!) rows returned for their preferences query. Yeah.

:cl:
- fix: Fixed some people's preferences taking ages to load, hopefully.