### PR TITLE
Added relevant tags to several cakes, and changed chem in Spacemans cake

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -135,6 +135,10 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 5
+  - type: Tag
+    tags:
+    - Cake
+    - Vegetable
 
 - type: entity
   name: slice of carrot cake
@@ -155,6 +159,11 @@
           Quantity: 1
         - ReagentId: Vitamin
           Quantity: 1
+  - type: Tag
+    tags:
+    - Cake
+    - Vegetable
+    - Slice
 
 # Tastes like sweetness, cake, carrot.
 
@@ -168,7 +177,10 @@
     state: brain
   - type: SliceableFood
     slice: FoodCakeBrainSlice
-
+  - type: Tag
+    tags:
+    - Cake
+    - Meat
 
 - type: entity
   name: slice of brain cake
@@ -178,6 +190,11 @@
   components:
   - type: Sprite
     state: brain-slice
+  - type: Tag
+    tags:
+    - Cake
+    - Meat
+    - Slice
 # Tastes like sweetness, cake, brains.
 
 - type: entity
@@ -429,6 +446,10 @@
     state: slime
   - type: SliceableFood
     slice: FoodCakeSlimeSlice
+  - type: Tag
+    tags:
+    - Cake
+    - Meat
 
 - type: entity
   name: slice of slime cake
@@ -438,6 +459,11 @@
   components:
   - type: Sprite
     state: slime-slice
+  - type: Tag
+    tags:
+    - Cake
+    - Meat
+    - Slice
 # Tastes like sweetness, cake, slime.
 
 - type: entity
@@ -498,6 +524,10 @@
     state: christmas
   - type: SliceableFood
     slice: FoodCakeChristmasSlice
+  - type: Tag
+    tags:
+    - Cake
+    - Fruit
 
 - type: entity
   name: slice of christmas cake
@@ -506,6 +536,11 @@
   components:
   - type: Sprite
     state: christmas-slice
+  - type: Tag
+    tags:
+    - Cake
+    - Fruit
+    - Slice
 # Tastes like sweetness, cake, christmas.
 
 - type: entity
@@ -634,7 +669,7 @@
           Quantity: 20
         - ReagentId: Vitamin
           Quantity: 5
-        - ReagentId: Omnizine #This is a really rare cake with healing stuff and we don't have any of its chems yet
+        - ReagentId: PolypyryliumOligomers
           Quantity: 15
 
 - type: entity
@@ -654,7 +689,7 @@
           Quantity: 4
         - ReagentId: Vitamin
           Quantity: 1
-        - ReagentId: Omnizine
+        - ReagentId: PolypyryliumOligomers
           Quantity: 3
 # Tastes like sweetness, cake, jam.
 


### PR DESCRIPTION
## About the PR
Tweaked numerous Tags in "Cake.yml" for consistency

## Why / Balance
Several cakes were missing relevant tags, and Spaceman's cake, which previously had omnizine, has had its relevant chem Polypyrylium Oligomers added.

## Technical details
Added tags to numerous Cakes, and changed the Chem in Spacemans Cake.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Spacemans cake now contains Polypyrylium Oligomers instead of Omnizine.
- fix: Slime, Brain and Christmas cakes can now be eaten by Lizards.
