### PR TITLE
Correct mobster suffix

### DIFF
--- a/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MobsterAccentSystem.cs
@@ -14,7 +14,7 @@ public sealed class MobsterAccentSystem : EntitySystem
     private static readonly Regex RegexUpperAr = new(@"(?<=\w)A[Rr](?=\w)");
     private static readonly Regex RegexFirstWord = new(@"^(\S+)");
     private static readonly Regex RegexLastWord = new(@"(\S+)$");
-
+    private static readonly Regex RegexLastPunctuation = new(@"([.!?]+$)(?!.*[.!?])|(?<![.!?])$");
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
 
@@ -84,7 +84,7 @@ public sealed class MobsterAccentSystem : EntitySystem
             }
             if (lastWordAllCaps)
                 suffix = suffix.ToUpper();
-            msg += suffix;
+            msg = RegexLastPunctuation.Replace(msg, suffix);
         }
 
         return msg;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Corrects the suffix appending of the mobster accent to correctly attach suffixes to sentences that already have punctuation.

## Why / Balance
Previously, the suffixes were just appended to the end of the string with no regard for how the sentence ended. This change prevents anyone with a mobster accent from appending suffixes to sentences ending with punctuation already, ie appending
`, see?` to `test!` as `test!, see?`

## Technical details
Adds a new Regex string to search for one of two things
1. The last single or block punctuation, i.e. ? or ?!
2. The end of the sentence

It is designed in such a way to use the equivalent of an `XOR` expression, so it looks for one or the other, not both.
It then replaces that punctuation or end with the suffix

## Media
before change
![image](https://github.com/user-attachments/assets/fbb0d557-bfe1-400a-94c5-03d05184665e)

after change
![image](https://github.com/user-attachments/assets/bd01c628-4569-4703-8bf6-b09a27d033f8)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->