### PR TITLE
Fix: Examine Damage now specifies no damage

### DIFF
--- a/Content.Shared/Damage/Systems/DamageExamineSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageExamineSystem.cs
@@ -61,15 +61,12 @@ public sealed class DamageExamineSystem : EntitySystem
         }
         else
         {
-            if (damageSpecifier.DamageDict.Count == 1)
+            if (damageSpecifier.GetTotal() == FixedPoint2.Zero && !damageSpecifier.AnyPositive())
             {
-                // May be simplified to using a foreach(Var x) despite being only one item
-                if(damageSpecifier.DamageDict.Values.GetEnumerator().Current == FixedPoint2.Zero)
-                {
-                    msg.AddMarkupOrThrow(Loc.GetString("damage-none"));
-                    return msg;
-                }
+                msg.AddMarkupOrThrow(Loc.GetString("damage-none"));
+                return msg;
             }
+
             msg.AddMarkupOrThrow(Loc.GetString("damage-examine-type", ("type", type)));
         }
 

--- a/Content.Shared/Damage/Systems/DamageExamineSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageExamineSystem.cs
@@ -61,6 +61,15 @@ public sealed class DamageExamineSystem : EntitySystem
         }
         else
         {
+            if (damageSpecifier.DamageDict.Count == 1)
+            {
+                // May be simplified to using a foreach(Var x) despite being only one item
+                if(damageSpecifier.DamageDict.Values.GetEnumerator().Current == FixedPoint2.Zero)
+                {
+                    msg.AddMarkupOrThrow(Loc.GetString("damage-none"));
+                    return msg;
+                }
+            }
             msg.AddMarkupOrThrow(Loc.GetString("damage-examine-type", ("type", type)));
         }
 

--- a/Resources/Locale/en-US/damage/damage-examine.ftl
+++ b/Resources/Locale/en-US/damage/damage-examine.ftl
@@ -10,3 +10,4 @@ damage-throw = throw
 damage-examine = It does the following damage:
 damage-examine-type = It does the following [color=cyan]{$type}[/color] damage:
 damage-value = - [color=red]{$amount}[/color] units of [color=yellow]{$type}[/color].
+damage-none = It does no damage.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
When you examine an item that is a weapon, but has no damage, IE a plushie, it now specifies that it does no damage.
May be paired with a revert of #33061 to once again show plushie 'damage'

## Why / Balance
Shows that the examined item is a weapon but does no damage.
Fix #33052 (Second try)

## Technical details
Checks the items damage dictionary to check if there is only one damage type and if that damage is 0.
Returns specific "no damage" message

## Media
![{35C8CA65-FA1E-4592-9019-5508252996CC}](https://github.com/user-attachments/assets/63e5485f-99c1-4fee-b0ba-d282b3058448)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Items with a damage of 0 now have correct damage examination text.
