### PR TITLE
Adds space ticks to vent spawn event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -20,6 +20,7 @@
     - id: SlimesSpawn
     - id: SolarFlare
     - id: SnakeSpawn
+    - id: TickSpawn
     - id: SpiderClownSpawn
     - id: SpiderSpawn
     - id: VentClog
@@ -390,6 +391,23 @@
     entries:
     - id: MobGiantSpiderAngry
       prob: 0.05
+
+- type: entity
+  id: TickSpawn
+  parent: BaseStationEventShortDelay
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-vent-creatures-start-announcement
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    earliestStart: 20
+    minimumPlayers: 15
+    weight: 5
+    duration: 60
+  - type: VentCrittersRule
+    entries:
+    - id: MobTick
+      prob: 0.10
 
 - type: entity
   id: SpiderClownSpawn


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds space ticks to vent spawn event.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Not enough variety in the vent spawn event, and ticks seemed to make sense as infestations on space stations.

They are fast, bunch up and inject a lot of poison, but are easy to take down with two or so crowbar swings.

## Technical details
<!-- Summary of code changes for easier review. -->
yml changes only

- `Resources/Prototypes/GameRules/events.yml` (adds space ticks game rule and event itself)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Vent spawns may now include space ticks.