### PR TITLE
Whitelist for blood packs

### DIFF
--- a/Content.Server/Medical/Components/HealingComponent.cs
+++ b/Content.Server/Medical/Components/HealingComponent.cs
@@ -31,6 +31,12 @@ namespace Content.Server.Medical.Components
         public float ModifyBloodLevel = 0.0f;
 
         /// <remarks>
+        ///     Whitelist bloodtypes that this item can restore
+        /// </remarks>
+        [DataField("bloodReagentWhitelist")]
+        public List<string> BloodReagentWhitelist = new List<string>();
+
+        /// <remarks>
         ///     The supported damage types are specified using a <see cref="DamageContainerPrototype"/>s. For a
         ///     HealingComponent this filters what damage container type this component should work on. If null,
         ///     all damage container types are supported.
@@ -39,14 +45,14 @@ namespace Content.Server.Medical.Components
         public List<string>? DamageContainers;
 
         /// <summary>
-        /// How long it takes to apply the damage.
+        ///     How long it takes to apply the damage.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("delay")]
         public float Delay = 3f;
 
         /// <summary>
-        /// Delay multiplier when healing yourself.
+        ///     Delay multiplier when healing yourself.
         /// </summary>
         [DataField("selfHealPenaltyMultiplier")]
         public float SelfHealPenaltyMultiplier = 3f;

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -216,6 +216,14 @@
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
     healingEndSound:
       path: "/Audio/Items/Medical/brutepack_end.ogg"
+    bloodReagentWhitelist:
+      - Blood
+      - InsectBlood
+      - CopperBlood
+      - Sap
+      - Sugar
+      - Slime
+      - AmmoniaBlood
   - type: Stack
     stackType: Bloodpack
     count: 10


### PR DESCRIPTION
## About the PR
Added white list to blood packs, now it can only restore generic species blood types

## Why / Balance
- It fixes chem duping exploit used with reagent slimes and blood packs. You could inject dead reagent slime with blood packs to replenish its blood infinitely, with it you could trade one blood pack for 100 of omnizine.
- If also fixes #28933 where repeat healing didn't take into consideration blood %

## Technical details
Added bloodReagentWhitelist to healing components, if left empty then it is ignored.
Added bloodReagentWhitelist basic blood types for blood pack.
Replaced private method HasDamage with bigger CanHealingCompomentBeUsed it takes blood % and whitelist into consideration. It's used when healing item is used or heal is auto repeated. 

## Media
https://www.youtube.com/watch?v=Bey-tbuAtyE

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Blood packs only work on species with generic blood (not reagent slimes)
- fix:  Blood packs autorepeat when blood levels are low
-->
