### PR TITLE
Dirty fix for RT-5289

### DIFF
--- a/runclient-Tools.bat
+++ b/runclient-Tools.bat
@@ -1,2 +1,4 @@
 @echo off
+dotnet build -c Release RobustToolbox\Robust.Client.Injectors
 dotnet run --project Content.Client --configuration Tools
+pause

--- a/runclient-Tools.sh
+++ b/runclient-Tools.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+dotnet build -c Release RobustToolbox/Robust.Client.Injectors
 dotnet run --project Content.Client --configuration Tools
 read -p "Press enter to continue"

--- a/runclient.bat
+++ b/runclient.bat
@@ -1,2 +1,3 @@
 @echo off
 dotnet run --project Content.Client
+pause


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds ``dotnet build -c Release RobustToolbox\Robust.Client.Injectors`` in all the client batch files to ensure we have RELEASE Robust.Client.Injectors

This frequently happens on people who just cloned the repo and never built release.

https://github.com/space-wizards/RobustToolbox/pull/5289 should fix this but it has been stuck for a while seemingly nowhere and I want a temporary fix for now

Also adds ``pause`` to let you see any errors.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->