### PR TITLE
HOTFIX spider clan charges can be armed again

### DIFF
--- a/Content.Server/Ninja/Systems/SpiderChargeSystem.cs
+++ b/Content.Server/Ninja/Systems/SpiderChargeSystem.cs
@@ -1,14 +1,12 @@
 using Content.Server.Explosion.EntitySystems;
-using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Mind;
 using Content.Server.Objectives.Components;
 using Content.Server.Popups;
 using Content.Server.Roles;
-using Content.Shared.Interaction;
 using Content.Shared.Ninja.Components;
 using Content.Shared.Ninja.Systems;
+using Content.Shared.Roles;
 using Content.Shared.Sticky;
-using Robust.Shared.GameObjects;
 
 namespace Content.Server.Ninja.Systems;
 
@@ -19,6 +17,7 @@ public sealed class SpiderChargeSystem : SharedSpiderChargeSystem
 {
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly SharedRoleSystem _role = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SpaceNinjaSystem _ninja = default!;
 
@@ -41,7 +40,10 @@ public sealed class SpiderChargeSystem : SharedSpiderChargeSystem
 
         var user = args.User;
 
-        if (!_mind.TryGetRole<NinjaRoleComponent>(user, out var _))
+        if (!_mind.TryGetMind(args.User, out var mind, out _))
+            return;
+
+        if (!_role.MindHasRole<NinjaRoleComponent>(mind))
         {
             _popup.PopupEntity(Loc.GetString("spider-charge-not-ninja"), user, user);
             args.Cancelled = true;

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -484,19 +484,6 @@ public abstract class SharedMindSystem : EntitySystem
     }
 
     /// <summary>
-    /// Gets a role component from a player's mind.
-    /// </summary>
-    /// <returns>Whether a role was found</returns>
-    public bool TryGetRole<T>(EntityUid user, [NotNullWhen(true)] out T? role) where T : IComponent
-    {
-        role = default;
-        if (!TryComp<MindContainerComponent>(user, out var mindContainer) || mindContainer.Mind == null)
-            return false;
-
-        return TryComp(mindContainer.Mind, out role);
-    }
-
-    /// <summary>
     /// Sets the Mind's UserId, Session, and updates the player's PlayerData. This should have no direct effect on the
     /// entity that any mind is connected to, except as a side effect of the fact that it may change a player's
     /// attached entity. E.g., ghosts get deleted.


### PR DESCRIPTION
## About the PR
Spider charges / ninja bombs failed their "are you a ninja" check, so even ninjas couldn't use them

## Why / Balance
Bug

## Technical details
Rather than calling SharedRoleSystem.MindHasRole to check if the user is a ninja, a different helper function was used, SharedMindSystem.TryGetRole . This function was not updated for Mind Role Entities, so it looks on the wrong Entity and returns False on every check. Since it was only used in this one place in the entire codebase, I just removed TryGetRole entirely and call MindHasRole instead like Ratvar intended.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
SharedMindSystem.TryGetRole() has been removed. If anything at all still used it, you can use SharedRoleSystem.MindHasRole() instead.

**Changelog**
:cl: Errant
- fix: Spider clan charges can once again be armed by ninjas.