### PR TITLE
Delay NukeOps round end by 10 seconds after the nuke explodes.

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -98,13 +98,13 @@ public sealed partial class NukeopsRuleComponent : Component
     /// <summary>
     ///     Delay between the nuke exploding and the round ending, to give time for the nuke to potentionally kill the nukies and downgrade their win.
     /// </summary>
-    [DataField]
+    [ViewVariables]
     public TimeSpan NukeExplodedRoundEndDelay = TimeSpan.FromSeconds(10);
 
     /// <summary>
     ///     Time when the nuke exploded, or null while it has not. Used to delay round end.
     /// </summary>
-    [DataField]
+    [ViewVariables]
     public TimeSpan? NukeExplodedTime;
 }
 

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -94,6 +94,18 @@ public sealed partial class NukeopsRuleComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier GreetSoundNotification = new SoundPathSpecifier("/Audio/Ambience/Antag/nukeops_start.ogg");
+
+    /// <summary>
+    ///     Delay between the nuke exploding and the round ending, to give time for the nuke to potentionally kill the nukies and downgrade their win.
+    /// </summary>
+    [DataField]
+    public TimeSpan NukeExplodedRoundEndDelay = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    ///     Time when the nuke exploded, or null while it has not. Used to delay round end.
+    /// </summary>
+    [DataField]
+    public TimeSpan? NukeExplodedTime;
 }
 
 public enum WinType : byte


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Delays round end from when the nuke explodes during NukeOps by 10 seconds.

The round end in this case is when the window pops up after the nuke would usually explode.

This delay should only occur if the nuke explodes on the right station, on the wrong station it will just cut to the end of round like before.

Note that this PR does not actually add any checks to see if the nukies survived.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This allows for time for the nuke to actually destory the station, and potentionally kill the NukeOps if they stay near it. This would then allow for their win to be downgraded in future from a major to a minor if they are all dead, with an extra line on the end of round window stating they all died.

It also allows for the nuke to explode the station a little before everything ends and the window gets in the way.

## Technical details
<!-- Summary of code changes for easier review. -->

Added an `Update` method to `NukeopsRuleSystem`, that will check to see if the round should end after the nuke explodes. I am not sure of a better way of doing this, or if this is the "correct" way. I've avoided using `Timer` since it has the issue of not being well tied to the game, and hard to cancel, leading to bugs.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: During NukeOps, the round will no longer end immeidately after the nuke explodes, and will instead be delayed by a short time.
