### PR TITLE
Add new player antag priority functionality

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/AntagPreferenceTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/AntagPreferenceTest.cs
@@ -58,7 +58,8 @@ public sealed class AntagPreferenceTest
         Assert.That(sys.IsEntityValid(client.AttachedEntity, def), Is.True);
         pool = sys.GetPlayerPool(rule, sessions, def);
         Assert.That(pool.Count, Is.EqualTo(1));
-        pool.TryPickAndTake(pair.Server.ResolveDependency<IRobustRandom>(), out var picked);
+        Assert.That(pool.First().Count, Is.EqualTo(1));
+        pool.First().TryPickAndTake(pair.Server.ResolveDependency<IRobustRandom>(), out var picked);
         Assert.That(picked, Is.EqualTo(pair.Player));
         Assert.That(sessions.Count, Is.EqualTo(1));
 

--- a/Content.IntegrationTests/Tests/GameRules/AntagPreferenceTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/AntagPreferenceTest.cs
@@ -48,15 +48,15 @@ public sealed class AntagPreferenceTest
 
         // By default, traitor/antag preferences are disabled, so the pool should be empty.
         var sessions = new List<ICommonSession> { pair.Player! };
-        var pool = sys.GetPlayerPool(rule, sessions, def);
-        Assert.That(pool.Count, Is.EqualTo(0));
+        var pool = sys.GetPlayerPool(rule, sessions, def, false);
+        Assert.That(pool.First().Count, Is.EqualTo(0));
 
         // Opt into the traitor role.
         await pair.SetAntagPreference("Traitor", true);
 
         Assert.That(sys.IsSessionValid(rule, pair.Player, def), Is.True);
         Assert.That(sys.IsEntityValid(client.AttachedEntity, def), Is.True);
-        pool = sys.GetPlayerPool(rule, sessions, def);
+        pool = sys.GetPlayerPool(rule, sessions, def, false);
         Assert.That(pool.Count, Is.EqualTo(1));
         Assert.That(pool.First().Count, Is.EqualTo(1));
         pool.First().TryPickAndTake(pair.Server.ResolveDependency<IRobustRandom>(), out var picked);
@@ -68,8 +68,8 @@ public sealed class AntagPreferenceTest
 
         Assert.That(sys.IsSessionValid(rule, pair.Player, def), Is.True);
         Assert.That(sys.IsEntityValid(client.AttachedEntity, def), Is.True);
-        pool = sys.GetPlayerPool(rule, sessions, def);
-        Assert.That(pool.Count, Is.EqualTo(0));
+        pool = sys.GetPlayerPool(rule, sessions, def, false);
+        Assert.That(pool.First().Count, Is.EqualTo(0));
 
         await server.WaitPost(() => server.EntMan.DeleteEntity(uid));
         await pair.CleanReturnAsync();

--- a/Content.Server/Antag/AntagSelectionPlayerPool.cs
+++ b/Content.Server/Antag/AntagSelectionPlayerPool.cs
@@ -23,5 +23,13 @@ public sealed class AntagSelectionPlayerPool (List<List<ICommonSession>> ordered
         return session != null;
     }
 
+    public void RemoveSessionFromLists(ICommonSession session)
+    {
+        foreach (var pool in orderedPools)
+        {
+            pool.Remove(session);
+        }
+    }
+
     public int Count => orderedPools.Sum(p => p.Count);
 }

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -251,7 +251,6 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             if (picking)
             {
                 var nextPool = false;
-                Logger.Debug("currentpool: " + currentPool + " and " + i);
 
                 if (newPlayerPriority && i == Math.Round(count * def.PlayerPriorityPercentage, 0, MidpointRounding.AwayFromZero))
                     nextPool = true;
@@ -421,17 +420,14 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             if (HasPrimaryAntagPreference(session, def))
             {
 
-                Logger.Debug("1");
                 preferredList.Add(session);
                 if (useNewPlayerPriority && def.PlayerPrioritySelection != NewPlayerPriority.DoNotPrioritize)
                 {
-                    Logger.Debug("2");
                     var playtime = _playtimeManager.GetPlayTimes(session);
                     if (playtime.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out TimeSpan overallTime) &&
                         ((def.PlayerPrioritySelection == NewPlayerPriority.PrioritizeNewPlayer && overallTime <= newPlayerHoursThreshold) ||
                          (def.PlayerPrioritySelection == NewPlayerPriority.PrioritizeExperiencedPlayer && overallTime > newPlayerHoursThreshold)))
                     {
-                        Logger.Debug(session.ToString()!);
                         preferredPrioritizedPlayer.Add(session);
                     }
                 }

--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -7,6 +7,8 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
 
 namespace Content.Server.Antag.Components;
 
@@ -182,6 +184,40 @@ public partial struct AntagSelectionDefinition()
     /// </remarks>
     [DataField]
     public EntProtoId? SpawnerPrototype;
+
+    /// <summary>
+    /// If CCVar.GameNewPlayerAntagPriority is set to true, this enum is used to select which behavior
+    /// the selection should have; if it should prioritize new players, old players, or no prioritization at all.
+    /// </summary>
+    [DataField]
+    public NewPlayerPriority PlayerPrioritySelection = NewPlayerPriority.PrioritizeNewPlayer;
+
+    /// <summary>
+    /// If CCVar.GameNewPlayerAntagPriority is set to true, this float determines the percentage of the available
+    /// selected antag slots are assigned to the prioritized player pool.
+    /// </summary>
+    [DataField]
+    public float PlayerPriorityPercentage = 0.5f;
+}
+
+
+[Serializable]
+public enum NewPlayerPriority
+{
+    /// <summary>
+    /// Prioritize players with playtime under CCVar.GameNewPlayerHoursThreshold.
+    /// </summary>
+    PrioritizeNewPlayer,
+
+    /// <summary>
+    /// Prioritize players with playtime over CCVar.GameNewPlayerHoursThreshold.
+    /// </summary>
+    PrioritizeExperiencedPlayer,
+
+    /// <summary>
+    /// Do not prioritize any player.
+    /// </summary>
+    DoNotPrioritize,
 }
 
 /// <summary>

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -457,6 +457,19 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> GameHostnameInTitlebar =
             CVarDef.Create("game.hostname_in_titlebar", true, CVar.SERVER | CVar.REPLICATED);
 
+        /// <summary>
+        /// The number of hours a player must reach to no longer be considered a "new player" for gameplay purposes.
+        /// Used in context with GameNewPlayerAntagPriority and GameNewPlayerAntagPercentage.
+        /// </summary>
+        public static readonly CVarDef<int> GameNewPlayerHoursThreshold =
+            CVarDef.Create("game.new_player_hours_threshold", 50, CVar.SERVER | CVar.REPLICATED);
+
+        /// <summary>
+        /// Should antag gamerules try to prioritize new players first?
+        /// </summary>
+        public static readonly CVarDef<bool> GameNewPlayerAntagPriority =
+            CVarDef.Create("game.new_player_antag_priority", true, CVar.SERVER | CVar.REPLICATED);
+
         /*
          * Discord
          */

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -468,7 +468,7 @@ namespace Content.Shared.CCVar
         /// Should antag gamerules try to prioritize new players first?
         /// </summary>
         public static readonly CVarDef<bool> GameNewPlayerAntagPriority =
-            CVarDef.Create("game.new_player_antag_priority", true, CVar.SERVER | CVar.REPLICATED);
+            CVarDef.Create("game.new_player_antag_priority", false, CVar.SERVER | CVar.REPLICATED);
 
         /*
          * Discord

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -116,6 +116,7 @@
         - Syndicate
       mindRoles:
       - MindRoleNukeopsCommander
+      playerPrioritySelection: PrioritizeExperiencedPlayer
     - prefRoles: [ NukeopsMedic ]
       fallbackRoles: [ Nukeops, NukeopsCommander ]
       spawnerPrototype: SpawnPointNukeopsMedic
@@ -133,6 +134,7 @@
         - Syndicate
       mindRoles:
       - MindRoleNukeopsMedic
+      playerPrioritySelection: DoNotPrioritize
     - prefRoles: [ Nukeops ]
       fallbackRoles: [ NukeopsCommander, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsOperative
@@ -152,6 +154,8 @@
         - Syndicate
       mindRoles:
       - MindRoleNukeops
+      playerPrioritySelection: PrioritizeNewPlayer
+      playerPriorityPercentage: 0.7
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds the ability to enable new player prioritization when it comes to antag selection. This makes the antag selection system attempt to give a certain percentage of antag roles to players below a certain hour threshold.

The CCvar `game.new_player_antag_priority` enables the functionality, `game.new_player_hours_threshold` is the threshold for what the game considers a "new player". 

`PlayerPrioritySelection` sets whether an antag selection should use a different kind of selection when new player prioritization is enabled; either to give an antag experienced player priority (used for NukeOps Commander) or no special priority (used for NukeOps Agent). 

`PlayerPriorityPercentage` sets the percentage of an antag selection that should use prioritization. Once that percentage of antags have been selected, it will use the normal, random selection.

**Note that this is disabled by default, and would need to be changed on a per-server basis.**

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

There's been an issue with players joining the new player server Hopper hoping to roll antag; this is often more likely since there are more newer players with antags disabled compared to other Wizden servers, and causes issues where the new players get steamrolled. Learning antags is an important part of SS14, so giving new players priority on the new player server makes sense.

With the initial values selected for this PR, half of all antags will be selected from a pool made up exclusively of players with less than 50 hours. Once those antags have been selected, or the pool is empty, it will instead select from all players as normal. 

The exception to this is NukeOps; NukeOps Commanders will instead prioritize players *over* 50 hours, as the complexities and leadership aspects of the role benefit from experience. NukeOps Agents have no prioritization, and normal NukeOps Operatives have a 70% new player prioritization percentage. (3 Operatives -> 2 guaranteed Newkies, 2 Operatives -> 1 guaranteed Newkie, 1 Operative -> 1 guaranteed Newkie). 

## Technical details
<!-- Summary of code changes for easier review. -->

If priority is on, the antag selection will return two player pools; the first one contains prioritized players, while the second one contains all eligible players. If a prioritized player is selected they are removed from both pools.

Once requisite number of prioritized players are selected, the selection is changed to the second pool. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

This is really hard to record.

## Steps to test

1. Boot up enough clients to meet the gamerule criteria. (It might be wise to lower the player requirements for some; e.g. NukeOps has 20 players minimum).
2. Ensure a certain number of them have playtimes below the requirement; you can the command `playtime_add_overall` to add/subtract.
3. Start the round with the desired gamepreset. Clients should be prioritized based on playtime.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

No cl, because it's not turned on.