### PR TITLE
Bug Fix for Station AI Loadout

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -336,6 +336,8 @@
     - state: base
     - state: ai
       shader: unshaded
+  - type: RandomMetadata
+    nameSegments: [names_ai]
 
 # The actual brain inside the core
 - type: entity

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -25,11 +25,6 @@
   - Trinkets
   - GroupSpeciesBreathTool
 
-# Silicons
-- type: roleLoadout
-  id: JobStationAi
-  nameDataset: names_ai
-
 # Civilian
 - type: roleLoadout
   id: JobPassenger


### PR DESCRIPTION
## About the PR

Fixed a bug where station ai in character customization would show an empty loadout rather than a greyed out one like cyborgs. 

## Why / Balance

Resolves #32360

## Technical details

Deleted the station_ai loadout from ./resources/loadouts/role_loadouts.yml
Added a RandomMetaData component to the PlayerStationAi entity in ./resources/entities/mobs/player/silicon.yml

## Media

![JobsLoadoutGreyed](https://github.com/user-attachments/assets/297d826c-1c7d-4f2c-8db0-909cf71fb934)

## Requirements

- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an in game showcase.


## Breaking changes

<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Fixed blank loadouts for Station AI in character customization
