### PR TITLE
Fix bounties(and potentially other things) running out of ids

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
@@ -423,7 +423,10 @@ public sealed partial class CargoSystem
         var newBounty = new CargoBountyData(bounty, randomVal);
         // This bounty id already exists! Probably because NameIdentifierSystem ran out of ids.
         if (component.Bounties.Any(b => b.Id == newBounty.Id))
+        {
+            Log.Error("Failed to add bounty {ID} because another one with the same ID already existed!", newBounty.Id);
             return false;
+        }
         component.Bounties.Add(new CargoBountyData(bounty, randomVal));
         _adminLogger.Add(LogType.Action, LogImpact.Low, $"Added bounty \"{bounty.ID}\" (id:{component.TotalBounties}) to station {ToPrettyString(uid)}");
         component.TotalBounties++;

--- a/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
@@ -420,6 +420,10 @@ public sealed partial class CargoSystem
             return false;
 
         _nameIdentifier.GenerateUniqueName(uid, BountyNameIdentifierGroup, out var randomVal);
+        var newBounty = new CargoBountyData(bounty, randomVal);
+        // This bounty id already exists! Probably because NameIdentifierSystem ran out of ids.
+        if (component.Bounties.Any(b => b.Id == newBounty.Id))
+            return false;
         component.Bounties.Add(new CargoBountyData(bounty, randomVal));
         _adminLogger.Add(LogType.Action, LogImpact.Low, $"Added bounty \"{bounty.ID}\" (id:{component.TotalBounties}) to station {ToPrettyString(uid)}");
         component.TotalBounties++;

--- a/Content.Server/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierSystem.cs
@@ -124,7 +124,7 @@ public sealed class NameIdentifierSystem : EntitySystem
         EnsureIds();
     }
 
-    private void FillGroup(NameIdentifierGroupPrototype proto, ref List<int> values)
+    private void FillGroup(NameIdentifierGroupPrototype proto, List<int> values)
     {
         values.Clear();
         for (var i = proto.MinValue; i < proto.MaxValue; i++)
@@ -137,16 +137,12 @@ public sealed class NameIdentifierSystem : EntitySystem
 
     private List<int> GetOrCreateIdList(NameIdentifierGroupPrototype proto)
     {
-        var found = true;
-
         if (!CurrentIds.TryGetValue(proto.ID, out var ids))
         {
             ids = new List<int>(proto.MaxValue - proto.MinValue);
             found = false;
-        }
-
-        if (!found)
             CurrentIds.Add(proto.ID, ids);
+        }
 
         return ids;
     }
@@ -157,7 +153,7 @@ public sealed class NameIdentifierSystem : EntitySystem
         {
             var ids = GetOrCreateIdList(proto);
 
-            FillGroup(proto, ref ids);
+            FillGroup(proto, ids);
         }
     }
 
@@ -190,7 +186,7 @@ public sealed class NameIdentifierSystem : EntitySystem
                 continue;
 
             var ids  = GetOrCreateIdList(name_proto);
-            FillGroup(name_proto, ref ids);
+            FillGroup(name_proto, ids);
         }
     }
 

--- a/Content.Server/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierSystem.cs
@@ -28,7 +28,7 @@ public sealed class NameIdentifierSystem : EntitySystem
     {
         base.Initialize();
 
-        _sawmill = _logManager.GetSawmill("NameIdentifierSystem");
+        _sawmill = _logManager.GetSawmill("name_identifier_system");
 
         SubscribeLocalEvent<NameIdentifierComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<NameIdentifierComponent, ComponentShutdown>(OnComponentShutdown);

--- a/Content.Server/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierSystem.cs
@@ -28,8 +28,6 @@ public sealed class NameIdentifierSystem : EntitySystem
     {
         base.Initialize();
 
-        _sawmill = _logManager.GetSawmill("name_identifier_system");
-
         SubscribeLocalEvent<NameIdentifierComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<NameIdentifierComponent, ComponentShutdown>(OnComponentShutdown);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(CleanupIds);

--- a/Content.Server/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierSystem.cs
@@ -22,8 +22,6 @@ public sealed class NameIdentifierSystem : EntitySystem
     [ViewVariables]
     public readonly Dictionary<string, List<int>> CurrentIds = new();
 
-    private ISawmill _sawmill = default!;
-
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Server/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierSystem.cs
@@ -140,7 +140,6 @@ public sealed class NameIdentifierSystem : EntitySystem
         if (!CurrentIds.TryGetValue(proto.ID, out var ids))
         {
             ids = new List<int>(proto.MaxValue - proto.MinValue);
-            found = false;
             CurrentIds.Add(proto.ID, ids);
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR makes the NameIdentitySystem refresh the ids for each name group instead of just scrambling the remaining ids. 

This is a bug that was originally discovered on leviathan with bounties all having the same id making it impossible to complete anything but the first one.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I am joining the war on bugs.

## Technical details
<!-- Summary of code changes for easier review. -->
The NameIdentitySystem generates a pool of ids for each group of things that require them. When an id is selected, it is removed from the pool. This means the pool will have less ids as time goes on. While this usually is not a problem since by default 10000 ids are created for each group, before this PR ids would not get refreshed between rounds and only get shuffled again. This means that over a long period a group of ids would be exhausted. We did not encounter this before because our servers would normally update almost daily, now that they don't this bug has become apparent.

Oh yeah also now trying to add a bounty fails if the id already exists.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: It is no longer impossible to do bounties other than the first one if the server has been up for a long period of time.