### PR TITLE
Updated an incorrect sprite in the smite menu

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -651,7 +651,7 @@ public sealed partial class AdminVerbSystem
         {
             Text = "admin-smite-become-mouse-name",
             Category = VerbCategory.Smite,
-            Icon = new SpriteSpecifier.Rsi(new ("/Textures/Objects/Fun/Instruments/h_synthesizer.rsi"), "icon"),
+            Icon = new SpriteSpecifier.Rsi(new ("/Textures/Objects/Fun/Instruments/h_synthesizer.rsi"), "supersynth"),
             Act = () =>
             {
                 _polymorphSystem.PolymorphEntity(args.Target, "AdminInstrumentSmite");


### PR DESCRIPTION
## About the PR
There is a smite that turns someone into a supersynth. The icon for the option uses a regular synth because when I created the supersynth sprite I overlooked updating the sprite used here. So I went and did that. It's a really really minor change.

## Media
![image](https://github.com/user-attachments/assets/019140e6-e689-4d9e-870e-19b567d55a79)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no