### PR TITLE
Note expiry time now use times instead of timestamps!

### DIFF
--- a/Content.Client/Administration/UI/Notes/NoteEdit.xaml
+++ b/Content.Client/Administration/UI/Notes/NoteEdit.xaml
@@ -5,7 +5,7 @@
     <BoxContainer Orientation="Vertical" Margin="4">
         <TextEdit Name="NoteTextEdit" HorizontalExpand="True" VerticalExpand="True" />
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
-            <Label Name="ExpiryLabel" Text="Expires in: " Visible="False" />
+            <Label Name="ExpiryLabel" Text="{Loc admin-note-editor-expiry-label}" Visible="False" />
             <HistoryLineEdit Name="ExpiryLineEdit" PlaceHolder="{Loc admin-note-editor-expiry-placeholder}"
                              Visible="False" HorizontalExpand="True" />
             <OptionButton Name="ExpiryLengthDropdown" Visible="False" />

--- a/Content.Client/Administration/UI/Notes/NoteEdit.xaml
+++ b/Content.Client/Administration/UI/Notes/NoteEdit.xaml
@@ -5,9 +5,10 @@
     <BoxContainer Orientation="Vertical" Margin="4">
         <TextEdit Name="NoteTextEdit" HorizontalExpand="True" VerticalExpand="True" />
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
-            <Label Name="ExpiryLabel" Text="{Loc admin-note-editor-expiry-label}" Visible="False" />
+            <Label Name="ExpiryLabel" Text="Expires in: " Visible="False" />
             <HistoryLineEdit Name="ExpiryLineEdit" PlaceHolder="{Loc admin-note-editor-expiry-placeholder}"
                              Visible="False" HorizontalExpand="True" />
+            <OptionButton Name="ExpiryLengthDropdown" Visible="False" />
         </BoxContainer>
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
             <OptionButton Name="TypeOption" HorizontalAlignment="Center" />

--- a/Content.Client/Administration/UI/Notes/NoteEdit.xaml.cs
+++ b/Content.Client/Administration/UI/Notes/NoteEdit.xaml.cs
@@ -52,7 +52,7 @@ public sealed partial class NoteEdit : FancyWindow
         ExpiryLengthDropdown.AddItem(Loc.GetString("admin-note-button-centuries"), (int) Multipliers.Centuries);
         ExpiryLengthDropdown.OnItemSelected += OnLengthChanged;
 
-        ExpiryLengthDropdown.SelectId((int) Multipliers.Days);
+        ExpiryLengthDropdown.SelectId((int) Multipliers.Weeks);
 
         ExpiryLineEdit.OnTextChanged += OnTextChanged;
 
@@ -199,7 +199,7 @@ public sealed partial class NoteEdit : FancyWindow
         ExpiryLineEdit.Visible = !PermanentCheckBox.Pressed;
         ExpiryLengthDropdown.Visible = !PermanentCheckBox.Pressed;
 
-        ExpiryLineEdit.Text = !PermanentCheckBox.Pressed ? 7.ToString() : string.Empty;
+        ExpiryLineEdit.Text = !PermanentCheckBox.Pressed ? 1.ToString() : string.Empty;
     }
 
     private void OnSecretPressed(BaseButton.ButtonEventArgs _)

--- a/Resources/Locale/en-US/administration/ui/admin-notes.ftl
+++ b/Resources/Locale/en-US/administration/ui/admin-notes.ftl
@@ -57,10 +57,10 @@ admin-note-editor-severity-medium = Medium
 admin-note-editor-severity-high = High
 admin-note-editor-expiry-checkbox = Permanent?
 admin-note-editor-expiry-checkbox-tooltip = Check this to make it expire
-admin-note-editor-expiry-label = Expires on:
+admin-note-editor-expiry-label = Expires In:
 admin-note-editor-expiry-label-params = Expires on: {$date} (in {$expiresIn})
 admin-note-editor-expiry-label-expired = Expired
-admin-note-editor-expiry-placeholder = Enter expiration date (yyyy-MM-dd HH:mm:ss)
+admin-note-editor-expiry-placeholder = Enter expiration time (integer).
 admin-note-editor-submit = Submit
 admin-note-editor-submit-confirm = Are you sure?
 

--- a/Resources/Locale/en-US/administration/ui/admin-notes.ftl
+++ b/Resources/Locale/en-US/administration/ui/admin-notes.ftl
@@ -57,12 +57,22 @@ admin-note-editor-severity-medium = Medium
 admin-note-editor-severity-high = High
 admin-note-editor-expiry-checkbox = Permanent?
 admin-note-editor-expiry-checkbox-tooltip = Check this to make it expire
-admin-note-editor-expiry-label = Expires In:
+admin-note-editor-expiry-label = Expires in:
 admin-note-editor-expiry-label-params = Expires on: {$date} (in {$expiresIn})
 admin-note-editor-expiry-label-expired = Expired
 admin-note-editor-expiry-placeholder = Enter expiration time (integer).
 admin-note-editor-submit = Submit
 admin-note-editor-submit-confirm = Are you sure?
+
+# Time
+admin-note-button-minutes = Minutes
+admin-note-button-hours = Hours
+admin-note-button-days = Days
+admin-note-button-weeks = Weeks
+admin-note-button-months = Months
+admin-note-button-years = Years
+admin-note-button-centuries = Centuries
+
 
 # Verb
 admin-notes-verb-text = Open Admin Notes


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When a entering an expiry time, the notes now use duration instead of dates. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves: #18534

## Technical details
<!-- Summary of code changes for easier review. -->
The ID's for the boxes are also their values which is odd but I think its OK? If someone with more experience could chime it that would be great!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/1bfb9a8b-1d31-4de1-8b43-8ac9bec99a98)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Beck Thompson
ADMIN:
- tweak: Notes now use duration instead of timestamps for note expiry times.