### PR TITLE
MMIs and positronic brains now talk like pAIs in plushies

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -52,7 +52,7 @@
   - type: ChangeVoiceInContainer
     whitelist:
       components:
-        - SecretStash
+      - SecretStash
 
 - type: entity
   parent: MMI
@@ -134,4 +134,4 @@
     - type: ChangeVoiceInContainer
       whitelist:
         components:
-          - SecretStash
+        - SecretStash

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -49,6 +49,10 @@
     guides:
     - Cyborgs
     - Robotics
+  - type: ChangeVoiceInContainer
+    whitelist:
+      components:
+        - SecretStash
 
 - type: entity
   parent: MMI
@@ -127,3 +131,7 @@
       guides:
       - Cyborgs
       - Robotics
+    - type: ChangeVoiceInContainer
+      whitelist:
+        components:
+          - SecretStash


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Lot of people in the discord really wanted the feature! It makes sense as well, pAIs are basically the same as MMIs and brains.

## Technical details
<!-- Summary of code changes for easier review. -->
Just added the necessary component so their name will get overwritten.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/a4e35de0-7875-41c9-a677-a54912295623)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Beck Thompson
- add: When MMIs and positronic brains are inserted into plushies, their names will be updated to the plushies name (Exactly the same way pAIs do).