### PR TITLE
Item HeldPrefix and Clothing EquippedPrefix toggler

### DIFF
--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -29,7 +29,6 @@ namespace Content.Server.Stunnable.Systems
             SubscribeLocalEvent<StunbatonComponent, SolutionContainerChangedEvent>(OnSolutionChange);
             SubscribeLocalEvent<StunbatonComponent, StaminaDamageOnHitAttemptEvent>(OnStaminaHitAttempt);
             SubscribeLocalEvent<StunbatonComponent, ItemToggleActivateAttemptEvent>(TryTurnOn);
-            SubscribeLocalEvent<StunbatonComponent, ItemToggledEvent>(ToggleDone);
             SubscribeLocalEvent<StunbatonComponent, ChargeChangedEvent>(OnChargeChanged);
         }
 
@@ -54,11 +53,6 @@ namespace Content.Server.Stunnable.Systems
                 var count = (int) (battery.CurrentCharge / entity.Comp.EnergyPerUse);
                 args.PushMarkup(Loc.GetString("melee-battery-examine", ("color", "yellow"), ("count", count)));
             }
-        }
-
-        private void ToggleDone(Entity<StunbatonComponent> entity, ref ItemToggledEvent args)
-        {
-            _item.SetHeldPrefix(entity.Owner, args.Activated ? "on" : "off");
         }
 
         private void TryTurnOn(Entity<StunbatonComponent> entity, ref ItemToggleActivateAttemptEvent args)

--- a/Content.Shared/Clothing/Components/ToggleClothingPrefixComponent.cs
+++ b/Content.Shared/Clothing/Components/ToggleClothingPrefixComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Clothing.Components;
+
+/// <summary>
+/// Handles the changes to ClothingComponent.EquippedPrefix when toggled.
+/// </summary>
+/// <remarks>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ToggleClothingPrefixComponent : Component
+{
+    /// <summary>
+    ///     Clothing's EquippedPrefix when activated.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string? PrefixOn = "on";
+
+    /// <summary>
+    ///     Clothing's EquippedPrefix when deactivated.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string? PrefixOff;
+}

--- a/Content.Shared/Clothing/EntitySystems/ToggleClothingPrefixSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleClothingPrefixSystem.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Clothing.Components;
+using Content.Shared.Item.ItemToggle.Components;
+
+namespace Content.Shared.Clothing.EntitySystems;
+
+/// <summary>
+/// On toggle handles the changes to ItemComponent.HeldPrefix. <see cref="ItemToggleHeldComponent"/>.
+/// </summary>
+public sealed class ToggleClothingPrefixSystem : EntitySystem
+{
+    [Dependency] private readonly ClothingSystem _clothing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ToggleClothingPrefixComponent, ItemToggledEvent>(OnToggled);
+    }
+
+    private void OnToggled(Entity<ToggleClothingPrefixComponent> ent, ref ItemToggledEvent args)
+    {
+        _clothing.SetEquippedPrefix(ent, args.Activated ? ent.Comp.PrefixOn : ent.Comp.PrefixOff);
+    }
+}

--- a/Content.Shared/Clothing/MagbootsSystem.cs
+++ b/Content.Shared/Clothing/MagbootsSystem.cs
@@ -42,10 +42,6 @@ public sealed class SharedMagbootsSystem : EntitySystem
         {
             UpdateMagbootEffects(container.Owner, ent, args.Activated);
         }
-
-        var prefix = args.Activated ? "on" : null;
-        _item.SetHeldPrefix(ent, prefix);
-        _clothing.SetEquippedPrefix(ent, prefix);
     }
 
     private void OnGotUnequipped(Entity<MagbootsComponent> ent, ref ClothingGotUnequippedEvent args)

--- a/Content.Shared/Item/ItemToggle/Components/ItemTogglePrefixComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ItemTogglePrefixComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Item.ItemToggle.Components;
+
+/// <summary>
+/// Handles the changes to ItemComponent.HeldPrefix when toggled.
+/// </summary>
+/// <remarks>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ItemTogglePrefixComponent : Component
+{
+    /// <summary>
+    ///     Item's HeldPrefix when activated.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string? PrefixOn = "on";
+
+    /// <summary>
+    ///     Item's HeldPrefix when deactivated.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string? PrefixOff;
+}

--- a/Content.Shared/Item/ItemToggle/ItemTogglePrefixSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemTogglePrefixSystem.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Item.ItemToggle.Components;
+
+namespace Content.Shared.Item.ItemToggle;
+
+/// <summary>
+/// On toggle handles the changes to ItemComponent.HeldPrefix. <see cref="ItemTogglePrefixComponent"/>.
+/// </summary>
+public sealed class ItemTogglePrefixSystem : EntitySystem
+{
+    [Dependency] private readonly SharedItemSystem _item = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ItemTogglePrefixComponent, ItemToggledEvent>(OnToggled);
+    }
+
+    private void OnToggled(Entity<ItemTogglePrefixComponent> ent, ref ItemToggledEvent args)
+    {
+        _item.SetHeldPrefix(ent.Owner, args.Activated ? ent.Comp.PrefixOn : ent.Comp.PrefixOff);
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -19,6 +19,10 @@
   - type: ComponentToggler
     components:
     - type: NoSlip
+  - type: ItemTogglePrefix
+    prefixOn: on
+  - type: ToggleClothingPrefix
+    prefixOn: on
   - type: Magboots
   - type: ClothingSpeedModifier
     walkModifier: 0.85

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -25,6 +25,9 @@
       path: /Audio/Machines/button.ogg
       params:
         variation: 0.250
+  - type: ItemTogglePrefix
+    prefixOn: on
+    prefixOff: off
   - type: ItemToggleMeleeWeapon
     activatedDamage:
       types:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
We have `GenericVisualizer` for dynamicly changing toggle icons in .yml, but don't have toggler for inhands/clothing sprites dynamic changes (on or off) directly in .yml without C#. This is fixes it by adding `ItemTogglePrefixComponent` and `ToggleClothingPrefixComponent` togglers respectively.
As example changed magboots and stunbatons to .yml `ItemTogglePrefixComponent` and `ToggleClothingPrefixComponent`.
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Just togglers, has `string? prefixOn`, `string? prefixOff`. By default inhand-left and inhand-left, if has prefix than PREFIX-inhand-left and PREFIX-inhand-left. The same for clothes.
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl no fun.
