### PR TITLE
Announcements now state the location of the Console used.

### DIFF
--- a/Content.Server/Communications/CommunicationsConsoleComponent.cs
+++ b/Content.Server/Communications/CommunicationsConsoleComponent.cs
@@ -59,7 +59,6 @@ namespace Content.Server.Communications
         /// <summary>
         /// Shows the location of the console used. (Physical consoles only.)
         /// </summary>
-        [ViewVariables]
         [DataField]
         public bool ShowLocation = false;
 

--- a/Content.Server/Communications/CommunicationsConsoleComponent.cs
+++ b/Content.Server/Communications/CommunicationsConsoleComponent.cs
@@ -57,6 +57,13 @@ namespace Content.Server.Communications
         public bool CanShuttle = true;
 
         /// <summary>
+        /// Shows the location of the console used. (Physical consoles only.)
+        /// </summary>
+        [ViewVariables]
+        [DataField]
+        public bool ShowLocation = false;
+
+        /// <summary>
         /// Announce on all grids (for nukies)
         /// </summary>
         [DataField]

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -264,7 +264,14 @@ namespace Content.Server.Communications
             Loc.TryGetString(comp.Title, out var title);
             title ??= comp.Title;
 
-            msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + " " + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null))) + ".";
+            if (comp.ShowLocation == true)
+            {
+                msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + " " + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null))) + ".";
+            }
+            else
+            {
+                msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author;
+            }
             if (comp.Global)
             {
                 _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.Sound, colorOverride: comp.Color);

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -270,7 +270,7 @@ namespace Content.Server.Communications
             }
             else
             {
-                msg += "\n" + Loc.GetString("comms-console-announcement-sent-by", ("author", author);
+                msg += "\n" + Loc.GetString("comms-console-announcement-sent-by", ("author", author));
             }
             if (comp.Global)
             {

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -251,6 +251,14 @@ namespace Content.Server.Communications
                 var tryGetIdentityShortInfoEvent = new TryGetIdentityShortInfoEvent(uid, mob);
                 RaiseLocalEvent(tryGetIdentityShortInfoEvent);
                 var author = tryGetIdentityShortInfoEvent.Title ?? Loc.GetString("comms-console-announcement-unknown-sender");
+                if (comp.ShowLocation == true)
+                {
+                    msg += "\n" + Loc.GetString("comms-console-announcement-sent-by-with-location", ("author", author), ("location", FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null)))));
+                }
+                else
+                {
+                    msg += "\n" + Loc.GetString("comms-console-announcement-sent-by", ("author", author));
+                }
             }
 
             comp.AnnouncementCooldownRemaining = comp.Delay;
@@ -263,14 +271,6 @@ namespace Content.Server.Communications
             Loc.TryGetString(comp.Title, out var title);
             title ??= comp.Title;
 
-            if (comp.ShowLocation == true)
-            {
-                msg += "\n" + Loc.GetString("comms-console-announcement-sent-by-with-location", ("author", author), ("location", FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null)))));
-            }
-            else
-            {
-                msg += "\n" + Loc.GetString("comms-console-announcement-sent-by", ("author", author));
-            }
             if (comp.Global)
             {
                 _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.Sound, colorOverride: comp.Color);

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -266,11 +266,11 @@ namespace Content.Server.Communications
 
             if (comp.ShowLocation == true)
             {
-                msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + " " + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null))) + ".";
+                msg += "\n" + Loc.GetString("comms-console-announcement-sent-by-with-location", ("author", author), ("location", FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null)))));
             }
             else
             {
-                msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author;
+                msg += "\n" + Loc.GetString("comms-console-announcement-sent-by", ("author", author);
             }
             if (comp.Global)
             {

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -264,7 +264,7 @@ namespace Content.Server.Communications
             Loc.TryGetString(comp.Title, out var title);
             title ??= comp.Title;
 
-            msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null))) + ".";
+            msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + " " + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null))) + ".";
             if (comp.Global)
             {
                 _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.Sound, colorOverride: comp.Color);

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -264,7 +264,7 @@ namespace Content.Server.Communications
             Loc.TryGetString(comp.Title, out var title);
             title ??= comp.Title;
 
-            msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + "in " + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null)));
+            msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null))) + ".";
             if (comp.Global)
             {
                 _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.Sound, colorOverride: comp.Color);

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -264,7 +264,7 @@ namespace Content.Server.Communications
             Loc.TryGetString(comp.Title, out var title);
             title ??= comp.Title;
 
-            if (comp.ShowLocation = true)
+            if (comp.ShowLocation == true)
             {
                 msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + " " + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null))) + ".";
             }

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -235,7 +235,6 @@ namespace Content.Server.Communications
         {
             var maxLength = _cfg.GetCVar(CCVars.ChatMaxAnnouncementLength);
             var msg = SharedChatSystem.SanitizeAnnouncement(message.Message, maxLength);
-            var author = Loc.GetString("comms-console-announcement-unknown-sender");
             if (message.Actor is { Valid: true } mob)
             {
                 if (!CanAnnounce(comp))
@@ -251,7 +250,7 @@ namespace Content.Server.Communications
 
                 var tryGetIdentityShortInfoEvent = new TryGetIdentityShortInfoEvent(uid, mob);
                 RaiseLocalEvent(tryGetIdentityShortInfoEvent);
-                author = tryGetIdentityShortInfoEvent.Title;
+                var author = tryGetIdentityShortInfoEvent.Title ?? Loc.GetString("comms-console-announcement-unknown-sender");
             }
 
             comp.AnnouncementCooldownRemaining = comp.Delay;

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -264,7 +264,7 @@ namespace Content.Server.Communications
             Loc.TryGetString(comp.Title, out var title);
             title ??= comp.Title;
 
-            if (comp.ShowLocation == true)
+            if (comp.ShowLocation = true)
             {
                 msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + " " + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null))) + ".";
             }

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -264,7 +264,7 @@ namespace Content.Server.Communications
             Loc.TryGetString(comp.Title, out var title);
             title ??= comp.Title;
 
-            msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + "in " + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, xform)));
+            msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + "in " + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, null)));
             if (comp.Global)
             {
                 _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.Sound, colorOverride: comp.Color);

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -39,7 +39,7 @@ namespace Content.Server.Communications
         [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
-        [Dependency] private readonly NavMapsystem _navMap = default!;
+        [Dependency] private readonly NavMapSystem _navMap = default!;
 
         private const float UIUpdateInterval = 5.0f;
 

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Chat.Systems;
 using Content.Server.DeviceNetwork.Components;
 using Content.Server.DeviceNetwork.Systems;
 using Content.Server.Interaction;
+using Content.Server.Pinpointer;
 using Content.Server.Popups;
 using Content.Server.RoundEnd;
 using Content.Server.Screens.Components;
@@ -261,7 +262,7 @@ namespace Content.Server.Communications
             Loc.TryGetString(comp.Title, out var title);
             title ??= comp.Title;
 
-            msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + ("location", FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, xform))));
+            msg += $"\n{Loc.GetString("comms-console-announcement-sent-by")} {author} in {("location", FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, xform))))}";
             if (comp.Global)
             {
                 _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.Sound, colorOverride: comp.Color);

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -261,7 +261,7 @@ namespace Content.Server.Communications
             Loc.TryGetString(comp.Title, out var title);
             title ??= comp.Title;
 
-            msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author;
+            msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + ("location", FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, xform))));
             if (comp.Global)
             {
                 _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.Sound, colorOverride: comp.Color);

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Popups;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Communications
 {
@@ -38,6 +39,7 @@ namespace Content.Server.Communications
         [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+        [Dependency] private readonly NavMapsystem _navMap = default!;
 
         private const float UIUpdateInterval = 5.0f;
 
@@ -262,7 +264,7 @@ namespace Content.Server.Communications
             Loc.TryGetString(comp.Title, out var title);
             title ??= comp.Title;
 
-            msg += $"\n{Loc.GetString("comms-console-announcement-sent-by")} {author} in {("location", FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, xform))))}";
+            msg += "\n" + Loc.GetString("comms-console-announcement-sent-by") + " " + author + "in " + FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString((uid, xform)));
             if (comp.Global)
             {
                 _chatSystem.DispatchGlobalAnnouncement(msg, title, announcementSound: comp.Sound, colorOverride: comp.Color);

--- a/Resources/Locale/en-US/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/communications/communications-console-component.ftl
@@ -17,7 +17,8 @@ comms-console-shuttle-unavailable = Shuttle is currently unavailable
 comms-console-message-too-long = Message is too long
 
 # Placeholder values
-comms-console-announcement-sent-by = Sent by
+comms-console-announcement-sent-by = Sent by {$author}
+comms-console-announcement-sent-by-with-location = Sent by {$author} {$location}.
 comms-console-announcement-unknown-sender = Unknown
 
 # Comms console variant titles

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -621,6 +621,7 @@
   - type: AccessReader
     access: [[ "Command" ]]
   - type: CommunicationsConsole
+    ShowLocation: true
     title: comms-console-announcement-title-station
   - type: DeviceNetwork
     transmitFrequencyId: ShuttleTimer

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -621,7 +621,7 @@
   - type: AccessReader
     access: [[ "Command" ]]
   - type: CommunicationsConsole
-    ShowLocation: true
+    showLocation: true
     title: comms-console-announcement-title-station
   - type: DeviceNetwork
     transmitFrequencyId: ShuttleTimer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

When a user makes a custom announcement using a physical Communications Console, the message now states the approximate area of the Console used to make the announcement using the station beacons.  This only works with physical Communication Consoles (not aghost or innate AI Comms messages) as requested.  I also changed the code that handled the creation and display of the author and location of console, it now uses the .ftl file and Loc.GetString for more multi language usage.

For example, at shift start the Captain makes a "Good morning crew!" announcement.  At the end of the message the announcement will say, "Sent by John Doe (Captain) near Bridge."  Meanwhile, an AI sending the same message using its innate Comms Console will only say "Sent by Sunny (Station AI)".

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The primary inspiration for this change is related to this proposed Revolutionary Rework.  In this rework, revolutionaries would be able to convert players using repeated code words, which could also be applied through announcements.  Naming the general area of the Console would allow crew to have reasonable counterplay by sweeping and clearing the console area listed on the announcement.  Without this, a Head Revolutionary would be able to spam major code words for significant conversion progress to every crew member while the crew has to manually search the entire station for where the console may be.  While this is not a fool proof system, as it is based off of station beacons and their values, it requires additional know how and means to forge/create station beacons and can still be seen through by clever crew members.

https://github.com/space-wizards/docs/pull/309/files

Outside of this rework, the change can still impact every day rounds.  Antags (or silly clowns) hoping to mislead the crew and use an announcement will now have to make sure they are sending the announcement from a legitimate area or find a way to forge/recreate a station beacon, as it would be very strange for an announcement to be coming from "near Southwest Solars".  This could also be used to intentionally draw attention to a different part of the station, and leaving the illegitimate console's location a secret.

## Technical details
<!-- Summary of code changes for easier review. -->

In CommunicationsConsoleSystems.cs
Line 7: Added using Content.Server.Pinpointer; for use in determining approximate Console location
Line 25: Added using Robust.Shared.Utility; for use in editing the Console location into the existing message code.
Line 42: Added [Dependency] private readonly NavMapSystem _navMap = default!; for use in determining approximate Console location
Line 251-261, 264: Reworked the author variable and the message lines so message uses the approximate Console location using station beacons, but only if it is sent using a physical Communications Console.  This also makes it use the .ftl file for different language support.

In CommunicationsConsoleComponet.cs
Line 59-74: Added a new Datafield entry set to false by default.  This is used to show the location of the Communications Console used for an announcement.

In computers.yml
Line 624: Added showLocation datafield value to be set to true for physical Communication Consoles to make use of ShowLocation.

In communications-console-component.ftl
Line 20-21: Reworked the sent-by line to use a variable, and added a new line to use the author and location as variables as requested.



## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![Test 1](https://github.com/user-attachments/assets/64b59197-95a6-4eb8-a305-b30e88713cce)
![Test 2](https://github.com/user-attachments/assets/086b1ebf-1a70-4c56-bbdb-3828edf73db7)
![Test 3](https://github.com/user-attachments/assets/454ff3c7-4d80-4e84-afa5-1b56b018a051)
![Test 4](https://github.com/user-attachments/assets/7a7281b2-7bc3-49de-8c3b-5220cbe581c1)
![Test 5](https://github.com/user-attachments/assets/f24bdf06-aad5-4525-a58c-4030c1287ea6)
![Test 6](https://github.com/user-attachments/assets/60aae3d1-719f-424f-b8bd-3b02e9b81431)
![Test 7](https://github.com/user-attachments/assets/6af94ae2-7d65-4a8c-88ca-98a330fabbbe)
![Test 8](https://github.com/user-attachments/assets/5e02e0c8-8adc-4c47-ba07-3601715b226e)
![Test 9](https://github.com/user-attachments/assets/f81a8674-b212-489d-a056-e7f631c46faa)
![Test 10](https://github.com/user-attachments/assets/e95f9af6-eed2-4675-964f-75761d42935b)
![Test 11](https://github.com/user-attachments/assets/e853e6a5-56cb-47bc-ac5d-a1c905e641c1)

Pictures 1-4 show the outcomes of my character making several announcements in different places to show that the announcements show the general location of the console.  

Pictures 5 and 6 show that these announcements are based on the values of the station beacons, and that by changing the beacon, you can alter the reported location of the console.

Pictures 7-9 show the updated version of the change, which allows only for the physical Communications Console to show a location as requested.

Pictures 10-11 show the use of the updated code utilizing the Loc.GetString and .ftl file.  

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: SaltCreator
- add: Announcements sent by players now show the approximate location of the Communications Console used. This is based off of the nearest station beacon. (Much like messages used for dragon carp rifts.)




