### PR TITLE
Allow strip removing items if you're holding something

### DIFF
--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -103,7 +103,7 @@ public abstract class SharedStrippableSystem : EntitySystem
 
         if (userHands.ActiveHandEntity != null && !hasEnt)
             StartStripInsertInventory((user, userHands), strippable.Owner, userHands.ActiveHandEntity.Value, args.Slot);
-        else if (userHands.ActiveHandEntity == null && hasEnt)
+        else if (hasEnt)
             StartStripRemoveInventory(user, strippable.Owner, held!.Value, args.Slot);
     }
 
@@ -135,7 +135,7 @@ public abstract class SharedStrippableSystem : EntitySystem
 
         if (user.Comp.ActiveHandEntity != null && handSlot.HeldEntity == null)
             StartStripInsertHand(user, target, user.Comp.ActiveHandEntity.Value, handId, targetStrippable);
-        else if (user.Comp.ActiveHandEntity == null && handSlot.HeldEntity != null)
+        else if (handSlot.HeldEntity != null)
             StartStripRemoveHand(user, target, handSlot.HeldEntity.Value, handId, targetStrippable);
     }
 


### PR DESCRIPTION
You were already able to strip more items at once from somebody than you could hold, and they would drop to the floor. This matched the behavior in SS13.

Annoyingly, however, you were not allowed to *start* a stripping action if you're holding something. This just feels like an annoying paper cut, so this is no longer a thing.

:cl:
- tweak: You can now start removing items via stripping while holding something. 