### PR TITLE
Bandaid fix to entityeffects on plant trays

### DIFF
--- a/Resources/Prototypes/Hydroponics/randomMutations.yml
+++ b/Resources/Prototypes/Hydroponics/randomMutations.yml
@@ -3,6 +3,7 @@
   mutations:  
     - name: Bioluminescent
       baseOdds: 0.036
+      appliesToPlant: false
       effect: !type:Glow
     - name: Sentient
       baseOdds: 0.0072
@@ -11,6 +12,7 @@
       effect: !type:MakeSentient # existing effect.
     - name: Slippery
       baseOdds: 0.036
+      appliesToPlant: false
       effect: !type:Slipify
     - name: ChangeSpecies
       baseOdds: 0.036


### PR DESCRIPTION
## About the PR
prevented the bioluminescent and slippery effects from being applied to the plant (and thus the plant tray)

## Why / Balance
Quick bandaid fix to address [#32529](https://github.com/space-wizards/space-station-14/issues/32529) before the [botany refactor](https://github.com/space-wizards/space-station-14/pull/31941) gets applied and makes this fix irrellevant, I could've made a check that removed the components after harvesting the plants to keep the visual indicators however that involved removing components that might've otherwise had a valid reason to be there (very small chance)

## Technical details
changed a couple lines in randonMutation.yml


## Requirements
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- fix: fixed slippery and bioluminescent effects persisting on planters after the plant has been harvested
- remove: removed the slippery and bioluminescent visuals from planters temporararily

