### PR TITLE
Make crew monitor update blips at consistent rates

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -432,17 +432,14 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
     /// </summary>
     private EntityCoordinates CoordinatesToLocal(EntityCoordinates refCoords)
     {
-        if (NavMap.MapUid == null || NavMap.MapUid == refCoords.EntityId)
+        if (NavMap.MapUid != null)
+        {
+            return _transformSystem.WithEntityId(refCoords, (EntityUid)NavMap.MapUid);
+        }
+        else
         {
             return refCoords;
         }
-
-        var refEntToWorld = _transformSystem.GetWorldMatrix(refCoords.EntityId);
-        var refPosition = Vector2.Transform(refCoords.Position, refEntToWorld);
-
-        var worldToMonitor = _transformSystem.GetInvWorldMatrix((EntityUid)NavMap.MapUid);
-        var refInMonitor = Vector2.Transform(refPosition, worldToMonitor);
-        return new EntityCoordinates((EntityUid)NavMap.MapUid, refInMonitor);
     }
 
     private void ClearOutDatedData()

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -291,7 +291,7 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
             {
                 NavMap.TrackedEntities.TryAdd(sensor.SuitSensorUid,
                     new NavMapBlip
-                    (CoordinatesToLocal(coordinates!.Value),
+                    (CoordinatesToLocal(coordinates.Value),
                     _blipTexture,
                     (_trackedEntity == null || sensor.SuitSensorUid == _trackedEntity) ? Color.LimeGreen : Color.LimeGreen * Color.DimGray,
                     sensor.SuitSensorUid == _trackedEntity));
@@ -436,15 +436,13 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
         {
             return refCoords;
         }
-        else
-        {
-            var refEntToWorld = _transformSystem.GetWorldMatrix(refCoords.EntityId);
-            var refPosition = Vector2.Transform(refCoords.Position, refEntToWorld);
 
-            var worldToMonitor = _transformSystem.GetInvWorldMatrix((EntityUid)NavMap.MapUid);
-            var refInMonitor = Vector2.Transform(refPosition, worldToMonitor);
-            return new EntityCoordinates((EntityUid)NavMap.MapUid, refInMonitor);
-        }
+        var refEntToWorld = _transformSystem.GetWorldMatrix(refCoords.EntityId);
+        var refPosition = Vector2.Transform(refCoords.Position, refEntToWorld);
+
+        var worldToMonitor = _transformSystem.GetInvWorldMatrix((EntityUid)NavMap.MapUid);
+        var refInMonitor = Vector2.Transform(refPosition, worldToMonitor);
+        return new EntityCoordinates((EntityUid)NavMap.MapUid, refInMonitor);
     }
 
     private void ClearOutDatedData()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Made crew monitor update off-grid entities at same rate as on-grid ones. Fixes #30338.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

UI was inconsistently being updated for monitored crew on different grids.

## Technical details
<!-- Summary of code changes for easier review. -->

Great big comment in the change. Map blips were using EntityCoordinates, so would see changes immediately when the transform of the parent entity changed. Just converts all the blips to use the same, fixed coordinate system. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/058e8cea-a5fe-4816-b972-f8b4c257a956


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
