### PR TITLE
Reduce chance of random angry animals event spawning

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -341,7 +341,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 1
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -362,7 +362,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 1
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -383,7 +383,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 2
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -400,7 +400,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 20
-    weight: 1.5
+    weight: 1
     duration: 60
   - type: VentCrittersRule
     entries:


### PR DESCRIPTION
## About the PR
Massively reduce the weight of the random angry animals spawn events. 

## Why / Balance
There are currently four random spawn events in the game with a combined weight of 16.5. These random enemies are frustrating for players, do not lead to any roleplay, prey disproportionately on new players, encourage powergaming, and cause rule issues when players take the open ghost roles and destroy station infrastructure or try to become station pets. I do not understand why these events should be so frequent.

Worth noting that I did not increase any of the other event weights in comparison. Let me know if I need to or if that breaks things.

## Technical details
I wrote this in webedit in like five minutes and haven't tested it. I'm welcome to making other changes to stop things from breaking.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Significantly reduced the frequency of the random killer animal spawn events.
