### PR TITLE
Allow containers to be dumped into a biomass reclaimer

### DIFF
--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerComponent.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerComponent.cs
@@ -34,13 +34,13 @@ namespace Content.Server.Medical.BiomassReclaimer
         public float CurrentExpectedYield = 0f;
 
         /// <summary>
-        /// The reagent that will be spilled while processing a mob.
+        /// The reagents that will be spilled while processing.
         /// </summary>
         [ViewVariables]
-        public string? BloodReagent;
+        public List<string> BloodReagents = new();
 
         /// <summary>
-        /// Entities that can be randomly spawned while processing a mob.
+        /// Entities that can be randomly spawned while processing.
         /// </summary>
         public List<EntitySpawnEntry> SpawnedEntities = new();
 


### PR DESCRIPTION
## About the PR
Biomass reclaimers can now be fed with containers, which will process all processable entities inside the container at once.

## Why / Balance
Following up from https://github.com/space-wizards/space-station-14/pull/32663#issuecomment-2395800226, so the same reasoning applies. Feeding many small entities like produce or rats to the biomass reclaimer is tedious, even more so with the reclaimer than the biogenerator because a player has to wait for each small item to be processed in turn.

## Technical details
I modified `BiomassReclaimerSystem` to allow interacting with either any entity which can be processed, or any entity with a `StorageComponent`. All entities inside the `StorageComponent` which can themselves be processed, are all inserted at once. 

The `doAfter` length, processing time, and total yield all scale with the total mass of the processable entities, as they're just the sum of the values for the individual items. The `doAfter` also takes into account the mass of the container, to still have some `doAfter` when using an empty container.

I also changed `BloodReagent` in `BiomassReclaimerComponent` to be a `List`, to allow for multiple blood reagents to be tracked, for example if you inserted both a mouse and a roach at once by using a bag. The reclaimer will then pick a random blood from the list when making a mess.

## Media
(Please ignore the audio sounding like hot garbage, it was fine outside the recording)
[reclaimer.webm](https://github.com/user-attachments/assets/edf823f6-6eb3-4130-b703-6b213ec0dfd1)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
BloodReagent in BiomassReclaimerComponent is now a List and is named BloodReagents. Anywhere you used BloodReagent, you should probably instead pick one element at random from BloodReagents.

**Changelog**
:cl:
- add: Containers can now be used to feed biomass reclaimers
