### PR TITLE
Sawn off in uplink

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -2,6 +2,9 @@
 uplink-pistol-viper-name = Viper
 uplink-pistol-viper-desc = A small, easily concealable, but somewhat underpowered gun. Retrofitted with a fully automatic receiver. Uses pistol magazines (.35 auto).
 
+uplink-sawn-off-name = Sawn-Off
+uplink-sawn-off-desc = A small, easily concealed weapon with great power up close. Uses .50.
+
 uplink-revolver-python-name = Python
 uplink-revolver-python-desc = A brutally simple, effective, and loud Syndicate revolver. Comes loaded with armor-piercing rounds. Uses .45 magnum.
 

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -88,6 +88,9 @@ uplink-pistol-magazine-desc = Pistol magazine with 10 catridges. Compatible with
 uplink-pistol-magazine-c20r-name = SMG magazine (.35 auto)
 uplink-pistol-magazine-c20r-desc = Rifle magazine with 30 catridges. Compatible with C-20r.
 
+uplink-box-shells-name = A box of .50
+uplink-box-shells-desc = A box of .50 for your shotgun.
+
 uplink-pistol-magazine-caseless-name = Pistol Magazine (.25 caseless)
 uplink-pistol-magazine-caseless-desc = Pistol magazine with 10 catridges. Compatible with the Cobra.
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -498,6 +498,18 @@
   categories:
   - UplinkAmmo
 
+# For any shotguns.. probably sawn-off 
+- type: listing
+  id: UplinkBoxShells
+  name: uplink-box-shells-name
+  description: uplink-box-shells-desc
+  productEntity: BoxLethalshot
+  icon: { sprite: /Textures/Objects/Storage/boxes.rsi, state: shelllethal }
+  cost:
+    Telecrystal: 8
+  categories:
+  - UplinkAmmo
+
 # For the Cobra
 - type: listing
   id: UplinkMagazinePistolCaselessRifle

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -15,6 +15,19 @@
   - UplinkWeaponry
 
 - type: listing
+  id: UplinkSawnOff
+  name: uplink-sawn-off-name
+  description: uplink-sawn-off-desc
+  productEntity: WeaponShotgunSawn
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 4
+  cost:
+    Telecrystal: 6
+  categories:
+  - UplinkWeaponry
+
+- type: listing
   id: UplinkRevolverPython
   name: uplink-revolver-python-name
   description: uplink-revolver-python-desc


### PR DESCRIPTION
## About the PR
Added sawn-off to uplink. You can buy it for 6tc.
Added a box of shells(.50) to uplink. You can but it for 8tc.

## Why / Balance
Traitor can oneshot an unarmored target (actually you need two shots). The bulletproof vest will reduce the damage from two hits to 84, still very effective. Maybe it should be made more expensive.

## Technical details
Adding something to uplink is like ctrl+c ctrl+v..
Just copied vipers code in uplink and changed it a bit, same with shells.

## Media
![image](https://github.com/user-attachments/assets/9870960e-477e-4af2-b971-52b5c086ed13)
![image](https://github.com/user-attachments/assets/b69355eb-5376-4da1-9e6d-0bcafd812716)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Sawn-off added to uplink for 6tc.
- add: Box of shells added to uplink for 8tc.
-->
