### PR TITLE
Add role prototype validation tests

### DIFF
--- a/Content.IntegrationTests/Pair/TestPair.Helpers.cs
+++ b/Content.IntegrationTests/Pair/TestPair.Helpers.cs
@@ -107,14 +107,14 @@ public sealed partial class TestPair
     /// <summary>
     /// Retrieve all entity prototypes that have some component.
     /// </summary>
-    public List<EntityPrototype> GetPrototypesWithComponent<T>(
+    public List<(EntityPrototype, T)> GetPrototypesWithComponent<T>(
         HashSet<string>? ignored = null,
         bool ignoreAbstract = true,
         bool ignoreTestPrototypes = true)
         where T : IComponent
     {
         var id = Server.ResolveDependency<IComponentFactory>().GetComponentName(typeof(T));
-        var list = new List<EntityPrototype>();
+        var list = new List<(EntityPrototype, T)>();
         foreach (var proto in Server.ProtoMan.EnumeratePrototypes<EntityPrototype>())
         {
             if (ignored != null && ignored.Contains(proto.ID))
@@ -126,8 +126,8 @@ public sealed partial class TestPair
             if (ignoreTestPrototypes && IsTestPrototype(proto))
                 continue;
 
-            if (proto.Components.ContainsKey(id))
-                list.Add(proto);
+            if (proto.Components.TryGetComponent(id, out var cmp))
+                list.Add((proto, (T)cmp));
         }
 
         return list;

--- a/Content.IntegrationTests/Pair/TestPair.Helpers.cs
+++ b/Content.IntegrationTests/Pair/TestPair.Helpers.cs
@@ -134,6 +134,34 @@ public sealed partial class TestPair
     }
 
     /// <summary>
+    /// Retrieve all entity prototypes that have some component.
+    /// </summary>
+    public List<EntityPrototype> GetPrototypesWithComponent(Type type,
+        HashSet<string>? ignored = null,
+        bool ignoreAbstract = true,
+        bool ignoreTestPrototypes = true)
+    {
+        var id = Server.ResolveDependency<IComponentFactory>().GetComponentName(type);
+        var list = new List<EntityPrototype>();
+        foreach (var proto in Server.ProtoMan.EnumeratePrototypes<EntityPrototype>())
+        {
+            if (ignored != null && ignored.Contains(proto.ID))
+                continue;
+
+            if (ignoreAbstract && proto.Abstract)
+                continue;
+
+            if (ignoreTestPrototypes && IsTestPrototype(proto))
+                continue;
+
+            if (proto.Components.ContainsKey(id))
+                list.Add((proto));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Set a user's antag preferences. Modified preferences are automatically reset at the end of the test.
     /// </summary>
     public async Task SetAntagPreference(ProtoId<AntagPrototype> id, bool value, NetUserId? user = null)

--- a/Content.IntegrationTests/Tests/Minds/RoleTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/RoleTests.cs
@@ -1,24 +1,92 @@
-﻿using Content.Shared.Roles;
+﻿using System.Linq;
+using Content.Server.Roles;
+using Content.Shared.Roles;
+using Content.Shared.Roles.Jobs;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Reflection;
 
 namespace Content.IntegrationTests.Tests.Minds;
 
 [TestFixture]
 public sealed class RoleTests
 {
+    /// <summary>
+    /// Check that any prototype with a <see cref="MindRoleComponent"/> is properly configured
+    /// </summary>
     [Test]
-    public async Task ValidatePrototypes()
+    public async Task ValidateRolePrototypes()
     {
         await using var pair = await PoolManager.GetServerClient();
+
+        var jobComp = pair.Server.ResolveDependency<IComponentFactory>().GetComponentName(typeof(JobRoleComponent));
 
         Assert.Multiple(() =>
         {
             foreach (var (proto, comp) in pair.GetPrototypesWithComponent<MindRoleComponent>())
             {
-                // According to MindGetAllRoleInfo(), having both prototypes on a single role is unsupported.
                 Assert.That(comp.AntagPrototype == null || comp.JobPrototype == null, $"Role {proto.ID} has both a job and antag prototype.");
                 Assert.That(!comp.ExclusiveAntag || comp.Antag, $"Role {proto.ID} is marked as an exclusive antag, despite not being an antag.");
                 Assert.That(comp.Antag || comp.AntagPrototype == null, $"Role {proto.ID} has an antag prototype, despite not being an antag.");
+
+                if (comp.JobPrototype != null)
+                    Assert.That(proto.Components.ContainsKey(jobComp), $"Role {proto.ID} is a job, despite not having a job prototype.");
+
+                // It is possible that this is meant to be supported? Though I would assume that it would be for
+                // admin / prototype uploads, and that pre-defined roles should still check this.
                 Assert.That(!comp.Antag || comp.AntagPrototype != null , $"Role {proto.ID} is an antag, despite not having a antag prototype.");
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Check that any prototype with a <see cref="JobRoleComponent"/> also has a properly configured
+    /// <see cref="MindRoleComponent"/>
+    /// </summary>
+    [Test]
+    public async Task ValidateJobPrototypes()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+
+        var mindCompId = pair.Server.ResolveDependency<IComponentFactory>().GetComponentName(typeof(MindRoleComponent));
+
+        Assert.Multiple(() =>
+        {
+            foreach (var (proto, comp) in pair.GetPrototypesWithComponent<JobRoleComponent>())
+            {
+                if (proto.Components.TryGetComponent(mindCompId, out var mindComp))
+                    Assert.That(((MindRoleComponent)mindComp).JobPrototype, Is.Not.Null);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Check that any prototype with a component that inherits from <see cref="BaseMindRoleComponent"/> also has a
+    /// <see cref="MindRoleComponent"/>
+    /// </summary>
+    [Test]
+    public async Task ValidateRolesHaveMindRoleComp()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+
+        var refMan = pair.Server.ResolveDependency<IReflectionManager>();
+        var mindCompId = pair.Server.ResolveDependency<IComponentFactory>().GetComponentName(typeof(MindRoleComponent));
+
+        var compTypes = refMan.GetAllChildren(typeof(BaseMindRoleComponent))
+            .Append(typeof(RoleBriefingComponent))
+            .Where(x => !x.IsAbstract);
+
+        Assert.Multiple(() =>
+        {
+            foreach (var comp in compTypes)
+            {
+                foreach (var proto in pair.GetPrototypesWithComponent(comp))
+                {
+                    Assert.That(proto.Components.ContainsKey(mindCompId), $"Role {proto.ID} does not have a {nameof(MindRoleComponent)} despite having a {comp.Name}");
+                }
             }
         });
 

--- a/Content.IntegrationTests/Tests/Minds/RoleTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/RoleTests.cs
@@ -1,0 +1,27 @@
+﻿using Content.Shared.Roles;
+
+namespace Content.IntegrationTests.Tests.Minds;
+
+[TestFixture]
+public sealed class RoleTests
+{
+    [Test]
+    public async Task ValidatePrototypes()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+
+        Assert.Multiple(() =>
+        {
+            foreach (var (proto, comp) in pair.GetPrototypesWithComponent<MindRoleComponent>())
+            {
+                // According to MindGetAllRoleInfo(), having both prototypes on a single role is unsupported.
+                Assert.That(comp.AntagPrototype == null || comp.JobPrototype == null, $"Role {proto.ID} has both a job and antag prototype.");
+                Assert.That(!comp.ExclusiveAntag || comp.Antag, $"Role {proto.ID} is marked as an exclusive antag, despite not being an antag.");
+                Assert.That(comp.Antag || comp.AntagPrototype == null, $"Role {proto.ID} has an antag prototype, despite not being an antag.");
+                Assert.That(!comp.Antag || comp.AntagPrototype != null , $"Role {proto.ID} is an antag, despite not having a antag prototype.");
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/Sprite/ItemSpriteTest.cs
+++ b/Content.IntegrationTests/Tests/Sprite/ItemSpriteTest.cs
@@ -40,7 +40,7 @@ public sealed class PrototypeSaveTest
 
         await pair.Client.WaitPost(() =>
         {
-            foreach (var proto in pair.GetPrototypesWithComponent<ItemComponent>(Ignored))
+            foreach (var (proto, _) in pair.GetPrototypesWithComponent<ItemComponent>(Ignored))
             {
                 var dummy = pair.Client.EntMan.Spawn(proto.ID);
                 pair.Client.EntMan.RunMapInit(dummy, pair.Client.MetaData(dummy));

--- a/Content.IntegrationTests/Tests/StorageTest.cs
+++ b/Content.IntegrationTests/Tests/StorageTest.cs
@@ -94,14 +94,13 @@ namespace Content.IntegrationTests.Tests
 
             await Assert.MultipleAsync(async () =>
             {
-                foreach (var proto in pair.GetPrototypesWithComponent<StorageFillComponent>())
+                foreach (var (proto, fill) in pair.GetPrototypesWithComponent<StorageFillComponent>())
                 {
                     if (proto.HasComponent<EntityStorageComponent>(compFact))
                         continue;
 
                     StorageComponent? storage = null;
                     ItemComponent? item = null;
-                    StorageFillComponent fill = default!;
                     var size = 0;
                     await server.WaitAssertion(() =>
                     {
@@ -112,7 +111,6 @@ namespace Content.IntegrationTests.Tests
                         }
 
                         proto.TryGetComponent("Item", out item);
-                        fill = (StorageFillComponent) proto.Components[id].Component;
                         size = GetFillSize(fill, false, protoMan, itemSys);
                     });
 
@@ -179,7 +177,7 @@ namespace Content.IntegrationTests.Tests
 
             var itemSys = entMan.System<SharedItemSystem>();
 
-            foreach (var proto in pair.GetPrototypesWithComponent<StorageFillComponent>())
+            foreach (var (proto, fill) in pair.GetPrototypesWithComponent<StorageFillComponent>())
             {
                 if (proto.HasComponent<StorageComponent>(compFact))
                     continue;
@@ -192,7 +190,6 @@ namespace Content.IntegrationTests.Tests
                     if (entStorage == null)
                         return;
 
-                    var fill = (StorageFillComponent) proto.Components[id].Component;
                     var size = GetFillSize(fill, true, protoMan, itemSys);
                     Assert.That(size, Is.LessThanOrEqualTo(entStorage.Capacity),
                         $"{proto.ID} storage fill is too large.");

--- a/Content.Server/EntityEffects/EffectConditions/JobCondition.cs
+++ b/Content.Server/EntityEffects/EffectConditions/JobCondition.cs
@@ -26,9 +26,17 @@ public sealed partial class JobCondition : EntityEffectCondition
             if(!args.EntityManager.HasComponent<JobRoleComponent>(roleId))
                 continue;
 
-            if(!args.EntityManager.TryGetComponent<MindRoleComponent>(roleId, out var mindRole)
-               || mindRole.JobPrototype is null)
+            if (!args.EntityManager.TryGetComponent<MindRoleComponent>(roleId, out var mindRole))
+            {
+                Logger.Error($"Encountered job mind role entity {roleId} without a {nameof(MindRoleComponent)}");
                 continue;
+            }
+
+            if (mindRole.JobPrototype == null)
+            {
+                Logger.Error($"Encountered job mind role entity {roleId} without a {nameof(JobPrototype)}");
+                continue;
+            }
 
             if (Job.Contains(mindRole.JobPrototype.Value))
                 return true;

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -155,8 +155,8 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
             if (_mind.TryGetMind(ev.User.Value, out var revMindId, out _))
             {
-                if (_role.MindHasRole<RevolutionaryRoleComponent>(revMindId, out _, out var role))
-                    role.Value.Comp.ConvertedCount++;
+                if (_role.MindHasRole<RevolutionaryRoleComponent>(revMindId, out var role))
+                    role.Value.Comp2.ConvertedCount++;
             }
         }
 

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -516,8 +516,8 @@ public sealed class GhostRoleSystem : EntitySystem
 
         _roleSystem.MindAddRole(newMind, "MindRoleGhostMarker");
 
-        if(_roleSystem.MindHasRole<GhostRoleMarkerRoleComponent>(newMind, out _, out var markerRole))
-            markerRole.Value.Comp.Name = role.RoleName;
+        if(_roleSystem.MindHasRole<GhostRoleMarkerRoleComponent>(newMind!, out var markerRole))
+            markerRole.Value.Comp2.Name = role.RoleName;
 
         _mindSystem.SetUserId(newMind, player.UserId);
         _mindSystem.TransferTo(newMind, mob);

--- a/Content.Shared/Roles/Jobs/SharedJobSystem.cs
+++ b/Content.Shared/Roles/Jobs/SharedJobSystem.cs
@@ -103,7 +103,6 @@ public abstract class SharedJobSystem : EntitySystem
     public bool MindHasJobWithId(EntityUid? mindId, string prototypeId)
     {
 
-        MindRoleComponent? comp = null;
         if (mindId is null)
             return false;
 
@@ -112,9 +111,7 @@ public abstract class SharedJobSystem : EntitySystem
         if (role is null)
             return false;
 
-        comp = role.Value.Comp;
-
-        return (comp.JobPrototype == prototypeId);
+        return role.Value.Comp1.JobPrototype == prototypeId;
     }
 
     public bool MindTryGetJob(
@@ -124,7 +121,7 @@ public abstract class SharedJobSystem : EntitySystem
         prototype = null;
         MindTryGetJobId(mindId, out var protoId);
 
-        return (_prototypes.TryIndex<JobPrototype>(protoId, out prototype) || prototype is not null);
+        return _prototypes.TryIndex(protoId, out prototype) || prototype is not null;
     }
 
     public bool MindTryGetJobId(
@@ -137,9 +134,9 @@ public abstract class SharedJobSystem : EntitySystem
             return false;
 
         if (_roles.MindHasRole<JobRoleComponent>(mindId.Value, out var role))
-            job = role.Value.Comp.JobPrototype;
+            job = role.Value.Comp1.JobPrototype;
 
-        return (job is not null);
+        return job is not null;
     }
 
     /// <summary>

--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -93,19 +93,18 @@ public abstract class SharedRoleSystem : EntitySystem
         bool silent = false,
         string? jobPrototype = null)
     {
-        // Can't have someone get paid for two jobs now, can we
-        if (MindHasRole<JobRoleComponent>(mindId, out var jobRole)
-            && jobRole.Value.Comp.JobPrototype != jobPrototype)
-        {
-            Resolve(mindId, ref mind);
-            if (mind is not null)
-            {
-                _adminLogger.Add(LogType.Mind,
-                    LogImpact.Low,
-                    $"Job Role of {ToPrettyString(mind.OwnedEntity)} changed from '{jobRole.Value.Comp.JobPrototype}' to '{jobPrototype}'");
-            }
+        if (!Resolve(mindId, ref mind))
+            return;
 
-            jobRole.Value.Comp.JobPrototype = jobPrototype;
+        // Can't have someone get paid for two jobs now, can we
+        if (MindHasRole<JobRoleComponent>((mindId, mind), out var jobRole)
+            && jobRole.Value.Comp1.JobPrototype != jobPrototype)
+        {
+            _adminLogger.Add(LogType.Mind,
+                LogImpact.Low,
+                $"Job Role of {ToPrettyString(mind.OwnedEntity)} changed from '{jobRole.Value.Comp1.JobPrototype}' to '{jobPrototype}'");
+
+            jobRole.Value.Comp1.JobPrototype = jobPrototype;
         }
         else
             MindAddRoleDo(mindId, "MindRoleJob", mind, silent, jobPrototype);
@@ -147,6 +146,9 @@ public abstract class SharedRoleSystem : EntitySystem
         {
             mindRoleComp.JobPrototype = jobPrototype;
             EnsureComp<JobRoleComponent>(mindRoleId);
+            DebugTools.AssertNull(mindRoleComp.AntagPrototype);
+            DebugTools.Assert(!mindRoleComp.Antag);
+            DebugTools.Assert(!mindRoleComp.ExclusiveAntag);
         }
 
         antagonist |= mindRoleComp.Antag;
@@ -181,51 +183,55 @@ public abstract class SharedRoleSystem : EntitySystem
     /// <summary>
     ///     Removes all instances of a specific role from this mind.
     /// </summary>
-    /// <param name="mindId">The mind to remove the role from.</param>
+    /// <param name="mind">The mind to remove the role from.</param>
     /// <typeparam name="T">The type of the role to remove.</typeparam>
-    /// <exception cref="ArgumentException">Thrown if the mind does not exist or does not have this role.</exception>
-    /// <returns>Returns False if there was something wrong with the mind or the removal. True if successful</returns>>
-    public bool MindRemoveRole<T>(EntityUid mindId) where T : IComponent
+    /// <returns>Returns false if the role did not exist. True if successful</returns>>
+    public bool MindRemoveRole<T>(Entity<MindComponent?> mind) where T : IComponent
     {
-        if (!TryComp<MindComponent>(mindId, out var mind) )
-            throw new ArgumentException($"{mindId} does not exist or does not have mind component");
+        if (typeof(T) == typeof(MindRoleComponent))
+            throw new InvalidOperationException();
+
+        if (!Resolve(mind.Owner, ref mind.Comp))
+            return false;
 
         var found = false;
         var antagonist = false;
         var delete = new List<EntityUid>();
-        foreach (var role in mind.MindRoles)
+        foreach (var role in mind.Comp.MindRoles)
         {
             if (!HasComp<T>(role))
                 continue;
 
-            var roleComp = Comp<MindRoleComponent>(role);
+            if (!TryComp(role, out MindRoleComponent? roleComp))
+            {
+                Log.Error($"Encountered mind role entity {ToPrettyString(role)} without a {nameof(MindRoleComponent)}");
+                continue;
+            }
+
             antagonist |= roleComp.Antag | roleComp.ExclusiveAntag;
             _entityManager.DeleteEntity(role);
-
             delete.Add(role);
             found = true;
-
-        }
-
-        foreach (var role in delete)
-        {
-            mind.MindRoles.Remove(role);
         }
 
         if (!found)
+            return false;
+
+        foreach (var role in delete)
         {
-            throw new ArgumentException($"{mindId} does not have this role: {typeof(T)}");
+            mind.Comp.MindRoles.Remove(role);
         }
 
-        var message = new RoleRemovedEvent(mindId, mind, antagonist);
-
-        if (mind.OwnedEntity != null)
+        if (mind.Comp.OwnedEntity != null)
         {
-            RaiseLocalEvent(mind.OwnedEntity.Value, message, true);
+            var message = new RoleRemovedEvent(mind.Owner, mind.Comp, antagonist);
+            RaiseLocalEvent(mind.Comp.OwnedEntity.Value, message, true);
         }
+
         _adminLogger.Add(LogType.Mind,
             LogImpact.Low,
-            $"'Role {typeof(T).Name}' removed from mind of {ToPrettyString(mind.OwnedEntity)}");
+            $"All roles of type '{typeof(T).Name}' removed from mind of {ToPrettyString(mind.Comp.OwnedEntity)}");
+
         return true;
     }
 
@@ -237,16 +243,14 @@ public abstract class SharedRoleSystem : EntitySystem
     /// <returns>True if the role existed and was removed</returns>
     public bool MindTryRemoveRole<T>(EntityUid mindId) where T : IComponent
     {
-        if (!MindHasRole<T>(mindId))
-        {
-            Log.Warning($"Failed to remove role {typeof(T)} from {mindId} : mind does not have role ");
-            return false;
-        }
-
         if (typeof(T) == typeof(MindRoleComponent))
             return false;
 
-        return MindRemoveRole<T>(mindId);
+        if (MindRemoveRole<T>(mindId))
+            return true;
+
+        Log.Warning($"Failed to remove role {typeof(T)} from {ToPrettyString(mindId)} : mind does not have role ");
+        return false;
     }
 
     /// <summary>
@@ -258,30 +262,29 @@ public abstract class SharedRoleSystem : EntitySystem
     /// <param name="role">The Mind Role entity component</param>
     /// <param name="roleT">The Mind Role's entity component for T</param>
     /// <returns>True if the role is found</returns>
-    public bool MindHasRole<T>(EntityUid mindId,
-        [NotNullWhen(true)] out Entity<MindRoleComponent>? role,
-        [NotNullWhen(true)] out Entity<T>? roleT) where T : IComponent
+    public bool MindHasRole<T>(Entity<MindComponent?> mind,
+        [NotNullWhen(true)] out Entity<MindRoleComponent, T>? role) where T : IComponent
     {
         role = null;
-        roleT = null;
-
-        if (!TryComp<MindComponent>(mindId, out var mind))
+        if (!Resolve(mind.Owner, ref mind.Comp))
             return false;
 
-        var found = false;
-
-        foreach (var roleEnt in mind.MindRoles)
+        foreach (var roleEnt in mind.Comp.MindRoles)
         {
-            if (!HasComp<T>(roleEnt))
+            if (!TryComp(roleEnt, out T? tcomp))
                 continue;
 
-            role = (roleEnt,Comp<MindRoleComponent>(roleEnt));
-            roleT = (roleEnt,Comp<T>(roleEnt));
-            found = true;
-            break;
+            if (!TryComp(roleEnt, out MindRoleComponent? roleComp))
+            {
+                Log.Error($"Encountered mind role entity {ToPrettyString(roleEnt)} without a {nameof(MindRoleComponent)}");
+                continue;
+            }
+
+            role = (roleEnt, roleComp, tcomp);
+            return true;
         }
 
-        return found;
+        return false;
     }
 
     /// <summary>
@@ -316,26 +319,18 @@ public abstract class SharedRoleSystem : EntitySystem
             if (!HasComp(roleEnt, type))
                 continue;
 
-            role = (roleEnt,Comp<MindRoleComponent>(roleEnt));
+            if (!TryComp(roleEnt, out MindRoleComponent? roleComp))
+            {
+                Log.Error($"Encountered mind role entity {ToPrettyString(roleEnt)} without a {nameof(MindRoleComponent)}");
+                continue;
+            }
+
+            role = (roleEnt, roleComp);
             found = true;
             break;
         }
 
         return found;
-    }
-
-    /// <summary>
-    /// Finds the first mind role of a specific type on a mind entity.
-    /// Outputs an entity component for the mind role's MindRoleComponent
-    /// </summary>
-    /// <param name="mindId">The mind entity</param>
-    /// <param name="role">The Mind Role entity component</param>
-    /// <typeparam name="T">The type of the role to find.</typeparam>
-    /// <returns>True if the role is found</returns>
-    public bool MindHasRole<T>(EntityUid mindId,
-        [NotNullWhen(true)] out Entity<MindRoleComponent>? role) where T : IComponent
-    {
-        return MindHasRole<T>(mindId, out role, out _);
     }
 
     /// <summary>
@@ -346,7 +341,7 @@ public abstract class SharedRoleSystem : EntitySystem
     /// <returns>True if the role is found</returns>
     public bool MindHasRole<T>(EntityUid mindId) where T : IComponent
     {
-        return MindHasRole<T>(mindId, out _, out _);
+        return MindHasRole<T>(mindId, out _);
     }
 
     //TODO: Delete this later
@@ -387,13 +382,16 @@ public abstract class SharedRoleSystem : EntitySystem
             var valid = false;
             var name = "game-ticker-unknown-role";
             var prototype = "";
-           string? playTimeTracker = null;
+            string? playTimeTracker = null;
 
-            var comp = Comp<MindRoleComponent>(role);
-            if (comp.AntagPrototype is not null)
+            if (!TryComp(role, out MindRoleComponent? comp))
             {
-                prototype = comp.AntagPrototype;
+                Log.Error($"Encountered mind role entity {ToPrettyString(role)} without a {nameof(MindRoleComponent)}");
+                continue;
             }
+
+            if (comp.AntagPrototype is not null)
+                prototype = comp.AntagPrototype;
 
             if (comp.JobPrototype is not null && comp.AntagPrototype is null)
             {
@@ -428,7 +426,7 @@ public abstract class SharedRoleSystem : EntitySystem
             }
 
             if (valid)
-                roleInfo.Add(new RoleInfo(name, comp.Antag || comp.ExclusiveAntag , playTimeTracker, prototype));
+                roleInfo.Add(new RoleInfo(name, comp.Antag, playTimeTracker, prototype));
         }
         return roleInfo;
     }
@@ -474,13 +472,10 @@ public abstract class SharedRoleSystem : EntitySystem
                 continue;
             }
 
-            if (roleComp.Antag)
-                antagonist = true;
-            if (roleComp.ExclusiveAntag)
-                exclusiveAntag = true;
+            antagonist |= roleComp.Antag;
+            exclusiveAntag |= roleComp.ExclusiveAntag;
         }
 
-        DebugTools.Assert(!exclusiveAntag || antagonist); // Exclusive antags must be antags.
         return (antagonist, exclusiveAntag);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds several new tests that would've caught the cause of #32792. This also makes some silent role related failures back into errors. E.g., trying to pass a non-mind entity as a mind should log errors, because someone probably confused two entity uid. This also changes the warning in #32753 back to an error, because AFAICT if that does somehow happen it does actually indicate that something is breaking.

## Breaking changes
- The signature of some `RoleSystem` methods have changed. In particular, more methods now use `Entity<T?>` instead of just an EntityUid

The return type of the `GetPrototypesWithComponent` test helper has changed, but its minor enough that it probably doesn't need its own `#codebase-changes`

