### PR TITLE
remove wanted list cartridge from captain PDA

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -496,7 +496,7 @@
     state: pda-janitor
 
 - type: entity
-  parent: BaseSecurityPDA
+  parent: BasePDA
   id: CaptainPDA
   name: captain PDA
   description: Surprisingly no different from your PDA.


### PR DESCRIPTION
## About the PR
See title.

## Why / Balance
The captain is not security and in general we do not want the captain to be valid hunting. They do not have a sec HUD for the same reason. They still can talk to security over coms and see important updates there if needed.

## Technical details
the only difference between BasePDA and BaseSecurityPDA are the installed cartridges

## Media
![grafik](https://github.com/user-attachments/assets/7b7eab16-3806-48a1-a364-3eab238a3bf3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- remove: Removed the wanted list cartridge from the captain's PDA.
