### PR TITLE
Fix: Plushies no longer delete items when recycled

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
@@ -14,6 +14,8 @@ using Content.Shared.Verbs;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Tools.EntitySystems;
 using Content.Shared.Whitelist;
+using Content.Shared.Materials;
+using Robust.Shared.Map;
 
 namespace Content.Shared.Storage.EntitySystems;
 
@@ -35,6 +37,7 @@ public sealed class SecretStashSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<SecretStashComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<SecretStashComponent, DestructionEventArgs>(OnDestroyed);
+        SubscribeLocalEvent<SecretStashComponent, GotReclaimedEvent>(OnReclaimed);
         SubscribeLocalEvent<SecretStashComponent, InteractUsingEvent>(OnInteractUsing, after: new[] { typeof(ToolOpenableSystem) });
         SubscribeLocalEvent<SecretStashComponent, InteractHandEvent>(OnInteractHand);
         SubscribeLocalEvent<SecretStashComponent, GetVerbsEvent<InteractionVerb>>(OnGetVerb);
@@ -47,12 +50,12 @@ public sealed class SecretStashSystem : EntitySystem
 
     private void OnDestroyed(Entity<SecretStashComponent> entity, ref DestructionEventArgs args)
     {
-        var storedInside = _containerSystem.EmptyContainer(entity.Comp.ItemContainer);
-        if (storedInside != null && storedInside.Count >= 1)
-        {
-            var popup = Loc.GetString("comp-secret-stash-on-destroyed-popup", ("stashname", GetStashName(entity)));
-            _popupSystem.PopupEntity(popup, storedInside[0], PopupType.MediumCaution);
-        }
+        DropContentsAndAlert(entity);
+    }
+
+    private void OnReclaimed(Entity<SecretStashComponent> entity, ref GotReclaimedEvent args)
+    {
+        DropContentsAndAlert(entity, args.ReclaimerCoordinates);
     }
 
     private void OnInteractUsing(Entity<SecretStashComponent> entity, ref InteractUsingEvent args)
@@ -209,6 +212,19 @@ public sealed class SecretStashSystem : EntitySystem
     private bool HasItemInside(Entity<SecretStashComponent> entity)
     {
         return entity.Comp.ItemContainer.ContainedEntity != null;
+    }
+
+    /// <summary>
+    ///     Drop the item stored in the stash and alert all nearby players with a popup.
+    /// </summary>
+    private void DropContentsAndAlert(Entity<SecretStashComponent> entity, EntityCoordinates? cords = null)
+    {
+        var storedInside = _containerSystem.EmptyContainer(entity.Comp.ItemContainer, true, cords);
+        if (storedInside != null && storedInside.Count >= 1)
+        {
+            var popup = Loc.GetString("comp-secret-stash-on-destroyed-popup", ("stashname", GetStashName(entity)));
+            _popupSystem.PopupPredicted(popup, storedInside[0], null, PopupType.MediumCaution);
+        }
     }
 
     #endregion


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title!

## Technical details
<!-- Summary of code changes for easier review. -->
Just had to listen for the `GotReclaimedEvent` and removed the item then.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/48e85b01-74d2-41dd-b84a-cab9c746ac49

\* I FIXED THE PREDICTION ISSUE HERE. I am too lazy to re-record 😔

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Beck Thompson
- fix: Plushies will now eject their contents when recycled in the recycler!

