### PR TITLE
allow building wallmountables on windows

### DIFF
--- a/Content.Shared/Construction/Conditions/WallmountCondition.cs
+++ b/Content.Shared/Construction/Conditions/WallmountCondition.cs
@@ -42,7 +42,15 @@ namespace Content.Shared.Construction.Conditions
             var tagSystem = entManager.System<TagSystem>();
 
             var userToObjRaycastResults = physics.IntersectRayWithPredicate(entManager.GetComponent<TransformComponent>(user).MapID, rUserToObj, maxLength: length,
-                predicate: (e) => !tagSystem.HasTag(e, "Wall"));
+                predicate: (e) => {
+                    if (tagSystem.HasTag(e, "Wall")) {
+                        return false;
+                    }
+                    if (!tagSystem.HasTag(e, "Window")) {
+                        return true;
+                    }
+                    return tagSystem.HasTag(e, "WindowDirectional");
+                });
 
             var targetWall = userToObjRaycastResults.FirstOrNull();
 

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -135,6 +135,7 @@
   - type: Tag
     tags:
       - Window
+      - WindowDirectional
   - type: MeleeSound
     soundGroups:
       Brute:

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1415,6 +1415,9 @@
   id: Window
 
 - type: Tag
+  id: WindowDirectional # differentiate for wall mounting
+
+- type: Tag
   id: Wine
 
 - type: Tag


### PR DESCRIPTION
## About the PR

This PR fixes #31474 by allowing the construction of wall-mountable entities on top of windows.

## Why / Balance

The issue was marked as a bug, so this is no more than a bug-fix.

## Technical details

1. Added a new tag to distinguish between windows and directional windows.
1. Adjusted the conditional to allow windows, but not directional windows.

- While this "fixes" the bug mentioned above, but it also allows for the placing of construction ghosts behind windows (but not the construction, so its only visual). Any help with this would be appreciated.

## Media


https://github.com/user-attachments/assets/c6726c67-a54c-49b1-909b-5b8e1b88c026



## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

None

**Changelog**

:cl:
- fix: Air-alarms, buttons and more can now be build on windows.
