### PR TITLE
Fix airlock autoclose mispredict

### DIFF
--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -2,15 +2,16 @@ using Content.Shared.Doors.Components;
 using Content.Shared.Popups;
 using Content.Shared.Prying.Components;
 using Content.Shared.Wires;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Doors.Systems;
 
 public abstract class SharedAirlockSystem : EntitySystem
 {
+    [Dependency] private   readonly IGameTiming _timing = default!;
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
     [Dependency] protected readonly SharedDoorSystem DoorSystem = default!;
-    [Dependency] protected readonly SharedPopupSystem Popup = default!;
-    [Dependency] private readonly SharedWiresSystem _wiresSystem = default!;
+    [Dependency] private   readonly SharedWiresSystem _wiresSystem = default!;
 
     public override void Initialize()
     {
@@ -46,6 +47,9 @@ public abstract class SharedAirlockSystem : EntitySystem
 
     private void OnStateChanged(EntityUid uid, AirlockComponent component, DoorStateChangedEvent args)
     {
+        if (_timing.ApplyingState)
+            return;
+
         // Only show the maintenance panel if the airlock is closed
         if (TryComp<WiresPanelComponent>(uid, out var wiresPanel))
         {

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -47,6 +47,7 @@ public abstract class SharedAirlockSystem : EntitySystem
 
     private void OnStateChanged(EntityUid uid, AirlockComponent component, DoorStateChangedEvent args)
     {
+        // This is here so we don't accidentally bulldoze state values and mispredict.
         if (_timing.ApplyingState)
             return;
 


### PR DESCRIPTION
It was hard to see this ingame due to animations masking it. The only way you'd notice currently is the light mispredicting.

:cl:
- fix: Fix airlock autoclose mispredicting.
