### PR TITLE
More pda space

### DIFF
--- a/Content.Shared/CartridgeLoader/CartridgeLoaderComponent.cs
+++ b/Content.Shared/CartridgeLoader/CartridgeLoaderComponent.cs
@@ -32,8 +32,8 @@ public sealed partial class CartridgeLoaderComponent : Component
     /// <summary>
     /// The maximum amount of programs that can be installed on the cartridge loader entity
     /// </summary>
-    [DataField]
-    public int DiskSpace = 5;
+    [DataField("diskSpace")] // TODO lower this while having pre-installed programs not count to the limit.
+    public int DiskSpace = 6;
 
     /// <summary>
     /// Controls whether the cartridge loader will play notifications if it supports it at all

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -517,6 +517,17 @@
     borderColor: "#7C5D00"
   - type: Icon
     state: pda-captain
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    diskSpace: 10 # Has Four extra pre-installed programs.
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NewsReaderCartridge
+      - MedTekCartridge
+      - WantedListCartridge
+      - LogProbeCartridge
+      - AstroNavCartridge
 
 - type: entity
   parent: BasePDA

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -120,6 +120,7 @@
   abstract: true
   components:
   - type: CartridgeLoader
+    diskSpace: 7 # Has one extra pre-installed program.
     preinstalled:
     - CrewManifestCartridge
     - NotekeeperCartridge
@@ -133,6 +134,7 @@
   components:
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key
+    diskSpace: 7 # Has one extra pre-installed program.
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
@@ -403,6 +405,7 @@
     state: pda-miner
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key
+    diskSpace: 7 # Has one extra pre-installed program.
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
@@ -684,6 +687,14 @@
     accentHColor: "#447987"
   - type: Icon
     state: pda-hos
+  - type: CartridgeLoader
+    diskSpace: 8 # Has two extra pre-installed programs.
+    preinstalled:
+    - CrewManifestCartridge
+    - NotekeeperCartridge
+    - NewsReaderCartridge
+    - WantedListCartridge
+    - LogProbeCartridge
 
 - type: entity
   parent: BaseSecurityPDA
@@ -732,6 +743,17 @@
     borderColor: "#00842e"
   - type: Icon
     state: pda-centcom
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    diskSpace: 10 # Has Four extra pre-installed programs.
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NewsReaderCartridge
+      - MedTekCartridge
+      - WantedListCartridge
+      - LogProbeCartridge
+      - AstroNavCartridge
 
 - type: entity
   parent: CentcomPDA
@@ -748,12 +770,15 @@
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key
     notificationsEnabled: false
+    diskSpace: 16 # Admeme rights matter.
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
       - NewsReaderCartridge
       - LogProbeCartridge
       - WantedListCartridge
+      - MedTekCartridge
+      - AstroNavCartridge
 
 - type: entity
   parent: CentcomPDA
@@ -843,6 +868,7 @@
     state: pda-syndi
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key
+    diskSpace: 4 # Has two less pre-installed programs.
     preinstalled:
       - NotekeeperCartridge
     cartridgeSlot:
@@ -870,6 +896,17 @@
     accentVColor: "#447987"
   - type: Icon
     state: pda-ert
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    diskSpace: 10 # Has Four extra pre-installed programs.
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NewsReaderCartridge
+      - MedTekCartridge
+      - WantedListCartridge
+      - LogProbeCartridge
+      - AstroNavCartridge
 
 - type: entity
   parent: ERTLeaderPDA
@@ -910,14 +947,6 @@
   components:
   - type: Pda
     id: ERTMedicIDCard
-  - type: CartridgeLoader
-    uiKey: enum.PdaUiKey.Key
-    preinstalled:
-      - CrewManifestCartridge
-      - NotekeeperCartridge
-      - NewsReaderCartridge
-      - MedTekCartridge
-      - WantedListCartridge
 
 - type: entity
   parent: ERTLeaderPDA
@@ -1019,6 +1048,14 @@
     borderColor: "#774705"
   - type: Icon
     state: pda-detective
+  - type: CartridgeLoader
+    diskSpace: 8 # Has two extra pre-installed programs.
+    preinstalled:
+    - CrewManifestCartridge
+    - NotekeeperCartridge
+    - NewsReaderCartridge
+    - WantedListCartridge
+    - LogProbeCartridge
 
 - type: entity
   parent: BaseMedicalPDA
@@ -1035,6 +1072,14 @@
     accentVColor: "#d7d7d0"
   - type: Icon
     state: pda-brigmedic
+  - type: CartridgeLoader
+    diskSpace: 8 # Has two extra pre-installed programs.
+    preinstalled:
+    - CrewManifestCartridge
+    - NotekeeperCartridge
+    - NewsReaderCartridge
+    - WantedListCartridge
+    - MedTekCartridge
 
 - type: entity
   parent: ClownPDA
@@ -1148,6 +1193,7 @@
     state: pda-syndi-agent
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key
+    diskSpace: 5 # Has one less pre-installed program.
     preinstalled:
       - NotekeeperCartridge
       - MedTekCartridge


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The following changes were made in this PR:
The max programs a PDA can have was set to 3, excluding the ones that come pre-installed on it.
The Brigmedic PDA now comes with the wanted list program.
The HoS and Detective PDA now come with the logprobe program.
Captain, ERT, CC, Admin and Deathsquad PDAs now all come with more programs (wanted list, logprobe, medtek, astronav), with admin and DS PDA's getting 9 extra program slots instead of 3.

## Why / Balance
With more and more PDA programs being added as functionality is moved from PDAs to these programs, some PDAs were only able to install one  more program or even no extra programs. This PR changes that to be 3 + whatever you already have roundstart.
In regards to the logprobe, this is essential equipment for the detective, and I believe they and their boss (the HoS) should be given it roundstart just like how doctors or salvagers are given their programs roundstart.
As for the cap and admeme pdas, these are all high-ranking positions that should realistically have access to all of these programs.

## Technical details
Just changed the max numbers for now, if somebody can code them to ignore the pre-installed ones thatd be nice.

## Media
Not much to show.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: BramvanZijp
- tweak: The maximum amount of programs that can be installed on a PDA has been reduced from 5 to 3, but no longer includes pre-installed programs.
- tweak: The Detective and Head of Security now get the logprobe program pre-installed on their PDA, while the captain gets all departmental programs.
ADMIN:
- tweak: CC, ERT, Admin, and Deathsquad PDA's now have all departmental programs pre-installed.
- tweak: Increased the max amount of programs that can be installed on the Admin and Deathsquad PDA's to 9.
