### PR TITLE
Correct IdentityBlocker to include specific outer clothing

### DIFF
--- a/Content.Shared/IdentityManagement/Components/IdentityBlockerComponent.cs
+++ b/Content.Shared/IdentityManagement/Components/IdentityBlockerComponent.cs
@@ -21,7 +21,8 @@ public enum IdentityBlockerCoverage
     NONE  = 0,
     MOUTH = 1 << 0,
     EYES  = 1 << 1,
-    FULL  = MOUTH | EYES
+    OUTER = 1 << 1,
+    FULL  = MOUTH | EYES | OUTER
 }
 
 /// <summary>
@@ -30,7 +31,7 @@ public enum IdentityBlockerCoverage
 public sealed class SeeIdentityAttemptEvent : CancellableEntityEventArgs, IInventoryRelayEvent
 {
     // i.e. masks, helmets, or glasses.
-    public SlotFlags TargetSlots => SlotFlags.MASK | SlotFlags.HEAD | SlotFlags.EYES;
+    public SlotFlags TargetSlots => SlotFlags.MASK | SlotFlags.HEAD | SlotFlags.EYES | SlotFlags.OUTERCLOTHING;
 
     // cumulative coverage from each relayed slot
     public IdentityBlockerCoverage TotalCoverage = IdentityBlockerCoverage.NONE;

--- a/Content.Shared/IdentityManagement/Components/IdentityBlockerComponent.cs
+++ b/Content.Shared/IdentityManagement/Components/IdentityBlockerComponent.cs
@@ -21,7 +21,7 @@ public enum IdentityBlockerCoverage
     NONE  = 0,
     MOUTH = 1 << 0,
     EYES  = 1 << 1,
-    OUTER = 1 << 1,
+    OUTER = 1 << 2,
     FULL  = MOUTH | EYES | OUTER
 }
 

--- a/Content.Shared/IdentityManagement/Components/IdentityBlockerComponent.cs
+++ b/Content.Shared/IdentityManagement/Components/IdentityBlockerComponent.cs
@@ -21,8 +21,7 @@ public enum IdentityBlockerCoverage
     NONE  = 0,
     MOUTH = 1 << 0,
     EYES  = 1 << 1,
-    OUTER = 1 << 2,
-    FULL  = MOUTH | EYES | OUTER
+    FULL  = MOUTH | EYES
 }
 
 /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Modify the Identity Blocker component to include flags for outer clothing, IE the ghost sheet.

## Why / Balance
Fix #32912

## Technical details
Adds flag for outer clothing to `IdentityBlockerComponent.cs`

## Media
![image](https://github.com/user-attachments/assets/dc76833d-1072-4ddd-8799-8b6c3c97cc2b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Specific outer clothing now correctly blocks your identity.
