### PR TITLE
Update Sap to Syrup conversion

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
@@ -26,12 +26,12 @@
   minTemp: 377
   reactants:
     Sap:
-      amount: 1.2
+      amount: 1
   effects:
   - !type:CreateGas
     gas: WaterVapor
   products:
-    Syrup: 0.1 #12:1 sap to syruop
+    Syrup: 0.5 #2:1 sap to syrup, you don't want to kill a diona for one pancake
 
 # Holy - TODO: make it so only the chaplain can use the bible to start these reactions, not anyone with a bible
 


### PR DESCRIPTION
## About the PR
Change Sap to Syrup conversion rate 

## Why / Balance
12 to 1 syrup is quite abysmal for a conversion rate for a flavor-only liquid, also you don't want to kill-murder a Diona for your pancake.

## Media

N/A


**Changelog**

:cl:
- add: Added Syrup!
- remove: Removed bleeding dry Diona!
- tweak: Changed Conversion rate!

