### PR TITLE
Minor and major space dust announcements

### DIFF
--- a/Resources/Locale/en-US/station-events/events/meteor-swarm.ftl
+++ b/Resources/Locale/en-US/station-events/events/meteor-swarm.ftl
@@ -1,5 +1,5 @@
-﻿station-event-meteor-swarm-start-announcement = Meteors have been detected on collision course with the station.
+﻿station-event-meteor-swarm-start-announcement = Meteors have been detected on collision course with the station. Personnel in space should seek shelter.
 station-event-meteor-swarm-end-announcement = The meteor swarm has passed. Please return to your stations.
-
 station-event-space-dust-start-announcement = The station is passing through a debris cloud, expect minor damage to external fittings and fixtures.
+station-event-space-dust-major-start-announcement = The station is passing through a dense debris cloud, expect moderate damage to external fittings and fixtures. Personnel in space should seek shelter.
 station-event-meteor-urist-start-announcement = The station is colliding with an unidentified swarm of debris. Please stay calm and do not listen to them.

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -129,7 +129,7 @@
     weight: 22
     minimumPlayers: 0
   - type: MeteorSwarm
-    announcement: station-event-space-dust-start-announcement
+    announcement: station-event-space-dust-major-start-announcement
     announcementSound: /Audio/Announcements/attention.ogg
     nonDirectional: true
     meteors:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Added announcement to space dust event
- Changed major space dust announcement message

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Although NT can't realistically track every bit of space dust, getting killed in space without warning is bad RNG. Announcing _all_ space dust events makes deaths more 'fair' from taking the risk of staying in space.

The minor space dust event reuses the existing space dust announcement, while the currently announced space event has a new line that better reflects its intensity.

## Technical details
<!-- Summary of code changes for easier review. -->
yml changes only

- `Resources/Prototypes/GameRules/meteorswarms.yml` (announcement added to space dust event)
- `Resources/Locale/en-US/station-events/events/meteor-swarm.ftl` (major and minor space dust announcements)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/4d7a0f47-9334-42bd-88ab-3bd3fbffe7b4)
![image](https://github.com/user-attachments/assets/f374e3d4-9574-4b16-be8d-552b634b539e)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: The minor space dust event is now announced.
- add: The major space dust event has a new announcement to reflect its intensity and higher risk to EVA crew.