### PR TITLE
Split out a system for moving liquids from dispenser

### DIFF
--- a/Content.Client/Chemistry/UI/ReagentCardControl.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentCardControl.xaml.cs
@@ -19,7 +19,7 @@ public sealed partial class ReagentCardControl : Control
 
         StorageSlotId = item.StorageSlotId;
         ColorPanel.PanelOverride = new StyleBoxFlat { BackgroundColor = item.ReagentColor };
-        ReagentNameLabel.Text = item.ReagentLabel;
+        ReagentNameLabel.Text = item.DisplayName;
         FillLabel.Text = Loc.GetString("reagent-dispenser-window-quantity-label-text", ("quantity", item.Quantity));;
         EjectButtonIcon.Text = Loc.GetString("reagent-dispenser-window-eject-container-button");
 

--- a/Content.Client/Chemistry/UI/ReagentDispenserBoundUserInterface.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserBoundUserInterface.cs
@@ -35,12 +35,12 @@ namespace Content.Client.Chemistry.UI
             _window.HelpGuidebookIds = EntMan.GetComponent<GuideHelpComponent>(Owner).Guides;
 
             // Setup static button actions.
-            _window.EjectButton.OnPressed += _ => SendMessage(new ItemSlotButtonPressedEvent(SharedReagentDispenser.OutputSlotName));
+            _window.EjectButton.OnPressed += (id) => SendMessage(new ItemSlotButtonPressedEvent(SharedSolutionTransferMachineSystem.BaseDispenserSlotId + 0));
             _window.ClearButton.OnPressed += _ => SendMessage(new ReagentDispenserClearContainerSolutionMessage());
 
             _window.AmountGrid.OnButtonPressed += s => SendMessage(new ReagentDispenserSetDispenseAmountMessage(s));
 
-            _window.OnDispenseReagentButtonPressed += (id) => SendMessage(new ReagentDispenserDispenseReagentMessage(id));
+            _window.OnDispenseReagentButtonPressed += (id) => SendMessage(new ReagentDispenserDispenseReagentMessage(id, SharedSolutionTransferMachineSystem.BaseDispenserSlotId + 0));
             _window.OnEjectJugButtonPressed += (id) => SendMessage(new ItemSlotButtonPressedEvent(id));
         }
 

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
@@ -42,7 +42,7 @@ namespace Content.Client.Chemistry.UI
 
             ReagentList.Children.Clear();
             //Sort inventory by reagentLabel
-            inventory.Sort((x, y) => x.ReagentLabel.CompareTo(y.ReagentLabel));
+            inventory.Sort((x, y) => x.DisplayName.CompareTo(y.DisplayName));
 
             foreach (var item in inventory)
             {
@@ -63,7 +63,7 @@ namespace Content.Client.Chemistry.UI
             UpdateContainerInfo(castState);
             UpdateReagentsList(castState.Inventory);
 
-            _entityManager.TryGetEntity(castState.OutputContainerEntity, out var outputContainerEnt);
+            _entityManager.TryGetEntity(castState.OutputContainer?.Entity, out var outputContainerEnt);
             View.SetEntity(outputContainerEnt);
 
             // Disable the Clear & Eject button if no beaker
@@ -93,7 +93,7 @@ namespace Content.Client.Chemistry.UI
 
             // Set Name of the container and its fill status (Ex: 44/100u)
             ContainerInfoName.Text = state.OutputContainer.DisplayName;
-            ContainerInfoFill.Text = state.OutputContainer.CurrentVolume + "/" + state.OutputContainer.MaxVolume;
+            ContainerInfoFill.Text = state.OutputContainer.Quantity + "/" + state.OutputContainer.Capacity;
 
             foreach (var (reagent, quantity) in state.OutputContainer.Reagents!)
             {

--- a/Content.IntegrationTests/Tests/Chemistry/DispenserTest.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/DispenserTest.cs
@@ -25,7 +25,7 @@ public sealed class DispenserTest : InteractionTest
         await Interact();
 
         // Eject beaker via BUI.
-        var ev = new ItemSlotButtonPressedEvent(SharedReagentDispenser.OutputSlotName);
+        var ev = new ItemSlotButtonPressedEvent(SharedSolutionTransferMachineSystem.BaseDispenserSlotId + 0);
         await SendBui(ReagentDispenserUiKey.Key, ev);
 
         // Beaker is back in the player's hands

--- a/Content.Server/Chemistry/Components/ReagentDispenserComponent.cs
+++ b/Content.Server/Chemistry/Components/ReagentDispenserComponent.cs
@@ -15,47 +15,6 @@ namespace Content.Server.Chemistry.Components
     [Access(typeof(ReagentDispenserSystem))]
     public sealed partial class ReagentDispenserComponent : Component
     {
-        /// <summary>
-        /// String with the pack name that stores the initial fill of the dispenser. The initial
-        /// fill is added to the dispenser on MapInit. Note that we don't use ContainerFill because
-        /// we have to generate the storage slots at MapInit first, then fill them.
-        /// </summary>
-        [DataField("pack", customTypeSerializer:typeof(PrototypeIdSerializer<ReagentDispenserInventoryPrototype>))]
-        [ViewVariables(VVAccess.ReadWrite)]
-        public string? PackPrototypeId = default!;
-
-        /// <summary>
-        /// Maximum number of internal storage slots. Dispenser can't store (or dispense) more than
-        /// this many chemicals (without unloading and reloading).
-        /// </summary>
-        [DataField("numStorageSlots")]
-        public int NumSlots = 25;
-
-        /// <summary>
-        /// For each created storage slot for the reagent containers being dispensed, apply this
-        /// entity whitelist. Makes sure weird containers don't fit in the dispenser and that beakers
-        /// don't accidentally get slotted into the source slots.
-        /// </summary>
-        [DataField]
-        public EntityWhitelist? StorageWhitelist;
-
-        [DataField]
-        public ItemSlot BeakerSlot = new();
-
-        /// <summary>
-        /// Prefix for automatically-generated slot name for storage, up to NumSlots.
-        /// </summary>
-        public static string BaseStorageSlotId = "ReagentDispenser-storageSlot";
-
-        /// <summary>
-        /// List of storage slots that were created at MapInit.
-        /// </summary>
-        [DataField]
-        public List<string> StorageSlotIds = new List<string>();
-
-        [DataField]
-        public List<ItemSlot> StorageSlots = new List<ItemSlot>();
-
         [DataField("clickSound"), ViewVariables(VVAccess.ReadWrite)]
         public SoundSpecifier ClickSound = new SoundPathSpecifier("/Audio/Machines/machine_switch.ogg");
 

--- a/Content.Server/Chemistry/Components/SolutionTransferMachineComponent.cs
+++ b/Content.Server/Chemistry/Components/SolutionTransferMachineComponent.cs
@@ -1,0 +1,66 @@
+using Content.Shared.Whitelist;
+using Content.Shared.Containers.ItemSlots;
+using Content.Server.Chemistry.EntitySystems;
+using Content.Shared.Chemistry;
+using Content.Shared.Chemistry.Dispenser;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.Chemistry.Components
+{
+    /// <summary>
+    /// A machine that dispenses reagents into a solution container from containers in its storage slots.
+    /// </summary>
+    [RegisterComponent]
+    [Access(typeof(SolutionTransferMachineSystem))]
+    public sealed partial class SolutionTransferMachineComponent : Component
+    {
+        /// <summary>
+        /// String with the pack name that stores the initial fill of the dispenser. The initial
+        /// fill is added to the dispenser on MapInit. Note that we don't use ContainerFill because
+        /// we have to generate the storage slots at MapInit first, then fill them.
+        /// </summary>
+        [DataField("pack", customTypeSerializer: typeof(PrototypeIdSerializer<ReagentDispenserInventoryPrototype>))]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public string? PackPrototypeId = default!;
+
+        /// <summary>
+        /// Maximum number of internal storage slots. Machines can't store (or dispense) more than
+        /// this many chemicals (without unloading and reloading).
+        /// </summary>
+        [DataField]
+        public int MaxStorageSlots = 25;
+        /// <summary>
+        /// List of storage slots that were created at MapInit.
+        /// </summary>
+        [DataField]
+        public List<string> StorageSlotIds = [];
+        [DataField]
+        public List<ItemSlot> StorageSlots = [];
+        /// <summary>
+        /// For each created storage slot for the reagent containers being dispensed, apply this
+        /// entity whitelist. Makes sure weird containers don't fit in the dispenser and that beakers
+        /// don't accidentally get slotted into the source slots.
+        /// </summary>
+        [DataField]
+        public EntityWhitelist? StorageWhitelist;
+
+        /// <summary>
+        /// Whether to allow cherry-picking specific reagents when moving solutions around into/out of containers
+        /// More specific checks can be done by whatever uses this system
+        /// </summary>
+        [DataField]
+        public bool AllowFiltering = false;
+
+        /// <summary>
+        /// Beakers for input/output operations of the machine. Created the same way storage slots do.
+        /// </summary>
+        [DataField]
+        public int MaxDispenserSlots = 1;
+        [DataField]
+        public List<string> DispenserSlotIds = [];
+        [DataField]
+        public List<ItemSlot> DispenserContainerSlots = [];
+        [DataField]
+        public EntityWhitelist? DispenserWhitelist;
+    }
+}

--- a/Content.Server/Chemistry/EntitySystems/SolutionTransferMachineSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionTransferMachineSystem.cs
@@ -1,0 +1,241 @@
+using Content.Server.Chemistry.Components;
+using Content.Server.Labels;
+using Content.Server.Popups;
+using Content.Server.Storage.EntitySystems;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Chemistry;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Dispenser;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Database;
+using Content.Shared.FixedPoint;
+using Content.Shared.Labels.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Nutrition.EntitySystems;
+using Content.Shared.Storage;
+using JetBrains.Annotations;
+using Robust.Server.Audio;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio;
+using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Content.Server.Chemistry.EntitySystems
+{
+
+    /// <summary>
+    /// System for any machine that transfers things between jugs and beakers
+    /// <seealso cref="SolutionTransferMachineComponent"/>
+    /// </summary>
+    [UsedImplicitly]
+    public sealed class SolutionTransferMachineSystem : EntitySystem
+    {
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
+        [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
+        [Dependency] private readonly SolutionTransferSystem _solutionTransferSystem = default!;
+        [Dependency] private readonly OpenableSystem _openable = default!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<SolutionTransferMachineComponent, MapInitEvent>(OnMapInit, before: [typeof(ItemSlotsSystem)]);
+        }
+
+        /// <summary>
+        /// Allows other systems to check if the transfer is valid without having to do all the work on their end,
+        /// and make sure the client didn't tell them to pick a chemical from a jug into another within a dispenser
+        /// </summary>
+        public bool ValidateTransfer(Entity<SolutionTransferMachineComponent?> machine, string inputSlot, string outputSlot, SolutionTransferMachineRestriction restriction)
+        {
+            if (!Resolve(machine, ref machine.Comp))
+                return false;
+
+            var check = SolutionTransferMachineRestriction.Unrestricted;
+
+            if (machine.Comp.StorageSlotIds.Contains(inputSlot))
+                check |= SolutionTransferMachineRestriction.FromStorage;
+            if (machine.Comp.DispenserSlotIds.Contains(inputSlot))
+                check |= SolutionTransferMachineRestriction.FromDispenser;
+
+            if (machine.Comp.StorageSlotIds.Contains(outputSlot))
+                check |= SolutionTransferMachineRestriction.IntoStorage;
+            if (machine.Comp.DispenserSlotIds.Contains(outputSlot))
+                check |= SolutionTransferMachineRestriction.IntoDispenser;
+
+            return (check & restriction) == 0;
+        }
+
+        public bool SolutionTransfer(Entity<SolutionTransferMachineComponent?> machine, string inputSlot, string outputSlot, int amount, ReagentId? reagentFilter = null, bool allowPartial = true)
+        {
+            if (!Resolve(machine, ref machine.Comp))
+                return false;
+
+            // Make sure both input and output containers exist. Not using FitsInDispenser because that should just be filtered for by whitelist
+
+            var inputContainer = _itemSlotsSystem.GetItemOrNull(machine, inputSlot);
+            if (inputContainer is not { Valid: true })
+                return false;
+
+            var outputContainer = _itemSlotsSystem.GetItemOrNull(machine, outputSlot);
+            if (outputContainer is not { Valid: true })
+                return false;
+
+            if (!_solutionContainerSystem.TryGetDrainableSolution(inputContainer.Value, out var source, out var sourceSolution) ||
+                !_solutionContainerSystem.TryGetRefillableSolution(outputContainer.Value, out var output, out var outputSolution))
+                return false;
+
+            // Force open container, if applicable, to avoid confusing people on why it doesn't dispense
+            _openable.SetOpen(inputContainer.Value, true);
+            _openable.SetOpen(outputContainer.Value, true);
+
+            var possibleAmount = FixedPoint2.Min(
+                amount,
+                reagentFilter is null ? sourceSolution.Volume : sourceSolution.GetReagentQuantity(reagentFilter.Value),
+                outputSolution.AvailableVolume
+            );
+
+            // Might want to have some feedback here for other things
+            if (possibleAmount == 0)
+                return false;
+
+            if (!allowPartial && possibleAmount < amount)
+                return false;
+
+            if (reagentFilter is null)
+            {
+                _solutionTransferSystem.Transfer(machine,
+                        inputContainer.Value, source.Value,
+                        outputContainer.Value, output.Value,
+                        possibleAmount
+                );
+                return true;
+            }
+
+            if (machine.Comp.AllowFiltering)
+            {
+                DebugTools.Assert("Solution transfer was requested with a filter despite the component not allowing such - disable such functionality if AllowFiltering is false");
+                return false;
+            }
+
+            // TODO: When Chemistry Refactor #30254 is merged, check if this is ok
+            var ignoredReagents = sourceSolution.Contents.Where(r => r.Reagent != reagentFilter.Value).Select(r => r.Reagent.Prototype).ToArray();
+
+            // Make sure to split the solution out and transfer that, don't just delete reagents to recreate them elsewhere
+            // Also preserves their temperature, woo
+            var isolatedReagentSolution = _solutionContainerSystem.SplitSolutionWithout(source.Value, possibleAmount, ignoredReagents);
+            _solutionContainerSystem.TryAddSolution(output.Value, isolatedReagentSolution);
+
+            return true;
+        }
+
+        public List<ReagentInventoryItem> GetInventory(Entity<SolutionTransferMachineComponent?> machine, bool dispenserInventory, bool withContents = false, bool fullName = false)
+        {
+            if (!Resolve(machine, ref machine.Comp))
+                return [];
+
+            List<ReagentInventoryItem> inventory = [];
+
+            foreach (var storageSlotId in dispenserInventory ? machine.Comp.DispenserSlotIds : machine.Comp.StorageSlotIds)
+            {
+                var info = GetSlotInfo(machine, storageSlotId, withContents, fullName);
+                if (info is not null)
+                    inventory.Add(info);
+            }
+
+            return inventory;
+        }
+
+        public ReagentInventoryItem? GetSlotInfo(Entity<SolutionTransferMachineComponent?> machine, string slotId, bool withContents, bool fullName)
+        {
+            if (!Resolve(machine, ref machine.Comp))
+                return null;
+
+            var storedContainer = _itemSlotsSystem.GetItemOrNull(machine, slotId);
+
+            // Set label from manually-applied label, or metadata if unavailable
+            string displayName;
+            if (!fullName && TryComp<LabelComponent>(storedContainer, out var label) && !string.IsNullOrEmpty(label.CurrentLabel))
+                displayName = label.CurrentLabel;
+            else if (storedContainer != null)
+                displayName = Name(storedContainer.Value);
+            else
+                return null;
+
+            if (storedContainer != null && _solutionContainerSystem.TryGetDrainableSolution(storedContainer.Value, out _, out var sol))
+            {
+                return new ReagentInventoryItem(
+                    slotId, displayName, sol.GetColor(_prototypeManager),
+                    sol.Volume, sol.MaxVolume,
+                    withContents ? sol.Contents : null,
+                    GetNetEntity(storedContainer)
+                );
+            }
+
+            return new ReagentInventoryItem(
+                slotId, displayName, Color.White,
+                0, null, null, GetNetEntity(storedContainer)
+            );
+        }
+
+        /// <summary>
+        /// Automatically generate storage slots for all NumSlots, and fill them with their initial chemicals.
+        /// The actual spawning of entities happens in ItemSlotsSystem's MapInit.
+        /// </summary>
+        private void OnMapInit(EntityUid uid, SolutionTransferMachineComponent component, MapInitEvent args)
+        {
+            // Get list of pre-loaded containers
+            List<string> preLoad = [];
+            if (component.PackPrototypeId is not null
+                && _prototypeManager.TryIndex(component.PackPrototypeId, out ReagentDispenserInventoryPrototype? packPrototype))
+            {
+                preLoad.AddRange(packPrototype.Inventory);
+            }
+
+            // Populate storage slots with base storage slot whitelist
+            for (var i = 0; i < component.MaxStorageSlots; i++)
+            {
+                var storageSlotId = SharedSolutionTransferMachineSystem.BaseStorageSlotId + i;
+                ItemSlot storageComponent = new()
+                {
+                    Whitelist = component.StorageWhitelist,
+                    Swap = false,
+                    EjectOnBreak = true
+                };
+
+                // Check corresponding index in pre-loaded container (if exists) and set starting item
+                if (i < preLoad.Count)
+                    storageComponent.StartingItem = preLoad[i];
+
+                component.StorageSlotIds.Add(storageSlotId);
+                component.StorageSlots.Add(storageComponent);
+                component.StorageSlots[i].Name = "Storage Slot " + (i + 1);
+                _itemSlotsSystem.AddItemSlot(uid, component.StorageSlotIds[i], component.StorageSlots[i]);
+            }
+
+            // Populate storage slots with base storage slot whitelist
+            for (var i = 0; i < component.MaxDispenserSlots; i++)
+            {
+                var storageSlotId = SharedSolutionTransferMachineSystem.BaseDispenserSlotId + i;
+                ItemSlot storageComponent = new()
+                {
+                    //WhitelistFailPopup = "reagent-dispenser-component-cannot-put-entity-message",
+                    Whitelist = component.DispenserWhitelist,
+                    Swap = true,
+                    EjectOnBreak = true
+                };
+
+                component.DispenserSlotIds.Add(storageSlotId);
+                component.DispenserContainerSlots.Add(storageComponent);
+                component.DispenserContainerSlots[i].Name = "Dispenser Slot " + (i + 1);
+                _itemSlotsSystem.AddItemSlot(uid, component.DispenserSlotIds[i], component.DispenserContainerSlots[i]);
+            }
+        }
+    }
+}

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionTransferMachineSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionTransferMachineSystem.cs
@@ -1,0 +1,35 @@
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Chemistry
+{
+    public sealed class SharedSolutionTransferMachineSystem
+    {
+        public const string BaseStorageSlotId = "SolutionTransferMachine-storageSlot";
+        public const string BaseDispenserSlotId = "SolutionTransferMachine-dispenserSlot";
+    }
+
+    public enum SolutionTransferMachineRestriction
+    {
+        Unrestricted = 0,
+        IntoStorage = 1 << 0,
+        IntoDispenser = 1 << 1,
+        FromStorage = 1 << 2,
+        FromDispenser = 1 << 3,
+        StoragePicking = 1 << 4,
+        DispenserPicking = 1 << 5,
+    }
+
+    [Serializable, NetSerializable]
+    public sealed class ReagentInventoryItem(string storageSlotId, string reagentLabel, Color reagentColor, FixedPoint2 quantity, FixedPoint2? capacity, List<ReagentQuantity>? reagents, NetEntity? entity)
+    {
+        public readonly string StorageSlotId = storageSlotId;
+        public readonly string DisplayName = reagentLabel;
+        public readonly FixedPoint2 Quantity = quantity;
+        public readonly FixedPoint2? Capacity = capacity;
+        public readonly Color ReagentColor = reagentColor;
+        public List<ReagentQuantity>? Reagents { get; init; } = reagents;
+        public readonly NetEntity? Entity = entity;
+    }
+}

--- a/Content.Shared/Chemistry/SharedReagentDispenser.cs
+++ b/Content.Shared/Chemistry/SharedReagentDispenser.cs
@@ -9,7 +9,6 @@ namespace Content.Shared.Chemistry
     /// </summary>
     public sealed class SharedReagentDispenser
     {
-        public const string OutputSlotName = "beakerSlot";
     }
 
     [Serializable, NetSerializable]
@@ -64,14 +63,10 @@ namespace Content.Shared.Chemistry
     }
 
     [Serializable, NetSerializable]
-    public sealed class ReagentDispenserDispenseReagentMessage : BoundUserInterfaceMessage
+    public sealed class ReagentDispenserDispenseReagentMessage(string slotId, string outputSlotId) : BoundUserInterfaceMessage
     {
-        public readonly string SlotId;
-
-        public ReagentDispenserDispenseReagentMessage(string slotId)
-        {
-            SlotId = slotId;
-        }
+        public readonly string SlotId = slotId;
+        public readonly string OutputSlotId = outputSlotId;
     }
 
     [Serializable, NetSerializable]
@@ -94,20 +89,9 @@ namespace Content.Shared.Chemistry
     }
 
     [Serializable, NetSerializable]
-    public sealed class ReagentInventoryItem(string storageSlotId, string reagentLabel, FixedPoint2 quantity, Color reagentColor)
-    {
-        public string StorageSlotId = storageSlotId;
-        public string ReagentLabel = reagentLabel;
-        public FixedPoint2 Quantity = quantity;
-        public Color ReagentColor = reagentColor;
-    }
-
-    [Serializable, NetSerializable]
     public sealed class ReagentDispenserBoundUserInterfaceState : BoundUserInterfaceState
     {
-        public readonly ContainerInfo? OutputContainer;
-
-        public readonly NetEntity? OutputContainerEntity;
+        public readonly ReagentInventoryItem? OutputContainer;
 
         /// <summary>
         /// A list of the reagents which this dispenser can dispense.
@@ -116,10 +100,9 @@ namespace Content.Shared.Chemistry
 
         public readonly ReagentDispenserDispenseAmount SelectedDispenseAmount;
 
-        public ReagentDispenserBoundUserInterfaceState(ContainerInfo? outputContainer, NetEntity? outputContainerEntity, List<ReagentInventoryItem> inventory, ReagentDispenserDispenseAmount selectedDispenseAmount)
+        public ReagentDispenserBoundUserInterfaceState(ReagentInventoryItem? outputContainer, List<ReagentInventoryItem> inventory, ReagentDispenserDispenseAmount selectedDispenseAmount)
         {
             OutputContainer = outputContainer;
-            OutputContainerEntity = outputContainerEntity;
             Inventory = inventory;
             SelectedDispenseAmount = selectedDispenseAmount;
         }

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -55,20 +55,18 @@
         sound:
           collection: MetalGlassBreak
   - type: ReagentDispenser
+  - type: SolutionTransferMachine
     storageWhitelist:
       tags:
       - Bottle
-    beakerSlot:
-      whitelistFailPopup: reagent-dispenser-component-cannot-put-entity-message
-      whitelist:
-        components:
-        - FitsInDispenser
+    dispenserWhitelist:
+      components:
+      - FitsInDispenser
   - type: ItemSlots
   - type: ContainerContainer
     containers:
       machine_board: !type:Container
       machine_parts: !type:Container
-      beakerSlot: !type:ContainerSlot
   - type: StaticPrice
     price: 1000
   - type: WiresPanel

--- a/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
@@ -11,9 +11,13 @@
     drawdepth: SmallObjects
     state: booze
   - type: ReagentDispenser
+  - type: SolutionTransferMachine
     storageWhitelist:
       tags:
       - DrinkBottle
+    dispenserWhitelist:
+      components:
+      - FitsInDispenser
     pack: BoozeDispenserInventory
   - type: Transform
     noRot: false
@@ -32,7 +36,11 @@
   parent: BoozeDispenser
   components:
   - type: ReagentDispenser
+  - type: SolutionTransferMachine
     storageWhitelist:
       tags:
       - DrinkBottle
+    dispenserWhitelist:
+      components:
+      - FitsInDispenser
     pack: EmptyInventory

--- a/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
@@ -10,9 +10,13 @@
     state: industrial-working
     snapCardinals: true
   - type: ReagentDispenser
+  - type: SolutionTransferMachine
     storageWhitelist:
       tags:
       - ChemDispensable
+    dispenserWhitelist:
+      components:
+      - FitsInDispenser
     pack: ChemDispenserStandardInventory
   - type: ApcPowerReceiver
   - type: ExtensionCableReceiver
@@ -56,4 +60,8 @@
   parent: ChemDispenser
   components:
   - type: ReagentDispenser
+  - type: SolutionTransferMachine
+    dispenserWhitelist:
+      components:
+      - FitsInDispenser
     pack: EmptyInventory

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -11,9 +11,13 @@
     drawdepth: SmallObjects
     state: soda
   - type: ReagentDispenser
+  - type: SolutionTransferMachine
     storageWhitelist:
       tags:
       - DrinkBottle
+    dispenserWhitelist:
+      components:
+      - FitsInDispenser
     pack: SodaDispenserInventory
   - type: Transform
     noRot: false
@@ -30,7 +34,11 @@
   suffix: Empty
   components:
   - type: ReagentDispenser
+  - type: SolutionTransferMachine
     storageWhitelist:
       tags:
       - DrinkBottle
+    dispenserWhitelist:
+      components:
+      - FitsInDispenser
     pack: EmptyInventory


### PR DESCRIPTION
## About the PR
Moved the whole "spawn with various jugs" thing out of the Dispenser so that we can implement whatever machine that does chemicals transfer between jugs and beakers (or whatever you want) without needing to duplicate much code beyond UI handling.

## Why / Balance
Non-balancing change.

As for why? Because I wanted to change ChemMaster to be based around jugs. Well, what do you know, I found having to copy stuff from ReagentDispenser. Over and over and over...

When I got to the inventory handling code, I fucking gave up and made this. Yay.

## Technical details
The `ReagentDispenser` is... big, and does a lot. If you want to make anything that takes a lot of jugs, spawns with them, and can have a beaker and it transfers between jugs and beaker, you have to duplicate pretty much entirety of the dispenser.

So, let's *not* do that, and split it out into own extensible generic component that does all the solution movement thing. All while the dispenser becomes just a wrapper around it for UI to talk to.

Current issues:
- It's not in Content.Shared, woo. Maybe later.
- Dispenser UI relies on magic `SharedSolutionTransferMachineSystem.BaseStorageSlotId` slot IDs for the beaker output. Though probably should move that back out of the UI and into the server handling, just have it grab the first dispenser slot.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- ChemicalDispenser component is no longer responsible for spawning the jugs, and SolutionTransferMachine must be used instead