### PR TITLE
Removed the name "Hujsak"

### DIFF
--- a/Resources/Prototypes/Datasets/Names/last.yml
+++ b/Resources/Prototypes/Datasets/Names/last.yml
@@ -219,7 +219,6 @@
   - Howe
   - Huey
   - Hughes
-  - Hujsak
   - Hunt
   - Hunter
   - Hussain


### PR DESCRIPTION
## About the PR/Why
A player complained to me about another player with the surname Hujsak, which seems to sound out as Huge Sack. When I asked them they informed me it was a default name, and after looking through the last-name pool it turns out they weren't lying.

In addition, this name only seems to have 90 people in the entire planet who has it, which by name standards is almost nonexistent.
![image](https://github.com/user-attachments/assets/4cb3aaed-3d4f-45ea-8cc3-02308cf1834b)

*Why the fuck is this in the game?*

## Technical details
All this PR does is remove a name from `last.yml`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no
