### PR TITLE
Meta map: remove arrivals chair, changed maints shotgun to beanbag rounds

### DIFF
--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -10880,7 +10880,7 @@ entities:
       pos: -42.5,29.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -5745.716
+      secondsUntilStateChange: -5834.8745
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 2
@@ -56105,11 +56105,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -73.5,7.5
-      parent: 5350
-  - uid: 6164
-    components:
-    - type: Transform
-      pos: -71.5,-8.5
       parent: 5350
   - uid: 6165
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Removed chair in arrivals that would block a firelock
- Maints DB shotgun to be loaded with beanbags instead of lethal shells

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Chair blocking firelock and causing spacing is bad

Shotgun in secret room now won't let you powergame and ruin an antag run 10 minutes into a shift

This is my first mapping PR, please leave feedback or let me know if my PR will break the map

## Technical details
<!-- Summary of code changes for easier review. -->
yml changes only

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/bd607c93-31f0-4a84-8e6d-db8ffc1b9f2b)

![image](https://github.com/user-attachments/assets/dcab6c15-3cd6-47fb-a652-f4003896cf24)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

N/A