### PR TITLE
Creating and destroying AI Cores

### DIFF
--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -264,7 +264,8 @@ public abstract partial class SharedStationAiSystem : EntitySystem
     private void OnCorePower(Entity<StationAiCoreComponent> ent, ref PowerChangedEvent args)
     {
         // TODO: I think in 13 they just straightup die so maybe implement that
-        if (args.Powered)
+        // Currently this would just make AI Eye die whenever the core is unanchored
+        /*if (args.Powered)
         {
             if (!SetupEye(ent))
                 return;
@@ -274,7 +275,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         else
         {
             ClearEye(ent);
-        }
+        }*/
     }
 
     private void OnAiMapInit(Entity<StationAiCoreComponent> ent, ref MapInitEvent args)

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -319,15 +319,32 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 200
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Machines/warning_buzzer.ogg
+          params:
+            volume: 5
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
       behaviors:
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: Damageable
+    damageContainer: Silicon
+  - type: Repairable
+    doAfterDelay: 10
+    allowSelfRepair: false
   - type: ApcPowerReceiver
     powerLoad: 1000
+  - type: ExtensionCableReceiver
+  - type: Anchorable
+  - type: Rotatable
   - type: StationAiCore
   - type: StationAiVision
   - type: InteractionOutline


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
AI Cores can now be destroyed and soon(tm) built.
## Why / Balance
AI Core currently lacks quite a lot of things to make it feel like it fits. One of those things is the fact it cannot die.

## Technical details
Mostly just added missing components

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
None yet.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: AI Core can now be broken, built, anchored, powered and unpowered.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
