### PR TITLE
 add maid uniform to service worker loadout

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -43,6 +43,8 @@ loadout-group-bartender-head = Bartender head
 loadout-group-bartender-jumpsuit = Bartender jumpsuit
 loadout-group-bartender-outerclothing = Bartender outer clothing
 
+loadout-group-service-worker-jumpsuit = Service worker jumpsuit
+
 loadout-group-chef-head = Chef head
 loadout-group-chef-mask = Chef mask
 loadout-group-chef-jumpsuit = Chef jumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
@@ -25,6 +25,16 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitBartenderPurple
 
+- type: loadout
+  id: MaidJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtJanimaid
+
+- type: loadout
+  id: MaidJumpskirtmini
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtJanimaidmini
+
 # Outer clothing
 - type: loadout
   id: BartenderApron

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
@@ -25,16 +25,6 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitBartenderPurple
 
-- type: loadout
-  id: MaidJumpskirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtJanimaid
-
-- type: loadout
-  id: MaidJumpskirtmini
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtJanimaidmini
-
 # Outer clothing
 - type: loadout
   id: BartenderApron

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -24,6 +24,11 @@
   equipment:
     jumpsuit: ClothingUniformJumpskirtJanitor
 
+- type: loadout
+  id: MaidJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtJanimaid
+
 # Gloves
 - type: loadout
   id: JanitorRubberGloves

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -29,7 +29,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpskirtJanimaid
 
-  - type: loadout
+- type: loadout
   id: MaidJumpskirtmini
   equipment:
     jumpsuit: ClothingUniformJumpskirtJanimaidmini

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -29,6 +29,11 @@
   equipment:
     jumpsuit: ClothingUniformJumpskirtJanimaid
 
+  - type: loadout
+  id: MaidJumpskirtmini
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtJanimaidmini
+
 # Gloves
 - type: loadout
   id: JanitorRubberGloves

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -358,6 +358,7 @@
   loadouts:
   - JanitorJumpsuit
   - JanitorJumpskirt
+  - MaidJumpskirt
 
 - type: loadoutGroup
   id: JanitorGloves

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -220,6 +220,8 @@
   - BartenderJumpsuit
   - BartenderJumpskirt
   - BartenderJumpsuitPurple
+  - ClothingUniformJumpskirtJanimaid
+  - ClothingUniformJumpskirtJanimaidmini
 
 - type: loadoutGroup
   id: BartenderOuterClothing

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -232,7 +232,7 @@
 
 - type: loadoutGroup
   id: ServiceWorkerJumpsuit
-  name: loadout-group-serwice-worker-jumpsuit
+  name: loadout-group-service-worker-jumpsuit
   loadouts:
   - BartenderJumpsuit
   - BartenderJumpskirt

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -220,8 +220,6 @@
   - BartenderJumpsuit
   - BartenderJumpskirt
   - BartenderJumpsuitPurple
-  - MaidJumpskirt
-  - MaidJumpskirtmini
 
 - type: loadoutGroup
   id: BartenderOuterClothing
@@ -231,6 +229,16 @@
   - BartenderVest
   - BartenderApron
   - BartenderWintercoat
+
+- type: loadoutGroup
+  id: ServiceWorkerJumpsuit
+  name: loadout-group-serwice-worker-jumpsuit
+  loadouts:
+  - BartenderJumpsuit
+  - BartenderJumpskirt
+  - BartenderJumpsuitPurple
+  - MaidJumpskirt
+  - MaidJumpskirtmini
 
 - type: loadoutGroup
   id: ChefHead

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -220,8 +220,8 @@
   - BartenderJumpsuit
   - BartenderJumpskirt
   - BartenderJumpsuitPurple
-  - ClothingUniformJumpskirtJanimaid
-  - ClothingUniformJumpskirtJanimaidmini
+  - MaidJumpskirt
+  - MaidJumpskirtmini
 
 - type: loadoutGroup
   id: BartenderOuterClothing

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -64,7 +64,7 @@
   id: JobServiceWorker
   groups:
   - GroupTankHarness
-  - BartenderJumpsuit
+  - ServiceWorkerJumpsuit
   - CommonBackpack
   - Glasses
   - Survival


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
it's just add maid uniform in service worker and janirator loadout.

## Why / Balance
maid uniform it's just a alternative version to bartrender's uniform.

## Technical details
bartrender and service worker now has diferent jumpsuit groups

## Media
![20241008193908_1](https://github.com/user-attachments/assets/7c433b65-8d7e-4a39-9910-51b950b4ffeb)
![20241008194351_1](https://github.com/user-attachments/assets/c7691106-1fda-4f3f-83ee-e7841bdf5563)
![20241011100033_1](https://github.com/user-attachments/assets/80b83db2-5aab-4988-a814-3c4470875401)



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

- add: maid uniform now in service worker loadout
- add: maid uniform now in janirator loadout

