### PR TITLE
RoomSpawner mask

### DIFF
--- a/Content.Server/Procedural/DungeonSystem.Rooms.cs
+++ b/Content.Server/Procedural/DungeonSystem.Rooms.cs
@@ -156,9 +156,9 @@ public sealed partial class DungeonSystem
                 if (!clearExisting && reservedTiles?.Contains(rounded) == true)
                     continue;
 
-                if (room.IgnoreTile.Count > 0)
+                if (room.IgnoreTile is not null)
                 {
-                    if (_maps.TryGetTileDef(templateGrid, indices, out var tileDef) && room.IgnoreTile.Contains(tileDef.ID))
+                    if (_maps.TryGetTileDef(templateGrid, indices, out var tileDef) && room.IgnoreTile == tileDef.ID)
                         continue;
                 }
 

--- a/Content.Server/Procedural/DungeonSystem.Rooms.cs
+++ b/Content.Server/Procedural/DungeonSystem.Rooms.cs
@@ -19,7 +19,7 @@ public sealed partial class DungeonSystem
     /// <summary>
     /// Gets a random dungeon room matching the specified area and whitelist.
     /// </summary>
-    public DungeonRoomPrototype? GetRoomPrototype(Vector2i size, Random random, EntityWhitelist? whitelist = null)
+    public DungeonRoomPrototype? GetRoomPrototype(Random random, EntityWhitelist? whitelist = null, Vector2i? size = null)
     {
         // Can never be true.
         if (whitelist is { Tags: null })
@@ -31,7 +31,7 @@ public sealed partial class DungeonSystem
 
         foreach (var proto in _prototype.EnumeratePrototypes<DungeonRoomPrototype>())
         {
-            if (proto.Size != size)
+            if (size is not null && proto.Size != size)
                 continue;
 
             if (whitelist == null)

--- a/Content.Server/Procedural/DungeonSystem.Rooms.cs
+++ b/Content.Server/Procedural/DungeonSystem.Rooms.cs
@@ -156,6 +156,12 @@ public sealed partial class DungeonSystem
                 if (!clearExisting && reservedTiles?.Contains(rounded) == true)
                     continue;
 
+                if (room.IgnoreTile.Count > 0)
+                {
+                    if (_maps.TryGetTileDef(templateGrid, indices, out var tileDef) && room.IgnoreTile.Contains(tileDef.ID))
+                        continue;
+                }
+
                 _tiles.Add((rounded, tileRef.Tile));
             }
         }

--- a/Content.Server/Procedural/RoomFillComponent.cs
+++ b/Content.Server/Procedural/RoomFillComponent.cs
@@ -33,5 +33,5 @@ public sealed partial class RoomFillComponent : Component
     /// Should any existing entities / decals be bulldozed first.
     /// </summary>
     [DataField]
-    public bool ClearExisting;
+    public bool ClearExisting = true;
 }

--- a/Content.Server/Procedural/RoomFillComponent.cs
+++ b/Content.Server/Procedural/RoomFillComponent.cs
@@ -20,15 +20,15 @@ public sealed partial class RoomFillComponent : Component
     /// <summary>
     /// Size of the room to fill.
     /// </summary>
-    [DataField(required: true)]
-    public Vector2i Size;
+    [DataField]
+    public Vector2i? Size;
 
     /// <summary>
     /// Rooms allowed for the marker.
     /// </summary>
     [DataField]
     public EntityWhitelist? RoomWhitelist;
-    
+
     /// <summary>
     /// Should any existing entities / decals be bulldozed first.
     /// </summary>

--- a/Content.Server/Procedural/RoomFillSystem.cs
+++ b/Content.Server/Procedural/RoomFillSystem.cs
@@ -24,7 +24,7 @@ public sealed class RoomFillSystem : EntitySystem
         if (xform.GridUid != null)
         {
             var random = new Random();
-            var room = _dungeon.GetRoomPrototype(component.Size, random, component.RoomWhitelist);
+            var room = _dungeon.GetRoomPrototype(random, component.RoomWhitelist, component.Size);
 
             if (room != null)
             {

--- a/Content.Shared/Procedural/DungeonRoomPrototype.cs
+++ b/Content.Shared/Procedural/DungeonRoomPrototype.cs
@@ -33,5 +33,5 @@ public sealed partial class DungeonRoomPrototype : IPrototype
     /// allowing you to make rooms of irregular shapes that blend seamlessly into their surroundings
     /// </summary>
     [DataField]
-    public HashSet<ProtoId<ContentTileDefinition>> IgnoreTile = new();
+    public ProtoId<ContentTileDefinition>? IgnoreTile;
 }

--- a/Content.Shared/Procedural/DungeonRoomPrototype.cs
+++ b/Content.Shared/Procedural/DungeonRoomPrototype.cs
@@ -1,6 +1,6 @@
+using Content.Shared.Maps;
 using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Procedural;
@@ -10,18 +10,28 @@ public sealed partial class DungeonRoomPrototype : IPrototype
 {
     [IdDataField] public string ID { get; } = string.Empty;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("tags", customTypeSerializer:typeof(PrototypeIdListSerializer<TagPrototype>))]
-    public List<string> Tags = new();
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public List<ProtoId<TagPrototype>> Tags = new();
 
-    [DataField("size", required: true)] public Vector2i Size;
+    [DataField(required: true)]
+    public Vector2i Size;
 
     /// <summary>
     /// Path to the file to use for the room.
     /// </summary>
-    [DataField("atlas", required: true)] public ResPath AtlasPath;
+    [DataField("atlas", required: true)]
+    public ResPath AtlasPath;
 
     /// <summary>
     /// Tile offset into the atlas to use for the room.
     /// </summary>
-    [DataField("offset", required: true)] public Vector2i Offset;
+    [DataField(required: true)]
+    public Vector2i Offset;
+
+    /// <summary>
+    /// These tiles will be ignored when copying from the atlas into the actual game,
+    /// allowing you to make rooms of irregular shapes that blend seamlessly into their surroundings
+    /// </summary>
+    [DataField]
+    public HashSet<ProtoId<ContentTileDefinition>> IgnoreTile = new();
 }

--- a/Resources/Maps/Dungeon/vgroidinterior.yml
+++ b/Resources/Maps/Dungeon/vgroidinterior.yml
@@ -35,11 +35,11 @@ entities:
           version: 6
         0,0:
           ind: 0,0
-          tiles: AgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAABAAAAAAABQAAAAAABQAAAAAABQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAgAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABgAAAAAAAQAAAAAAAwAAAAAABgAAAAAAAwAAAAAABgAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAAwAAAAAABgAAAAAAAQAAAAAABgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABgAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAABAAAAAAAAwAAAAAABAAAAAAABgAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAQAAAAAABgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABgAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAA
+          tiles: UgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAABAAAAAAABQAAAAAABQAAAAAABQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAUgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAUgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAUgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAUgAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAUgAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAUgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAAUgAAAAAAAwAAAAAAUgAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAUgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAABAAAAAAAAwAAAAAABAAAAAAAUgAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAQAAAAAAUgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAA
           version: 6
         0,1:
           ind: 0,1
-          tiles: BgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAABgAAAAAAAwAAAAAABgAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          tiles: UgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAUgAAAAAAAwAAAAAAUgAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAUgAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAAQAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
@@ -59,11 +59,11 @@ entities:
           version: 6
         1,0:
           ind: 1,0
-          tiles: BAAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAABwAAAAAACAAAAAAABwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAABwAAAAAABwAAAAAACAAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAACAAAAAAABwAAAAAABwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAABgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABgAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: BAAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAUgAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAABwAAAAAACAAAAAAABwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAABwAAAAAABwAAAAAACAAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAACAAAAAAABwAAAAAABwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAUgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAUgAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAWQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         1,1:
           ind: 1,1
-          tiles: AwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAAAWQAAAAAAAwAAAAAABwAAAAAABwAAAAAABwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAWQAAAAAAWQAAAAAABwAAAAAABwAAAAAABwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAWQAAAAAAWQAAAAAABwAAAAAABwAAAAAABwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,2:
           ind: -1,2
@@ -172,612 +172,649 @@ entities:
     - type: RadiationGridResistance
 - proto: AirlockMaintLocked
   entities:
-  - uid: 75
+  - uid: 2
     components:
     - type: Transform
       pos: 20.5,6.5
       parent: 1
-  - uid: 113
+  - uid: 3
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 1
-  - uid: 207
+  - uid: 4
     components:
     - type: Transform
       pos: 14.5,8.5
       parent: 1
-  - uid: 225
+  - uid: 5
     components:
     - type: Transform
       pos: 20.5,12.5
       parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,19.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,21.5
+      parent: 1
 - proto: AtmosFixInstantPlasmaFireMarker
   entities:
-  - uid: 233
+  - uid: 6
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 1
 - proto: Bed
   entities:
-  - uid: 71
+  - uid: 7
     components:
     - type: Transform
       pos: 21.5,9.5
       parent: 1
 - proto: BedsheetSpawner
   entities:
-  - uid: 89
+  - uid: 8
     components:
     - type: Transform
       pos: 21.5,9.5
       parent: 1
 - proto: BookshelfFilled
   entities:
-  - uid: 90
+  - uid: 9
     components:
     - type: Transform
       pos: 19.5,9.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 3
+  - uid: 10
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-  - uid: 4
+  - uid: 11
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 5
+  - uid: 12
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 6
+  - uid: 13
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 7
+  - uid: 14
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
 - proto: ChairWood
   entities:
-  - uid: 76
+  - uid: 15
     components:
     - type: Transform
       pos: 19.45475,8.339682
       parent: 1
 - proto: CrateMaterialPlasma
   entities:
-  - uid: 232
+  - uid: 16
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 1
 - proto: GeneratorRTG
   entities:
-  - uid: 2
+  - uid: 17
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
 - proto: GeneratorRTGDamaged
   entities:
-  - uid: 11
+  - uid: 18
     components:
     - type: Transform
       pos: 20.5,2.5
       parent: 1
 - proto: Girder
   entities:
-  - uid: 231
+  - uid: 19
     components:
     - type: Transform
       pos: 16.5,12.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 8
+  - uid: 20
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 9
+  - uid: 21
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 10
+  - uid: 22
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
-  - uid: 175
+  - uid: 23
     components:
     - type: Transform
       pos: 12.5,15.5
       parent: 1
-  - uid: 176
+  - uid: 24
     components:
     - type: Transform
       pos: 16.5,15.5
       parent: 1
-  - uid: 177
+  - uid: 25
     components:
     - type: Transform
       pos: 13.5,16.5
       parent: 1
-  - uid: 183
+  - uid: 26
     components:
     - type: Transform
       pos: 12.5,13.5
       parent: 1
-  - uid: 184
+  - uid: 27
     components:
     - type: Transform
       pos: 13.5,12.5
       parent: 1
-  - uid: 185
+  - uid: 28
     components:
     - type: Transform
       pos: 15.5,16.5
       parent: 1
-  - uid: 214
+  - uid: 29
     components:
     - type: Transform
       pos: 12.5,14.5
       parent: 1
-  - uid: 215
+  - uid: 30
     components:
     - type: Transform
       pos: 16.5,14.5
       parent: 1
-  - uid: 216
+  - uid: 31
     components:
     - type: Transform
       pos: 14.5,16.5
       parent: 1
-  - uid: 312
+  - uid: 32
     components:
     - type: Transform
       pos: 1.5,15.5
       parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,19.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,19.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,21.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,21.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      pos: 14.5,19.5
+      parent: 1
+  - uid: 475
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,19.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,20.5
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,21.5
+      parent: 1
 - proto: GrilleBroken
   entities:
-  - uid: 186
+  - uid: 33
     components:
     - type: Transform
       pos: 14.5,12.5
       parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,18.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,18.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,18.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 7.5,22.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 8.5,22.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 3.5,22.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,19.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,21.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,22.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 14.5,21.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,21.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      pos: 15.5,21.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,19.5
+      parent: 1
 - proto: GrilleSpawner
   entities:
-  - uid: 133
+  - uid: 34
     components:
     - type: Transform
       pos: 16.5,13.5
       parent: 1
-  - uid: 217
+  - uid: 35
     components:
     - type: Transform
       pos: 15.5,12.5
       parent: 1
 - proto: IronRockDiamond
   entities:
-  - uid: 167
+  - uid: 36
     components:
     - type: Transform
       pos: 14.5,14.5
       parent: 1
-- proto: IronRockGold
-  entities:
-  - uid: 30
-    components:
-    - type: Transform
-      pos: 13.5,7.5
-      parent: 1
-  - uid: 78
-    components:
-    - type: Transform
-      pos: 0.5,6.5
-      parent: 1
-  - uid: 99
-    components:
-    - type: Transform
-      pos: 0.5,10.5
-      parent: 1
-  - uid: 283
-    components:
-    - type: Transform
-      pos: 4.5,10.5
-      parent: 1
-  - uid: 284
-    components:
-    - type: Transform
-      pos: 4.5,8.5
-      parent: 1
-  - uid: 289
-    components:
-    - type: Transform
-      pos: 14.5,7.5
-      parent: 1
-  - uid: 299
-    components:
-    - type: Transform
-      pos: 15.5,7.5
-      parent: 1
-  - uid: 301
-    components:
-    - type: Transform
-      pos: 0.5,8.5
-      parent: 1
-  - uid: 303
-    components:
-    - type: Transform
-      pos: 4.5,6.5
-      parent: 1
-- proto: IronRockPlasma
-  entities:
-  - uid: 100
-    components:
-    - type: Transform
-      pos: 10.5,15.5
-      parent: 1
-  - uid: 255
-    components:
-    - type: Transform
-      pos: 9.5,16.5
-      parent: 1
-  - uid: 265
-    components:
-    - type: Transform
-      pos: 7.5,16.5
-      parent: 1
-  - uid: 266
-    components:
-    - type: Transform
-      pos: 6.5,13.5
-      parent: 1
-  - uid: 282
-    components:
-    - type: Transform
-      pos: 6.5,15.5
-      parent: 1
-  - uid: 285
-    components:
-    - type: Transform
-      pos: 18.5,12.5
-      parent: 1
-  - uid: 286
-    components:
-    - type: Transform
-      pos: 22.5,12.5
-      parent: 1
-  - uid: 287
-    components:
-    - type: Transform
-      pos: 4.5,12.5
-      parent: 1
-  - uid: 295
-    components:
-    - type: Transform
-      pos: 7.5,12.5
-      parent: 1
-  - uid: 305
-    components:
-    - type: Transform
-      pos: 0.5,16.5
-      parent: 1
-  - uid: 306
-    components:
-    - type: Transform
-      pos: 4.5,13.5
-      parent: 1
-  - uid: 313
-    components:
-    - type: Transform
-      pos: 9.5,12.5
-      parent: 1
-  - uid: 314
-    components:
-    - type: Transform
-      pos: 10.5,13.5
-      parent: 1
-- proto: IronRockSilver
-  entities:
-  - uid: 81
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 1
-  - uid: 82
-    components:
-    - type: Transform
-      pos: 4.5,0.5
-      parent: 1
-  - uid: 83
-    components:
-    - type: Transform
-      pos: 0.5,0.5
-      parent: 1
-  - uid: 84
-    components:
-    - type: Transform
-      pos: 0.5,4.5
-      parent: 1
-  - uid: 281
-    components:
-    - type: Transform
-      pos: 10.5,7.5
-      parent: 1
-  - uid: 288
-    components:
-    - type: Transform
-      pos: 10.5,6.5
-      parent: 1
-  - uid: 298
-    components:
-    - type: Transform
-      pos: 6.5,6.5
-      parent: 1
-  - uid: 300
-    components:
-    - type: Transform
-      pos: 6.5,7.5
-      parent: 1
-- proto: IronRockUranium
-  entities:
-  - uid: 85
-    components:
-    - type: Transform
-      pos: 18.5,2.5
-      parent: 1
-  - uid: 86
-    components:
-    - type: Transform
-      pos: 20.5,0.5
-      parent: 1
-  - uid: 87
-    components:
-    - type: Transform
-      pos: 22.5,2.5
-      parent: 1
-  - uid: 88
-    components:
-    - type: Transform
-      pos: 20.5,4.5
-      parent: 1
 - proto: LandMineExplosive
   entities:
-  - uid: 164
+  - uid: 71
     components:
     - type: Transform
       pos: 13.439286,14.473711
       parent: 1
-  - uid: 166
+  - uid: 72
     components:
     - type: Transform
       pos: 15.486161,14.504961
       parent: 1
-  - uid: 198
+  - uid: 73
     components:
     - type: Transform
       pos: 14.525224,15.4346485
       parent: 1
-  - uid: 199
+  - uid: 74
     components:
     - type: Transform
       pos: 14.525224,13.442461
       parent: 1
 - proto: PoweredLightPostSmallEmpty
   entities:
-  - uid: 204
+  - uid: 75
     components:
     - type: Transform
       pos: 16.5,0.5
       parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 471
+    components:
+    - type: Transform
+      pos: 20.5,21.5
+      parent: 1
+- proto: PoweredSmallLightEmpty
+  entities:
+  - uid: 469
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,19.5
+      parent: 1
 - proto: Rack
   entities:
-  - uid: 213
+  - uid: 76
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 1
+- proto: ReinforcedWindow
+  entities:
+  - uid: 427
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,19.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,20.5
+      parent: 1
+  - uid: 453
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,21.5
+      parent: 1
 - proto: SalvageCanisterSpawner
   entities:
-  - uid: 239
+  - uid: 77
     components:
     - type: Transform
       pos: 20.5,9.5
       parent: 1
-  - uid: 302
+  - uid: 78
     components:
     - type: Transform
       pos: 15.5,3.5
       parent: 1
 - proto: SalvageSpawnerEquipment
   entities:
-  - uid: 234
+  - uid: 79
     components:
     - type: Transform
       pos: 21.5,7.5
       parent: 1
-  - uid: 262
+  - uid: 80
     components:
     - type: Transform
       pos: 21.5,7.5
       parent: 1
-  - uid: 412
+  - uid: 81
     components:
     - type: Transform
       pos: 21.5,14.5
       parent: 1
-  - uid: 413
+  - uid: 82
     components:
     - type: Transform
       pos: 20.5,13.5
       parent: 1
 - proto: SalvageSpawnerEquipmentValuable
   entities:
-  - uid: 143
+  - uid: 83
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 1
-  - uid: 144
+  - uid: 84
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1
-  - uid: 145
+  - uid: 85
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 146
+  - uid: 86
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 1
-  - uid: 147
+  - uid: 87
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 169
+  - uid: 88
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 170
+  - uid: 89
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 172
+  - uid: 90
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 1
-  - uid: 182
+  - uid: 91
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 191
+  - uid: 92
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 1
-  - uid: 210
+  - uid: 93
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 211
+  - uid: 94
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 221
+  - uid: 95
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 1
-  - uid: 222
+  - uid: 96
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 1
-  - uid: 257
+  - uid: 97
     components:
     - type: Transform
       pos: 21.5,9.5
       parent: 1
-  - uid: 261
+  - uid: 98
     components:
     - type: Transform
       pos: 21.5,9.5
       parent: 1
-  - uid: 342
+  - uid: 99
     components:
     - type: Transform
       pos: 13.5,9.5
       parent: 1
-  - uid: 343
+  - uid: 100
     components:
     - type: Transform
       pos: 13.5,9.5
       parent: 1
-  - uid: 344
+  - uid: 101
     components:
     - type: Transform
       pos: 15.5,9.5
       parent: 1
-  - uid: 345
+  - uid: 102
     components:
     - type: Transform
       pos: 15.5,9.5
       parent: 1
-  - uid: 346
+  - uid: 103
     components:
     - type: Transform
       pos: 15.5,9.5
       parent: 1
-  - uid: 347
+  - uid: 104
     components:
     - type: Transform
       pos: 13.5,9.5
       parent: 1
-  - uid: 404
+  - uid: 105
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-  - uid: 405
+  - uid: 106
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
-  - uid: 406
+  - uid: 107
     components:
     - type: Transform
       pos: 19.5,15.5
       parent: 1
-  - uid: 407
+  - uid: 108
     components:
     - type: Transform
       pos: 20.5,15.5
       parent: 1
-  - uid: 408
+  - uid: 109
     components:
     - type: Transform
       pos: 21.5,15.5
       parent: 1
-  - uid: 409
+  - uid: 110
     components:
     - type: Transform
       pos: 21.5,15.5
       parent: 1
-  - uid: 410
+  - uid: 111
     components:
     - type: Transform
       pos: 20.5,15.5
       parent: 1
-  - uid: 411
+  - uid: 112
     components:
     - type: Transform
       pos: 19.5,15.5
       parent: 1
 - proto: SalvageSpawnerScrapCommon
   entities:
+  - uid: 37
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,20.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,20.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 14.5,0.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 12.5,0.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 15.5,2.5
+      parent: 1
   - uid: 116
+    components:
+    - type: Transform
+      pos: 13.5,0.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 15.5,0.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 14.5,0.5
+      parent: 1
+  - uid: 119
     components:
     - type: Transform
       pos: 14.5,0.5
@@ -785,1577 +822,1881 @@ entities:
   - uid: 120
     components:
     - type: Transform
-      pos: 12.5,0.5
-      parent: 1
-  - uid: 123
-    components:
-    - type: Transform
-      pos: 15.5,2.5
-      parent: 1
-  - uid: 129
-    components:
-    - type: Transform
-      pos: 13.5,0.5
-      parent: 1
-  - uid: 130
-    components:
-    - type: Transform
-      pos: 15.5,0.5
-      parent: 1
-  - uid: 131
-    components:
-    - type: Transform
-      pos: 14.5,0.5
-      parent: 1
-  - uid: 132
-    components:
-    - type: Transform
-      pos: 14.5,0.5
-      parent: 1
-  - uid: 148
-    components:
-    - type: Transform
       pos: 13.5,2.5
       parent: 1
-  - uid: 149
+  - uid: 121
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 1
-  - uid: 150
+  - uid: 122
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 1
-  - uid: 212
+  - uid: 123
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 219
+  - uid: 124
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 1
-  - uid: 220
+  - uid: 125
     components:
     - type: Transform
       pos: 15.5,0.5
       parent: 1
-  - uid: 236
+  - uid: 126
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 1
-  - uid: 238
+  - uid: 127
     components:
     - type: Transform
       pos: 19.5,8.5
       parent: 1
-  - uid: 241
+  - uid: 128
     components:
     - type: Transform
       pos: 21.5,7.5
       parent: 1
-  - uid: 256
+  - uid: 129
     components:
     - type: Transform
       pos: 20.5,7.5
       parent: 1
-  - uid: 258
+  - uid: 130
     components:
     - type: Transform
       pos: 20.5,8.5
       parent: 1
-  - uid: 259
+  - uid: 131
     components:
     - type: Transform
       pos: 21.5,8.5
       parent: 1
-  - uid: 260
+  - uid: 132
     components:
     - type: Transform
       pos: 21.5,9.5
       parent: 1
-  - uid: 263
+  - uid: 133
     components:
     - type: Transform
       pos: 15.5,0.5
       parent: 1
-  - uid: 264
+  - uid: 134
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 1
-  - uid: 280
+  - uid: 135
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1
-  - uid: 315
+  - uid: 136
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 1
-  - uid: 316
+  - uid: 137
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 317
+  - uid: 138
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 318
+  - uid: 139
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 319
+  - uid: 140
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 320
+  - uid: 141
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 1
-  - uid: 321
+  - uid: 142
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 322
+  - uid: 143
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 323
+  - uid: 144
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 324
+  - uid: 145
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 325
+  - uid: 146
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 326
+  - uid: 147
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 351
+  - uid: 148
     components:
     - type: Transform
       pos: 13.5,9.5
       parent: 1
-  - uid: 352
+  - uid: 149
     components:
     - type: Transform
       pos: 14.5,9.5
       parent: 1
-  - uid: 353
+  - uid: 150
     components:
     - type: Transform
       pos: 15.5,9.5
       parent: 1
-  - uid: 363
+  - uid: 151
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 364
+  - uid: 152
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 365
+  - uid: 153
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 366
+  - uid: 154
     components:
     - type: Transform
       pos: 13.5,15.5
       parent: 1
-  - uid: 367
+  - uid: 155
     components:
     - type: Transform
       pos: 14.5,15.5
       parent: 1
-  - uid: 368
+  - uid: 156
     components:
     - type: Transform
       pos: 15.5,15.5
       parent: 1
-  - uid: 369
+  - uid: 157
     components:
     - type: Transform
       pos: 15.5,14.5
       parent: 1
-  - uid: 370
+  - uid: 158
     components:
     - type: Transform
       pos: 15.5,13.5
       parent: 1
-  - uid: 371
+  - uid: 159
     components:
     - type: Transform
       pos: 14.5,13.5
       parent: 1
-  - uid: 372
+  - uid: 160
     components:
     - type: Transform
       pos: 13.5,13.5
       parent: 1
-  - uid: 373
+  - uid: 161
     components:
     - type: Transform
       pos: 13.5,14.5
       parent: 1
-  - uid: 374
+  - uid: 162
     components:
     - type: Transform
       pos: 13.5,15.5
       parent: 1
-  - uid: 375
+  - uid: 163
     components:
     - type: Transform
       pos: 14.5,15.5
       parent: 1
-  - uid: 376
+  - uid: 164
     components:
     - type: Transform
       pos: 15.5,15.5
       parent: 1
-  - uid: 377
+  - uid: 165
     components:
     - type: Transform
       pos: 15.5,14.5
       parent: 1
-  - uid: 378
+  - uid: 166
     components:
     - type: Transform
       pos: 15.5,13.5
       parent: 1
-  - uid: 379
+  - uid: 167
     components:
     - type: Transform
       pos: 14.5,13.5
       parent: 1
-  - uid: 380
+  - uid: 168
     components:
     - type: Transform
       pos: 13.5,13.5
       parent: 1
-  - uid: 381
+  - uid: 169
     components:
     - type: Transform
       pos: 13.5,14.5
       parent: 1
-  - uid: 417
+  - uid: 170
     components:
     - type: Transform
       pos: 19.5,14.5
       parent: 1
-  - uid: 418
+  - uid: 171
     components:
     - type: Transform
       pos: 19.5,15.5
       parent: 1
-  - uid: 419
+  - uid: 172
     components:
     - type: Transform
       pos: 20.5,14.5
       parent: 1
-  - uid: 420
+  - uid: 173
     components:
     - type: Transform
       pos: 20.5,15.5
       parent: 1
-  - uid: 421
+  - uid: 174
     components:
     - type: Transform
       pos: 21.5,14.5
       parent: 1
-  - uid: 422
+  - uid: 175
     components:
     - type: Transform
       pos: 21.5,15.5
       parent: 1
-  - uid: 423
+  - uid: 176
     components:
     - type: Transform
       pos: 20.5,13.5
       parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,20.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,20.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,19.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,21.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,19.5
+      parent: 1
 - proto: SalvageSpawnerScrapCommon75
   entities:
-  - uid: 398
+  - uid: 177
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-  - uid: 399
+  - uid: 178
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
-  - uid: 400
+  - uid: 179
     components:
     - type: Transform
       pos: 2.5,15.5
       parent: 1
-  - uid: 401
+  - uid: 180
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
 - proto: SalvageSpawnerScrapValuable
   entities:
-  - uid: 25
+  - uid: 181
     components:
     - type: Transform
       pos: 21.5,8.5
       parent: 1
-  - uid: 118
+  - uid: 182
     components:
     - type: Transform
       pos: 20.5,7.5
       parent: 1
-  - uid: 119
+  - uid: 183
     components:
     - type: Transform
       pos: 21.5,7.5
       parent: 1
-  - uid: 171
+  - uid: 184
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 1
-  - uid: 208
+  - uid: 185
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 209
+  - uid: 186
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 235
+  - uid: 187
     components:
     - type: Transform
       pos: 19.5,8.5
       parent: 1
-  - uid: 240
+  - uid: 188
     components:
     - type: Transform
       pos: 20.5,8.5
       parent: 1
-  - uid: 389
+  - uid: 189
     components:
     - type: Transform
       pos: 8.5,9.5
       parent: 1
-  - uid: 390
+  - uid: 190
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 1
-  - uid: 414
+  - uid: 191
     components:
     - type: Transform
       pos: 19.5,14.5
       parent: 1
-  - uid: 415
+  - uid: 192
     components:
     - type: Transform
       pos: 20.5,14.5
       parent: 1
-  - uid: 416
+  - uid: 193
     components:
     - type: Transform
       pos: 21.5,14.5
       parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,19.5
+      parent: 1
 - proto: SalvageSpawnerScrapValuable75
   entities:
-  - uid: 121
+  - uid: 42
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,20.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,20.5
+      parent: 1
+  - uid: 194
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 1
-  - uid: 122
+  - uid: 195
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 1
-  - uid: 124
+  - uid: 196
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 1
-  - uid: 327
+  - uid: 197
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 328
+  - uid: 198
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 329
+  - uid: 199
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 330
+  - uid: 200
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 331
+  - uid: 201
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 332
+  - uid: 202
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 333
+  - uid: 203
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 334
+  - uid: 204
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 335
+  - uid: 205
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 336
+  - uid: 206
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 337
+  - uid: 207
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 338
+  - uid: 208
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 382
+  - uid: 209
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 1
-  - uid: 383
+  - uid: 210
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 1
-  - uid: 384
+  - uid: 211
     components:
     - type: Transform
       pos: 8.5,9.5
       parent: 1
-  - uid: 385
+  - uid: 212
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 1
-  - uid: 386
+  - uid: 213
     components:
     - type: Transform
       pos: 8.5,9.5
       parent: 1
-  - uid: 387
+  - uid: 214
     components:
     - type: Transform
       pos: 9.5,9.5
       parent: 1
-  - uid: 388
+  - uid: 215
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 402
+  - uid: 216
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
-  - uid: 403
+  - uid: 217
     components:
     - type: Transform
       pos: 3.5,15.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,20.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,19.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,19.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,21.5
       parent: 1
 - proto: SalvageSpawnerTreasure
   entities:
-  - uid: 188
+  - uid: 218
     components:
     - type: Transform
       pos: 15.5,2.5
       parent: 1
-  - uid: 348
+  - uid: 219
     components:
     - type: Transform
       pos: 13.5,9.5
       parent: 1
-  - uid: 349
+  - uid: 220
     components:
     - type: Transform
       pos: 14.5,9.5
       parent: 1
-  - uid: 350
+  - uid: 221
     components:
     - type: Transform
       pos: 15.5,9.5
       parent: 1
-  - uid: 360
+  - uid: 222
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 361
+  - uid: 223
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 362
+  - uid: 224
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 393
+  - uid: 225
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 1
-  - uid: 394
+  - uid: 226
     components:
     - type: Transform
       pos: 14.5,9.5
       parent: 1
 - proto: SalvageSpawnerTreasureValuable
   entities:
-  - uid: 189
+  - uid: 43
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,20.5
+      parent: 1
+  - uid: 227
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 1
-  - uid: 190
+  - uid: 228
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 1
-  - uid: 237
+  - uid: 229
     components:
     - type: Transform
       pos: 19.5,7.5
       parent: 1
-  - uid: 242
+  - uid: 230
     components:
     - type: Transform
       pos: 20.5,8.5
       parent: 1
-  - uid: 304
+  - uid: 231
     components:
     - type: Transform
       pos: 19.5,7.5
       parent: 1
-  - uid: 339
+  - uid: 232
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 340
+  - uid: 233
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 341
+  - uid: 234
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 354
+  - uid: 235
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 355
+  - uid: 236
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 356
+  - uid: 237
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 357
+  - uid: 238
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 358
+  - uid: 239
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 359
+  - uid: 240
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 391
+  - uid: 241
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 1
-  - uid: 392
+  - uid: 242
     components:
     - type: Transform
       pos: 8.5,9.5
       parent: 1
-  - uid: 395
+  - uid: 243
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 396
+  - uid: 244
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 397
+  - uid: 245
     components:
     - type: Transform
       pos: 1.5,13.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,19.5
       parent: 1
 - proto: ShuttersWindow
   entities:
-  - uid: 65
+  - uid: 246
     components:
     - type: Transform
       pos: 15.5,1.5
       parent: 1
 - proto: SignMaterials
   entities:
-  - uid: 136
+  - uid: 247
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 1
 - proto: SignRadiationMed
   entities:
-  - uid: 193
+  - uid: 248
     components:
     - type: Transform
       pos: 19.5,2.5
       parent: 1
-  - uid: 203
+  - uid: 249
     components:
     - type: Transform
       pos: 20.5,3.5
       parent: 1
-  - uid: 205
+  - uid: 250
     components:
     - type: Transform
       pos: 21.5,2.5
       parent: 1
-  - uid: 226
+  - uid: 251
     components:
     - type: Transform
       pos: 20.5,1.5
       parent: 1
 - proto: SignSecureMedRed
   entities:
-  - uid: 178
+  - uid: 252
     components:
     - type: Transform
       pos: 12.5,12.5
       parent: 1
-  - uid: 187
+  - uid: 253
     components:
     - type: Transform
       pos: 12.5,16.5
       parent: 1
-  - uid: 218
+  - uid: 254
     components:
     - type: Transform
       pos: 16.5,16.5
       parent: 1
+- proto: TableStone
+  entities:
+  - uid: 466
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,19.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,19.5
+      parent: 1
 - proto: TableWood
   entities:
-  - uid: 74
+  - uid: 255
     components:
     - type: Transform
       pos: 19.5,7.5
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 28
+  - uid: 38
     components:
     - type: Transform
-      pos: 7.5,14.5
-      parent: 1
-  - uid: 29
-    components:
-    - type: Transform
-      pos: 8.5,12.5
+      pos: 8.5,21.5
       parent: 1
   - uid: 39
     components:
     - type: Transform
-      pos: 10.5,4.5
-      parent: 1
-  - uid: 40
-    components:
-    - type: Transform
-      pos: 10.5,2.5
-      parent: 1
-  - uid: 41
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-  - uid: 42
-    components:
-    - type: Transform
-      pos: 7.5,0.5
-      parent: 1
-  - uid: 43
-    components:
-    - type: Transform
-      pos: 6.5,2.5
+      pos: 9.5,20.5
       parent: 1
   - uid: 44
     components:
     - type: Transform
-      pos: 6.5,3.5
+      pos: 9.5,21.5
       parent: 1
   - uid: 46
     components:
     - type: Transform
-      pos: 21.5,0.5
-      parent: 1
-  - uid: 50
-    components:
-    - type: Transform
-      pos: 19.5,0.5
-      parent: 1
-  - uid: 51
-    components:
-    - type: Transform
-      pos: 18.5,0.5
-      parent: 1
-  - uid: 52
-    components:
-    - type: Transform
-      pos: 22.5,0.5
-      parent: 1
-  - uid: 53
-    components:
-    - type: Transform
-      pos: 19.5,4.5
-      parent: 1
-  - uid: 55
-    components:
-    - type: Transform
-      pos: 22.5,3.5
-      parent: 1
-  - uid: 56
-    components:
-    - type: Transform
-      pos: 22.5,4.5
-      parent: 1
-  - uid: 57
-    components:
-    - type: Transform
-      pos: 22.5,1.5
-      parent: 1
-  - uid: 58
-    components:
-    - type: Transform
-      pos: 21.5,4.5
-      parent: 1
-  - uid: 59
-    components:
-    - type: Transform
-      pos: 18.5,3.5
-      parent: 1
-  - uid: 60
-    components:
-    - type: Transform
-      pos: 18.5,4.5
-      parent: 1
-  - uid: 63
-    components:
-    - type: Transform
-      pos: 18.5,1.5
-      parent: 1
-  - uid: 67
-    components:
-    - type: Transform
-      pos: 18.5,14.5
-      parent: 1
-  - uid: 70
-    components:
-    - type: Transform
-      pos: 8.5,15.5
-      parent: 1
-  - uid: 73
-    components:
-    - type: Transform
-      pos: 0.5,12.5
-      parent: 1
-  - uid: 77
-    components:
-    - type: Transform
-      pos: 10.5,12.5
-      parent: 1
-  - uid: 79
-    components:
-    - type: Transform
-      pos: 10.5,16.5
-      parent: 1
-  - uid: 80
-    components:
-    - type: Transform
-      pos: 6.5,16.5
-      parent: 1
-  - uid: 92
-    components:
-    - type: Transform
-      pos: 4.5,16.5
-      parent: 1
-  - uid: 96
-    components:
-    - type: Transform
-      pos: 6.5,14.5
-      parent: 1
-  - uid: 114
-    components:
-    - type: Transform
-      pos: 8.5,16.5
-      parent: 1
-  - uid: 115
-    components:
-    - type: Transform
-      pos: 6.5,12.5
-      parent: 1
-  - uid: 117
-    components:
-    - type: Transform
-      pos: 9.5,14.5
-      parent: 1
-  - uid: 137
-    components:
-    - type: Transform
-      pos: 16.5,8.5
-      parent: 1
-  - uid: 138
-    components:
-    - type: Transform
-      pos: 16.5,7.5
-      parent: 1
-  - uid: 152
-    components:
-    - type: Transform
-      pos: 16.5,10.5
-      parent: 1
-  - uid: 153
-    components:
-    - type: Transform
-      pos: 13.5,10.5
-      parent: 1
-  - uid: 154
-    components:
-    - type: Transform
-      pos: 14.5,10.5
-      parent: 1
-  - uid: 156
-    components:
-    - type: Transform
-      pos: 15.5,8.5
-      parent: 1
-  - uid: 174
-    components:
-    - type: Transform
-      pos: 16.5,16.5
-      parent: 1
-  - uid: 192
-    components:
-    - type: Transform
-      pos: 12.5,7.5
-      parent: 1
-  - uid: 223
-    components:
-    - type: Transform
-      pos: 12.5,8.5
-      parent: 1
-  - uid: 224
-    components:
-    - type: Transform
-      pos: 12.5,6.5
-      parent: 1
-  - uid: 229
-    components:
-    - type: Transform
-      pos: 12.5,16.5
-      parent: 1
-  - uid: 230
-    components:
-    - type: Transform
-      pos: 12.5,12.5
-      parent: 1
-  - uid: 243
-    components:
-    - type: Transform
-      pos: 9.5,15.5
-      parent: 1
-  - uid: 244
-    components:
-    - type: Transform
-      pos: 7.5,15.5
-      parent: 1
-  - uid: 250
-    components:
-    - type: Transform
-      pos: 20.5,16.5
-      parent: 1
-  - uid: 251
-    components:
-    - type: Transform
-      pos: 21.5,16.5
-      parent: 1
-  - uid: 252
-    components:
-    - type: Transform
-      pos: 10.5,14.5
-      parent: 1
-  - uid: 253
-    components:
-    - type: Transform
-      pos: 9.5,13.5
-      parent: 1
-  - uid: 254
-    components:
-    - type: Transform
-      pos: 7.5,13.5
-      parent: 1
-  - uid: 267
-    components:
-    - type: Transform
-      pos: 8.5,13.5
-      parent: 1
-  - uid: 268
-    components:
-    - type: Transform
-      pos: 22.5,14.5
-      parent: 1
-  - uid: 269
-    components:
-    - type: Transform
-      pos: 22.5,16.5
-      parent: 1
-  - uid: 270
-    components:
-    - type: Transform
-      pos: 21.5,12.5
-      parent: 1
-  - uid: 275
-    components:
-    - type: Transform
-      pos: 18.5,13.5
-      parent: 1
-  - uid: 276
-    components:
-    - type: Transform
-      pos: 19.5,12.5
-      parent: 1
-  - uid: 278
-    components:
-    - type: Transform
-      pos: 22.5,13.5
-      parent: 1
-  - uid: 279
-    components:
-    - type: Transform
-      pos: 18.5,15.5
-      parent: 1
-  - uid: 292
-    components:
-    - type: Transform
-      pos: 3.5,14.5
-      parent: 1
-  - uid: 293
-    components:
-    - type: Transform
-      pos: 4.5,14.5
-      parent: 1
-  - uid: 294
-    components:
-    - type: Transform
-      pos: 1.5,12.5
-      parent: 1
-  - uid: 296
-    components:
-    - type: Transform
-      pos: 1.5,14.5
-      parent: 1
-  - uid: 309
-    components:
-    - type: Transform
-      pos: 2.5,12.5
-      parent: 1
-  - uid: 310
-    components:
-    - type: Transform
-      pos: 4.5,15.5
-      parent: 1
-  - uid: 311
-    components:
-    - type: Transform
-      pos: 1.5,16.5
-      parent: 1
-- proto: WallReinforcedRust
-  entities:
-  - uid: 32
-    components:
-    - type: Transform
-      pos: 6.5,1.5
-      parent: 1
-  - uid: 33
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 1
-  - uid: 34
-    components:
-    - type: Transform
-      pos: 10.5,3.5
-      parent: 1
-  - uid: 35
-    components:
-    - type: Transform
-      pos: 9.5,0.5
-      parent: 1
-  - uid: 36
-    components:
-    - type: Transform
-      pos: 10.5,0.5
-      parent: 1
-  - uid: 37
-    components:
-    - type: Transform
-      pos: 10.5,1.5
-      parent: 1
-  - uid: 38
-    components:
-    - type: Transform
-      pos: 6.5,4.5
-      parent: 1
-  - uid: 45
-    components:
-    - type: Transform
-      pos: 19.5,3.5
+      pos: 1.5,19.5
       parent: 1
   - uid: 47
     components:
     - type: Transform
-      pos: 20.5,3.5
+      pos: 2.5,19.5
       parent: 1
   - uid: 48
     components:
     - type: Transform
-      pos: 19.5,2.5
+      pos: 3.5,19.5
       parent: 1
   - uid: 49
     components:
     - type: Transform
-      pos: 21.5,3.5
+      pos: 5.5,19.5
       parent: 1
-  - uid: 54
+  - uid: 50
     components:
     - type: Transform
-      pos: 21.5,1.5
+      pos: 4.5,19.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 9.5,19.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 8.5,19.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 1.5,21.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 1.5,20.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 6.5,21.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 5.5,21.5
       parent: 1
   - uid: 61
     components:
     - type: Transform
-      pos: 19.5,1.5
+      pos: 4.5,21.5
       parent: 1
   - uid: 62
     components:
     - type: Transform
-      pos: 20.5,1.5
+      pos: 7.5,21.5
       parent: 1
-  - uid: 64
+  - uid: 256
     components:
     - type: Transform
-      pos: 21.5,2.5
+      pos: 7.5,14.5
       parent: 1
-  - uid: 68
+  - uid: 257
     components:
     - type: Transform
-      pos: 19.5,16.5
+      pos: 8.5,12.5
       parent: 1
-  - uid: 69
+  - uid: 258
     components:
     - type: Transform
-      pos: 19.5,13.5
+      pos: 10.5,4.5
       parent: 1
-  - uid: 91
+  - uid: 259
     components:
     - type: Transform
-      pos: 0.5,14.5
+      pos: 10.5,2.5
       parent: 1
-  - uid: 95
+  - uid: 260
     components:
     - type: Transform
-      pos: 18.5,16.5
+      pos: 8.5,0.5
       parent: 1
-  - uid: 157
+  - uid: 261
     components:
     - type: Transform
-      pos: 13.5,8.5
+      pos: 7.5,0.5
       parent: 1
-  - uid: 158
+  - uid: 262
     components:
     - type: Transform
-      pos: 12.5,9.5
+      pos: 6.5,2.5
       parent: 1
-  - uid: 194
+  - uid: 263
     components:
     - type: Transform
-      pos: 12.5,10.5
+      pos: 6.5,3.5
       parent: 1
-  - uid: 195
+  - uid: 264
     components:
     - type: Transform
-      pos: 16.5,9.5
+      pos: 21.5,0.5
       parent: 1
-  - uid: 196
+  - uid: 265
     components:
     - type: Transform
-      pos: 15.5,10.5
+      pos: 19.5,0.5
       parent: 1
-  - uid: 206
+  - uid: 266
     components:
     - type: Transform
-      pos: 16.5,6.5
+      pos: 18.5,0.5
       parent: 1
-  - uid: 245
+  - uid: 267
     components:
     - type: Transform
-      pos: 21.5,13.5
+      pos: 22.5,0.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 19.5,4.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      pos: 22.5,3.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      pos: 22.5,4.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 22.5,1.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: 21.5,4.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 18.5,3.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 18.5,4.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 18.5,1.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 18.5,14.5
       parent: 1
   - uid: 277
     components:
     - type: Transform
-      pos: 22.5,15.5
+      pos: 8.5,15.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: 10.5,12.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: 10.5,16.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 6.5,16.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 6.5,14.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 8.5,16.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 9.5,14.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 16.5,8.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 16.5,7.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 16.5,10.5
       parent: 1
   - uid: 290
     components:
     - type: Transform
-      pos: 3.5,12.5
+      pos: 13.5,10.5
       parent: 1
   - uid: 291
     components:
     - type: Transform
-      pos: 2.5,16.5
+      pos: 14.5,10.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 15.5,8.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 16.5,16.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 12.5,7.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: 12.5,6.5
       parent: 1
   - uid: 297
     components:
     - type: Transform
-      pos: 3.5,16.5
+      pos: 12.5,16.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: 12.5,12.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: 9.5,15.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 7.5,15.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 20.5,16.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: 21.5,16.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 10.5,14.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 9.5,13.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 7.5,13.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 8.5,13.5
       parent: 1
   - uid: 307
     components:
     - type: Transform
-      pos: 3.5,13.5
+      pos: 22.5,14.5
       parent: 1
   - uid: 308
+    components:
+    - type: Transform
+      pos: 22.5,16.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 21.5,12.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 18.5,13.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 19.5,12.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 22.5,13.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 18.5,15.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,18.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,20.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,18.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,18.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,20.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,18.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,20.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,18.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,20.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,20.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,18.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,22.5
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,22.5
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,20.5
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,22.5
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,18.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,22.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,22.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,18.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,19.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,18.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,18.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,18.5
+      parent: 1
+  - uid: 462
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,22.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,21.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,22.5
+      parent: 1
+- proto: WallReinforcedRust
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 19.5,3.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 20.5,3.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 19.5,2.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 21.5,3.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 21.5,1.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 19.5,1.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 20.5,1.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 21.5,2.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 19.5,16.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      pos: 19.5,13.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 18.5,16.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 13.5,8.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      pos: 12.5,9.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      pos: 12.5,10.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      pos: 16.5,9.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      pos: 15.5,10.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      pos: 16.5,6.5
+      parent: 1
+  - uid: 346
+    components:
+    - type: Transform
+      pos: 21.5,13.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 22.5,15.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 351
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 352
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
 - proto: WallSolid
   entities:
-  - uid: 14
+  - uid: 353
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 15
+  - uid: 354
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 17
+  - uid: 355
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 18
+  - uid: 356
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 19
+  - uid: 357
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 23
+  - uid: 358
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 26
+  - uid: 359
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 27
+  - uid: 360
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 31
+  - uid: 361
     components:
     - type: Transform
       pos: 21.5,6.5
       parent: 1
-  - uid: 66
+  - uid: 362
     components:
     - type: Transform
       pos: 20.5,10.5
       parent: 1
-  - uid: 72
+  - uid: 363
     components:
     - type: Transform
       pos: 22.5,8.5
       parent: 1
-  - uid: 93
+  - uid: 364
     components:
     - type: Transform
       pos: 18.5,7.5
       parent: 1
-  - uid: 94
+  - uid: 365
     components:
     - type: Transform
       pos: 18.5,6.5
       parent: 1
-  - uid: 97
+  - uid: 366
     components:
     - type: Transform
       pos: 22.5,9.5
       parent: 1
-  - uid: 98
+  - uid: 367
     components:
     - type: Transform
       pos: 21.5,10.5
       parent: 1
-  - uid: 101
+  - uid: 368
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 1
-  - uid: 104
+  - uid: 369
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 1
-  - uid: 105
+  - uid: 370
     components:
     - type: Transform
       pos: 13.5,4.5
       parent: 1
-  - uid: 108
+  - uid: 371
     components:
     - type: Transform
       pos: 16.5,4.5
       parent: 1
-  - uid: 110
+  - uid: 372
     components:
     - type: Transform
       pos: 16.5,2.5
       parent: 1
-  - uid: 111
+  - uid: 373
     components:
     - type: Transform
       pos: 16.5,1.5
       parent: 1
-  - uid: 134
+  - uid: 374
     components:
     - type: Transform
       pos: 6.5,9.5
       parent: 1
-  - uid: 135
+  - uid: 375
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 151
+  - uid: 376
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 1
-  - uid: 155
+  - uid: 377
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 159
+  - uid: 378
     components:
     - type: Transform
       pos: 9.5,7.5
       parent: 1
-  - uid: 160
+  - uid: 379
     components:
     - type: Transform
       pos: 10.5,8.5
       parent: 1
-  - uid: 161
+  - uid: 380
     components:
     - type: Transform
       pos: 9.5,10.5
       parent: 1
-  - uid: 162
+  - uid: 381
     components:
     - type: Transform
       pos: 8.5,10.5
       parent: 1
-  - uid: 165
+  - uid: 382
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 168
+  - uid: 383
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 173
+  - uid: 384
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 179
+  - uid: 385
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 180
+  - uid: 386
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 181
+  - uid: 387
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 197
+  - uid: 388
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 200
+  - uid: 389
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 247
+  - uid: 390
     components:
     - type: Transform
       pos: 18.5,9.5
       parent: 1
 - proto: WallSolidRust
   entities:
-  - uid: 12
+  - uid: 391
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 13
+  - uid: 392
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 16
+  - uid: 393
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 20
+  - uid: 394
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 21
+  - uid: 395
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 22
+  - uid: 396
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 24
+  - uid: 397
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 102
+  - uid: 398
     components:
     - type: Transform
       pos: 12.5,3.5
       parent: 1
-  - uid: 103
+  - uid: 399
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 1
-  - uid: 106
+  - uid: 400
     components:
     - type: Transform
       pos: 15.5,4.5
       parent: 1
-  - uid: 107
+  - uid: 401
     components:
     - type: Transform
       pos: 14.5,4.5
       parent: 1
-  - uid: 109
+  - uid: 402
     components:
     - type: Transform
       pos: 16.5,3.5
       parent: 1
-  - uid: 112
+  - uid: 403
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 1
-  - uid: 125
+  - uid: 404
     components:
     - type: Transform
       pos: 9.5,6.5
       parent: 1
-  - uid: 126
+  - uid: 405
     components:
     - type: Transform
       pos: 9.5,8.5
       parent: 1
-  - uid: 127
+  - uid: 406
     components:
     - type: Transform
       pos: 7.5,10.5
       parent: 1
-  - uid: 128
+  - uid: 407
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 139
+  - uid: 408
     components:
     - type: Transform
       pos: 10.5,9.5
       parent: 1
-  - uid: 140
+  - uid: 409
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 1
-  - uid: 141
+  - uid: 410
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 142
+  - uid: 411
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 1
-  - uid: 163
+  - uid: 412
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 1
-  - uid: 201
+  - uid: 413
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 202
+  - uid: 414
     components:
     - type: Transform
       pos: 10.5,10.5
       parent: 1
-  - uid: 227
+  - uid: 415
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 228
+  - uid: 416
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 246
+  - uid: 417
     components:
     - type: Transform
       pos: 18.5,10.5
       parent: 1
-  - uid: 248
+  - uid: 418
     components:
     - type: Transform
       pos: 19.5,10.5
       parent: 1
-  - uid: 249
+  - uid: 419
     components:
     - type: Transform
       pos: 18.5,8.5
       parent: 1
-  - uid: 271
+  - uid: 420
     components:
     - type: Transform
       pos: 22.5,6.5
       parent: 1
-  - uid: 272
+  - uid: 421
     components:
     - type: Transform
       pos: 19.5,6.5
       parent: 1
-  - uid: 273
+  - uid: 422
     components:
     - type: Transform
       pos: 22.5,10.5
       parent: 1
-  - uid: 274
+  - uid: 423
     components:
     - type: Transform
       pos: 22.5,7.5

--- a/Resources/Prototypes/Entities/Markers/rooms.yml
+++ b/Resources/Prototypes/Entities/Markers/rooms.yml
@@ -1,11 +1,9 @@
 - type: entity
   id: BaseRoomMarker
-  name: Room marker
+  name: room spawner
   parent: MarkerBase
-  suffix: Weh
   components:
   - type: RoomFill
-    size: 5,5
   - type: Sprite
     layers:
       - state: red

--- a/Resources/Prototypes/Procedural/Themes/vgroidinterior.yml
+++ b/Resources/Prototypes/Procedural/Themes/vgroidinterior.yml
@@ -3,8 +3,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 0,0
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -13,8 +12,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 6,0
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -23,8 +21,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 12,0
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -33,8 +30,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 18,0
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -43,8 +39,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 0,6
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
     - VGRoidInterior
 
@@ -53,8 +48,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 6,6
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -63,8 +57,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 12,6
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -73,8 +66,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 18,6
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -83,8 +75,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 0,12
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -93,8 +84,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 6,12
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -103,8 +93,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 12,12
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -113,8 +102,7 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 18,12
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -123,8 +111,7 @@
   size: 11,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 0,18
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -133,8 +120,7 @@
   size: 11,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 12,18
-  ignoreTile:
-  - FloorShuttleOrange
+  ignoreTile: FloorShuttleOrange
   tags:
   - VGRoidInterior
 

--- a/Resources/Prototypes/Procedural/Themes/vgroidinterior.yml
+++ b/Resources/Prototypes/Procedural/Themes/vgroidinterior.yml
@@ -3,6 +3,8 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 0,0
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -11,6 +13,8 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 6,0
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -19,6 +23,8 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 12,0
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -27,6 +33,8 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 18,0
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -35,6 +43,8 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 0,6
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
     - VGRoidInterior
 
@@ -43,6 +53,8 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 6,6
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -51,6 +63,8 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 12,6
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -59,6 +73,8 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 18,6
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -67,6 +83,8 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 0,12
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -75,6 +93,8 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 6,12
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -83,6 +103,8 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 12,12
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
   - VGRoidInterior
 
@@ -91,6 +113,28 @@
   size: 5,5
   atlas: /Maps/Dungeon/vgroidinterior.yml
   offset: 18,12
+  ignoreTile:
+  - FloorShuttleOrange
+  tags:
+  - VGRoidInterior
+
+- type: dungeonRoom
+  id: VGRoidInterior11x5a
+  size: 11,5
+  atlas: /Maps/Dungeon/vgroidinterior.yml
+  offset: 0,18
+  ignoreTile:
+  - FloorShuttleOrange
+  tags:
+  - VGRoidInterior
+
+- type: dungeonRoom
+  id: VGRoidInterior11x5b
+  size: 11,5
+  atlas: /Maps/Dungeon/vgroidinterior.yml
+  offset: 12,18
+  ignoreTile:
+  - FloorShuttleOrange
   tags:
   - VGRoidInterior
 


### PR DESCRIPTION
## About the PR
Add tilemask for room spawning.
In the room prototype, you can specify a tile that will be ignored when transferred to the actual game. This is EXTREMELY useful for procedural generation:

right now, in the game all rooms have clear square dimensions, and are copied in their entirety. If we want to have irregularly shaped rooms, we have to do a terrible thing: stitch environment elements into the room itself. As it is done now on VGroid: 

![image](https://github.com/user-attachments/assets/cddc406a-a353-438a-aa6f-0a976f50cf1d)

this has the disadvantage that these rooms cannot be reused, for example in generation with a different kind of stone and floor.

What I did: I added the ability to specify a tile mask that will be ignored

![image](https://github.com/user-attachments/assets/ba9cdd99-0b0b-46d4-804c-63b04265b9d6)

and now these rooms fit perfectly into any biome or asteroid:

![image](https://github.com/user-attachments/assets/f0b4de7b-7177-4958-88be-9ba4f30e9838)

I also removed the restriction that room spawners can only spawn rooms of 1 size. Now they can spawn rooms of any size, although the restriction can be rewritten through prototypes.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
