### PR TITLE
Removes PKA from salvage vending

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -9,4 +9,3 @@
     HandheldGPSBasic: 2
     RadioHandheld: 2
     WeaponGrapplingGun: 2
-    WeaponProtoKineticAccelerator: 4


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes PKA from salvage vending

## Why / Balance
Based on salvage design doc
- [Salvage Weapons.](https://docs.spacestation14.com/en/space-station-14/departments/cargo-salvage/proposals/salvage-proposal.html#salvage-weapons)
 including the PKA, combat knife, dagger, crusher and glaive do not need to be available from the starting salvage vendor.

- You still can ask RnD for PKA and find it on wrecks.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
-  [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- remove: Proto-Kinetic Accelerators removed from salvage vendor, you still can obtain it at wrecks and unlock Salvage Weapons technology in RnD.