### PR TITLE
Headphones activated animation now plays again

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -328,3 +328,13 @@
       itemIconStyle: NoItem
       useDelay: 1 # emote spam
       event: !type:ToggleActionEvent
+
+- type: entity
+  id: ActionToggleHeadphones
+  name: Toggle Headphones
+  description: Toggles the headphones on and off.
+  components:
+    - type: InstantAction
+      itemIconStyle: BigItem
+      useDelay: 1
+      event: !type:ToggleActionEvent

--- a/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
@@ -8,28 +8,31 @@
     sprite: Clothing/Neck/Misc/headphones.rsi
     layers:
     - state: icon
-      map: [ "enum.ToggleVisuals.Layer" ]
+    - state: icon-on
+      visible: false
+      shader: unshaded
+      map: [ "light" ]
+  - type: Appearance
   - type: Clothing
-    equippedPrefix: off
     sprite: Clothing/Neck/Misc/headphones.rsi
+    equippedPrefix: off
+  - type: ItemToggle
+    predictable: false
+    onUse: false
+    soundActivate:
+      path: /Audio/Items/flashlight_on.ogg
+    soundDeactivate:
+      path: /Audio/Items/flashlight_off.ogg
+  - type: ItemTogglePointLight
   - type: ToggleableLightVisuals
     spriteLayer: enum.ToggleVisuals.Layer
     clothingVisuals:
       neck:
       - state: on-equipped-NECK
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ToggleVisuals.Toggled:
-        enum.ToggleVisuals.Layer:
-          True: {state: icon-on}
-          False: {state: icon}
-  - type: ItemToggle
-    predictable: false
-    soundActivate:
-      path: /Audio/Items/flashlight_on.ogg
-    soundDeactivate:
-      path: /Audio/Items/flashlight_off.ogg
+  - type: PointLight
+    enabled: false
+    radius: 0
+    energy: 0
 
 - type: entity
   parent: ClothingNeckBase

--- a/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
@@ -9,7 +9,7 @@
     layers:
     - state: icon
     - state: icon-on
-      visible: false
+      visible: true
       shader: unshaded
       map: [ "light" ]
   - type: Appearance
@@ -33,6 +33,10 @@
     enabled: false
     radius: 0
     energy: 0
+  - type: ToggleClothing
+    action: ActionToggleHeadphones
+  - type: UseDelay
+    delay: 1.0
 
 - type: entity
   parent: ClothingNeckBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes the little sprite animation that plays when you enable the headphones.

## Why / Balance
Broke on #31655
This fixes #31755 

SHITCODE ALERT! This is horrible! But, you know, it was just as bad before this change if you look at the old system. So it's equally as bad, but it works this time. I call that a net improvement!

## Media
![Content Client_cbUcPIPzyi](https://github.com/user-attachments/assets/089249b4-89a3-4976-86a5-4c275d5582de)


_Within the inner heart I plead,
for you to talk to me
I wanna hear all the good and bad,
the new stories you have
As I drift across the skyyy,
The hours hand turns hiiiigh,
So goooodniiight~_

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Headphones now correctly displays the activated sprite.
