### PR TITLE
Fix borg hands showing up in stripping menu

### DIFF
--- a/Content.Client/Inventory/StrippableBoundUserInterface.cs
+++ b/Content.Client/Inventory/StrippableBoundUserInterface.cs
@@ -98,7 +98,7 @@ namespace Content.Client.Inventory
                 }
             }
 
-            if (EntMan.TryGetComponent<HandsComponent>(Owner, out var handsComp))
+            if (EntMan.TryGetComponent<HandsComponent>(Owner, out var handsComp) && handsComp.CanBeStripped)
             {
                 // good ol hands shit code. there is a GuiHands comparer that does the same thing... but these are hands
                 // and not gui hands... which are different...

--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -80,6 +80,12 @@ public sealed partial class HandsComponent : Component
 
     [DataField]
     public DisplacementData? HandDisplacement;
+
+    /// <summary>
+    /// If false, hands cannot be stripped, and they do not show up in the stripping menu.
+    /// </summary>
+    [DataField]
+    public bool CanBeStripped = true;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -352,6 +352,9 @@ public abstract class SharedStrippableSystem : EntitySystem
             !Resolve(target, ref target.Comp))
             return false;
 
+        if (!target.Comp.CanBeStripped)
+            return false;
+
         if (user.Comp.ActiveHand == null)
             return false;
 
@@ -450,6 +453,9 @@ public abstract class SharedStrippableSystem : EntitySystem
         string handName)
     {
         if (!Resolve(target, ref target.Comp))
+            return false;
+
+        if (!target.Comp.CanBeStripped)
             return false;
 
         if (!_handsSystem.TryGetHand(target, handName, out var handSlot, target.Comp))

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -118,6 +118,9 @@ public abstract class SharedStrippableSystem : EntitySystem
             !Resolve(target, ref targetStrippable))
             return;
 
+        if (!target.Comp.CanBeStripped)
+            return;
+
         if (!_handsSystem.TryGetHand(target.Owner, handId, out var handSlot))
             return;
 

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -85,6 +85,7 @@
   - type: Hands
     showInHands: false
     disableExplosionRecursion: true
+    canBeStripped: false
   - type: ComplexInteraction
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter


### PR DESCRIPTION
Borgs can't drop their items anyways, and the amount of hands borgs have causes the UI to just bug out.

![image](https://github.com/user-attachments/assets/ab020338-9637-4200-9d58-99a11bfbdc3d)

:cl:
- fix: Fixed borg "hands" showing up in their stripping menu.