### PR TITLE
contrabandInventory Changes (Fixed)

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/atmosdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/atmosdrobe.yml
@@ -13,3 +13,5 @@
     ClothingOuterSuitFire: 2
     ClothingOuterWinterAtmos: 2
     ClothingNeckScarfStripedLightBlue: 3
+  contrabandInventory:
+    ToyFigurineAtmosTech: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/bardrobe.yml
@@ -16,4 +16,5 @@
     ClothingOuterVest: 2
     ClothingBeltBandolier: 2
     ClothingEyesGlassesSunglasses: 2
-
+  contrabandInventory:
+    ToyFigurineBartender: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
@@ -46,5 +46,8 @@
     DrinkSakeBottleFull: 3
     DrinkBeerCan: 5
     DrinkWineCan: 5
+  contrabandInventory:
+    EthanolChemistryBottle: 3
+    DrinkBottleOfNothingFull: 1
   emaggedInventory:
     DrinkPoisonWinebottleFull: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cargodrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cargodrobe.yml
@@ -15,3 +15,7 @@
     ClothingOuterWinterMiner: 2
     ClothingNeckScarfStripedBrown: 3
     ClothingShoesBootsWinterCargo: 2
+  contrabandInventory:
+    ToyFigurineCargoTech: 1
+    ToyFigurineSalvage: 1
+    ToyFigurineQuartermaster: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -16,3 +16,6 @@
     EncryptionKeyScience: 2
     EncryptionKeySecurity: 1
     EncryptionKeyService: 3
+  contrabandInventory:
+    RubberStampGreytide: 1
+    LuxuryPen: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -17,5 +17,5 @@
     EncryptionKeySecurity: 1
     EncryptionKeyService: 3
   contrabandInventory:
-    RubberStampGreytide: 1
+    BalloonNT: 2
     LuxuryPen: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
@@ -18,3 +18,6 @@
     ClothingOuterCoatExpensive: 1
     ClothingNeckScarfStripedCentcom: 3
     ClothingNeckCloakCentcom: 3
+  contrabandInventory:
+    ToyFigurineCaptain: 1
+    ToyFigurineHeadOfPersonnel: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chang.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chang.yml
@@ -8,4 +8,7 @@
     FoodSnackChowMein: 3
     FoodSnackDanDanNoodles: 3
     PairedChopsticks: 3
+  contrabandInventory:
+    FoodBakedDumplings: 2
+    FoodSoupMiso: 2
 # rice?

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -21,6 +21,10 @@
     BoxCandleSmall: 2
     Urn: 5
     Bible: 1
+  contrabandInventory:
+    FoodBakedBunHotX: 2
+    DrinkWineBottleFull: 1
+    ToyFigurineChaplain: 1
   emaggedInventory:
     ClothingOuterArmorCult: 1
     ClothingHeadHelmetCult: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -22,7 +22,6 @@
     Urn: 5
     Bible: 1
   contrabandInventory:
-    Bible: 1
     FoodBakedBunHotX: 2
     DrinkWineBottleFull: 1
     ToyFigurineChaplain: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -22,6 +22,7 @@
     Urn: 5
     Bible: 1
   contrabandInventory:
+    Bible: 1
     FoodBakedBunHotX: 2
     DrinkWineBottleFull: 1
     ToyFigurineChaplain: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
@@ -12,3 +12,5 @@
     ClothingShoesColorBlack: 2
     ClothingShoesChef: 2
     ClothingBeltChef: 2
+  contrabandInventory:
+    ToyFigurineChef: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -20,4 +20,8 @@
     FoodButter: 3
     FoodCheese: 1
     FoodMeat: 6
+  contrabandInventory:
+    EggBoxBroken: 1
+    FoodBreadMoldySlice: 2
+    FoodBoxDonkpocket: 1
     

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -22,6 +22,7 @@
     FoodMeat: 6
   contrabandInventory:
     EggBoxBroken: 1
-    FoodBreadMoldySlice: 2
     FoodBoxDonkpocket: 1
+    FoodFrozenSandwich: 2
+    FoodFrozenSandwichStrawberry: 2
     

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemdrobe.yml
@@ -14,3 +14,5 @@
     ClothingHandsGlovesLatex: 2
     ClothingHeadsetMedical: 2
     ClothingOuterWinterChem: 2
+  contrabandInventory:
+    ToyFigurineChemist: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -22,6 +22,9 @@
     JugSodium: 2
     JugSugar: 3
     JugSulfur: 1
+  contrabandInventory:
+    DrinkLithiumFlask: 1
+    StrangePill: 3
   emaggedInventory:
     ToxinChemistryBottle: 1
 
@@ -50,6 +53,9 @@
     JugSugar: 3
     JugSulfur: 1
     JugWeldingFuel: 1
+  contrabandInventory:
+    DrinkLithiumFlask: 1
+    StrangePill: 3
   emaggedInventory:
     PaxChemistryBottle: 3
     MuteToxinChemistryBottle: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
@@ -14,5 +14,9 @@
     CheapLighter: 4
     Lighter: 2
     FlippoLighter: 2
+  contrabandInventory:
+    GroundTobacco: 3
+    CigarGold: 2
+    Igniter: 1
   emaggedInventory:
     CigPackSyndicate: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -96,4 +96,6 @@
     ClothingMaskNeckGaiter: 2
     ClothingUniformJumpsuitTacticool: 1
     ClothingUniformJumpskirtTacticool: 1
+    ToyFigurinePassenger: 1
+    ToyFigurineGreytider: 1
   # DO NOT ADD MORE, USE UNIFORM DYING

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/coffee.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/coffee.yml
@@ -1,4 +1,4 @@
-﻿- type: vendingMachineInventory
+- type: vendingMachineInventory
   id: HotDrinksMachineInventory
   startingInventory:
     DrinkHotCoffee: 5
@@ -6,5 +6,7 @@
     DrinkTeacup: 5
     DrinkGreenTea: 5
     DrinkHotCoco: 5
+  contrabandInventory:
+    DrinkTeapot: 2
   emaggedInventory:
     DrinkNothing: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
@@ -9,6 +9,8 @@
     DrinkLemonLimeCan: 2
     DrinkLemonLimeCranberryCan: 2
     DrinkFourteenLokoCan: 2
+  contrabandInventory:
+    DrinkColaBottleFull: 2
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/condiments.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/condiments.yml
@@ -18,3 +18,8 @@
     KnifePlastic: 10
     FoodPlatePlastic: 10
     FoodPlateSmallPlastic: 10
+  contrabandInventory:
+    FoodShakerSalt: 1
+    FoodShakerPepper: 1
+    FoodCondimentBottleKetchup: 1
+    ReagentContainerMayo: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/curadrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/curadrobe.yml
@@ -14,4 +14,6 @@
     ClothingUniformJumpskirtLibrarian: 3
     ClothingShoesBootsLaceup: 2
     ClothingHeadsetService: 2
+  contrabandInventory:
+    ToyFigurineLibrarian: 1
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
@@ -15,3 +15,5 @@
     ClothingHandsGlovesColorBlack: 2
     ClothingHandsGlovesLatex: 2
     ClothingHeadsetSecurity: 2
+  contrabandInventory:
+    ToyFigurineDetective: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/dinnerware.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/dinnerware.yml
@@ -1,4 +1,4 @@
-﻿- type: vendingMachineInventory
+- type: vendingMachineInventory
   id: DinnerwareInventory
   startingInventory:
     ButchCleaver: 1
@@ -27,3 +27,7 @@
     DrinkMugOne: 1
     DrinkMugRainbow: 2
     DrinkMugRed: 2
+  contrabandInventory:
+    CandyBowl: 1
+    BarSpoon: 2
+    DrinkShaker: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/discount.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/discount.yml
@@ -1,4 +1,4 @@
-﻿- type: vendingMachineInventory
+- type: vendingMachineInventory
   id: DiscountDansInventory
   startingInventory:
     FoodSnackCheesie: 3
@@ -8,3 +8,6 @@
     FoodSnackPopcorn: 3
     FoodSnackEnergy: 3
     CigPackMixed: 2
+  contrabandInventory:
+    FoodFrozenSandwich: 3
+    FoodFrozenSandwichStrawberry: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/discount.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/discount.yml
@@ -9,5 +9,5 @@
     FoodSnackEnergy: 3
     CigPackMixed: 2
   contrabandInventory:
-    FoodFrozenSandwich: 3
-    FoodFrozenSandwichStrawberry: 3
+    FoodSnackDanDanNoodles: 3
+    FoodBakedBunHoney: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/donut.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/donut.yml
@@ -5,5 +5,8 @@
     FoodDonutApple: 3
     FoodDonutPink: 3
     FoodDonutBungo: 3
+  contrabandInventory:
+    FoodBagel: 2
+    FoodBagelPoppy: 2
   emaggedInventory:
     FoodDonutPoison: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
@@ -16,3 +16,6 @@
     ClothingOuterWinterEngi: 2
     ClothingNeckScarfStripedOrange: 3
     ClothingShoesBootsWinterEngi: 2
+  contrabandInventory:
+    ToyFigurineEngineer: 1
+    ToyFigurineChiefEngineer: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -10,3 +10,5 @@
     ClothingHandsGlovesColorYellow: 6
     BoxInflatable: 2
     ClothingHeadHatCone: 4
+  contrabandInventory:
+    DrinkBeerCan: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -11,4 +11,5 @@
     BoxInflatable: 2
     ClothingHeadHatCone: 4
   contrabandInventory:
+    CowToolboxFilled: 1
     DrinkBeerCan: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/games.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/games.yml
@@ -16,3 +16,7 @@
     PaperCNCSheet: 6
     MysteryFigureBox: 2
     BooksBag: 3
+  contrabandInventory:
+    Basketball: 1
+    FoodSnackBoritos: 3
+    DrinkSpaceMountainWindCan: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/gib.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/gib.yml
@@ -9,6 +9,10 @@
     DrinkLemonLimeCan: 2
     DrinkLemonLimeCranberryCan: 2
     DrinkFourteenLokoCan: 2
+  contrabandInventory:
+    ClothingNeckStethoscope: 2
+    Saw: 2
+    Tourniquet: 3
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/happyhonk.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/happyhonk.yml
@@ -1,8 +1,12 @@
-﻿- type: vendingMachineInventory
+- type: vendingMachineInventory
   id: HappyHonkDispenserInventory
   startingInventory:
     HappyHonk: 10
     HappyHonkMime: 4
+  contrabandInventory:
+    ToyFigurineClown: 1
+    ToyFigurineMime: 1
+    ToyFigurineNukie: 1
   emaggedInventory:
     HappyHonkCluwne: 1
     HappyHonkNukie: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/hydrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/hydrobe.yml
@@ -12,4 +12,6 @@
     ClothingHeadBandBotany: 3
     ClothingHeadsetService: 2
     ClothingOuterWinterHydro: 2
+  contrabandInventory:
+    ToyFigurineBotanist: 1
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
@@ -10,7 +10,8 @@
     ClothingHeadsetService: 2
     ClothingOuterWinterJani: 2
     ClothingNeckScarfStripedPurple: 3
-
+  contrabandInventory:
+    ToyFigurineJanitor: 1
   emaggedInventory:
     ClothingUniformJumpskirtJanimaid: 2
     ClothingUniformJumpskirtJanimaidmini: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
@@ -23,5 +23,6 @@
     ClothingHeadHatPwig: 1
     # "Legally" obtained currency
     SpaceCash100: 2
+    ToyFigurineLawyer: 1
   emaggedInventory:
     CyberPen: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
@@ -9,6 +9,9 @@
     ClothingHeadHatVioletwizard: 3
     ClothingOuterWizardViolet: 3
     ClothingShoesWizard: 9
+  contrabandInventory:
+    ToyFigurineWizard: 1
+    ToyFigurineWizardFake: 1
     #TODO:
     #only missing staff
     #and if wizarditis reagent when hacked if we want this.

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
@@ -9,9 +9,6 @@
     ClothingHeadHatVioletwizard: 3
     ClothingOuterWizardViolet: 3
     ClothingShoesWizard: 9
-  contrabandInventory:
-    ToyFigurineWizard: 1
-    ToyFigurineWizardFake: 1
     #TODO:
     #only missing staff
     #and if wizarditis reagent when hacked if we want this.

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -11,5 +11,4 @@
     ClothingEyesHudMedical: 2
     ClothingEyesEyepatchHudMedical: 2
   contrabandInventory:
-    BrutepackAdvanced1: 1
-    OintmentAdvanced1: 1
+    FoodApple: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -11,4 +11,5 @@
     ClothingEyesHudMedical: 2
     ClothingEyesEyepatchHudMedical: 2
   contrabandInventory:
-    Defibrillator: 1
+    BrutepackAdvanced1: 1
+    OintmentAdvanced1: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -10,4 +10,5 @@
     BoxBottle: 3
     ClothingEyesHudMedical: 2
     ClothingEyesEyepatchHudMedical: 2
-
+  contrabandInventory:
+    Defibrillator: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
@@ -25,3 +25,6 @@
     ClothingShoesBootsWinterMed: 2
   contrabandInventory:
     ClothingUniformJumpskirtOfLife: 1
+    ToyFigurineMedicalDoctor: 1
+    ToyFigurineParamedic: 1
+    ToyFigurineChiefMedicalOfficer: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
@@ -19,5 +19,8 @@
     BoxAgrichem: 1
     #TO DO:
     #plant analyzer
+  contrabandInventory:
+    UnstableMutagenChemistryBottle: 1
+    Joint: 1
   emaggedInventory:
     Left4ZedChemistryBottle: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/pwrgame.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/pwrgame.yml
@@ -10,6 +10,8 @@
     DrinkLemonLimeCan: 2
     DrinkLemonLimeCranberryCan: 2
     DrinkFourteenLokoCan: 2
+  contrabandInventory:
+    DrinkDrGibbCan: 3
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
@@ -18,3 +18,5 @@
     Welder: 1
     Screwdriver: 2
     Crowbar: 2
+  contrabandInventory:
+    FoodBurgerRobot: 1  

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -1,4 +1,4 @@
-﻿- type: vendingMachineInventory
+- type: vendingMachineInventory
   id: SalvageEquipmentInventory
   startingInventory:
     Crowbar: 2
@@ -10,3 +10,5 @@
     RadioHandheld: 2
     WeaponGrapplingGun: 4
     WeaponProtoKineticAccelerator: 4
+  contrabandInventory:
+    PlushieCarp: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/scidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/scidrobe.yml
@@ -15,3 +15,5 @@
     ClothingOuterWinterSci: 2
     ClothingNeckScarfStripedPurple: 3
     ClothingShoesBootsWinterSci: 2
+  contrabandInventory:
+    ToyFigurineResearchDirector: 1  

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -22,6 +22,7 @@
     RadioHandheldSecurity: 5
   # security officers need to follow a diet regimen!
   contrabandInventory:
+    WeaponMeleeNeedle: 2
     FoodDonutHomer: 12
     FoodBoxDonut: 2
     #box evidence

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
@@ -27,3 +27,6 @@
     ClothingHeadHelmetJustice: 1
   contrabandInventory:
     ClothingMaskClownSecurity: 1
+    ToyFigurineSecurity: 1
+    ToyFigurineWarden: 1
+    ToyFigurineHeadOfSecurity: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
@@ -39,5 +39,7 @@
     TowercapSeeds: 5
     WheatSeeds: 5
     WatermelonSeeds: 5
+  contrabandInventory:
+    NettleSeeds: 2
   emaggedInventory:
     FlyAmanitaSeeds: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
@@ -41,5 +41,6 @@
     WatermelonSeeds: 5
   contrabandInventory:
     NettleSeeds: 2
+    FoodSnackSemki: 2
   emaggedInventory:
     FlyAmanitaSeeds: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
@@ -40,7 +40,7 @@
     WheatSeeds: 5
     WatermelonSeeds: 5
   contrabandInventory:
-    NettleSeeds: 2
+    BungoSeeds: 2
     FoodSnackSemki: 2
   emaggedInventory:
     FlyAmanitaSeeds: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
@@ -40,7 +40,7 @@
     WheatSeeds: 5
     WatermelonSeeds: 5
   contrabandInventory:
-    BungoSeeds: 2
+    TobaccoSeeds: 2
     FoodSnackSemki: 2
   emaggedInventory:
     FlyAmanitaSeeds: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/shamblersjuice.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/shamblersjuice.yml
@@ -9,6 +9,7 @@
     DrinkLemonLimeCan: 2
     DrinkLemonLimeCranberryCan: 2
     DrinkFourteenLokoCan: 2
+  contrabandInventory:
+    DrinkChangelingStingCan: 2
   emaggedInventory:
     DrinkNukieCan: 2
-    DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/snack.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/snack.yml
@@ -7,6 +7,5 @@
     FoodSnackPistachios: 3
     FoodSnackSus: 3
     FoodSnackSemki: 3
-  emaggedInventory:
+  contrabandInventory:
     FoodSnackSyndi: 3
-

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
@@ -1,4 +1,4 @@
-﻿- type: vendingMachineInventory
+- type: vendingMachineInventory
   id: SodaInventory
   startingInventory:
     DrinkColaCan: 3
@@ -9,6 +9,8 @@
     DrinkLemonLimeCan: 3
     DrinkLemonLimeCranberryCan: 3
     DrinkFourteenLokoCan: 3
+  contrabandInventory:
+    DrinkColaBottleFull: 2
   emaggedInventory:
     DrinkNukieCan: 3
     DrinkChangelingStingCan: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sovietsoda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sovietsoda.yml
@@ -3,4 +3,6 @@
   startingInventory:
     DrinkSodaWaterCan: 10 #typically hacked product. Default product is "soda"
   contrabandInventory:
+    DrinkSodaWaterBottleFull: 2
     DrinkColaCan: 10
+    ClothingHeadHatUshanka: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
@@ -1,4 +1,4 @@
-﻿- type: vendingMachineInventory
+- type: vendingMachineInventory
   id: SpaceUpInventory
   startingInventory:
     DrinkSpaceUpCan: 3
@@ -10,6 +10,9 @@
     DrinkLemonLimeCan: 2
     DrinkLemonLimeCranberryCan: 2
     DrinkFourteenLokoCan: 2
+  contrabandInventory:
+    DrinkSpaceMountainWindBottleFull: 2
+    DrinkSpaceUpBottleFull: 2
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
@@ -1,4 +1,4 @@
-﻿- type: vendingMachineInventory
+- type: vendingMachineInventory
   id: StarkistInventory
   startingInventory:
     DrinkStarkistCan: 4
@@ -9,6 +9,8 @@
     DrinkLemonLimeCan: 2
     DrinkLemonLimeCranberryCan: 2
     DrinkFourteenLokoCan: 2
+  contrabandInventory:
+    FoodMealSashimi: 2
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
@@ -10,7 +10,7 @@
     DrinkLemonLimeCranberryCan: 2
     DrinkFourteenLokoCan: 2
   contrabandInventory:
-    FoodMealSashimi: 2
+    FoodBurgerCarp: 2
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -5,6 +5,8 @@
     FoodSnackNutribrick: 5
     FoodSnackMREBrownie: 5
     FoodCondimentPacketKetchup: 5
+  contrabandInventory:
+    DrinkBeerCan: 3
   emaggedInventory:
     KitchenKnife: 2
     ClothingMaskBreath: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -6,7 +6,10 @@
     FoodSnackMREBrownie: 5
     FoodCondimentPacketKetchup: 5
   contrabandInventory:
-    DrinkBeerCan: 3
+    FoodTinMRE: 3
+    FoodTinBeans: 3
+    FoodTinPeaches: 3
+    DrinkBeerCan: 6
   emaggedInventory:
     KitchenKnife: 2
     ClothingMaskBreath: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/syndiedrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/syndiedrobe.yml
@@ -15,7 +15,10 @@
     ClothingNeckScarfStripedSyndieGreen: 2
     ClothingNeckScarfStripedSyndieRed: 2
     ClothingShoesBootsWinterSyndicate: 2
-    
+  contrabandInventory:
+    ToyFigurineFootsoldier: 1
+    ToyFigurineNukieElite: 1
+    ToyFigurineNukieCommander: 1
   emaggedInventory:
     ClothingOuterCoatSyndieCapArmored: 1
     ClothingOuterWinterSyndieCapArmored: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -55,6 +55,10 @@
     ClothingShoesBootsCowboyBrown: 1
     ClothingShoesBootsCowboyBlack: 1
     ClothingShoesBootsCowboyWhite: 1
+  contrabandInventory:
+    ClothingHeatHatRichard: 1
+    ToyFigurineBoxer: 1
+    ToyFigurineMusician: 1
   emaggedInventory:
     ClothingShoesBling: 1
     ClothingShoesBootsCowboyFancy: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -56,7 +56,7 @@
     ClothingShoesBootsCowboyBlack: 1
     ClothingShoesBootsCowboyWhite: 1
   contrabandInventory:
-    ClothingHeatHatRichard: 1
+    ClothingHeadHatRichard: 1
     ToyFigurineBoxer: 1
     ToyFigurineMusician: 1
   emaggedInventory:

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
@@ -10,3 +10,5 @@
     MatterBinStockPart: 4
     CapacitorStockPart: 4
     MicroManipulatorStockPart: 4
+  contrabandInventory:
+    KitchenKnife: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
@@ -11,4 +11,5 @@
     CapacitorStockPart: 4
     MicroManipulatorStockPart: 4
   contrabandInventory:
-    NetworkConfigurator: 1
+    ProximitySensor: 1
+    LeftArmBorg: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
@@ -11,4 +11,4 @@
     CapacitorStockPart: 4
     MicroManipulatorStockPart: 4
   contrabandInventory:
-    KitchenKnife: 1
+    Scalpel: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
@@ -11,5 +11,4 @@
     CapacitorStockPart: 4
     MicroManipulatorStockPart: 4
   contrabandInventory:
-    ProximitySensor: 1
-    LeftArmBorg: 1
+    NetworkConfigurator: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
@@ -11,4 +11,4 @@
     CapacitorStockPart: 4
     MicroManipulatorStockPart: 4
   contrabandInventory:
-    Scalpel: 1
+    NetworkConfigurator: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
@@ -6,3 +6,5 @@
     Bloodpack: 3
     EpinephrineChemistryBottle: 3
     Syringe: 3
+  contrabandInventory:
+    PowerCellSmall: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
@@ -16,5 +16,6 @@
   # Some engineer forgot to take the multitool out the youtool when working on it, happens.
   contrabandInventory:
     Multitool: 1
+    CowToolboxFilled: 1
   emaggedInventory:
     ClothingHandsGlovesColorYellow: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
@@ -16,6 +16,5 @@
   # Some engineer forgot to take the multitool out the youtool when working on it, happens.
   contrabandInventory:
     Multitool: 1
-    CowToolboxFilled: 1
   emaggedInventory:
     ClothingHandsGlovesColorYellow: 1


### PR DESCRIPTION
## About the PR
I've added contrabandInventory menus, the kind that you access by manipulating the "Manager" wire on vending machines, to nearly every vending machine SS14. This is the second attempt, the first pull request had a merge conflict that required me to redo this process. [You can see the previous PR here.](https://github.com/space-wizards/space-station-14/pull/32911)

## Why / Balance
contrabandInventory is a woefully under-explored mechanic in SS14, and I wanted to take advantage if the world-building, flavour and gameplay opportunities available from populating these secret menus.

To note, beyond securing the equipment, hacking a vending machine isn't hard once you locate the Manager Wire in any given round. There are a few goals I have in mind:

1. The items inside of the machines should be faithful to what those machines are.
2. The items inside of the machines should raise questions about the SS14 universe, the corporations behind these machines, and what happened on the space station before the crew arrived on disaster day.
3. None of these items should become meta. If a vending machine begs to be hacked every shift, the items inside are too powerful.
4. The items shouldn't be high-end prestige items, but they should be interesting.
5. The vending machine stocks should never invalidate the role of Cargo in station function.

Two major changes of note:
First, Changeling Sting has been removed from the Shamblers EMAG menu, and Syndi-Cakes has been removed from the GetMore EMAG menu, to move those items to their contrabandInventory menus.
Second, figurines have been placed in their revelevant Drobe machines.

My reasoning for adding figurines to the machines is as follows:

1. It removes a lot of weight from purchasing figurines from Cargo, which is a fairly frivolous purchase, and makes obtaining a full crew set much more reasonable.
2. It gives a reason for innocent people to trespass or seek permission to hack Drobes for roleplaying purposes. It makes every department a bit less secure, which is fun for antags and an added joy for Security.
3. It can allow us to return the figurine objective back to Thief by making obtaining figurines accessible by hacking a crap-ton of Drobes across the station. It adds an element to thief gameplay that is interesting and different, but isn't in itself illegal.
4. Toys are fun, seeing more figures is part of what makes Cog interesting in its design, I'd love to see them show up more often.
5. This makes the Cargo figurine bounty much less awful to accomplish by making it reasonable to complete for knowledgeable players.

## Technical details
I went through every vending machine .yml file, added a "contrabandInventory:" line if there wasn't one, then added each item for those menus. I kept formatting consistent with the currently .yml files.

## Media
[Here is a new and revised video](https://youtu.be/xI2oJzyzJ84?si=FFCIIzYQcvv6VMxH) of how to access the contrabandInventory menu, and showing every vending machine contrabandInventory menu. EMAG menus not included. Video uploaded to YouTube due to file size, video is approximately 5 minutes long. Alternatively you can look at the Files changed menu on the top bar of this PR, and see every list directly from the .yml files, highlighted for your convenience.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
Previous merge conflict resolved, and this shouldn't interfere with other PR's I've seen.

**Changelog**
:cl: AgentSmithRadio
- add: Added manager wire hacking menus to nearly all vending machines. Get hacking and see what's hidden!