### PR TITLE
Skull Helm Hand Sprite now turns

### DIFF
--- a/Resources/Textures/Clothing/Head/Helmets/bone_helmet.rsi/meta.json
+++ b/Resources/Textures/Clothing/Head/Helmets/bone_helmet.rsi/meta.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "inhand-right",
-      "direction": 4
+      "directions": 4
     }
   ]
 }


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Skull Helm Hand Sprite now turns correctly.
fixes #30979

## Why / Balance
It was broken before.

## Technical details
I fixed a typo in the bone helmet's meta.json so it now rotates correctly when held in the right hand.

## Media
![1](https://github.com/user-attachments/assets/19475877-b86d-4353-a88f-3a52b58b226e)
![2](https://github.com/user-attachments/assets/522ca3f1-6589-4a07-9f5e-131c18cccb28)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
