### PR TITLE
make gas pumps only consume power when enabled

### DIFF
--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPressurePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasPressurePumpSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Power;
+using Content.Server.Power.EntitySystems;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
@@ -30,6 +31,7 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
         [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
+        [Dependency] private readonly PowerReceiverSystem _power = default!;
 
         public override void Initialize()
         {
@@ -68,6 +70,10 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
         private void OnPowerChanged(EntityUid uid, GasPressurePumpComponent component, ref PowerChangedEvent args)
         {
             UpdateAppearance(uid, component);
+            if (TryComp<ApcPowerReceiverComponent>(uid, out var power) && !(power.Powered == component.Enabled)) {
+                //This check is for the case where the power changed event was not from UI toggle, IE anchoring
+                _power.TogglePower(uid);
+            }
         }
 
         private void OnPumpUpdated(EntityUid uid, GasPressurePumpComponent pump, ref AtmosDeviceUpdateEvent args)
@@ -137,6 +143,9 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
                 $"{ToPrettyString(args.Actor):player} set the power on {ToPrettyString(uid):device} to {args.Enabled}");
             DirtyUI(uid, pump);
             UpdateAppearance(uid, pump);
+            if (TryComp<ApcPowerReceiverComponent>(uid, out var power) && !(power.Powered == pump.Enabled)) {
+                _power.TogglePower(uid, user: args.Actor);
+            }
         }
 
         private void OnOutputPressureChangeMessage(EntityUid uid, GasPressurePumpComponent pump, GasPressurePumpChangeOutputPressureMessage args)


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Make pressure and volume gas pumps only consume power when enabled

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I was playing the game and wondered where my power consumption was when I was trying to optimize power in a small area. It took me a while to figure out that the gas pumps that were off were the culprits that were consuming power. I consider this as a bug, so I came here to try to change it, I think that the pumps should not consume power when disabled.

## Technical details
<!-- Summary of code changes for easier review. -->
* toggle power of gas pumps when UI button to enable/disable is pressed to match the enabled value of the pump

* toggle power of gas pumps to match the enabled status of the pump whenever there is a change to the power of the pump (most likely case other than UI toggle is anchoring the pump to the floor, if this isnt dont then pump would consume power when off when first anchored)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Gas pumps no longer consume power when disabled.
