### PR TITLE
make meteors snipe people and shittles less

### DIFF
--- a/Content.Server/StationEvents/Components/MeteorSwarmComponent.cs
+++ b/Content.Server/StationEvents/Components/MeteorSwarmComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class MeteorSwarmComponent : Component
     public int WaveCounter;
 
     [DataField]
-    public float MeteorVelocity = 10f;
+    public float MeteorVelocity = 5f;
 
     /// <summary>
     /// If true, meteors will be thrown from all angles instead of from a singular source

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -15,7 +15,11 @@
       types:
         Blunt: 1
   - type: TimedDespawn
-    lifetime: 120
+    lifetime: 240
+  - type: PointLight # sunlight reflecting off them or something, prevents meteor stealthops sniping you
+    radius: 2
+    energy: 1
+    castShadows: false
   - type: Clickable
   - type: Physics
     bodyType: Dynamic

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -7,9 +7,6 @@
   - type: Sprite
     noRot: false
     sprite: Objects/Misc/meteor.rsi
-    layers:
-    - state: "medium"
-      shader: unshaded # sunlight reflecting off them or something, prevents meteor stealthops sniping you
   - type: Projectile
     damage: {}
     deleteOnCollide: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -7,6 +7,9 @@
   - type: Sprite
     noRot: false
     sprite: Objects/Misc/meteor.rsi
+    layers:
+    - state: "medium"
+      shader: unshaded # sunlight reflecting off them or something, prevents meteor stealthops sniping you
   - type: Projectile
     damage: {}
     deleteOnCollide: false
@@ -16,10 +19,6 @@
         Blunt: 1
   - type: TimedDespawn
     lifetime: 240
-  - type: PointLight # sunlight reflecting off them or something, prevents meteor stealthops sniping you
-    radius: 2
-    energy: 1
-    castShadows: false
   - type: Clickable
   - type: Physics
     bodyType: Dynamic
@@ -56,7 +55,9 @@
   description: Makes a station sneeze.
   components:
   - type: Sprite
-    state: space_dust
+    layers:
+    - state: "space_dust"
+      shader: unshaded
   - type: Fixtures
     fixtures:
       projectile:
@@ -91,7 +92,9 @@
   suffix: Small
   components:
   - type: Sprite
-    state: small
+    layers:
+    - state: "small"
+      shader: unshaded
   - type: Fixtures
     fixtures:
       projectile:
@@ -131,7 +134,9 @@
   suffix: Medium
   components:
   - type: Sprite
-    state: medium
+    layers:
+    - state: "medium"
+      shader: unshaded
   - type: Fixtures
     fixtures:
       projectile:
@@ -172,7 +177,9 @@
   suffix: Large
   components:
   - type: Sprite
-    state: big
+    layers:
+    - state: "big"
+      shader: unshaded
   - type: Explosive
     totalIntensity: 150
   - type: Destructible


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
does the following:
- halves meteor speed
- doubles meteor lifetime so they travel the same distance
- makes meteor sprites unshaded

## Why / Balance
currently meteors have very little counterplay (hiding somewhere can often (salv) not be possible, and shuttles are just never safe), so this PR makes it possible to dodge or shoot them

if you're making/driving a shittle currently there's a good chance a meteor will just snipe you and your shuttle so you permadie and/or have an irrecoverable shuttle wreck

## Media
https://github.com/user-attachments/assets/ad94307c-271a-48df-a34c-f7414a3251ba

video showcases meteors being visible and slow enough to shoot and hit them

video shows outdated implementation of meteors being pointlights and not unshaded, unshaded meteors here:
![image](https://github.com/user-attachments/assets/aee52356-5705-4e8f-b20d-486f39cf26e9)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Increased meteor visibility and halved their speed.