### PR TITLE
Fixes HoS's energy shotgun not being marked as restricted contraband

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -720,7 +720,7 @@
 
 - type: entity
   name: energy shotgun
-  parent: [BaseWeaponBattery, BaseGunWieldable, BaseSecurityCommandContraband, BaseGrandTheftContraband]
+  parent: [BaseWeaponBattery, BaseGunWieldable, BaseGrandTheftContraband]
   id: WeaponEnergyShotgun
   description: A one-of-a-kind prototype energy weapon that uses various shotgun configurations. It offers the possibility of both lethal and non-lethal shots, making it a versatile weapon.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -720,7 +720,7 @@
 
 - type: entity
   name: energy shotgun
-  parent: [BaseWeaponBattery, BaseGunWieldable]
+  parent: [BaseWeaponBattery, BaseGunWieldable, BaseSecurityCommandContraband, BaseGrandTheftContraband]
   id: WeaponEnergyShotgun
   description: A one-of-a-kind prototype energy weapon that uses various shotgun configurations. It offers the possibility of both lethal and non-lethal shots, making it a versatile weapon.
   components:


### PR DESCRIPTION
## About the PR
HoS's energy shotgun is now correctly marked as grand theft contraband.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
HoS's shotgun is a theft target and is obviously a shotgun that only command/security should have.

Note: I tried to actually mark the HoS shotgun as command and security restricted + grand theft contra but the current contraband system just takes the first parent into account and draws it in the examine. I went with the grand theft contraband because people who legitimately have this usually have a good reason so it makes sense.

## Technical details
YAML.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Content Client_vncPuHh0Zk](https://github.com/user-attachments/assets/43f2efcf-9de4-44a6-9075-af6991816320)
![Content Client_vSman1HMDS](https://github.com/user-attachments/assets/adb3b6bc-7dee-43d4-8ba0-ab4efd80cc89)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: HoS's energy shotgun is now correctly marked as grand theft contraband.