### PR TITLE
Feature/make radial menu great again

### DIFF
--- a/Content.Client/Chat/UI/EmotesMenu.xaml
+++ b/Content.Client/Chat/UI/EmotesMenu.xaml
@@ -7,25 +7,25 @@
                 MinSize="450 450">
 
     <!-- Main -->
-    <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" Radius="64" ReserveSpaceForHiddenChildren="False">
-        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-general'}" TargetLayer="General" Visible="False">
+    <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" InitialRadius="100" ReserveSpaceForHiddenChildren="False">
+        <ui:RadialMenuTextureButtonWithSector SetSize="64 64" ToolTip="{Loc 'emote-menu-category-general'}" TargetLayer="General" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Clothing/Head/Soft/mimesoft.rsi/icon.png"/>
         </ui:RadialMenuTextureButtonWithSector>
-        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-vocal'}" TargetLayer="Vocal" Visible="False">
+        <ui:RadialMenuTextureButtonWithSector SetSize="64 64" ToolTip="{Loc 'emote-menu-category-vocal'}" TargetLayer="Vocal" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Emotes/vocal.png"/>
         </ui:RadialMenuTextureButtonWithSector>
-        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-hands'}" TargetLayer="Hands" Visible="False">
+        <ui:RadialMenuTextureButtonWithSector SetSize="64 64" ToolTip="{Loc 'emote-menu-category-hands'}" TargetLayer="Hands" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Clothing/Hands/Gloves/latex.rsi/icon.png"/>
         </ui:RadialMenuTextureButtonWithSector>
     </ui:RadialContainer>
 
     <!-- General -->
-    <ui:RadialContainer Name="General"  VerticalExpand="True" HorizontalExpand="True" Radius="64"/>
+    <ui:RadialContainer Name="General"  VerticalExpand="True" HorizontalExpand="True" InitialRadius="100"/>
 
     <!-- Vocal -->
-    <ui:RadialContainer Name="Vocal"  VerticalExpand="True" HorizontalExpand="True" Radius="64"/>
+    <ui:RadialContainer Name="Vocal"  VerticalExpand="True" HorizontalExpand="True" InitialRadius="100"/>
 
     <!-- Hands -->
-    <ui:RadialContainer Name="Hands"  VerticalExpand="True" HorizontalExpand="True" Radius="64"/>
+    <ui:RadialContainer Name="Hands"  VerticalExpand="True" HorizontalExpand="True" InitialRadius="100"/>
 
 </ui:RadialMenu>

--- a/Content.Client/Chat/UI/EmotesMenu.xaml
+++ b/Content.Client/Chat/UI/EmotesMenu.xaml
@@ -8,7 +8,7 @@
 
     <!-- Main -->
     <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" Radius="64" ReserveSpaceForHiddenChildren="False">
-        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" DisplayDebug="True" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-general'}" TargetLayer="General" Visible="False">
+        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-general'}" TargetLayer="General" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Clothing/Head/Soft/mimesoft.rsi/icon.png"/>
         </ui:RadialMenuTextureButton>
         <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-vocal'}" TargetLayer="Vocal" Visible="False">

--- a/Content.Client/Chat/UI/EmotesMenu.xaml
+++ b/Content.Client/Chat/UI/EmotesMenu.xaml
@@ -1,4 +1,4 @@
-﻿<ui:RadialMenu xmlns="https://spacestation14.io"
+<ui:RadialMenu xmlns="https://spacestation14.io"
                 xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
                 BackButtonStyleClass="RadialMenuBackButton"
                 CloseButtonStyleClass="RadialMenuCloseButton"
@@ -8,7 +8,7 @@
 
     <!-- Main -->
     <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" Radius="64" ReserveSpaceForHiddenChildren="False">
-        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-general'}" TargetLayer="General" Visible="False">
+        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" DisplayDebug="True" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-general'}" TargetLayer="General" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Clothing/Head/Soft/mimesoft.rsi/icon.png"/>
         </ui:RadialMenuTextureButton>
         <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-vocal'}" TargetLayer="Vocal" Visible="False">

--- a/Content.Client/Chat/UI/EmotesMenu.xaml
+++ b/Content.Client/Chat/UI/EmotesMenu.xaml
@@ -8,15 +8,15 @@
 
     <!-- Main -->
     <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" Radius="64" ReserveSpaceForHiddenChildren="False">
-        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-general'}" TargetLayer="General" Visible="False">
+        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-general'}" TargetLayer="General" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Clothing/Head/Soft/mimesoft.rsi/icon.png"/>
-        </ui:RadialMenuTextureButton>
-        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-vocal'}" TargetLayer="Vocal" Visible="False">
+        </ui:RadialMenuTextureButtonWithSector>
+        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-vocal'}" TargetLayer="Vocal" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Emotes/vocal.png"/>
-        </ui:RadialMenuTextureButton>
-        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-hands'}" TargetLayer="Hands" Visible="False">
+        </ui:RadialMenuTextureButtonWithSector>
+        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'emote-menu-category-hands'}" TargetLayer="Hands" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Clothing/Hands/Gloves/latex.rsi/icon.png"/>
-        </ui:RadialMenuTextureButton>
+        </ui:RadialMenuTextureButtonWithSector>
     </ui:RadialContainer>
 
     <!-- General -->

--- a/Content.Client/Chat/UI/EmotesMenu.xaml.cs
+++ b/Content.Client/Chat/UI/EmotesMenu.xaml.cs
@@ -50,7 +50,6 @@ public sealed partial class EmotesMenu : RadialMenu
 
             var button = new EmoteMenuButton
             {
-                StyleClasses = { "RadialMenuButton" },
                 SetSize = new Vector2(64f, 64f),
                 ToolTip = Loc.GetString(emote.Name),
                 ProtoId = emote.ID,

--- a/Content.Client/Chat/UI/EmotesMenu.xaml.cs
+++ b/Content.Client/Chat/UI/EmotesMenu.xaml.cs
@@ -106,7 +106,7 @@ public sealed partial class EmotesMenu : RadialMenu
 }
 
 
-public sealed class EmoteMenuButton : RadialMenuTextureButton
+public sealed class EmoteMenuButton : RadialMenuTextureButtonWithSector
 {
     public ProtoId<EmotePrototype> ProtoId { get; set; }
 }

--- a/Content.Client/Ghost/GhostRoleRadioMenu.xaml.cs
+++ b/Content.Client/Ghost/GhostRoleRadioMenu.xaml.cs
@@ -51,7 +51,6 @@ public sealed partial class GhostRoleRadioMenu : RadialMenu
 
             var button = new GhostRoleRadioMenuButton()
             {
-                StyleClasses = { "RadialMenuButton" },
                 SetSize = new Vector2(64, 64),
                 ToolTip = Loc.GetString(ghostRoleProto.Name),
                 ProtoId = ghostRoleProto.ID,

--- a/Content.Client/Ghost/GhostRoleRadioMenu.xaml.cs
+++ b/Content.Client/Ghost/GhostRoleRadioMenu.xaml.cs
@@ -100,7 +100,7 @@ public sealed partial class GhostRoleRadioMenu : RadialMenu
     }
 }
 
-public sealed class GhostRoleRadioMenuButton : RadialMenuTextureButton
+public sealed class GhostRoleRadioMenuButton : RadialMenuTextureButtonWithSector
 {
     public ProtoId<GhostRolePrototype> ProtoId { get; set; }
 }

--- a/Content.Client/RCD/RCDMenu.xaml
+++ b/Content.Client/RCD/RCDMenu.xaml
@@ -11,37 +11,37 @@
     <!-- The radial menu will try to open so that its center is located where the player's cursor is currently -->
 
     <!-- Entry layer (shows main categories) -->
-    <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" Radius="64" ReserveSpaceForHiddenChildren="False">
-        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-walls-and-flooring'}" TargetLayer="WallsAndFlooring" Visible="False">
+    <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" InitialRadius="100" ReserveSpaceForHiddenChildren="False">
+        <ui:RadialMenuTextureButtonWithSector SetSize="64 64" ToolTip="{Loc 'rcd-component-walls-and-flooring'}" TargetLayer="WallsAndFlooring" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Radial/RCD/walls_and_flooring.png"/>
         </ui:RadialMenuTextureButtonWithSector>
-        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-windows-and-grilles'}" TargetLayer="WindowsAndGrilles" Visible="False">
+        <ui:RadialMenuTextureButtonWithSector SetSize="64 64" ToolTip="{Loc 'rcd-component-windows-and-grilles'}" TargetLayer="WindowsAndGrilles" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Radial/RCD/windows_and_grilles.png"/>
         </ui:RadialMenuTextureButtonWithSector>
-        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-airlocks'}" TargetLayer="Airlocks" Visible="False">
+        <ui:RadialMenuTextureButtonWithSector SetSize="64 64" ToolTip="{Loc 'rcd-component-airlocks'}" TargetLayer="Airlocks" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Radial/RCD/airlocks.png"/>
         </ui:RadialMenuTextureButtonWithSector>
-        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-electrical'}" TargetLayer="Electrical" Visible="False">
+        <ui:RadialMenuTextureButtonWithSector SetSize="64 64" ToolTip="{Loc 'rcd-component-electrical'}" TargetLayer="Electrical" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Radial/RCD/multicoil.png"/>
         </ui:RadialMenuTextureButtonWithSector>
-        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-lighting'}" TargetLayer="Lighting" Visible="False">
+        <ui:RadialMenuTextureButtonWithSector SetSize="64 64" ToolTip="{Loc 'rcd-component-lighting'}" TargetLayer="Lighting" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Radial/RCD/lighting.png"/>
         </ui:RadialMenuTextureButtonWithSector>
     </ui:RadialContainer>
 
     <!-- Walls and flooring -->
-    <ui:RadialContainer Name="WallsAndFlooring"  VerticalExpand="True" HorizontalExpand="True" Radius="64"/>
+    <ui:RadialContainer Name="WallsAndFlooring"  VerticalExpand="True" HorizontalExpand="True" InitialRadius="100"/>
 
     <!-- Windows and grilles -->
-    <ui:RadialContainer Name="WindowsAndGrilles"  VerticalExpand="True" HorizontalExpand="True" Radius="64"/>
+    <ui:RadialContainer Name="WindowsAndGrilles"  VerticalExpand="True" HorizontalExpand="True" InitialRadius="100"/>
 
     <!-- Airlocks -->
-    <ui:RadialContainer Name="Airlocks"  VerticalExpand="True" HorizontalExpand="True" Radius="64"/>
+    <ui:RadialContainer Name="Airlocks"  VerticalExpand="True" HorizontalExpand="True" InitialRadius="100"/>
 
     <!-- Computer and machine frames -->
-    <ui:RadialContainer Name="Electrical"  VerticalExpand="True" HorizontalExpand="True" Radius="64"/>
+    <ui:RadialContainer Name="Electrical"  VerticalExpand="True" HorizontalExpand="True" InitialRadius="100"/>
        
     <!-- Lighting -->
-    <ui:RadialContainer Name="Lighting"  VerticalExpand="True" HorizontalExpand="True" Radius="64"/>
+    <ui:RadialContainer Name="Lighting"  VerticalExpand="True" HorizontalExpand="True" InitialRadius="100"/>
 
 </ui:RadialMenu>

--- a/Content.Client/RCD/RCDMenu.xaml
+++ b/Content.Client/RCD/RCDMenu.xaml
@@ -12,21 +12,21 @@
 
     <!-- Entry layer (shows main categories) -->
     <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" Radius="64" ReserveSpaceForHiddenChildren="False">
-        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-walls-and-flooring'}" TargetLayer="WallsAndFlooring" Visible="False">
+        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-walls-and-flooring'}" TargetLayer="WallsAndFlooring" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Radial/RCD/walls_and_flooring.png"/>
-        </ui:RadialMenuTextureButton>
-        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-windows-and-grilles'}" TargetLayer="WindowsAndGrilles" Visible="False">
+        </ui:RadialMenuTextureButtonWithSector>
+        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-windows-and-grilles'}" TargetLayer="WindowsAndGrilles" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Radial/RCD/windows_and_grilles.png"/>
-        </ui:RadialMenuTextureButton>
-        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-airlocks'}" TargetLayer="Airlocks" Visible="False">
+        </ui:RadialMenuTextureButtonWithSector>
+        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-airlocks'}" TargetLayer="Airlocks" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Radial/RCD/airlocks.png"/>
-        </ui:RadialMenuTextureButton>
-        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-electrical'}" TargetLayer="Electrical" Visible="False">
+        </ui:RadialMenuTextureButtonWithSector>
+        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-electrical'}" TargetLayer="Electrical" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Radial/RCD/multicoil.png"/>
-        </ui:RadialMenuTextureButton>
-        <ui:RadialMenuTextureButton StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-lighting'}" TargetLayer="Lighting" Visible="False">
+        </ui:RadialMenuTextureButtonWithSector>
+        <ui:RadialMenuTextureButtonWithSector StyleClasses="RadialMenuButton" SetSize="64 64" ToolTip="{Loc 'rcd-component-lighting'}" TargetLayer="Lighting" Visible="False">
             <TextureRect VerticalAlignment="Center" HorizontalAlignment="Center" TextureScale="2 2" TexturePath="/Textures/Interface/Radial/RCD/lighting.png"/>
-        </ui:RadialMenuTextureButton>
+        </ui:RadialMenuTextureButtonWithSector>
     </ui:RadialContainer>
 
     <!-- Walls and flooring -->

--- a/Content.Client/RCD/RCDMenu.xaml.cs
+++ b/Content.Client/RCD/RCDMenu.xaml.cs
@@ -74,7 +74,6 @@ public sealed partial class RCDMenu : RadialMenu
 
             var button = new RCDMenuButton()
             {
-                StyleClasses = { "RadialMenuButton" },
                 SetSize = new Vector2(64f, 64f),
                 ToolTip = tooltip,
                 ProtoId = protoId,

--- a/Content.Client/RCD/RCDMenu.xaml.cs
+++ b/Content.Client/RCD/RCDMenu.xaml.cs
@@ -99,9 +99,7 @@ public sealed partial class RCDMenu : RadialMenu
             // is visible in the main radial container (as these all start with Visible = false)
             foreach (var child in main.Children)
             {
-                var castChild = child as RadialMenuTextureButton;
-
-                if (castChild is not RadialMenuTextureButton)
+                if (child is not RadialMenuTextureButton castChild)
                     continue;
 
                 if (castChild.TargetLayer == proto.Category)
@@ -169,12 +167,7 @@ public sealed partial class RCDMenu : RadialMenu
     }
 }
 
-public sealed class RCDMenuButton : RadialMenuTextureButton
+public sealed class RCDMenuButton : RadialMenuTextureButtonWithSector
 {
     public ProtoId<RCDPrototype> ProtoId { get; set; }
-
-    public RCDMenuButton()
-    {
-
-    }
 }

--- a/Content.Client/Silicons/StationAi/StationAiMenu.xaml
+++ b/Content.Client/Silicons/StationAi/StationAiMenu.xaml
@@ -1,4 +1,4 @@
-﻿<ui:RadialMenu xmlns="https://spacestation14.io"
+<ui:RadialMenu xmlns="https://spacestation14.io"
                 xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
                 BackButtonStyleClass="RadialMenuBackButton"
                 CloseButtonStyleClass="RadialMenuCloseButton"
@@ -7,7 +7,7 @@
                 MinSize="450 450">
 
     <!-- Main -->
-    <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" Radius="64" ReserveSpaceForHiddenChildren="False">
+    <ui:RadialContainer Name="Main" VerticalExpand="True" HorizontalExpand="True" InitialRadius="100" ReserveSpaceForHiddenChildren="False">
     </ui:RadialContainer>
 
 </ui:RadialMenu>

--- a/Content.Client/Silicons/StationAi/StationAiMenu.xaml.cs
+++ b/Content.Client/Silicons/StationAi/StationAiMenu.xaml.cs
@@ -54,7 +54,6 @@ public sealed partial class StationAiMenu : RadialMenu
             // TODO: This radial boilerplate is quite annoying
             var button = new StationAiMenuButton(action.Event)
             {
-                StyleClasses = { "RadialMenuButton" },
                 SetSize = new Vector2(64f, 64f),
                 ToolTip = action.Tooltip != null ? Loc.GetString(action.Tooltip) : null,
             };

--- a/Content.Client/Silicons/StationAi/StationAiMenu.xaml.cs
+++ b/Content.Client/Silicons/StationAi/StationAiMenu.xaml.cs
@@ -121,7 +121,7 @@ public sealed partial class StationAiMenu : RadialMenu
     }
 }
 
-public sealed class StationAiMenuButton(BaseStationAiAction action) : RadialMenuTextureButton
+public sealed class StationAiMenuButton(BaseStationAiAction action) : RadialMenuTextureButtonWithSector
 {
     public BaseStationAiAction Action = action;
 }

--- a/Content.Client/UserInterface/Controls/RadialContainer.cs
+++ b/Content.Client/UserInterface/Controls/RadialContainer.cs
@@ -8,6 +8,9 @@ namespace Content.Client.UserInterface.Controls;
 [Virtual]
 public class RadialContainer : LayoutContainer
 {
+    private const float BaseRadius = 100f;
+    private const float RadiusIncrement = 5f;
+
     /// <summary>
     /// Specifies the anglular range, in radians, in which child elements will be placed.
     /// The first value denotes the angle at which the first element is to be placed, and
@@ -55,6 +58,17 @@ public class RadialContainer : LayoutContainer
     public float Radius { get; set; } = 100f;
 
     /// <summary>
+    /// Determines radial menu button sectors inner radius, is a multiplier of <see cref="Radius"/>.
+    /// </summary>
+    public float InnerRadiusMultiplier { get; set; } = 0.5f;
+
+    /// <summary>
+    /// Determines radial menu button sectors outer radius, is a multiplier of <see cref="Radius"/>.
+    /// </summary>
+    public float OuterRadiusMultiplier { get; set; } = 1.5f;
+
+
+    /// <summary>
     /// Sets whether the container should reserve a space on the layout for child which are not currently visible
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
@@ -71,9 +85,6 @@ public class RadialContainer : LayoutContainer
     /// <inheritdoc />
     protected override Vector2 ArrangeOverride(Vector2 finalSize)
     {
-        const float baseRadius = 100f;
-        const float radiusIncrement = 5f;
-
         var children = ReserveSpaceForHiddenChildren
             ? Children
             : Children.Where(x => x.Visible);
@@ -81,7 +92,7 @@ public class RadialContainer : LayoutContainer
         var childCount = children.Count();
 
         // Add padding from the center at higher child counts so they don't overlap.
-        Radius = baseRadius + (childCount * radiusIncrement);
+        Radius = BaseRadius + (childCount * RadiusIncrement);
 
         var isAntiClockwise = RadialAlignment == RAlignment.AntiClockwise;
 
@@ -131,8 +142,8 @@ public class RadialContainer : LayoutContainer
                 tb.AngleSectorFrom = sepAngle * childIndex;
                 tb.AngleSectorTo = sepAngle * (childIndex + 1);
                 tb.AngleOffset = angleOffset;
-                tb.InnerRadius = Radius / 2;
-                tb.OuterRadius = Radius * 2;
+                tb.InnerRadius = Radius * InnerRadiusMultiplier;
+                tb.OuterRadius = Radius * OuterRadiusMultiplier;
                 tb.ParentCenter = controlCenter;
             }
         }

--- a/Content.Client/UserInterface/Controls/RadialContainer.cs
+++ b/Content.Client/UserInterface/Controls/RadialContainer.cs
@@ -111,11 +111,15 @@ public class RadialContainer : LayoutContainer
         var query = children.Select((x, index) => (index, x));
         foreach (var (childIndex, child) in query)
         {
-            var targetAngleOfChild = AngularRange.X + sepAngle * (childIndex + 0.5f);
+            const float angleOffset = MathF.PI * 0.5f;
 
+            var targetAngleOfChild = AngularRange.X + sepAngle * (childIndex + 0.5f) + angleOffset;
+
+            // flooring values for snapping float values to physical grid -
+            // it prevents gaps and overlapping between different button segments
             var position = new Vector2(
-                    Radius * MathF.Cos(targetAngleOfChild),
-                    -Radius * MathF.Sin(targetAngleOfChild)
+                    MathF.Floor(Radius * MathF.Cos(targetAngleOfChild)),
+                    MathF.Floor(-Radius * MathF.Sin(targetAngleOfChild))
                 ) + controlCenter - child.DesiredSize * 0.5f + Position;
 
             SetPosition(child, position);
@@ -126,6 +130,7 @@ public class RadialContainer : LayoutContainer
             {
                 tb.AngleSectorFrom = sepAngle * childIndex;
                 tb.AngleSectorTo = sepAngle * (childIndex + 1);
+                tb.AngleOffset = angleOffset;
                 tb.InnerRadius = Radius / 2;
                 tb.OuterRadius = Radius * 2;
                 tb.ParentCenter = controlCenter;

--- a/Content.Client/UserInterface/Controls/RadialContainer.cs
+++ b/Content.Client/UserInterface/Controls/RadialContainer.cs
@@ -114,8 +114,8 @@ public class RadialContainer : LayoutContainer
             var targetAngleOfChild = AngularRange.X + sepAngle * (childIndex + 0.5f);
 
             var position = new Vector2(
-                    Radius * MathF.Sin(targetAngleOfChild),
-                    -Radius * MathF.Cos(targetAngleOfChild)
+                    Radius * MathF.Cos(targetAngleOfChild),
+                    -Radius * MathF.Sin(targetAngleOfChild)
                 ) + controlCenter - child.DesiredSize * 0.5f + Position;
 
             SetPosition(child, position);

--- a/Content.Client/UserInterface/Controls/RadialContainer.cs
+++ b/Content.Client/UserInterface/Controls/RadialContainer.cs
@@ -79,8 +79,6 @@ public class RadialContainer : LayoutContainer
             : Children.Where(x => x.Visible);
 
         var childCount = children.Count();
-        // elements are children (buttons) and dividers, they all are spread evenly
-        var childrenAndDividerCount = childCount * 2;
 
         // Add padding from the center at higher child counts so they don't overlap.
         Radius = baseRadius + (childCount * radiusIncrement);
@@ -102,7 +100,7 @@ public class RadialContainer : LayoutContainer
             : 1;
 
         // Determine the separation between child elements
-        var sepAngle = arc / (childrenAndDividerCount - childMod);
+        var sepAngle = arc / (childCount - childMod);
         sepAngle *= isAntiClockwise
             ? -1f
             : 1f;
@@ -113,10 +111,7 @@ public class RadialContainer : LayoutContainer
         var query = children.Select((x, index) => (index, x));
         foreach (var (childIndex, child) in query)
         {
-            // odd indexes are child elements (buttons), even - dividers between child elements
-            var indexForChildElement = childIndex * 2 + 1;
-
-            var targetAngleOfChild = AngularRange.X + sepAngle * indexForChildElement;
+            var targetAngleOfChild = AngularRange.X + sepAngle * (childIndex + 0.5f);
 
             var position = new Vector2(
                     Radius * MathF.Sin(targetAngleOfChild),
@@ -129,8 +124,8 @@ public class RadialContainer : LayoutContainer
             // they should be rendered, how much space sector should should take etc.
             if (child is IRadialMenuItemWithSector tb)
             {
-                tb.AngleSectorFrom = sepAngle * (indexForChildElement - 1);
-                tb.AngleSectorTo = sepAngle * (indexForChildElement + 1);
+                tb.AngleSectorFrom = sepAngle * childIndex;
+                tb.AngleSectorTo = sepAngle * (childIndex + 1);
                 tb.InnerRadius = Radius / 2;
                 tb.OuterRadius = Radius * 2;
                 tb.ParentCenter = controlCenter;

--- a/Content.Client/UserInterface/Controls/RadialContainer.cs
+++ b/Content.Client/UserInterface/Controls/RadialContainer.cs
@@ -105,8 +105,8 @@ public class RadialContainer : LayoutContainer
 
             if (child is RadialMenuTextureButton tb)
             {
-                tb.AngleSectorFrom = sepAngle * positionInRadius-1;
-                tb.AngleSectorTo = sepAngle * positionInRadius + 1;
+                tb.AngleSectorFrom = sepAngle * (positionInRadius-1);
+                tb.AngleSectorTo = sepAngle * (positionInRadius + 1);
             }
 
             var positionOfRail = index * 2;
@@ -115,12 +115,12 @@ public class RadialContainer : LayoutContainer
                 new Vector2(
                     Radius/2 * MathF.Sin(AngularRange.X + sepAngle * positionOfRail) + Width / 2f ,
                     -Radius/2 * MathF.Cos(AngularRange.X + sepAngle * positionOfRail) + Height / 2f 
-                ),
+                ) * UIScale ,
                 new Vector2(
                     Radius * 2 * MathF.Sin(AngularRange.X + sepAngle * positionOfRail) + Width / 2f ,
                     -Radius * 2 * MathF.Cos(AngularRange.X + sepAngle * positionOfRail) + Height / 2f 
-                ),
-                Color.Red
+                ) * UIScale,
+                new Color(173, 216, 230, 180)
             );
         }
 

--- a/Content.Client/UserInterface/Controls/RadialContainer.cs
+++ b/Content.Client/UserInterface/Controls/RadialContainer.cs
@@ -113,6 +113,7 @@ public class RadialContainer : LayoutContainer
 
         foreach (var (index, child) in query)
         {
+            // odd indexes are child elements (buttons)
             var indexForChildElement = index * 2 + 1;
 
             var targetAngleOfChild = AngularRange.X + sepAngle * indexForChildElement;
@@ -122,12 +123,14 @@ public class RadialContainer : LayoutContainer
 
             SetPosition(child, position);
 
+            // radial menu buttons need to know in which sector around container they should be rendered
             if (child is RadialMenuTextureButton tb)
             {
                 tb.AngleSectorFrom = sepAngle * (indexForChildElement - 1);
                 tb.AngleSectorTo = sepAngle * (indexForChildElement + 1);
             }
 
+            // draw separator lines for buttons
             var positionOfSeparator = index * 2;
 
             var targetAngleOfSeparator = AngularRange.X + sepAngle * positionOfSeparator;
@@ -145,8 +148,6 @@ public class RadialContainer : LayoutContainer
                 new Color(173, 216, 230, 180) // todo: use stylesheets
             );
         }
-
-        base.Draw(handle);
     }
 
     /// <summary>

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -102,8 +102,8 @@ public class RadialMenu : BaseWindow
         if (child is RadialContainer { Visible: true } container)
         {
             ContextualButton.ParentCenter = MinSize * 0.5f;
-            ContextualButton.InnerRadius = container.Radius * container.InnerRadiusMultiplier;
-            ContextualButton.OuterRadius = container.Radius * container.OuterRadiusMultiplier;
+            ContextualButton.InnerRadius = container.CalculatedRadius * container.InnerRadiusMultiplier;
+            ContextualButton.OuterRadius = container.CalculatedRadius * container.OuterRadiusMultiplier;
         }
     }
 

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -333,6 +333,11 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
     private bool _isWholeCircle;
     private Vector2? _parentCenter;
 
+    private Color _backgroundColor = Color.ToSrgb(new Color(70, 73, 102, 128));
+    private Color _hoverBackgroundColor = Color.ToSrgb(new Color(87, 91, 127, 128));
+    private Color _borderColor = Color.ToSrgb(new Color(173, 216, 230, 70));
+    private Color _hoverBorderColor = Color.ToSrgb(new Color(87, 91, 127, 128));
+
     /// <summary>
     /// Marker, that control should render border of segment. Is false by default.
     /// </summary>
@@ -355,24 +360,40 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
     public bool DrawSeparators { get; set; } = true;
 
     /// <summary>
-    /// Color of background in non-hovered state.
+    /// Color of background in non-hovered state. Accepts RGB color, works with sRGB for DrawPrimitive internally.
     /// </summary>
-    public Color BackgroundColor { get; set; } = new Color(70, 73, 102, 128);
+    public Color BackgroundColor
+    {
+        get => Color.FromSrgb(_backgroundColor);
+        set => _backgroundColor = Color.ToSrgb(value);
+    }
 
     /// <summary>
-    /// Color of background in hovered state.
+    /// Color of background in hovered state. Accepts RGB color, works with sRGB for DrawPrimitive internally.
     /// </summary>
-    public Color HoverBackgroundColor { get; set; } = new Color(87, 91, 127, 128);
+    public Color HoverBackgroundColor
+    {
+        get => Color.FromSrgb(_hoverBackgroundColor);
+        set => _hoverBackgroundColor = Color.ToSrgb(value);
+    }
 
     /// <summary>
-    /// Color of button border.
+    /// Color of button border. Accepts RGB color, works with sRGB for DrawPrimitive internally.
     /// </summary>
-    public Color BorderColor { get; set; } = new Color(173, 216, 230, 70);
+    public Color BorderColor
+    {
+        get => Color.FromSrgb(_borderColor);
+        set => _borderColor = Color.ToSrgb(value);
+    }
 
     /// <summary>
-    /// Color of button border when button is hovered.
+    /// Color of button border when button is hovered. Accepts RGB color, works with sRGB for DrawPrimitive internally.
     /// </summary>
-    public Color HoverBorderColor { get; set; } = new Color(87, 91, 127, 128);
+    public Color HoverBorderColor
+    {
+        get => Color.FromSrgb(_hoverBorderColor);
+        set => _hoverBorderColor = Color.ToSrgb(value);
+    }
 
     /// <summary>
     /// Color of separator lines.
@@ -437,8 +458,8 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
         if (DrawBackground)
         {
             var segmentColor = DrawMode == DrawModeEnum.Hover
-                ? HoverBackgroundColor
-                : BackgroundColor;
+                ? _hoverBackgroundColor
+                : _backgroundColor;
 
             DrawAnnulusSector(handle, containerCenter, _innerRadius, _outerRadius, angleFrom, angleTo, segmentColor);
         }
@@ -446,8 +467,8 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
         if (DrawBorder)
         {
             var borderColor = DrawMode == DrawModeEnum.Hover
-                ? HoverBorderColor
-                : BorderColor;
+                ? _hoverBorderColor
+                : _borderColor;
             DrawAnnulusSector(handle, containerCenter, _innerRadius, _outerRadius, angleFrom, angleTo, borderColor, false);
         }
 
@@ -550,7 +571,7 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
         var type = filled
             ? DrawPrimitiveTopology.TriangleStrip
             : DrawPrimitiveTopology.LineStrip;
-        drawingHandleScreen.DrawPrimitives(type, _sectorPointsForDrawing, Color.ToSrgb(color));
+        drawingHandleScreen.DrawPrimitives(type, _sectorPointsForDrawing, color);
     }
 
     private static void DrawSeparatorLines(

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -220,7 +220,7 @@ public sealed class RadialMenuContextualCentralTextureButton : TextureButton
     /// <inheritdoc />
     public RadialMenuContextualCentralTextureButton()
     {
-
+        EnableAllKeybinds = true;
     }
 
     /// <inheritdoc />
@@ -258,6 +258,7 @@ public class RadialMenuTextureButton : TextureButton
     /// </summary>
     public RadialMenuTextureButton()
     {
+        EnableAllKeybinds = true;
         OnButtonUp += OnClicked;
     }
 

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -102,8 +102,8 @@ public class RadialMenu : BaseWindow
         if (child is RadialContainer { Visible: true } container)
         {
             ContextualButton.ParentCenter = MinSize * 0.5f;
-            ContextualButton.InnerRadius = container.Radius * 0.5f;
-            ContextualButton.OuterRadius = container.Radius * 2;
+            ContextualButton.InnerRadius = container.Radius * container.InnerRadiusMultiplier;
+            ContextualButton.OuterRadius = container.Radius * container.OuterRadiusMultiplier;
         }
     }
 
@@ -357,12 +357,12 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
     /// <summary>
     /// Color of background in non-hovered state.
     /// </summary>
-    public Color BackgroundColor { get; set; } = new Color(173, 216, 230, 70);
+    public Color BackgroundColor { get; set; } = new Color(70, 73, 102, 128);
 
     /// <summary>
     /// Color of background in hovered state.
     /// </summary>
-    public Color HoverBackgroundColor { get; set; } = new Color(173, 216, 230, 100);
+    public Color HoverBackgroundColor { get; set; } = new Color(87, 91, 127, 128);
 
     /// <summary>
     /// Color of button border.
@@ -372,13 +372,13 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
     /// <summary>
     /// Color of button border when button is hovered.
     /// </summary>
-    public Color HoverBorderColor { get; set; } = new Color(173, 216, 230, 100);
+    public Color HoverBorderColor { get; set; } = new Color(87, 91, 127, 128);
 
     /// <summary>
     /// Color of separator lines.
     /// Separator lines are used to visually separate sector of radial menu items.
     /// </summary>
-    public Color SeparatorColor { get; set; } = new Color(173, 216, 230, 180);
+    public Color SeparatorColor { get; set; } = new Color(128, 128, 128, 128);
 
     /// <inheritdoc />
     float IRadialMenuItemWithSector.AngleSectorFrom
@@ -513,7 +513,7 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
         bool filled = true
     )
     {
-        const float minimalSegmentSize = MathF.Tau / 32;
+        const float minimalSegmentSize = MathF.Tau / 128f;
 
         var requestedSegmentSize = angleSectorTo - angleSectorFrom;
         var segmentCount = (int)(requestedSegmentSize / minimalSegmentSize) + 1;
@@ -550,7 +550,7 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
         var type = filled
             ? DrawPrimitiveTopology.TriangleStrip
             : DrawPrimitiveTopology.LineStrip;
-        drawingHandleScreen.DrawPrimitives(type, _sectorPointsForDrawing, color);
+        drawingHandleScreen.DrawPrimitives(type, _sectorPointsForDrawing, Color.ToSrgb(color));
     }
 
     private static void DrawSeparatorLines(

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -333,10 +333,10 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
     private bool _isWholeCircle;
     private Vector2? _parentCenter;
 
-    private Color _backgroundColor = Color.ToSrgb(new Color(70, 73, 102, 128));
-    private Color _hoverBackgroundColor = Color.ToSrgb(new Color(87, 91, 127, 128));
-    private Color _borderColor = Color.ToSrgb(new Color(173, 216, 230, 70));
-    private Color _hoverBorderColor = Color.ToSrgb(new Color(87, 91, 127, 128));
+    private Color _backgroundColorSrgb = Color.ToSrgb(new Color(70, 73, 102, 128));
+    private Color _hoverBackgroundColorSrgb = Color.ToSrgb(new Color(87, 91, 127, 128));
+    private Color _borderColorSrgb = Color.ToSrgb(new Color(173, 216, 230, 70));
+    private Color _hoverBorderColorSrgb = Color.ToSrgb(new Color(87, 91, 127, 128));
 
     /// <summary>
     /// Marker, that control should render border of segment. Is false by default.
@@ -364,8 +364,8 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
     /// </summary>
     public Color BackgroundColor
     {
-        get => Color.FromSrgb(_backgroundColor);
-        set => _backgroundColor = Color.ToSrgb(value);
+        get => Color.FromSrgb(_backgroundColorSrgb);
+        set => _backgroundColorSrgb = Color.ToSrgb(value);
     }
 
     /// <summary>
@@ -373,8 +373,8 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
     /// </summary>
     public Color HoverBackgroundColor
     {
-        get => Color.FromSrgb(_hoverBackgroundColor);
-        set => _hoverBackgroundColor = Color.ToSrgb(value);
+        get => Color.FromSrgb(_hoverBackgroundColorSrgb);
+        set => _hoverBackgroundColorSrgb = Color.ToSrgb(value);
     }
 
     /// <summary>
@@ -382,8 +382,8 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
     /// </summary>
     public Color BorderColor
     {
-        get => Color.FromSrgb(_borderColor);
-        set => _borderColor = Color.ToSrgb(value);
+        get => Color.FromSrgb(_borderColorSrgb);
+        set => _borderColorSrgb = Color.ToSrgb(value);
     }
 
     /// <summary>
@@ -391,8 +391,8 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
     /// </summary>
     public Color HoverBorderColor
     {
-        get => Color.FromSrgb(_hoverBorderColor);
-        set => _hoverBorderColor = Color.ToSrgb(value);
+        get => Color.FromSrgb(_hoverBorderColorSrgb);
+        set => _hoverBorderColorSrgb = Color.ToSrgb(value);
     }
 
     /// <summary>
@@ -458,8 +458,8 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
         if (DrawBackground)
         {
             var segmentColor = DrawMode == DrawModeEnum.Hover
-                ? _hoverBackgroundColor
-                : _backgroundColor;
+                ? _hoverBackgroundColorSrgb
+                : _backgroundColorSrgb;
 
             DrawAnnulusSector(handle, containerCenter, _innerRadius, _outerRadius, angleFrom, angleTo, segmentColor);
         }
@@ -467,8 +467,8 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
         if (DrawBorder)
         {
             var borderColor = DrawMode == DrawModeEnum.Hover
-                ? _hoverBorderColor
-                : _borderColor;
+                ? _hoverBorderColorSrgb
+                : _borderColorSrgb;
             DrawAnnulusSector(handle, containerCenter, _innerRadius, _outerRadius, angleFrom, angleTo, borderColor, false);
         }
 

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -226,8 +226,6 @@ public class RadialMenuTextureButton : TextureButton
     public float AngleSectorFrom { get; set; }
     public float AngleSectorTo { get; set; }
 
-    public bool DisplayDebug { get; set; }
-    
     /// <summary>
     /// A simple texture button that can move the user to a different layer within a radial menu
     /// </summary>
@@ -255,51 +253,40 @@ public class RadialMenuTextureButton : TextureButton
         var pX = -Position.X + Parent!.Width / 2;
         var pY = -Position.Y + Parent.Width / 2;
 
-        var position = new Vector2(pX, pY);
-        
-        // drawing shit
-        if (!DisplayDebug)
-        {
-            //return;
-        }
-
+        var position = new Vector2(pX, pY) * UIScale;
 
         var singleSegmentSize = MathF.Tau / 32;
 
         var controlSegmentSize = AngleSectorTo - AngleSectorFrom;
-        var segCount = (int) (controlSegmentSize / singleSegmentSize)+2;
+        var segCount = (int) (controlSegmentSize / singleSegmentSize) +1;
+
         // CHANGE TO STACKALLOC AND MOVE THIS STUFF TO TOOLBOX!111
         var buffer = new Vector2[segCount * 2];
 
-        var radius = (Parent as RadialContainer)!.Radius;
+        var radius = (Parent as RadialContainer)!.Radius * UIScale;
 
-        var i = 0;
-        for (i = 0; i < segCount; i++)
+        for (var i = 0; i < segCount; i++)
         {
-            var angle = MathF.PI - AngleSectorFrom + singleSegmentSize* i;
-            var pos = new Angle(angle).RotateVec(new Vector2(1, 0));
+            float angle;
+            if (i == segCount - 1)
+            {
+                angle = AngleSectorTo;
+            }
+            else
+            {
+                angle = AngleSectorFrom + singleSegmentSize * i;
+            }
+
+            var pos = new Angle(angle).RotateVec(-Vector2.UnitY);
 
             buffer[i * 2] = position + pos * radius * 2;
             buffer[i * 2 + 1] = position + pos * radius / 2;
         }
 
-        var color = this.DrawMode == DrawModeEnum.Hover
-            ? new Color(225, 0, 0, 100)
-            : new Color(225, 0, 0, 50);
+        var color = DrawMode == DrawModeEnum.Hover
+            ? new Color(173, 216, 230, 100)
+            : new Color(173, 216, 230, 70);
         handle.DrawPrimitives(DrawPrimitiveTopology.TriangleStrip, buffer, color);
-
-        if (!DisplayDebug)
-        {
-            return;
-        }
-
-        var vectorFont = new VectorFont(IoCManager.Resolve<IResourceCache>().GetResource<FontResource>("/Fonts/NotoSans/NotoSans-Regular.ttf"), 12);
-        for (int j = 0; j < buffer.Length; j++)
-        {
-            handle.DrawString(vectorFont, buffer[j], j.ToString());
-            handle.DrawCircle(buffer[j], 5, new Color(0, 225, 0, 50));
-        }
-
     }
 
     /// <inheritdoc />

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -412,7 +412,7 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
                 ? HoverBackgroundColor
                 : BackgroundColor;
 
-            DrawBagleSector(handle, containerCenter, _innerRadius, _outerRadius, _angleSectorFrom, _angleSectorTo, segmentColor);
+            DrawAnnulusSector(handle, containerCenter, _innerRadius, _outerRadius, _angleSectorFrom, _angleSectorTo, segmentColor);
         }
 
         if (DrawBorder)
@@ -420,7 +420,7 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
             var borderColor = DrawMode == DrawModeEnum.Hover
                 ? HoverBorderColor
                 : BorderColor;
-            DrawBagleSector(handle, containerCenter, _innerRadius, _outerRadius, _angleSectorFrom, _angleSectorTo, borderColor, false);
+            DrawAnnulusSector(handle, containerCenter, _innerRadius, _outerRadius, _angleSectorFrom, _angleSectorTo, borderColor, false);
         }
 
         if (!_isWholeCircle && DrawSeparators)
@@ -468,7 +468,7 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
     /// <param name="angleSectorTo">Angle in radian, from which sector should start.</param>
     /// <param name="color">Color for drawing.</param>
     /// <param name="filled">Should figure be filled, or have only border.</param>
-    private void DrawBagleSector(
+    private void DrawAnnulusSector(
         DrawingHandleScreen drawingHandleScreen,
         Vector2 center,
         float radiusInner,

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -221,7 +221,14 @@ public class RadialMenuTextureButton : TextureButton
     /// </summary>
     public string TargetLayer { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Angle in radian where button sector should start.
+    /// </summary>
     public float AngleSectorFrom { get; set; }
+
+    /// <summary>
+    /// Angle in radian where button sector should end.
+    /// </summary>
     public float AngleSectorTo { get; set; }
 
     /// <summary>
@@ -283,7 +290,8 @@ public class RadialMenuTextureButton : TextureButton
 
         var color = DrawMode == DrawModeEnum.Hover
             ? new Color(173, 216, 230, 100)
-            : new Color(173, 216, 230, 70);
+            : new Color(173, 216, 230, 70); // todo: use stylesheets
+
         handle.DrawPrimitives(DrawPrimitiveTopology.TriangleStrip, buffer, color);
     }
 

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -4,7 +4,6 @@ using Robust.Client.UserInterface.CustomControls;
 using System.Linq;
 using System.Numerics;
 using Robust.Client.Graphics;
-using Robust.Client.ResourceManagement;
 
 namespace Content.Client.UserInterface.Controls;
 

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -255,10 +255,10 @@ public class RadialMenuTextureButton : TextureButton
 
         var position = new Vector2(pX, pY) * UIScale;
 
-        var singleSegmentSize = MathF.Tau / 32;
+        const float singleSegmentSize = MathF.Tau / 32;
 
         var controlSegmentSize = AngleSectorTo - AngleSectorFrom;
-        var segCount = (int) (controlSegmentSize / singleSegmentSize) +1;
+        var segCount = (int) (controlSegmentSize / singleSegmentSize) + 1;
 
         // CHANGE TO STACKALLOC AND MOVE THIS STUFF TO TOOLBOX!111
         var buffer = new Vector2[segCount * 2];
@@ -289,20 +289,6 @@ public class RadialMenuTextureButton : TextureButton
         handle.DrawPrimitives(DrawPrimitiveTopology.TriangleStrip, buffer, color);
     }
 
-    /// <inheritdoc />
-    protected override void MouseEntered()
-    {
-        //Console.WriteLine(this._texturePath?.ToString());
-        base.MouseEntered();
-    }
-
-    /// <inheritdoc />
-    protected override void MouseExited()
-    {
-        //Console.WriteLine(this._texturePath?.ToString());
-        base.MouseExited();
-    }
-
     private void OnClicked(ButtonEventArgs args)
     {
         if (TargetLayer == string.Empty)
@@ -319,19 +305,7 @@ public class RadialMenuTextureButton : TextureButton
     /// <inheritdoc />
     public override bool IsPositionInside(Vector2i point)
     {
-        var cX = -Position.X + Parent!.Width / 2;
-        var cY = -Position.Y + Parent.Width / 2;
-
-        var dist = GetDistance(cX, cY, point.X, point.Y);
-
-        var dX = cX - point.X;
-        var dY = cY - point.Y;
-        var angle = dX > 0 ? -MathF.Atan2(dX, dY) + MathF.PI * 2 : -MathF.Atan2(dX, dY);
-        var parent = (RadialContainer)Parent;
-        var isInAngle = angle > AngleSectorFrom && angle < AngleSectorTo;
-        var isInRadius = dist < parent.Radius * 2 && dist > parent.Radius / 2;
-        var hasPoint = isInRadius && isInAngle;
-        return hasPoint;
+        return HasPoint(point);
     }
 
     /// <inheritdoc />
@@ -340,29 +314,21 @@ public class RadialMenuTextureButton : TextureButton
         var cX = -Position.X + Parent!.Width / 2;
         var cY = -Position.Y + Parent.Width / 2;
 
-        var dist = GetDistance(cX, cY, point.X, point.Y);
+        var dist = Math.Sqrt(Math.Pow(point.X - cX, 2) + Math.Pow(point.Y - cY, 2));
+        var parent = (RadialContainer)Parent;
+        var isInRadius = dist < parent.Radius * 2 && dist > parent.Radius / 2;
+        if (!isInRadius)
+        {
+            return false;
+        }
 
         var dX = cX - point.X;
         var dY = cY - point.Y;
-        var angle = dX > 0 ? -MathF.Atan2(dX,dY) + MathF.PI *2: - MathF.Atan2(dX, dY);
-        var parent = (RadialContainer)Parent;
+        var angle = dX > 0
+            ? -MathF.Atan2(dX, dY) + MathF.PI * 2
+            : -MathF.Atan2(dX, dY);
         var isInAngle = angle > AngleSectorFrom && angle < AngleSectorTo;
-        var isInRadius = dist < parent.Radius*2 && dist > parent.Radius/2;
-        var hasPoint = isInRadius && isInAngle;
-        return hasPoint;
-    }
-
-    public static float ConvertRadiansToDegrees(float radians)
-    {
-        float degrees = (180f / MathF.PI) * radians;
-        return (degrees);
-    }
-
-
-    private static double GetDistance(float x1, float y1, float x2, float y2)
-    {
-        return Math.Sqrt(Math.Pow(x2 - x1, 2) + Math.Pow(y2 - y1, 2));
-
+        return isInAngle;
     }
 
     private RadialMenu? FindParentMultiLayerContainer(Control control)

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -93,9 +93,18 @@ public class RadialMenu : BaseWindow
         OnChildAdded += child =>
         {
             child.Visible = GetCurrentActiveLayer() == child;
-            if (child is RadialContainer { Visible: true } container)
-                ContextualButton.ActiveContainer = container;
+            SetupContextualButtonData(child);
         };
+    }
+
+    private void SetupContextualButtonData(Control child)
+    {
+        if (child is RadialContainer { Visible: true } container)
+        {
+            ContextualButton.ParentCenter = Size * 0.5f;
+            ContextualButton.InnerRadius = container.Radius * 0.5f;
+            ContextualButton.OuterRadius = container.Radius * 2;
+        }
     }
 
     private Control? GetCurrentActiveLayer()
@@ -135,8 +144,7 @@ public class RadialMenu : BaseWindow
             else
             {
                 child.Visible = true;
-                if (child is RadialContainer container)
-                    ContextualButton.ActiveContainer = container;
+                SetupContextualButtonData(child);
                 result = true;
             }
         }
@@ -189,6 +197,11 @@ public class RadialMenu : BaseWindow
 /// </summary>
 public sealed class RadialMenuContextualCentralTextureButton : TextureButton
 {
+    public float InnerRadius { get; set; }
+
+    public float OuterRadius { get; set; }
+
+    public Vector2? ParentCenter { get; set; }
 
     /// <inheritdoc />
     public RadialMenuContextualCentralTextureButton()
@@ -196,65 +209,35 @@ public sealed class RadialMenuContextualCentralTextureButton : TextureButton
 
     }
 
-    /// <summary>
-    /// Reference for container of radial menu.
-    /// Is required to properly consider radius of circles menu will draw.
-    /// </summary>
-    public RadialContainer? ActiveContainer { get; set; }
-
     /// <inheritdoc />
     protected override bool HasPoint(Vector2 point)
     {
-        if (ActiveContainer == null || Parent == null)
+        if (ParentCenter == null)
         {
             return base.HasPoint(point);
         }
 
-        var cX = -Position.X + Parent.Width * 0.5f;
-        var cY = -Position.Y + Parent.Height * 0.5f;
-
-        var dist = Math.Pow(point.X - cX, 2) + Math.Pow(point.Y - cY, 2);
+        var distSquared = (point + Position - ParentCenter.Value).LengthSquared();
 
         // Button space is inside half of container radius / or outside double of its radius.
         // half of radius and double the radius are radial menu concentric circles that are
         // created by radial menu buttons.
-        var outerRadiusSquared = Math.Pow(ActiveContainer.Radius * 2, 2);
-        var innerRadiusSquared = Math.Pow(ActiveContainer.Radius * 0.5f, 2);
+        var outerRadiusSquared = OuterRadius * OuterRadius;
+        var innerRadiusSquared = InnerRadius * InnerRadius;
 
         // comparing to squared values is faster then making sqrt
-        return dist > outerRadiusSquared || dist < innerRadiusSquared;
+        return distSquared > outerRadiusSquared || distSquared < innerRadiusSquared;
     }
 }
+
 
 [Virtual]
 public class RadialMenuTextureButton : TextureButton
 {
-    private Vector2[]? _sectorPointsForDrawing;
-
     /// <summary>
     /// Upon clicking this button the radial menu will be moved to the named layer
     /// </summary>
     public string TargetLayer { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Angle in radian where button sector should start.
-    /// </summary>
-    public float AngleSectorFrom { get; set; }
-
-    /// <summary>
-    /// Angle in radian where button sector should end.
-    /// </summary>
-    public float AngleSectorTo { get; set; }
-
-    /// <summary>
-    /// Outer radius for drawing segment and pointer detection.
-    /// </summary>
-    public float OuterRadius { get; set; }
-
-    /// <summary>
-    /// Outer radius for drawing segment and pointer detection.
-    /// </summary>
-    public float InnerRadius { get; set; }
 
     /// <summary>
     /// A simple texture button that can move the user to a different layer within a radial menu
@@ -262,45 +245,6 @@ public class RadialMenuTextureButton : TextureButton
     public RadialMenuTextureButton()
     {
         OnButtonUp += OnClicked;
-    }
-
-    /// <inheritdoc />
-    protected override void Draw(DrawingHandleScreen handle)
-    {
-        var texture = TextureNormal;
-
-        if (texture == null)
-        {
-            if (TryGetStyleProperty(StylePropertyTexture, out texture) && texture != null)
-            {
-                // draw texture
-                handle.DrawTextureRectRegion(texture, PixelSizeBox);
-            }
-        }
-
-        if (Parent == null)
-        {
-            return;
-        }
-
-        // draw sector where space that button occupies actually is
-        var pX = -Position.X + Parent.Width * 0.5f;
-        var pY = -Position.Y + Parent.Height * 0.5f;
-
-        var containerCenter = new Vector2(pX, pY) * UIScale;
-
-        if (Parent is not RadialContainer container)
-        {
-            return;
-        }
-
-        var radius = container.Radius * UIScale;
-
-        var color = DrawMode == DrawModeEnum.Hover
-            ? new Color(173, 216, 230, 100)
-            : new Color(173, 216, 230, 70); // todo: use stylesheets
-
-        DrawBagleSector(handle, containerCenter, radius * 0.5f, radius * 2, AngleSectorFrom, AngleSectorTo, color);
     }
 
     private void OnClicked(ButtonEventArgs args)
@@ -316,34 +260,6 @@ public class RadialMenuTextureButton : TextureButton
         parent.TryToMoveToNewLayer(TargetLayer);
     }
 
-    /// <inheritdoc />
-    protected override bool HasPoint(Vector2 point)
-    {
-        if (Parent == null)
-        {
-            return false;
-        }
-
-        var cX = -Position.X + Parent.Width * 0.5f;
-        var cY = -Position.Y + Parent.Height * 0.5f;
-
-        var dist = Math.Sqrt(Math.Pow(point.X - cX, 2) + Math.Pow(point.Y - cY, 2));
-        var parent = (RadialContainer)Parent;
-        var isInRadius = dist < parent.Radius * 2 && dist > parent.Radius * 0.5f;
-        if (!isInRadius)
-        {
-            return false;
-        }
-
-        var dX = cX - point.X;
-        var dY = cY - point.Y;
-        var angle = dX > 0
-            ? -MathF.Atan2(dX, dY) + MathF.PI * 2
-            : -MathF.Atan2(dX, dY);
-        var isInAngle = angle > AngleSectorFrom && angle < AngleSectorTo;
-        return isInAngle;
-    }
-
     private RadialMenu? FindParentMultiLayerContainer(Control control)
     {
         foreach (var ancestor in control.GetSelfAndLogicalAncestors())
@@ -353,6 +269,192 @@ public class RadialMenuTextureButton : TextureButton
         }
 
         return null;
+    }
+}
+
+public interface IRadialMenuItemWithSector
+{
+    /// <summary>
+    /// Angle in radian where button sector should start.
+    /// </summary>
+    public float AngleSectorFrom { set; }
+
+    /// <summary>
+    /// Angle in radian where button sector should end.
+    /// </summary>
+    public float AngleSectorTo { set; }
+
+    /// <summary>
+    /// Outer radius for drawing segment and pointer detection.
+    /// </summary>
+    public float OuterRadius { set; }
+
+    /// <summary>
+    /// Outer radius for drawing segment and pointer detection.
+    /// </summary>
+    public float InnerRadius { set; }
+
+    public Vector2 ParentCenter { set; }
+}
+
+[Virtual]
+public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadialMenuItemWithSector
+{
+    private Vector2[]? _sectorPointsForDrawing;
+
+    private float _angleSectorFrom;
+    private float _angleSectorTo;
+    private float _outerRadius;
+    private float _innerRadius;
+
+    private bool _isWholeCircle;
+    private Vector2? _parentCenter;
+
+    /// <summary>
+    /// Marker, that control should render border of segment. Is false by default.
+    /// </summary>
+    /// <remarks>
+    /// By default color of border is same as color of background. Use <see cref="BorderColor"/>
+    /// and <see cref="HoverBorderColor"/> to change it.
+    /// </remarks>
+    public bool DrawBorder { get; set; } = false;
+
+    /// <summary>
+    /// Marker, that control should render background of all sector. Is true by default.
+    /// </summary>
+    public bool DrawBackground { get; set; } = true;
+
+    /// <summary>
+    /// Marker, that control should render separator lines.
+    /// Separator lines are used to visually separate sector of radial menu items.
+    /// Is true by default
+    /// </summary>
+    public bool DrawSeparators { get; set; } = true;
+
+    /// <summary>
+    /// Color of background in non-hovered state.
+    /// </summary>
+    public Color BackgroundColor { get; set; } = new Color(173, 216, 230, 70);
+
+    /// <summary>
+    /// Color of background in hovered state.
+    /// </summary>
+    public Color HoverBackgroundColor { get; set; } = new Color(173, 216, 230, 100);
+
+    /// <summary>
+    /// Color of button border.
+    /// </summary>
+    public Color BorderColor { get; set; } = new Color(173, 216, 230, 70);
+
+    /// <summary>
+    /// Color of button border when button is hovered.
+    /// </summary>
+    public Color HoverBorderColor { get; set; } = new Color(173, 216, 230, 100);
+
+    /// <summary>
+    /// Color of separator lines.
+    /// Separator lines are used to visually separate sector of radial menu items.
+    /// </summary>
+    public Color SeparatorColor { get; set; } = new Color(173, 216, 230, 180);
+
+    /// <inheritdoc />
+    float IRadialMenuItemWithSector.AngleSectorFrom
+    {
+        set
+        {
+            _angleSectorFrom = value;
+            _isWholeCircle = IsWholeCircle(value, _angleSectorTo);
+        }
+    }
+
+    /// <inheritdoc />
+    float IRadialMenuItemWithSector.AngleSectorTo
+    {
+        set
+        {
+            _angleSectorTo = value;
+            _isWholeCircle = IsWholeCircle(_angleSectorFrom, value);
+        }
+    }
+
+    /// <inheritdoc />
+    float IRadialMenuItemWithSector.OuterRadius { set => _outerRadius = value; }
+
+    /// <inheritdoc />
+    float IRadialMenuItemWithSector.InnerRadius { set => _innerRadius = value; }
+
+    /// <inheritdoc />
+    Vector2 IRadialMenuItemWithSector.ParentCenter { set => _parentCenter = value; }
+
+    /// <summary>
+    /// A simple texture button that can move the user to a different layer within a radial menu
+    /// </summary>
+    public RadialMenuTextureButtonWithSector()
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void Draw(DrawingHandleScreen handle)
+    {
+        base.Draw(handle);
+
+        if (_parentCenter == null)
+        {
+            return;
+        }
+
+        // draw sector where space that button occupies actually is
+        var containerCenter = (_parentCenter.Value - Position) * UIScale;
+
+        if (DrawBackground)
+        {
+            var segmentColor = DrawMode == DrawModeEnum.Hover
+                ? HoverBackgroundColor
+                : BackgroundColor;
+
+            DrawBagleSector(handle, containerCenter, _innerRadius, _outerRadius, _angleSectorFrom, _angleSectorTo, segmentColor);
+        }
+
+        if (DrawBorder)
+        {
+            var borderColor = DrawMode == DrawModeEnum.Hover
+                ? HoverBorderColor
+                : BorderColor;
+            DrawBagleSector(handle, containerCenter, _innerRadius, _outerRadius, _angleSectorFrom, _angleSectorTo, borderColor, false);
+        }
+
+        if (!_isWholeCircle && DrawSeparators)
+        {
+            DrawSeparatorLines(handle, containerCenter, _innerRadius, _outerRadius, _angleSectorFrom, _angleSectorTo, SeparatorColor);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override bool HasPoint(Vector2 point)
+    {
+        if (_parentCenter == null)
+        {
+            return base.HasPoint(point);
+        }
+
+        var outerRadiusSquared = _outerRadius * _outerRadius;
+        var innerRadiusSquared = _innerRadius * _innerRadius;
+
+        var distSquared = (point + Position - _parentCenter.Value).LengthSquared();
+        var isInRadius = distSquared < outerRadiusSquared && distSquared > innerRadiusSquared;
+        if (!isInRadius)
+        {
+            return false;
+        }
+
+        // diff x/y from point to container center
+        var diff = -Position + _parentCenter.Value - point;
+
+        var angle = diff.X > 0
+            ? -MathF.Atan2(diff.X, diff.Y) + MathF.PI * 2
+            : -MathF.Atan2(diff.X, diff.Y);
+        var isInAngle = angle > _angleSectorFrom && angle < _angleSectorTo;
+        return isInAngle;
     }
 
     /// <summary>
@@ -418,23 +520,39 @@ public class RadialMenuTextureButton : TextureButton
             }
         }
 
-        var fromPoint = new Angle(angleSectorFrom).RotateVec(-Vector2.UnitY);
-        drawingHandleScreen.DrawLine(
-            (center + fromPoint * radiusOuter) * UIScale,
-            (center + fromPoint * radiusInner) * UIScale,
-            new Color(173, 216, 230, 180) // todo: use stylesheets
-        );
-
-        var toPoint = new Angle(angleSectorTo).RotateVec(-Vector2.UnitY);
-        drawingHandleScreen.DrawLine(
-            (center + toPoint * radiusOuter) * UIScale,
-            (center + toPoint * radiusInner) * UIScale,
-            new Color(173, 216, 230, 180) // todo: use stylesheets
-        );
-
         var type = filled
             ? DrawPrimitiveTopology.TriangleStrip
             : DrawPrimitiveTopology.LineStrip;
         drawingHandleScreen.DrawPrimitives(type, _sectorPointsForDrawing, color);
+    }
+
+    private static void DrawSeparatorLines(
+        DrawingHandleScreen drawingHandleScreen,
+        Vector2 center,
+        float radiusInner,
+        float radiusOuter,
+        float angleSectorFrom,
+        float angleSectorTo,
+        Color color
+    )
+    {
+        var fromPoint = new Angle(angleSectorFrom).RotateVec(-Vector2.UnitY);
+        drawingHandleScreen.DrawLine(
+            center + fromPoint * radiusOuter,
+            center + fromPoint * radiusInner,
+            color
+        );
+
+        var toPoint = new Angle(angleSectorTo).RotateVec(-Vector2.UnitY);
+        drawingHandleScreen.DrawLine(
+            center + toPoint * radiusOuter,
+            center + toPoint * radiusInner,
+            color
+        );
+    }
+
+    private static bool IsWholeCircle(float angleSectorFrom, float angleSectorTo)
+    {
+        return new Angle(angleSectorFrom).EqualsApprox(new Angle(angleSectorTo));
     }
 }

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -462,7 +462,7 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
                 ? _hoverBackgroundColorSrgb
                 : _backgroundColorSrgb;
 
-            DrawAnnulusSector(handle, containerCenter, _innerRadius, _outerRadius, angleFrom, angleTo, segmentColor);
+            DrawAnnulusSector(handle, containerCenter, _innerRadius * UIScale, _outerRadius * UIScale, angleFrom, angleTo, segmentColor);
         }
 
         if (DrawBorder)
@@ -470,12 +470,12 @@ public class RadialMenuTextureButtonWithSector : RadialMenuTextureButton, IRadia
             var borderColor = DrawMode == DrawModeEnum.Hover
                 ? _hoverBorderColorSrgb
                 : _borderColorSrgb;
-            DrawAnnulusSector(handle, containerCenter, _innerRadius, _outerRadius, angleFrom, angleTo, borderColor, false);
+            DrawAnnulusSector(handle, containerCenter, _innerRadius * UIScale, _outerRadius * UIScale, angleFrom, angleTo, borderColor, false);
         }
 
         if (!_isWholeCircle && DrawSeparators)
         {
-            DrawSeparatorLines(handle, containerCenter, _innerRadius, _outerRadius, angleFrom, angleTo, SeparatorColor);
+            DrawSeparatorLines(handle, containerCenter, _innerRadius * UIScale, _outerRadius * UIScale, angleFrom, angleTo, SeparatorColor);
         }
     }
 

--- a/Content.Client/UserInterface/Controls/RadialMenu.cs
+++ b/Content.Client/UserInterface/Controls/RadialMenu.cs
@@ -4,6 +4,7 @@ using Robust.Client.UserInterface.CustomControls;
 using System.Linq;
 using System.Numerics;
 using Robust.Client.Graphics;
+using Robust.Shared.Input;
 
 namespace Content.Client.UserInterface.Controls;
 
@@ -86,7 +87,13 @@ public class RadialMenu : BaseWindow
             SetSize = new Vector2(64f, 64f),
         };
 
-        ContextualButton.OnButtonUp += _ => ReturnToPreviousLayer();
+        ContextualButton.OnButtonUp += args =>
+        {
+            // this button uses enableAllKeybinds mode, which propagates more events,
+            // then just click, but we need only click and only once per user interaction
+            if (args.Event.Function == EngineKeyFunctions.UIClick)
+                ReturnToPreviousLayer();
+        };
         AddChild(ContextualButton);
 
         // Hide any further add children, unless its promoted to the active layer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Radial menu was great addition to UI but it requires precision as it is now. To bring up better UX it needs to be usable without too much precision so it can be used effectively in panic situations. This problem was already solved by wheel menu in most modern games - use sectors of circle to pick options and not icons themselves.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Robust wheel UI!

## Technical details
<!-- Summary of code changes for easier review. -->

RadialMenu now uses 'special' button as context button in center - RadialMenuContextualCentralTextureButton. It considers space inside inner circle of parent RadialContainer half radius, and ALL outer space outside twice of its radius - as itself.
RadialContainer now puts angle sector data in each child  RadialMenuTextureButton.
RadialMenuTextureButton now can draw bagle segments!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

[new-radia-menu.webm](https://github.com/user-attachments/assets/addb3dd8-45f8-45fe-8dce-770123c5adab)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

removed RadialMenuButton - was not used.
now RadialMenuTextureButton requires to be inside RadialContainer to work properly

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Fildrance, SaphireLattice, eoineoineoin
- tweak: Radial menu UIs have been updated for readability.