### PR TITLE
Let station AI use long range fax machines

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -4,7 +4,6 @@
   name: long range fax machine
   description: Bluespace technologies on the application of bureaucracy.
   components:
-  - type: StationAiWhitelist
   - type: Sprite
     sprite: Structures/Machines/fax_machine.rsi
     drawdepth: SmallObjects
@@ -35,6 +34,7 @@
     interfaces:
       enum.FaxUiKey.Key:
         type: FaxBoundUi
+  - type: StationAiWhitelist
   - type: ApcPowerReceiver
     powerLoad: 250
   - type: Faxecute

--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -4,6 +4,7 @@
   name: long range fax machine
   description: Bluespace technologies on the application of bureaucracy.
   components:
+  - type: StationAiWhitelist
   - type: Sprite
     sprite: Structures/Machines/fax_machine.rsi
     drawdepth: SmallObjects


### PR DESCRIPTION
## About the PR
Station AI can now interact with long range fax machines. You can't insert paper into the tray (because you have no hands), but at least you can print something (yes, the "print from file" button actualy works).
It would be cool to give the AI an ingame text editor when interacting with fax machines, but i won't do that now because _reasons_.

## Why / Balance
1. Paperwork is good, but paperwork done by AI is better.
2. Could create some interesting RP situations.
3. Why not?

## Technical details
Added StationAIWhitelist component to the FaxMachineBase entity.

## Media
![изображение](https://github.com/user-attachments/assets/116bea59-d704-4377-9e35-9b6068c20d87)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Station AI can now interact with long range fax machines.
