### PR TITLE
Add Sunglow plant mutation

### DIFF
--- a/Content.Server/EntityEffects/Effects/Glow.cs
+++ b/Content.Server/EntityEffects/Effects/Glow.cs
@@ -13,6 +13,9 @@ public sealed partial class Glow : EntityEffect
     public float Radius = 2f;
 
     [DataField]
+    public float Energy = 1f;
+
+    [DataField]
     public Color Color = Color.Black;
 
     private static readonly List<Color> Colors = new()
@@ -38,6 +41,7 @@ public sealed partial class Glow : EntityEffect
         var light = lightSystem.EnsureLight(args.TargetEntity);
         lightSystem.SetRadius(args.TargetEntity, Radius, light);
         lightSystem.SetColor(args.TargetEntity, Color, light);
+        lightSystem.SetEnergy(args.TargetEntity, Energy, light);
         lightSystem.SetCastShadows(args.TargetEntity, false, light); // this is expensive, and botanists make lots of plants
     }
 

--- a/Resources/Prototypes/Hydroponics/randomMutations.yml
+++ b/Resources/Prototypes/Hydroponics/randomMutations.yml
@@ -177,3 +177,9 @@
       baseOdds: 0.036
       persists: false
       effect: !type:PlantMutateHarvest
+    - name: Sunglow
+      baseOdds: 0.000001 #1 in 100k units of mutagen
+      effect: !type:Glow
+        power: 8
+        radius: 8
+        color: '#FFFFFF'

--- a/Resources/Prototypes/Hydroponics/randomMutations.yml
+++ b/Resources/Prototypes/Hydroponics/randomMutations.yml
@@ -180,6 +180,6 @@
     - name: Sunglow
       baseOdds: 0.000001 #1 in 100k units of mutagen
       effect: !type:Glow
-        power: 8
+        energy: 8
         radius: 8
         color: '#FFFFFF'


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Add a new plant mutation: Sunglow. It's Bioluminescent with the numbers cranked up to 8. The super-bright produce make a great light source in the event that the entire station loses power, as long as no mice sneak around to eat them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Showing off that botany mutation effects can be added now without messing with the rest of botany code. Also allowing glowing plants to be of significantly more use on rare occasion.

I intend for this to be part of a 2nd process for rarer mutations (see [my Hydroponics proposal writeup](https://github.com/space-wizards/docs/pull/290) for a full explanation of that. For now, I want to start adding that content in small pieces and make it show up very rarely, so that when the 2nd process gets implemented in people do not feel like stuff is being taken away.

Odds: On a station with 3 full ChemMasters that get used purely for Unstable Mutagen, you can make 1,800u of mutagen. If the station uses all 1,800u in an hour-long shift, every shift, you will see this mutation approximately twice in a week at the current 1/100,000 odds. It would be once every 3 weeks at 1 in a million odds with the same scenario. I look forward to anecdotes about this showing up multiple times a round every round.

## Technical details
<!-- Summary of code changes for easier review. -->
A new mutation is applied with a 1/100,000 chance. 
The Glow EntityEffect had a parameter added to enable this to work.  Beyond that, this is all YML. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Standard Bioluminescent (for comparison):
![image](https://github.com/user-attachments/assets/a4d4b42f-c8cc-4321-8d58-e6813b662e5b)
Sunglow:
![image](https://github.com/user-attachments/assets/ee2f72d5-6927-4622-b1f2-8ae7630c2c0f)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added a very rare plant mutation: Sunglow. Plants and produce may shine bright enough to illuminate rooms.