### PR TITLE
Add Nuclear Cola centrifuge recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -777,14 +777,10 @@
     NuclearCola:
       amount: 10 # assuming we loose all o2 released as gas in the centrifugal process
   products:
-    Ipecac:
-      amount: 2
-    Water:
-      amount: 2
-    Sugar:
-      amount: 2
-    Uranium:
-      amount: 1
+    Ipecac: 2
+    Water: 2
+    Sugar: 2
+    Uranium: 1
 
 - type: reaction
   id: Patron

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -769,6 +769,20 @@
     NuclearCola: 5
 
 - type: reaction
+  id: NuclearColaBreakdown
+  source: true
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    NuclearCola:
+      amount: 10
+  products:
+    Cola:
+      amount: 9
+    Uranium:
+      amount: 1
+
+- type: reaction
   id: Patron
   requiredMixerCategories:
   - Shake

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -775,10 +775,14 @@
   - Centrifuge
   reactants:
     NuclearCola:
-      amount: 10
+      amount: 10 # assuming we loose all o2 released as gas in the centrifugal process
   products:
-    Cola:
-      amount: 9
+    Ipecac:
+      amount: 2
+    Water:
+      amount: 2
+    Sugar:
+      amount: 2
     Uranium:
       amount: 1
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Added a recipe that allows anyone to turn Nuclear Cola into some of it's constituent parts. This recipe does require the use of the centrifuge. 

## Why / Balance

I was playing bartender one day and I had the fake nuke with the tap on the side which dispenses Nuclear Cola. I wished there was something more I could do with that. This now adds the ability for robust bartenders to get themselves a little uranium they could then reuse in other drinks with the help of a friendly chemist. Chemists also get a little bit of Ipecac out of it (which is used in the original cola recipe) so they might opt to use this technique as well. 

Bartenders in real life do actually use centrifuges to refine their ingredients, especially the really experienced ones. It can be a great way to isolate certain flavors and ingredients. 

I do plan to add more recipes like this, and maybe even map some centrifuges into bars in the future. I won't expand these to every single drink, since not only is that exhausting, it's also a little ridiculous. I would like to see it added to a hand full of drinks that use really valuable ingredients which are usually difficult for bartenders to obtain. The idea is not to be feature complete or anything, but more to provide ways to use things that tend to exist on stations by default to augment your bartending. 

The reaction is
| Input | | Output |
| :--- | :---: | :--- |
| 10 Nuclear Cola | -> | 2 Ipecac |
| | | 2 Water |
| | | 2 Sugar |
| | | 1 Uranium |

I went with this recipe because I didn't want to just remove the cola entirely, so instead I figured it should break down as well. This does introduce a bit of a funny situation where regular cola can't be broken down but nuclear cola can. I can add that as a recipe if that's seen as an issue. Regular cola is equal parts Ipecac, Oxygen, Water, and Sugar. I'm assuming that the Ipecac and Oxygen are supposed to react to form C02 (for carbonation) and the flavor. I decided to just pretend the Oxygen is lost as a gas during the centrifugal process. 

Also you will notice that you get out half the Uranium you put in, this is to help prevent any sort of accidental infinite uranium glitch in the future. I could adjust the values if that is seen as a concern. 

## Technical details

Added a new recipe in `Resources/Prototypes/Recipes/Reactions/drinks.yml` which causes Nuclear Cola to break down into some of it's constituent parts. 

## Media

https://github.com/user-attachments/assets/153c96c5-7117-419a-b394-982b660acb92

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

None that I know of.

**Changelog**

:cl: Southbridge
- add: Nuclear Cola can now be broken down in a centrifuge.

