### PR TITLE
add maid uniform to service worker loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
@@ -25,6 +25,16 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitBartenderPurple
 
+- type: loadout
+  id: MaidJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtJanimaid
+
+- type: loadout
+  id: MaidJumpskirtmini
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtJanimaidmini
+
 # Outer clothing
 - type: loadout
   id: BartenderApron

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -220,6 +220,8 @@
   - BartenderJumpsuit
   - BartenderJumpskirt
   - BartenderJumpsuitPurple
+  - ClothingUniformJumpskirtJanimaid
+  - ClothingUniformJumpskirtJanimaidmini
 
 - type: loadoutGroup
   id: BartenderOuterClothing

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -220,8 +220,8 @@
   - BartenderJumpsuit
   - BartenderJumpskirt
   - BartenderJumpsuitPurple
-  - ClothingUniformJumpskirtJanimaid
-  - ClothingUniformJumpskirtJanimaidmini
+  - MaidJumpskirt
+  - MaidJumpskirtmini
 
 - type: loadoutGroup
   id: BartenderOuterClothing


### PR DESCRIPTION

## About the PR
it's just add maid uniform into service worker loadout.

## Why / Balance
maid uniform it's just a alternative version to bartrender's uniform.

## Technical details
also it's add maid uniform to bartrender's loadout, becouse it's has same groups.

## Media
![20241008193908_1](https://github.com/user-attachments/assets/c149d3c4-0aad-4f82-ae14-c7580593cc82)
![20241008194351_1](https://github.com/user-attachments/assets/9b4d8c1e-1ef5-441d-a5c8-726ab9166d67)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes

**Changelog**

- add: maid uniform now in service worker loadout

