### PR TITLE
Fixes StoredOffset not affecting StoredSprite

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
@@ -167,7 +167,7 @@ public sealed class ItemGridPiece : Control, IEntityControl
         if (itemComponent.StoredSprite is { } storageSprite)
         {
             var scale = 2 * UIScale;
-            var offset = (((Box2) boundingGrid).Size - Vector2.One) * size;
+            var offset = (((Box2) boundingGrid).Size - Vector2.One) * size + new Vector2(itemComponent.StoredOffset.X, itemComponent.StoredOffset.Y);
             var sprite = _entityManager.System<SpriteSystem>().Frame0(storageSprite);
 
             var spriteBox = new Box2Rotated(new Box2(0f, sprite.Height * scale, sprite.Width * scale, 0f), -iconRotation, Vector2.Zero);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes it so specifying a StoredOffset in ItemComponent actually affects a specified StoredSprite

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ive been making more storage sprites for grid inv, and I noticed when I tried to make offset adjustments that if you are using a unique sprite for a grid inv icon that it is unaffected by offset.

## Technical details
<!-- Summary of code changes for easier review. -->
To be clear, the StoredOffset specifically works perfectly fine when a unique storage sprite is not specified. This is because the value calculated using the StoredOffset value is only used in the code block of an If/Else statement for when a storage sprite is not specified. I didnt think too hard about this one and just stuck the values in but its a small fix so im sure its fine.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No CL needed.
