### PR TITLE
Throw and embed everything sharp (shards, knives, swords)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -44,6 +44,9 @@
         density: 30
         mask:
         - ItemMask
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
   - type: DamageOtherOnHit
     damage:
       types:
@@ -126,6 +129,10 @@
     refineResult:
     - id: SheetGlass1
     - id: PartRodMetal1
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 4.5
   - type: DamageUserOnTrigger
     damage:
       types:
@@ -162,6 +169,10 @@
     refineResult:
     - id: SheetGlass1
     - id: SheetPlasma1
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 5.5
   - type: DamageUserOnTrigger
     damage:
       types:
@@ -201,6 +212,11 @@
     refineResult:
     - id: SheetGlass1
     - id: SheetUranium1
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 4.5
+        Radiation: 2
   - type: DamageUserOnTrigger
     damage:
       types:
@@ -236,6 +252,10 @@
     refineResult:
     - id: SheetGlass1
     - id: SheetBrass1
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 4.5
   - type: DamageUserOnTrigger
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml
@@ -17,6 +17,9 @@
   - type: Sprite
     sprite: Objects/Consumable/TrashDrinks/broken_bottle.rsi
     state: icon
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
   - type: DamageOtherOnHit
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -56,6 +56,13 @@
     damage:
       types:
         Slash: 10
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 10
   - type: Item
     size: Normal
   - type: Clothing
@@ -81,6 +88,14 @@
   - type: MeleeWeapon
     wideAnimationRotation: 135
     swingLeft: true
+    damage:
+      types:
+        Slash: 8
+        Piercing: 2
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
     damage:
       types:
         Slash: 8

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -90,6 +90,13 @@
         Slash: 8
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 8
 
 - type: entity
   name: shiv
@@ -116,6 +123,11 @@
     damage:
       types:
         Slash: 12
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 12
+
 
 - type: entity
   name: laser scalpel

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
@@ -14,6 +14,13 @@
     damage:
       types:
         Slash: 12
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 12
   - type: Item
     size: Normal
   - type: Clothing
@@ -35,6 +42,13 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 0.75
+    damage:
+      types:
+        Slash: 16
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
     damage:
       types:
         Slash: 16
@@ -76,6 +90,15 @@
         Blunt: 5
         Slash: 5
         Structural: 10
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 15
+        Slash: 15
+        Structural: 15
   - type: Item
     size: Ginormous
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -31,6 +31,15 @@
       types:
         Slash: 10
         Structural: 40
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 5
+        Slash: 20
+        Structural: 50
   - type: Item
     size: Ginormous
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -19,6 +19,13 @@
         Slash: 10
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 10
   - type: Sprite
   - type: Item
     size: Small
@@ -67,6 +74,10 @@
     damage:
       types:
         Slash: 13
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 13
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/cleaver.rsi
@@ -94,13 +105,6 @@
     damage:
       types:
         Slash: 12
-  - type: EmbeddableProjectile
-    sound: /Audio/Weapons/star_hit.ogg
-  - type: LandAtCursor
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Slash: 10
   - type: Item
     sprite: Objects/Weapons/Melee/combat_knife.rsi
     storedSprite:
@@ -135,6 +139,10 @@
     state: icon
   - type: MeleeWeapon
     attackRate: 1.0
+    damage:
+      types:
+        Slash: 15
+  - type: DamageOtherOnHit
     damage:
       types:
         Slash: 15
@@ -202,6 +210,10 @@
     damage:
       types:
         Slash: 5.5
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 2 # a bit of cloth shouldn't increase throwing damage above existing glass shard value
   - type: Item
     sprite: Objects/Weapons/Melee/shiv.rsi
   - type: DisarmMalus
@@ -221,6 +233,10 @@
     damage:
       types:
         Slash: 7 #each "tier" grants an additional 2 damage
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 4.5
   - type: Item
     sprite: Objects/Weapons/Melee/reinforced_shiv.rsi
   - type: Sprite
@@ -240,6 +256,10 @@
     damage:
       types:
         Slash: 9
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 5.5
   - type: Item
     sprite: Objects/Weapons/Melee/plasma_shiv.rsi
   - type: Sprite
@@ -260,6 +280,11 @@
       types:
         Slash: 7
         Radiation: 4
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 4.5
+        Radiation: 2
   - type: Item
     sprite: Objects/Weapons/Melee/uranium_shiv.rsi
   - type: Sprite
@@ -284,9 +309,6 @@
     damage:
       types:
         Slash: 5
-  - type: EmbeddableProjectile
-    sound: /Audio/Weapons/star_hit.ogg
-  - type: LandAtCursor
   - type: DamageOtherOnHit
     ignoreResistances: true
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -165,11 +165,13 @@
     damage:
       types:
         Slash: 5
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 10
-  - type: LandAtCursor
+        Slash: 5
   - type: Sprite
     sprite: Clothing/Head/Hats/greyflatcap.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -169,6 +169,13 @@
     damage:
       types:
         Slash: 15
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 15
   - type: Tag
     tags:
     - Knife

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -18,6 +18,9 @@
   - type: Tool
     qualities:
     - Slicing
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: LandAtCursor
 
 - type: entity
   name: captain's sabre
@@ -34,6 +37,10 @@
         Slash: 17 #cmon, it has to be at least BETTER than the rest.
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 17
   - type: Reflect
     reflectProb: .1
     spread: 90
@@ -64,6 +71,10 @@
     damage:
       types:
         Slash: 15
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 15
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item
@@ -83,6 +94,10 @@
     damage:
       types:
         Slash: 30
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 15 # would otherwise be stupidly strong with recall
   - type: Item
     sprite: Objects/Weapons/Melee/energykatana.rsi
   - type: EnergyKatana
@@ -116,6 +131,10 @@
         Slash: 15
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 15
   - type: Item
     sprite: Objects/Weapons/Melee/machete.rsi
   - type: DisarmMalus
@@ -135,6 +154,10 @@
         Slash: 20
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 20
   - type: Item
   - type: Clothing
     sprite: Objects/Weapons/Melee/claymore.rsi
@@ -159,6 +182,10 @@
         Slash: 16
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 16
   - type: Item
     sprite: Objects/Weapons/Melee/cutlass.rsi
   - type: DisarmMalus
@@ -183,6 +210,15 @@
           Radiation: 10
       soundHit:
         path: /Audio/Effects/explosion_small1.ogg
+    - type: DamageOtherOnHit
+      damage:
+        types:
+          Structural: 150
+          Slash: 20 #Horror
+          Blunt: 20
+          Heat: 20
+          Piercing: 20
+          Radiation: 10
     - type: Reflect
       reflectProb: .25
       spread: 90

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -71,12 +71,12 @@
     damage:
       types:
         Slash: 15
+    soundHit:
+        path: /Audio/Weapons/bladeslice.ogg
   - type: DamageOtherOnHit
     damage:
       types:
         Slash: 15
-    soundHit:
-        path: /Audio/Weapons/bladeslice.ogg
   - type: Item
     sprite: Objects/Weapons/Melee/katana.rsi
   - type: DisarmMalus
@@ -97,7 +97,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 15 # would otherwise be stupidly strong with recall
+        Slash: 20 # would otherwise be stupidly strong with recall
   - type: Item
     sprite: Objects/Weapons/Melee/energykatana.rsi
   - type: EnergyKatana


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds embedding to a bunch of sharp objects where it would make sense, including:
- Glass shards, shivs and broken bottles
- Knives
- Scalpels
- Flatcaps
- Swords and katanas
- Hatchets and fireaxes

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Added embedding property to items missing them (i.e. throwing dmg with no embed) for parity to match with spears and knives, meaning glass shards now embed on throwing. This sort of nerfs any glass cannons but also makes explosions with glass shards more interesting.

Added throwing damage to a lot of knives and swords because it seems to make sense, as well as adding some more depth to improvised combat. For instance, the ninja could throw their katana at an opponent then recall it. It also didn't make sense why only survival/combat knives could do throwing damage but not something like normal kitchen knives.

## Technical details
<!-- Summary of code changes for easier review. -->
- `Resources/Prototypes/Entities/Objects/Materials/shards.yml` (glass shards now embed)
- `Resources/Prototypes/Entities/Objects/Misc/broken_bottle.yml` (broken bottle now embeds)
- `Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml` (scalpels do throwing damage and embed)
- `Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml` (added throwing damage and embed to a bunch of shivs and kitchen knives)
- `Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml` (added throwing damage and embed to crusher dagger)
- `Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml` (added throwing damage and embed to all swords)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/7342fe06-abd0-4200-82a8-b2971f32fc95)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: items under the category of swords (including katanas, sabres and machetes), knives (including glass shivs, kitchen knives, kukris) now deal throwing damage and embed in mobs.
- add: axes, hatchets, scythes, crusher daggers, and scalpels now deal throwing damage and embed in mobs.
- tweak: glass shards and broken bottles now embed in mobs.