### PR TITLE
Added Illeism as a speech trait

### DIFF
--- a/Content.Server/Speech/Components/IlleismAccentComponent.cs
+++ b/Content.Server/Speech/Components/IlleismAccentComponent.cs
@@ -1,0 +1,8 @@
+using Content.Server.Speech.EntitySystems;
+
+namespace Content.Server.Speech.Components;
+
+[RegisterComponent]
+[Access(typeof(IlleismAccentSystem))]
+public sealed partial class IlleismAccentComponent : Component
+{ }

--- a/Content.Server/Speech/EntitySystems/IlleismAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/IlleismAccentSystem.cs
@@ -1,0 +1,79 @@
+using System.Text.RegularExpressions;
+using Content.Server.Speech.Components;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class IlleismAccentSystem : EntitySystem
+{
+    // I am going to Sec -> Bean is going to Sec
+    private static readonly Regex RegexIAmUpper = new(@"\bI\s*AM\b");
+    private static readonly Regex RegexIAmLower = new(@"\bi\s*am\b", RegexOptions.IgnoreCase);
+
+    // I have it -> Bean has it
+    private static readonly Regex RegexIHaveUpper = new(@"\bI\s*HAVE\b");
+    private static readonly Regex RegexIHaveLower = new(@"\bi\s*have\b", RegexOptions.IgnoreCase);
+
+    // I do! -> Bean does!
+    private static readonly Regex RegexIDoUpper = new(@"\bI\s*DO\b");
+    private static readonly Regex RegexIDoLower = new(@"\bi\s*do\b", RegexOptions.IgnoreCase);
+
+    // I don't! -> Bean doesn't!
+    private static readonly Regex RegexIDontUpper = new(@"\bI\s+DON'?T\b");
+    private static readonly Regex RegexIDontLower = new(@"\bi\s+don'?t\b", RegexOptions.IgnoreCase);
+
+    // I -> Bean
+    private static readonly Regex RegexI = new(@"\bI\b");
+
+    // Me -> Bean
+    private static readonly Regex RegexMeUpper = new(@"\bME\b");
+    private static readonly Regex RegexMeLower = new(@"\bme\b", RegexOptions.IgnoreCase);
+
+    // My crowbar -> Bean's crowbar
+    private static readonly Regex RegexMyUpper = new(@"\bMY\b");
+    private static readonly Regex RegexMyLower = new(@"\bmy\b\b", RegexOptions.IgnoreCase);
+
+
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<IlleismAccentComponent, AccentGetEvent>(OnAccent);
+    }
+
+    private void OnAccent(EntityUid uid, IlleismAccentComponent component, AccentGetEvent args)
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var message = args.Message;
+
+        // I am going to Sec -> Bean is going to Sec
+        message = RegexIAmUpper.Replace(message, (Name(uid) + " is").ToUpper());
+        message = RegexIAmLower.Replace(message, Name(uid) + " is");
+
+        // I have it -> Bean has it
+        message = RegexIHaveUpper.Replace(message, (Name(uid) + " has").ToUpper());
+        message = RegexIHaveLower.Replace(message, Name(uid) + " has");
+
+        // I do! -> Bean does!
+        message = RegexIDoUpper.Replace(message, (Name(uid) + " does").ToUpper());
+        message = RegexIDoLower.Replace(message, Name(uid) + " does");
+
+        // I don't! -> Bean doesn't!
+        message = RegexIDontUpper.Replace(message, (Name(uid) + " doesn't").ToUpper());
+        message = RegexIDontLower.Replace(message, Name(uid) + " doesn't");
+
+        // I -> Bean
+        message = RegexI.Replace(message, Name(uid));
+
+        // Me -> Bean
+        message = RegexMeUpper.Replace(message, Name(uid).ToUpper());
+        message = RegexMeLower.Replace(message, Name(uid));
+
+        // My crowbar -> Bean's crowbar
+        message = RegexMyUpper.Replace(message, (Name(uid) + "'s").ToUpper());
+        message = RegexMyLower.Replace(message, Name(uid) + "'s");
+
+        args.Message = message;
+    }
+};

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -45,6 +45,9 @@ trait-snoring-desc = You will snore while sleeping.
 trait-liar-name = Pathological liar
 trait-liar-desc = You can hardly bring yourself to tell the truth. Sometimes you lie anyway.
 
+trait-illeism-name = Illeism
+trait-illeism-desc = You seem to only be able to refer to yourself by name
+
 trait-cowboy-name = Cowboy accent
 trait-cowboy-desc = You speak with a distinct cowboy accent!
 

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -17,6 +17,15 @@
 # 1 Cost
 
 - type: trait
+  id: illeism
+  name: trait-illeism-name
+  description: trait-illeism-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: IlleismAccent
+
+- type: trait
   id: SouthernAccent
   name: trait-southern-name
   description: trait-southern-desc


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a new speech trait, "**illeism**", IE: referring to yourself in third person.

## Why / Balance
This added trait makes roleplaying as an illeist much easier, automatically changing references of I, me, my, and some corresponding phrases, to their correct form, rather than having to do it manually. This saves time and makes roleplaying as an illeist much more appealing to a wider audience. Illeism is compatible with other speech traits, including racial speech patterns. 

## Technical details
This PR adds two new files, `IlleismAccentSystem.cs` & `IlleismAccentComponent.cs`, as well as modifies `traits.ftl` & `speech.yml`.

`IlleismAccentSystem.cs` includes the regex functions to search for and replace the correct phrases.
Phrases include:
I am -> NAME is
I have -> NAME has
I do -> NAME does
I don't -> NAME doesn't
I -> NAME
Me -> NAME
My -> NAME's
_This includes fully capitalized versions_

`IlleismAccentComponent.cs` is the corresponding component.
`traits.ftl` was modified to include a trait name and description.
`speech.yml` was modified to include illeism as a selectable trait worth 1 speech point, as this trait is compatible with others.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added Illeism as a selectable speech trait!

