### PR TITLE
Ensure wires can always be cut

### DIFF
--- a/Content.Server/Wires/ComponentWireAction.cs
+++ b/Content.Server/Wires/ComponentWireAction.cs
@@ -22,13 +22,14 @@ public abstract partial class ComponentWireAction<TComponent> : BaseWireAction w
     public override bool Cut(EntityUid user, Wire wire)
     {
         base.Cut(user, wire);
-        return EntityManager.TryGetComponent(wire.Owner, out TComponent? component) && Cut(user, wire, component);
+        // if the entity doesn't exist, we need to return true otherwise the wire sprite is never updated
+        return EntityManager.TryGetComponent(wire.Owner, out TComponent? component) ? Cut(user, wire, component) : true;
     }
 
     public override bool Mend(EntityUid user, Wire wire)
     {
         base.Mend(user, wire);
-        return EntityManager.TryGetComponent(wire.Owner, out TComponent? component) && Mend(user, wire, component);
+        return EntityManager.TryGetComponent(wire.Owner, out TComponent? component) ? Mend(user, wire, component) : true;
     }
 
     public override void Pulse(EntityUid user, Wire wire)


### PR DESCRIPTION
## About the PR
Fixes #32433

## Why / Balance
Currently only the sound plays when the player clicks on these useless wires, which makes it feel like something is supposed to happen but doesn't. With this change now the wire will get cut/mended properly, even if they don't do anything.

It's possible the issue is the wiring appearing at all for nonexistent components, but I haven't looked into it too deeply. Regardless this PR could provide a fallback interaction in case wires like this happen again in the future.

## Technical details
When the cut action is executed, a bool is returned and the wire's cut state is updated based on that. If the vending machine did not have an associated component for it, this would always return false. If the component exists it can still return false if the associated Cut method can return false. Now if the component does not exist, it always returns true.

## Media
In this example the AtmosDrobe has an AccessComponent, while the ClothesMate does not. I messed with the AtmosDrobe first to show that it still functions as expected.

https://github.com/user-attachments/assets/2eb2f8a6-1c29-48ec-91fb-5aa67d83130c


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Useless wires some vending machines have can be cut now.

