### PR TITLE
Added tag "Meat" to Brain Cake and Brain Cake Slice

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -171,6 +171,7 @@
   - type: Tag
     tags:
     - Meat
+    - Cake
 
 - type: entity
   name: slice of brain cake

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -184,6 +184,8 @@
   - type: Tag
     tags:
     - Meat
+    - Cake
+    - Slice
 # Tastes like sweetness, cake, brains.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -168,7 +168,9 @@
     state: brain
   - type: SliceableFood
     slice: FoodCakeBrainSlice
-
+  - type: Tag
+    tags:
+    - Meat
 
 - type: entity
   name: slice of brain cake
@@ -178,6 +180,9 @@
   components:
   - type: Sprite
     state: brain-slice
+  - type: Tag
+    tags:
+    - Meat
 # Tastes like sweetness, cake, brains.
 
 - type: entity


### PR DESCRIPTION
## About the PR
Added Tag "Meat and Cake" to brain cake, so Lizard Species can eat it.

## Why / Balance
Allows Lizards to eat brain cake, which they could not previously.

## Technical details
Added Tag "Meat and Cake" to Brain Cake and "Meat, Cake and Slice" to it's slices

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Brain Cake is now meat, and can be eaten by Lizards.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
