### PR TITLE
Increase recharger wattage and charge speeds, blacklists cells from rechargers

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -150,6 +150,7 @@
   parent: BaseItemRecharger
   id: WeaponCapacitorRecharger
   name: recharger
+  description: A recharger with a properitary weapon-only port.
   components:
   - type: Sprite
     sprite: Structures/Power/recharger.rsi
@@ -172,7 +173,7 @@
   parent: BaseItemRecharger
   id: TurboItemRecharger
   name: turbo recharger
-  description: An overclocked recharger that's been adapted with a global port.
+  description: An overclocked recharger with a global port adaptor for power cells, cages and weapons.
   components:
   - type: Sprite
     sprite: Structures/Power/turbo_recharger.rsi
@@ -195,9 +196,10 @@
           - PotatoBattery
 
 - type: entity
-  parent: BaseItemRecharger
+  parent: BaseItemRecharger # cannot parent to normal rechargers as wallmount version can't be built
   id: WallWeaponCapacitorRecharger
   name: wall recharger
+  description: A space-saving wallmount recharger and another blinking light on the wall. Only recharges weapons.
   components:
   - type: Sprite
     sprite: Structures/Power/wall_recharger.rsi

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -168,6 +168,9 @@
           - HitscanBatteryAmmoProvider
           - ProjectileBatteryAmmoProvider
           - Stunbaton
+        blacklist:
+          components:
+          - PowerCell # only charges weapons due to higher wattage
 
 - type: entity
   parent: BaseItemRecharger
@@ -221,6 +224,9 @@
           - HitscanBatteryAmmoProvider
           - ProjectileBatteryAmmoProvider
           - Stunbaton
+        blacklist:
+          components:
+          - PowerCell
 
 - type: entity
   parent: BaseRecharger

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -156,6 +156,8 @@
   - type: Machine
     board: WeaponCapacitorRechargerCircuitboard
   # no powercellslot since stun baton etc arent powercells
+  - type: Charger
+    chargeRate: 40
   - type: ItemSlots
     slots:
       charger_slot:
@@ -207,7 +209,7 @@
       shader: "unshaded"
   - type: WallMount
   - type: Charger
-    chargeRate: 25
+    chargeRate: 40
   - type: ItemSlots
     slots:
       charger_slot:

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -157,7 +157,7 @@
     board: WeaponCapacitorRechargerCircuitboard
   # no powercellslot since stun baton etc arent powercells
   - type: Charger
-    chargeRate: 40
+    chargeRate: 35
   - type: ItemSlots
     slots:
       charger_slot:
@@ -209,7 +209,7 @@
       shader: "unshaded"
   - type: WallMount
   - type: Charger
-    chargeRate: 40
+    chargeRate: 35
   - type: ItemSlots
     slots:
       charger_slot:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Changed charge rate of rechargers and wall rechargers from 20W to 35W



| | Recharge time at 20W (s) | Recharge time at 35W (s) | 
| --- | :---: | :---: |
| Disabler (1000 charge) | 50 | **28** |
| Laser rifle (1000 charge) | 50 | **28** |
| Stun baton (1000 charge) | 50 | **28** |

(Generally decreases recharging times from 50 seconds to 28 seconds)

- Blacklists power cells from rechargers

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Current recharging times are unreasonably long - half the magazine of most energy weapons is required to down opponents, leading to between 30 or 50 seconds recharge between encounters depending on aim. This adds up over time as well and severely impacts low-pop security depts that can't afford to wait a minute at the first callout.

In addition, rechargers are crafted using MV cables, which would imply a higher wattage anyway over the LV cables of cell chargers.

I've added a blacklist so people don't just build rechargers over cell chargers and stop using the latter. I believe it was unintended for rechargers to accept cells (will add on this later).

## Technical details
yml changes only
- `Resources/Prototypes/Entities/Structures/Power/chargers.yml` (charge rate of recharger and wall recharger increased to 35W, added blacklists to cells to both rechargers)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Increased wattages of both normal rechargers (20W) and wall rechargers (25W) to 35W, halving most recharge times.
- tweak: Rechargers can no longer charge power cells.
