### PR TITLE
CorporealSystem cleanup + revenant fixes

### DIFF
--- a/Content.Server/Revenant/EntitySystems/CorporealSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/CorporealSystem.cs
@@ -6,32 +6,46 @@ using Robust.Server.GameObjects;
 
 namespace Content.Server.Revenant.EntitySystems;
 
+/// <summary>
+/// Handles server-specific aspects of the corporeal state, particularly managing visibility changes.
+/// </summary>
 public sealed class CorporealSystem : SharedCorporealSystem
 {
     [Dependency] private readonly VisibilitySystem _visibilitySystem = default!;
-    [Dependency] private readonly GameTicker _ticker = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
 
-    public override void OnStartup(EntityUid uid, CorporealComponent component, ComponentStartup args)
+    protected override void OnInit(EntityUid uid, CorporealComponent component, ComponentStartup args)
     {
-        base.OnStartup(uid, component, args);
-
-        if (TryComp<VisibilityComponent>(uid, out var visibility))
-        {
-            _visibilitySystem.RemoveLayer((uid, visibility), (int) VisibilityFlags.Ghost, false);
-            _visibilitySystem.AddLayer((uid, visibility), (int) VisibilityFlags.Normal, false);
-            _visibilitySystem.RefreshVisibility(uid, visibility);
-        }
+        base.OnInit(uid, component, args);
+        UpdateVisibility(uid, true);
     }
 
-    public override void OnShutdown(EntityUid uid, CorporealComponent component, ComponentShutdown args)
+    protected override void OnShutdown(EntityUid uid, CorporealComponent component, ComponentShutdown args)
     {
         base.OnShutdown(uid, component, args);
 
-        if (TryComp<VisibilityComponent>(uid, out var visibility) && _ticker.RunLevel != GameRunLevel.PostRound)
+        if (_gameTicker.RunLevel != GameRunLevel.PostRound)
         {
-            _visibilitySystem.AddLayer((uid, visibility), (int) VisibilityFlags.Ghost, false);
-            _visibilitySystem.RemoveLayer((uid, visibility), (int) VisibilityFlags.Normal, false);
-            _visibilitySystem.RefreshVisibility(uid, visibility);
+            UpdateVisibility(uid, false);
         }
+    }
+
+    private void UpdateVisibility(EntityUid uid, bool isCorporeal)
+    {
+        if (!TryComp<VisibilityComponent>(uid, out var visibility))
+            return;
+
+        if (isCorporeal)
+        {
+            _visibilitySystem.RemoveLayer((uid, visibility), (int)VisibilityFlags.Ghost, false);
+            _visibilitySystem.AddLayer((uid, visibility), (int)VisibilityFlags.Normal, false);
+        }
+        else
+        {
+            _visibilitySystem.AddLayer((uid, visibility), (int)VisibilityFlags.Ghost, false);
+            _visibilitySystem.RemoveLayer((uid, visibility), (int)VisibilityFlags.Normal, false);
+        }
+
+        _visibilitySystem.RefreshVisibility(uid, visibility);
     }
 }

--- a/Content.Shared/Revenant/Components/CorporealComponent.cs
+++ b/Content.Shared/Revenant/Components/CorporealComponent.cs
@@ -10,6 +10,6 @@ public sealed partial class CorporealComponent : Component
     /// <summary>
     /// The debuff applied when the component is present.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float MovementSpeedDebuff = 0.66f;
 }

--- a/Content.Shared/Revenant/EntitySystems/SharedCorporealSystem.cs
+++ b/Content.Shared/Revenant/EntitySystems/SharedCorporealSystem.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Revenant.EntitySystems;
 /// </summary>
 public abstract class SharedCorporealSystem : EntitySystem
 {
-    [Dependency] protected readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 

--- a/Content.Shared/Revenant/EntitySystems/SharedCorporealSystem.cs
+++ b/Content.Shared/Revenant/EntitySystems/SharedCorporealSystem.cs
@@ -1,28 +1,26 @@
-using Content.Shared.Physics;
-using Robust.Shared.Physics;
 using System.Linq;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Physics;
 using Content.Shared.Revenant.Components;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared.Revenant.EntitySystems;
 
 /// <summary>
-/// Makes the revenant solid when the component is applied.
-/// Additionally applies a few visual effects.
-/// Used for status effect.
+/// Manages the shared aspects of the corporeal state, collision and movement speed changes.
 /// </summary>
 public abstract class SharedCorporealSystem : EntitySystem
 {
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] protected readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-
-        SubscribeLocalEvent<CorporealComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<CorporealComponent, ComponentStartup>(OnInit);
         SubscribeLocalEvent<CorporealComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<CorporealComponent, RefreshMovementSpeedModifiersEvent>(OnRefresh);
     }
@@ -32,32 +30,41 @@ public abstract class SharedCorporealSystem : EntitySystem
         args.ModifySpeed(component.MovementSpeedDebuff, component.MovementSpeedDebuff);
     }
 
-    public virtual void OnStartup(EntityUid uid, CorporealComponent component, ComponentStartup args)
+    protected virtual void OnInit(EntityUid uid, CorporealComponent component, ComponentStartup args)
     {
         _appearance.SetData(uid, RevenantVisuals.Corporeal, true);
-
-        if (TryComp<FixturesComponent>(uid, out var fixtures) && fixtures.FixtureCount >= 1)
-        {
-            var fixture = fixtures.Fixtures.First();
-
-            _physics.SetCollisionMask(uid, fixture.Key, fixture.Value, (int) (CollisionGroup.SmallMobMask | CollisionGroup.GhostImpassable), fixtures);
-            _physics.SetCollisionLayer(uid, fixture.Key, fixture.Value, (int) CollisionGroup.SmallMobLayer, fixtures);
-        }
+        UpdateCollision(uid, true);
         _movement.RefreshMovementSpeedModifiers(uid);
     }
 
-    public virtual void OnShutdown(EntityUid uid, CorporealComponent component, ComponentShutdown args)
+    protected virtual void OnShutdown(EntityUid uid, CorporealComponent component, ComponentShutdown args)
     {
         _appearance.SetData(uid, RevenantVisuals.Corporeal, false);
-
-        if (TryComp<FixturesComponent>(uid, out var fixtures) && fixtures.FixtureCount >= 1)
-        {
-            var fixture = fixtures.Fixtures.First();
-
-            _physics.SetCollisionMask(uid, fixture.Key, fixture.Value, (int) CollisionGroup.GhostImpassable, fixtures);
-            _physics.SetCollisionLayer(uid, fixture.Key, fixture.Value, 0, fixtures);
-        }
-        component.MovementSpeedDebuff = 1; //just so we can avoid annoying code elsewhere
+        UpdateCollision(uid, false);
+        component.MovementSpeedDebuff = 1f;
         _movement.RefreshMovementSpeedModifiers(uid);
+    }
+
+    private void UpdateCollision(EntityUid uid, bool isCorporeal)
+    {
+        if (!TryComp<FixturesComponent>(uid, out var fixtures) || fixtures.FixtureCount == 0)
+            return;
+
+        var fixture = fixtures.Fixtures.First();
+
+        if (isCorporeal)
+        {
+            _physics.SetCollisionMask(uid, fixture.Key, fixture.Value,
+                (int)(CollisionGroup.SmallMobMask | CollisionGroup.GhostImpassable), fixtures);
+            _physics.SetCollisionLayer(uid, fixture.Key, fixture.Value,
+                (int)CollisionGroup.SmallMobLayer, fixtures);
+        }
+        else
+        {
+            _physics.SetCollisionMask(uid, fixture.Key, fixture.Value,
+                (int)CollisionGroup.None, fixtures);
+            _physics.SetCollisionLayer(uid, fixture.Key, fixture.Value,
+                (int)CollisionGroup.GhostImpassable, fixtures);
+        }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Refactors and cleans up SharedCorporealSystem and CorporealSystem. Fixes https://github.com/space-wizards/space-station-14/issues/32540.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bug fix good

## Technical details
<!-- Summary of code changes for easier review. -->
### SharedCorporealSystem
- Moved collision updates into a separate helper method `UpdateCollision`
- Changed `OnInit` and `OnShutdown` to protected virtual methods to allow overriding in derived classes
- Overall formatting and unused code cleanup

### CorporealSystem changes
- Moved visibility updates into a separate method `UpdateVisibility`
- Overrode `OnInit` and `OnShutdown` methods to call the base implementation and then handle visibility changes.
- Renamed `_ticker` to `_gameTicker`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
hopefully none

**Changelog**
no cl, no fun
