### PR TITLE
fix artifact debug assert

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
@@ -59,6 +59,10 @@
       - Xenoarchaeology
     - type: StealTarget
       stealGroup: XenoArtifact
+    - type: ContainerContainer # needed for the EffectStorage artifactEffect
+      containers:
+        storagebase: !type:Container
+          ents: [ ]
 
 - type: entity
   parent: BaseXenoArtifact

--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -49,10 +49,6 @@
   permanentComponents:
   - type: Item
     size: Huge
-  - type: ContainerContainer
-    containers:
-      storagebase: !type:Container
-        ents: [ ]
   - type: Storage
     maxItemSize: Huge
     grid:


### PR DESCRIPTION
## About the PR
Fixes #30761
Fixes a common debug assert, which is also a rare heisentest.
It happens when an alien artifact with the EffectStorage artifactEffect is triggered.

## Why / Balance
bugfix

## Technical details
Artifacts get the ActionArtifactActivate action, which they need in case they get sentient. An action is an entity that is stored in a container in the artifact. For this purpose the `ActionsContainerComponent` adds the `ContainerManagerComponent` to the artifact.
When the EffectStorage node is triggered the all the components in the component registry for the effect are deleted and then added again with the new datafields defined there.
![grafik](https://github.com/user-attachments/assets/89240305-d96b-44e2-87f1-fd4579d29502)
However, this will also delete the container the action is using, triggering the debug assert. To solve this we make the container for the storage a permanent part of the artifact. It will only be accessible once the StorageComponent is added by entering the node.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
no gameplay impact
