### PR TITLE
Fixed issue where entities in containers would be deleted when the construction process advances to another node

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -371,33 +371,10 @@ namespace Content.Server.Construction
             {
                 // Ensure the new entity has a container manager. Also for resolve goodness.
                 var newContainerManager = EntityManager.EnsureComponent<ContainerManagerComponent>(newUid);
-				var oldContainerManager = EntityManager.EnsureComponent<ContainerManagerComponent>(uid);
+                var oldContainerManager = EntityManager.EnsureComponent<ContainerManagerComponent>(uid);
 
-				// Transfer all containers owned by the previous entity to the new one.
-				foreach (string container in new List<string>(oldContainerManager.Containers.Keys))
-				{					
-					if (!_container.TryGetContainer(uid, container, out var ourContainer, containerManager))
-                        continue;
-
-					if (!_container.TryGetContainer(newUid, container, out var otherContainer, newContainerManager))
-                    {
-						// NOTE: Only Container is supported by Construction!
-                        // todo: one day, the ensured container should be the same type as ourContainer
-						if (oldContainerManager.Containers[container].GetType() != typeof(Container))
-							continue;
-                        otherContainer = _container.EnsureContainer<Container>(newUid, container, newContainerManager);
-                    }
-
-					for (var i = ourContainer.ContainedEntities.Count - 1; i >= 0; i--)
-                    {
-                        var entity = ourContainer.ContainedEntities[i];
-                        _container.Remove(entity, ourContainer, reparent: false, force: true);
-                        _container.Insert(entity, otherContainer);
-                    }
-				}
-
-                // Transfer all construction-owned containers from the old entity to the new one.
-                foreach (var container in construction.Containers)
+                // Transfer all containers owned by the previous entity to the new one.
+                foreach (string container in new List<string>(oldContainerManager.Containers.Keys))
                 {
                     if (!_container.TryGetContainer(uid, container, out var ourContainer, containerManager))
                         continue;
@@ -406,6 +383,8 @@ namespace Content.Server.Construction
                     {
                         // NOTE: Only Container is supported by Construction!
                         // todo: one day, the ensured container should be the same type as ourContainer
+                        if (oldContainerManager.Containers[container].GetType() != typeof(Container))
+                            continue;
                         otherContainer = _container.EnsureContainer<Container>(newUid, container, newContainerManager);
                     }
 

--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -371,6 +371,26 @@ namespace Content.Server.Construction
             {
                 // Ensure the new entity has a container manager. Also for resolve goodness.
                 var newContainerManager = EntityManager.EnsureComponent<ContainerManagerComponent>(newUid);
+				var oldContainerManager = EntityManager.EnsureComponent<ContainerManagerComponent>(uid);
+
+				// Transfer all containers owned by the previous entity to the new one.
+				foreach (string container in new List<string>(oldContainerManager.Containers.Keys))
+				{					
+					if (!_container.TryGetContainer(uid, container, out var ourContainer, containerManager))
+                        continue;
+
+					if (!_container.TryGetContainer(newUid, container, out var otherContainer, newContainerManager))
+                    {
+                        otherContainer = _container.EnsureContainer<Container>(newUid, container, newContainerManager);
+                    }
+
+					for (var i = ourContainer.ContainedEntities.Count - 1; i >= 0; i--)
+                    {
+                        var entity = ourContainer.ContainedEntities[i];
+                        _container.Remove(entity, ourContainer, reparent: false, force: true);
+                        _container.Insert(entity, otherContainer);
+                    }
+				}
 
                 // Transfer all construction-owned containers from the old entity to the new one.
                 foreach (var container in construction.Containers)

--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -381,6 +381,10 @@ namespace Content.Server.Construction
 
 					if (!_container.TryGetContainer(newUid, container, out var otherContainer, newContainerManager))
                     {
+						// NOTE: Only Container is supported by Construction!
+                        // todo: one day, the ensured container should be the same type as ourContainer
+						if (oldContainerManager.Containers[container].GetType() != typeof(Container))
+							continue;
                         otherContainer = _container.EnsureContainer<Container>(newUid, container, newContainerManager);
                     }
 

--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -374,7 +374,7 @@ namespace Content.Server.Construction
                 var oldContainerManager = EntityManager.EnsureComponent<ContainerManagerComponent>(uid);
 
                 // Transfer all containers owned by the previous entity to the new one.
-                foreach (string container in new List<string>(oldContainerManager.Containers.Keys))
+                foreach (string container in oldContainerManager.Containers.Keys)
                 {
                     if (!_container.TryGetContainer(uid, container, out var ourContainer, containerManager))
                         continue;

--- a/Content.Shared/Containers/ContainerFillComponent.cs
+++ b/Content.Shared/Containers/ContainerFillComponent.cs
@@ -30,6 +30,13 @@ public sealed partial class ContainerFillComponent : Component
     /// </summary>
     [DataField("ignoreConstructionSpawn")]
     public bool IgnoreConstructionSpawn = true;
+
+    /// <summary>
+    ///     If true, entities whose containers already contain contents cannot have more contents added by the systems
+    ///		utilizing this component.
+    /// </summary>
+    [DataField("fillEmptyContainersOnly")]
+    public bool FillEmptyContainersOnly = true;
 }
 
 // all of this exists just to validate prototype ids.

--- a/Content.Shared/Containers/ContainerFillSystem.cs
+++ b/Content.Shared/Containers/ContainerFillSystem.cs
@@ -34,6 +34,9 @@ public sealed class ContainerFillSystem : EntitySystem
                 continue;
             }
 
+            else if (component.FillEmptyContainersOnly && container.Count > 0)
+                continue;
+
             foreach (var proto in prototypes)
             {
                 var ent = Spawn(proto, coords);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The `Content.Server/Construction/ConstructionSystem.Graph.cs` file was changed to allow entities inside containers to persist during construction as the entity is changed from node to node.

## Why / Balance
The development docs (specifically https://docs.spacestation14.com/en/space-station-14/core-tech/construction.html#containers) state that "When the entity changes due to reaching a node with a different entity prototype, all those containers *will be transferred to the new entity*. " I discovered this bug when creating a new entity that involved a multi-node/multi-entity construction process, and also necessitated that the specific entities stored within the construct are available to be edited and retrieved in order to function. I found that when the construction involves more than one step, the entities stored within the containers are deleted/not carried over to the next entity.

This also fixes issue #32590

Before: 
![image](https://github.com/user-attachments/assets/407019a1-d286-4955-af2e-54d1eb73458f)

After:
![image](https://github.com/user-attachments/assets/8d0a992a-bd04-4a9d-a90c-84e5a0e70f90)


## Technical details
Within the previously mentioned file, the `ChangeEntity` method was altered. This alteration is within the "Container transferring" section of the method. The alteration iterates over all containers in the previous construction entity and ensures that they are transferred along to the next entity.

## Media
N/A, unless requested

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
N/A
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
