### PR TITLE
Singularity and Tesla now require generator access to activate

### DIFF
--- a/Content.Server/Singularity/EntitySystems/SingularityGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/SingularityGeneratorSystem.cs
@@ -50,6 +50,7 @@ public sealed class SingularityGeneratorSystem : EntitySystem
         if (_lock.IsLocked(uid))
         {
             _popup.PopupEntity(Loc.GetString("singularity-generator-component-locked"), uid);
+            SetPower(uid, 0, comp);
             return;
         }
 

--- a/Content.Server/Singularity/EntitySystems/SingularityGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/SingularityGeneratorSystem.cs
@@ -1,6 +1,9 @@
 using Content.Server.ParticleAccelerator.Components;
 using Content.Server.Singularity.Components;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Singularity.Components;
+using Content.Shared.Lock;
+using Content.Shared.Popups;
 using Robust.Shared.Physics.Events;
 
 namespace Content.Server.Singularity.EntitySystems;
@@ -9,6 +12,8 @@ public sealed class SingularityGeneratorSystem : EntitySystem
 {
     #region Dependencies
     [Dependency] private readonly IViewVariablesManager _vvm = default!;
+    [Dependency] private readonly LockSystem _lock= default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
     #endregion Dependencies
 
     public override void Initialize()
@@ -42,6 +47,11 @@ public sealed class SingularityGeneratorSystem : EntitySystem
     {
         if (!Resolve(uid, ref comp))
             return;
+        if (_lock.IsLocked(uid))
+        {
+            _popup.PopupEntity(Loc.GetString("singularity-generator-component-locked"), uid);
+            return;
+        }
 
         SetPower(uid, 0, comp);
         EntityManager.SpawnEntity(comp.SpawnPrototype, Transform(uid).Coordinates);

--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -59,6 +59,7 @@ public sealed partial class IdCardConsoleComponent : Component
         "Cryogenics",
         "Engineering",
         "External",
+        "Generator",
         "HeadOfPersonnel",
         "HeadOfSecurity",
         "Hydroponics",

--- a/Resources/Locale/en-US/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/prototypes/access/accesses.ftl
@@ -12,6 +12,7 @@ id-card-access-level-detective = Detective
 id-card-access-level-chief-engineer = Chief Engineer
 id-card-access-level-engineering = Engineering
 id-card-access-level-atmospherics = Atmospherics
+id-card-access-level-generator = Generator
 
 id-card-access-level-research-director = Research Director
 id-card-access-level-research = Research

--- a/Resources/Locale/en-US/singularity/components/singularity-generator-component.ftl
+++ b/Resources/Locale/en-US/singularity/components/singularity-generator-component.ftl
@@ -1,0 +1,1 @@
+﻿singularity-generator-component-locked = The generator is locked!

--- a/Resources/Prototypes/Access/engineering.yml
+++ b/Resources/Prototypes/Access/engineering.yml
@@ -20,4 +20,4 @@
   - ChiefEngineer
   - Engineering
   - Atmospherics
-  - -Generator
+  - Generator

--- a/Resources/Prototypes/Access/engineering.yml
+++ b/Resources/Prototypes/Access/engineering.yml
@@ -10,9 +10,14 @@
   id: Atmospherics
   name: id-card-access-level-atmospherics
 
+- type: accessLevel
+  id: Generator
+  name: id-card-access-level-generator
+
 - type: accessGroup
   id: Engineering
   tags:
   - ChiefEngineer
   - Engineering
   - Atmospherics
+  - -Generator

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -32,3 +32,4 @@
   - Chapel
   - Hydroponics
   - Atmospherics
+  - Generator

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
@@ -26,7 +26,7 @@
     boardName: wires-board-name-pa
     layoutId: ParticleAccelerator
   - type: AccessReader
-    access: [["Engineering"]]
+    access: [["Generator"]]
 
 # Unfinished
 

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -87,7 +87,7 @@
   - type: LockedAnchorable
   - type: LockedWiresPanel
   - type: AccessReader
-    access: [[ "Engineering" ]]
+    access: [[ "Generator" ]]
   - type: Machine
     board: EmitterCircuitboard
   - type: GuideHelp

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
@@ -37,4 +37,4 @@
     locked: true
   - type: AccessReader
     access: [["Captain"]]
-    BreackOnEmag: false
+    BreakOnEmag: false

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
@@ -36,5 +36,5 @@
   - type: Lock
     locked: true
   - type: AccessReader
-    access: [["Captain"]]
+    access: [["Generator"]]
     BreakOnEmag: false

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
@@ -35,6 +35,6 @@
     guides: [ Singularity, Power ]
   - type: Lock
     locked: true
-    BreakOnEmag: false
+    breakOnEmag: false
   - type: AccessReader
     access: [["Generator"]]

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
@@ -35,6 +35,6 @@
     guides: [ Singularity, Power ]
   - type: Lock
     locked: true
+    BreakOnEmag: false
   - type: AccessReader
     access: [["Generator"]]
-    BreakOnEmag: false

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
@@ -33,4 +33,8 @@
   - type: Pullable
   - type: GuideHelp
     guides: [ Singularity, Power ]
-
+  - type: Lock
+    locked: true
+  - type: AccessReader
+    access: [["Captain"]]
+    BreackOnEmag: false

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
@@ -25,6 +25,8 @@
         layer:
         - Opaque
   - type: Anchorable
+  - type: Lock
+    locked: true
   - type: AccessReader
     access: [ [ "Generator" ] ]
     BreakOnEmag: false

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
@@ -27,7 +27,7 @@
   - type: Anchorable
   - type: Lock
     locked: true
-    BreakOnEmag: false
+    breakOnEmag: false
   - type: AccessReader
     access: [ [ "Generator" ] ]
   #- type: GuideHelp # TODO - add Tesla Guide

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     noRot: true
     sprite: Structures/Power/Generation/Tesla/generator.rsi
-    state: icon 
+    state: icon
   - type: SingularityGenerator # TODO: rename the generator
     spawnId: TeslaEnergyBall
   - type: InteractionOutline
@@ -25,5 +25,8 @@
         layer:
         - Opaque
   - type: Anchorable
+  - type: AccessReader
+    access: [ [ "Generator" ] ]
+    BreakOnEmag: false
   #- type: GuideHelp # TODO - add Tesla Guide
 

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
@@ -27,8 +27,8 @@
   - type: Anchorable
   - type: Lock
     locked: true
+    BreakOnEmag: false
   - type: AccessReader
     access: [ [ "Generator" ] ]
-    BreakOnEmag: false
   #- type: GuideHelp # TODO - add Tesla Guide
 

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -49,6 +49,7 @@
   - Cargo
   - Atmospherics
   - Medical
+  - Generator
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -15,6 +15,7 @@
   - Engineering
   - External
   - Atmospherics
+  - Generator
 
 - type: startingGear
   id: AtmosphericTechnicianGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -30,6 +30,7 @@
   - Atmospherics
   - Brig
   - Cryogenics
+  - Generator
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -14,6 +14,7 @@
   - Maintenance
   - Engineering
   - External
+  - Generator
   extendedAccess:
   - Atmospherics
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Singularity and tesla generators + associated equipment with access readers now require the new generator access level. This level is given roundstart to Cap, HoP, CE, Atmos Techs and Station Engineers. Singulo + Tesla generators now spawn in locked by default, and must be unlocked before they can create their entity. There is a popup when they reach the power threshold but are locked. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is mostly designed to prevent TA raiders from being able to loose the moment the round starts, as no role that requires bare minimum playtime should really have an end the round button the way TAs do. This means well meaning TAs must get a full engi to come and check their work when trying to setup a generator (as they can still move all the parts into place), which also facilitates learning as well as preventing raiding.

This also limits mass station destruction for antags, as they are required to gain generator access somehow to loose via this method, since EMAGs do not break the lock on generators. I would consider adding an uplink item like an access card with just generator access available after 30 mins, but didnt want to put it in this PR. Relates to #20064 by limiting mass sabotage, especially if an uplink item is added for this.

Reason for new access level is there is no access TAs dont have but regular engies do; using CE or Atmos is theoretically possible but would likely make the roundstart yelling at engi bcs theres no power worse if regular engies can't get things going themselves

Overall will hopefully reduce admin workload a bit

## Technical details
<!-- Summary of code changes for easier review. -->
Add lock component and access reader to singulo and tesla generator prototypes, added if to `SingularityGeneratorSystem` to check if its locked, added access level to id card console. Rest is YAML

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/82bbbb34-fbef-4471-b73a-b13a78f48005)
![image](https://github.com/user-attachments/assets/c4b86893-21a2-40d2-9298-5bb26a503a2b)
![image](https://github.com/user-attachments/assets/fa2e4099-fb58-4999-9d3c-221508d657b5)

https://github.com/user-attachments/assets/d52f227c-e29b-4db1-a90b-5af978df202f

https://github.com/user-attachments/assets/6ec21eec-f3ba-403a-8b39-e7f3fc776281

https://github.com/user-attachments/assets/27fb44aa-c5c8-437e-b35f-ebd6214ac6d3




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A I hope

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
-tweak: Singularity and Tesla generators, and associated items, now require Generator access to unlock and use, available to all of engineering except assistants. Generators must be unlocked to create the Singularity or Tesla
