### PR TITLE
add: water vapor hurts slimes

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -447,6 +447,18 @@
       effects:
       - !type:SatiateThirst
         factor: 4
+    Gas:
+      effects:
+        - !type:HealthChange
+          scaleByQuantity: true
+          ignoreResistances: true
+          conditions:
+          - !type:OrganType
+            type: Slime
+            shouldHave: true
+          damage:
+            types:
+              Heat: 8
 
 - type: reagent
   id: Ice

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -449,16 +449,16 @@
         factor: 4
     Gas:
       effects:
-        - !type:HealthChange
-          scaleByQuantity: true
-          ignoreResistances: true
-          conditions:
-          - !type:OrganType
-            type: Slime
-            shouldHave: true
-          damage:
-            types:
-              Heat: 3
+      - !type:HealthChange
+        scaleByQuantity: true
+        ignoreResistances: true
+        conditions:
+        - !type:OrganType
+          type: Slime
+          shouldHave: true
+        damage:
+          types:
+            Heat: 3
 
 - type: reagent
   id: Ice

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -458,7 +458,7 @@
             shouldHave: true
           damage:
             types:
-              Heat: 8
+              Heat: 3
 
 - type: reagent
   id: Ice


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Water vapor now hurts slimes by skin contact. In a room filled with vapor residue from a spread gas leak (a few mol of vapor ) won't be hurt at all because of slime's fast regen, but entering a room with all air entirely replaced with vapor will crit in 10 seconds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

![forgor](https://github.com/user-attachments/assets/5ac92847-4513-4fd1-9fd7-25f7736dc6ae)

water in general is meant to damage slimes. splashing water already does that.

**Changelog**

:cl:
- add: Water vapor is now dangerous to slime life-forms.
