### PR TITLE
HOTFIX latejoin traitor activations

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -286,7 +286,6 @@
       - !type:NestedSelector
         tableId: SpicyPestEventsTable
 
-
 - type: entityTable
   id: SpaceTrafficControlTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -191,12 +191,17 @@
 
 - type: entity
   id: TraitorReinforcement
-  parent: Traitor
+  parent: BaseTraitorRule
   components:
   - type: TraitorRule
     giveUplink: false
     giveCodewords: false # It would actually give them a different set of codewords than the regular traitors, anyway
     giveBriefing: false
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ Traitor ]
+      mindRoles:
+      - MindRoleTraitor
 
 - type: entity
   id: Revolutionary
@@ -280,7 +285,7 @@
         tableId: CalmPestEventsTable
       - !type:NestedSelector
         tableId: SpicyPestEventsTable
-        
+
 
 - type: entityTable
   id: SpaceTrafficControlTable


### PR DESCRIPTION
## About the PR
Traitor activations were bugged and some players became traitor without getting WEWLAD, chat briefing, code words and uplink. This no longer happens.

## Technical details
What actually happened is that they are "bonus traitors" on top of everything else generated by the round, but they are based off the TraitorReinforcement profile  (used by the Reinforcement Beacon ghostroles), which intentionally does not give an uplink and needs no briefing since normally you take them via the ghostrole menu

Due to a prototype inheritance mistake, every time a player took a Traitor Reinforcement ghostrole, the gamerule that was created to track this allowed latejoin antagrolls for subsequent players. For additional bug detection difficulty, this new gamerule was delayed by the usual traitor delay amount before it would start granting antag rolls. 

What this means is: if traitors call in 5 monkey reinforcements, and those monkeys are all taken by players, 5 new game rules are created after 4-6 minutes, each of which have a 50% chance to grant someone antag status. This potentially created a large number of additional antagonists, however many players probably never realised this until round end, due to Traitor Reinforcements not giving out the standard notification, and don't grant an uplink anway. This bug also required reinforcement ghostroles to be summoned and taken in the first place, which is I guess not that common

The TraitorReinforcement prototype is now inherited from an earlier prototype, before it gets some undesired/unnecessary settings

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Errant
- fix: Late-joining traitors no longer have a chance to spawn without notification, codewords and their uplink.