### PR TITLE
fix lava expeds

### DIFF
--- a/Resources/Prototypes/Procedural/dungeon_configs.yml
+++ b/Resources/Prototypes/Procedural/dungeon_configs.yml
@@ -127,6 +127,8 @@
       Junction: BaseAirlock
       WallMounts: ScienceLabsWalls
       Window: BaseWindow
+    tiles:
+      FallbackTile: FloorDark
     whitelists:
       Rooms:
         tags:


### PR DESCRIPTION
## About the PR
it had no fallbacktile so it failed to generate

## Why / Balance
11 minutes of sitting on your ass because theres no dungeon or ore, only moth round removal tile

## Media
its like an ad for a fuckin bug fixing centa
before:
![08:03:21](https://github.com/user-attachments/assets/1ab33d2c-0514-43f1-b545-badd6d310048)

an WAY before:
![08:07:38](https://github.com/user-attachments/assets/6c96371e-4c2c-45c8-a22a-1d353a5a4cea)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed lava planet expeditions not working.