### PR TITLE
Sap-Syrup balance

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
@@ -26,12 +26,12 @@
   minTemp: 377
   reactants:
     Sap:
-      amount: 1.2
+      amount: 1
   effects:
   - !type:CreateGas
     gas: WaterVapor
   products:
-    Syrup: 0.1 #12:1 sap to syruop
+    Syrup: 0.5 #2:1 sap to syrup, killing diona for pancakes isn't really fun
 
 # Holy - TODO: make it so only the chaplain can use the bible to start these reactions, not anyone with a bible
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Change the Sap-Syrup conversion rate from 12:1 to 2:1

## Why / Balance
12 to 1 syrup is quite abysmal for a conversion rate for a flavor-only liquid, also you don't want to kill-murder a Diona for your pancake because there is no other way to get sap.

## Technical details
Change a few numerical value

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase. (not needed)
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Not that i'm aware, i know code witchcraft sometime act up and might cause problems on totally unrelated code sections

**Changelog**
:cl:
- tweak: Changed Sap-Syrup conversion value.