### PR TITLE
Two additional checks to prevent FTLing stations

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -124,6 +124,9 @@ public sealed partial class ShuttleConsoleSystem
         if (!TryComp(shuttleUid, out ShuttleComponent? shuttleComp))
             return;
 
+        if (shuttleComp.Enabled == false)
+            return;
+
         // Check shuttle can even FTL
         if (!_shuttle.CanFTL(shuttleUid.Value, out var reason))
         {

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -225,18 +225,28 @@ public sealed partial class ShuttleSystem
     /// </summary>
     public bool CanFTL(EntityUid shuttleUid, [NotNullWhen(false)] out string? reason)
     {
+        // Currently in FTL already
         if (HasComp<FTLComponent>(shuttleUid))
         {
             reason = Loc.GetString("shuttle-console-in-ftl");
             return false;
         }
 
-        if (FTLMassLimit > 0 &&
-            TryComp(shuttleUid, out PhysicsComponent? shuttlePhysics) &&
-            shuttlePhysics.Mass > FTLMassLimit)
+        if (TryComp<PhysicsComponent>(shuttleUid, out var shuttlePhysics))
         {
-            reason = Loc.GetString("shuttle-console-mass");
-            return false;
+            // Static physics type is set when station anchor is enabled
+            if (shuttlePhysics.BodyType == BodyType.Static)
+            {
+                reason = Loc.GetString("shuttle-console-static");
+                return false;
+            }
+
+            // Too large to FTL
+            if (FTLMassLimit > 0 &&  shuttlePhysics.Mass > FTLMassLimit)
+            {
+                reason = Loc.GetString("shuttle-console-mass");
+                return false;
+            }
         }
 
         if (HasComp<PreventPilotComponent>(shuttleUid))

--- a/Resources/Locale/en-US/shuttles/console.ftl
+++ b/Resources/Locale/en-US/shuttles/console.ftl
@@ -4,6 +4,7 @@ shuttle-pilot-end = Stopped piloting
 shuttle-console-in-ftl = Currently in FTL
 shuttle-console-mass = Too large to FTL
 shuttle-console-prevent = You are unable to pilot this ship
+shuttle-console-static = Grid is static
 
 # NAV
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added more safeguards to prevent FTLing when it shouldn't happen

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People have been FTLing stations because the station anchor's changes were not accounted for in the FTL code at the moment and this kind of ruins rounds

## Technical details
<!-- Summary of code changes for easier review. -->
1. Station anchors allow FTLing because setting the grid to a static physics body causes it to have 0 mass, the mass check is the only thing stopping stations from FTLing normally
2. Add a check in the FTL code for the grid being static
3. Add a check in the FTL code for if the shuttleComp is disabled

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Spam clicking FTL

https://github.com/user-attachments/assets/9cad51ce-4066-4dd5-8f82-9b6612c67e3e


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
nae

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: You can no longer FTL the station.