### PR TITLE
Fix inconsistent borg flashlight state

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -281,8 +281,11 @@ public sealed partial class BorgSystem : SharedBorgSystem
     public void BorgActivate(EntityUid uid, BorgChassisComponent component)
     {
         Popup.PopupEntity(Loc.GetString("borg-mind-added", ("name", Identity.Name(uid, EntityManager))), uid);
-        Toggle.TryActivate(uid);
-        _powerCell.SetDrawEnabled(uid, _mobState.IsAlive(uid));
+        if (_powerCell.HasDrawCharge(uid))
+        {
+            Toggle.TryActivate(uid);
+            _powerCell.SetDrawEnabled(uid, _mobState.IsAlive(uid));
+        }
         _appearance.SetData(uid, BorgVisuals.HasPlayer, true);
     }
 

--- a/Content.Shared/Light/EntitySystems/ItemTogglePointLightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/ItemTogglePointLightSystem.cs
@@ -11,6 +11,7 @@ public sealed class ItemTogglePointLightSystem : EntitySystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedPointLightSystem _light = default!;
+    [Dependency] private readonly SharedHandheldLightSystem _handheldLight = default!;
 
     public override void Initialize()
     {
@@ -25,5 +26,6 @@ public sealed class ItemTogglePointLightSystem : EntitySystem
 
         _appearance.SetData(ent, ToggleableLightVisuals.Enabled, args.Activated);
         _light.SetEnabled(ent.Owner, args.Activated, comp: light);
+        _handheldLight.SetActivated(ent.Owner, args.Activated);
     }
 }

--- a/Content.Shared/Light/EntitySystems/ItemTogglePointLightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/ItemTogglePointLightSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.Light.Components;
 using Content.Shared.Toggleable;
 using ItemTogglePointLightComponent = Content.Shared.Light.Components.ItemTogglePointLightComponent;
 
@@ -26,6 +27,9 @@ public sealed class ItemTogglePointLightSystem : EntitySystem
 
         _appearance.SetData(ent, ToggleableLightVisuals.Enabled, args.Activated);
         _light.SetEnabled(ent.Owner, args.Activated, comp: light);
-        _handheldLight.SetActivated(ent.Owner, args.Activated);
+        if (TryComp<HandheldLightComponent>(ent.Owner, out var handheldLight))
+        {
+            _handheldLight.SetActivated(ent.Owner, args.Activated, handheldLight);
+        }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes #30315.

Two issues:

* If a brain was inserted to a borg which did not have a power cell inserted, the flashlight would be enabled, but couldn't be turned off ("No cell inserted" message)
* When a brain was inserted to a borg which *did* have a power cell, the SharedPointLightComponent.Enabled would be set to true, but HandheldLightComponent.Active would be set to false. This would cause the "toggle light" action to apparently do nothing the first time it was activated - it would set HandheldLightComponent.Active=true, but the light was already enabled. From this point, subsequent activations of that action *would* work, as the handheld light and point light components were in sync.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->

SharedPointLightComponent.Enabled and HandheldLightComponent.Active look like they're attempting to provide the same functionality, so not sure why they're separate - when they get out of sync with each other, actions like the ActionToggleLight don't behave correctly. Maybe @deltanedas can weigh in here on what the utility of having these booleans be seperate is - is it worth refactoring to remove one?

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
