### PR TITLE
remove possibility of having different antag objectives targeting the same person

### DIFF
--- a/Content.Server/Antag/AntagRandomObjectivesSystem.cs
+++ b/Content.Server/Antag/AntagRandomObjectivesSystem.cs
@@ -33,7 +33,7 @@ public sealed class AntagRandomObjectivesSystem : EntitySystem
         }
 
         var difficulty = 0f;
-        var assignedTargetObjectives = new HashSet<(string? title, string? target)>();
+        var assignedTargetObjectives = new HashSet<EntityUid?>();
         foreach (var set in ent.Comp.Sets.Where(set => _random.Prob(set.Prob)))
         {
             for (var pick = 0; pick < set.MaxPicks && ent.Comp.MaxDifficulty > difficulty; pick++)
@@ -44,9 +44,8 @@ public sealed class AntagRandomObjectivesSystem : EntitySystem
 
                 if (TryComp<TargetObjectiveComponent>(objective, out var targetObjective))
                 {
-                    var title = targetObjective.Title;
-                    var target = ToPrettyString(targetObjective.Target);
-                    if (!assignedTargetObjectives.Add((title, target)))
+                    var target = targetObjective.Target;
+                    if (!assignedTargetObjectives.Add(target))
                     {
                         continue;
                     }

--- a/Content.Server/Antag/AntagRandomObjectivesSystem.cs
+++ b/Content.Server/Antag/AntagRandomObjectivesSystem.cs
@@ -4,7 +4,6 @@ using Content.Server.Objectives;
 using Content.Server.Objectives.Components;
 using Content.Shared.Mind;
 using Content.Shared.Objectives.Components;
-using FastAccessors;
 using Robust.Shared.Random;
 
 namespace Content.Server.Antag;
@@ -59,6 +58,7 @@ public sealed class AntagRandomObjectivesSystem : EntitySystem
                 _mind.AddObjective(mindId, mind, objective);
                 var adding = Comp<ObjectiveComponent>(objective).Difficulty;
                 difficulty += adding;
+                Log.Debug($"Added objective {ToPrettyString(objective):objective} to {ToPrettyString(args.EntityUid):player} with {adding} difficulty");
             }
         }
     }

--- a/Content.Server/Antag/AntagRandomObjectivesSystem.cs
+++ b/Content.Server/Antag/AntagRandomObjectivesSystem.cs
@@ -36,9 +36,6 @@ public sealed class AntagRandomObjectivesSystem : EntitySystem
         var assignedTargetObjectives = new HashSet<(string? title, string? target)>();
         foreach (var set in ent.Comp.Sets.Where(set => _random.Prob(set.Prob)))
         {
-            if (!_random.Prob(set.Prob))
-                continue;
-
             for (var pick = 0; pick < set.MaxPicks && ent.Comp.MaxDifficulty > difficulty; pick++)
             {
                 var remainingDifficulty = ent.Comp.MaxDifficulty - difficulty;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Now, when choosing random objectives, the servers checks if the objective has the TargetObjectiveComponent and if the target's EntityUid belongs to an already assigned objective. This prevents having stuff like "Ensure fellow traitor X stays alive" multiple times with the same X.
 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Related to #10152 I'd say. This issue has been recently reported again.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed a bug which made it possible for antags to get the same objective multiple times