### PR TITLE
Replaces the fire extinguisher in salvager lockers with a mini-jetpack

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -16,7 +16,7 @@
     - id: HandheldGPSBasic
     - id: RadioHandheld
     - id: AppraisalTool
-    - id: FireExtinguisher
+    - id: JetpackMiniFilled
     - id: Flare
       prob: 0.3
       rolls: !type:ConstantNumberSelector


### PR DESCRIPTION
## About the PR
Replaced the fire extinguisher in salvage specialist locker fills with mini-jetpacks.

## Why / Balance
While the idea of salvage specialists traversing wrecks and other debris using fire extinguishers is entertaining, giving them a roundstart mini-jetpack offers them mobility that's more in-line with actual equipment you'd expect for their job. Additionally, while mini-jetpacks have more mobility than a fire extinguisher does, salvagers must still make conscious choices about how they arrange their loadouts.

Salvagers must also be careful and deliberate with a mini-jetpack; the limited propellant means they must manage it as a resource (while also offering the chance for interim restoration of said resource, should encounters provide the resource).

## Technical details
Switched the line in YML to accommodate the change.

## Media

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes


**Changelog**

:cl:

- tweak: Replaced fire extinguishers in salvager lockers with mini-jetpacks.

