### PR TITLE
Fix error log when recycling something with small material counts.

### DIFF
--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -175,6 +175,10 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
         var materialPerStack = composition.MaterialComposition[materialProto.ID];
         var amountToSpawn = amount / materialPerStack;
         overflowMaterial = amount - amountToSpawn * materialPerStack;
+
+        if (amountToSpawn == 0)
+            return [];
+
         return _stackSystem.SpawnMultiple(materialProto.StackEntity, amountToSpawn, coordinates);
     }
 

--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -177,7 +177,7 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
         overflowMaterial = amount - amountToSpawn * materialPerStack;
 
         if (amountToSpawn == 0)
-            return [];
+            return new List<EntityUid>();
 
         return _stackSystem.SpawnMultiple(materialProto.StackEntity, amountToSpawn, coordinates);
     }


### PR DESCRIPTION
MaterialStorageSystem.SpawnMultipleFromMaterial now doesn't call StackSystem.SpawnMultiple if it tries to spawn zero. This happens because the recycler calls SpawnMultipleFromMaterial for everything recycled, even if the amount it has stored is < the amount for one sheet.
