### PR TITLE
Adds toolbox lathe recipes to autolathe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -204,7 +204,6 @@
       - ToolboxMechanical
       - ToolboxElectrical
       - ToolboxArtistic
-      - ToolboxGolden
   - type: EmagLatheRecipes
     emagStaticRecipes:
       - BoxLethalshot

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -200,6 +200,11 @@
       - WetFloorSign
       - ClothingHeadHatCone
       - FreezerElectronics
+      - ToolboxEmergency
+      - ToolboxMechanical
+      - ToolboxElectrical
+      - ToolboxArtistic
+      - ToolboxGolden
   - type: EmagLatheRecipes
     emagStaticRecipes:
       - BoxLethalshot
@@ -225,6 +230,7 @@
       - RiotShield
       - SpeedLoaderMagnum
       - SpeedLoaderMagnumEmpty
+      - ToolboxSyndicate
   - type: BlueprintReceiver
     whitelist:
       tags:

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -230,43 +230,41 @@
     Plastic: 200
 
 - type: latheRecipe
+  abstract: true
+  id: BaseToolbox
+  category: Tools
+  completetime: 3
+  materials:
+    Steel: 500
+
+- type: latheRecipe
+  parent: BaseToolbox
   id: ToolboxEmergency
   result: ToolboxEmergency
-  completetime: 3
-  materials:
-    Steel: 500
 
 - type: latheRecipe
+  parent: BaseToolbox
   id: ToolboxMechanical
   result: ToolboxMechanical
-  completetime: 3
-  materials:
-    Steel: 500
 
 - type: latheRecipe
+  parent: BaseToolbox
   id: ToolboxElectrical
   result: ToolboxElectrical
-  completetime: 3
-  materials:
-    Steel: 500
 
 - type: latheRecipe
+  parent: BaseToolbox
   id: ToolboxArtistic
   result: ToolboxArtistic
-  completetime: 3
-  materials:
-    Steel: 500
 
 - type: latheRecipe
+  parent: BaseToolbox
   id: ToolboxGolden
   result: ToolboxGolden
-  completetime: 3
   materials:
     Gold: 500
 
 - type: latheRecipe
+  parent: BaseToolbox
   id: ToolboxSyndicate
   result: ToolboxSyndicate
-  completetime: 3
-  materials:
-    Steel: 500

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -228,3 +228,45 @@
   completetime: 3
   materials:
     Plastic: 200
+
+- type: latheRecipe
+  id: ToolboxEmergency
+  result: ToolboxEmergency
+  completetime: 3
+  materials:
+    Steel: 500
+
+- type: latheRecipe
+  id: ToolboxMechanical
+  result: ToolboxMechanical
+  completetime: 3
+  materials:
+    Steel: 500
+
+- type: latheRecipe
+  id: ToolboxElectrical
+  result: ToolboxElectrical
+  completetime: 3
+  materials:
+    Steel: 500
+
+- type: latheRecipe
+  id: ToolboxArtistic
+  result: ToolboxArtistic
+  completetime: 3
+  materials:
+    Steel: 500
+
+- type: latheRecipe
+  id: ToolboxGolden
+  result: ToolboxGolden
+  completetime: 3
+  materials:
+    Gold: 500
+
+- type: latheRecipe
+  id: ToolboxSyndicate
+  result: ToolboxSyndicate
+  completetime: 3
+  materials:
+    Steel: 500

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -259,12 +259,5 @@
 
 - type: latheRecipe
   parent: BaseToolbox
-  id: ToolboxGolden
-  result: ToolboxGolden
-  materials:
-    Gold: 500
-
-- type: latheRecipe
-  parent: BaseToolbox
   id: ToolboxSyndicate
   result: ToolboxSyndicate


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes the basic four colored toolboxes and the suspicious toolbox printable in the autolathe. The suspicious toolbox specifically is an emagged recipe.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I like carrying things around in toolboxes and I want to enable hand-carried storage as a more standard storage option for characters/roles by making them printable rather than needing to find one somewhere.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![toolbox lathing](https://github.com/user-attachments/assets/b39a7497-03d4-4db2-a96b-3a2a3e681812)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: RiceMar1244
- add: Toolboxes can now be printed in the autolathe.
