### PR TITLE
Fix AME power generation

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -169,12 +169,13 @@ public sealed class AmeNodeGroup : BaseNodeGroup
     public float CalculatePower(int fuel, int cores)
     {
         // Balanced around a single core AME with injection level 2 producing 120KW.
-        // Two core with four injection is 147kW. Two core with two injection is 117kW. 
+        // Two core with four injection is 150kW. Two core with two injection is 90kW.
 
         // Increasing core count creates diminishing returns, increasing injection amount increases 
         // Unlike the previous solution, increasing fuel and cores always leads to an increase in power, even if by very small amounts.
         // Increasing core count without increasing fuel always leads to reduced power as well.
-        return 100000f * MathF.Log10(8 * fuel * MathF.Pow(cores, -1 / 10));
+        // At 18+ cores and 2 inject, the power produced is less than 0, the Max ensures the AME can never produce "negative" power.
+        return MathF.Max(200000f * MathF.Log10(2 * fuel * MathF.Pow(cores, (float)-0.5)), 0);
     }
 
     public int GetTotalStability()

--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -169,11 +169,12 @@ public sealed class AmeNodeGroup : BaseNodeGroup
     public float CalculatePower(int fuel, int cores)
     {
         // Balanced around a single core AME with injection level 2 producing 120KW.
-        // Overclocking yields diminishing returns until it evens out at around 360KW.
+        // Two core with four injection is 147kW. Two core with two injection is 117kW. 
 
-        // The adjustment for cores make it so that a 1 core AME at 2 injections is better than a 2 core AME at 2 injections.
-        // However, for the relative amounts for each (1 core at 2 and 2 core at 4), more cores has more output.
-        return 200000f * MathF.Log10(fuel * fuel) * MathF.Pow(0.75f, cores - 1);
+        // Increasing core count creates diminishing returns, increasing injection amount increases 
+        // Unlike the previous solution, increasing fuel and cores always leads to an increase in power, even if by very small amounts.
+        // Increasing core count without increasing fuel always leads to reduced power as well.
+        return 100000f * MathF.Log10(8 * fuel * MathF.Pow(cores, -1 / 10));
     }
 
     public int GetTotalStability()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adjusted the formula for the AME power generation to not punish larger AMEs. Previously, any AME above 2 core would produce less power, the new formula adjusts it to no longer do that. With the new formula, a 4 core AME (the highest naturally mapped in-game atm) is equivalent to a 2-core AME - 180kW. Additionally, I ensured that having more cores but the same injection amount does lead to decreased power. 

If the AME is returned to cargo for purchase, the realistic cap is around 300kW with ~60 cores, but if you REALLY wanted to and could source 600 cores (and somehow 1200 fuel per injection) you can hit 400kW. 

Check the math [at desmos](https://www.desmos.com/calculator/70hhvmc524) along with some explanatory comments, if you want further proof of this really being an AME nerf in disguise. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #31758, check it for more details, but at the moment higher core AMEs are less than worthless, as they actively produce less power. This change makes higher core AMEs at least somewhat desireable, as they produce marginally more power, even if they take significantly more fuel.


## Technical details
<!-- Summary of code changes for easier review. -->
Adjusted one equation, added some explanatory comments. 
Formula can be messed with and tested [here.](https://www.desmos.com/calculator/70hhvmc524) (leads to desmos). 


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Red line is current formula, Blue line is new one. As shown, at one core the power production is the exact same. 

Y-axis is kW produces, X axis is number of cores, assuming optimal (1:2) core to fuel ratio. 
![image](https://github.com/user-attachments/assets/ef1735ba-5d02-445e-b6a5-64130590d765)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: AMEs larger than 2 cores now produce more power, instead of less.