### PR TITLE
Tweak to the "Chameleon Kit" in the Thief Toolbox (Thief gets Chameleon Backpack)

### DIFF
--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -6,15 +6,7 @@
     sprite: /Textures/Clothing/OuterClothing/Misc/black_hoodie.rsi
     state: icon
   content:
-  - ClothingUniformJumpsuitChameleon
-  - ClothingOuterChameleon
-  - ClothingNeckChameleon
-  - ClothingMaskGasChameleon
-  - ClothingHeadHatChameleon
-  - ClothingEyesChameleon
-  - ClothingHeadsetChameleon
-  - ClothingShoesChameleon
-  - BarberScissors
+  - ClothingBackpackChameleonFill
   - ChameleonProjector
   - AgentIDCard
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Inside the thief toolbox, once the thief chooses and receives the chameleon set, they don't get a bag with it. In this change, they get the chameleon bag filled with the chameleon clothing and with barber scissors like one would get from the Syndicate uplink.

## Why / Balance
There are times where the Thief needs the backpack as well as the clothing, but this is also just fixing an imbalance. Why should one get the chameleon backpack with all the clothing inside as a Syndicate agent but not as a thief? 

## Technical details
Erases all chameleon clothing items and the barber scissors from `Resources/Prototypes/Catalog/thief_toolbox_sets.yml`'s Chameleon Kit section and instead adds the "ClothingBackpackChameleonFill" (filled chameleon backpack) to it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/8dfa8300-62ad-440b-b89d-b5d1c6a4dc1c



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed the thief toolbox Chameleon Kit giving all the individual clothing items. Instead, it will give the chameleon backpack with all the chameleon clothing inside.
