### PR TITLE
CMO Hardsuit Protection Buff

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -366,7 +366,7 @@
         Heat: 0.65
         Radiation: 0.6
         Caustic: 0
-        Genetic: 0.5
+        Cellular: 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.95

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -355,10 +355,18 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.70
   - type: Armor
     modifiers:
       coefficients:
-        Caustic: 0.1
+        Blunt: 0.8
+        Slash: 0.75
+        Piercing: 0.9
+        Heat: 0.65
+        Radiation: 0.6
+        Caustic: 0
+        Genetic: 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.95

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -368,8 +368,8 @@
         Caustic: 0
         Cellular: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.95
+    walkModifier: 0.85
+    sprintModifier: 0.90
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMedical


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The following changes have been made to the CMOs Hardsuit.
Blunt: 0% > 20%
Slash: 0% > 25%
Piercing: 0% > 10%
Heat: 0% > 35%
Radiation: 0% > 40%
Caustic: 90% > 100%
Cellular: 0% > 50%
Explosive: 0% > 30%

Walk Slowdown: 10% > 15%
Sprint Slowdown: 5% > 10%

## Why / Balance
Because there is no reason for a HARDsuit to not protect you at all unless its made out of literal fucking plastic. (It just being made out of cheap plastic is now my headcanon for why it currently offers literally no protection against anything other then caustic.)
Also, caustic immunity makes sense if CE can be radiation immune, and RD can be p much explosive immune.
Lastly, the cellular resist will be nice for slimes or if #32136 gets merged assuming its cellular damage is changed to be effected by armor, since then the CMO will have specialized gear to not take nearly as much cellular damage from an implanter failure.

## Media
Not Neccesary.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
- tweak: The Chief Medical Officers Hardsuit now slightly protects the wearer, alongside making them immune to caustic substances and reducing genetic damage from external sources, but makes the wearer slightly slower.