### PR TITLE
Fixes tech anomalies being able to do their thing every single tick

### DIFF
--- a/Content.Server/Anomaly/Effects/TechAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/TechAnomalySystem.cs
@@ -37,7 +37,7 @@ public sealed class TechAnomalySystem : EntitySystem
             if (_timing.CurTime < tech.NextTimer)
                 continue;
 
-            tech.NextTimer += TimeSpan.FromSeconds(tech.TimerFrequency);
+            tech.NextTimer = _timing.CurTime + TimeSpan.FromSeconds(tech.TimerFrequency);
 
             _signal.InvokePort(uid, tech.TimerPort);
         }


### PR DESCRIPTION
## About the PR
This PR fixes a bug where tech anomalies will almost always pulse every tick until they've existed a sufficiently long amount of time

## Why / Balance
Lights flashing literally every tick is no bueno :<

## Technical details
The old logic was simple: if the next time for the tech anomaly to do it's thing is less than the current time, then objects get pulsed, and the next time gets the timer frequency added onto it.

The issue: the next time is never updated with the actual current time, meaning it initializes as 0, in turn meaning it's almost always valid for the tech anomaly's effects to proc every tick during a natural round. A tech anomaly needs to exist for quite a long while in order to finally start pulsing at the actual intended rate.

So this PR fixes that by making it so that when the tech anomaly hits its timer, the next time is set to current time + timer frequency. This fixes the issue entirely.

## Media
N/A

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- fix: Tech anomalies no longer pulse devices every single server tick until they have existed for a sufficiently long amount of time. In laymen's terms, this means they no longer turn the station's lighting into strobe lights.
