### PR TITLE
Add Silicon Law cues to Every method a Silicon can have their laws change 

### DIFF
--- a/Content.Server/Silicons/Laws/SiliconLawEui.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawEui.cs
@@ -52,10 +52,8 @@ public sealed class SiliconLawEui : BaseEui
             return;
 
         var player = _entityManager.GetEntity(message.Target);
-        _siliconLawSystem.SetLaws(message.Laws, player);
-
         if (_entityManager.TryGetComponent<SiliconLawProviderComponent>(player, out var playerProviderComp))
-            _siliconLawSystem.CueEntityMind(player, playerProviderComp.LawUploadSound);
+            _siliconLawSystem.SetLaws(message.Laws, player, playerProviderComp.LawUploadSound);
     }
 
     private bool IsAllowed()

--- a/Content.Server/Silicons/Laws/SiliconLawEui.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawEui.cs
@@ -52,8 +52,12 @@ public sealed class SiliconLawEui : BaseEui
             return;
 
         var player = _entityManager.GetEntity(message.Target);
+        var playerProviderComp = _entityManager.GetComponentOrNull<SiliconLawProviderComponent>(player);
 
         _siliconLawSystem.SetLaws(message.Laws, player);
+
+        if (playerProviderComp != null)
+            _siliconLawSystem.CueEntityMind(player, playerProviderComp?.LawUploadSound);
     }
 
     private bool IsAllowed()

--- a/Content.Server/Silicons/Laws/SiliconLawEui.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawEui.cs
@@ -55,7 +55,7 @@ public sealed class SiliconLawEui : BaseEui
         _siliconLawSystem.SetLaws(message.Laws, player);
 
         if (_entityManager.TryGetComponent<SiliconLawProviderComponent>(player, out var playerProviderComp))
-            _siliconLawSystem.CueEntityMind(player, playerProviderComp?.LawUploadSound);
+            _siliconLawSystem.CueEntityMind(player, playerProviderComp.LawUploadSound);
     }
 
     private bool IsAllowed()

--- a/Content.Server/Silicons/Laws/SiliconLawEui.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawEui.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Administration.Managers;
+using Content.Server.Administration.Managers;
 using Content.Server.EUI;
 using Content.Shared.Administration;
 using Content.Shared.Eui;
@@ -52,11 +52,9 @@ public sealed class SiliconLawEui : BaseEui
             return;
 
         var player = _entityManager.GetEntity(message.Target);
-        var playerProviderComp = _entityManager.GetComponentOrNull<SiliconLawProviderComponent>(player);
-
         _siliconLawSystem.SetLaws(message.Laws, player);
 
-        if (playerProviderComp != null)
+        if (_entityManager.TryGetComponent<SiliconLawProviderComponent>(player, out var playerProviderComp))
             _siliconLawSystem.CueEntityMind(player, playerProviderComp?.LawUploadSound);
     }
 

--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -21,6 +21,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
+using Robust.Shared.Audio;
 
 namespace Content.Server.Silicons.Laws;
 
@@ -114,6 +115,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
 
             // gotta tell player to check their laws
             NotifyLawsChanged(uid);
+            CueEntityMind(uid, component.LawUploadSound);
 
             // new laws may allow antagonist behaviour so make it clear for admins
             if (TryComp<EmagSiliconLawComponent>(uid, out var emag))
@@ -154,9 +156,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
 
         _stunSystem.TryParalyze(uid, component.StunTime, true);
 
-        if (!_mind.TryGetMind(uid, out var mindId, out _))
-            return;
-        _roles.MindPlaySound(mindId, component.EmaggedSound);
+        CueEntityMind(uid, component.EmaggedSound);
     }
 
     private void OnEmagMindAdded(EntityUid uid, EmagSiliconLawComponent component, MindAddedMessage args)
@@ -293,9 +293,16 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
         while (query.MoveNext(out var update))
         {
             SetLaws(lawset, update);
-            if (provider.LawUploadSound != null && _mind.TryGetMind(update, out var mindId, out _))
-                _roles.MindPlaySound(mindId, provider.LawUploadSound);
+            CueEntityMind(update, provider.LawUploadSound);
         }
+    }
+    /// <summary>
+    /// Send a Sound cue to an entity that has a mind associated with it.
+    /// </summary>
+    private void CueEntityMind(EntityUid entity, SoundSpecifier? cue)
+    {
+        if (cue != null && _mind.TryGetMind(entity, out var mindId, out _))
+            _roles.MindPlaySound(mindId, cue);
     }
 }
 

--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -299,7 +299,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
     /// <summary>
     /// Send a Sound cue to an entity that has a mind associated with it.
     /// </summary>
-    private void CueEntityMind(EntityUid entity, SoundSpecifier? cue)
+    public void CueEntityMind(EntityUid entity, SoundSpecifier? cue)
     {
         if (cue != null && _mind.TryGetMind(entity, out var mindId, out _))
             _roles.MindPlaySound(mindId, cue);

--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Audio;
+using Robust.Shared.GameObjects;
 
 namespace Content.Server.Silicons.Laws;
 
@@ -114,8 +115,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
             component.Lawset = args.Lawset;
 
             // gotta tell player to check their laws
-            NotifyLawsChanged(uid);
-            CueEntityMind(uid, component.LawUploadSound);
+            NotifyLawsChanged(uid, component.LawUploadSound);
 
             // new laws may allow antagonist behaviour so make it clear for admins
             if (TryComp<EmagSiliconLawComponent>(uid, out var emag))
@@ -151,12 +151,11 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
             return;
 
         base.OnGotEmagged(uid, component, ref args);
-        NotifyLawsChanged(uid);
+        NotifyLawsChanged(uid, component.EmaggedSound);
         EnsureEmaggedRole(uid, component);
 
         _stunSystem.TryParalyze(uid, component.StunTime, true);
 
-        CueEntityMind(uid, component.EmaggedSound);
     }
 
     private void OnEmagMindAdded(EntityUid uid, EmagSiliconLawComponent component, MindAddedMessage args)
@@ -237,7 +236,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
         return ev.Laws;
     }
 
-    public void NotifyLawsChanged(EntityUid uid)
+    public void NotifyLawsChanged(EntityUid uid, SoundSpecifier? cue = null)
     {
         if (!TryComp<ActorComponent>(uid, out var actor))
             return;
@@ -245,6 +244,9 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
         var msg = Loc.GetString("laws-update-notify");
         var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", msg));
         _chatManager.ChatMessageToOne(ChatChannel.Server, msg, wrappedMessage, default, false, actor.PlayerSession.Channel, colorOverride: Color.Red);
+
+        if (cue != null && _mind.TryGetMind(uid, out var mindId, out _))
+            _roles.MindPlaySound(mindId, cue);
     }
 
     /// <summary>
@@ -269,7 +271,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
     /// <summary>
     /// Set the laws of a silicon entity while notifying the player.
     /// </summary>
-    public void SetLaws(List<SiliconLaw> newLaws, EntityUid target)
+    public void SetLaws(List<SiliconLaw> newLaws, EntityUid target, SoundSpecifier? cue = null)
     {
         if (!TryComp<SiliconLawProviderComponent>(target, out var component))
             return;
@@ -278,7 +280,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
             component.Lawset = new SiliconLawset();
 
         component.Lawset.Laws = newLaws;
-        NotifyLawsChanged(target);
+        NotifyLawsChanged(target, cue);
     }
 
     protected override void OnUpdaterInsert(Entity<SiliconLawUpdaterComponent> ent, ref EntInsertedIntoContainerMessage args)
@@ -292,17 +294,8 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
 
         while (query.MoveNext(out var update))
         {
-            SetLaws(lawset, update);
-            CueEntityMind(update, provider.LawUploadSound);
+            SetLaws(lawset, update, provider.LawUploadSound);
         }
-    }
-    /// <summary>
-    /// Send a Sound cue to an entity that has a mind associated with it.
-    /// </summary>
-    public void CueEntityMind(EntityUid entity, SoundSpecifier? cue)
-    {
-        if (cue != null && _mind.TryGetMind(entity, out var mindId, out _))
-            _roles.MindPlaySound(mindId, cue);
     }
 }
 

--- a/Content.Shared/Silicons/Laws/Components/SiliconLawProviderComponent.cs
+++ b/Content.Shared/Silicons/Laws/Components/SiliconLawProviderComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class SiliconLawProviderComponent : Component
 
     /// <summary>
     /// The sound that plays for the Silicon player
-    /// When the Law change is processed for the provider.
+    /// when the law change is processed for the provider.
     /// </summary>
     [DataField]
     public SoundSpecifier? LawUploadSound = new SoundPathSpecifier("/Audio/Misc/cryo_warning.ogg");

--- a/Content.Shared/Silicons/Laws/Components/SiliconLawProviderComponent.cs
+++ b/Content.Shared/Silicons/Laws/Components/SiliconLawProviderComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class SiliconLawProviderComponent : Component
 
     /// <summary>
     /// The sound that plays for the Silicon player
-    /// when the particular lawboard has been inserted.
+    /// When the Law change is processed for the provider.
     /// </summary>
     [DataField]
     public SoundSpecifier? LawUploadSound = new SoundPathSpecifier("/Audio/Misc/cryo_warning.ogg");


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
All silicons will now get notified if their laws change via any method their laws CAN change, Mostly by adding Cues to ION law changes and Admin Law changes
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Discussion from #32625 showed that the QoL introduced in that change should also be extended to Borgs getting Ion Laws to ensure a player is aware their laws changed via a sound cue.
## Technical details
<!-- Summary of code changes for easier review. -->
Moved all instances of `_roles.MindPlaySound` into its own method (`CueEntityMind`) for easier usage and to keep the relevant code more DRY, this includes For Emag and for the Law board Upload cue introduced in #32625.

Added a call to the new `CueEntityMind` for `OnIonStormLaws` as well as any lawchanges done through `SiliconLawEui`, though this is likely pending a more bespoke Admin Panel change to allow an admin to more directly notify a silicon utilizing any sound they wish (presently defers to the `SiliconLawProviderComponent` already stuck to the target player)
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/0a313a5d-dda3-45d6-a805-bf22c9be7242


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Kickguy223
- add: Ion Storms now notify a Borg that their laws have changed via a sound cue.


