### PR TITLE
Makes `BaseAdvancedPen` abstract

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -59,6 +59,7 @@
 - type: entity
   id: BaseAdvancedPen
   parent: PenEmbeddable
+  abstract: true
   components:
   - type: Tag
     tags:


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Was showing up in mapping. Pretty sure this wasn't meant to be more than a base. Otherwise, it could be suffixed
![image](https://github.com/user-attachments/assets/0ea55851-8812-4a44-b0db-ad82ed25e163)

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
n/a
