### PR TITLE
Fix ninja stunlocking-shorter stun, shorter cooldown, higher energy c…

### DIFF
--- a/Content.Shared/Ninja/Components/StunProviderComponent.cs
+++ b/Content.Shared/Ninja/Components/StunProviderComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class StunProviderComponent : Component
     /// Joules required in the battery to stun someone.  Equals 5 uses on a small battery.
     /// </summary>
     [DataField]
-    public float StunCharge = 72f;
+    public float StunCharge = 60f;
 
     /// <summary>
     /// Damage dealt when stunning someone

--- a/Content.Shared/Ninja/Components/StunProviderComponent.cs
+++ b/Content.Shared/Ninja/Components/StunProviderComponent.cs
@@ -49,13 +49,13 @@ public sealed partial class StunProviderComponent : Component
     /// Time that someone is stunned for, stacks if done multiple times.
     /// </summary>
     [DataField]
-    public TimeSpan StunTime = TimeSpan.FromSeconds(1);
+    public TimeSpan StunTime = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// How long stunning is disabled after stunning something.
     /// </summary>
     [DataField]
-    public TimeSpan Cooldown = TimeSpan.FromSeconds(1);
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// ID of the cooldown use delay.

--- a/Content.Shared/Ninja/Components/StunProviderComponent.cs
+++ b/Content.Shared/Ninja/Components/StunProviderComponent.cs
@@ -28,10 +28,10 @@ public sealed partial class StunProviderComponent : Component
     public SoundSpecifier Sound = new SoundCollectionSpecifier("sparks");
 
     /// <summary>
-    /// Joules required in the battery to stun someone. Defaults to 10 uses on a small battery.
+    /// Joules required in the battery to stun someone.  Equals 5 uses on a small battery.
     /// </summary>
     [DataField]
-    public float StunCharge = 36f;
+    public float StunCharge = 72f;
 
     /// <summary>
     /// Damage dealt when stunning someone
@@ -49,13 +49,13 @@ public sealed partial class StunProviderComponent : Component
     /// Time that someone is stunned for, stacks if done multiple times.
     /// </summary>
     [DataField]
-    public TimeSpan StunTime = TimeSpan.FromSeconds(5);
+    public TimeSpan StunTime = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// How long stunning is disabled after stunning something.
     /// </summary>
     [DataField]
-    public TimeSpan Cooldown = TimeSpan.FromSeconds(2);
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// ID of the cooldown use delay.


### PR DESCRIPTION
TL;DR Ninja can still stunlock, but for a shorter amount of time and higher energy cost.  Each stun applied is 2 seconds, with a 2 second cool down.  The ninja may now stun only 5 times on one small-capacity powercell, for a total of a maximum 10 second stunlock if they use all the energy in their cell.

## About the PR
There is a conflict in the design of ninja stunlocking with their gloves.

Content.Server/Ninja/Systems/StunProviderSystem.cs Has a comment:

```
// short cooldown to prevent instant stunlocking
        _useDelay.SetLength((uid, useDelay), comp.Cooldown, id: comp.DelayId);
        _useDelay.TryResetDelay((uid, useDelay), id: comp.DelayId);

```
However, 
Content.Shared/Ninja/Components/StunProviderComponent.cs has the following code:

```
/// <summary>
    /// Time that someone is stunned for, stacks if done multiple times.
    /// </summary>
    [DataField]
    public TimeSpan StunTime = TimeSpan.FromSeconds(5);

    /// <summary>
    /// How long stunning is disabled after stunning something.
    /// </summary>
    [DataField]
    public TimeSpan Cooldown = TimeSpan.FromSeconds(2);
```

## Why / Balance
Currently, a ninja may apply a 5 second stun every 2 seconds, and may do this 10 times on a full small capacity energy cell.  This requires too little skill and energy to be considered balanced, considering the ninja's entire toolkit.  

The PR adjusts the stun length to 2 seconds with a 2 second cooldown, and doubles the energy cost of stunning.  Stunlocking is now still possible, but the ninja can only stunlock for a maximum of 10 seconds (as opposed to 50!!!) and must consume all energy in a small capacity powercell to do so.  This will incentivize ninjas to find other ways of dealing with threats such as crafting cable cuffs or upgrade their suit cell.

## Technical details
Energy requirement for stun doubled from 36 to 72
Stun length decreased from 5 seconds to 2 second
Stun cooldown unchanged

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
None

**Changelog**
Stun length increased from 1 second to 2 seconds to allow for cuffing
Stun cooldown restored to original 2 seconds from 1 second.

:cl:
- tweak: Made ninja stunlocking shorter and require more suit energy.

