### PR TITLE
Update immortal snail ghost role

### DIFF
--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -38,6 +38,9 @@ ghost-role-information-mothroach-description = A cute but mischievous mothroach.
 ghost-role-information-snail-name = Snail
 ghost-role-information-snail-description = A little snail who doesn't mind a bit of space. Just stay on grid!
 
+ghost-role-information-snailinstantdeath-name = Immortal Snail
+ghost-role-information-snailinstantdeath-description = An immortal snail with the ability to gib anyone close to you. Terrorize the crew for food or fight for what you think is right. The choice is yours to make.
+
 ghost-role-information-snailspeed-name = Snail
 ghost-role-information-snailspeed-description = A little snail with snailborn thrusters.
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -511,6 +511,11 @@
   id: MobSnailInstantDeath
   suffix: Smite
   components:
+  - type: GhostRole
+    name: ghost-role-information-snailinstantdeath-name
+    description: ghost-role-information-snailinstantdeath-description
+    raffle:
+      settings: default
   - type: MobStateActions
     actions:
       Alive:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gave the immortal snail a unique ghost role name and description
Added a raffle to the immortal snail's ghost role

## Why / Balance
I believe ghosts should be able to know when an immortal snail appears so it actually gets chosen.
Also added a raffle since the role would most likely be wanted by a few ghosts

## Technical details
## Media
![immortal_snail](https://github.com/user-attachments/assets/1b2cad2f-8d78-4e00-8bc1-44ab3d2843f3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- tweak: The immortal snail now has unique ghost role information
- tweak: The immortal snail now has a raffle