### PR TITLE
Fixing Thief Beacon Role Check Logic (to use new mindrole system)

### DIFF
--- a/Content.Server/Thief/Systems/ThiefBeaconSystem.cs
+++ b/Content.Server/Thief/Systems/ThiefBeaconSystem.cs
@@ -39,9 +39,7 @@ public sealed class ThiefBeaconSystem : EntitySystem
             return;
 
         var mind = _mind.GetMind(args.User);
-        if (mind == null)
-            return;
-        if (!_roles.MindHasRole<ThiefRoleComponent>(mind!.Value))
+        if (mind == null || !_roles.MindHasRole<ThiefRoleComponent>(mind.Value))
             return;
 
         var user = args.User;

--- a/Content.Server/Thief/Systems/ThiefBeaconSystem.cs
+++ b/Content.Server/Thief/Systems/ThiefBeaconSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Examine;
 using Content.Shared.Foldable;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
+using Content.Shared.Roles;
 using Robust.Shared.Audio.Systems;
 
 namespace Content.Server.Thief.Systems;
@@ -18,6 +19,7 @@ public sealed class ThiefBeaconSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly MindSystem _mind = default!;
+    [Dependency] private readonly SharedRoleSystem _roles = default!;
 
     public override void Initialize()
     {
@@ -37,7 +39,9 @@ public sealed class ThiefBeaconSystem : EntitySystem
             return;
 
         var mind = _mind.GetMind(args.User);
-        if (!HasComp<ThiefRoleComponent>(mind))
+        if (mind == null)
+            return;
+        if (!_roles.MindHasRole<ThiefRoleComponent>(mind!.Value))
             return;
 
         var user = args.User;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The Thief Beacon currently directly checks if the user has the thief role instead of using the new mindrole system. This means that on master, the thief beacon currently doesn't give users the dialogue option to set its coordinates, even if they're a thief. I've updated the thief beacon logic to use the new mindrole system, fixing this bug. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Thieves should be able to set their beacon coordinates as intended. Fixes https://github.com/space-wizards/space-station-14/issues/32763
## Technical details
<!-- Summary of code changes for easier review. -->
Added a using declaration for the content shared roles system to allow the use of MindHasRole. Replaced the existing HasComp check with MindHasRole.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/ea1d42d2-ec3a-4444-9a78-203613dfa18d)
(just trust me the set coordinates option was missing before my changes)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
