### PR TITLE
Removed bola stam damage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -44,7 +44,7 @@
     breakoutTime: 3.5 #all bola should generally be fast to remove
     walkSpeed: 0.7 #makeshift bola shouldn't slow too much
     sprintSpeed: 0.7
-    staminaDamage: 55 # Sudden weight increase sapping stamina
+    staminaDamage: 0 # anything but this is gamebreaking
     canThrowTrigger: true
     canMoveBreakout: true
   - type: LandAtCursor

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -42,8 +42,8 @@
   - type: Ensnaring
     freeTime: 2.0
     breakoutTime: 3.5 #all bola should generally be fast to remove
-    walkSpeed: 0.7 #makeshift bola shouldn't slow too much
-    sprintSpeed: 0.7
+    walkSpeed: 0.5 #makeshift bola shouldn't slow too much
+    sprintSpeed: 0.5
     staminaDamage: 0 # anything but this is gamebreaking
     canThrowTrigger: true
     canMoveBreakout: true


### PR DESCRIPTION
Bola stam damage consistently allows for a 0.5 second stun, this can be done in 5 or 6 ways with different items, its bad for combat.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed bola stam damage

## Why / Balance
Bola + Baton / prod throw (wall bounce) = 0.5 second stun
Bola + Prod throw = 1 second stun
Bola + Boxing gloves = 2-3 second stun
Bola + Rigged gloves = ~1 second stun
There are several other combos that are absolutely disgusting, this on top of the fact that you can bind remove from backpack and throw to the same key to insta launch bolas without warning makes them a mess. A solution that would also be fine is giving them some sort of slowdown from taking from bag to throwing. IIRC they do not even have an in-hand sprite.

**Changelog**
:cl: remove bola stam damage