### PR TITLE
Make it possible to use plain Ambuzol with a hypo

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -610,7 +610,7 @@
         - !type:CureZombieInfection
           conditions:
             - !type:ReagentThreshold
-              min: 10
+              min: 9
 
 - type: reagent
   id: AmbuzolPlus
@@ -1160,7 +1160,7 @@
         conditions:
         - !type:ReagentThreshold
           min: 12
-          
+
 - type: reagent
   id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
   name: reagent-name-opporozidone


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed Ambuzol (plain, not plus) threshold to be 9 units, so that a CMO with a hypo can actually cure people.

## Why / Balance
Using a hypo is a silent failure for Ambuzol. Also, if you don't have a syringe around, you'll have to waste additional 5u per person (most CMOs probably have a syringe around but still). For most doctors nothing will change unless they decide to micromanage with a pipette, then sure they waste 1u less per person. Also chem would gain 10% free with this... if they even could manage to clear their buffer. Which probably isn't gonna happen, let's be real.

Technically this allows for much easier mass innoculation without much/any loss. Which might be actually a concern? Not sure. But feels odd to have a 10u threshold that can't be achieved with a hypo. And rushing in to cure people in middle of a battle will likely backfire as zombies have rather strong attacks.

Alternative would be to use an increasing status effect that requires ~10u of the stuff and only kick in after enough got processed.

## Technical details
YAML only, threshold change. Removed extra whitespace.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Ambuzol now requires 9 units to cure infected
