### PR TITLE
fix exped caves generation

### DIFF
--- a/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenWallMount.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenWallMount.cs
@@ -20,7 +20,11 @@ public sealed partial class DungeonJob
         }
 
         var tileDef = _prototype.Index(tileProto);
-        data.SpawnGroups.TryGetValue(DungeonDataKey.WallMounts, out var spawnProto);
+        if (!data.SpawnGroups.TryGetValue(DungeonDataKey.WallMounts, out var spawnProto))
+        {
+            // caves can have no walls
+            return;
+        }
 
         var checkedTiles = new HashSet<Vector2i>();
         var allExterior = new HashSet<Vector2i>(dungeon.CorridorExteriorTiles);


### PR DESCRIPTION
## About the PR
now cave expeds can have ore instead of it throwing

## Why / Balance
.

## Technical details
ignoring the result of TryGetValue then using a null index to IPrototypeManager.Index truly genius

## Media


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed expeditions on cave planets not having any ore.