### PR TITLE
fix grappling hooks getting bricked

### DIFF
--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -114,19 +114,14 @@ public abstract class SharedGrapplingGunSystem : EntitySystem
 
     private void OnGunActivate(EntityUid uid, GrapplingGunComponent component, ActivateInWorldEvent args)
     {
-        if (!Timing.IsFirstTimePredicted || args.Handled || !args.Complex)
-            return;
-
-        if (Deleted(component.Projectile))
+        if (!Timing.IsFirstTimePredicted || args.Handled || !args.Complex || component.Projectile is not {} projectile)
             return;
 
         _audio.PlayPredicted(component.CycleSound, uid, args.User);
         _appearance.SetData(uid, SharedTetherGunSystem.TetherVisualsStatus.Key, true);
 
         if (_netManager.IsServer)
-        {
-            QueueDel(component.Projectile.Value);
-        }
+            QueueDel(projectile);
 
         component.Projectile = null;
         SetReeling(uid, component, false, args.User);


### PR DESCRIPTION
## About the PR
previously if the hook gets deleted by any means (e.g. mining rock its attached to) it would permanently brick the grappling gun. now you just press z like nothing ever happened

## Why / Balance
good

## Technical details
remove Deleted check basically

## Media


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed grappling hooks sometimes getting bricked.