### PR TITLE
Fix cursed mask bug

### DIFF
--- a/Content.Server/Clothing/Systems/CursedMaskSystem.cs
+++ b/Content.Server/Clothing/Systems/CursedMaskSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Ghost;
 using Content.Server.Mind;

--- a/Content.Server/Clothing/Systems/CursedMaskSystem.cs
+++ b/Content.Server/Clothing/Systems/CursedMaskSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Ghost;
 using Content.Server.Mind;
@@ -51,7 +52,7 @@ public sealed class CursedMaskSystem : SharedCursedMaskSystem
         }
 
         var npcFaction = EnsureComp<NpcFactionMemberComponent>(wearer);
-        ent.Comp.OldFactions = npcFaction.Factions;
+        ent.Comp.OldFactions = [.. npcFaction.Factions];
         _npcFaction.ClearFactions((wearer, npcFaction), false);
         _npcFaction.AddFaction((wearer, npcFaction), ent.Comp.CursedMaskFaction);
 

--- a/Content.Server/Clothing/Systems/CursedMaskSystem.cs
+++ b/Content.Server/Clothing/Systems/CursedMaskSystem.cs
@@ -51,7 +51,8 @@ public sealed class CursedMaskSystem : SharedCursedMaskSystem
         }
 
         var npcFaction = EnsureComp<NpcFactionMemberComponent>(wearer);
-        ent.Comp.OldFactions = [.. npcFaction.Factions];
+        ent.Comp.OldFactions.Clear();
+        ent.Comp.OldFactions.UnionWith(npcFaction.Factions);
         _npcFaction.ClearFactions((wearer, npcFaction), false);
         _npcFaction.AddFaction((wearer, npcFaction), ent.Comp.CursedMaskFaction);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed bug where you can equip cursed mask that makes you angry, die, get rid of cursed mask and get healed. With this bug after these actions you will be `notarget` for almost all NPCs. But with this fix behavior will be expectable.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix.

## Technical details
Save copy of faction list.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No changelog.