### PR TITLE
Fix: Radio jammer now doesn't show setting changes to other players

### DIFF
--- a/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
@@ -44,7 +44,7 @@ public abstract class SharedJammerSystem : EntitySystem
                     Dirty(entity);
                     if (_jammer.TrySetRange(entity.Owner, GetCurrentRange(entity)))
                     {
-                        Popup.PopupPredicted(Loc.GetString(setting.Message), user, user);
+                        Popup.PopupClient(Loc.GetString(setting.Message), user, user);
                     }
                 },
                 Text = Loc.GetString(setting.Name),

--- a/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
@@ -42,10 +42,12 @@ public abstract class SharedJammerSystem : EntitySystem
                 {
                     entity.Comp.SelectedPowerLevel = currIndex;
                     Dirty(entity);
-                    if (_jammer.TrySetRange(entity.Owner, GetCurrentRange(entity)))
-                    {
-                        Popup.PopupClient(Loc.GetString(setting.Message), user, user);
-                    }
+
+                    // If the jammer is off, this won't do anything which is fine.
+                    // The range should be updated when it turns on again!
+                    _jammer.TrySetRange(entity.Owner, GetCurrentRange(entity));
+
+                    Popup.PopupClient(Loc.GetString(setting.Message), user, user);
                 },
                 Text = Loc.GetString(setting.Name),
             };


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title! Before the jammer used `PopupPredicted` which showed the change to anyone nearby. I changed it to `PopupClient` so only the client actually changing the settings gets the popup. I also fixed a bug where it wouldn't show the popup unless the jammer was on.

 I did test this but I can't record and have two clients open at once 😔 