### PR TITLE
Lower in-round votekick requirements

### DIFF
--- a/Content.Client/Voting/UI/VoteCallMenu.xaml.cs
+++ b/Content.Client/Voting/UI/VoteCallMenu.xaml.cs
@@ -62,7 +62,7 @@ namespace Content.Client.Voting.UI
 
             Stylesheet = IoCManager.Resolve<IStylesheetManager>().SheetSpace;
             CloseButton.OnPressed += _ => Close();
-            VoteNotTrustedLabel.Text = Loc.GetString("ui-vote-trusted-users-notice", ("timeReq", _cfg.GetCVar(CCVars.VotekickEligibleVoterDeathtime) / 60));
+            VoteNotTrustedLabel.Text = Loc.GetString("ui-vote-trusted-users-notice", ("timeReq", _cfg.GetCVar(CCVars.VotekickEligibleVoterDeathtime)));
 
             foreach (StandardVoteType voteType in Enum.GetValues<StandardVoteType>())
             {

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1448,7 +1448,7 @@ namespace Content.Shared.CCVar
         ///     Config for when the votekick should be allowed to be called based on number of eligible voters.
         /// </summary>
         public static readonly CVarDef<int> VotekickEligibleNumberRequirement =
-            CVarDef.Create("votekick.eligible_number", 10, CVar.SERVERONLY);
+            CVarDef.Create("votekick.eligible_number", 5, CVar.SERVERONLY);
 
         /// <summary>
         ///     Whether a votekick initiator must be a ghost or not.
@@ -1472,7 +1472,7 @@ namespace Content.Shared.CCVar
         ///     Config for how many seconds a player must have been dead to initiate a votekick / be able to vote on a votekick.
         /// </summary>
         public static readonly CVarDef<int> VotekickEligibleVoterDeathtime =
-            CVarDef.Create("votekick.voter_deathtime", 180, CVar.REPLICATED | CVar.SERVER);
+            CVarDef.Create("votekick.voter_deathtime", 30, CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
         ///     The required ratio of eligible voters that must agree for a votekick to go through.

--- a/Resources/Locale/en-US/voting/ui/vote-call-menu.ftl
+++ b/Resources/Locale/en-US/voting/ui/vote-call-menu.ftl
@@ -26,7 +26,7 @@ ui-vote-type-not-available = This vote type has been disabled
 # Vote option only available for specific users.
 ui-vote-trusted-users-notice =
   This vote option is only available to whitelisted players.
-  In addition, you must have been a ghost for { $timeReq } minutes.
+  In addition, you must have been a ghost for { $timeReq } seconds.
 
 # Warning to not abuse a specific vote option.
 ui-vote-abuse-warning =


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR lowers the *in-round* votekick requirements;
- Eligible voters requirement: 10 -> 5
- Ghost time requirement for eligibility: 180 -> 30 seconds

It also changes a "minutes" to "seconds" in the votekick notice text, as the text didn't support decimals.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The initial values were set too high, making votekicking very unlikely to happen. This will be a monitored test to see if lowered in-round requirements will help, and to check for false positives.

## Technical details
<!-- Summary of code changes for easier review. -->

Changed cvars, edited the vote eligibility string (and accompanying .ftl) from minutes to seconds.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl