### PR TITLE
Allow bags to be dumped into a biogenerator

### DIFF
--- a/Content.Server/Materials/ProduceMaterialExtractorSystem.cs
+++ b/Content.Server/Materials/ProduceMaterialExtractorSystem.cs
@@ -4,6 +4,8 @@ using Content.Server.Materials.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Storage;
+using Content.Shared.Storage.Components;
 using Robust.Server.Audio;
 
 namespace Content.Server.Materials;
@@ -28,11 +30,32 @@ public sealed class ProduceMaterialExtractorSystem : EntitySystem
         if (!this.IsPowered(ent, EntityManager))
             return;
 
-        if (!TryComp<ProduceComponent>(args.Used, out var produce))
-            return;
+        bool success = false;
 
-        if (!_solutionContainer.TryGetSolution(args.Used, produce.SolutionName, out var solution))
-            return;
+        // Handle using bags (mainly plant bags)
+        if (ExtractFromStorage(ent, args.Used))
+            success = true;
+
+        // Handle using produce directly
+        if (ExtractFromProduce(ent, args.Used))
+            success = true;
+
+        // TODO: What if a bag is also a plant?
+
+        if (success)
+        {
+            _audio.PlayPvs(ent.Comp.ExtractSound, ent);
+            args.Handled = true;
+        }
+    }
+
+    private bool ExtractFromProduce(Entity<ProduceMaterialExtractorComponent> ent, EntityUid used)
+    {
+        if (!TryComp<ProduceComponent>(used, out var produce))
+            return false;
+
+        if (!_solutionContainer.TryGetSolution(used, produce.SolutionName, out var solution))
+            return false;
 
         // Can produce even have fractional amounts? Does it matter if they do?
         // Questions man was never meant to answer.
@@ -41,8 +64,22 @@ public sealed class ProduceMaterialExtractorSystem : EntitySystem
             .Sum(r => r.Quantity.Float());
         _materialStorage.TryChangeMaterialAmount(ent, ent.Comp.ExtractedMaterial, (int) matAmount);
 
-        _audio.PlayPvs(ent.Comp.ExtractSound, ent);
-        QueueDel(args.Used);
-        args.Handled = true;
+        QueueDel(used);
+
+        return true;
+    }
+
+    private bool ExtractFromStorage(Entity<ProduceMaterialExtractorComponent> ent, EntityUid used)
+    {
+        if (!TryComp<StorageComponent>(used, out var storage))
+            return false;
+
+        bool success = false;
+
+        foreach (var (item, _location) in storage.StoredItems)
+            if (ExtractFromProduce(ent, item))
+                success = true;
+
+        return success;
     }
 }


### PR DESCRIPTION
## About the PR
Players can now either feed produce one at a time to biogenerators, or in bulk using a container (presumably a plant bag, but any container should work too).

## Why / Balance
Adding produce to the biogenerator one at a time is tedious and gets old really quickly.

## Technical details
I modified `ProduceMaterialExtractorSystem` to check if the used item has a `StorageComponent`, and if it does, process each item in the container with the same code as if they were being used directly.

## Media
[Screencast from 2024-10-06 16-58-28.webm](https://github.com/user-attachments/assets/6eef29a9-6438-4493-bcfa-6e65593c04ba)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No breaking changes.

**Changelog**
:cl:
- add: Plant bags (and other containers) can now be used to feed produce to a biogenerator
