### PR TITLE
BUGFIX: Fix APEs being able to be turned on without power

### DIFF
--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -196,7 +196,8 @@ namespace Content.Server.Singularity.EntitySystems
             if (TryComp<ApcPowerReceiverComponent>(uid, out var apcReceiver))
             {
                 apcReceiver.Load = component.PowerUseActive;
-                PowerOn(uid, component);
+                if (apcReceiver.Powered)
+                    PowerOn(uid, component);
             }
             // Do not directly PowerOn().
             // OnReceivedPowerChanged will get fired due to DrawRate change which will turn it on.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed a bug where you could turn on an APE without it having APC power.

Also, first PR!

## Why / Balance
If your APE lost power you could just turn it off and on again. You could also turn on an APE in an area without power at all.

## Technical details
The Emitter subsystem turned on the emitter without checking if the APC was actually powered.

## Media
Tiny one line fix, will add an gif if really necessary

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: APEs could be powered on without local power

