### PR TITLE
Chat Objective Summaries

### DIFF
--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.EUI;
+using Content.Server.Chat.Managers;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Ghost.Roles.Events;
 using Content.Shared.Ghost.Roles.Raffles;
@@ -34,6 +35,7 @@ using Content.Shared.Verbs;
 using Robust.Shared.Collections;
 using Content.Shared.Ghost.Roles.Components;
 using Content.Shared.Roles.Jobs;
+using Content.Shared.Chat;
 
 namespace Content.Server.Ghost.Roles;
 
@@ -52,6 +54,7 @@ public sealed class GhostRoleSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!;
 
     private uint _nextRoleIdentifier;
     private bool _needsUpdateGhostRoleCount = true;
@@ -403,8 +406,8 @@ public sealed class GhostRoleSystem : EntitySystem
         if (raffle.AllMembers.Add(player) && raffle.AllMembers.Count > 1
             && raffle.CumulativeTime.Add(raffle.JoinExtendsDurationBy) <= raffle.MaxDuration)
         {
-                raffle.Countdown += raffle.JoinExtendsDurationBy;
-                raffle.CumulativeTime += raffle.JoinExtendsDurationBy;
+            raffle.Countdown += raffle.JoinExtendsDurationBy;
+            raffle.CumulativeTime += raffle.JoinExtendsDurationBy;
         }
 
         UpdateAllEui();
@@ -510,9 +513,13 @@ public sealed class GhostRoleSystem : EntitySystem
         var newMind = _mindSystem.CreateMind(player.UserId,
             EntityManager.GetComponent<MetaDataComponent>(mob).EntityName);
         _roleSystem.MindAddRole(newMind, new GhostRoleMarkerRoleComponent { Name = role.RoleName });
-
         _mindSystem.SetUserId(newMind, player.UserId);
         _mindSystem.TransferTo(newMind, mob);
+
+        var message = Loc.GetString("ghost-role-greet", ("role", role.RoleName), ("rules", role.RoleRules));
+        var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", message));
+
+        _chatManager.ChatMessageToOne(ChatChannel.Server, message, wrappedMessage, default, false, player.Channel);
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -27,9 +27,6 @@ traitor-role-greeting =
     You are an agent sent by {$corporation} on behalf of [color = darkred]The Syndicate.[/color]
     Your objectives and codewords are listed in the character menu.
     Use the uplink loaded into your PDA to buy the tools you'll need for this mission.
-traitor-role-objectives =
-    Your objectives are: [color = lightgray]
-    {$objectives}[/color]
     Death to Nanotrasen!
 traitor-role-codewords =
     The codewords are: [color = lightgray]

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -27,6 +27,9 @@ traitor-role-greeting =
     You are an agent sent by {$corporation} on behalf of [color = darkred]The Syndicate.[/color]
     Your objectives and codewords are listed in the character menu.
     Use the uplink loaded into your PDA to buy the tools you'll need for this mission.
+traitor-role-objectives =
+    Your objectives are: [color = lightgray]
+    {$objectives}[/color]
     Death to Nanotrasen!
 traitor-role-codewords =
     The codewords are: [color = lightgray]
@@ -34,8 +37,8 @@ traitor-role-codewords =
     Codewords can be used in regular conversation to identify yourself discretely to other syndicate agents.
     Listen for them, and keep them secret.
 traitor-role-uplink-code =
-    Set your ringtone to the notes [color = lightgray]{$code}[/color] to lock or unlock your uplink.
-    Remember to lock it after, or the stations crew will easily open it too!
+    Set your ringtone to the notes [color = lightgray]{$code}[/color] to unlock your uplink.
+    Remember to lock it after, or the station's crew can easily access it too!
 
 # don't need all the flavour text for character menu
 traitor-role-codewords-short =

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -1,4 +1,7 @@
 # also used in MakeGhostRuleWindow and MakeGhostRoleCommand
+ghost-role-greet = Your role is now: {$role}.
+                   Remember: {$rules}
+
 ghost-role-component-default-rules = All normal rules apply unless an administrator tells you otherwise.
                                      You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
                                      You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.

--- a/Resources/Locale/en-US/objectives/objective-summary.ftl
+++ b/Resources/Locale/en-US/objectives/objective-summary.ftl
@@ -1,0 +1,3 @@
+generic-role-objectives =
+    Your objectives are: [color = lightgray]
+    {$objectives}[/color]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a summary in the chat window for your Traitor and Thief objectives.

Also states your Ghost Role rules in the chat window when you take a role.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Succinctly being briefed with your objectives helps digest the torrent of information that appears on rolling antag.

Once you pick a ghost role, it's easy to forget whether you're a non-antag, free agent, familiar, etc. This avoids that by providing a permanent reminder of what the role's rules are.

## Technical details
<!-- Summary of code changes for easier review. -->
No major changes, just adds on to the antag briefings and sends a chat message on loading into a ghost role.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/f5fc1063-4d77-45f2-a592-34f4cf1c9214)
![Content Client_2024-09-29_06-07-33](https://github.com/user-attachments/assets/06e4476e-4f12-4175-9aba-73261a440836)
![Content Client_2024-09-29_06-20-15](https://github.com/user-attachments/assets/501ca768-79fd-4a7c-be7b-5ee6e17c2ab4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`MakeBriefing` method in `ThiefRuleSystem` now takes `(MindComponent mind, EntityUid mindId, EntityUid thief)` as args instead of just `(EntityUid thief)`.

**Changelog**
:cl:
- add: A summary of your objectives is now shown in chat when you become a Traitor or Criminal.
- add: The rules for ghost roles are now displayed in chat upon taking the role.
