### PR TITLE
Fix accidental erase of paper contents by spamming save action

### DIFF
--- a/Content.Client/Paper/UI/PaperWindow.xaml.cs
+++ b/Content.Client/Paper/UI/PaperWindow.xaml.cs
@@ -319,6 +319,8 @@ namespace Content.Client.Paper.UI
 
         private void RunOnSaved()
         {
+            // Prevent further saving while text processing still in
+            SaveButton.Disabled = true;
             OnSaved?.Invoke(Rope.Collapse(Input.TextRope));
         }
 


### PR DESCRIPTION
## About the PR
`RunOnSaved()` now disables the save button, making it unspammable.

## Why / Balance
Fixes https://github.com/space-wizards/space-station-14/issues/26024

## Technical details
As the text rope processing takes a while, it was possible to click (or hit ctrl+enter) the save button multiple times during this process and launch multiple  `RunOnSaved()` event handlers.
One of the step in the text processing is clearing the textbox, which makes last handler to save the empty contents.

Added button disabling to `RunOnSaved()`  to prevent this from happening. As Ctrl+Enter also checks for button disabled, this fixes both accidental keyboard shortcut spam and click spam.

## Media
None required

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- fix: Fixed accidental erase of paper contents by spamming save action.