### PR TITLE
fix mutation system debug assert

### DIFF
--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -27,7 +27,7 @@ public sealed class MutationSystem : EntitySystem
     {
         foreach (var mutation in _randomMutations.mutations)
         {
-            if (Random(mutation.BaseOdds * severity))
+            if (Random(Math.Min(mutation.BaseOdds * severity, 1.0f)))
             {
                 if (mutation.AppliesToPlant)
                 {


### PR DESCRIPTION
## About the PR
title

## Why / Balance
bugfix

## Technical details
A high baseOdds value for the mutation chance combined with a high severity for the mutation (Left4Zed + lots of mutagen) can cause the mutation chance to become greater than one, triggering a debug assert.
Add a Math.Min to make sure the maximum probability passed into Random is 1.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
not needed, debug only
