### PR TITLE
Remove drag & drop dropping items from containers

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
+++ b/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
@@ -7,7 +7,6 @@ using Content.Client.UserInterface.Systems.Hotbar.Widgets;
 using Content.Client.UserInterface.Systems.Storage.Controls;
 using Content.Client.Verbs.UI;
 using Content.Shared.CCVar;
-using Content.Shared.Hands.Components;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
@@ -234,15 +233,6 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
 
         if (args.Function == ContentKeyFunctions.MoveStoredItem)
         {
-            var handsSystem = _entity.System<HandsSystem>();
-
-            if (handsSystem.TryGetPlayerHands(out HandsComponent? handsComponent) &&
-                handsComponent.ActiveHandEntity != null)
-            {
-                args.Handle();
-                return;
-            }
-
             DraggingRotation = control.Location.Rotation;
 
             _menuDragHelper.MouseDown(control);
@@ -316,12 +306,6 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
                     _entity.GetNetEntity(draggingGhost.Entity),
                     _entity.GetNetEntity(storageEnt),
                     new ItemStorageLocation(DraggingRotation, position)));
-            }
-            else
-            {
-                _entity.RaisePredictiveEvent(new StorageRemoveItemEvent(
-                    _entity.GetNetEntity(draggingGhost.Entity),
-                    _entity.GetNetEntity(storageEnt)));
             }
 
             _menuDragHelper.EndDrag();

--- a/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
+++ b/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
@@ -7,6 +7,7 @@ using Content.Client.UserInterface.Systems.Hotbar.Widgets;
 using Content.Client.UserInterface.Systems.Storage.Controls;
 using Content.Client.Verbs.UI;
 using Content.Shared.CCVar;
+using Content.Shared.Hands.Components;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
@@ -233,6 +234,15 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
 
         if (args.Function == ContentKeyFunctions.MoveStoredItem)
         {
+            var handsSystem = _entity.System<HandsSystem>();
+
+            if (handsSystem.TryGetPlayerHands(out HandsComponent? handsComponent) &&
+                handsComponent.ActiveHandEntity != null)
+            {
+                args.Handle();
+                return;
+            }
+
             DraggingRotation = control.Location.Rotation;
 
             _menuDragHelper.MouseDown(control);

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1508,27 +1508,6 @@ public abstract class SharedStorageSystem : EntitySystem
         return true;
     }
 
-    /// <summary>
-    /// Check if the entity interacting with the container is doing so with an empty hand.
-    /// </summary>
-    private bool ValidateEmptyHand(EntitySessionEventArgs args, [NotNullWhen(true)] out Hand? emptyHand)
-    {
-        emptyHand = null;
-
-        if (args.SenderSession.AttachedEntity is not { } playerUid)
-            return false;
-
-        if (!TryComp(playerUid, out HandsComponent? hands) || hands.Count == 0)
-            return false;
-
-        if (hands.ActiveHand == null || hands.ActiveHand.HeldEntity != null)
-            return false;
-
-        emptyHand = hands.ActiveHand;
-
-        return true;
-    }
-
     [Serializable, NetSerializable]
     protected sealed class StorageComponentState : ComponentState
     {

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -129,7 +129,6 @@ public abstract class SharedStorageSystem : EntitySystem
         SubscribeAllEvent<StorageInteractWithItemEvent>(OnInteractWithItem);
         SubscribeAllEvent<StorageSetItemLocationEvent>(OnSetItemLocation);
         SubscribeAllEvent<StorageInsertItemIntoLocationEvent>(OnInsertItemIntoLocation);
-        SubscribeAllEvent<StorageRemoveItemEvent>(OnRemoveItem);
         SubscribeAllEvent<StorageSaveItemLocationEvent>(OnSaveItemLocation);
 
         SubscribeLocalEvent<StorageComponent, GotReclaimedEvent>(OnReclaimed);
@@ -631,35 +630,12 @@ public abstract class SharedStorageSystem : EntitySystem
         if (!ValidateInput(args, msg.StorageEnt, msg.ItemEnt, out var player, out var storage, out var item))
             return;
 
-        if (!ValidateEmptyHand(args, out var hand))
-            return;
-
-        if (_sharedHandsSystem.TryPickup(player, item, hand, animate: false, handsComp: player.Comp))
-            InsertAt(storage!, item!, msg.Location, out _, player, true, false);
-
         _adminLog.Add(
             LogType.Storage,
             LogImpact.Low,
             $"{ToPrettyString(player):player} is updating the location of {ToPrettyString(item):item} within {ToPrettyString(storage):storage}");
-    }
 
-    private void OnRemoveItem(StorageRemoveItemEvent msg, EntitySessionEventArgs args)
-    {
-        if (!ValidateInput(args, msg.StorageEnt, msg.ItemEnt, out var player, out var storage, out var item))
-            return;
-
-        if (!ValidateEmptyHand(args, out var hand))
-            return;
-
-        _sharedHandsSystem.TryPickup(player, item, hand, animate: false, handsComp: player.Comp);
-
-        _adminLog.Add(
-            LogType.Storage,
-            LogImpact.Low,
-            $"{ToPrettyString(player):player} is removing {ToPrettyString(item):item} from {ToPrettyString(storage):storage}");
-        _sharedHandsSystem.TryDrop(player, hand);
-
-        Audio.PlayPredicted(storage.Comp.StorageRemoveSound, storage, player, _audioParams);
+        TrySetItemStorageLocation(item!, storage!, msg.Location);
     }
 
     private void OnInsertItemIntoLocation(StorageInsertItemIntoLocationEvent msg, EntitySessionEventArgs args)

--- a/Content.Shared/Storage/StorageComponent.cs
+++ b/Content.Shared/Storage/StorageComponent.cs
@@ -170,20 +170,6 @@ namespace Content.Shared.Storage
     }
 
     [Serializable, NetSerializable]
-    public sealed class StorageRemoveItemEvent : EntityEventArgs
-    {
-        public readonly NetEntity ItemEnt;
-
-        public readonly NetEntity StorageEnt;
-
-        public StorageRemoveItemEvent(NetEntity itemEnt, NetEntity storageEnt)
-        {
-            ItemEnt = itemEnt;
-            StorageEnt = storageEnt;
-        }
-    }
-
-    [Serializable, NetSerializable]
     public sealed class StorageInsertItemIntoLocationEvent : EntityEventArgs
     {
         public readonly NetEntity ItemEnt;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR makes dragging items out of the container UI no longer drop the item on the ground.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The drag & drop is a nice feature to have, but it bypasses a few key systems in a way that wouldn't be intuitive. This includes forensics, glue/lube and dual wielding.

Originally the PR hindered players from moving items entirely in their bag while their hands were full, however after discussion this was decided to be QoL to justify it. Dropping, on the other hand, was seen as more of an obscure mechanic and since it changes the item state it's less desireable.

## Technical details
<!-- Summary of code changes for easier review. -->

This simply removes the drop functionality and all accompanying code.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: It's no longer possible to drag an item out of a container's UI to drop it.
