### PR TITLE
make emergency lights (de)constructable

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -43,7 +43,7 @@
   - type: RCDDeconstructable
     cost: 4
     delay: 2
-    fx: EffectRCDDeconstruct2  
+    fx: EffectRCDDeconstruct2
   - type: Destructible
     thresholds:
     - trigger:
@@ -74,7 +74,7 @@
     mode: SnapgridCenter
     snap:
     - Wallmount
-    
+
 - type: entity
   name: light
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
@@ -400,6 +400,37 @@
       shader: "unshaded"
       visible: false
   - type: Appearance
+  - type: Construction
+    graph: LightFixture
+    node: emergencyLight
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors: #excess damage, don't spawn entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
+    - trigger:
+        !type:DamageTrigger
+        damage: 25
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 1
+          ShardGlass:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
   placement:
     mode: SnapgridCenter
     snap:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/lighting.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/lighting.yml
@@ -24,6 +24,14 @@
             - material: Steel
               amount: 1
               doAfter: 2.0
+        - to: emergencyLight
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 1.0
+            - material: Glass
+              amount: 1
+              doAfter: 1.0
     - node: tubeLight
       entity: PoweredlightEmpty
       edges:
@@ -82,5 +90,20 @@
           completed:
             - !type:SpawnPrototype
               prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+    - node: emergencyLight
+      entity: EmergencyLight
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:SpawnPrototype
+              prototype: SheetGlass1
               amount: 1
             - !type:DeleteEntity {}

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -1457,6 +1457,24 @@
     - !type:TileNotBlocked
 
 - type: construction
+  name: emergency light
+  id: EmergencyLightFixture
+  graph: LightFixture
+  startNode: start
+  targetNode: emergencyLight
+  category: construction-category-structures
+  description: An emergency light.
+  icon:
+    sprite: Structures/Wallmounts/Lighting/emergency_light.rsi
+    state: base
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
   name: ground light post
   id: LightGroundFixture
   graph: LightFixture


### PR DESCRIPTION
* add an emergency light node to the LightFixture construction graph
* add a recipe entry to the construction menu for emergency light
* make emergency light entity at the emergency light node on the graph

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I made emergency lights constructible and deconstructible.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
When I was playing the game, I right clicked an emergency light and there was an option to "Begin Deconstructing". which I clicked, and then I examined the emergency light and it said to use a screwdriver next. But when I went to do that, nothing happened. It turns out this examine shows up I think because the parent of the emergency light entity has it at the light tube point on the light fixture construction graph by default. So, being annoyed, I went and looked up how to code for ss14 to fix this. The recipe is one steel and one glass, and I figure since the emergency light looks almost exactly like the empty light fixture, just adding glass to the recipe would be fine. It's a pretty simple (and very small) looking structure with not much use so I think it would be overkill to require using a lathe to print an emergency light like with the other wall lights like bulbs and tubes. 

## Technical details
<!-- Summary of code changes for easier review. -->
I fixed it by adding a new node on the light fixture graph for emergency lights. This only required changing the yamls to:
* add a construction node for emergency lights in light fixture graph
* add the recipe to the construction menu
* emergency light entity construction component set to this new node

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Emergency lights can be constructed and deconstructed
