### PR TITLE
pass Actor to cartridge messages

### DIFF
--- a/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
+++ b/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
@@ -428,6 +428,7 @@ public sealed class CartridgeLoaderSystem : SharedCartridgeLoaderSystem
     {
         var cartridgeEvent = args.MessageEvent;
         cartridgeEvent.LoaderUid = GetNetEntity(uid);
+        cartridgeEvent.Actor = args.Actor;
 
         RelayEvent(component, cartridgeEvent, true);
     }

--- a/Content.Shared/CartridgeLoader/CartridgeUiMessage.cs
+++ b/Content.Shared/CartridgeLoader/CartridgeUiMessage.cs
@@ -17,4 +17,6 @@ public sealed class CartridgeUiMessage : BoundUserInterfaceMessage
 public abstract class CartridgeMessageEvent : EntityEventArgs
 {
     public NetEntity LoaderUid;
+
+    public EntityUid Actor;
 }

--- a/Content.Shared/CartridgeLoader/CartridgeUiMessage.cs
+++ b/Content.Shared/CartridgeLoader/CartridgeUiMessage.cs
@@ -18,5 +18,6 @@ public abstract class CartridgeMessageEvent : EntityEventArgs
 {
     public NetEntity LoaderUid;
 
+    [NonSerialized]
     public EntityUid Actor;
 }


### PR DESCRIPTION
## About the PR
title

## Why / Balance
needed downstream, no reason not to pass it

## Technical details
EntityUid not NetEntity since its not sent over network, no idea why LoaderUid is a NetEntity since its assigned by server to a GetNetEntity result... (on top of not making sense to use what the client says)

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
.