### PR TITLE
Fix quick-swap stacks of items

### DIFF
--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -149,10 +149,7 @@ public sealed class SmartEquipSystem : EntitySystem
             }
 
             _hands.TryDrop(uid, hands.ActiveHand, handsComp: hands);
-            _storage.Insert(slotItem, handItem.Value, out var stacked, out _);
-
-            if (stacked != null)
-                _hands.TryPickup(uid, stacked.Value, handsComp: hands);
+            _storage.Insert(slotItem, handItem.Value, out _, out _);
 
             return;
         }

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Input;
 using Content.Shared.Inventory;
 using Content.Shared.Popups;
+using Content.Shared.Stacks;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Whitelist;
@@ -149,7 +150,15 @@ public sealed class SmartEquipSystem : EntitySystem
             }
 
             _hands.TryDrop(uid, hands.ActiveHand, handsComp: hands);
-            _storage.Insert(slotItem, handItem.Value, out _, out _);
+            _storage.Insert(slotItem, handItem.Value, out var stacked, out _);
+
+            // if the hand item stacked with the things in inventory, but there's no more space left for the rest
+            // of the stack, place the stack back in hand rather than dropping it on the floor
+            if (stacked != null && !_storage.CanInsert(slotItem, handItem.Value, out _))
+            {
+                if (TryComp<StackComponent>(handItem.Value, out var handStack) && handStack.Count > 0)
+                    _hands.TryPickup(uid, handItem.Value, handsComp: hands);
+            }
 
             return;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Quick-swapping a stack of items now prioritizes storing the item instead of putting the completed stack in your hand

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
If you had an unfilled stack in your inventory, and a filled stack in your hand, you would go into an infinite loop of trying to store your stack, the stack filling in the inventory, and then the stack going into your hand with you being unable to actually store the item.

This makes quick-swapping a stack of items match the behavior of clicking a bag with a stack where it properly stores the stack.

Anyone who's used quick swapping knows what the issue I'm talking about is, where you can't store ointments or bruise packs or whatever because you chose to use one of them.

## Technical details
<!-- Summary of code changes for easier review. -->
We check to see if the item in hand can still fit in the storage because the original _storage.Insert() call doesn't tell us if there is anything leftover in our hands that didn't fit into the storage. This could technically be a stack of zero.

If there's extra in our hands that doesn't fit in the storage, and the stack count is greater than zero, place the stack back in hands rather than dropping it on the floor. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:

https://github.com/user-attachments/assets/9a15caf1-9cc0-471e-9af3-aed8db99d796

After:

https://github.com/user-attachments/assets/36dd708c-22b1-4873-811f-813c625f4764



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: You can now quick-swap uneven stacks of items into your inventory without it getting "stuck" in your hands.