### PR TITLE
Simplify separated screen top menu

### DIFF
--- a/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
+++ b/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
@@ -11,17 +11,21 @@
            Orientation="Horizontal"
            HorizontalAlignment="Stretch"
            VerticalAlignment="Top"
-           SeparationOverride="5"
 >
+    <GridContainer
+        Rows="2"
+        HSeparationOverride="5"
+        VSeparationOverride="5"
+        HorizontalExpand="True">
     <ui:MenuButton
         Name="EscapeButton"
         Access="Internal"
         Icon="{xe:Tex '/Textures/Interface/hamburger.svg.192dpi.png'}"
         BoundKey = "{x:Static ic:EngineKeyFunctions.EscapeMenu}"
         ToolTip="{Loc 'game-hud-open-escape-menu-button-tooltip'}"
-        MinSize="70 64"
+        MinSize="48 64"
         HorizontalExpand="True"
-        AppendStyleClass="{x:Static style:StyleBase.ButtonOpenRight}"
+        AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
         />
     <ui:MenuButton
         Name="GuidebookButton"
@@ -29,7 +33,7 @@
         Icon="{xe:Tex '/Textures/Interface/VerbIcons/information.svg.192dpi.png'}"
         ToolTip="{Loc 'game-hud-open-guide-menu-button-tooltip'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenGuidebook}"
-        MinSize="42 64"
+        MinSize="48 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
         />
@@ -39,7 +43,7 @@
         Icon="{xe:Tex '/Textures/Interface/character.svg.192dpi.png'}"
         ToolTip="{Loc 'game-hud-open-character-menu-button-tooltip'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenCharacterMenu}"
-        MinSize="42 64"
+        MinSize="48 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
         />
@@ -49,7 +53,7 @@
         Icon="{xe:Tex '/Textures/Interface/emotes.svg.192dpi.png'}"
         ToolTip="{Loc 'game-hud-open-emotes-menu-button-tooltip'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenEmotesMenu}"
-        MinSize="42 64"
+        MinSize="48 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
         />
@@ -59,7 +63,7 @@
         Icon="{xe:Tex '/Textures/Interface/hammer.svg.192dpi.png'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenCraftingMenu}"
         ToolTip="{Loc 'game-hud-open-crafting-menu-button-tooltip'}"
-        MinSize="42 64"
+        MinSize="48 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
         />
@@ -69,7 +73,7 @@
         Icon="{xe:Tex '/Textures/Interface/fist.svg.192dpi.png'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenActionsMenu}"
         ToolTip="{Loc 'game-hud-open-actions-menu-button-tooltip'}"
-        MinSize="42 64"
+        MinSize="48 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
         />
@@ -79,7 +83,7 @@
         Icon="{xe:Tex '/Textures/Interface/gavel.svg.192dpi.png'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenAdminMenu}"
         ToolTip="{Loc 'game-hud-open-admin-menu-button-tooltip'}"
-        MinSize="42 64"
+        MinSize="48 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
         />
@@ -89,7 +93,7 @@
         Icon="{xe:Tex '/Textures/Interface/sandbox.svg.192dpi.png'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenSandboxWindow}"
         ToolTip="{Loc 'game-hud-open-sandbox-menu-button-tooltip'}"
-        MinSize="42 64"
+        MinSize="48 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
         />
@@ -99,8 +103,9 @@
         Icon="{xe:Tex '/Textures/Interface/info.svg.192dpi.png'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenAHelp}"
         ToolTip="{Loc 'ui-options-function-open-a-help'}"
-        MinSize="42 64"
+        MinSize="48 64"
         HorizontalExpand="True"
-        AppendStyleClass="{x:Static style:StyleBase.ButtonOpenLeft}"
+        AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
         />
+    </GridContainer>
 </widgets:GameTopMenuBar>


### PR DESCRIPTION
After:
![image](https://github.com/user-attachments/assets/129a4d30-fb32-4901-9f32-2af51a68da3c)

Okay so the problem is we try to fit a heap of buttons, with images, into a tiny space, which leads to the controls either spilling over the edge or being cramped. This is even worse if you're an admin and have even more buttons.. Realistically you don't need all of the vertical chat space on separated screen and we can just make this a gridcontainer instead.

:cl:
- tweak: Adjusted the top menu on the separated game screen. The buttons will now form multiple rows and no longer overflow into the viewport.
