### PR TITLE
Make the plant anom more useful to service

### DIFF
--- a/Resources/Prototypes/Entities/Effects/mobspawn.yml
+++ b/Resources/Prototypes/Entities/Effects/mobspawn.yml
@@ -102,8 +102,33 @@
     - id: FoodOnionRed
     - id: FoodWatermelon
     - id: FoodCherry
+    - id: FoodBanana
     - id: MobTomatoKiller
     - id: MobLuminousEntity
     - id: MobLuminousObject
+    - id: FoodFlyAmanita #exotic seed stuffs
+      weight: 0.60
+    - id: LeavesCannabis
+      weight: 0.60
+    - id: Nettle
+      weight: 0.60
+    - id: FoodHolymelon #mutated plant stuffs
+      weight: 0.30
+    - id: FoodAmbrosiaVulgaris
+      weight: 0.30
+    - id: FoodKoibean
+      weight: 0.30
+    - id: FoodLily
+      weight: 0.30
+    - id: LeavesCannabisRainbow
+      weight: 0.30
+    - id: FoodMimana
+      weight: 0.30
+    - id: MeatwheatBushel
+      weight: 0.30
     - id: FoodGatfruit # 0.007% spawn chance. 1 / 141
       weight: 0.10
+    - id: FoodFakeCapfruit #hehe
+      weight: 0.01
+    - id: FoodRealCapfruit
+      weight: 0.01

--- a/Resources/Prototypes/Entities/Effects/mobspawn.yml
+++ b/Resources/Prototypes/Entities/Effects/mobspawn.yml
@@ -103,6 +103,10 @@
     - id: FoodWatermelon
     - id: FoodCherry
     - id: FoodBanana
+    - id: WheatBushel #maybe if you put so many things sci can't eat, they'll go to botany...
+    - id: FoodSoybeans
+    - id: FoodLingzhi
+    - id: Log
     - id: MobTomatoKiller
     - id: MobLuminousEntity
     - id: MobLuminousObject
@@ -112,6 +116,10 @@
       weight: 0.60
     - id: Nettle
       weight: 0.60
+    - id: LeavesTobacco
+      weight: 0.60
+    - id: FoodBungo
+      weight: 0.60
     - id: FoodHolymelon #mutated plant stuffs
       weight: 0.30
     - id: FoodAmbrosiaVulgaris
@@ -120,13 +128,23 @@
       weight: 0.30
     - id: FoodLily
       weight: 0.30
+    - id: Bluetomato
+      weight: 0.30
     - id: LeavesCannabisRainbow
       weight: 0.30
     - id: FoodMimana
       weight: 0.30
+    - id: SteelLog
+      weight: 0.30
     - id: MeatwheatBushel
       weight: 0.30
-    - id: FoodGatfruit # 0.007% spawn chance. 1 / 141
+    - id: FoodLaughinPeaPod
+      weight: 0.30
+    - id: FoodLemoon
+      weight: 0.30
+    - id: DeathNettle
+      weight: 0.10
+    - id: FoodGatfruit
       weight: 0.10
     - id: FoodFakeCapfruit #hehe
       weight: 0.01

--- a/Resources/Prototypes/Entities/Effects/mobspawn.yml
+++ b/Resources/Prototypes/Entities/Effects/mobspawn.yml
@@ -122,7 +122,7 @@
       weight: 0.60
     - id: FoodHolymelon #mutated plant stuffs
       weight: 0.30
-    - id: FoodAmbrosiaVulgaris
+    - id: FoodAmbrosiaDeus
       weight: 0.30
     - id: FoodKoibean
       weight: 0.30
@@ -144,7 +144,7 @@
       weight: 0.30
     - id: DeathNettle
       weight: 0.10
-    - id: FoodGatfruit
+    - id: FoodGatfruit #about 1 in 250 now
       weight: 0.10
     - id: FoodFakeCapfruit #hehe
       weight: 0.01

--- a/Resources/Prototypes/Entities/Effects/mobspawn.yml
+++ b/Resources/Prototypes/Entities/Effects/mobspawn.yml
@@ -128,7 +128,7 @@
       weight: 0.30
     - id: FoodLily
       weight: 0.30
-    - id: Bluetomato
+    - id: FoodBlueTomato
       weight: 0.30
     - id: LeavesCannabisRainbow
       weight: 0.30

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -121,8 +121,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           SpaceQuartz1:
-            min: 2
-            max: 4
+            min: 4
+            max: 8
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -152,8 +152,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           SteelOre1:
-            min: 2
-            max: 4
+            min: 4
+            max: 8
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -183,8 +183,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           UraniumOre1:
-            min: 1
-            max: 3
+            min: 2
+            max: 5
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: PointLight
@@ -216,8 +216,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           SilverOre1:
-            min: 1
-            max: 3
+            min: 2
+            max: 5
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -225,19 +225,9 @@
         maxRange: 4.5
       spawns:
       - MobFleshJared
-      - MobFleshJared
-      - MobFleshGolem
       - MobFleshGolem
       - MobFleshClamp
-      - MobFleshClamp
       - MobFleshLover
-      - MobFleshLover
-      - MobCow
-      - MobGorilla
-      - MobKobold
-      - MobMonkey
-      - MobCorgi
-      - MobPig
     - settings:
         spawnOnSuperCritical: true
         minAmount: 10

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -234,7 +234,7 @@
       - MobFleshLover
       - MobCow
       - MobGorilla
-      - MobBaseKobold
+      - MobKobold
       - MobMonkey
       - MobCorgi
       - MobPig

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -225,10 +225,19 @@
         maxRange: 4.5
       spawns:
       - MobFleshJared
+      - MobFleshJared
+      - MobFleshGolem
       - MobFleshGolem
       - MobFleshClamp
+      - MobFleshClamp
+      - MobFleshLover
       - MobFleshLover
       - MobCow
+      - MobGorilla
+      - MobBaseKobold
+      - MobMonkey
+      - MobCorgi
+      - MobPig
     - settings:
         spawnOnSuperCritical: true
         minAmount: 10

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -228,6 +228,7 @@
       - MobFleshGolem
       - MobFleshClamp
       - MobFleshLover
+      - MobCow
     - settings:
         spawnOnSuperCritical: true
         minAmount: 10

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
@@ -192,19 +192,9 @@
         maxRange: 4.5
       spawns:
       - MobFleshJared
-      - MobFleshJared
-      - MobFleshGolem
       - MobFleshGolem
       - MobFleshClamp
-      - MobFleshClamp
       - MobFleshLover
-      - MobFleshLover
-      - MobCow
-      - MobGorilla
-      - MobKobold
-      - MobMonkey
-      - MobCorgi
-      - MobPig
     - settings:
         spawnOnSuperCritical: true
         minAmount: 5

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
@@ -201,7 +201,7 @@
       - MobFleshLover
       - MobCow
       - MobGorilla
-      - MobBaseKobold
+      - MobKobold
       - MobMonkey
       - MobCorgi
       - MobPig
@@ -267,7 +267,7 @@
   - type: PointLight
     color: "#56c1e8"
   - type: TechAnomaly
-    linkRadius: 
+    linkRadius:
       min: 2
       max: 5
     linkCountPerPulse:

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
@@ -192,9 +192,19 @@
         maxRange: 4.5
       spawns:
       - MobFleshJared
+      - MobFleshJared
+      - MobFleshGolem
       - MobFleshGolem
       - MobFleshClamp
+      - MobFleshClamp
       - MobFleshLover
+      - MobFleshLover
+      - MobCow
+      - MobGorilla
+      - MobBaseKobold
+      - MobMonkey
+      - MobCorgi
+      - MobPig
     - settings:
         spawnOnSuperCritical: true
         minAmount: 5


### PR DESCRIPTION
## About the PR
Plant anomaly bulbs now have exotic plants (bungo, cannabis, tobacco, etc) at a 2/3 weight, and some mutated plants (lemoons, deus, steel caps, etc) at a 1/3 weight. Rock crabs from rock anoms also have about double the ores dropped on death.

## Why / Balance
Currently anomalies are a nuisance to every member of the station, all but the liquid anomaly, which can bring useful or interesting reagents for chemistry or the bar to use. This is because they have no upside, but making points for science. I recently had botanists help take care of a plant anomaly because they slightly benefited from the plants and were the most capable of destroying the kudzu with their scythes, and thought, maybe this could be a normal thing with worthwhile benefits, as some anomalies are nearly tailored to be handled by a department, but they don't get anything from it. 
An obvious way to make plant anomalies a nice gift for botany would be getting exotic plants that they can only get from cargo ordering, and mutated plants that are easy to get with mutagen, but most are never grown because mutagen is usually limited. The plants previous to these changes were things that botany have an extreme surplus of in their seed vendor. Rock anomalies also currently don't make enough ore for it to be considered a factor in whether to kill the anomaly or not, especially after the ore processor rates were nerfed, and as they produce a single ore type over their lives, might be able to supply a station's need for a single material the entire shift. 

## Technical details
added more items to yaml lists
despite testing it all in game, something might be terribly wrong as this is my second pr

## Media
![Screenshot (804)](https://github.com/user-attachments/assets/32a2381b-2dca-4c1c-a3ef-fe8e00cbbe34)


## Breaking Changes
none

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: The plant anomaly's bulbs now have a chance to drop exotic and mutated plants when harvested.