### PR TITLE
Fix random test fail in DeleteAllThenGhost

### DIFF
--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -478,7 +478,13 @@ public abstract class SharedRoleSystem : EntitySystem
         var exclusiveAntag = false;
         foreach (var role in mind.MindRoles)
         {
-            var roleComp = Comp<MindRoleComponent>(role);
+            if (!TryComp<MindRoleComponent>(role, out var roleComp))
+            {
+                //If this ever shows up outside of an integration test, then we need to look into this further.
+                Log.Warning($"Mind Role Entity {role} does not have MindRoleComponent!");
+                continue;
+            }
+
             if (roleComp.Antag || exclusiveAntag)
                 antagonist = true;
             if (roleComp.ExclusiveAntag)


### PR DESCRIPTION
Fixes #32740

## Technical details
The error appears when a CheckAntagonistStatus is performed on an entity without MindRoleComponent. Since the possibility of a mind role without their signature component existing was never even considered, the code just assumed that it will be there and there was no handling if thats not the case. Now it will just consider this particular mind role as "not an antagonist" and log a warning. Creating a component with default/null values could cause other, more subtle failures elswhere. Better if it's more visible if this error ever occurs in real conditions

I was unable to determine HOW this situation comes by, since it only occurs if ALL tests are run, never when only the impacted test is ran alone, and the engine does not seem to be able to run Debug on the full test set without choking up and forcibly timing out after 20 minutes. The occurences are now logged as warnings, so if it ever shows up in a real round then further investigation could be warranted

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
