### PR TITLE
contraband tips appear only in the relevant hud

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -431,6 +431,12 @@ namespace Content.Shared.CCVar
             CVarDef.Create("game.contraband_examine", true, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
+        /// If true, contraband severity can be viewed in the examine menu only in relevant hud
+        /// </summary>
+        public static readonly CVarDef<bool> ContrabandExamineOnlyInHud =
+            CVarDef.Create("game.contraband_examine_only_in_hud", true, CVar.SERVER | CVar.REPLICATED);
+
+        /// <summary>
         /// Size of the lookup area for adding entities to the context menu
         /// </summary>
         public static readonly CVarDef<float> GameEntityMenuLookup =

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -434,7 +434,7 @@ namespace Content.Shared.CCVar
         /// If true, contraband severity can be viewed in the examine menu only in relevant hud
         /// </summary>
         public static readonly CVarDef<bool> ContrabandExamineOnlyInHud =
-            CVarDef.Create("game.contraband_examine_only_in_hud", true, CVar.SERVER | CVar.REPLICATED);
+            CVarDef.Create("game.contraband_examine_only_in_hud", false, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
         /// Size of the lookup area for adding entities to the context menu

--- a/Content.Shared/Contraband/ContrabandSystem.cs
+++ b/Content.Shared/Contraband/ContrabandSystem.cs
@@ -22,6 +22,7 @@ public sealed class ContrabandSystem : EntitySystem
     [Dependency] private readonly InventorySystem _inventorySystem = default!;
 
     private bool _contrabandExamineEnabled;
+    private bool _contrabandExamineOnlyInHudEnabled;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -29,11 +30,17 @@ public sealed class ContrabandSystem : EntitySystem
         SubscribeLocalEvent<ContrabandComponent, ExaminedEvent>(OnExamined);
 
         Subs.CVar(_configuration, CCVars.ContrabandExamine, SetContrabandExamine, true);
+        Subs.CVar(_configuration, CCVars.ContrabandExamineOnlyInHud, SetContrabandExamineOnlyInHud, true);
     }
 
     private void SetContrabandExamine(bool val)
     {
         _contrabandExamineEnabled = val;
+    }
+
+    private void SetContrabandExamineOnlyInHud(bool val)
+    {
+        _contrabandExamineOnlyInHudEnabled = val;
     }
 
     public void CopyDetails(EntityUid uid, ContrabandComponent other, ContrabandComponent? contraband = null)
@@ -51,10 +58,11 @@ public sealed class ContrabandSystem : EntitySystem
         if (!_contrabandExamineEnabled)
             return;
 
-        if (TryComp<InventoryComponent>(args.Examiner, out var comp))
-            if (_inventorySystem.TryGetContainerSlotEnumerator(new Entity<InventoryComponent?>(args.Examiner, comp), out var inventorySlot, SlotFlags.EYES))
-                if(inventorySlot.NextItem(out var item))
-                    if (!TryComp<ShowJobIconsComponent>(item, out var jComp)) return;
+        if(_contrabandExamineOnlyInHudEnabled)
+            if (TryComp<InventoryComponent>(args.Examiner, out var comp))
+                if (_inventorySystem.TryGetContainerSlotEnumerator(new Entity<InventoryComponent?>(args.Examiner, comp), out var inventorySlot, SlotFlags.EYES))
+                    if(inventorySlot.NextItem(out var item))
+                        if (!TryComp<ShowJobIconsComponent>(item, out var jComp)) return;
         // two strings:
         // one, the actual informative 'this is restricted'
         // then, the 'you can/shouldn't carry this around' based on the ID the user is wearing

--- a/Content.Shared/Contraband/ContrabandSystem.cs
+++ b/Content.Shared/Contraband/ContrabandSystem.cs
@@ -58,11 +58,25 @@ public sealed class ContrabandSystem : EntitySystem
         if (!_contrabandExamineEnabled)
             return;
 
-        if(_contrabandExamineOnlyInHudEnabled)
-            if (TryComp<InventoryComponent>(args.Examiner, out var comp))
-                if (_inventorySystem.TryGetContainerSlotEnumerator(new Entity<InventoryComponent?>(args.Examiner, comp), out var inventorySlot, SlotFlags.EYES))
-                    if(inventorySlot.NextItem(out var item))
-                        if (!TryComp<ShowJobIconsComponent>(item, out var jComp)) return;
+        if (_contrabandExamineOnlyInHudEnabled)
+        {
+            if (TryComp<InventoryComponent>(args.Examiner, out var comp) && _inventorySystem.TryGetContainerSlotEnumerator(new Entity<InventoryComponent?>(args.Examiner, comp), out var inventorySlot, SlotFlags.EYES))
+            {
+                if (inventorySlot.NextItem(out var item))
+                {
+                    if (!TryComp<ShowContrabandDetailsComponent>(item, out var jComp)) return;
+                }
+                else
+                {
+                    return;
+                }
+            }
+            else
+            {
+                return;
+            }
+        }
+
         // two strings:
         // one, the actual informative 'this is restricted'
         // then, the 'you can/shouldn't carry this around' based on the ID the user is wearing

--- a/Content.Shared/Contraband/ContrabandSystem.cs
+++ b/Content.Shared/Contraband/ContrabandSystem.cs
@@ -1,8 +1,10 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Shared.Access.Systems;
 using Content.Shared.CCVar;
 using Content.Shared.Examine;
+using Content.Shared.Inventory;
 using Content.Shared.Localizations;
+using Content.Shared.Overlays;
 using Content.Shared.Roles;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
@@ -17,6 +19,7 @@ public sealed class ContrabandSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _configuration = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly SharedIdCardSystem _id = default!;
+    [Dependency] private readonly InventorySystem _inventorySystem = default!;
 
     private bool _contrabandExamineEnabled;
 
@@ -48,6 +51,10 @@ public sealed class ContrabandSystem : EntitySystem
         if (!_contrabandExamineEnabled)
             return;
 
+        if (TryComp<InventoryComponent>(args.Examiner, out var comp))
+            if (_inventorySystem.TryGetContainerSlotEnumerator(new Entity<InventoryComponent?>(args.Examiner, comp), out var inventorySlot, SlotFlags.EYES))
+                if(inventorySlot.NextItem(out var item))
+                    if (!TryComp<ShowJobIconsComponent>(item, out var jComp)) return;
         // two strings:
         // one, the actual informative 'this is restricted'
         // then, the 'you can/shouldn't carry this around' based on the ID the user is wearing

--- a/Content.Shared/Contraband/ShowContrabandDetailsComponent.cs
+++ b/Content.Shared/Contraband/ShowContrabandDetailsComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+namespace Content.Shared.Contraband;
+
+/// <summary>
+///     This component allows you to see Controband details on examine items
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ShowContrabandDetailsComponent : Component
+{
+
+}

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -6,6 +6,7 @@
   - type: ShowJobIcons
   - type: ShowMindShieldIcons
   - type: ShowCriminalRecordIcons
+  - type: ShowContrabandDetails
 
 - type: entity
   id: ShowMedicalIcons


### PR DESCRIPTION
## About the PR
This pr makes changes to the ContrabandSystem so that smuggling hints appear only if the character is wearing glasses that show work.
I also added a corresponding cvar to enable or disable the need to have a hud: game.contraband_examine_only_in_hud

## Why / Balance
This is a very useful feature that has improved the lives of all players, especially for safety. But it is surprising that these hints can be seen by absolutely everyone, without special equipment on mrp+ servers.

## Technical details
Changed the ContrabandSystem. It now checks the Examiner's inventory for glasses in the eye slot with the ShowJobIconsComponent.
Of course, it might be better to add a corresponding component for this. If it is necessary to do so, I will definitely do so.

## Media
![example](https://github.com/user-attachments/assets/a9e17ac5-2a04-474d-a7e6-0998075158ac)


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
nothing, i think.

**Changelog**
:cl:
- tweak: Сontraband tips appear only in the relevant hud
ADMIN:
- add:  cvar to enable or disable the need to have a hud to display the contraband tips: game.contraband_examine_only_in_hud
