### PR TITLE
Fixes Lambordeere bolt buttons not being connected

### DIFF
--- a/Resources/Maps/Shuttles/ShuttleEvent/lambordeere.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/lambordeere.yml
@@ -21,7 +21,7 @@ entities:
       name: NT-Lambordeere
     - type: Transform
       pos: -0.453125,-0.4375
-      parent: invalid
+      parent: 216
     - type: MapGrid
       chunks:
         0,0:
@@ -225,6 +225,18 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+  - uid: 216
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
 - proto: AirCanister
   entities:
   - uid: 2
@@ -1206,6 +1218,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 1
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        50:
+        - Pressed: DoorBolt
   - uid: 199
     components:
     - type: MetaData
@@ -1214,6 +1232,10 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 0.5,2.5
       parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        82:
+        - Pressed: DoorBolt
 - proto: SMESBasic
   entities:
   - uid: 65

--- a/Resources/Maps/Shuttles/ShuttleEvent/lambordeere.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/lambordeere.yml
@@ -21,7 +21,7 @@ entities:
       name: NT-Lambordeere
     - type: Transform
       pos: -0.453125,-0.4375
-      parent: 216
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -225,18 +225,6 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
-  - uid: 216
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: PhysicsMap
-    - type: GridTree
-    - type: MovedGrids
-    - type: Broadphase
-    - type: OccluderTree
 - proto: AirCanister
   entities:
   - uid: 2
@@ -1218,8 +1206,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 1
-    - type: SignalSwitch
-      state: True
     - type: DeviceLinkSource
       linkedPorts:
         50:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

## Media
![BoltButtons](https://github.com/user-attachments/assets/1a036c78-d02d-496a-83fc-2977fa9995eb)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: PopGamer46
- fix: Fixed Lambordeere (botany shuttle) bolt buttons not being connected
