### PR TITLE
Hide role entities in the spawn menu

### DIFF
--- a/Content.Server/Atmos/Components/AtmosFixMarkerComponent.cs
+++ b/Content.Server/Atmos/Components/AtmosFixMarkerComponent.cs
@@ -1,9 +1,11 @@
+using Robust.Shared.Prototypes;
+
 namespace Content.Server.Atmos.Components
 {
     /// <summary>
     /// Used by FixGridAtmos. Entities with this may get magically auto-deleted on map initialization in future.
     /// </summary>
-    [RegisterComponent]
+    [RegisterComponent, EntityCategory("Mapping")]
     public sealed partial class AtmosFixMarkerComponent : Component
     {
         // See FixGridAtmos for more details

--- a/Content.Shared/Roles/MindRoleComponent.cs
+++ b/Content.Shared/Roles/MindRoleComponent.cs
@@ -42,6 +42,8 @@ public sealed partial class MindRoleComponent : BaseMindRoleComponent
     public ProtoId<JobPrototype>? JobPrototype { get; set; }
 }
 
+// Why does this base component actually exist? It does make auto-categorization easy, but before that it was useless?
+[EntityCategory("Roles")]
 public abstract partial class BaseMindRoleComponent : Component
 {
 

--- a/Resources/Locale/en-US/entity-categories.ftl
+++ b/Resources/Locale/en-US/entity-categories.ftl
@@ -1,3 +1,5 @@
 entity-category-name-actions = Actions
 entity-category-name-game-rules = Game Rules
 entity-category-name-objectives = Objectives
+entity-category-name-roles = Mind Roles
+entity-category-name-mapping = Mapping

--- a/Resources/Prototypes/Entities/categories.yml
+++ b/Resources/Prototypes/Entities/categories.yml
@@ -12,3 +12,13 @@
   id: Objectives
   name: entity-category-name-objectives
   hideSpawnMenu: true
+
+- type: entityCategory
+  id: Roles
+  name: entity-category-name-roles
+  hideSpawnMenu: true
+
+# markers, atmos fixing, etc
+- type: entityCategory
+  id: Mapping
+  name: entity-category-name-mapping


### PR DESCRIPTION

## About the PR
Gives mind role entities an entity category, and hides them from the spawn menu,
Also gives mapping markers a category, though they still appear in the menu.

