### PR TITLE
Don't show Reinforcement codewords on round end

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -172,7 +172,8 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
     // TODO: AntagCodewordsComponent
     private void OnObjectivesTextPrepend(EntityUid uid, TraitorRuleComponent comp, ref ObjectivesTextPrependEvent args)
     {
-        args.Text += "\n" + Loc.GetString("traitor-round-end-codewords", ("codewords", string.Join(", ", comp.Codewords)));
+        if(comp.GiveCodewords)
+            args.Text += "\n" + Loc.GetString("traitor-round-end-codewords", ("codewords", string.Join(", ", comp.Codewords)));
     }
 
     // TODO: figure out how to handle this? add priority to briefing event?


### PR DESCRIPTION
## About the PR
Traitors who are not given codewords (mostly, Reinforcements) no longer display their generated but unused codeword sets on the round end screen

## Why / Balance
It's pointless to show a bunch of codewords at the end of the game that no one ever knew about and only exist because it was simpler to hide them than to make them not exist

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:

![Screenshot_2024-11-05_171524](https://github.com/user-attachments/assets/d50739bd-2714-444a-affb-9c8e5e198002)

After:

![Screenshot_2024-11-05_171240](https://github.com/user-attachments/assets/8df36add-f5a4-4f00-a9f4-a4bd2d4fd113)




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Errant
- fix: Syndicate Reinforcements no longer list their (hidden and unused) codewords on the Round End window.