### PR TITLE
Reloading in-hand weapon with ammo provider now attempts ammo counter update

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -147,7 +147,6 @@ public abstract partial class SharedGunSystem
                 // play sound to be cool
                 Audio.PlayPredicted(component.SoundInsert, uid, args.User);
                 SimulateInsertAmmo(ent.Value, args.Target.Value, Transform(args.Target.Value).Coordinates);
-
             }
 
             if (IsClientSide(ent.Value))

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -119,7 +119,7 @@ public abstract partial class SharedGunSystem
         {
             var evInsert = new InteractUsingEvent(args.User, ammo, ammoProvider, coordinates);
             RaiseLocalEvent(ammoProvider, evInsert);
-            UpdateAmmoCount(ammoProvider);
+
         }
 
         List<(EntityUid? Entity, IShootable Shootable)> ammo = new();
@@ -151,6 +151,7 @@ public abstract partial class SharedGunSystem
             }
 
             if (IsClientSide(ent.Value))
+                UpdateAmmoCount(args.Target.Value);
                 Del(ent.Value);
         }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -119,6 +119,7 @@ public abstract partial class SharedGunSystem
         {
             var evInsert = new InteractUsingEvent(args.User, ammo, ammoProvider, coordinates);
             RaiseLocalEvent(ammoProvider, evInsert);
+            UpdateAmmoCount(ammoProvider);
         }
 
         List<(EntityUid? Entity, IShootable Shootable)> ammo = new();
@@ -146,10 +147,10 @@ public abstract partial class SharedGunSystem
                 // play sound to be cool
                 Audio.PlayPredicted(component.SoundInsert, uid, args.User);
                 SimulateInsertAmmo(ent.Value, args.Target.Value, Transform(args.Target.Value).Coordinates);
+
             }
 
             if (IsClientSide(ent.Value))
-                UpdateAmmoCount(args.Target.Value);
                 Del(ent.Value);
         }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -146,6 +146,7 @@ public abstract partial class SharedGunSystem
                 // play sound to be cool
                 Audio.PlayPredicted(component.SoundInsert, uid, args.User);
                 SimulateInsertAmmo(ent.Value, args.Target.Value, Transform(args.Target.Value).Coordinates);
+                UpdateAmmoCount(args.Target.Value);
             }
 
             if (IsClientSide(ent.Value))

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -119,6 +119,7 @@ public abstract partial class SharedGunSystem
         {
             var evInsert = new InteractUsingEvent(args.User, ammo, ammoProvider, coordinates);
             RaiseLocalEvent(ammoProvider, evInsert);
+            UpdateAmmoCount(ammoProvider);
         }
 
         List<(EntityUid? Entity, IShootable Shootable)> ammo = new();
@@ -146,7 +147,7 @@ public abstract partial class SharedGunSystem
                 // play sound to be cool
                 Audio.PlayPredicted(component.SoundInsert, uid, args.User);
                 SimulateInsertAmmo(ent.Value, args.Target.Value, Transform(args.Target.Value).Coordinates);
-                UpdateAmmoCount(args.Target.Value);
+
             }
 
             if (IsClientSide(ent.Value))

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -119,7 +119,6 @@ public abstract partial class SharedGunSystem
         {
             var evInsert = new InteractUsingEvent(args.User, ammo, ammoProvider, coordinates);
             RaiseLocalEvent(ammoProvider, evInsert);
-
         }
 
         List<(EntityUid? Entity, IShootable Shootable)> ammo = new();
@@ -147,7 +146,6 @@ public abstract partial class SharedGunSystem
                 // play sound to be cool
                 Audio.PlayPredicted(component.SoundInsert, uid, args.User);
                 SimulateInsertAmmo(ent.Value, args.Target.Value, Transform(args.Target.Value).Coordinates);
-
             }
 
             if (IsClientSide(ent.Value))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added an extra ammoCount update to reloading weapons with ammo provider so now the hot bar ammo is updates before firing.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #28550.
## Technical details
<!-- Summary of code changes for easier review. -->
Added UpdateAmmoCount to SimulateInsertAmmo in OnBallisticAmmoFillDoAfter.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:

https://github.com/user-attachments/assets/e1d0fc0a-4fa4-478d-8c69-d9b7e0e85bcc

After:

https://github.com/user-attachments/assets/8e901923-6b0d-4424-8d7e-5dcdcc848cbf


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--:cl:
TheKittehJesus:
- fix: Reloading shotguns with cartridges now accurately updates the hotbar ammo count. -->
Small fix, no changelog needed
