### PR TITLE
Swap the advanced tool borg modules omnitool for jaws and a power drill

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -237,9 +237,10 @@
     - state: icon-tools-adv
   - type: ItemBorgModule
     items:
-    - Omnitool
+    - JawsOfLife
+    - PowerDrill
+    - Multitool
     - WelderExperimental
-    - NetworkConfigurator
     - RemoteSignaller
     - GasAnalyzer
     - GeigerCounter


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The Engineering Cyborg Advanced Tool Module no longer has an omnitool, but instead jaws of life and a power drill, with the network configurator being swapped for a multitool.

## Why / Balance
The omnitool is a pain to use since you have to spam Z to cycle to the correct tool, with this being much easier to use. Also, this way the borg keeps a blunt weapon for simplemobs, etc. with the jaws. Which it loses since the module loses its toolbar, and the welder is a much worse blunt weapon.

## Media
Not Neccesary.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: BramvanZijp
- tweak: The Engineering Cyborg's Advanced Tool Module now has jaws of life and a power drill instead of an omnitool, with a multitool replacing the network configurator.
