### PR TITLE
Fix Centcom cloning scanner

### DIFF
--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -18851,6 +18851,8 @@ entities:
       linkedPorts:
         722:
         - CloningPodSender: CloningPodReceiver
+        723:
+        - MedicalScannerSender: MedicalScannerReceiver
 - proto: ComputerComms
   entities:
   - uid: 652
@@ -27707,6 +27709,13 @@ entities:
     components:
     - type: Transform
       pos: -17.485325,-31.461966
+      parent: 1668
+- proto: NetworkConfigurator
+  entities:
+  - uid: 2823
+    components:
+    - type: Transform
+      pos: 13.484868,-12.584605
       parent: 1668
 - proto: NitrogenCanister
   entities:

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -27712,7 +27712,7 @@ entities:
       parent: 1668
 - proto: NetworkConfigurator
   entities:
-  - uid: 2823
+  - uid: 1461
     components:
     - type: Transform
       pos: 13.484868,-12.584605


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Actually made the medical scanner link up to the cloning computer. Also added a network configurator in the same room.

## Why / Balance
It's frustrating to hunt down the engineers with a multitool round end.

## Technical details
Mapping only

## Media
N/A, it's just invisible plus a network configurator on a table

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->