### PR TITLE
Add health analyzer unrevivability warning

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -47,8 +47,7 @@
 
             <PanelContainer Name="AlertsDivider" Visible="False" StyleClasses="LowDivider" />
 
-            <BoxContainer Name="AlertsContainer" Visible="False" Margin="0 5" Orientation="Horizontal"
-                          HorizontalExpand="True" HorizontalAlignment="Center">
+            <BoxContainer Name="AlertsContainer" Visible="False" Margin="0 5" Orientation="Vertical" HorizontalAlignment="Center">
 
             </BoxContainer>
 

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -116,7 +116,6 @@ namespace Content.Client.HealthAnalyzer.UI
             AlertsContainer.Visible = showAlerts;
 
             if (showAlerts)
-                // Wouldn't this end up with these being stuck on after bleeding/etc stops?
                 AlertsContainer.DisposeAllChildren();
 
             if (msg.Unrevivable == true)

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -110,18 +110,30 @@ namespace Content.Client.HealthAnalyzer.UI
 
             // Alerts
 
-            AlertsDivider.Visible = msg.Bleeding == true;
-            AlertsContainer.Visible = msg.Bleeding == true;
+            var showAlerts = msg.Unrevivable == true || msg.Bleeding == true;
+
+            AlertsDivider.Visible = showAlerts;
+            AlertsContainer.Visible = showAlerts;
+
+            if (showAlerts)
+                // Wouldn't this end up with these being stuck on after bleeding/etc stops?
+                AlertsContainer.DisposeAllChildren();
+
+            if (msg.Unrevivable == true)
+                AlertsContainer.AddChild(new RichTextLabel
+                {
+                    Text = Loc.GetString("health-analyzer-window-entity-unrevivable-text"),
+                    Margin = new Thickness(0, 4),
+                    MaxWidth = 300
+                });
 
             if (msg.Bleeding == true)
-            {
-                AlertsContainer.DisposeAllChildren();
-                AlertsContainer.AddChild(new Label
+                AlertsContainer.AddChild(new RichTextLabel
                 {
                     Text = Loc.GetString("health-analyzer-window-entity-bleeding-text"),
-                    FontColorOverride = Color.Red,
+                    Margin = new Thickness(0, 4),
+                    MaxWidth = 300
                 });
-            }
 
             // Damage Groups
 

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -201,6 +201,7 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
                 ? bloodSolution.FillFraction
                 : 0,
             null,
+            null,
             null
         ));
     }

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Body.Components;
 using Content.Server.Medical.Components;
 using Content.Server.PowerCell;
 using Content.Server.Temperature.Components;
+using Content.Server.Traits.Assorted;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
@@ -196,6 +197,7 @@ public sealed class HealthAnalyzerSystem : EntitySystem
 
         var bloodAmount = float.NaN;
         var bleeding = false;
+        var unrevivable = false;
 
         if (TryComp<BloodstreamComponent>(target, out var bloodstream) &&
             _solutionContainerSystem.ResolveSolution(target, bloodstream.BloodSolutionName,
@@ -205,12 +207,16 @@ public sealed class HealthAnalyzerSystem : EntitySystem
             bleeding = bloodstream.BleedAmount > 0;
         }
 
+        if (HasComp<UnrevivableComponent>(target))
+            unrevivable = true;
+
         _uiSystem.ServerSendUiMessage(healthAnalyzer, HealthAnalyzerUiKey.Key, new HealthAnalyzerScannedUserMessage(
             GetNetEntity(target),
             bodyTemperature,
             bloodAmount,
             scanMode,
-            bleeding
+            bleeding,
+            unrevivable
         ));
     }
 }

--- a/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
@@ -13,14 +13,16 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
     public float BloodLevel;
     public bool? ScanMode;
     public bool? Bleeding;
+    public bool? Unrevivable;
 
-    public HealthAnalyzerScannedUserMessage(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding)
+    public HealthAnalyzerScannedUserMessage(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable)
     {
         TargetEntity = targetEntity;
         Temperature = temperature;
         BloodLevel = bloodLevel;
         ScanMode = scanMode;
         Bleeding = bleeding;
+        Unrevivable = unrevivable;
     }
 }
 

--- a/Resources/Locale/en-US/medical/components/health-analyzer-component.ftl
+++ b/Resources/Locale/en-US/medical/components/health-analyzer-component.ftl
@@ -15,7 +15,8 @@ health-analyzer-window-entity-damage-total-text = Total Damage:
 health-analyzer-window-damage-group-text = {$damageGroup}: {$amount}
 health-analyzer-window-damage-type-text = {$damageType}: {$amount}
 
-health-analyzer-window-entity-bleeding-text = Patient is bleeding!
+health-analyzer-window-entity-unrevivable-text = [color=red]Unique body composition detected! Patient can not be resuscitated by normal means![/color]
+health-analyzer-window-entity-bleeding-text = [color=red]Patient is bleeding![/color]
 
 health-analyzer-window-scan-mode-text = Scan Mode:
 health-analyzer-window-scan-mode-active = Active


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a warning about unrevivability of the patient when scanning them

## Why / Balance
Nobody wants to use up half of the medbay's topicals on an atmos tech that was in a fire, only to discover they can not be revived. Something something medical records?

## Technical details
Added yet another field into health analyzer UI message. Changed a bit of the health analyzer UI. Also the bleeding warning FTL is now using formatting.

## Media
![image](https://github.com/user-attachments/assets/0114bace-29af-40aa-9683-8b8adc70c488)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added a warning about unrevivability in the health analyzer UI.