### PR TITLE
HOTFIX: Fix Security Shell Gun being uncraftable.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -768,6 +768,7 @@
       - TargetHuman
       - TargetSyndicate
       - WeaponDisablerPractice
+      - WeaponFlaregunSecurity
       - WeaponLaserCarbinePractice
       - Zipties
     dynamicRecipes:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -768,7 +768,7 @@
       - TargetHuman
       - TargetSyndicate
       - WeaponDisablerPractice
-      - WeaponFlaregunSecurity
+      - WeaponFlareGunSecurity
       - WeaponLaserCarbinePractice
       - Zipties
     dynamicRecipes:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Add the sec shell gun to the lathe list since I forgor.

## Why / Balance
Because I forgor and it should already be there.

## Technical details
No

## Media
No

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
**Changelog**
:cl: BramvanZijp
- fix: The Security Shell Gun can now actually be crafted.