### PR TITLE
tweak: weather command tooltip

### DIFF
--- a/Content.Server/Weather/WeatherSystem.cs
+++ b/Content.Server/Weather/WeatherSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Weather;
 using Robust.Shared.Console;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
+using System.Linq;
 
 namespace Content.Server.Weather;
 
@@ -85,6 +86,7 @@ public sealed class WeatherSystem : SharedWeatherSystem
             return CompletionResult.FromHintOptions(CompletionHelper.MapIds(EntityManager), "Map Id");
 
         var a = CompletionHelper.PrototypeIDs<WeatherPrototype>(true, ProtoMan);
-        return CompletionResult.FromHintOptions(a, Loc.GetString("cmd-weather-hint"));
+        var b = a.Concat(new[] { new CompletionOption("null", Loc.GetString("cmd-weather-null")) });
+        return CompletionResult.FromHintOptions(b, Loc.GetString("cmd-weather-hint"));
     }
 }

--- a/Resources/Locale/en-US/weather/weather.ftl
+++ b/Resources/Locale/en-US/weather/weather.ftl
@@ -1,6 +1,7 @@
 cmd-weather-desc = Sets the weather for the current map.
 cmd-weather-help = weather <mapId> <prototype / null>
 cmd-weather-hint = Weather prototype
+cmd-weather-null = Clears the weather
 
 cmd-weather-error-no-arguments = Not enough arguments!
 cmd-weather-error-unknown-proto = Unknown Weather prototype!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

For reasons different commands have random ways to unset things that they set. 
For the `weather` command it takes "null" to clear the weather prototype.
I added that to its completionhelper.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
ADMIN
- tweak: weather now has a completion result for how to unset the weather.