### PR TITLE
make bounty arbitrage test less stupid

### DIFF
--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -71,6 +71,7 @@ public sealed class CargoTest
         var cargo = entManager.System<CargoSystem>();
 
         var bounties = protoManager.EnumeratePrototypes<CargoBountyPrototype>().ToList();
+        bounties.RemoveAll(bounty => bounty.AllowArbitrage);
 
         await server.WaitAssertion(() =>
         {

--- a/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
@@ -4,6 +4,7 @@ using Content.Server.Cargo.Components;
 using Content.Server.Labels;
 using Content.Server.NameIdentifier;
 using Content.Shared.Access.Components;
+using Content.Shared.Body.Components;
 using Content.Shared.Cargo;
 using Content.Shared.Cargo.Components;
 using Content.Shared.Cargo.Prototypes;
@@ -29,6 +30,7 @@ public sealed partial class CargoSystem
     [ValidatePrototypeId<NameIdentifierGroupPrototype>]
     private const string BountyNameIdentifierGroup = "Bounty";
 
+    private EntityQuery<BodyComponent> _bodyQuery;
     private EntityQuery<StackComponent> _stackQuery;
     private EntityQuery<ContainerManagerComponent> _containerQuery;
     private EntityQuery<CargoBountyLabelComponent> _bountyLabelQuery;
@@ -42,6 +44,7 @@ public sealed partial class CargoSystem
         SubscribeLocalEvent<EntitySoldEvent>(OnSold);
         SubscribeLocalEvent<StationCargoBountyDatabaseComponent, MapInitEvent>(OnMapInit);
 
+        _bodyQuery = GetEntityQuery<BodyComponent>();
         _stackQuery = GetEntityQuery<StackComponent>();
         _containerQuery = GetEntityQuery<ContainerManagerComponent>();
         _bountyLabelQuery = GetEntityQuery<CargoBountyLabelComponent>();
@@ -359,6 +362,10 @@ public sealed partial class CargoSystem
             uid
         };
         if (!TryComp<ContainerManagerComponent>(uid, out var containers))
+            return entities;
+
+        // don't count organs of ungibbed mobs for organ bounties, do the grunt work and gib them!
+        if (_bodyQuery.HasComp(uid))
             return entities;
 
         foreach (var container in containers.Containers.Values)

--- a/Content.Shared/Cargo/Prototypes/CargoBountyPrototype.cs
+++ b/Content.Shared/Cargo/Prototypes/CargoBountyPrototype.cs
@@ -39,6 +39,12 @@ public sealed partial class CargoBountyPrototype : IPrototype
     /// </summary>
     [DataField]
     public string IdPrefix = "NT";
+
+    /// <summary>
+    /// When true, the arbitrage test skips this bounty.
+    /// </summary>
+    [DataField]
+    public bool AllowArbitrage;
 }
 
 [DataDefinition, Serializable, NetSerializable]

--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -426,6 +426,7 @@
   id: BountyTrash
   reward: 500
   description: bounty-description-trash
+  allowArbitrage: true # its trash, why would you buy things for it
   entries:
   - name: bounty-item-trash
     amount: 10


### PR DESCRIPTION
## About the PR
- dont count organs inside mobs, this also means that putting 2 mice in a crate wont complete an organ bounty. now you have to actually gib them
- in the bounty arbitrage test, skip checking the trash bounty entirely.

## Why / Balance
you do not buy things to do a trash bounty, its *trash*
