### PR TITLE
Execution System uses the identity of an entity; added "the" to execution message

### DIFF
--- a/Content.Shared/Execution/SharedExecutionSystem.cs
+++ b/Content.Shared/Execution/SharedExecutionSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.CombatMode;
 using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
@@ -155,7 +156,7 @@ public sealed class SharedExecutionSystem : EntitySystem
         if (predict)
         {
             _popup.PopupClient(
-               Loc.GetString(locString, ("attacker", attacker), ("victim", victim), ("weapon", weapon)),
+               Loc.GetString(locString, ("attacker", attacker), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
                attacker,
                attacker,
                PopupType.MediumCaution
@@ -164,7 +165,7 @@ public sealed class SharedExecutionSystem : EntitySystem
         else
         {
             _popup.PopupEntity(
-               Loc.GetString(locString, ("attacker", attacker), ("victim", victim), ("weapon", weapon)),
+               Loc.GetString(locString, ("attacker", attacker), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
                attacker,
                attacker,
                PopupType.MediumCaution
@@ -175,7 +176,7 @@ public sealed class SharedExecutionSystem : EntitySystem
     private void ShowExecutionExternalPopup(string locString, EntityUid attacker, EntityUid victim, EntityUid weapon)
     {
         _popup.PopupEntity(
-            Loc.GetString(locString, ("attacker", attacker), ("victim", victim), ("weapon", weapon)),
+            Loc.GetString(locString, ("attacker", attacker), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
             attacker,
             Filter.PvsExcept(attacker),
             true,

--- a/Content.Shared/Execution/SharedExecutionSystem.cs
+++ b/Content.Shared/Execution/SharedExecutionSystem.cs
@@ -156,7 +156,7 @@ public sealed class SharedExecutionSystem : EntitySystem
         if (predict)
         {
             _popup.PopupClient(
-               Loc.GetString(locString, ("attacker", attacker), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
+               Loc.GetString(locString, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
                attacker,
                attacker,
                PopupType.MediumCaution
@@ -165,7 +165,7 @@ public sealed class SharedExecutionSystem : EntitySystem
         else
         {
             _popup.PopupEntity(
-               Loc.GetString(locString, ("attacker", attacker), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
+               Loc.GetString(locString, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
                attacker,
                attacker,
                PopupType.MediumCaution
@@ -176,7 +176,7 @@ public sealed class SharedExecutionSystem : EntitySystem
     private void ShowExecutionExternalPopup(string locString, EntityUid attacker, EntityUid victim, EntityUid weapon)
     {
         _popup.PopupEntity(
-            Loc.GetString(locString, ("attacker", attacker), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
+            Loc.GetString(locString, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
             attacker,
             Filter.PvsExcept(attacker),
             true,

--- a/Resources/Locale/en-US/execution/execution.ftl
+++ b/Resources/Locale/en-US/execution/execution.ftl
@@ -7,11 +7,11 @@ execution-verb-message = Use your weapon to execute someone.
 # weapon (the weapon used for the execution)
 
 execution-popup-melee-initial-internal = You ready {THE($weapon)} against {THE($victim)}'s throat.
-execution-popup-melee-initial-external = {$attacker} readies {POSS-ADJ($attacker)} {$weapon} against the throat of {THE($victim)}.
+execution-popup-melee-initial-external = { CAPITALIZE(THE($attacker)) } readies {POSS-ADJ($attacker)} {$weapon} against the throat of {THE($victim)}.
 execution-popup-melee-complete-internal = You slit the throat of {THE($victim)}!
-execution-popup-melee-complete-external = {$attacker} slits the throat of {THE($victim) }!
+execution-popup-melee-complete-external = { CAPITALIZE(THE($attacker)) } slits the throat of {THE($victim)}!
 
 execution-popup-self-initial-internal = You ready {THE($weapon)} against your own throat.
-execution-popup-self-initial-external = {$attacker} readies {POSS-ADJ($attacker)} {$weapon} against their own throat.
+execution-popup-self-initial-external = { CAPITALIZE(THE($attacker)) } readies {POSS-ADJ($attacker)} {$weapon} against their own throat.
 execution-popup-self-complete-internal = You slit your own throat!
-execution-popup-self-complete-external = {$attacker} slits their own throat!
+execution-popup-self-complete-external = { CAPITALIZE(THE($attacker)) } slits their own throat!

--- a/Resources/Locale/en-US/execution/execution.ftl
+++ b/Resources/Locale/en-US/execution/execution.ftl
@@ -6,10 +6,10 @@ execution-verb-message = Use your weapon to execute someone.
 # victim (the person being executed)
 # weapon (the weapon used for the execution)
 
-execution-popup-melee-initial-internal = You ready {THE($weapon)} against {$victim}'s throat.
-execution-popup-melee-initial-external = {$attacker} readies {POSS-ADJ($attacker)} {$weapon} against the throat of {$victim}.
-execution-popup-melee-complete-internal = You slit the throat of {$victim}!
-execution-popup-melee-complete-external = {$attacker} slits the throat of {$victim}!
+execution-popup-melee-initial-internal = You ready {THE($weapon)} against {THE($victim)}'s throat.
+execution-popup-melee-initial-external = {$attacker} readies {POSS-ADJ($attacker)} {$weapon} against the throat of {THE($victim)}.
+execution-popup-melee-complete-internal = You slit the throat of {THE($victim)}!
+execution-popup-melee-complete-external = {$attacker} slits the throat of {THE($victim) }!
 
 execution-popup-self-initial-internal = You ready {THE($weapon)} against your own throat.
 execution-popup-self-initial-external = {$attacker} readies {POSS-ADJ($attacker)} {$weapon} against their own throat.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The execution system now checks against the Identity of the victim and uses the name provided by IdentityManager.Name().

Additionally added the optional THE in the localization strings so it correctly displays as "ready the (weapon) against the young man's throat" 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/32509

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the execution system to check against the Identity of the victim and use the name provided by IdentityManagement.Entity().

Additionally added the optional THE in the localization strings so it correctly displays as "ready the (weapon) against the young man's throat" 


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Screenshot showing changed behaviour:
![2024-09-29 21_50_46-Space Station 14](https://github.com/user-attachments/assets/c261baec-8a68-425c-86c8-a49e57a4cfb9)
![2024-09-29 21_50_50-Space Station 14](https://github.com/user-attachments/assets/b28b2659-84c0-4aaa-bb4b-27953e6c9381)
![2024-09-29 21_50_55-Space Station 14](https://github.com/user-attachments/assets/a3d18aa6-093d-4008-83ef-da14c7279e19)
![2024-09-29 21_50_59-Space Station 14](https://github.com/user-attachments/assets/2f07637b-625f-44b9-a18d-3debea1a79a3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed execution system showing character name instead of their identity