### PR TITLE
Medibot doAfter and some other improvements

### DIFF
--- a/Content.Server/NPC/HTN/Preconditions/TargetInRangePrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/TargetInRangePrecondition.cs
@@ -20,6 +20,9 @@ public sealed partial class TargetInRangePrecondition : HTNPrecondition
         _transformSystem = sysManager.GetEntitySystem<SharedTransformSystem>();
     }
 
+    [DataField("invert")]
+    public bool Invert = false;
+
     public override bool IsMet(NPCBlackboard blackboard)
     {
         if (!blackboard.TryGetValue<EntityCoordinates>(NPCBlackboard.OwnerCoordinates, out var coordinates, _entManager))
@@ -30,6 +33,6 @@ public sealed partial class TargetInRangePrecondition : HTNPrecondition
             return false;
 
         var transformSystem = _entManager.System<SharedTransformSystem>;
-        return _transformSystem.InRange(coordinates, targetXform.Coordinates, blackboard.GetValueOrDefault<float>(RangeKey, _entManager));
+        return _transformSystem.InRange(coordinates, targetXform.Coordinates, blackboard.GetValueOrDefault<float>(RangeKey, _entManager)) ^ Invert;
     }
 }

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/SpeakOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/SpeakOperator.cs
@@ -1,9 +1,12 @@
 using Content.Server.Chat.Systems;
+using Robust.Shared.Timing;
 
 namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators;
 
 public sealed partial class SpeakOperator : HTNOperator
 {
+    [Dependency] private readonly IEntityManager _entMan = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
     private ChatSystem _chat = default!;
 
     [DataField(required: true)]
@@ -15,6 +18,18 @@ public sealed partial class SpeakOperator : HTNOperator
     [DataField]
     public bool Hidden;
 
+    /// <summary>
+    /// Skip speaking for `cooldown` seconds, intended to stop spam
+    /// </summary>
+    [DataField]
+    public TimeSpan Cooldown = TimeSpan.Zero;
+
+    /// <summary>
+    /// Define what key is used for storing the cooldown
+    /// </summary>
+    [DataField]
+    public string CooldownID = String.Empty;
+
     public override void Initialize(IEntitySystemManager sysManager)
     {
         base.Initialize(sysManager);
@@ -24,6 +39,15 @@ public sealed partial class SpeakOperator : HTNOperator
 
     public override HTNOperatorStatus Update(NPCBlackboard blackboard, float frameTime)
     {
+        if (Cooldown != TimeSpan.Zero && CooldownID != string.Empty)
+        {
+            if(blackboard.TryGetValue<TimeSpan>(CooldownID, out var nextSpeechTime, _entMan))
+                if(_gameTiming.CurTime < nextSpeechTime)
+                    return base.Update(blackboard, frameTime);
+
+            blackboard.SetValue(CooldownID, _gameTiming.CurTime + Cooldown);
+        }
+
         var speaker = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
         _chat.TrySendInGameICMessage(speaker, Loc.GetString(Speech), InGameICChatType.Speak, hideChat: Hidden, hideLog: Hidden);
 

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/EnsureComponentOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/EnsureComponentOperator.cs
@@ -1,0 +1,34 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Specific;
+
+public sealed partial class EnsureComponentOperator : HTNOperator
+{
+    [Dependency] private readonly IEntityManager _entMan = default!;
+
+    /// <summary>
+    /// Target entity to inject.
+    /// </summary>
+    [DataField("targetKey", required: true)]
+    public string TargetKey = string.Empty;
+
+    /// <summary>
+    /// Components to be added
+    /// </summary>
+    [DataField("components")]
+    public ComponentRegistry Components = new();
+
+    public override void Initialize(IEntitySystemManager sysManager)
+    {
+        base.Initialize(sysManager);
+    }
+
+    public override HTNOperatorStatus Update(NPCBlackboard blackboard, float frameTime)
+    {
+        if (!blackboard.TryGetValue<EntityUid>(TargetKey, out var target, _entMan))
+            return HTNOperatorStatus.Failed;
+
+        _entMan.AddComponents(target, Components);
+        return HTNOperatorStatus.Finished;
+    }
+}

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/UtilityOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/UtilityOperator.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +18,8 @@ public sealed partial class UtilityOperator : HTNOperator
 
     [DataField("key")] public string Key = "Target";
 
+    [DataField("returnType")] public string ReturnType = "Highest";
+
     /// <summary>
     /// The EntityCoordinates of the specified target.
     /// </summary>
@@ -30,19 +33,38 @@ public sealed partial class UtilityOperator : HTNOperator
         CancellationToken cancelToken)
     {
         var result = _entManager.System<NPCUtilitySystem>().GetEntities(blackboard, Prototype);
-        var target = result.GetHighest();
+        Dictionary<string, object> effects;
 
-        if (!target.IsValid())
+        switch (ReturnType)
         {
-            return (false, new Dictionary<string, object>());
+            case "Highest":
+                var target = result.GetHighest();
+
+                if (!target.IsValid())
+                {
+                    return (false, new Dictionary<string, object>());
+                }
+
+                effects = new Dictionary<string, object>()
+                {
+                    {Key, target},
+                    {KeyCoordinates, new EntityCoordinates(target, Vector2.Zero)},
+                };
+
+                return (true, effects);
+
+            case "EnumerableDescending":
+                var targetList = result.GetEnumerable();
+
+                effects = new Dictionary<string, object>()
+                {
+                    {"TargetList", targetList},
+                };
+
+                return (true, effects);
+
+            default:
+                throw new NotImplementedException();
         }
-
-        var effects = new Dictionary<string, object>()
-        {
-            {Key, target},
-            {KeyCoordinates, new EntityCoordinates(target, Vector2.Zero)}
-        };
-
-        return (true, effects);
     }
 }

--- a/Content.Server/NPC/Queries/Queries/ComponentFilter.cs
+++ b/Content.Server/NPC/Queries/Queries/ComponentFilter.cs
@@ -5,8 +5,14 @@ namespace Content.Server.NPC.Queries.Queries;
 public sealed partial class ComponentFilter : UtilityQueryFilter
 {
     /// <summary>
-    /// Components to filter for.
+    /// Entities must have these components
     /// </summary>
-    [DataField("components", required: true)]
+    [DataField("components")]
     public ComponentRegistry Components = new();
+
+    /// <summary>
+    /// Remove entities which have this component
+    /// </summary>
+    [DataField("excludedComponents")]
+    public ComponentRegistry ExcludedComponents = new();
 }

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -489,6 +489,22 @@ public sealed class NPCUtilitySystem : EntitySystem
 
                 foreach (var ent in entities)
                 {
+                    bool removed = false;
+
+                    foreach (var comp in compFilter.ExcludedComponents)
+                    {
+                        if (!HasComp(ent, comp.Value.Component.GetType()))
+                            continue;
+
+                        _entityList.Add(ent);
+                        removed = true;
+                        break;
+                    }
+
+                    // If first foreach removed the entity, just skip the other foreach
+                    if (removed)
+                        continue;
+
                     foreach (var comp in compFilter.Components)
                     {
                         if (HasComp(ent, comp.Value.Component.GetType()))
@@ -579,5 +595,13 @@ public readonly record struct UtilityResult(Dictionary<EntityUid, float> Entitie
             return EntityUid.Invalid;
 
         return Entities.MinBy(x => x.Value).Key;
+    }
+
+    /// <summary>
+    /// Returns a GetEnumerable sorted in descending score.
+    /// </summary>
+    public IEnumerable<KeyValuePair<EntityUid, float>> GetEnumerable()
+    {
+        return Entities.OrderByDescending(x => x.Value);
     }
 }

--- a/Content.Shared/Silicons/Bots/MedibotSystem.cs
+++ b/Content.Shared/Silicons/Bots/MedibotSystem.cs
@@ -1,5 +1,9 @@
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Emag.Systems;
+using Content.Shared.Interaction;
 using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Robust.Shared.Audio.Systems;
 using System.Diagnostics.CodeAnalysis;
 
@@ -11,12 +15,54 @@ namespace Content.Shared.Silicons.Bots;
 public sealed class MedibotSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
+
+    private EntityQuery<InjectorComponent> _injectorQuery = default!;
+    private EntityQuery<MobStateComponent> _mobStateQuery = default!;
+    private EntityQuery<MedibotComponent> _medibotQuery = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<EmaggableMedibotComponent, GotEmaggedEvent>(OnEmagged);
+        SubscribeLocalEvent<MedibotComponent, UserActivateInWorldEvent>(OnActivateInWorld);
+        SubscribeLocalEvent<MedibotComponent, InjectorDoAfterEvent>(OnDoAfter);
+
+        _injectorQuery = GetEntityQuery<InjectorComponent>();
+        _mobStateQuery = GetEntityQuery<MobStateComponent>();
+        _medibotQuery = GetEntityQuery<MedibotComponent>();
+    }
+
+    private void OnDoAfter(Entity<MedibotComponent> ent, ref InjectorDoAfterEvent args)
+    {
+        if (!_solutionContainer.TryGetSolution(ent.Owner, "injector", out var solution))
+            return;
+
+        // Empty the "syringe" after a doafter, to stop people from duping trico and inaprov
+        _solutionContainer.RemoveAllSolution(solution.Value);
+    }
+
+    private void OnActivateInWorld(Entity<MedibotComponent> ent, ref UserActivateInWorldEvent args)
+    {
+        if (!TryComp(args.Target, out TransformComponent? xform))
+            return;
+
+        if(!TryGetTreatment(ent, args.Target, out var treatment))
+            return;
+
+        if (!_injectorQuery.TryComp(ent.Owner, out var injector))
+            return;
+
+        if (!_solutionContainer.TryGetSolution(ent.Owner, "injector", out var solution))
+            return;
+
+        _solutionContainer.TryAddReagent(solution.Value, treatment.Reagent, treatment.Quantity, out var quantityAdded);
+        injector.ToggleState = InjectorToggleMode.Inject;
+
+        _interactionSystem.InteractDoAfter(ent, ent, args.Target, xform.Coordinates, true);
+        args.Handled = true;
     }
 
     private void OnEmagged(EntityUid uid, EmaggableMedibotComponent comp, ref GotEmaggedEvent args)
@@ -32,6 +78,22 @@ public sealed class MedibotSystem : EntitySystem
         }
 
         args.Handled = true;
+    }
+
+    public bool TryGetTreatment(EntityUid ent, EntityUid target, [NotNullWhen(true)] out MedibotTreatment? treatment)
+    {
+        treatment = null;
+
+        if (!_mobStateQuery.TryComp(target, out var MobState))
+            return false;
+
+        if (!_medibotQuery.TryComp(ent, out var medibot))
+            return false;
+
+        if(!TryGetTreatment(medibot, MobState.CurrentState, out treatment))
+            return false;
+
+        return true;
     }
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -347,6 +347,21 @@
     pack: MedibotAds
   - type: Inventory
     templateId: medibot
+  - type: DoAfter
+  - type: SolutionContainerManager
+    solutions:
+      injector:
+        maxVol: 30
+  - type: Injector
+    injectOnly: true
+    delay: 3
+    delayPerVolume: 0
+    minTransferAmount: 30
+    maxTransferAmount: 30
+    transferAmount: 30
+    needHand: false
+    breakOnHandChange: false
+    movementThreshold: 0.3
 
 - type: entity
   parent:

--- a/Resources/Prototypes/NPCs/medibot.yml
+++ b/Resources/Prototypes/NPCs/medibot.yml
@@ -1,45 +1,63 @@
 - type: htnCompound
   id: MedibotCompound
   branches:
+    # Observe for targets
     - tasks:
+        - !type:HTNPrimitiveTask
+          operator: !type:UtilityOperator
+            proto: MedibotInjectable
+            returnType: EnumerableDescending
+        - !type:HTNPrimitiveTask
+          operator: !type:PickNearbyInjectableOperator
+            targetKey: Target
+            targetMoveKey: TargetCoordinates
+
         - !type:HTNCompoundTask
-          task: InjectNearbyCompound
+          task: MedibotGetInRange
+        - !type:HTNCompoundTask
+          task: MedibotInject
+
+    # Idle when targets not found
     - tasks:
         - !type:HTNCompoundTask
           task: IdleCompound
 
 - type: htnCompound
-  id: InjectNearbyCompound
+  id: MedibotGetInRange
   branches:
-    - tasks:
-        # TODO: Kill this shit
-        - !type:HTNPrimitiveTask
-          operator: !type:PickNearbyInjectableOperator
-            targetKey: InjectTarget
-            targetMoveKey: TargetCoordinates
-
+    # Move to target if out of range
+    - preconditions:
+        - !type:TargetInRangePrecondition
+          invert: true
+          targetKey: Target
+          rangeKey: InteractRange
+      tasks:
         - !type:HTNPrimitiveTask
           operator: !type:SpeakOperator
             speech: medibot-start-inject
             hidden: true
-
+            cooldownID: medibot-start-inject
+            cooldown: 5
         - !type:HTNPrimitiveTask
           operator: !type:MoveToOperator
             pathfindInPlanning: false
 
+    - tasks:
         - !type:HTNPrimitiveTask
-          operator: !type:SetFloatOperator
-            targetKey: IdleTime
-            amount: 3
+          operator: !type:NoOperator
 
+# Should be called only when in range
+- type: htnCompound
+  id: MedibotInject
+  branches:
+    - tasks:
         - !type:HTNPrimitiveTask
-          operator: !type:WaitOperator
-            key: IdleTime
-          preconditions:
-            - !type:KeyExistsPrecondition
-              key: IdleTime
+          operator: !type:InteractWithOperator
+            expectDoAfter: true
+            targetKey: Target
+        - !type:HTNPrimitiveTask
+          operator: !type:EnsureComponentOperator
+            targetKey: Target
+            components:
+            - type: NPCRecentlyInjected
 
-        # TODO: Kill this
-        - !type:HTNPrimitiveTask
-          operator: !type:MedibotInjectOperator
-            targetKey: InjectTarget

--- a/Resources/Prototypes/NPCs/utility_queries.yml
+++ b/Resources/Prototypes/NPCs/utility_queries.yml
@@ -182,6 +182,28 @@
       curve: !type:BoolCurve
 
 - type: utilityQuery
+  id: MedibotInjectable
+  query:
+    - !type:ComponentQuery
+      components:
+        - type: InjectableSolution
+        - type: Damageable
+        - type: MobState
+    - !type:ComponentFilter
+      excludedComponents:
+        - type: NPCRecentlyInjected
+  considerations:
+    - !type:TargetIsCritCon
+      curve: !type:QuadraticCurve
+        slope: 1
+        exponent: 1
+        yOffset: 0.1
+        xOffset: 0
+    - !type:TargetDistanceCon
+      curve: !type:PresetCurve
+        preset: TargetDistance
+
+- type: utilityQuery
   id: NearbyGunTargets
   query:
     - !type:NearbyHostilesQuery


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made the Medibot use doafters. 
To the players this appears as generally more responsive NPC, no more waiting multiple seconds just for the bot to inject someone else. Or nothing.
Right, no more apparent instant injects.

Besides that, there's a bunch of small changes to various related HTN operators, more details on the Technical details section.

## Why / Balance
You never knew whether the bot was injecting you or someone else, and sometimes the bot would do apparently instant injections. I'd link the clip where Liltenhead fell victim to it, but I don't have it on hand... 
Also the bot gave almost no feedback on what it was doing. 
The injection was implemented by manually adding reagents to the player's body, and manually playing popups. 

## Technical details
<!-- Summary of code changes for easier review. -->
### Operators
* `TargetInRangePrecondition` got `invert` variable, for when you want `TargetOutOfRange` behaviour. Implemented this way to reduce code duplication.
* `SpeakOperator` got a cooldown implementation, so the NPC wouldn't talk everytime it started a new plan. It gets annoying when they scream at you every 0.45 seconds.
* `EnsureComponentOperator` was added, to replace the Medibot's hardcoded adding of `NPCRecentlyInjectedComponent`. 

### NPCUtilitySystem
* `ComponentFilter` of the `NPCUtilitySystem` was expanded a bit, and got slightly less ambiguous comments.
* `NPCUtilitySystem` can now return a sorted Enumerable of the results, instead of just the highest scoring one.
* `UtilityOperator` got the `returnType` option, to specify whether to return the highest scoring result, or the aforementioned enumerable.

### Medibot
`PickNearbyInjectable` went through quite minimal alterations, now it takes the results provided by the `UtilityOperator`, and picks the first treatable result. The `UtilityOperator`'s considerations are made to treat crit patients first, and then by distance. I haven't added the healthconsideration for this because I was too lazy to decide on a proper curve for it.

The most disgusting part of this PR must be what I have done to the `MedibotSystem`.
Because I was too lazy to figure out how to give Medibot hands and do it that way, I just subscribed to the `UserActivateInWorldEvent`, and used it to start an interaction using the Medibot as the syringe. 
You read that right, I'm using the Medibot as a syringe. 
I also subscribed on `InjectorDoAfterEvent`, in order to empty the syringe incase it had anything in it, in order to avoid chem duping.

Right, currently the Medibot's range has been increased from 4 tiles to 10, since right now `TargetDistanceCon` makes changing it a pain.
I was also planning on adding a `IdleNearLocation` compound task, but decided not to include it due to pathfinding possibly being too expensive during cases where there is no path, such as when doors close.
The DoAfter bar also is a bit high, it gets hidden behind the speech bubbles.

Also sorry for making this PR this verbose, I seem to get a bit too talkative late at night.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Here's the apparent instant inject I mentioned

https://github.com/user-attachments/assets/9194dbe8-e1d9-4c6b-b4bc-3af61a557570

Here's a recording of my changes, the Medibot prioritizes the crit Urist first, and then in the order of distance.
The DoAfter can also be seen, as well as the InjectorSystem's multiplier for crit people. 

https://github.com/user-attachments/assets/8a8c0139-f6af-41e2-ba1e-ea48cc7aaee8


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
## Breaking changes
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Now the Medibot has a DoAfter bar, displaying injection progress.