### PR TITLE
bowls now make drinking sounds

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/bowl.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/bowl.yml
@@ -21,6 +21,10 @@
       visible: false
   - type: MixableSolution
     solution: food
+  - type: Drink
+    solution: food
+    useSound:
+      path: /Audio/Items/drink.ogg
   - type: DamageOnLand
     damage:
       types:


### PR DESCRIPTION
## About the PR
Bowls, which can be filled with fluid, now make a drinking sound when drank from. No longer can you *eat* water.
Conveniently they still make an eating sound when filled with food (IE used in cooking recipe) so that's a plus as well.

## Why / Balance
Fixes #32224

## Technical details


## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
:cl:
- fix: Bowls no longer make an eating sound when drinking from them.