### PR TITLE
make conveyor belt assemblies cheaper

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/cargo.yml
@@ -3,7 +3,7 @@
   result: ConveyorBeltAssembly
   completetime: 4
   materials:
-    Steel: 500
+    Steel: 250
     Plastic: 50
 
 - type: latheRecipe


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
5 steel -> 2.5 steel

## Why / Balance
5 steel seems expensive since you will generally want to place many belts

## Media
untested

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Steel cost of conveyor belt assemblies halved.
