### PR TITLE
ExaminableDamage now puts its message at the bottom and in color

### DIFF
--- a/Content.Server/Damage/Systems/ExaminableDamageSystem.cs
+++ b/Content.Server/Damage/Systems/ExaminableDamageSystem.cs
@@ -39,7 +39,7 @@ public sealed class ExaminableDamageSystem : EntitySystem
 
         var level = GetDamageLevel(uid, component);
         var msg = Loc.GetString(messages[level]);
-        args.PushMarkup(msg,-5);
+        args.PushMarkup(msg,-99);
     }
 
     private int GetDamageLevel(EntityUid uid, ExaminableDamageComponent? component = null,

--- a/Content.Server/Damage/Systems/ExaminableDamageSystem.cs
+++ b/Content.Server/Damage/Systems/ExaminableDamageSystem.cs
@@ -39,7 +39,7 @@ public sealed class ExaminableDamageSystem : EntitySystem
 
         var level = GetDamageLevel(uid, component);
         var msg = Loc.GetString(messages[level]);
-        args.PushMarkup(msg);
+        args.PushMarkup(msg,-5);
     }
 
     private int GetDamageLevel(EntityUid uid, ExaminableDamageComponent? component = null,

--- a/Resources/Locale/en-US/window/window-component.ftl
+++ b/Resources/Locale/en-US/window/window-component.ftl
@@ -2,13 +2,14 @@
 
 # Shown when examining the window. Each entry represents the window's health condition
 comp-window-damaged-1 = It looks fully intact.
-comp-window-damaged-2 = It has a few scratches
+comp-window-damaged-2 = It has a few scratches.
 comp-window-damaged-3 = It has a few small cracks.
-comp-window-damaged-4 = It has several big cracks running along its surface.
-comp-window-damaged-5 = It has deep cracks across multiple layers.
-comp-window-damaged-6 = It's extremely cracked and on the verge of shattering.
+comp-window-damaged-4 = [color=yellow]It has several big cracks running along its surface.[/color]
+comp-window-damaged-5 = [color=orange]It has deep cracks across multiple layers.[/color]
+comp-window-damaged-6 = [color=red]It's extremely cracked and on the verge of shattering.[/color]
 
 ### Interaction Messages
 
 # Shown when knocking on a window
 comp-window-knock = *knock knock*
+


### PR DESCRIPTION
## About the PR
When examining damage on windows or tesla-coils, the message was sorted by alphabetical order and in things with lots of examine messages (like tesla-coils) it sort of gets lost in the noise.

Damage examine is now at the bottom of the examine page, always. And for the last 3 damage states it is now in color, to make it even more obvious.

## Why / Balance
Resolves #32797, looks better and is easier to read

## Technical details
PushMarkup has a "priority" argument which I made use of. Strangely enough I couldn't find *any* other examples of this being used anywhere in the code (probably just missed it) but it worked in my testing so :tada:

## Media
![2024-10-14_13-36_4](https://github.com/user-attachments/assets/2576da98-50d5-4b4b-a431-0373dd6d32cd)
![2024-10-14_13-36_3](https://github.com/user-attachments/assets/9af4cb52-f9bc-471c-820a-859b08d5a9e3) 
![2024-10-14_13-36_2](https://github.com/user-attachments/assets/f4024533-6d4a-49cf-b053-ab67bb70e029)
![2024-10-14_13-36_1](https://github.com/user-attachments/assets/8786812f-853e-4119-a649-f1eabc77cd1d)
![2024-10-14_13-36](https://github.com/user-attachments/assets/b27e315a-9850-4c8f-a398-e41df2525340)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Shouldn't be any

**Changelog**
nah