### PR TITLE
Fix TestSuicideByHeldItem and TestSuicideByHeldItemSpreadDamage

### DIFF
--- a/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
+++ b/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
@@ -168,7 +168,7 @@ public sealed class SuicideCommandTests
         await pair.CleanReturnAsync();
     }
 
-        /// <summary>
+    /// <summary>
     /// Run the suicide command in the console
     /// Should only ghost the player but not kill them
     /// </summary>
@@ -241,6 +241,7 @@ public sealed class SuicideCommandTests
         var mindSystem = entManager.System<SharedMindSystem>();
         var mobStateSystem = entManager.System<MobStateSystem>();
         var transformSystem = entManager.System<TransformSystem>();
+        var damageableSystem = entManager.System<DamageableSystem>();
 
         // We need to know the player and whether they can be hurt, killed, and whether they have a mind
         var player = playerMan.Sessions.First().AttachedEntity!.Value;
@@ -276,6 +277,8 @@ public sealed class SuicideCommandTests
         // and that all the damage is concentrated in the Slash category
         await server.WaitAssertion(() =>
         {
+            // Heal all damage first (possible low pressure damage taken)
+            damageableSystem.SetAllDamage(player, damageableComp, 0);
             consoleHost.GetSessionShell(playerMan.Sessions.First()).ExecuteCommand("suicide");
             var lethalDamageThreshold = mobThresholdsComp.Thresholds.Keys.Last();
 
@@ -313,6 +316,7 @@ public sealed class SuicideCommandTests
         var mindSystem = entManager.System<SharedMindSystem>();
         var mobStateSystem = entManager.System<MobStateSystem>();
         var transformSystem = entManager.System<TransformSystem>();
+        var damageableSystem = entManager.System<DamageableSystem>();
 
         // We need to know the player and whether they can be hurt, killed, and whether they have a mind
         var player = playerMan.Sessions.First().AttachedEntity!.Value;
@@ -348,6 +352,8 @@ public sealed class SuicideCommandTests
         // and that slash damage is split in half
         await server.WaitAssertion(() =>
         {
+            // Heal all damage first (possible low pressure damage taken)
+            damageableSystem.SetAllDamage(player, damageableComp, 0);
             consoleHost.GetSessionShell(playerMan.Sessions.First()).ExecuteCommand("suicide");
             var lethalDamageThreshold = mobThresholdsComp.Thresholds.Keys.Last();
 


### PR DESCRIPTION
## About the PR
When `Content.Shared.Atmos.Atmospherics.LowPressureDamage` is set to anything other than 1 or 0 `TestSuicideByHeldItem` and `TestSuicideByHeldItemSpreadDamage` fail assertions of damage done.

With `LowPressureDamage = 4`
```
  Failed TestSuicideByHeldItemSpreadDamage [475 ms]
  Error Message:
     Assert.That(damageableComp.Damage.DamageDict["Slash"], Is.EqualTo(lethalDamageThreshold / 2))
  Expected: 100
  But was:  99
```

```
  Failed TestSuicideByHeldItem [955 ms]
  Error Message:
     Assert.That(damageableComp.Damage.DamageDict["Slash"], Is.EqualTo(lethalDamageThreshold))
  Expected: 200
  But was:  198
```

The tests are fine with `Atmospherics.LowPressureDamage = 1` due to rounding up to next integer (199.5->200) which is why this issue was not spotted sooner.

I've noticed that tests fail only on full or expanded test runs.
Example: `--filter SuicideCommandTests` passes, `--filter Commands` fails.
The test player must take a tick of barotrauma damage at some point.

Healing all damage before running the command and the damage assertions fixes the issue.

Special thanks to @SlamBamActionman for tracking down the bug.

## Why / Balance
Bug fix. Needed downstream due to changed low pressure damage.

## Technical details
`DamageableSystem.SetAllDamage()` to 0 before running the commands and asserting the damage.

## Media
N/A

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
Not player facing
