### PR TITLE
fix pie throwing sound not playing

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/CreamPieSystem.cs
@@ -41,7 +41,9 @@ namespace Content.Server.Nutrition.EntitySystems
 
         protected override void SplattedCreamPie(EntityUid uid, CreamPieComponent creamPie)
         {
-            _audio.PlayPvs(_audio.GetSound(creamPie.Sound), uid, AudioParams.Default.WithVariation(0.125f));
+            // The entity is deleted, so play the sound at its position rather than parenting
+            var coordinates = Transform(uid).Coordinates;
+            _audio.PlayPvs(_audio.GetSound(creamPie.Sound), coordinates, AudioParams.Default.WithVariation(0.125f));
 
             if (EntityManager.TryGetComponent(uid, out FoodComponent? foodComp))
             {


### PR DESCRIPTION
## About the PR
The sound effect when throwing a banana cream pie wasn't playing. Now it does again.

## Why / Balance
vital clown content

## Technical details
the sound was parented to the entity, but the entity is immediately deleted

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed pie throwing sound not playing.
