### PR TITLE
enable ejecting in biogenerator UI

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1177,7 +1177,6 @@
     board: BiogeneratorMachineCircuitboard
   - type: MaterialStorage
     insertOnInteract: false
-    canEjectStoredMaterials: false
   - type: ProduceMaterialExtractor
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1176,7 +1176,6 @@
   - type: Machine
     board: BiogeneratorMachineCircuitboard
   - type: MaterialStorage
-    insertOnInteract: false
   - type: ProduceMaterialExtractor
   - type: ItemSlots
     slots:


### PR DESCRIPTION
## About the PR
title
also allowed inserting biomass so you dont troll yourself

## Why / Balance
you can just crowbar it anyway, this is just less annoying *and why ejecting exists*

## Technical details
removed 2 lines

## Media
X

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: You can now eject biomass from a biogenerator without having to deconstruct it.
