### PR TITLE
the return of pen embedding

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -26,12 +26,6 @@
         maxDistance: 2
   - type: UseDelay
     delay: 1.5
-
-- type: entity
-  parent: Pen
-  id: PenEmbeddable
-  abstract: true
-  components:
   - type: EmbeddableProjectile
     offset: 0.3,0.0
     removalTime: 0.0
@@ -58,7 +52,7 @@
 
 - type: entity
   id: BaseAdvancedPen
-  parent: PenEmbeddable
+  parent: Pen
   abstract: true
   components:
   - type: Tag
@@ -104,7 +98,7 @@
 
 - type: entity
   name: captain's fountain pen
-  parent: PenEmbeddable
+  parent: Pen
   id: PenCap
   description: A luxurious fountain pen for the captain of the station.
   components:
@@ -113,7 +107,7 @@
 
 - type: entity
   name: hop's fountain pen
-  parent: PenEmbeddable
+  parent: Pen
   id: PenHop
   description: A luxurious fountain pen for the hop of the station.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: pen
   suffix: Exploding
-  parent: PenEmbeddable
+  parent: Pen
   description: A dark ink pen.
   id: PenExploding
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
returns embeddability to all pens

## Why / Balance
this is funny and doesn't really affect balance

could also increase advanced pens' (redpen, NT pen) throwing damage to 15 once again

## Technical details
moves embeddability from PenEmbeddable into Pen, removes PenEmbeddable

## Media
tested, works, trust

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
PenEmbeddable removed

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: All pens now embed on throw.