### PR TITLE
Encryption key boxes as well as the keys inside are now contraband ba…

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -260,7 +260,7 @@
 
 - type: entity
   name: cargo encryption key box
-  parent: BoxEncryptionKeyPassenger
+  parent: [BoxEncryptionKeyPassenger, BaseCargoContraband]
   id: BoxEncryptionKeyCargo
   components:
   - type: StorageFill
@@ -270,7 +270,7 @@
 
 - type: entity
   name: engineering encryption key box
-  parent: BoxEncryptionKeyPassenger
+  parent: [BoxEncryptionKeyPassenger, BaseEngineeringContraband]
   id: BoxEncryptionKeyEngineering
   components:
   - type: StorageFill
@@ -280,7 +280,7 @@
 
 - type: entity
   name: med-sci encryption key box
-  parent: BoxEncryptionKeyPassenger
+  parent: [BoxEncryptionKeyPassenger, BaseMedicalScienceContraband]
   id: BoxEncryptionKeyMedicalScience
   components:
   - type: StorageFill
@@ -290,7 +290,7 @@
 
 - type: entity
   name: medical encryption key box
-  parent: BoxEncryptionKeyPassenger
+  parent: [BoxEncryptionKeyPassenger, BaseMedicalContraband]
   id: BoxEncryptionKeyMedical
   components:
   - type: StorageFill
@@ -300,7 +300,7 @@
 
 - type: entity
   name: robotech encryption key box
-  parent: BoxEncryptionKeyPassenger
+  parent: [BoxEncryptionKeyPassenger, BaseScienceContraband]
   id: BoxEncryptionKeyRobo
   components:
   - type: StorageFill
@@ -310,7 +310,7 @@
 
 - type: entity
   name: science encryption key box
-  parent: BoxEncryptionKeyPassenger
+  parent: [BoxEncryptionKeyPassenger, BaseScienceContraband]
   id: BoxEncryptionKeyScience
   components:
   - type: StorageFill
@@ -320,7 +320,7 @@
 
 - type: entity
   name: security encryption key box
-  parent: BoxEncryptionKeyPassenger
+  parent: [BoxEncryptionKeyPassenger, BaseSecurityContraband]
   id: BoxEncryptionKeySecurity
   components:
   - type: StorageFill
@@ -330,7 +330,7 @@
 
 - type: entity
   name: service encryption key box
-  parent: BoxEncryptionKeyPassenger
+  parent: [BoxEncryptionKeyPassenger, BaseCivilianContraband]
   id: BoxEncryptionKeyService
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -260,7 +260,7 @@
 
 - type: entity
   name: cargo encryption key box
-  parent: [BoxEncryptionKeyPassenger, BaseCargoContraband]
+  parent: [BoxEncryptionKeyPassenger, BaseCargoCommandContraband]
   id: BoxEncryptionKeyCargo
   components:
   - type: StorageFill
@@ -270,7 +270,7 @@
 
 - type: entity
   name: engineering encryption key box
-  parent: [BoxEncryptionKeyPassenger, BaseEngineeringContraband]
+  parent: [BoxEncryptionKeyPassenger, BaseEngineeringCommandContraband]
   id: BoxEncryptionKeyEngineering
   components:
   - type: StorageFill
@@ -290,7 +290,7 @@
 
 - type: entity
   name: medical encryption key box
-  parent: [BoxEncryptionKeyPassenger, BaseMedicalContraband]
+  parent: [BoxEncryptionKeyPassenger, BaseMedicalCommandContraband]
   id: BoxEncryptionKeyMedical
   components:
   - type: StorageFill
@@ -300,7 +300,7 @@
 
 - type: entity
   name: robotech encryption key box
-  parent: [BoxEncryptionKeyPassenger, BaseScienceContraband]
+  parent: [BoxEncryptionKeyPassenger, BaseScienceCommandContraband]
   id: BoxEncryptionKeyRobo
   components:
   - type: StorageFill
@@ -310,7 +310,7 @@
 
 - type: entity
   name: science encryption key box
-  parent: [BoxEncryptionKeyPassenger, BaseScienceContraband]
+  parent: [BoxEncryptionKeyPassenger, BaseScienceCommandContraband]
   id: BoxEncryptionKeyScience
   components:
   - type: StorageFill
@@ -320,7 +320,7 @@
 
 - type: entity
   name: security encryption key box
-  parent: [BoxEncryptionKeyPassenger, BaseSecurityContraband]
+  parent: [BoxEncryptionKeyPassenger, BaseSecurityCommandContraband]
   id: BoxEncryptionKeySecurity
   components:
   - type: StorageFill
@@ -330,7 +330,7 @@
 
 - type: entity
   name: service encryption key box
-  parent: [BoxEncryptionKeyPassenger, BaseCivilianContraband]
+  parent: [BoxEncryptionKeyPassenger, BaseCivilianCommandContraband]
   id: BoxEncryptionKeyService
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -27,7 +27,7 @@
     - state: common_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseCargoContraband ]
+  parent: [ EncryptionKey, BaseCargoCommandContraband ]
   id: EncryptionKeyCargo
   name: cargo encryption key
   description: An encryption key used by supply employees.
@@ -94,7 +94,7 @@
     - state: com_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseEngineeringContraband ]
+  parent: [ EncryptionKey, BaseEngineeringCommandContraband ]
   id: EncryptionKeyEngineering
   name: engineering encryption key
   description: An encryption key used by the engineers.
@@ -109,7 +109,7 @@
     - state: eng_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseMedicalContraband ]
+  parent: [ EncryptionKey, BaseMedicalCommandContraband ]
   id: EncryptionKeyMedical
   name: medical encryption key
   description: An encryption key used by those who save lives.
@@ -140,7 +140,7 @@
     - state: medsci_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseScienceContraband ]
+  parent: [ EncryptionKey, BaseScienceCommandContraband ]
   id: EncryptionKeyScience
   name: science encryption key
   description: An encryption key used by scientists. Maybe it is plasmaproof?
@@ -155,7 +155,7 @@
     - state: sci_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseScienceContraband ]
+  parent: [ EncryptionKey, BaseScienceCommandContraband ]
   id: EncryptionKeyRobo
   name: robotech encryption key
   description: An encryption key used by robototech engineers. Maybe it has a LAH-6000 on it?
@@ -170,7 +170,7 @@
     - state: robotics_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseSecurityContraband ]
+  parent: [ EncryptionKey, BaseSecurityCommandContraband ]
   id: EncryptionKeySecurity
   name: security encryption key
   description: An encryption key used by security.
@@ -185,7 +185,7 @@
     - state: sec_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseCivilianContraband ]
+  parent: [ EncryptionKey, BaseCivilianCommandContraband ]
   id: EncryptionKeyService
   name: service encryption key
   description: An encryption key used by the service staff, tasked with keeping the station full, happy and clean.

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -118,6 +118,46 @@
     allowedDepartments: [ Security, Command ]
 
 - type: entity
+  id: BaseScienceCommandContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Science, Command ]
+
+- type: entity
+  id: BaseEngineeringCommandContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Engineering, Command ]
+
+- type: entity
+  id: BaseMedicalCommandContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Medical, Command ]
+
+- type: entity
+  id: BaseCivilianCommandContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Civilian, Command ]
+
+- type: entity
+  id: BaseCargoCommandContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Cargo, Command ]
+
+- type: entity
   id: BaseSecurityScienceCommandContraband
   parent: BaseRestrictedContraband
   abstract: true
@@ -155,7 +195,7 @@
   abstract: true
   components:
   - type: Contraband
-    allowedDepartments: [ Medical, Science ]
+    allowedDepartments: [ Medical, Science, Command ]
 
 # for ~objective items
 - type: entity


### PR DESCRIPTION
Encryption key boxes are now contraband

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made the boxes for encryption keys contraband based on their department. An exception from these changes are the passenger/common encryption keys.

## Why / Balance
Might help security in investigations. 

## Technical details
Updated:
 parent: BoxEncryptionKeyPassenger ->  parent: [BoxEncryptionKeyPassenger, Base$DepartmentContraband]

## Media
![image](https://github.com/user-attachments/assets/62f7167f-5498-4bb3-9010-c3cd0f1a45dd)
![image](https://github.com/user-attachments/assets/9ab76a83-904b-443e-8728-522917c023d4)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ /] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ /] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
- tweak: Encryption key boxes from departments are now contraband to the respective department.

