### PR TITLE
Wizard Summon Guns/Magic

### DIFF
--- a/Content.Shared/Magic/Events/RandomGlobalSpawnSpellEvent.cs
+++ b/Content.Shared/Magic/Events/RandomGlobalSpawnSpellEvent.cs
@@ -6,8 +6,17 @@ namespace Content.Shared.Magic.Events;
 
 public sealed partial class RandomGlobalSpawnSpellEvent : InstantActionEvent, ISpeakSpell
 {
-    [DataField(required: true)]
-    public List<EntitySpawnEntry> Spawns;
+    /// <summary>
+    /// The list of prototypes this spell can spawn, will select one randomly
+    /// </summary>
+    [DataField]
+    public List<EntitySpawnEntry> Spawns = new();
+
+    /// <summary>
+    /// Whether or not to include players without minds (i.e. disconnected from the server).
+    /// </summary>
+    [DataField]
+    public bool RequireMind = true;
 
     [DataField]
     public string? Speech { get; private set; }

--- a/Content.Shared/Magic/Events/RandomGlobalSpawnSpellEvent.cs
+++ b/Content.Shared/Magic/Events/RandomGlobalSpawnSpellEvent.cs
@@ -1,0 +1,14 @@
+using Content.Shared.Actions;
+using Content.Shared.Storage;
+using System.ComponentModel.DataAnnotations;
+
+namespace Content.Shared.Magic.Events;
+
+public sealed partial class RandomGlobalSpawnSpellEvent : InstantActionEvent, ISpeakSpell
+{
+    [DataField(required: true)]
+    public List<EntitySpawnEntry> Spawns;
+
+    [DataField]
+    public string? Speech { get; private set; }
+}

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -552,8 +552,6 @@ public abstract class SharedMagicSystem : EntitySystem
             foreach (var spawn in EntitySpawnCollection.GetSpawns(spawns, _random))
             {
                 Spawn(spawn, mapCoords);
-                var test = new SpeakSpellEvent(ev.Performer, spawn);
-                RaiseLocalEvent(ref test);
             }
         }
     }

--- a/Resources/Locale/en-US/magic/spells-actions.ftl
+++ b/Resources/Locale/en-US/magic/spells-actions.ftl
@@ -3,4 +3,5 @@ action-speech-spell-knock = AULIE OXIN FIERA
 action-speech-spell-smite = EI NATH!
 action-speech-spell-summon-magicarp = AIE KHUSE EU
 action-speech-spell-fireball = ONI'SOMA!
-action-speech-spell-summon-guns = YOR'NEE VES-FROKA
+action-speech-spell-summon-guns = YOR'NEE VES-KORFA
+action-speech-spell-summon-magic = RYGOIN FEMA-VERECO

--- a/Resources/Locale/en-US/magic/spells-actions.ftl
+++ b/Resources/Locale/en-US/magic/spells-actions.ftl
@@ -1,5 +1,6 @@
-﻿action-speech-spell-forcewall = TARCOL MINTI ZHERI
+action-speech-spell-forcewall = TARCOL MINTI ZHERI
 action-speech-spell-knock = AULIE OXIN FIERA
 action-speech-spell-smite = EI NATH!
 action-speech-spell-summon-magicarp = AIE KHUSE EU
 action-speech-spell-fireball = ONI'SOMA!
+action-speech-spell-summon-guns = YOR'NEE VES-FROKA

--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -1,4 +1,4 @@
-﻿# Spells
+# Spells
 spellbook-fireball-name = Fireball
 spellbook-fireball-desc = Get most crew exploding with rage when they see this fireball heading toward them!
 
@@ -29,6 +29,9 @@ spellbook-wand-polymorph-carp-description = For when you need a carp filet quick
 
 spellbook-event-summon-ghosts-name = Summon Ghosts
 spellbook-event-summon-ghosts-description = Who ya gonna call?
+
+spellbook-event-summon-guns-name = Summon Guns
+spellbook-event-summon-guns-description = AK47s for everyone! Places a random gun in front of everybody.
 
 # Upgrades
 spellbook-upgrade-fireball-name = Upgrade Fireball

--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -33,6 +33,9 @@ spellbook-event-summon-ghosts-description = Who ya gonna call?
 spellbook-event-summon-guns-name = Summon Guns
 spellbook-event-summon-guns-description = AK47s for everyone! Places a random gun in front of everybody.
 
+spellbook-event-summon-magic-name = Summon Magic
+spellbook-event-summon-magic-description = Places a random magical item in front of everybody. Nothing could go wrong!
+
 # Upgrades
 spellbook-upgrade-fireball-name = Upgrade Fireball
 spellbook-upgrade-fireball-description = Upgrades Fireball to a maximum of level 3!

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -1,4 +1,4 @@
-﻿# Offensive
+# Offensive
 - type: listing
   id: SpellbookFireball
   name: spellbook-fireball-name
@@ -112,6 +112,19 @@
   productAction: ActionSummonGhosts
   cost:
     WizCoin: 0
+  categories:
+  - SpellbookEvents
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
+  id: SpellbookEventSummonGuns
+  name: spellbook-event-summon-guns-name
+  description: spellbook-event-summon-guns-description
+  productAction: ActionSummonGuns
+  cost:
+    WizCoin: 2
   categories:
   - SpellbookEvents
   conditions:

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -131,6 +131,19 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
+- type: listing
+  id: SpellbookEventSummonMagic
+  name: spellbook-event-summon-magic-name
+  description: spellbook-event-summon-magic-description
+  productAction: ActionSummonMagic
+  cost:
+    WizCoin: 2
+  categories:
+  - SpellbookEvents
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
 # Upgrades
 - type: listing
   id: SpellbookFireballUpgrade

--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: ActionSummonGhosts
   name: Summon Ghosts
   description: Makes all current ghosts permanently invisible
@@ -10,3 +10,26 @@
       sprite: Mobs/Ghosts/ghost_human.rsi
       state: icon
     event: !type:ToggleGhostVisibilityToAllEvent
+
+- type: entity
+  id: ActionSummonGuns
+  name: Summon Guns
+  description: AK47s for everyone! Places a random gun in front of everybody.
+  components:
+  - type: Magic
+  - type: InstantAction
+    useDelay: 2
+    itemIconStyle: BigAction
+    icon:
+      sprite: Objects/Weapons/Guns/Rifles/ak.rsi
+      state: base
+    event: !type:RandomGlobalSpawnSpellEvent
+      spawns:
+      - id: FoodPacketSyndiTrash
+        prob: 0.5
+        orGroup: Trash
+      - id: FoodPacketSemkiTrash
+        prob: 0.5
+        orGroup: Trash
+      speech: action-speech-spell-summon-guns
+      

--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -32,4 +32,5 @@
         prob: 0.5
         orGroup: Trash
       speech: action-speech-spell-summon-guns
+      requireMind: false
       

--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -18,19 +18,185 @@
   components:
   - type: Magic
   - type: InstantAction
-    useDelay: 2
+    useDelay: 600
     itemIconStyle: BigAction
     icon:
       sprite: Objects/Weapons/Guns/Rifles/ak.rsi
       state: base
     event: !type:RandomGlobalSpawnSpellEvent
       spawns:
-      - id: FoodPacketSyndiTrash
-        prob: 0.5
-        orGroup: Trash
-      - id: FoodPacketSemkiTrash
-        prob: 0.5
-        orGroup: Trash
+      - id: WeaponPistolViper
+        orGroup: Guns
+      - id: WeaponPistolCobra
+        orGroup: Guns
+      - id: WeaponPistolMk58
+        orGroup: Guns
+      - id: WeaponPistolN1984
+        orGroup: Guns
+      - id: WeaponRevolverDeckard
+        orGroup: Guns
+      - id: WeaponRevolverInspector
+        orGroup: Guns
+      - id: WeaponRevolverMateba
+        orGroup: Guns
+      - id: WeaponRevolverPython
+        orGroup: Guns
+      - id: WeaponRevolverPirate
+        orGroup: Guns
+      - id: WeaponRifleAk
+        orGroup: Guns
+      - id: WeaponRifleM90GrenadeLauncher
+        orGroup: Guns
+      - id: WeaponRifleLecter
+        orGroup: Guns
+      - id: WeaponShotgunBulldog
+        orGroup: Guns
+      - id: WeaponShotgunDoubleBarreled
+        orGroup: Guns
+      - id: WeaponShotgunEnforcer
+        orGroup: Guns
+      - id: WeaponShotgunKammerer
+        orGroup: Guns
+      - id: WeaponShotgunSawn
+        orGroup: Guns
+      - id: WeaponShotgunHandmade
+        orGroup: Guns
+      - id: WeaponShotgunBlunderbuss
+        orGroup: Guns
+      - id: WeaponShotgunImprovised
+        orGroup: Guns
+      - id: WeaponSubMachineGunAtreides
+        orGroup: Guns
+      - id: WeaponSubMachineGunC20r
+        orGroup: Guns
+      - id: WeaponSubMachineGunDrozd
+        orGroup: Guns
+      - id: WeaponSubMachineGunWt550
+        orGroup: Guns
+      - id: WeaponSniperMosin
+        orGroup: Guns
+      - id: WeaponSniperHristov
+        orGroup: Guns
+      - id: Musket
+        orGroup: Guns
+      - id: WeaponPistolFlintlock
+        orGroup: Guns
+      - id: WeaponLauncherChinaLake
+        orGroup: Guns
+      - id: WeaponLauncherRocket
+        orGroup: Guns
+      - id: WeaponLauncherPirateCannon
+        orGroup: Guns
+      - id: WeaponTetherGun
+        orGroup: Guns
+      - id: WeaponForceGun
+        orGroup: Guns
+      - id: WeaponGrapplingGun
+        orGroup: Guns
+      - id: WeaponLightMachineGunL6
+        orGroup: Guns
+      - id: WeaponLaserSvalinn
+        orGroup: Guns
+      - id: WeaponLaserGun
+        orGroup: Guns
+      - id: WeaponMakeshiftLaser
+        orGroup: Guns
+      - id: WeaponTeslaGun
+        orGroup: Guns
+      - id: WeaponLaserCarbinePractice
+        orGroup: Guns
+      - id: WeaponLaserCarbine
+        orGroup: Guns
+      - id: WeaponPulsePistol
+        orGroup: Guns
+      - id: WeaponPulseCarbine
+        orGroup: Guns
+      - id: WeaponPulseRifle
+        orGroup: Guns
+      - id: WeaponLaserCannon
+        orGroup: Guns
+      - id: WeaponParticleDecelerator
+        orGroup: Guns
+      - id: WeaponXrayCannon
+        orGroup: Guns
+      - id: WeaponDisablerPractice
+        orGroup: Guns
+      - id: WeaponDisabler
+        orGroup: Guns
+      - id: WeaponDisablerSMG
+        orGroup: Guns
+      - id: WeaponTaser
+        orGroup: Guns
+      - id: WeaponAntiqueLaser
+        orGroup: Guns
+      - id: WeaponAdvancedLaser
+        orGroup: Guns
+      - id: WeaponPistolCHIMP
+        orGroup: Guns
+      - id: WeaponBehonkerLaser
+        orGroup: Guns
+      - id: WeaponEnergyShotgun
+        orGroup: Guns
+      - id: WeaponMinigun
+        orGroup: Guns
+      - id: BowImprovised
+        orGroup: Guns
+      - id: WeaponFlareGun
+        orGroup: Guns
+      - id: WeaponImprovisedPneumaticCannon
+        orGroup: Guns
+      - id: WeaponWaterPistol
+        orGroup: Guns
+      - id: WeaponWaterBlaster
+        orGroup: Guns
+      - id: WeaponWaterBlasterSuper
+        orGroup: Guns
       speech: action-speech-spell-summon-guns
-      requireMind: false
+      requireMind: true
       
+- type: entity
+  id: ActionSummonMagic
+  name: Summon Magic
+  description: Places a random magical item in front of everybody. Nothing could go wrong!
+  components:
+  - type: Magic
+  - type: InstantAction
+    useDelay: 600
+    itemIconStyle: BigAction
+    icon:
+      sprite: Objects/Magic/magicactions.rsi
+      state: magicmissile
+    event: !type:RandomGlobalSpawnSpellEvent
+      spawns:
+      - id: SpawnSpellbook
+        orGroup: Magics
+      - id: ForceWallSpellbook
+        orGroup: Magics
+      - id: BlinkBook
+        orGroup: Magics
+      - id: SmiteBook
+        orGroup: Magics
+      - id: KnockSpellbook
+        orGroup: Magics
+      - id: FireballSpellbook
+        orGroup: Magics
+      - id: WeaponWandPolymorphCarp
+        orGroup: Magics
+      - id: WeaponWandPolymorphMonkey
+        orGroup: Magics
+      - id: WeaponWandFireball
+        orGroup: Magics
+      - id: WeaponWandDeath
+        orGroup: Magics
+      - id: WeaponWandPolymorphDoor
+        orGroup: Magics
+      - id: WeaponWandCluwne
+        orGroup: Magics
+      - id: WeaponWandPolymorphBread
+        orGroup: Magics
+      - id: WeaponStaffHealing
+        orGroup: Magics
+      - id: WeaponStaffPolymorphDoor
+        orGroup: Magics
+      speech: action-speech-spell-summon-magic
+      requireMind: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I added two new event spells: Summon Guns, which summons one random gun for every living player-controlled humanoid, and Summon Magic, which does the same except with spellbooks/wands instead of guns.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Granted permission by KeronSHB, they're in charge of the wizard/magic PR freeze. These are two spells they want. Functionally similar so I did them both in one.

I can only imagine the chaos this will cause. Not necessarily beneficial to the wizard though to give all the people you're going to antagonize weapons/spells to fight you back with. Sometimes you'll get a water gun, other times you'll get a rocket launcher. You can see the full list of possible guns/spells in event_spells.yml. Will probably need numbers / list tweaking for proper balance but functionality exists.
## Technical details
<!-- Summary of code changes for easier review. -->
event_spells.yml contains the data for the actual spells and all of the possible items they can spawn
Event is called RandomGlobalSpawnSpellEvent located with other SpellEvent files
Event is handled in SharedMagicSystem under OnRandomGlobalSpawnSpell
It queries through every entity that has a MindContainer, MobState, HumanoidAppearance and Transform
It checks if the Mind is null (nobody is playing them) and checks if they're alive
HumanoidAppearance prevents stuff like pAIs, mice and other ghost roles
Transform is necessary to get their location so as to spawn the item at their position
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/a1b043bb-37a8-453c-8512-dbc06e59a034
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->