### PR TITLE
Fix cloth dupe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Decoration/curtains.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/curtains.yml
@@ -49,7 +49,7 @@
         spawn:
           MaterialCloth1:
             min: 1
-            max: 2
+            max: 1
   - type: WallMount
     arc: 360
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
If you make curtains using a carpet that costs 1 cloth, then when destroyed, two cloth may fall out with a 50% chance instead of one.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fixed dupe
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: When curtains are destroyed, only 1 cloth drops out