### PR TITLE
Adds a variety of new options for passenger loadouts.

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -1,3 +1,13 @@
+# SmallTide Time
+- type: loadoutEffectGroup
+  id: SmallTide
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobPassenger
+      time: 18000 #5 hrs, stopgap for newbies and raiders
+
 # Greytide Time
 - type: loadoutEffectGroup
   id: GreyTider
@@ -38,6 +48,312 @@
   id: GreyJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtColorGrey
+
+# Black
+- type: loadout
+  id: BlackJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorBlack
+
+- type: loadout
+  id: BlackJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorBlack
+
+# Blue
+- type: loadout
+  id: BlueJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorBlue
+
+- type: loadout
+  id: BlueJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorBlue
+
+# Dark Blue
+- type: loadout
+  id: DarkBlueJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorDarkBlue
+
+- type: loadout
+  id: DarkBlueJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorDarkBlue
+
+# Teal
+- type: loadout
+  id: TealJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorTeal
+
+- type: loadout
+  id: TealJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorTeal
+
+# Green
+- type: loadout
+  id: GreenJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorGreen
+
+- type: loadout
+  id: GreenJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorGreen
+
+# Dark Green
+- type: loadout
+  id: DarkGreenJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorDarkGreen
+
+- type: loadout
+  id: DarkGreenJumpskirt 
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorDarkGreen
+
+# Orange
+- type: loadout
+  id: OrangeJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorOrange
+
+- type: loadout
+  id: OrangeJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorOrange
+
+# Pink
+- type: loadout
+  id: PinkJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorPink
+
+- type: loadout
+  id: PinkJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorPink
+
+# Purple
+- type: loadout
+  id: PurpleJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorPurple
+
+- type: loadout
+  id: PurpleJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorPurple
+
+# Light Brown
+- type: loadout
+  id: LightBrownJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorLightBrown
+
+- type: loadout
+  id: LightBrownJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorLightBrown
+
+# Brown
+- type: loadout
+  id: BrownJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorBrown
+
+- type: loadout
+  id: BrownJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorBrown
+
+# Maroon
+- type: loadout
+  id: MaroonJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitColorMaroon
+
+- type: loadout
+  id: MaroonJumpskirt 
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtColorMaroon
+
+# Hawaiian Shirts
+- type: loadout
+  id: HawaiiBlack
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitHawaiBlack
+
+- type: loadout
+  id: HawaiiBlue
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitHawaiBlue
+
+- type: loadout
+  id: HawaiiRed
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitHawaiRed
+
+- type: loadout
+  id: HawaiiYellow
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitHawaiYellow
+
+# Flannel
+- type: loadout
+  id: FlannelRed
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitFlannel
+
+# Loungewear
+- type: loadout
+  id: Loungewear
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitLoungewear
+
+# Casual Blue
+- type: loadout
+  id: CasualBlueJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitCasualBlue
+
+- type: loadout
+  id: CasualBlueJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtCasualBlue
+
+# Casual Purple
+- type: loadout
+  id: CasualPurpleJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitCasualPurple
+
+- type: loadout
+  id: CasualPurpleJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtCasualPurple
+
+# Casual Red
+- type: loadout
+  id: CasualRedJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitCasualRed
+
+- type: loadout
+  id: CasualRedJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtCasualRed
 
 # Rainbow
 - type: loadout
@@ -89,10 +405,10 @@
 
 # Gloves
 - type: loadout
-  id: PassengerGloves
+  id: FingerlessInsuls
   effects:
   - !type:GroupLoadoutEffect
-    proto: GreyTider
+    proto: MasterGrey
   equipment:
     gloves: ClothingHandsGlovesFingerlessInsulated
 
@@ -102,11 +418,62 @@
   equipment:
     outerClothing: ClothingOuterWinterCoat
 
+- type: loadout
+  id: BomberCoat
+  equipment:
+    outerClothing: ClothingOuterCoatBomber
+
+- type: loadout
+  id: GentleCoat
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment:
+    outerClothing: ClothingOuterCoatGentle
+
+- type: loadout
+  id: JensenCoat
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SmallTide
+  equipment:
+    outerClothing: ClothingOuterCoatJensen
+
 # Shoes
 - type: loadout
   id: BlackShoes
   equipment:
     shoes: ClothingShoesColorBlack
+
+- type: loadout
+  id: GreenShoes
+  equipment:
+    shoes: ClothingShoesColorGreen
+
+- type: loadout
+  id: OrangeShoes
+  equipment:
+    shoes: ClothingShoesColorOrange
+
+- type: loadout
+  id: RedShoes
+  equipment:
+    shoes: ClothingShoesColorRed
+
+- type: loadout
+  id: YellowShoes
+  equipment:
+    shoes: ClothingShoesColorYellow
+
+- type: loadout
+  id: PurpleShoes
+  equipment:
+    shoes: ClothingShoesColorPurple
+
+- type: loadout
+  id: TouristShoes
+  equipment:
+    shoes: ClothingShoesTourist
 
 - type: loadout
   id: WinterBoots

--- a/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/glasses.yml
@@ -24,6 +24,26 @@
   equipment:
     eyes: ClothingEyesGlasses
 
+- type: loadout
+  id: GarGlasses
+  equipment:
+    eyes: ClothingEyesGlassesGar
+
+- type: loadout
+  id: OrangeGarGlasses
+  equipment:
+    eyes: ClothingEyesGlassesGarOrange
+
+- type: loadout
+  id: GigaGarGlasses
+  equipment:
+    eyes: ClothingEyesGlassesGarGiga
+
+- type: loadout
+  id: CheapSunglasses
+  equipment:
+    eyes: ClothingEyesGlassesCheapSunglasses
+
 # Special options
 # Jamjar
 - type: loadout

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -33,6 +33,10 @@
   minLimit: 0
   loadouts:
   - Glasses
+  - GarGlasses
+  - OrangeGarGlasses
+  - GigaGarGlasses
+  - CheapSunglasses
   - GlassesJamjar
   - GlassesJensen
 
@@ -157,6 +161,46 @@
   loadouts:
   - GreyJumpsuit
   - GreyJumpskirt
+  - WhiteJumpsuit
+  - WhiteJumpskirt
+  - BlackJumpsuit
+  - BlackJumpskirt
+  - BlueJumpsuit
+  - BlueJumpskirt
+  - YellowJumpsuit
+  - YellowJumpskirt
+  - DarkBlueJumpsuit
+  - DarkBlueJumpskirt
+  - TealJumpsuit
+  - TealJumpskirt
+  - GreenJumpsuit
+  - GreenJumpskirt
+  - DarkGreenJumpsuit
+  - DarkGreenJumpskirt
+  - OrangeJumpsuit
+  - OrangeJumpskirt
+  - PinkJumpsuit
+  - PinkJumpskirt
+  - PurpleJumpsuit
+  - PurpleJumpskirt
+  - LightBrownJumpsuit
+  - LightBrownJumpskirt
+  - BrownJumpsuit
+  - BrownJumpskirt
+  - MaroonJumpsuit
+  - MaroonJumpskirt
+  - HawaiiBlack
+  - HawaiiBlue
+  - HawaiiRed
+  - HawaiiYellow
+  - FlannelRed
+  - Loungewear
+  - CasualBlueJumpsuit
+  - CasualBlueJumpskirt
+  - CasualPurpleJumpsuit
+  - CasualPurpleJumpskirt
+  - CasualRedJumpsuit
+  - CasualRedJumpskirt
   - AncientJumpsuit
   - RainbowJumpsuit
 
@@ -172,7 +216,7 @@
   name: loadout-group-passenger-gloves
   minLimit: 0
   loadouts:
-  - PassengerGloves
+  - FingerlessInsuls
 
 - type: loadoutGroup
   id: CommonBackpack
@@ -195,12 +239,23 @@
   minLimit: 0
   loadouts:
   - PassengerWintercoat
+  - BomberCoat
+  - GentleCoat
+  - JensenCoat
 
 - type: loadoutGroup
   id: PassengerShoes
   name: loadout-group-passenger-shoes
   loadouts:
   - BlackShoes
+  - WhiteShoes
+  - BrownShoes
+  - GreenShoes
+  - OrangeShoes
+  - RedShoes
+  - YellowShoes
+  - PurpleShoes
+  - TouristShoes
   - WinterBoots
 
 - type: loadoutGroup


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a lot of new options for passenger loadouts. Mainly jumpsuits - colored jumpsuits, Hawaiian shirts, casual jumpsuits - but also adds a few new misc items, like cheap sunglasses and colored shoes.

## Why / Balance
Passenger has the least responsibility and the most adaptability when it comes to character creation, gameplay variety, and roleplay. Almost every single item added to their loadouts in this PR can be obtained from basic clothing vendors scattered around the station, cargo, and uniform printers. Nothing added to their loadouts is generally out of their control to obtain, and almost all of it can be obtained very easily. The only real exception to this is the Gar Glasses, which I would accept being removed in favor of remaining as maintenance loot.  

Very few of these outfits can be used to disguise yourself as another department, and acquiring the outfits to do so is already quite easy. However, to prevent raiders from abusing this, and to ensure that it is still somewhat readable when someone is a new join, there is a 5 hour playtime requirement on most of these additional clothing items.

## Technical details
Changes the passenger.yml loadout file, and the loadout_groups.yml file.

## Media

**https://youtu.be/hKRkzUpxIxY**

![Screenshot (1523)](https://github.com/user-attachments/assets/aee3a2d7-5dd8-4eb2-bc58-f214acb116c5)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added new customization options for passenger loadouts.
