### PR TITLE
Convert PlanAccumulator to TimeSpan

### DIFF
--- a/Content.Server/NPC/HTN/HTNComponent.cs
+++ b/Content.Server/NPC/HTN/HTNComponent.cs
@@ -32,10 +32,10 @@ public sealed partial class HTNComponent : NPCComponent
     public float PlanCooldown = 0.45f;
 
     /// <summary>
-    /// How much longer until we can try re-planning. This will happen even during update in case something changed.
+    /// Game time when we can next try re-planning.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float PlanAccumulator = 0f;
+    public TimeSpan NextPlanTime;
 
     [ViewVariables]
     public HTNPlanJob? PlanningJob = null;


### PR DESCRIPTION
## About the PR
This allows keeping track of the HTN plan cooldown without having to decrement frameTime every single tick. This allows, for example, a future improvement where HTN does not have to update every tick.

## Why / Balance
N/A - no effect in-game

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- Replace uses of `PlanAccumulator` in `HTNComponent` with `TimeSpan NextPlanTime`

**Changelog**
N/A
