### PR TITLE
Fix crash that was happening while testing nukeops

### DIFF
--- a/Content.Server/Power/Generation/Teg/TegSystem.cs
+++ b/Content.Server/Power/Generation/Teg/TegSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Power;
 using Content.Shared.Power.Generation.Teg;
 using Content.Shared.Rounding;
 using Robust.Server.GameObjects;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Power.Generation.Teg;
 
@@ -259,13 +260,18 @@ public sealed class TegSystem : EntitySystem
         // Otherwise, make sure circulator is set to nothing.
         if (!group.IsFullyBuilt)
         {
-            UpdateCirculatorAppearance(uid, false);
+            UpdateCirculatorAppearance((uid, component), false);
         }
     }
 
-    private void UpdateCirculatorAppearance(EntityUid uid, bool powered)
+    private void UpdateCirculatorAppearance(Entity<TegCirculatorComponent?> ent, bool powered)
     {
-        var circ = Comp<TegCirculatorComponent>(uid);
+        if (!Resolve(ent, ref ent.Comp))
+            return;
+
+        var (uid, circ) = ent;
+
+        DebugTools.Assert(circ is not null);
 
         TegCirculatorSpeed speed;
         if (powered && circ.LastPressureDelta > 0 && circ.LastMolesTransferred > 0)

--- a/Content.Server/Power/Generation/Teg/TegSystem.cs
+++ b/Content.Server/Power/Generation/Teg/TegSystem.cs
@@ -268,10 +268,8 @@ public sealed class TegSystem : EntitySystem
     {
         if (!Resolve(ent, ref ent.Comp))
             return;
-
+            
         var (uid, circ) = ent;
-
-        DebugTools.Assert(circ is not null);
 
         TegCirculatorSpeed speed;
         if (powered && circ.LastPressureDelta > 0 && circ.LastMolesTransferred > 0)

--- a/Content.Server/Power/Generation/Teg/TegSystem.cs
+++ b/Content.Server/Power/Generation/Teg/TegSystem.cs
@@ -268,8 +268,8 @@ public sealed class TegSystem : EntitySystem
     {
         if (!Resolve(ent, ref ent.Comp))
             return;
-            
-        var (uid, circ) = ent;
+
+        var circ = ent.Comp;
 
         TegCirculatorSpeed speed;
         if (powered && circ.LastPressureDelta > 0 && circ.LastMolesTransferred > 0)
@@ -284,13 +284,13 @@ public sealed class TegSystem : EntitySystem
             speed = TegCirculatorSpeed.SpeedStill;
         }
 
-        _appearance.SetData(uid, TegVisuals.CirculatorSpeed, speed);
-        _appearance.SetData(uid, TegVisuals.CirculatorPower, powered);
+        _appearance.SetData(ent, TegVisuals.CirculatorSpeed, speed);
+        _appearance.SetData(ent, TegVisuals.CirculatorPower, powered);
 
-        if (_pointLight.TryGetLight(uid, out var pointLight))
+        if (_pointLight.TryGetLight(ent, out var pointLight))
         {
-            _pointLight.SetEnabled(uid, powered, pointLight);
-            _pointLight.SetColor(uid, speed == TegCirculatorSpeed.SpeedFast ? circ.LightColorFast : circ.LightColorSlow, pointLight);
+            _pointLight.SetEnabled(ent, powered, pointLight);
+            _pointLight.SetColor(ent, speed == TegCirculatorSpeed.SpeedFast ? circ.LightColorFast : circ.LightColorSlow, pointLight);
         }
     }
 


### PR DESCRIPTION
Some bug that was happening while testing NukeOps, not sure if this is the "correct" fix but it stopped it crashing.

## Technical details
Swapped a `Comp` call for a `Resolve` call since the component wasn't garrenteed to exist.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
