### PR TITLE
Add Fragile plant mutation

### DIFF
--- a/Content.Server/Destructible/Thresholds/DamageThreshold.cs
+++ b/Content.Server/Destructible/Thresholds/DamageThreshold.cs
@@ -40,7 +40,7 @@ namespace Content.Server.Destructible.Thresholds
         /// <summary>
         ///     Behaviors to activate once this threshold is triggered.
         /// </summary>
-        [ViewVariables] public IReadOnlyList<IThresholdBehavior> Behaviors => _behaviors;
+        [ViewVariables] public IList<IThresholdBehavior> Behaviors => _behaviors;
 
         public bool Reached(DamageableComponent damageable, DestructibleSystem system)
         {

--- a/Content.Server/EntityEffects/Effects/Fragile.cs
+++ b/Content.Server/EntityEffects/Effects/Fragile.cs
@@ -1,0 +1,50 @@
+using Content.Server.Damage.Components;
+using Content.Server.Destructible;
+using Content.Server.Destructible.Thresholds;
+using Content.Server.Destructible.Thresholds.Behaviors;
+using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Damage;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+using System.Linq;
+
+namespace Content.Server.EntityEffects.Effects;
+
+/// <summary>
+///     Makes the entity very fragile, enough to break when thrown. Will spill contents if this is a SolutionContainer.
+/// </summary>
+public sealed partial class Fragile : EntityEffect
+{
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        var damageable = args.EntityManager.EnsureComponent<DamageableComponent>(args.TargetEntity);
+
+        var hurtOnThrow = args.EntityManager.EnsureComponent<DamageOnLandComponent>(args.TargetEntity);
+        hurtOnThrow.Damage = new() { DamageDict = new() { { "Blunt", 5 } } };
+
+        var destroy = args.EntityManager.EnsureComponent<DestructibleComponent>(args.TargetEntity);
+        var dt = new DamageThreshold()
+        {
+            Trigger = new Destructible.Thresholds.Triggers.DamageTrigger() { Damage = 5 },
+        };
+
+        if (args.EntityManager.TryGetComponent<SolutionContainerManagerComponent>(args.TargetEntity, out var solutionContainerManager))
+        {
+            var toSpill = solutionContainerManager?.Containers?.FirstOrDefault();
+            if (toSpill != null)
+            {
+                dt.Behaviors.Add(new SpillBehavior() { Solution = toSpill });
+            }
+        }
+
+        dt.Behaviors.Add(new DoActsBehavior() { Acts = ThresholdActs.Destruction });
+        dt.Behaviors.Add(new PlaySoundBehavior() { Sound = new SoundCollectionSpecifier("desecration") });
+        destroy.Thresholds.Add(dt);
+    }
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+    {
+        return "TODO";
+    }
+}

--- a/Resources/Prototypes/Hydroponics/randomMutations.yml
+++ b/Resources/Prototypes/Hydroponics/randomMutations.yml
@@ -180,3 +180,7 @@
       baseOdds: 0.036
       persists: false
       effect: !type:PlantMutateHarvest
+    - name: Fragile
+      baseOdds: 0.018
+      appliesToPlant: false
+      effect: !type:Fragile


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Plants can now mutate to be fragile. Throwing one will cause it to pop and spill its chemicals.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A small part of a continuing effort to expand Hydroponics content. More mutation options allow Botanists to do more stuff. 
Some plants already have this or a similar effect. This allows all plants to have a small chance to do this.  This can allow plants to potentially apply effects from a distance, without being ground up in a beaker first. 

## Technical details
<!-- Summary of code changes for easier review. -->
New EntityEffect was written, with a check so that this could be applies to other, non-produce entities in the future.
New mutation entry was added to yml.
DamageThreshold's behavior list had to be made editable in order to be set in C# code dynamically.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/ac63dbde-2a55-462a-b935-146d44d313d5)
_Lying Dog Has Disgust Registered With Them, 2584, Artist Unknown_

![image](https://github.com/user-attachments/assets/2443d750-482b-41b7-b264-e031c4aa7fc3)
_Lying Dog Experiences Consequence For Lying, 2584, Artist Unknown_

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Plants can now be mutated to make fragile produce. They will break when thrown. 