### PR TITLE
Fix vape use without check if doafter cancelled

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/SmokingSystem.Vape.cs
+++ b/Content.Server/Nutrition/EntitySystems/SmokingSystem.Vape.cs
@@ -122,8 +122,7 @@ namespace Content.Server.Nutrition.EntitySystems
 
         private void OnVapeDoAfter(Entity<VapeComponent> entity, ref VapeDoAfterEvent args)
         {
-            if (args.Handled
-            || args.Args.Target == null)
+            if (args.Cancelled || args.Handled || args.Args.Target == null)
                 return;
 
             var environment = _atmos.GetContainingMixture(args.Args.Target.Value, true, true);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed a small bug that allowed players to use vape without waiting for the doafter action delay  just clicking on a character second time.


## Technical details
Just check if doafter cancelled

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/b563a7bc-1f84-4a49-9e40-417186117799


https://github.com/user-attachments/assets/46f69e54-a827-4744-8282-c4ee57880098

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Fixed a bug that allowed characters to use vape without waiting doafter timer.
-->
