### PR TITLE
fix resolve in ChangeHeat

### DIFF
--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -130,7 +130,7 @@ public sealed class TemperatureSystem : EntitySystem
     public void ChangeHeat(EntityUid uid, float heatAmount, bool ignoreHeatResistance = false,
         TemperatureComponent? temperature = null)
     {
-        if (!Resolve(uid, ref temperature))
+        if (!Resolve(uid, ref temperature, false))
             return;
 
         if (!ignoreHeatResistance)
@@ -311,7 +311,7 @@ public sealed class TemperatureSystem : EntitySystem
 
     private void ChangeTemperatureOnCollide(Entity<ChangeTemperatureOnCollideComponent> ent, ref ProjectileHitEvent args)
     {
-        _temperature.ChangeHeat(args.Target, ent.Comp.Heat, ent.Comp.IgnoreHeatResistance);// adjust the temperature 
+        _temperature.ChangeHeat(args.Target, ent.Comp.Heat, ent.Comp.IgnoreHeatResistance);// adjust the temperature
     }
 
     private void OnParentChange(EntityUid uid, TemperatureComponent component,


### PR DESCRIPTION
## About the PR
Fixes another heisentest, happening when a Watcher is spawned in SpawnAndDeleteAllEntitiesInTheSameSpot and its projectile  hits an object like a wall without the TemperatureComponent. See this stack trace:
```
2024-09-25T22:52:32.0636233Z Starting test execution, please wait...
2024-09-25T22:52:32.0865736Z A total of 1 test files matched the specified pattern.
2024-09-25T22:55:43.4418978Z   Failed SpawnAndDeleteAllEntitiesInTheSameSpot [26 s]
2024-09-25T22:55:43.4420084Z   Error Message:
2024-09-25T22:55:43.4422685Z    SERVER: 26.897s [ERRO] system.temperature: Can't resolve "Content.Server.Temperature.Components.TemperatureComponent" on entity luminous object (754) (36799/n36799, MobLuminousObject)!
2024-09-25T22:55:43.4424479Z    at System.Environment.get_StackTrace()
2024-09-25T22:55:43.4452397Z    at Content.Server.Temperature.Systems.TemperatureSystem.ChangeHeat(EntityUid uid, Single heatAmount, Boolean ignoreHeatResistance, TemperatureComponent temperature) in /home/runner/work/space-station-14/space-station-14/Content.Server/Temperature/Systems/TemperatureSystem.cs:line 133
2024-09-25T22:55:43.4460876Z    at Content.Server.Temperature.Systems.TemperatureSystem.ChangeTemperatureOnCollide(Entity`1 ent, ProjectileHitEvent& args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Temperature/Systems/TemperatureSystem.cs:line 314
2024-09-25T22:55:43.4468237Z    at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass57_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 324
2024-09-25T22:55:43.4499884Z    at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass67_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 460
2024-09-25T22:55:43.4504481Z    at Robust.Shared.GameObjects.EntityEventBus.EntDispatch(EntityUid euid, Type eventType, Unit& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 633
2024-09-25T22:55:43.4509445Z    at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEventCore(EntityUid uid, Unit& unitRef, Type type, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 240
2024-09-25T22:55:43.4514122Z    at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 218
2024-09-25T22:55:43.4518730Z    at Robust.Shared.GameObjects.EntitySystem.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystem.cs:line 170
2024-09-25T22:55:43.4523670Z    at Content.Server.Projectiles.ProjectileSystem.OnStartCollide(EntityUid uid, ProjectileComponent component, StartCollideEvent& args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Projectiles/ProjectileSystem.cs:line 45
2024-09-25T22:55:43.4528883Z    at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass56_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 305
2024-09-25T22:55:43.4533218Z    at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass67_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 460
2024-09-25T22:55:43.4537068Z    at Robust.Shared.GameObjects.EntityEventBus.EntDispatch(EntityUid euid, Type eventType, Unit& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 633
2024-09-25T22:55:43.4541192Z    at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEventCore(EntityUid uid, Unit& unitRef, Type type, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 240
2024-09-25T22:55:43.4578441Z    at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 218
2024-09-25T22:55:43.4583004Z    at Robust.Shared.GameObjects.EntitySystem.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystem.cs:line 170
2024-09-25T22:55:43.4608848Z    at Robust.Shared.Physics.Systems.SharedPhysicsSystem.CollideContacts() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs:line 563
2024-09-25T22:55:43.4613056Z    at Robust.Shared.Physics.Systems.SharedPhysicsSystem.SimulateWorld(Single deltaTime, Boolean prediction) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs:line 302
2024-09-25T22:55:43.4617448Z    at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 265
2024-09-25T22:55:43.4621722Z    at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 196
2024-09-25T22:55:43.4625419Z    at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 704
2024-09-25T22:55:43.4629230Z    at Robust.UnitTesting.RobustIntegrationTest.IntegrationGameLoop.SingleThreadRunUntilEmpty() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 1098
2024-09-25T22:55:43.4633013Z    at Robust.UnitTesting.RobustIntegrationTest.IntegrationGameLoop.Run() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 1085
2024-09-25T22:55:43.4636604Z    at Robust.UnitTesting.RobustIntegrationTest.ServerIntegrationInstance._serverMain() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 656
2024-09-25T22:55:43.4639653Z    at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state) Exception: 
2024-09-25T22:55:43.4641038Z   Stack Trace:
2024-09-25T22:55:43.4643067Z      at Content.IntegrationTests.PoolTestLogHandler.Log(String sawmillName, LogEvent message) in /home/runner/work/space-station-14/space-station-14/Content.IntegrationTests/PoolTestLogHandler.cs:line 66
2024-09-25T22:55:43.4646917Z    at Robust.Shared.Log.LogManager.Sawmill.LogInternal(String sourceSawmill, LogEvent message) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Log/LogManager.Sawmill.cs:line 106
2024-09-25T22:55:43.4650785Z    at Robust.Shared.Log.LogManager.Sawmill.LogInternal(String sourceSawmill, LogEvent message) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Log/LogManager.Sawmill.cs:line 125
2024-09-25T22:55:43.4654424Z    at Robust.Shared.Log.LogManager.Sawmill.LogInternal(String sourceSawmill, LogEvent message) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Log/LogManager.Sawmill.cs:line 125
2024-09-25T22:55:43.4658228Z    at Robust.Shared.Log.LogManager.Sawmill.Log(LogLevel level, String message, Object[] args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Log/LogManager.Sawmill.cs:line 96
2024-09-25T22:55:43.4661618Z    at Robust.Shared.Log.LogManager.Sawmill.Error(String message) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Log/LogManager.Sawmill.cs:line 174
2024-09-25T22:55:43.4665734Z    at Content.Server.Temperature.Systems.TemperatureSystem.ChangeHeat(EntityUid uid, Single heatAmount, Boolean ignoreHeatResistance, TemperatureComponent temperature) in /home/runner/work/space-station-14/space-station-14/Content.Server/Temperature/Systems/TemperatureSystem.cs:line 133
2024-09-25T22:55:43.4670594Z    at Content.Server.Temperature.Systems.TemperatureSystem.ChangeTemperatureOnCollide(Entity`1 ent, ProjectileHitEvent& args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Temperature/Systems/TemperatureSystem.cs:line 314
2024-09-25T22:55:43.4675519Z    at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass57_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 324
2024-09-25T22:55:43.4680257Z    at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass67_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 460
2024-09-25T22:55:43.4684518Z    at Robust.Shared.GameObjects.EntityEventBus.EntDispatch(EntityUid euid, Type eventType, Unit& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 633
2024-09-25T22:55:43.4688953Z    at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEventCore(EntityUid uid, Unit& unitRef, Type type, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 240
2024-09-25T22:55:43.4693390Z    at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 218
2024-09-25T22:55:43.4697762Z    at Robust.Shared.GameObjects.EntitySystem.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystem.cs:line 170
2024-09-25T22:55:43.4701964Z    at Content.Server.Projectiles.ProjectileSystem.OnStartCollide(EntityUid uid, ProjectileComponent component, StartCollideEvent& args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Projectiles/ProjectileSystem.cs:line 45
2024-09-25T22:55:43.4706546Z    at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass56_0`2.<SubscribeLocalEvent>g__EventHandler|0(EntityUid uid, IComponent comp, TEvent& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 305
2024-09-25T22:55:43.4711569Z    at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass67_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 460
2024-09-25T22:55:43.4715809Z    at Robust.Shared.GameObjects.EntityEventBus.EntDispatch(EntityUid euid, Type eventType, Unit& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 633
2024-09-25T22:55:43.4720220Z    at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEventCore(EntityUid uid, Unit& unitRef, Type type, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 240
2024-09-25T22:55:43.4724573Z    at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 218
2024-09-25T22:55:43.4728934Z    at Robust.Shared.GameObjects.EntitySystem.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystem.cs:line 170
2024-09-25T22:55:43.4732940Z    at Robust.Shared.Physics.Systems.SharedPhysicsSystem.CollideContacts() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Contacts.cs:line 563
2024-09-25T22:55:43.4736980Z    at Robust.Shared.Physics.Systems.SharedPhysicsSystem.SimulateWorld(Single deltaTime, Boolean prediction) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/Physics/Systems/SharedPhysicsSystem.cs:line 302
2024-09-25T22:55:43.4741653Z    at Robust.Shared.GameObjects.EntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityManager.cs:line 265
2024-09-25T22:55:43.4745942Z    at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 196
2024-09-25T22:55:43.4749787Z    at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Server/BaseServer.cs:line 704
2024-09-25T22:55:43.4753341Z    at Robust.UnitTesting.RobustIntegrationTest.IntegrationGameLoop.SingleThreadRunUntilEmpty() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 1098
2024-09-25T22:55:43.4756578Z    at Robust.UnitTesting.RobustIntegrationTest.IntegrationGameLoop.Run() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 1085
2024-09-25T22:55:43.4760426Z    at Robust.UnitTesting.RobustIntegrationTest.ServerIntegrationInstance._serverMain() in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 656
2024-09-25T22:55:43.4762708Z --- End of stack trace from previous location ---
2024-09-25T22:55:43.4765656Z    at Robust.UnitTesting.RobustIntegrationTest.IntegrationInstance.WaitIdleImplAsync(Boolean throwOnUnhandled, CancellationToken cancellationToken) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 450
2024-09-25T22:55:43.4770165Z    at Robust.UnitTesting.RobustIntegrationTest.IntegrationInstance.WaitRunTicks(Int32 ticks) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.UnitTesting/RobustIntegrationTest.cs:line 542
2024-09-25T22:55:43.4773916Z    at Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteAllEntitiesInTheSameSpot() in /home/runner/work/space-station-14/space-station-14/Content.IntegrationTests/Tests/EntityTest.cs:line 110
2024-09-25T22:55:43.4777902Z    at Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteAllEntitiesInTheSameSpot() in /home/runner/work/space-station-14/space-station-14/Content.IntegrationTests/Tests/EntityTest.cs:line 133
2024-09-25T22:55:43.4780339Z    at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
2024-09-25T22:55:43.4782076Z    at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
2024-09-25T22:55:43.4783786Z    at NUnit.Framework.Internal.AsyncToSyncAdapter.Await[TResult](Func`1 invoke)
2024-09-25T22:55:43.4784959Z    at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
2024-09-25T22:55:43.4786370Z    at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
2024-09-25T22:55:43.4788215Z    at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
2024-09-25T22:55:43.4789809Z    at NUnit.Framework.Internal.Execution.SimpleWorkItem.<>c__DisplayClass3_0.<PerformWork>b__0()
2024-09-25T22:55:43.4791299Z    at NUnit.Framework.Internal.ContextUtils.<>c__DisplayClass1_0`1.<DoIsolated>b__0(Object _)
2024-09-25T22:55:43.4792109Z 
2024-09-25T22:55:43.4793857Z 1)    at Content.IntegrationTests.Pair.TestPair.OnDirtyDispose() in /home/runner/work/space-station-14/space-station-14/Content.IntegrationTests/Pair/TestPair.Recycle.cs:line 34
2024-09-25T22:55:43.4796202Z    at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
2024-09-25T22:55:43.4797813Z    at Content.IntegrationTests.Pair.TestPair.OnDirtyDispose()
2024-09-25T22:55:43.4800282Z    at Content.IntegrationTests.Pair.TestPair.DisposeAsync() in /home/runner/work/space-station-14/space-station-14/Content.IntegrationTests/Pair/TestPair.Recycle.cs:line 121
2024-09-25T22:55:43.4802638Z    at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
2024-09-25T22:55:43.4804052Z    at Content.IntegrationTests.Pair.TestPair.DisposeAsync()
2024-09-25T22:55:43.4806478Z    at Content.IntegrationTests.Tests.EntityTest.SpawnAndDeleteAllEntitiesInTheSameSpot() in /home/runner/work/space-station-14/space-station-14/Content.IntegrationTests/Tests/EntityTest.cs:line 133
2024-09-25T22:55:43.4809323Z    at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
```

## Why / Balance
bugfix

## Technical details
Passing TemperatureComponent is optional in ChangeHeat and some entities it is applied to don't have that component, so it needs `logMissing = false`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
no cl no fun
