### PR TITLE
silent footsteps for ninja

### DIFF
--- a/Content.Client/Tips/TippyUIController.cs
+++ b/Content.Client/Tips/TippyUIController.cs
@@ -104,7 +104,7 @@ public sealed class TippyUIController : UIController
                 ? -WaddleRotation
                 : WaddleRotation;
 
-            if (EntityManager.TryGetComponent(_entity, out FootstepModifierComponent? step))
+            if (EntityManager.TryGetComponent(_entity, out FootstepModifierComponent? step) && step.FootstepSoundCollection != null)
             {
                 var audioParams = step.FootstepSoundCollection.Params
                     .AddVolume(-7f)

--- a/Content.Shared/Movement/Components/FootstepModifierComponent.cs
+++ b/Content.Shared/Movement/Components/FootstepModifierComponent.cs
@@ -9,6 +9,6 @@ namespace Content.Shared.Movement.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class FootstepModifierComponent : Component
 {
-    [DataField(required: true), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public SoundSpecifier? FootstepSoundCollection;
 }

--- a/Content.Shared/Movement/Components/FootstepModifierComponent.cs
+++ b/Content.Shared/Movement/Components/FootstepModifierComponent.cs
@@ -10,5 +10,5 @@ namespace Content.Shared.Movement.Components;
 public sealed partial class FootstepModifierComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]
-    public SoundSpecifier FootstepSoundCollection = default!;
+    public SoundSpecifier? FootstepSoundCollection;
 }

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -253,7 +253,7 @@ public abstract partial class SharedMoverController : VirtualController
             }
 
             if (!weightless && MobMoverQuery.TryGetComponent(uid, out var mobMover) &&
-                TryGetSound(weightless, uid, mover, mobMover, xform, out var sound, tileDef: tileDef))
+                TryGetSound(weightless, uid, mover, mobMover, xform, out var sound, tileDef: tileDef) && sound is not null)
             {
                 var soundModifier = mover.Sprinting ? 3.5f : 1.5f;
 
@@ -396,7 +396,7 @@ public abstract partial class SharedMoverController : VirtualController
         InputMoverComponent mover,
         MobMoverComponent mobMover,
         TransformComponent xform,
-        [NotNullWhen(true)] out SoundSpecifier? sound,
+        out SoundSpecifier? sound,
         ContentTileDefinition? tileDef = null)
     {
         sound = null;
@@ -456,7 +456,7 @@ public abstract partial class SharedMoverController : VirtualController
         EntityUid uid,
         TransformComponent xform,
         bool haveShoes,
-        [NotNullWhen(true)] out SoundSpecifier? sound,
+        out SoundSpecifier? sound,
         ContentTileDefinition? tileDef = null)
     {
         sound = null;

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -253,7 +253,7 @@ public abstract partial class SharedMoverController : VirtualController
             }
 
             if (!weightless && MobMoverQuery.TryGetComponent(uid, out var mobMover) &&
-                TryGetSound(weightless, uid, mover, mobMover, xform, out var sound, tileDef: tileDef) && sound is not null)
+                TryGetSound(weightless, uid, mover, mobMover, xform, out var sound, tileDef: tileDef))
             {
                 var soundModifier = mover.Sprinting ? 3.5f : 1.5f;
 
@@ -396,7 +396,7 @@ public abstract partial class SharedMoverController : VirtualController
         InputMoverComponent mover,
         MobMoverComponent mobMover,
         TransformComponent xform,
-        out SoundSpecifier? sound,
+        [NotNullWhen(true)] out SoundSpecifier? sound,
         ContentTileDefinition? tileDef = null)
     {
         sound = null;
@@ -439,14 +439,14 @@ public abstract partial class SharedMoverController : VirtualController
         if (FootstepModifierQuery.TryComp(uid, out var moverModifier))
         {
             sound = moverModifier.FootstepSoundCollection;
-            return true;
+            return sound != null;
         }
 
         if (_inventory.TryGetSlotEntity(uid, "shoes", out var shoes) &&
             FootstepModifierQuery.TryComp(shoes, out var modifier))
         {
             sound = modifier.FootstepSoundCollection;
-            return true;
+            return sound != null;
         }
 
         return TryGetFootstepSound(uid, xform, shoes != null, out sound, tileDef: tileDef);
@@ -456,7 +456,7 @@ public abstract partial class SharedMoverController : VirtualController
         EntityUid uid,
         TransformComponent xform,
         bool haveShoes,
-        out SoundSpecifier? sound,
+        [NotNullWhen(true)] out SoundSpecifier? sound,
         ContentTileDefinition? tileDef = null)
     {
         sound = null;
@@ -467,10 +467,9 @@ public abstract partial class SharedMoverController : VirtualController
             if (FootstepModifierQuery.TryComp(xform.MapUid, out var modifier))
             {
                 sound = modifier.FootstepSoundCollection;
-                return true;
             }
 
-            return false;
+            return sound != null;
         }
 
         var position = grid.LocalToTile(xform.Coordinates);
@@ -493,7 +492,7 @@ public abstract partial class SharedMoverController : VirtualController
             if (FootstepModifierQuery.TryComp(maybeFootstep, out var footstep))
             {
                 sound = footstep.FootstepSoundCollection;
-                return true;
+                return sound != null;
             }
         }
 

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -136,6 +136,11 @@
     # ninja are masters of sneaking around relatively quickly, won't break cloak
     walkModifier: 1.1
     sprintModifier: 1.3
+  - type: FootstepModifier
+    footstepSoundCollection:
+      collection: FootstepSnake
+      params:
+        volume: -100
 
 - type: entity
   parent: ClothingShoesBaseButcherable

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -138,9 +138,7 @@
     sprintModifier: 1.3
   - type: FootstepModifier
     footstepSoundCollection:
-      collection: FootstepSnake
-      params:
-        volume: -100
+      collection: null
 
 - type: entity
   parent: ClothingShoesBaseButcherable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes ninja footsteps completely silent by making their shoes produce no audible footstep sounds.
doesn't make anything else silent if you're wondering.

## Why / Balance
ninjas having normal footstep sounds that you can easily hear makes them a dead giveaway if you hear them a single time in maints, their abnormally fast footsteps make it super obvious there's a ninja on station. unless someone's been giving away meth, it's 100% a ninja you're hearing.

should hopefully open up more opportunities for cool ninja stealth gameplay, making it much harder to be noticed when you're in a dark area. the not completely invisible cloaking makes them fairly easy to spot them in the open, so this still encourages ninjas to use the darkness to their advantage, effectively disappearing if they run off into the dark.

this was kind of made in response to https://github.com/space-wizards/space-station-14/pull/33244, incentivizing ninjas to actually be stealthy and not just rely on their instant meme stun ability.

## Technical details
just gives ninja shoes a footstep sound collection ~~with volume -100, if this is too shitty of a way to do this or has unforeseen consequences let me know :)~~ with null attached so it draws from no soundpool (silent)
(disclaimer: i am not very smart)

## Media
nothing to see or hear here

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Space Ninjas now have silent footsteps.