### PR TITLE
Make thieving gloves require the user to be behind the target

### DIFF
--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -61,7 +61,11 @@ namespace Content.Shared.Strip.Components
     ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
     /// </remarks>
     [ByRefEvent]
-    public sealed class BeforeStripEvent(EntityUid target, TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(target, initialTime, stealth);
+    public sealed class BeforeStripEvent(EntityUid user, EntityUid target, TimeSpan initialTime, bool stealth = false)
+        : BaseBeforeStripEvent(target, initialTime, stealth)
+    {
+        public readonly EntityUid User = user;
+    }
 
     /// <summary>
     ///     Used to modify strip times. Raised directed at the target.

--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -32,8 +32,9 @@ namespace Content.Shared.Strip.Components
     public sealed class StrippingEnsnareButtonPressed : BoundUserInterfaceMessage;
 
     [ByRefEvent]
-    public abstract class BaseBeforeStripEvent(TimeSpan initialTime, bool stealth = false) : EntityEventArgs, IInventoryRelayEvent
+    public abstract class BaseBeforeStripEvent(EntityUid target, TimeSpan initialTime, bool stealth = false) : EntityEventArgs, IInventoryRelayEvent
     {
+        public readonly EntityUid Target = target;
         public readonly TimeSpan InitialTime = initialTime;
         public float Multiplier = 1f;
         public TimeSpan Additive = TimeSpan.Zero;
@@ -51,7 +52,7 @@ namespace Content.Shared.Strip.Components
     ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
     /// </remarks>
     [ByRefEvent]
-    public sealed class BeforeItemStrippedEvent(TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(initialTime, stealth);
+    public sealed class BeforeItemStrippedEvent(EntityUid target, TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(target, initialTime, stealth);
 
     /// <summary>
     ///     Used to modify strip times. Raised directed at the user.
@@ -60,7 +61,7 @@ namespace Content.Shared.Strip.Components
     ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
     /// </remarks>
     [ByRefEvent]
-    public sealed class BeforeStripEvent(TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(initialTime, stealth);
+    public sealed class BeforeStripEvent(EntityUid target, TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(target, initialTime, stealth);
 
     /// <summary>
     ///     Used to modify strip times. Raised directed at the target.
@@ -69,7 +70,7 @@ namespace Content.Shared.Strip.Components
     ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
     /// </remarks>
     [ByRefEvent]
-    public sealed class BeforeGettingStrippedEvent(TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(initialTime, stealth);
+    public sealed class BeforeGettingStrippedEvent(EntityUid target, TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(target, initialTime, stealth);
 
     /// <summary>
     ///     Organizes the behavior of DoAfters for <see cref="StrippableSystem">.

--- a/Content.Shared/Strip/Components/ThievingComponent.cs
+++ b/Content.Shared/Strip/Components/ThievingComponent.cs
@@ -19,4 +19,10 @@ public sealed partial class ThievingComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("stealthy")]
     public bool Stealthy;
+
+    /// <summary>
+    /// How far away the user can be from behind the target for the stealing to be stealthy, in percents
+    /// </summary>
+    [DataField]
+    public double MaxStealthAngleTolerance = 0.25;
 }

--- a/Content.Shared/Strip/Components/ThievingComponent.cs
+++ b/Content.Shared/Strip/Components/ThievingComponent.cs
@@ -21,8 +21,8 @@ public sealed partial class ThievingComponent : Component
     public bool Stealthy;
 
     /// <summary>
-    /// How far away the user can be from behind the target for the stealing to be stealthy, in percents
+    /// How far away the user can be from behind the target for the stealing to be stealthy
     /// </summary>
     [DataField]
-    public double MaxStealthAngleTolerance = 0.25;
+    public Angle? MaxStealthAngle;
 }

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -609,12 +609,12 @@ public abstract class SharedStrippableSystem : EntitySystem
     /// </summary>
     public (TimeSpan Time, bool Stealth) GetStripTimeModifiers(EntityUid user, EntityUid targetPlayer, EntityUid? targetItem, TimeSpan initialTime)
     {
-        var itemEv = new BeforeItemStrippedEvent(initialTime, false);
+        var itemEv = new BeforeItemStrippedEvent(targetPlayer, initialTime, false);
         if (targetItem != null)
             RaiseLocalEvent(targetItem.Value, ref itemEv);
-        var userEv = new BeforeStripEvent(itemEv.Time, itemEv.Stealth);
+        var userEv = new BeforeStripEvent(targetPlayer, itemEv.Time, itemEv.Stealth);
         RaiseLocalEvent(user, ref userEv);
-        var targetEv = new BeforeGettingStrippedEvent(userEv.Time, userEv.Stealth);
+        var targetEv = new BeforeGettingStrippedEvent(targetPlayer, userEv.Time, userEv.Stealth);
         RaiseLocalEvent(targetPlayer, ref targetEv);
         return (targetEv.Time, targetEv.Stealth);
     }

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -612,7 +612,7 @@ public abstract class SharedStrippableSystem : EntitySystem
         var itemEv = new BeforeItemStrippedEvent(targetPlayer, initialTime, false);
         if (targetItem != null)
             RaiseLocalEvent(targetItem.Value, ref itemEv);
-        var userEv = new BeforeStripEvent(targetPlayer, itemEv.Time, itemEv.Stealth);
+        var userEv = new BeforeStripEvent(user, targetPlayer, itemEv.Time, itemEv.Stealth);
         RaiseLocalEvent(user, ref userEv);
         var targetEv = new BeforeGettingStrippedEvent(targetPlayer, userEv.Time, userEv.Stealth);
         RaiseLocalEvent(targetPlayer, ref targetEv);

--- a/Content.Shared/Strip/ThievingSystem.cs
+++ b/Content.Shared/Strip/ThievingSystem.cs
@@ -6,6 +6,7 @@ namespace Content.Shared.Strip;
 
 public sealed class ThievingSystem : EntitySystem
 {
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
     {
@@ -17,7 +18,25 @@ public sealed class ThievingSystem : EntitySystem
 
     private void OnBeforeStrip(EntityUid uid, ThievingComponent component, BeforeStripEvent args)
     {
-        args.Stealth |= component.Stealthy;
+        if (component.Stealthy && CanStealStealthily(uid, component, args.Target))
+            args.Stealth = true;
+
         args.Additive -= component.StripTimeReduction;
+    }
+
+    public bool CanStealStealthily(EntityUid user, ThievingComponent? component, EntityUid target)
+    {
+        if (!Resolve(user, ref component))
+            return false;
+
+        var targetBackRotation = _transform.GetWorldRotation(target) - Angle.FromDegrees(180);
+
+        var userRelativeRotation =
+            (_transform.GetWorldPosition(user) - _transform.GetWorldPosition(target)).ToWorldAngle();
+
+        var isWithinStealthRange =
+            userRelativeRotation.EqualsApprox(targetBackRotation, component.MaxStealthAngleTolerance);
+
+        return isWithinStealthRange;
     }
 }

--- a/Content.Shared/Strip/ThievingSystem.cs
+++ b/Content.Shared/Strip/ThievingSystem.cs
@@ -18,15 +18,21 @@ public sealed class ThievingSystem : EntitySystem
 
     private void OnBeforeStrip(EntityUid uid, ThievingComponent component, BeforeStripEvent args)
     {
-        if (component.Stealthy && CanStealStealthily(uid, component, args.Target))
+        if (CanStealStealthily(uid, component, args.Target))
             args.Stealth = true;
 
         args.Additive -= component.StripTimeReduction;
     }
 
+    /// <summary>
+    /// Checks if the <paramref name="user"/> is able to steal stealthily from the <paramref name="target"/>
+    /// </summary>
     public bool CanStealStealthily(EntityUid user, ThievingComponent? component, EntityUid target)
     {
         if (!Resolve(user, ref component))
+            return false;
+
+        if (!component.Stealthy)
             return false;
 
         var targetBackRotation = _transform.GetWorldRotation(target) - Angle.FromDegrees(180);

--- a/Resources/Locale/en-US/strip/thieving-component.ftl
+++ b/Resources/Locale/en-US/strip/thieving-component.ftl
@@ -1,0 +1,1 @@
+thieving-component-failed = You failed to steal stealthily from {$owner}!

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -228,6 +228,7 @@
   - type: Thieving
     stripTimeReduction: 1
     stealthy: true
+    maxStealthAngleTolerance: 1 # I'm not even sure why ninja gloves have the thieving components but whatever
   - type: ToggleClothing
     action: ActionToggleNinjaGloves
   - type: NinjaGloves

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -228,7 +228,6 @@
   - type: Thieving
     stripTimeReduction: 1
     stealthy: true
-    maxStealthAngleTolerance: 1 # I'm not even sure why ninja gloves have the thieving components but whatever
   - type: ToggleClothing
     action: ActionToggleNinjaGloves
   - type: NinjaGloves
@@ -368,6 +367,7 @@
   - type: Thieving
     stripTimeReduction: 1.5
     stealthy: true
+    maxStealthAngle: 45
 
 - type: entity
   parent: ClothingHandsGlovesColorWhite

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -84,6 +84,7 @@
   - type: Thieving
     stripTimeReduction: 9999
     stealthy: true
+    maxStealthAngleTolerance: 1
   - type: Stripping
   - type: SolutionScanner
   - type: IgnoreUIRange

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -84,7 +84,6 @@
   - type: Thieving
     stripTimeReduction: 9999
     stealthy: true
-    maxStealthAngleTolerance: 1
   - type: Stripping
   - type: SolutionScanner
   - type: IgnoreUIRange


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I have made the thieving gloves require the user to be behind the target when starting to steal or they will fail to be stealthy.
This does *not* affect their speed.

## Why / Balance
The thieving gloves in their current state are not fun at all to play against as crew since they require heads to either be always moving or staying out of interaction range or their items might be lost and most likely never found back due to the lack of any traces that are left behind.
This change means command has to worry much less about the person they are talking to trying to steal their things and makes heads much more likely to actually go and directly interact and roleplay with the crew due to them only having to keep their backs clear.
Thieving gloves will still be useful because they can still be used on a head that is focused on a task and does not notice you.

I can reduce the cost of thieving gloves if needed.

## Technical details
Added a check before setting the stealth value of the before strip event that the difference between the user's direction relative to the target and the opposite of the target's visible direction is less than the defined maximum stealth angle.
This does not use Angle.EqualsApprox function because it just did not work.

## Media

https://github.com/user-attachments/assets/19ec5be1-85e2-45bf-a75d-793d305fd529



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The thieving gloves now require the user to be behind the target in order to be stealthy