### PR TITLE
Grindable ammo cartridges

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
@@ -40,3 +40,107 @@
         volume: -1
   - type: StaticPrice
     price: 1
+  - type: Extractable
+    grindableSolutionName: cartridge
+  - type: SolutionContainerManager #there are no reagents that work as the "primer" as far as i'm aware, so it is simply omitted
+    solutions:
+      cartridge:
+        reagents:
+        - ReagentId: Lead
+          Quantity: 2
+        - ReagentId: Copper
+          Quantity: 1
+
+- type: entity
+  id: BaseCartridgePractice
+  parent: BaseItem
+  abstract: true
+  components:
+  - type: Extractable
+    grindableSolutionName: practice
+  - type: SolutionContainerManager
+    solutions:
+      practice:
+        reagents:
+        - ReagentId: Cellulose
+          Quantity: 3
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#dbdbdb"
+
+- type: entity
+  id: BaseCartridgeIncendiary
+  parent: BaseItem
+  abstract: true
+  components:
+  - type: Extractable
+    grindableSolutionName: incendiary
+  - type: SolutionContainerManager
+    solutions:
+      incendiary:
+        reagents:
+        - ReagentId: Lead
+          Quantity: 2
+        - ReagentId: Copper
+          Quantity: 1
+        - ReagentId: ChlorineTrifluoride
+          Quantity: 1
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#ff6e52"
+
+- type: entity
+  id: BaseCartridgeArmorPiercing
+  parent: BaseItem
+  abstract: true
+  components:
+  - type: Extractable
+    grindableSolutionName: ap
+  - type: SolutionContainerManager
+    solutions:
+      ap:
+        reagents:
+        - ReagentId: Iron
+          Quantity: 2
+        - ReagentId: Carbon
+          quantity: 0.2
+        - ReagentId: Copper
+          Quantity: 1
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#0a0a0a"
+
+- type: entity
+  id: BaseCartridgeUranium
+  parent: BaseItem
+  abstract: true
+  components:
+  - type: Extractable
+    grindableSolutionName: uranium
+  - type: SolutionContainerManager
+    solutions:
+      uranium:
+        reagents:
+        - ReagentId: Uranium
+          Quantity: 2
+        - ReagentId: Copper
+          Quantity: 1
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#65fe08"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
@@ -29,44 +29,23 @@
 - type: entity
   id: CartridgeLightRiflePractice
   name: cartridge (.30 rifle practice)
-  parent: BaseCartridgeLightRifle
+  parent: [BaseCartridgePractice, BaseCartridgeLightRifle]
   components:
   - type: CartridgeAmmo
     proto: BulletLightRiflePractice
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#dbdbdb"
 
 - type: entity
   id: CartridgeLightRifleIncendiary
   name: cartridge (.30 rifle incendiary)
-  parent: BaseCartridgeLightRifle
+  parent: [BaseCartridgeIncendiary, BaseCartridgeLightRifle]
   components:
   - type: CartridgeAmmo
     proto: BulletLightRifleIncendiary
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#ff6e52"
 
 - type: entity
   id: CartridgeLightRifleUranium
   name: cartridge (.30 rifle uranium)
-  parent: BaseCartridgeLightRifle
+  parent: [BaseCartridgeUranium, BaseCartridgeLightRifle]
   components:
   - type: CartridgeAmmo
     proto: BulletLightRifleUranium
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#65fe08"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -29,60 +29,31 @@
 - type: entity
   id: CartridgeMagnumPractice
   name: cartridge (.45 magnum practice)
-  parent: BaseCartridgeMagnum
+  parent: [BaseCartridgePractice, BaseCartridgeMagnum]
   components:
   - type: CartridgeAmmo
     proto: BulletMagnumPractice
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#dbdbdb"
 
 - type: entity
   id: CartridgeMagnumIncendiary
   name: cartridge (.45 magnum incendiary)
-  parent: BaseCartridgeMagnum
+  parent: [BaseCartridgeIncendiary, BaseCartridgeMagnum]
   components:
   - type: CartridgeAmmo
     proto: BulletMagnumIncendiary
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#ff6e52"
 
 - type: entity
   id: CartridgeMagnumAP
   name: cartridge (.45 magnum armor-piercing)
-  parent: BaseCartridgeMagnum
+  parent: [BaseCartridgeMagnum, BaseCartridgeArmorPiercing]
   components:
   - type: CartridgeAmmo
     proto: BulletMagnumAP
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#0a0a0a"
 
 - type: entity
   id: CartridgeMagnumUranium
   name: cartridge (.45 magnum uranium)
-  parent: BaseCartridgeMagnum
+  parent: [BaseCartridgeUranium, BaseCartridgeMagnum]
   components:
   - type: CartridgeAmmo
     proto: BulletMagnumUranium
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#65fe08"
-

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -29,44 +29,23 @@
 - type: entity
   id: CartridgePistolPractice
   name: cartridge (.35 auto practice)
-  parent: BaseCartridgePistol
+  parent: [BaseCartridgePractice, BaseCartridgePistol]
   components:
   - type: CartridgeAmmo
     proto: BulletPistolPractice
-  -  type: Sprite
-     layers:
-       - state: base
-         map: [ "enum.AmmoVisualLayers.Base" ]
-       - state: tip
-         map: [ "enum.AmmoVisualLayers.Tip" ]
-         color: "#dbdbdb"
 
 - type: entity
   id: CartridgePistolIncendiary
   name: cartridge (.35 auto incendiary)
-  parent: BaseCartridgePistol
+  parent: [BaseCartridgeIncendiary, BaseCartridgePistol]
   components:
   - type: CartridgeAmmo
     proto: BulletPistolIncendiary
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#ff6e52"
 
 - type: entity
   id: CartridgePistolUranium
   name: cartridge (.35 auto uranium)
-  parent: BaseCartridgePistol
+  parent: [BaseCartridgeUranium, BaseCartridgePistol]
   components:
   - type: CartridgeAmmo
     proto: BulletPistolUranium
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#65fe08"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
@@ -29,44 +29,23 @@
 - type: entity
   id: CartridgeRiflePractice
   name: cartridge (.20 rifle practice)
-  parent: BaseCartridgeRifle
+  parent: [BaseCartridgePractice, BaseCartridgeRifle]
   components:
   - type: CartridgeAmmo
     proto: BulletRiflePractice
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#dbdbdb"
 
 - type: entity
   id: CartridgeRifleIncendiary
   name: cartridge (.20 rifle incendiary)
-  parent: BaseCartridgeRifle
+  parent: [BaseCartridgeIncendiary,  BaseCartridgeRifle]
   components:
   - type: CartridgeAmmo
     proto: BulletRifleIncendiary
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#ff6e52"
 
 - type: entity
   id: CartridgeRifleUranium
   name: cartridge (.20 rifle uranium)
-  parent: BaseCartridgeRifle
+  parent: [BaseCartridgeUranium, BaseCartridgeRifle]
   components:
   - type: CartridgeAmmo
     proto: BulletRifleUranium
-  - type: Sprite
-    layers:
-      - state: base
-        map: [ "enum.AmmoVisualLayers.Base" ]
-      - state: tip
-        map: [ "enum.AmmoVisualLayers.Tip" ]
-        color: "#65fe08"

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -32,6 +32,16 @@
     proto: PelletShotgunBeanbag
   - type: SpentAmmoVisuals
     state: "beanbag"
+  - type: SolutionContainerManager
+    solutions:
+      shell:
+        reagents:
+        - ReagentId: Cellulose
+          Quantity: 2
+        - ReagentId: Lead
+          Quantity: 2
+        - ReagentId: Fiber
+          Quantity: 2
 
 - type: entity
   id: ShellShotgunSlug
@@ -46,6 +56,14 @@
     proto: PelletShotgunSlug
   - type: SpentAmmoVisuals
     state: "slug"
+  - type: SolutionContainerManager
+    solutions:
+      slug:
+        reagents:
+        - ReagentId: Cellulose
+          Quantity: 2
+        - ReagentId: Lead
+          Quantity: 3
 
 - type: entity
   id: ShellShotgunFlare
@@ -60,6 +78,24 @@
     proto: PelletShotgunFlare
   - type: SpentAmmoVisuals
     state: "flare"
+  - type: SolutionContainerManager
+    solutions:
+      flare:
+        reagents:
+        - ReagentId: Cellulose
+          Quantity: 2
+          # the actual flare part
+        - ReagentId: Phosphorus
+          Quantity: 3
+        - ReagentId: Carbon
+          Quantity: 1
+        - ReagentId: Oxygen
+          Quantity: 2
+          # from flare.yml: "fuel or something"
+        - ReagentId: Sulfur
+          Quantity: 1
+        - ReagentId: Charcoal
+          Quantity: 1
 
 - type: entity
   id: ShellShotgun
@@ -72,6 +108,16 @@
         map: [ "enum.AmmoVisualLayers.Base" ]
   - type: CartridgeAmmo
     proto: PelletShotgunSpread
+  - type: Extractable
+    grindableSolutionName: shell
+  - type: SolutionContainerManager # shotgun shells have plastic casing, and therefore need their own reagent entries
+    solutions:
+      shell:
+        reagents:
+        - ReagentId: Cellulose
+          Quantity: 2
+        - ReagentId: Lead
+          Quantity: 2
 
 - type: entity
   id: ShellShotgunIncendiary
@@ -86,6 +132,18 @@
     proto: PelletShotgunIncendiarySpread
   - type: SpentAmmoVisuals
     state: "incendiary"
+  - type: Extractable
+    grindableSolutionName: incendiary
+  - type: SolutionContainerManager # shotgun shells have more shot in them + have plastic casing, and therefore need their own reagent entries
+    solutions:
+      incendiary:
+        reagents:
+        - ReagentId: Cellulose
+          Quantity: 2
+        - ReagentId: Lead
+          Quantity: 2
+        - ReagentId: ChlorineTrifluoride
+          Quantity: 2
 
 - type: entity
   id: ShellShotgunPractice
@@ -100,6 +158,14 @@
     proto: PelletShotgunPracticeSpread
   - type: SpentAmmoVisuals
     state: "practice"
+  - type: Extractable
+    grindableSolutionName: practice
+  - type: SolutionContainerManager # shotgun shells have more shot in them + have plastic casing, and therefore need their own reagent entries
+    solutions:
+      practice:
+        reagents:
+        - ReagentId: Cellulose
+          Quantity: 6
 
 - type: entity
   id: ShellTranquilizer
@@ -113,12 +179,20 @@
   - type: CartridgeAmmo
     proto: PelletShotgunTranquilizer
   - type: ChemicalAmmo
+  - type: Extractable
+    grindableSolutionName: grinded
   - type: SolutionContainerManager
     solutions:
       ammo:
         reagents:
         - ReagentId: ChloralHydrate
           Quantity: 7
+      grinded:
+        reagents:
+        - ReagentId: ChloralHydrate
+          Quantity: 7
+        - ReagentId: Cellulose
+          Quantity: 2
   - type: SolutionTransfer
     maxTransferAmount: 7
   - type: SpentAmmoVisuals
@@ -141,10 +215,24 @@
     proto: PelletShotgunImprovisedSpread
   - type: SpentAmmoVisuals
     state: "improvised"
+  - type: Extractable
+    grindableSolutionName: improvised
+  - type: SolutionContainerManager
+    solutions:
+      improvised:
+        reagents:
+        - ReagentId: Cellulose
+          Quantity: 2
+        - ReagentId: Iron
+          Quantity: 2
+        - ReagentId: Carbon
+          Quantity: 0.2
+        - ReagentId: Silicon
+          Quantity: 6
 
 - type: entity
   id: ShellShotgunUranium
-  name: uranium shotgun shell
+  name: shell (.50 uranium)
   parent: BaseShellShotgun
   components:
     - type: Sprite
@@ -155,3 +243,13 @@
       proto: PelletShotgunUraniumSpread
     - type: SpentAmmoVisuals
       state: "depleted-uranium"
+    - type: Extractable
+      grindableSolutionName: uranium
+    - type: SolutionContainerManager
+      solutions:
+        uranium:
+          reagents:
+          - ReagentId: Cellulose
+            Quantity: 2
+          - ReagentId: Uranium
+            Quantity: 4


### PR DESCRIPTION
## About the PR
You can now grind ammo cartridges in the all-in-one grinder. This includes special ammo (for example, incendiary ammunition has CLF3 in it.)
Additionally, with the power of MULTI-INHERITANCE™, this reduces on yaml copypaste for special ammo bullet colors.

Also makes the uranium shotgun shell's name consistent.

## Why / Balance
There are no currently obtainable sources of lead in the game (at least that I'm aware of.) This adds probably one of the most immediately logical ones you could possibly have.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
![Content Client_uTh4Haul3d](https://github.com/user-attachments/assets/8b6990cc-cfa8-4d84-9ba3-7e7fdc32c080)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: You can now grind bullets to get lead (among other materials.)
