### PR TITLE
fix light bulbs not fitting into the trash bag

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -129,6 +129,7 @@
   - type: Tag
     tags:
     - LightBulb
+    - Trash
 
 - type: entity
   parent: BaseLightbulb
@@ -147,6 +148,7 @@
   - type: Tag
     tags:
     - LightBulb
+    - Trash
 
 - type: entity
   parent: LightBulb
@@ -160,9 +162,6 @@
     lightEnergy: 0.3 # old incandescents just arent as bright
     lightRadius: 6
     lightSoftness: 1.1
-  - type: Tag
-    tags:
-    - LightBulb
 
 - type: entity
   suffix: Broken
@@ -190,6 +189,7 @@
   - type: Tag
     tags:
     - LightBulb
+    - Trash
 
 - type: entity
   parent: BaseLightTube


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
#31905 added a new tag to light bulbs for crafting, but overlooked that this overwrites the inherited Trash tag

## Why / Balance
bugfix

## Technical details
add missing tag

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**

:cl:
- fix: Light bulbs now fit into the trash bag again.
