### PR TITLE
Bloodpacks can be ground for blood

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -216,6 +216,16 @@
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
     healingEndSound:
       path: "/Audio/Items/Medical/brutepack_end.ogg"
+  - type: Extractable
+    grindableSolutionName: contents
+  - type: SolutionContainerManager
+    solutions:
+      contents:
+        reagents:
+        - ReagentId: Blood
+          Quantity: 8
+        - ReagentId: Saline
+          Quantity: 2
   - type: Stack
     stackType: Bloodpack
     count: 10

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -223,9 +223,9 @@
       contents:
         reagents:
         - ReagentId: Blood
-          Quantity: 8
+          Quantity: 9
         - ReagentId: Saline
-          Quantity: 2
+          Quantity: 1
   - type: Stack
     stackType: Bloodpack
     count: 10


### PR DESCRIPTION
## About the PR
Bloodpacks can now be ground for blood. Now if chemists need a bit of blood for a recipe they don't have to grab a syringe and extract it from themselves, they can use bloodpacks. Which from an RP standpoint both seems more sanitary, and makes more sense. I did my best to make it balanced so it's not an excessive amount but also where chem doesn't need to grind every single bloodpack in med. I ended up at
\>one bloodpack = 8 blood, 2 saline
\>a stack of 10 is 80 blood, 20 saline
Which I think is a good middle ground, though I am welcome to thoughts on this.

EDIT: bloodpack contents was changed to 9 blood, 1 saline. This is because 2u saline is actually more effective than a bloodpack itself is.

## Why / Balance
As mentioned before, this makes more sense RP wise.

## Technical details
made bloodpacks extractable fluidcontainers

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None. Probably.

**Changelog**
:cl:
- tweak: Bloodpacks now actually contain blood, and can be put in a grinder to extract said blood.
