### PR TITLE
fix playtime stats window

### DIFF
--- a/Content.Client/Info/PlaytimeStats/PlaytimeStatsEntry.cs
+++ b/Content.Client/Info/PlaytimeStats/PlaytimeStatsEntry.cs
@@ -16,17 +16,8 @@ public sealed partial class PlaytimeStatsEntry : ContainerButton
 
         RoleLabel.Text = role;
         Playtime = playtime;  // store the TimeSpan value directly
-        PlaytimeLabel.Text = ConvertTimeSpanToHoursMinutes(playtime);  // convert to string for display
+        PlaytimeLabel.Text = playtime.ToString(Loc.GetString("ui-playtime-time-format"));  // convert to string for display
         BackgroundColorPanel.PanelOverride = styleBox;
-    }
-
-    private static string ConvertTimeSpanToHoursMinutes(TimeSpan timeSpan)
-    {
-        var hours = (int)timeSpan.TotalHours;
-        var minutes = timeSpan.Minutes;
-
-        var formattedTimeLoc = Loc.GetString("ui-playtime-time-format", ("hours", hours), ("minutes", minutes));
-        return formattedTimeLoc;
     }
 
     public void UpdateShading(StyleBoxFlat styleBox)


### PR DESCRIPTION
## About the PR
Fixes #32855

## Why / Balance
buxfix

## Technical details
This was missed in #32806 where the loc string was changed.
The playtime stats seem to be weird for me for some reason (captain time > total time), someone please double check this.
Might be because this is in dev mode.

## Media
![grafik](https://github.com/user-attachments/assets/215fcdda-d36c-42d7-8e64-af08536bec80)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed the playtime stats window not showing entries correctly.
