### PR TITLE
Pills are explosion resistant (partially reverts #15851)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -482,7 +482,7 @@
       food:
         maxVol: 20
   - type: ExplosionResistance
-    damageCoefficient: 0.025
+    damageCoefficient: 0.025 # survives conventional explosives and not minibombs and nukes
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -481,6 +481,20 @@
     solutions:
       food:
         maxVol: 20
+  - type: ExplosionResistance
+    damageCoefficient: 0.025
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:SpillBehavior
+        solution: food
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
   - type: SolutionSpiker
     sourceSolution: food
   - type: Extractable

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -482,7 +482,7 @@
       food:
         maxVol: 20
   - type: ExplosionResistance
-    damageCoefficient: 0.025 # survives conventional explosives and not minibombs and nukes
+    damageCoefficient: 0.025 # survives conventional explosives but not minibombs and nukes
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -487,18 +487,6 @@
     grindableSolutionName: food
   - type: StaticPrice
     price: 0
-  - type: Damageable
-    damageContainer: Inorganic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 10
-      behaviors:
-      - !type:SpillBehavior
-        solution: food
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
   - type: Tag
     tags:
     - Pill


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Partially reverts #15851; adds 97.5% explosion resist to pills.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Gives utility to pills as explosion-resistant drugs, making them attractive for combat.

It is also currently unintuitive to why pills and not other items (e.g. topicals and syringes) should be destroyed in explosions.

The original PR was likely intended to dissuade 200+ pill piles in older gameplay, which caused entity spam and lag. However, pills have almost disappeared for other reasons:
- Jugmed and infinite storage ChemMasters
- Moths can't eat pills, vox can't eat them safely
- Limited chems in ChemDispensers

As such, reverting is unlikely to cause pill piles to return.

## Technical details
<!-- Summary of code changes for easier review. -->
yml changes only

`Resources/Prototypes/Entities/Objects/Specific/chemistry.yml` (adds explosion damage coefficient 0.025 to pills)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] ~I have added media to this PR or~ it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: Pills are explosion resistant.