### PR TITLE
Fix Emote Chat Sanitizer

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -35,7 +35,7 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { ":D", "chatsan-smiles-widely" },
         { "D:", "chatsan-frowns-deeply" },
         { ":O", "chatsan-surprised" },
-        { ":3", "chatsan-smiles" }, //nope
+        { ":3", "chatsan-smiles" },
         { ":S", "chatsan-uncertain" },
         { ":>", "chatsan-grins" },
         { ":<", "chatsan-pouts" },

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -746,15 +746,12 @@ public sealed partial class ChatSystem : SharedChatSystem
     // ReSharper disable once InconsistentNaming
     private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool punctuate = false, bool capitalizeTheWordI = true)
     {
-        var newMessage = message.Trim();
-        newMessage = SanitizeMessageReplaceWords(newMessage);
+        var newMessage = SanitizeMessageReplaceWords(message.Trim());
 
-        GetRadioPrefix(source, message, out newMessage, out var prefix);
+        GetRadioKeycodePrefix(source, newMessage, out newMessage, out var prefix);
 
         // Sanitize it first as it might change the word order
         _sanitizer.TrySanitizeEmoteShorthands(newMessage, source, out newMessage, out emoteStr);
-
-        newMessage = prefix + newMessage;
 
         if (capitalize)
             newMessage = SanitizeMessageCapital(newMessage);
@@ -763,7 +760,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         if (punctuate)
             newMessage = SanitizeMessagePeriod(newMessage);
 
-        return newMessage;
+        return prefix + newMessage;
     }
 
     private string SanitizeInGameOOCMessage(string message)

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -749,8 +749,12 @@ public sealed partial class ChatSystem : SharedChatSystem
         var newMessage = message.Trim();
         newMessage = SanitizeMessageReplaceWords(newMessage);
 
+        GetRadioPrefix(source, message, out newMessage, out var prefix);
+
         // Sanitize it first as it might change the word order
         _sanitizer.TrySanitizeEmoteShorthands(newMessage, source, out newMessage, out emoteStr);
+
+        newMessage = prefix + newMessage;
 
         if (capitalize)
             newMessage = SanitizeMessageCapital(newMessage);

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -92,7 +92,7 @@ public abstract class SharedChatSystem : EntitySystem
         output = input;
         prefix = string.Empty;
 
-        if (input.StartsWith(RadioCommonPrefix))
+        if (input.StartsWith(RadioCommonPrefix) && input.Length < 1)
         {
             output = input[1..];
             prefix = input[..1];
@@ -102,15 +102,11 @@ public abstract class SharedChatSystem : EntitySystem
         if (!(input.StartsWith(RadioChannelPrefix) || input.StartsWith(RadioChannelAltPrefix)))
             return;
 
-        if (input.Length < 2 || char.IsWhiteSpace(input[1]))
+        if (_keyCodes.TryGetValue(input[1], out _) || char.IsWhiteSpace(input[1]))
         {
-            output = input[1..];
-            prefix = input[..1];
-            return;
+            output = input[2..];
+            prefix = input[..2];
         }
-
-        output = input[2..];
-        prefix = input[..2];
     }
 
     /// <summary>

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -92,11 +92,9 @@ public abstract class SharedChatSystem : EntitySystem
         output = input;
         prefix = string.Empty;
 
-        // Lets ;P pass as it will just throw it into chatsan unless it's smaller (;-; or ;))
-        if (input.StartsWith(RadioCommonPrefix) && input.Length < 3)
+        if (input.StartsWith(RadioCommonPrefix))
         {
-            output = input[1..];
-            prefix = input[..1];
+            // Charsan will handle this properly as ;) => ;) and ;shoot => ;shoot
             return;
         }
 

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -84,6 +84,35 @@ public abstract class SharedChatSystem : EntitySystem
         return current ?? _prototypeManager.Index<SpeechVerbPrototype>(speech.SpeechVerb);
     }
 
+    public void GetRadioPrefix(EntityUid source,
+        string input,
+        out string output,
+        out string prefix)
+    {
+        output = input;
+        prefix = string.Empty;
+
+        if (input.StartsWith(RadioCommonPrefix))
+        {
+            output = input[1..];
+            prefix = input[..1];
+            return;
+        }
+
+        if (!(input.StartsWith(RadioChannelPrefix) || input.StartsWith(RadioChannelAltPrefix)))
+            return;
+
+        if (input.Length < 2 || char.IsWhiteSpace(input[1]))
+        {
+            output = input[1..];
+            prefix = input[..1];
+            return;
+        }
+
+        output = input[2..];
+        prefix = input[..2];
+    }
+
     /// <summary>
     ///     Attempts to resolve radio prefixes in chat messages (e.g., remove a leading ":e" and resolve the requested
     ///     channel. Returns true if a radio message was attempted, even if the channel is invalid.

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -92,7 +92,8 @@ public abstract class SharedChatSystem : EntitySystem
         output = input;
         prefix = string.Empty;
 
-        if (input.StartsWith(RadioCommonPrefix) && input.Length < 1)
+        // Lets ;P pass as it will just throw it into chatsan unless it's smaller (;-; or ;))
+        if (input.StartsWith(RadioCommonPrefix) && input.Length < 3)
         {
             output = input[1..];
             prefix = input[..1];
@@ -102,6 +103,7 @@ public abstract class SharedChatSystem : EntitySystem
         if (!(input.StartsWith(RadioChannelPrefix) || input.StartsWith(RadioChannelAltPrefix)))
             return;
 
+        // lets :) pass as ")" isn't valid key
         if (_keyCodes.TryGetValue(input[1], out _) || char.IsWhiteSpace(input[1]))
         {
             output = input[2..];

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -94,7 +94,7 @@ public abstract class SharedChatSystem : EntitySystem
 
         if (input.StartsWith(RadioCommonPrefix))
         {
-            // Charsan will handle this properly as ;) => ;) and ;shoot => ;shoot
+            // Chatsan will handle this properly as ;) => *winks* and ;shoot => ;shoot
             return;
         }
 
@@ -102,6 +102,7 @@ public abstract class SharedChatSystem : EntitySystem
             return;
 
         // lets :) pass as ")" isn't valid key
+        // :c => *emote*; ":c hi" = :c + "hi"
         if (_keyCodes.TryGetValue(input[1], out _) || char.IsWhiteSpace(input[1]))
         {
             output = input[2..];

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -84,30 +84,33 @@ public abstract class SharedChatSystem : EntitySystem
         return current ?? _prototypeManager.Index<SpeechVerbPrototype>(speech.SpeechVerb);
     }
 
-    public void GetRadioPrefix(EntityUid source,
+    /// <summary>
+    /// Splits the input message into a radio prefix part and the rest to preserve it during sanitization.
+    /// </summary>
+    /// <remarks>
+    /// This is primarily for the chat emote sanitizer, which can match against ":b" as an emote, which is a valid radio keycode.
+    /// </remarks>
+    public void GetRadioKeycodePrefix(EntityUid source,
         string input,
         out string output,
         out string prefix)
     {
-        output = input;
         prefix = string.Empty;
+        output = input;
 
-        if (input.StartsWith(RadioCommonPrefix))
-        {
-            // Chatsan will handle this properly as ;) => *winks* and ;shoot => ;shoot
+        // If the string is less than 2, then it's probably supposed to be an emote.
+        // No one is sending empty radio messages!
+        if (input.Length <= 2)
             return;
-        }
 
         if (!(input.StartsWith(RadioChannelPrefix) || input.StartsWith(RadioChannelAltPrefix)))
             return;
 
-        // lets :) pass as ")" isn't valid key
-        // :c => *emote*; ":c hi" = :c + "hi"
-        if (_keyCodes.TryGetValue(input[1], out _) || char.IsWhiteSpace(input[1]))
-        {
-            output = input[2..];
-            prefix = input[..2];
-        }
+        if (!_keyCodes.TryGetValue(input[1], out _))
+            return;
+
+        prefix = input[..2];
+        output = input[2..];
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes bug introduced in #28645.

This fixes a bug with the previous emote sanitizer as it erroneously sanitized short0hands used for radio communication (ex. ":u" and ":s"). 

This has been fixed by excluding the radio prefixes from all sanitization methods.

## Technical details

I can't make the chat code any worse, right?

The chat sanitizer works correctly for all cases except the case for the actual radio keycodes, so I just selectively split the string on them so that the radio part is saved separately and re-added at the end of sanitization.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

No pictures/videos as it's just basic functionality.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

no cl, me fixing my own bug :(