### PR TITLE
Slime organs metabolizing slime restores blood level

### DIFF
--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -77,6 +77,14 @@
       effects:
       - !type:SatiateHunger
         factor: 1
+    Drink:
+      effects:
+      - !type:ModifyBloodLevel
+        amount: 0.5 # drawing 15u removes 5% blood level from a slimeperson, this will add 5% when injecting 15u
+        conditions:
+        - !type:OrganType
+          type: Slime
+          shouldHave: true
   footstepSound:
     collection: FootstepBlood
     params:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Slimes metabolizing slime now restores blood level.

Removing 15us of slime from a slime person reduces their blood level to 95%, so injecting (or otherwise metabolizing) 15us of slime will lead to their blood level being increased by 5%.

## Why / Balance
Currently when a slime (or anyone, really) is injected with slime it only satiates their hunger. Slimes have slime in them, so it makes sense for the amount of slime in them to be restored when it's put back in them.

Note, this is nowhere near as effective as saline, it's a 1 to 1.
When you drink slime off of the floor, you drink 1u after the do-after, so... you're getting there in terms of your blood level but it's not crazy.

Although it would be pretty funny to see the police barge in on a nuclear operative slime person drinking their slime off the floor because the agent died.

## Technical details
YAML editing lmao.
Makes it so that the slime reagent has a drink metabolism that restores blood level by an amount of 0.5 if the metabolizing organ is a slime organ.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Slime has variables changed so they no longer restore blood on their own accord. 30u of slime is removed from their body. Blood level falls to 90%.
![Content Client_48Weyvg4D3](https://github.com/user-attachments/assets/bc50f5fc-695d-46ee-82c7-9c5951e9f771)
15u of slime is injected into them. Their blood level increases to 95%.
![Content Client_0MrAmsRjfM](https://github.com/user-attachments/assets/95e57a7b-f6f7-4b9c-a5b2-7529f4b4c035)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Slimes can now metabolize their own slime to restore their blood level.
