### PR TITLE
Extends the minimum round time for meteor swarm events

### DIFF
--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -57,7 +57,7 @@
   components:
   - type: GameRule
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 900 # 15 min
+    minimumTimeUntilFirstEvent: 600 # 10 min
     minMaxEventTiming:
       min: 750 # 12.5 min
       max: 930 # 17.5 min
@@ -70,7 +70,7 @@
   components:
   - type: GameRule
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 900 # 15 min 
+    minimumTimeUntilFirstEvent: 600 # 10 min 
     minMaxEventTiming:
       min: 750 # 12.5 min
       max: 930 # 17.5 min

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -57,7 +57,7 @@
   components:
   - type: GameRule
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 300 # 5 min
+    minimumTimeUntilFirstEvent: 1200 # 20 min
     minMaxEventTiming:
       min: 750 # 12.5 min
       max: 930 # 17.5 min
@@ -70,7 +70,7 @@
   components:
   - type: GameRule
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 300 # 5 min 
+    minimumTimeUntilFirstEvent: 1200 # 20 min 
     minMaxEventTiming:
       min: 750 # 12.5 min
       max: 930 # 17.5 min

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -57,7 +57,7 @@
   components:
   - type: GameRule
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 1200 # 20 min
+    minimumTimeUntilFirstEvent: 900 # 15 min
     minMaxEventTiming:
       min: 750 # 12.5 min
       max: 930 # 17.5 min
@@ -70,7 +70,7 @@
   components:
   - type: GameRule
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 1200 # 20 min 
+    minimumTimeUntilFirstEvent: 900 # 15 min 
     minMaxEventTiming:
       min: 750 # 12.5 min
       max: 930 # 17.5 min


### PR DESCRIPTION
## About the PR
Adjusted minimum event timing for meteor swarms to go from 5 minutes to 10 minutes.

## Why / Balance
Stations need time to get their bearings. A bad meteor swarm can greatly hamper roundstart gameplay, in a way that's more detrimental to roundflow than it is interesting.

## Technical details
Edited the meteorswarms.yml file to adjust meteor swarm timing.

## Media


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes


**Changelog**

:cl:

- tweak: Extended the minimum round time for meteor swarm events.


