### PR TITLE
Adds vox box station beacon

### DIFF
--- a/Resources/Locale/en-US/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/navmap-beacons/station-beacons.ftl
@@ -73,4 +73,4 @@ station-beacon-tools = Tools
 station-beacon-disposals = Disposals
 station-beacon-cryosleep = Cryosleep
 station-beacon-escape-pod = Escape Pod
-station-beacon-vox-box = Vox Box
+station-beacon-vox = Vox Break Room

--- a/Resources/Locale/en-US/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/navmap-beacons/station-beacons.ftl
@@ -73,3 +73,4 @@ station-beacon-tools = Tools
 station-beacon-disposals = Disposals
 station-beacon-cryosleep = Cryosleep
 station-beacon-escape-pod = Escape Pod
+station-beacon-vox-box = Vox Box

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -646,4 +646,4 @@
   suffix: Vox
   components:
   - type: NavMapBeacon
-    defaultText: station-beacon-vox-box
+    defaultText: station-beacon-vox

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -639,3 +639,11 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-escape-pod
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconVox
+  suffix: Vox
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-vox-box


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Self explanatory. Added the beacon to maps in their individual PRs

## Why / Balance
Vox boxes didnt show up in the map

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: You can now find vox break rooms through the station's map.
