### PR TITLE
fix conveyor belt default linking

### DIFF
--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -35,6 +35,11 @@
         - DoorPassable
         hard: False
   - type: Conveyor
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
   - type: DeviceLinkSink
     ports:
       - Reverse


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
you could link defaults (alt+lmb) from conveyor to lever but not the other way. now you can do it from lever to conveyor too.

## Technical details
`NetworkConfiguratorSystem.OnAddAlternativeSaveDeviceVerb` listens for event on `DeviceNetworkComponent` which conveyor didn't have.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/59ad8c39-d344-4878-87a1-cf58deafaa84

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.

:cl:
- tweak: Changed fun!
 -->