### PR TITLE
Hunger and thirst huds fix

### DIFF
--- a/Content.Client/Overlays/ShowThirstIconsSystem.cs
+++ b/Content.Client/Overlays/ShowThirstIconsSystem.cs
@@ -22,6 +22,6 @@ public sealed class ShowThirstIconsSystem : EquipmentHudSystem<ShowThirstIconsCo
             return;
 
         if (_thirst.TryGetStatusIconPrototype(component, out var iconPrototype))
-            ev.StatusIcons.Add(iconPrototype!);
+            ev.StatusIcons.Add(iconPrototype);
     }
 }

--- a/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
@@ -41,9 +41,10 @@ public sealed class HungerSystem : EntitySystem
     {
         base.Initialize();
 
-        DebugTools.Assert(_prototype.TryIndex(HungerIconOverfedId, out _hungerIconOverfed) &&
-                          _prototype.TryIndex(HungerIconPeckishId, out _hungerIconPeckish) &&
-                          _prototype.TryIndex(HungerIconStarvingId, out _hungerIconStarving));
+        var tryIndexIcons = _prototype.TryIndex(HungerIconOverfedId, out _hungerIconOverfed) &&
+                            _prototype.TryIndex(HungerIconPeckishId, out _hungerIconPeckish) &&
+                            _prototype.TryIndex(HungerIconStarvingId, out _hungerIconStarving);
+        DebugTools.Assert(tryIndexIcons);
 
         SubscribeLocalEvent<HungerComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<HungerComponent, ComponentShutdown>(OnShutdown);

--- a/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
@@ -9,6 +9,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Content.Shared.Nutrition.EntitySystems;
 
@@ -39,9 +40,10 @@ public sealed class ThirstSystem : EntitySystem
     {
         base.Initialize();
 
-        DebugTools.Assert(_prototype.TryIndex(ThirstIconOverhydratedId, out _thirstIconOverhydrated) &&
-                          _prototype.TryIndex(ThirstIconThirstyId, out _thirstIconThirsty) &&
-                          _prototype.TryIndex(ThirstIconParchedId, out _thirstIconParched));
+        var tryIndexIcons = _prototype.TryIndex(ThirstIconOverhydratedId, out _thirstIconOverhydrated) &&
+                            _prototype.TryIndex(ThirstIconThirstyId, out _thirstIconThirsty) &&
+                            _prototype.TryIndex(ThirstIconParchedId, out _thirstIconParched);
+        DebugTools.Assert(tryIndexIcons);
 
         SubscribeLocalEvent<ThirstComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
         SubscribeLocalEvent<ThirstComponent, MapInitEvent>(OnMapInit);
@@ -128,26 +130,28 @@ public sealed class ThirstSystem : EntitySystem
         }
     }
 
-    public bool TryGetStatusIconPrototype(ThirstComponent component, out SatiationIconPrototype? prototype)
+    public bool TryGetStatusIconPrototype(ThirstComponent component, [NotNullWhen(true)] out SatiationIconPrototype? prototype)
     {
         switch (component.CurrentThirstThreshold)
         {
             case ThirstThreshold.OverHydrated:
                 prototype = _thirstIconOverhydrated;
-                return true;
+                break;
 
             case ThirstThreshold.Thirsty:
                 prototype = _thirstIconThirsty;
-                return true;
+                break;
 
             case ThirstThreshold.Parched:
                 prototype = _thirstIconParched;
-                return true;
+                break;
 
             default:
                 prototype = null;
-                return false;
+                break;
         }
+
+        return prototype != null;
     }
 
     private void UpdateEffects(EntityUid uid, ThirstComponent component)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed display of icons when using hunger or thirst huds

Fixed errors spam when using beer goggles

https://github.com/user-attachments/assets/dec980f9-6bd5-440c-b377-b4e9c844e34e



## Technical details
<!-- Summary of code changes for easier review. -->
Huds were not displayed because prototypes are seted only in debug build. (because `TryIndex` was in `DebugTools.Assert` what doesn't work on other builds)

Also `ThirstSystem.TryGetStatusIconPrototype` could return true when prototype = null, what caused the error spam.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: kirus59
- fix: Fixed display of icons when using hunger or thirst huds 
- fix: Fixed errors spam when using beer goggles
