### PR TITLE
Fixed collision for gas and volumetric pumps

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: GasPipeBase
   abstract: true
   id: GasBinaryBase
@@ -24,13 +24,16 @@
         pipeDirection: South
 
 - type: entity
-  parent: [BaseMachinePowered, GasBinaryBase]
+  parent: GasBinaryBase
   id: GasPressurePump
   name: gas pump
   description: A pump that moves gas by pressure.
   placement:
     mode: SnapgridCenter
   components:
+  - type: ExtensionCableReceiver
+  - type: LightningTarget
+    priority: 1
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: Rotatable
@@ -69,13 +72,16 @@
       path: /Audio/Ambience/Objects/gas_pump.ogg
 
 - type: entity
-  parent: [BaseMachinePowered, GasBinaryBase]
+  parent: GasBinaryBase
   id: GasVolumePump
   name: volumetric gas pump
   description: A pump that moves gas by volume.
   placement:
     mode: SnapgridCenter
   components:
+    - type: ExtensionCableReceiver
+    - type: LightningTarget
+      priority: 1
     - type: ApcPowerReceiver
       powerLoad: 200
     - type: Rotatable


### PR DESCRIPTION

## About the PR
Gas and volumetric pumps were being treated as machines, causing them to push people around when moved or thrown.

## Why / Balance
This restores gas and volumetric pumps back to a functioning state according to their purpose.

## Technical details
Removed BaseMachinePowered from gas and volumetric pump entities in binary.yml, added relevant types.

## Media

Media shows bug in action.
Credit: @Sarahon - https://medal.tv/?contentId=iLduDWR8kwcl38oW2&invite=cr-MSxNRk4sMjEzMjkxMTQ4LA&spok=d1337uKFHJ3y

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes


**Changelog**

:cl:

- fix: Fixed collision properties of gas and volumetric pumps.

