### PR TITLE
Replace direct uses of GameTicker dictionary with `TryGetValue`

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -184,7 +184,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             return;
 
         var players = _playerManager.Sessions
-            .Where(x => GameTicker.PlayerGameStatuses[x.UserId] == PlayerGameStatus.JoinedGame)
+            .Where(x => GameTicker.PlayerGameStatuses.TryGetValue(x.UserId, out var status) && status == PlayerGameStatus.JoinedGame)
             .ToList();
 
         ChooseAntags((uid, component), players, midround: true);

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -184,6 +184,6 @@ namespace Content.Server.GameTicking
             => UserHasJoinedGame(session.UserId);
 
         public bool UserHasJoinedGame(NetUserId userId)
-            => PlayerGameStatuses[userId] == PlayerGameStatus.JoinedGame;
+            => PlayerGameStatuses.TryGetValue(userId, out var status) && status == PlayerGameStatus.JoinedGame;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

- The following is copied from my messages in #contributors chat (https://discord.com/channels/310555209753690112/770682801607278632/1302357518504165377)

Apparently if a player's `SessionStatus` stays on `Connected` for whatever reason, station events and antag selection might break in some way. The issue is some functions try to get a value from `PlayerGameStatuses` dictionary without checking if the player exists or not. For example:
```cs
var players = _playerManager.Sessions
    .Where(x => GameTicker.PlayerGameStatuses[x.UserId] == PlayerGameStatus.JoinedGame)
    .ToList();
```
The thing is that `_playerManager.Sessions` contains any sessions (including the `Connected` ones) while `PlayerGameStatuses` does not, meaning that if there's a player stuck (intentionally or not) on `Connected`, that specific line would throw an error `The key 'blahblah' was not present in the dictionary`.

And this **possibly** can lead to station events spam.
Not sure exactly this is the issue of events spam, but I've been reported about this and when looking at the logs the only errors I could find is `The key 'blahblahblah' was not present in the dictionary` and the stacktrace leading to `UserHasJoinedGame(NetUserId userId)` which is basically this:
```cs
public bool UserHasJoinedGame(NetUserId userId)
    => PlayerGameStatuses[userId] == PlayerGameStatus.JoinedGame;
```

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced all<sup>\*</sup> `PlayerGameStatuses[user] == Something` with `PlayerGameStatuses.TryGetValue(user, out var status) && status == Something`

<sup>\*</sup> — except its usages in integration tests because I believe there is no chance to get the error in the tests (lmk if I'm wrong thinking that way)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
N/A