### PR TITLE
Fix currency duplication bug

### DIFF
--- a/Content.Server/Implants/SubdermalImplantSystem.cs
+++ b/Content.Server/Implants/SubdermalImplantSystem.cs
@@ -74,14 +74,12 @@ public sealed class SubdermalImplantSystem : SharedSubdermalImplantSystem
             return;
 
         // same as store code, but message is only shown to yourself
-        args.Handled = _store.TryAddCurrency(_store.GetCurrencyValue(args.Used, currency), uid, store);
-
-        if (!args.Handled)
+        if (!_store.TryAddCurrency((args.Used, currency), (uid, store)))
             return;
 
+        args.Handled = true;
         var msg = Loc.GetString("store-currency-inserted-implant", ("used", args.Used));
         _popup.PopupEntity(msg, args.User, args.User);
-        QueueDel(args.Used);
     }
 
     private void OnFreedomImplant(EntityUid uid, SubdermalImplantComponent component, UseFreedomImplantEvent args)

--- a/Content.Server/Stack/StackSystem.cs
+++ b/Content.Server/Stack/StackSystem.cs
@@ -100,6 +100,13 @@ namespace Content.Server.Stack
         /// </summary>
         public List<EntityUid> SpawnMultiple(string entityPrototype, int amount, EntityCoordinates spawnPosition)
         {
+            if (amount <= 0)
+            {
+                Log.Error(
+                    $"Attempted to spawn an invalid stack: {entityPrototype}, {amount}. Trace: {Environment.StackTrace}");
+                return new();
+            }
+
             var spawns = CalculateSpawns(entityPrototype, amount);
 
             var spawnedEnts = new List<EntityUid>();
@@ -116,6 +123,13 @@ namespace Content.Server.Stack
         /// <inheritdoc cref="SpawnMultiple(string,int,EntityCoordinates)"/>
         public List<EntityUid> SpawnMultiple(string entityPrototype, int amount, EntityUid target)
         {
+            if (amount <= 0)
+            {
+                Log.Error(
+                    $"Attempted to spawn an invalid stack: {entityPrototype}, {amount}. Trace: {Environment.StackTrace}");
+                return new();
+            }
+
             var spawns = CalculateSpawns(entityPrototype, amount);
 
             var spawnedEnts = new List<EntityUid>();

--- a/Content.Server/Store/Components/CurrencyComponent.cs
+++ b/Content.Server/Store/Components/CurrencyComponent.cs
@@ -8,6 +8,11 @@ namespace Content.Server.Store.Components;
 /// Identifies a component that can be inserted into a store
 /// to increase its balance.
 /// </summary>
+/// <remarks>
+/// Note that if this entity is a stack of items, then this is meant to represent the value per stack item, not
+/// the whole stack. This also means that in general, the actual value should not be modified from the initial
+/// prototype value because otherwise stack merging/splitting may modify the total value.
+/// </remarks>
 [RegisterComponent]
 public sealed partial class CurrencyComponent : Component
 {
@@ -16,6 +21,12 @@ public sealed partial class CurrencyComponent : Component
     /// The string is the currency type that will be added.
     /// The FixedPoint2 is the value of each individual currency entity.
     /// </summary>
+    /// <remarks>
+    /// Note that if this entity is a stack of items, then this is meant to represent the value per stack item, not
+    /// the whole stack. This also means that in general, the actual value should not be modified from the initial
+    /// prototype value
+    /// because otherwise stack merging/splitting may modify the total value.
+    /// </remarks>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("price", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<FixedPoint2, CurrencyPrototype>))]
     public Dictionary<string, FixedPoint2> Price = new();

--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -283,6 +283,9 @@ public sealed partial class StoreSystem
     /// </remarks>
     private void OnRequestWithdraw(EntityUid uid, StoreComponent component, StoreRequestWithdrawMessage msg)
     {
+        if (msg.Amount <= 0)
+            return;
+
         //make sure we have enough cash in the bank and we actually support this currency
         if (!component.Balance.TryGetValue(msg.Currency, out var currentAmount) || currentAmount < msg.Amount)
             return;
@@ -306,7 +309,8 @@ public sealed partial class StoreSystem
             var cashId = proto.Cash[value];
             var amountToSpawn = (int) MathF.Floor((float) (amountRemaining / value));
             var ents = _stack.SpawnMultiple(cashId, amountToSpawn, coordinates);
-            _hands.PickupOrDrop(buyer, ents.First());
+            if (ents.FirstOrDefault() is {} ent)
+                _hands.PickupOrDrop(buyer, ent);
             amountRemaining -= value * amountToSpawn;
         }
 


### PR DESCRIPTION
Prevents store currency from being used multiple times in a single tick.

:cl:
- fix: Fixed a store currency duplication bug/exploit.
