### PR TITLE
Fix research disk crash

### DIFF
--- a/Content.Server/Research/Disk/ResearchDiskSystem.cs
+++ b/Content.Server/Research/Disk/ResearchDiskSystem.cs
@@ -23,14 +23,22 @@ namespace Content.Server.Research.Disk
         private void OnAfterInteract(EntityUid uid, ResearchDiskComponent component, AfterInteractEvent args)
         {
             if (!args.CanReach)
+            {
+                args.Handled = true;
                 return;
+            }
 
             if (!TryComp<ResearchServerComponent>(args.Target, out var server))
+            {
+                args.Handled = true;
                 return;
+            }
+
 
             _research.ModifyServerPoints(args.Target.Value, component.Points, server);
             _popupSystem.PopupEntity(Loc.GetString("research-disk-inserted", ("points", component.Points)), args.Target.Value, args.User);
             EntityManager.QueueDeleteEntity(uid);
+            args.Handled = true;
         }
 
         private void OnMapInit(EntityUid uid, ResearchDiskComponent component, MapInitEvent args)

--- a/Content.Server/Research/Disk/ResearchDiskSystem.cs
+++ b/Content.Server/Research/Disk/ResearchDiskSystem.cs
@@ -23,16 +23,10 @@ namespace Content.Server.Research.Disk
         private void OnAfterInteract(EntityUid uid, ResearchDiskComponent component, AfterInteractEvent args)
         {
             if (!args.CanReach)
-            {
-                args.Handled = true;
                 return;
-            }
 
             if (!TryComp<ResearchServerComponent>(args.Target, out var server))
-            {
-                args.Handled = true;
                 return;
-            }
 
             _research.ModifyServerPoints(args.Target.Value, component.Points, server);
             _popupSystem.PopupEntity(Loc.GetString("research-disk-inserted", ("points", component.Points)), args.Target.Value, args.User);

--- a/Content.Server/Research/Disk/ResearchDiskSystem.cs
+++ b/Content.Server/Research/Disk/ResearchDiskSystem.cs
@@ -34,7 +34,6 @@ namespace Content.Server.Research.Disk
                 return;
             }
 
-
             _research.ModifyServerPoints(args.Target.Value, component.Points, server);
             _popupSystem.PopupEntity(Loc.GetString("research-disk-inserted", ("points", component.Points)), args.Target.Value, args.User);
             EntityManager.QueueDeleteEntity(uid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed a bug in which putting Research disks into R&D Server crashes the game.

## Why / Balance
Easier to test with R&D servers now. Fixes #33188

## Technical details
added args.Handled = true; to OnAfterInteract in ResearchDiskSystem.

## Media
![image](https://github.com/user-attachments/assets/e2d04e14-9bca-4a2f-8ba1-cc7efa17829a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
no

**Changelog**
no cl