### PR TITLE
Fix Industrial Reagent Grinder sprite

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
@@ -86,7 +86,7 @@
   - type: GenericVisualizer
     visuals:
       enum.ConveyorVisuals.State:
-        enum.RecyclerVisualLayers.Main:
+        enum.ConveyorState.Off:
           Forward: { state: grinder-b1 }
           Reverse: { state: grinder-b1 }
           Off: { state: grinder-b0 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The industrial Reagent Grinder's visuals have somehow been bugged and replaced with the recycle's visuals. This should fix the issue

## Why / Balance
Fixes a visual bug

## Technical details
Replaces the enum.RecyclerVisualLayers.Main with enum.ConveyorState.Off as the former does not have the proper support for Forward, Reverse, and Off.

## Media
Visuals pre-fix
![Visuals notfixed](https://github.com/user-attachments/assets/07fd40f0-c299-4038-a7db-0ff9520a7a9d)
Visuals post-fix
![Visuals fixed](https://github.com/user-attachments/assets/2e989bed-0482-487c-bfc3-c42f14b84057)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed the Industrial Reagent Grinder's visuals


