### PR TITLE
fix votekicks being always unavailable unless ghosted

### DIFF
--- a/Content.Client/Voting/VotingSystem.cs
+++ b/Content.Client/Voting/VotingSystem.cs
@@ -1,4 +1,3 @@
-using Content.Client.Ghost;
 using Content.Shared.Voting;
 
 namespace Content.Client.Voting;
@@ -7,8 +6,6 @@ public sealed class VotingSystem : EntitySystem
 {
 
     public event Action<VotePlayerListResponseEvent>? VotePlayerListResponse; //Provides a list of players elligble for vote actions
-
-    [Dependency] private readonly GhostSystem _ghostSystem = default!;
 
     public override void Initialize()
     {
@@ -19,11 +16,6 @@ public sealed class VotingSystem : EntitySystem
 
     private void OnVotePlayerListResponseEvent(VotePlayerListResponseEvent msg)
     {
-        if (!_ghostSystem.IsGhost)
-        {
-            return;
-        }
-
         VotePlayerListResponse?.Invoke(msg);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed the `IsGhost` check and the associated dependencies in the `VotingSystem` class.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The `IsGhost` check was redundant because the server already performs eligibility checks for votekick initiators, based on the configuration and player status. It created an issue where, despite having the `votekick.initiator_ghost_requirement` CVar set to false, you still couldn't call a votekick if not ghosted.

## Technical details
<!-- Summary of code changes for easier review. -->
Deleted the `IsGhost` check in the `OnVotePlayerListResponseEvent` method, allowing the event to be invoked for all users who passed the server-side checks. Removed the `GhostSystem` dependency and the `_ghostSystem` field from `VotingSystem`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl, no fun
