### PR TITLE
Reduce Syndicate Raid Suit / Syndicate Elite Hardsuit slow to 5%

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -125,8 +125,8 @@
   - type: ExplosionResistance
     damageCoefficient: 0.35
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.95
+    sprintModifier: 0.95
   #Shoulder mounted flashlight
   - type: ToggleableLightVisuals
     spriteLayer: light

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -563,8 +563,8 @@
   - type: Item
     size: Huge
   - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 0.9
+    walkModifier: 0.95
+    sprintModifier: 0.95
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reduces Syndicate Raid Suit and Elite Hardsuit walk/run slowdown to 5%.

## Why / Balance
This corrects the minor clerical error in the uplink, stating the elite suit has "better mobility" than the standard bloodred, as well as adding additional incentive to buy the elite suit in the first place. As for the raid suit, I'd think it approximate to the webvest in mobility - trading a slight bit of speed for more armour. Also, this makes it faster than a bloodred (hardsuits being static, metal suits with built in joints).
As with both, 8/12 TC is a significant part of a Nukie's loadout (traitors, even more so), so there should be genuine benefit to these suits.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: FloatingFeeling
- tweak: The Raid Suit and Elite Hardsuit slow has been reduced from 10% to 5%.
