### PR TITLE
Fix loneop spawnrate by reverting it to not use the shuttle event system.

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -35,6 +35,7 @@
     - id: RevenantSpawn
     - id: SleeperAgents
     - id: ZombieOutbreak
+    - id: LoneOpsSpawn
 
 - type: entity
   id: BaseStationEvent
@@ -451,7 +452,7 @@
     duration: 1
   - type: RuleGrids
   - type: LoadMapRule
-    preloadedGrid: ShuttleStriker
+    mapPath: /Maps/Shuttles/ShuttleEvent/striker.yml
   - type: NukeopsRule
     roundEndBehavior: Nothing
   - type: AntagSelection

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -20,7 +20,6 @@
     - id: UnknownShuttleMeatZone
     - id: UnknownShuttleMicroshuttle
     - id: UnknownShuttleSpacebus
-    - id: UnknownShuttleInstigator
 
 - type: entityTable
   id: UnknownShuttlesFreelanceTable
@@ -32,9 +31,9 @@
   id: UnknownShuttlesHostileTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
-    - id: LoneOpsSpawn
+    - id: UnknownShuttleInstigator
 
-# Shuttle Game Rules 
+# Shuttle Game Rules
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
+++ b/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
@@ -1,9 +1,4 @@
 - type: preloadedGrid
-  id: ShuttleStriker
-  path: /Maps/Shuttles/ShuttleEvent/striker.yml
-  copies: 2
-
-- type: preloadedGrid
   id: ShuttleCargoLost
   path: /Maps/Shuttles/ShuttleEvent/lost_cargo.yml
   copies: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reverts the LoneOp midround antag to use the old events system instead of the new shuttle one, since the shuttle event system means loneops are INCREDIBLY rare.

Also, I moved the instigator to the hostile table since it is NOT a friendly shuttle.

## Why / Balance
I can understand this rarity for for example an instigator shuttle or other niche antag shuttles, but not for loneops which are key antags the game has. So they should now follow their previous rarity and conditions, alongside no longer being limited to a maximum of 2.

If we want to tweak those numbers later on in another PR, thats fine, but since it was essentially a stealth effect of #24490, I believe it should be reverted and possibly later looked at in more detail.

## Technical details
Just reverted it to the old system.

## Media
Unneccesary

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: BramvanZijp
- fix: Fixed the Lone Nuclear Operative mid-round antagonist being extremely rare.
