### PR TITLE
Add 3 bottle boxes to nanomed plus

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -7,6 +7,7 @@
     Bloodpack: 5
     EpinephrineChemistryBottle: 3
     Syringe: 5
+    BoxBottle: 3
     ClothingEyesHudMedical: 2
     ClothingEyesEyepatchHudMedical: 2
 


### PR DESCRIPTION
## About the PR
Adds three boxes of bottles to the nanomed plus
18 bottles in total

## Why / Balance
I kinda don't like that medical is entirely crippled the moment someone bombs the chem locker. If doctors are better encouraged to carry small amounts of medicine on them then at least the department can function for a bit for chem to restock or evac to arrive.

## Media
![image](https://github.com/user-attachments/assets/1325a917-549c-4944-b4cf-6dcdc46e611c)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added three bottle boxes to the nanomed plus inventory for doctors to carry small amounts of chemicals on their person
