### PR TITLE
Added the ability for pAIs and station maps to be stored in engineering belts

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -97,7 +97,6 @@
     # TODO: Fill this out more.
     whitelist:
       tags:
-        - StationMap
         - Wirecutter
         - Crowbar
         - Screwdriver
@@ -114,6 +113,7 @@
         - Multitool
         - AppraisalTool
       components:
+        - StationMap
         - SprayPainter
         - NetworkConfigurator
         - RCD

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -97,6 +97,7 @@
     # TODO: Fill this out more.
     whitelist:
       tags:
+        - StationMap
         - Wirecutter
         - Crowbar
         - Screwdriver

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -33,6 +33,7 @@
         - GPS
         - WeldingMask
       components:
+        - StationMap
         - SprayPainter
         - NetworkConfigurator
         - RCD


### PR DESCRIPTION
## About the PR
Added the ability for pAIs and station maps to be stored in utility and CE belts.

## Why / Balance
This is primarily aimed at improving navigation throughout the station, as stations can sometimes be disparate in signage or provided maps. In particular, for engineers, it improves responsiveness to damage or other emergencies. For pAIs, the most pertinent benefit is simply having additional storage space (which is accurate for the pAI's size.)

## Technical details
Added the StationMapComponent to engineering belt whitelists.

## Media
![image](https://github.com/user-attachments/assets/ea2a6d26-9ee0-490e-99b4-c9d54c126ab2)


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

:cl:
- tweak: Utility and CE belts can now hold the pAI and the handheld station map.


