### PR TITLE
Minor energy shield rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -418,7 +418,7 @@
       color: blue
     - type: ItemTogglePointLight
     - type: Reflect
-      reflectProb: 0.95
+      reflectProb: 0.8
       reflects:
         - Energy
     - type: Blocking
@@ -426,13 +426,13 @@
         coefficients:
           Blunt: 1.0
           Slash: 0.9
-          Piercing: 0.85
+          Piercing: 0.7
           Heat: 0.6
       activeBlockModifier:
         coefficients:
           Blunt: 1.2
           Slash: 0.85
-          Piercing: 0.5
+          Piercing: 0.4
           Heat: 0.4
         flatReductions:
           Heat: 1


### PR DESCRIPTION
## About the PR
Energy shield is now slightly worse against lasers, but slightly more durable against bullets.
Exact numbers:
- Reflect chance (only reflects energy weapons) 95% -> 80%
- Shield passive pierce resist 15% -> 30%
- Shield active pierce resist 50% -> 60%

## Why / Balance
Energy shield, being an 8 TC purchase, makes you basicaly immune to any laser weapons. If the captain will try to kill you with their laser pistol, you can just turn on your shield and win by doing nothing. 80% chаnce is still very strong, but at least it doesn't make you invincible.
On the other hand, being an 8 TC purchase, eshield is hillariously bad against everything else. WT550 can destroy an active shield in mere 3 seconds, which is kinda bad for a shield, which disallows you to use anything except for pistols and/or esword.
This PR makes eshield more of an all-round item, while keeping heavy emphasis on it being mostly an anti-laser option.

## Technical details
YAML changes.

## Media
Nah.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Energy shields are now slightly more durable, but have less reflect chance.
