### PR TITLE
Add potential for Bible to heal eye damage

### DIFF
--- a/Content.Server/Bible/Components/BibleComponent.cs
+++ b/Content.Server/Bible/Components/BibleComponent.cs
@@ -34,6 +34,20 @@ namespace Content.Server.Bible.Components
         [ViewVariables(VVAccess.ReadWrite)]
         public float FailChance = 0.34f;
 
+        /// <summary>
+        /// Chance the bible will heal someones eyesight
+        /// </summary>
+        [DataField("eyeHealChance")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float EyeHealChance = 0.20f;
+
+        /// <summary>
+        /// Amount of eye damage the bible will heal
+        /// </summary>
+        [DataField("eyeHealAmount")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public int EyeHealAmount = -1;
+
         [DataField("sizzleSound")]
         public SoundSpecifier SizzleSoundPath = new SoundPathSpecifier("/Audio/Effects/lightburn.ogg");
         [DataField("healSound")]

--- a/Resources/Locale/en-US/chapel/bible.ftl
+++ b/Resources/Locale/en-US/chapel/bible.ftl
@@ -2,7 +2,15 @@ bible-heal-success-self = You hit {THE($target)} with {THE($bible)}, and their w
 bible-heal-success-others = {CAPITALIZE(THE($user))} hits {THE($target)} with {THE($bible)}, and their wounds close in a flash of holy light!
 bible-heal-success-none-self = You hit {THE($target)} with {THE($bible)}, but they have no wounds you can heal!
 bible-heal-success-none-others = {CAPITALIZE(THE($user))} hits {THE($target)} with {THE($bible)}!
+bible-eye-success-only-self = You hit {THE($target)} with {THE($bible)}, and their eyes regain some focus!
+bible-eye-success-only-others = {CAPITALIZE(THE($user))} hits {THE($target)} with {THE($bible)}, and their eyes regain some focus!
+bible-heal-success-full-self = You hit {THE($target)} with {THE($bible)}, and their wounds close and eyes regain focus in a flash of holy light!
+bible-heal-success-full-others = {CAPITALIZE(THE($user))} hits {THE($target)} with {THE($bible)}, and their wounds close and eyes regain focus in a flash of holy light!
 
+bible-heal-success-partial-self = You hit {THE($target)} with {THE($bible)}, and their wounds close in a flash of holy light, but their eyes remain glossy!
+bible-heal-success-partial-others = {CAPITALIZE(THE($user))} hits {THE($target)} with {THE($bible)}, and their wounds close in a flash of holy light, but their eyes remain glossy!
+
+bible-eye-fail-self = You hit {THE($target)} with {THE($bible)}, but their eyes remaing glossy!
 bible-heal-fail-self = You hit {THE($target)} with {THE($bible)}, and it lands with a sad thwack, dazing {OBJECT($target)}!
 bible-heal-fail-others = {CAPITALIZE(THE($user))} hits {THE($target)} with {THE($bible)}, and it lands with a sad thack, dazing {OBJECT($target)}!
 bible-sizzle = The book sizzles in your hands!

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -66,6 +66,7 @@
       types:
         Caustic: 50
     failChance: 0
+    eyeHealChance: 0 # Makes it so that it can not heal eye damage
     locPrefix: "necro"
     healSound: "/Audio/Effects/lightburn.ogg"
   - type: Summonable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a 20% chance for chaplains to heal eye damage.
Includes new possible popups based on the outcome and required healing:
- You hit {THE($target)} with {THE($bible)}, and their wounds close and eyes regain focus in a flash of holy light!
- You hit {THE($target)} with {THE($bible)}, and their wounds close in a flash of holy light, but their eyes remain glossy!
- You hit {THE($target)} with {THE($bible)}, and their eyes regain some focus!

## Why / Balance
Proposed by @lzk228. Additionally, a miracle inside the bible is the restoration of eyesight.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds two new fields to `BibleComponent`, `EyeHealChance & EyeHealAmount`. The default values are a 20% chance to heal eyesight and for it to restore one eye damage (equal to one instance of welding without goggles). Modifies BibleSystem's `OnAfterInteract` to check if the target can be blinded, has eye damage, and that the roll is favorable. This does not remove roundstart blindness. This change also includes new phrases corresponding to if the target was healed, if they have eye damage, and if that eye damage was healed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: The chaplain's Bible now has a 20% chance to heal eye damage.

