### PR TITLE
Seismic charge now craftable

### DIFF
--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Shared.Research.Components;
 
 namespace Content.Shared.Materials;
 
@@ -34,6 +35,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
 
         SubscribeLocalEvent<MaterialStorageComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<MaterialStorageComponent, InteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<MaterialStorageComponent, TechnologyDatabaseModifiedEvent>(OnDatabaseModified);
     }
 
     public override void Update(float frameTime)
@@ -310,6 +312,11 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         if (args.Handled || !component.InsertOnInteract)
             return;
         args.Handled = TryInsertMaterialEntity(args.User, args.Used, uid, component);
+    }
+
+    private void OnDatabaseModified(Entity<MaterialStorageComponent> ent, ref TechnologyDatabaseModifiedEvent args)
+    {
+        UpdateMaterialWhitelist(ent);
     }
 
     public int GetSheetVolume(MaterialPrototype material)

--- a/Content.Shared/Research/Systems/BlueprintSystem.cs
+++ b/Content.Shared/Research/Systems/BlueprintSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Materials;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Lathe;
@@ -15,6 +16,7 @@ public sealed class BlueprintSystem : EntitySystem
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedMaterialStorageSystem _materialStorage = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -66,6 +68,9 @@ public sealed class BlueprintSystem : EntitySystem
 
         var ev = new TechnologyDatabaseModifiedEvent();
         RaiseLocalEvent(ent, ref ev);
+
+        _materialStorage.UpdateMaterialWhitelist(ent);
+
         return true;
     }
 

--- a/Content.Shared/Research/Systems/BlueprintSystem.cs
+++ b/Content.Shared/Research/Systems/BlueprintSystem.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Materials;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Lathe;
@@ -16,7 +15,6 @@ public sealed class BlueprintSystem : EntitySystem
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly SharedMaterialStorageSystem _materialStorage = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -68,9 +66,6 @@ public sealed class BlueprintSystem : EntitySystem
 
         var ev = new TechnologyDatabaseModifiedEvent();
         RaiseLocalEvent(ent, ref ev);
-
-        _materialStorage.UpdateMaterialWhitelist(ent);
-
         return true;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made it so when adding a blueprint to an auto lathe, the auto lathe will gain the ability to accept the resources needed to craft the new blueprint.
fixes #31887

## Why / Balance
Blueprints for Seismic charges could be found but not crafted in the auto lathe.

## Technical details
 Changed sharedMaterialStorageSystem to subscribe to TechnologyDatabaseModifiedEvent which will call UpdateMaterialWhitelist.

## Media


https://github.com/user-attachments/assets/ba680e70-40ad-4d8a-ba81-ffba300d887f



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl: Zylo
- fix: Seismic charges being uncraftable