### PR TITLE
Clonegenesis

### DIFF
--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -71,3 +71,4 @@ research-technology-advanced-spray = Advanced Spray
 research-technology-bluespace-cargo-transport = Bluespace Cargo Transport
 research-technology-quantum-fiber-weaving = Quantum Fiber Weaving
 research-technology-bluespace-chemistry = Bluespace Chemistry
+research-technology-clonegenesis = Clonegenesis

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: AutolatheMachineCircuitboard
   parent: BaseMachineCircuitboard
   name: autolathe machine board
@@ -485,8 +485,9 @@
       stackRequirements:
         MatterBin: 2
         Manipulator: 2
-        Glass: 1
+        Glass: 5
         Cable: 1
+        Plasma: 5
 
 - type: entity
   id: MedicalScannerMachineCircuitboard

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -151,3 +151,17 @@
   cost: 10000
   recipeUnlocks:
   - DeviceQuantumSpinInverter
+
+- type: technology
+  id: Clonegenesis
+  name: research-technology-clonegenesis
+  icon:
+    sprite: Structures/Machines/cloning.rsi
+    state: pod_0
+  discipline: Experimental
+  tier: 3
+  cost: 50000
+  recipeUnlocks:
+  - CloningPodMachineCircuitboard
+  - CloningConsoleComputerCircuitboard
+  - MedicalScannerMachineCircuitboard


### PR DESCRIPTION
## About the PR
A new experimental discipline technology, "Clonogenesis", has been added to the game. This tech costs 50,000 points and is a Tier 3 technology. Unlocking it provides access to everything needed for human cloning, including the medical scanner, cloning pod, and cloning console. The process of constructing the cloning pod has also been made slightly more challenging, now requiring 5 plasma and 5 glass.

## Why / Balance
The cloning machine represents an interesting mechanic, and I believe it’s unfair to deny players the opportunity to interact with it. Currently, seeing a functioning cloning machine even once in 20 rounds is quite rare. It doesn’t seem right that the only ones who can bring the cloning machine to the station are the disposals. Adding this machine to the experimental discipline would significantly increase its popularity. Furthermore, a tier 3 technology priced at 50,000 points seems quite justified for a cloning machine.

## Media
![image](https://github.com/user-attachments/assets/897e6b11-fa5f-480e-8ece-8b720af64a24)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
**Changelog**
:cl:
- add: A new experimental discipline technology, "Clonogenesis", has been added to the game!
- tweak: Now, in addition to everything else, you'll need 5 glass and 5 plasma to create the cloning pod!