### PR TITLE
fix voice mask chameleon menu

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
@@ -35,6 +35,8 @@
       - Snout
     - type: UserInterface
       interfaces:
+        enum.ChameleonUiKey.Key:
+          type: ChameleonBoundUserInterface
         enum.VoiceMaskUIKey.Key:
           type: VoiceMaskBoundUserInterface
 


### PR DESCRIPTION
## About the PR
Reported on discord by TheGlorifiedWard
![grafik](https://github.com/user-attachments/assets/23155631-e8f3-444d-bf78-7137e05e0b87)
Fixes #32551

## Why / Balance
bugfix

## Technical details
Fixes a small error in #30798
The list of interfaces inherited from ClothingMaskGasChameleon is overwritten, so we have to add ChameleonBoundUserInterface again.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed the chameleon settings menu not showing up for the voice mask.
