### PR TITLE
improve BiomeDunGen

### DIFF
--- a/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiome.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiome.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Content.Server.Parallax;
+using Content.Shared.Maps;
 using Content.Shared.Parallax.Biomes;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.PostGeneration;

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiome.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiome.cs
@@ -30,6 +30,12 @@ public sealed partial class DungeonJob
 
             if (reservedTiles.Contains(node))
                 continue;
+            
+            if (dunGen.TileMask is not null)
+            {
+                if (dunGen.TileMask.Contains(((ContentTileDefinition) _tileDefManager[tileRef.Value.Tile.TypeId]).ID))
+                    continue;
+            }
 
             // Need to set per-tile to override data.
             if (biomeSystem.TryGetTile(node, indexedBiome.Layers, seed, _grid, out var tile))

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiome.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiome.cs
@@ -34,7 +34,7 @@ public sealed partial class DungeonJob
             
             if (dunGen.TileMask is not null)
             {
-                if (dunGen.TileMask.Contains(((ContentTileDefinition) _tileDefManager[tileRef.Value.Tile.TypeId]).ID))
+                if (!dunGen.TileMask.Contains(((ContentTileDefinition) _tileDefManager[tileRef.Value.Tile.TypeId]).ID))
                     continue;
             }
 

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiome.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.PostGenBiome.cs
@@ -15,27 +15,29 @@ public sealed partial class DungeonJob
     /// </summary>
     private async Task PostGen(BiomeDunGen dunGen, DungeonData data, Dungeon dungeon, HashSet<Vector2i> reservedTiles, Random random)
     {
-        if (_entManager.TryGetComponent(_gridUid, out BiomeComponent? biomeComp))
+        if (!_prototype.TryIndex(dunGen.BiomeTemplate, out var indexedBiome))
             return;
 
-        biomeComp = _entManager.AddComponent<BiomeComponent>(_gridUid);
         var biomeSystem = _entManager.System<BiomeSystem>();
-        biomeSystem.SetTemplate(_gridUid, biomeComp, _prototype.Index(dunGen.BiomeTemplate));
+
         var seed = random.Next();
         var xformQuery = _entManager.GetEntityQuery<TransformComponent>();
 
-        foreach (var node in dungeon.RoomTiles)
+        var tiles = _maps.GetAllTilesEnumerator(_gridUid, _grid);
+        while (tiles.MoveNext(out var tileRef))
         {
+            var node = tileRef.Value.GridIndices;
+
             if (reservedTiles.Contains(node))
                 continue;
 
             // Need to set per-tile to override data.
-            if (biomeSystem.TryGetTile(node, biomeComp.Layers, seed, _grid, out var tile))
+            if (biomeSystem.TryGetTile(node, indexedBiome.Layers, seed, _grid, out var tile))
             {
                 _maps.SetTile(_gridUid, _grid, node, tile.Value);
             }
 
-            if (biomeSystem.TryGetDecals(node, biomeComp.Layers, seed, _grid, out var decals))
+            if (biomeSystem.TryGetDecals(node, indexedBiome.Layers, seed, _grid, out var decals))
             {
                 foreach (var decal in decals)
                 {
@@ -43,7 +45,7 @@ public sealed partial class DungeonJob
                 }
             }
 
-            if (biomeSystem.TryGetEntity(node, biomeComp, _grid, out var entityProto))
+            if (tile is not null && biomeSystem.TryGetEntity(node, indexedBiome.Layers, tile.Value, seed, _grid, out var entityProto))
             {
                 var ent = _entManager.SpawnEntity(entityProto, new EntityCoordinates(_gridUid, node + _grid.TileSizeHalfVector));
                 var xform = xformQuery.Get(ent);
@@ -61,7 +63,5 @@ public sealed partial class DungeonJob
             if (!ValidateResume())
                 return;
         }
-
-        biomeComp.Enabled = false;
     }
 }

--- a/Content.Shared/Parallax/Biomes/SharedBiomeSystem.cs
+++ b/Content.Shared/Parallax/Biomes/SharedBiomeSystem.cs
@@ -183,7 +183,7 @@ public abstract class SharedBiomeSystem : EntitySystem
     }
 
 
-    private bool TryGetEntity(Vector2i indices, List<IBiomeLayer> layers, Tile tileRef, int seed, MapGridComponent grid,
+    public bool TryGetEntity(Vector2i indices, List<IBiomeLayer> layers, Tile tileRef, int seed, MapGridComponent grid,
         [NotNullWhen(true)] out string? entity)
     {
         var tileId = TileDefManager[tileRef.TypeId].ID;

--- a/Content.Shared/Procedural/PostGeneration/BiomeDunGen.cs
+++ b/Content.Shared/Procedural/PostGeneration/BiomeDunGen.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Maps;
 using Content.Shared.Parallax.Biomes;
 using Robust.Shared.Prototypes;
 
@@ -11,4 +12,10 @@ public sealed partial class BiomeDunGen : IDunGenLayer
 {
     [DataField(required: true)]
     public ProtoId<BiomeTemplatePrototype> BiomeTemplate;
+
+    /// <summary>
+    /// creates a biome only on the specified tiles
+    /// </summary>
+    [DataField]
+    public HashSet<ProtoId<ContentTileDefinition>>? TileMask;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Improves the reuse of BiomeDunGen by allowing you to “flood” tiles on the grid with a specific biome.

The generation itself hasn't changed anywhere, but there are more possibilities with it now

Example of use: forest biome on VGroid (not added to the game)
![image](https://github.com/user-attachments/assets/357db49f-d6ad-4284-8b97-10ef62636ecc)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
