### PR TITLE
Make button frames constructable and destructible

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -517,6 +517,28 @@
     state: grey
   - type: Rotatable
   - type: Fixtures
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 80
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
+          damage: 40
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+          - !type:PlaySoundBehavior
+            sound:
+              collection: MetalBreak
+              params:
+                volume: -8
 
 - type: entity
   id: ButtonFrameGrey
@@ -527,6 +549,9 @@
     drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch_frame.rsi
     state: grey
+  - type: Construction
+    graph: ButtonFrameGraph
+    node: ButtonFrameGreyNode
 
 - type: entity
   id: ButtonFrameCaution
@@ -537,6 +562,9 @@
     drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch_frame.rsi
     state: caution
+  - type: Construction
+    graph: ButtonFrameGraph
+    node: ButtonFrameCautionNode
 
 - type: entity
   id: ButtonFrameCautionSecurity
@@ -547,6 +575,9 @@
     drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch_frame.rsi
     state: caution_security
+  - type: Construction
+    graph: ButtonFrameGraph
+    node: ButtonFrameCautionSecurityNode
 
 - type: entity
   id: ButtonFrameExit
@@ -557,6 +588,9 @@
     drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch_frame.rsi
     state: exit
+  - type: Construction
+    graph: ButtonFrameGraph
+    node: ButtonFrameExitNode
 
 - type: entity
   id: ButtonFrameJanitor
@@ -567,3 +601,7 @@
     drawdepth: SmallObjects
     sprite: Structures/Wallmounts/switch_frame.rsi
     state: janitor
+  - type: Construction
+    graph: ButtonFrameGraph
+    node: ButtonFrameJanitorNode
+

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/switching.yml
@@ -204,3 +204,95 @@
               prototype: CableApcStack1
               amount: 1
             - !type:DeleteEntity {}
+
+- type: constructionGraph
+  id: ButtonFrameGraph
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: ButtonFrameGreyNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameCautionNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameCautionSecurityNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameExitNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+        - to: ButtonFrameJanitorNode
+          steps:
+            - material: Steel
+              amount: 1
+              doAfter: 2.0
+    - node: ButtonFrameGreyNode
+      entity: ButtonFrameGrey
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+    - node: ButtonFrameCautionSecurityNode
+      entity: ButtonFrameCautionSecurity
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+    - node: ButtonFrameCautionNode
+      entity: ButtonFrameCaution
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+    - node: ButtonFrameExitNode
+      entity: ButtonFrameExit
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}
+    - node: ButtonFrameJanitorNode
+      entity: ButtonFrameJanitor
+      edges:
+        - to: start
+          steps:
+            - tool: Screwing
+              doAfter: 2.0
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 1
+            - !type:DeleteEntity {}

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -1747,3 +1747,84 @@
     state: closed
   conditions:
     - !type:TileNotBlocked
+
+# an entry for each of the switch frames from switch.yml
+- type: construction
+  name: Gray Button Frame
+  id: ButtonFrameGrey
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameGreyNode
+  category: construction-category-structures
+  description: A grey button frame
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  canRotate: true
+  icon:
+    sprite: Structures/Wallmounts/switch_frame.rsi
+    state: grey
+- type: construction
+  name: Caution Button Frame
+  id: CautionButtonFrame
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameCautionNode
+  category: construction-category-structures
+  description: A caution button frame
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  canRotate: true
+  icon:
+    sprite: Structures/Wallmounts/switch_frame.rsi
+    state: caution
+- type: construction
+  name: CautionSecurity Button Frame
+  id: CautionSecurityButtonFrame
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameCautionSecurityNode
+  category: construction-category-structures
+  description: A security caution button frame
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  canRotate: true
+  icon:
+    sprite: Structures/Wallmounts/switch_frame.rsi
+    state: caution_security
+- type: construction
+  name: Exit Button Frame
+  id: ExitButtonFrame
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameExitNode
+  category: construction-category-structures
+  description: An exit button frame
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  canRotate: true
+  icon:
+    sprite: Structures/Wallmounts/switch_frame.rsi
+    state: exit
+- type: construction
+  name: Janitor Button Frame
+  id: JanitorButtonFrame
+  graph: ButtonFrameGraph
+  startNode: start
+  targetNode: ButtonFrameJanitorNode
+  category: construction-category-structures
+  description: A janitor button frame
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+  canRotate: true
+  icon:
+    sprite: Structures/Wallmounts/switch_frame.rsi
+    state: janitor
+
+
+
+


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
* Make button frames constructable and deconstructable
* Make button frames desctuctible

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Some people on discord were complaining that button frames were invincible and that it was annoying

## Technical details
<!-- Summary of code changes for easier review. -->
* Add construction graph for button frames
* Add button frames to construction menu
* Make button frames desctructible


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
 - add: Button Frames can be constructed, deconstructed, and destroyed
