### PR TITLE
Adds headphones to loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -21,6 +21,13 @@
     back:
     - ClothingHeadHatHairflower
 
+# Headphones
+- type: loadout
+  id: Headphones
+  storage:
+    back:
+    - ClothingNeckHeadphones
+
 # Plushies
 - type: loadout
   id: PlushieLizard
@@ -165,7 +172,7 @@
       !type:OverallPlaytimeRequirement
       time: 36000 # 10hr
   storage:
-    back: 
+    back:
     - TowelColorWhite
 
 - type: loadout
@@ -176,9 +183,9 @@
       !type:OverallPlaytimeRequirement
       time: 1800000 # 500hr
   storage:
-    back: 
+    back:
     - TowelColorSilver
-    
+
 - type: loadout
   id: TowelColorGold
   effects:
@@ -187,7 +194,7 @@
       !type:OverallPlaytimeRequirement
       time: 3600000 # 1000hr
   storage:
-    back: 
+    back:
     - TowelColorGold
 
 - type: loadout
@@ -199,7 +206,7 @@
       department: Cargo
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorLightBrown
 
 - type: loadout
@@ -211,7 +218,7 @@
       department: Civilian
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorGreen
 
 - type: loadout
@@ -223,7 +230,7 @@
       department: Command
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorDarkBlue
 
 - type: loadout
@@ -235,9 +242,9 @@
       department: Engineering
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorOrange
-    
+
 - type: loadout
   id: TowelColorLightBlue
   effects:
@@ -247,7 +254,7 @@
       department: Medical
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorLightBlue
 
 - type: loadout
@@ -259,7 +266,7 @@
       department: Science
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorPurple
 
 - type: loadout
@@ -271,7 +278,7 @@
       department: Security
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorRed
 
 - type: loadout
@@ -283,7 +290,7 @@
       role: JobPassenger
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorGray
 
 - type: loadout
@@ -295,7 +302,7 @@
       role: JobChaplain
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorBlack
 
 - type: loadout
@@ -307,7 +314,7 @@
       role: JobLibrarian
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorDarkGreen
 
 - type: loadout
@@ -319,7 +326,7 @@
       role: JobLawyer
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorMaroon
 
 - type: loadout
@@ -331,7 +338,7 @@
       role: JobClown
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorYellow
 
 - type: loadout
@@ -343,5 +350,5 @@
       role: JobMime
       time: 360000 # 100hr
   storage:
-    back: 
+    back:
     - TowelColorMime

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -7,6 +7,7 @@
   loadouts:
   - FlowerWreath
   - Hairflower
+  - Headphones
   - PlushieLizard
   - PlushieSpaceLizard
   - Lighter


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Self explanatory. The headphones are in the trinket section for all roles.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
![image](https://github.com/user-attachments/assets/996e10e8-a959-4a5f-ba1a-9e536dcf7e1b)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Headphones are now selectable in loadouts.
