### PR TITLE
Prevent borgs from being able to be briefly toggled off.

### DIFF
--- a/Content.Shared/Item/ItemToggle/Components/ItemToggleComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ItemToggleComponent.cs
@@ -20,6 +20,12 @@ public sealed partial class ItemToggleComponent : Component
     public bool Activated = false;
 
     /// <summary>
+    /// Can the entity be toggled with a verb or interaction.
+    /// </summary>
+    [DataField]
+    public bool ManualToggle {get; set;} = true;
+
+    /// <summary>
     /// Can the entity be activated in the world.
     /// </summary>
     [DataField]

--- a/Content.Shared/Item/ItemToggle/Components/ItemToggleComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ItemToggleComponent.cs
@@ -20,12 +20,6 @@ public sealed partial class ItemToggleComponent : Component
     public bool Activated = false;
 
     /// <summary>
-    /// Can the entity be toggled with a verb or interaction.
-    /// </summary>
-    [DataField]
-    public bool ManualToggle {get; set;} = true;
-
-    /// <summary>
     /// Can the entity be activated in the world.
     /// </summary>
     [DataField]

--- a/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
@@ -71,7 +71,7 @@ public sealed class ItemToggleSystem : EntitySystem
 
     private void OnActivateVerb(Entity<ItemToggleComponent> ent, ref GetVerbsEvent<ActivationVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract)
+        if (!args.CanAccess || !args.CanInteract || !ent.Comp.ManualToggle)
             return;
 
         var user = args.User;
@@ -88,7 +88,7 @@ public sealed class ItemToggleSystem : EntitySystem
 
     private void OnActivate(Entity<ItemToggleComponent> ent, ref ActivateInWorldEvent args)
     {
-        if (args.Handled || !ent.Comp.OnActivate)
+        if (args.Handled || !ent.Comp.OnActivate || !ent.Comp.ManualToggle)
             return;
 
         args.Handled = true;

--- a/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
@@ -71,7 +71,7 @@ public sealed class ItemToggleSystem : EntitySystem
 
     private void OnActivateVerb(Entity<ItemToggleComponent> ent, ref GetVerbsEvent<ActivationVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract || !ent.Comp.ManualToggle)
+        if (!args.CanAccess || !args.CanInteract || !ent.Comp.OnActivate)
             return;
 
         var user = args.User;
@@ -88,7 +88,7 @@ public sealed class ItemToggleSystem : EntitySystem
 
     private void OnActivate(Entity<ItemToggleComponent> ent, ref ActivateInWorldEvent args)
     {
-        if (args.Handled || !ent.Comp.OnActivate || !ent.Comp.ManualToggle)
+        if (args.Handled || !ent.Comp.OnActivate)
             return;
 
         args.Handled = true;

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -121,7 +121,7 @@
     cellSlotId: cell_slot
     fitsInCharger: true
   - type: ItemToggle
-    manualToggle: false # You should not be able to turn off a borg temporarily.
+    onActivate: false # You should not be able to turn off a borg temporarily.
     activated: false # gets activated when a mind is added
     onUse: false # no item-borg toggling sorry
   - type: ItemTogglePointLight

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -121,6 +121,7 @@
     cellSlotId: cell_slot
     fitsInCharger: true
   - type: ItemToggle
+    manualToggle: false # You should not be able to turn off a borg temporarily.
     activated: false # gets activated when a mind is added
     onUse: false # no item-borg toggling sorry
   - type: ItemTogglePointLight


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Borgs can no longer be briefly turned off via pressing E on them or via right-click verb.

## Why / Balance
This should not be possible, and is annoying for the borg player as it resets the action order for modules and briefly slows them down & disables their AA.

## Technical details
ItemToggleComponent has a new ManualToggle field which defaults to true, but is set to false, which prevents the item from being manually toggles or having a toggle verb.

## Media
Not neccesary.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: BramvanZijp
- fix: Fixed borgs being able to be briefly disabled by others.
