### PR TITLE
fix solution contents duplication on spill behavior

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/SpillBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpillBehavior.cs
@@ -1,42 +1,60 @@
-using Content.Shared.Chemistry.EntitySystems;
 using Content.Server.Fluids.EntitySystems;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Fluids.Components;
 using JetBrains.Annotations;
 
-namespace Content.Server.Destructible.Thresholds.Behaviors
+namespace Content.Server.Destructible.Thresholds.Behaviors;
+
+[UsedImplicitly]
+[DataDefinition]
+public sealed partial class SpillBehavior : IThresholdBehavior
 {
-    [UsedImplicitly]
-    [DataDefinition]
-    public sealed partial class SpillBehavior : IThresholdBehavior
+    /// <summary>
+    /// Optional fallback solution name if SpillableComponent is not present.
+    /// </summary>
+    [DataField]
+    public string? Solution;
+
+    /// <summary>
+    /// When triggered, spills the entity's solution onto the ground.
+    /// Will first try to use the solution from a SpillableComponent if present,
+    /// otherwise falls back to the solution specified in the behavior's data fields.
+    /// The solution is properly drained/split before spilling to prevent double-spilling with other behaviors.
+    /// </summary>
+    /// <param name="owner">Entity whose solution will be spilled</param>
+    /// <param name="system">System calling this behavior</param>
+    /// <param name="cause">Optional entity that caused this behavior to trigger</param>
+    public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
     {
-        [DataField]
-        public string? Solution;
+        var solutionContainerSystem = system.EntityManager.System<SharedSolutionContainerSystem>();
+        var spillableSystem = system.EntityManager.System<PuddleSystem>();
+        var coordinates = system.EntityManager.GetComponent<TransformComponent>(owner).Coordinates;
 
-        /// <summary>
-        /// If there is a SpillableComponent on EntityUidowner use it to create a puddle/smear.
-        /// Or whatever solution is specified in the behavior itself.
-        /// If none are available do nothing.
-        /// </summary>
-        /// <param name="owner">Entity on which behavior is executed</param>
-        /// <param name="system">system calling the behavior</param>
-        /// <param name="cause"></param>
-        public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
+        Solution targetSolution;
+
+        // First try to get solution from SpillableComponent
+        if (system.EntityManager.TryGetComponent(owner, out SpillableComponent? spillableComponent) &&
+            solutionContainerSystem.TryGetSolution(owner, spillableComponent.SolutionName, out var solution, out var compSolution))
         {
-            var solutionContainerSystem = system.EntityManager.System<SharedSolutionContainerSystem>();
-            var spillableSystem = system.EntityManager.System<PuddleSystem>();
-
-            var coordinates = system.EntityManager.GetComponent<TransformComponent>(owner).Coordinates;
-
-            if (system.EntityManager.TryGetComponent(owner, out SpillableComponent? spillableComponent) &&
-                solutionContainerSystem.TryGetSolution(owner, spillableComponent.SolutionName, out _, out var compSolution))
-            {
-                spillableSystem.TrySplashSpillAt(owner, coordinates, compSolution, out _, false, user: cause);
-            }
-            else if (Solution != null &&
-                     solutionContainerSystem.TryGetSolution(owner, Solution, out _, out var behaviorSolution))
-            {
-                spillableSystem.TrySplashSpillAt(owner, coordinates, behaviorSolution, out _, user: cause);
-            }
+            // If entity is drainable, drain the solution. Otherwise just split it.
+            // Both methods ensure the solution is properly removed.
+            targetSolution = system.EntityManager.HasComponent<DrainableSolutionComponent>(owner)
+                ? solutionContainerSystem.Drain((owner, system.EntityManager.GetComponent<DrainableSolutionComponent>(owner)), solution.Value, compSolution.Volume)
+                : compSolution.SplitSolution(compSolution.Volume);
         }
+        // Fallback to solution specified in behavior data
+        else if (Solution != null &&
+                 solutionContainerSystem.TryGetSolution(owner, Solution, out var solutionEnt, out var behaviorSolution))
+        {
+            targetSolution = system.EntityManager.HasComponent<DrainableSolutionComponent>(owner)
+                ? solutionContainerSystem.Drain((owner, system.EntityManager.GetComponent<DrainableSolutionComponent>(owner)), solutionEnt.Value, behaviorSolution.Volume)
+                : behaviorSolution.SplitSolution(behaviorSolution.Volume);
+        }
+        else
+            return;
+
+        // Spill the solution that was drained/split
+        spillableSystem.TrySplashSpillAt(owner, coordinates, targetSolution, out _, false, cause);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
fixes a bug allowing you to duplicate the solution contents by throwing a beaker on the ground

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
vestine dupe bad

## Technical details
<!-- Summary of code changes for easier review. -->
apparently the SpillBehavior doesn't properly remove the solution so it gets spilled again by SpillOnLand which causes it to duplicate

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
before the fix:

https://github.com/user-attachments/assets/38e49fad-2002-4cb5-b7dd-8ddcc1e9957b

after the fix:

https://github.com/user-attachments/assets/349215ff-55c6-46de-8981-a919e5ca9a25


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed beaker solutions duplicating whenever it's thrown.
