### PR TITLE
Fixes bolt lights of previously unpowered bolted doors

### DIFF
--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -46,8 +46,8 @@ public sealed class DoorSystem : SharedDoorSystem
                 SetBoltsDown(ent, true);
         }
 
-        UpdateBoltLightStatus(ent);
         ent.Comp.Powered = args.Powered;
         Dirty(ent, ent.Comp);
+        UpdateBoltLightStatus(ent);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: PopGamer46
- fix: Fixed bolt lights of recently unpowered bolted doors
