### PR TITLE
Four new food crates for the ATS

### DIFF
--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -561,6 +561,7 @@
       - Cake
       - Pie
       - Bread
+      - Pistachios  
 
 - type: cargoBounty
   id: BountyVegetable

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -89,16 +89,6 @@
   group: market
 
 - type: cargoProduct
-  id: FoodCannibal
-  icon:
-    sprite: Structures/Storage/Crates/freezer.rsi
-    state: icon
-  product: CrateFoodCannibal
-  cost: 550
-  category: cargoproduct-category-name-food
-  group: market
-
-- type: cargoProduct
   id: FoodPizzaMoth
   icon:
     sprite: Objects/Consumable/Food/Baked/pizza.rsi

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -84,7 +84,7 @@
     sprite: Objects/Consumable/Food/snacks.rsi
     state: raisins
   product: CrateFoodGetMore
-  cost: 720
+  cost: 750
   category: cargoproduct-category-name-food
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -77,3 +77,63 @@
   cost: 2400
   category: cargoproduct-category-name-food
   group: market
+
+- type: cargoProduct
+  id: FoodCookGetmore
+  icon:
+    sprite: Objects/Consumable/Food/snacks.rsi
+    state: raisins
+  product: CrateFoodGetMore
+  cost: 720
+  category: cargoproduct-category-name-food
+  group: market
+
+- type: cargoProduct
+  id: FoodCannibal
+  icon:
+    sprite: Structures/Storage/Crates/freezer.rsi
+    state: icon
+  product: CrateFoodCannibal
+  cost: 550
+  category: cargoproduct-category-name-food
+  group: market
+
+- type: cargoProduct
+  id: FoodPizzaMoth
+  icon:
+    sprite: Objects/Consumable/Food/Baked/pizza.rsi
+    state: cotton-slice
+  product: CrateFoodPizzaMoth
+  cost: 450
+  category: cargoproduct-category-name-food
+  group: market
+
+- type: cargoProduct
+  id: FoodSurprise
+  icon:
+    sprite: Objects/Consumable/Food/burger.rsi
+    state: crazy
+  product: CrateFoodSurprise
+  cost: 850
+  category: cargoproduct-category-name-food
+  group: market
+
+- type: cargoProduct
+  id: FoodIceCream
+  icon:
+    sprite: Objects/Consumable/Food/frozen.rsi
+    state: sandwich
+  product: CrateFoodIceCream
+  cost: 1200
+  category: cargoproduct-category-name-food
+  group: market
+
+- type: cargoProduct
+  id: FoodSnowcone
+  icon:
+    sprite: Objects/Consumable/Food/frozen.rsi
+    state: cone
+  product: CrateFoodSnowcone
+  cost: 1100
+  category: cargoproduct-category-name-food
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -93,7 +93,7 @@
   icon:
     sprite: Objects/Consumable/Food/burger.rsi
     state: bigbite
-  product: CrateFoodHappyHonkMeals
+  product: CrateFoodHappyHonkBigBite
   cost: 1000
   category: cargoproduct-category-name-food
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -89,12 +89,12 @@
   group: market
 
 - type: cargoProduct
-  id: FoodSurprise
+  id: FoodHappyHonkMeals
   icon:
     sprite: Objects/Consumable/Food/burger.rsi
-    state: crazy
-  product: CrateFoodSurprise
-  cost: 850
+    state: bigbite
+  product: CrateFoodHappyHonkMeals
+  cost: 1000
   category: cargoproduct-category-name-food
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -89,16 +89,6 @@
   group: market
 
 - type: cargoProduct
-  id: FoodPizzaMoth
-  icon:
-    sprite: Objects/Consumable/Food/Baked/pizza.rsi
-    state: cotton-slice
-  product: CrateFoodPizzaMoth
-  cost: 450
-  category: cargoproduct-category-name-food
-  group: market
-
-- type: cargoProduct
   id: FoodSurprise
   icon:
     sprite: Objects/Consumable/Food/burger.rsi

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -194,10 +194,10 @@
       amount: 1
 
 - type: entity
-  id: CrateFoodHappyHonkMeals
+  id: CrateFoodHappyHonkBigBite
   parent: CratePlastic
   name: Happy Honk meal delivery
-  description: Two fully loaded Happy Honk Big Bite burger meals, complete with cheesy fries, a bottle of Space Cola, a slice of apple pie and a toy! For those who just can't wait for the next transport to a Happy Honk franchise location!
+  description: Two fully loaded Happy Honk Big Bite burger meals, complete with cheesy fries, a bottle of Space Cola, a slice of apple pie and a toy!
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -192,21 +192,6 @@
       amount: 2
 
 - type: entity
-  id: CrateFoodCannibal
-  parent: CrateFreezer
-  name: black market meats freezer
-  description: Some meat for the kitchen, just don't ask where it came from. Includes 8 pieces of meat.
-  components:
-  - type: StorageFill
-    contents:
-    - id: FoodMeatHuman
-      amount: 4
-    - id: FoodMeatLizard
-      amount: 2
-    - id: FoodMeatPlant
-      amount: 2
-
-- type: entity
   id: CrateFoodPizzaMoth
   parent: CratePlastic
   name: moth pizza delivery

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -197,7 +197,7 @@
   id: CrateFoodHappyHonkMeals
   parent: CratePlastic
   name: Happy Honk meal delivery
-  description: Two fully loaded Happy Honk Big Bite Burger meals, complete with cheesy fries, a bottle of Space Cola, a slice of apple pie, and a toy! For those who just can't wait for the next transport to a Happy Honk franchise location!
+  description: Two fully loaded Happy Honk Big Bite burger meals, complete with cheesy fries, a bottle of Space Cola, a slice of apple pie and a toy! For those who just can't wait for the next transport to a Happy Honk franchise location!
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -192,19 +192,6 @@
       amount: 2
 
 - type: entity
-  id: CrateFoodPizzaMoth
-  parent: CratePlastic
-  name: moth pizza delivery
-  description: Help feed your station's hungry moths with some tasty cotton pizzas! Includes 4 pizzas.
-  components:
-  - type: StorageFill
-    contents:
-    - id: FoodBoxPizzaFilledMoth
-      amount: 4
-    - id: LidSalami
-      prob: 0.01
-
-- type: entity
   id: CrateFoodSurprise
   parent: CratePlastic
   name: personnel surprise crate

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -194,17 +194,6 @@
       amount: 1
 
 - type: entity
-  id: CrateFoodHappyHonkBigBite
-  parent: CratePlastic
-  name: Happy Honk meal delivery
-  description: Two fully loaded Happy Honk Big Bite burger meals, complete with cheesy fries, a bottle of Space Cola, a slice of apple pie and a toy!
-  components:
-  - type: StorageFill
-    contents:
-      id: FoodMealHappyHonkBigBite
-      amount: 2
-
-- type: entity
   id: CrateFoodIceCream
   parent: CrateFreezer
   name: ice cream delivery
@@ -246,4 +235,15 @@
     - id: FoodFrozenSnowconeClown
       amount: 2
     - id: FoodFrozenSnowconeMime
+      amount: 2
+
+- type: entity
+  id: CrateFoodHappyHonkBigBite
+  parent: CratePlastic
+  name: Happy Honk meal delivery
+  description: Two fully loaded Happy Honk Big Bite burger meals, complete with cheesy fries, a bottle of Space Cola, a slice of apple pie and a toy!
+  components:
+  - type: StorageFill
+    contents:
+    - id: FoodMealHappyHonkBigBite
       amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -175,11 +175,11 @@
   - type: StorageFill
     contents:
     - id: FoodSnackRaisins
-      amount: 6
+      amount: 4
     - id: FoodSnackChocolate
       amount: 6
     - id: FoodSnackPistachios
-      amount: 6
+      amount: 4
     - id: ReagentContainerFlour
       amount: 3
     - id: ReagentContainerSugar
@@ -190,31 +190,23 @@
       amount: 2
     - id: FoodContainerEgg
       amount: 2
+    - id: FoodBoxCloth
+      amount: 1
 
 - type: entity
-  id: CrateFoodSurprise
+  id: CrateFoodHappyHonkMeals
   parent: CratePlastic
-  name: personnel surprise crate
-  description: A tasty surprise for a special person on the station. Not made for sharing!
+  name: Happy Honk meal delivery
+  description: Two fully loaded Happy Honk Big Bite Burger meals, complete with cheesy fries, a bottle of Space Cola, a slice of apple pie, and a toy! For those who just can't wait for the next transport to a Happy Honk franchise location!
   components:
   - type: StorageFill
     contents:
-    - id: FoodBurgerCrazy
-      amount: 1
-    - id: FoodMealFriesCheesy
-      amount: 1
-    - id: DrinkColaBottleFull
-      amount: 1
-    - id: FoodCakeBirthdaySlice
-      amount: 1
-    - id: ClothingHeadHatPartyWaterCup
-      amount: 1
-    - id: MysteryFigureBox
-      amount: 1
+      id: FoodMealHappyHonkBigBite
+      amount: 2
 
 - type: entity
   id: CrateFoodIceCream
-  parent: CratePlastic
+  parent: CrateFreezer
   name: ice cream delivery
   description: An assortment of ice cream delights for any occasion! Includes 16 frozen treats.
   components:
@@ -237,9 +229,9 @@
 
 - type: entity
   id: CrateFoodSnowcone
-  parent: CratePlastic
+  parent: CrateFreezer
   name: snowcone delivery
-  description: A packed crate of refreshing snowcones for a hard working crew, or even a lazy one! Includes 16 snowcones.
+  description: A freezer packed with refreshing snowcones for a hard working crew, or even a lazy one! Includes 16 snowcones.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -170,7 +170,7 @@
   id: CrateFoodGetMore
   parent: CratePlastic
   name: Getmore Bakemore crate
-  description: GetMore branded snacks and baking supplies for the creative chef, all without the need of emptying your station's GetMore machines!
+  description: Getmore branded snacks and baking supplies for the creative chef, all without the need of emptying your station's Getmore machines!
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -166,3 +166,120 @@
       - id: DrinkFourteenLokoCan
         amount: 4
 
+- type: entity
+  id: CrateFoodGetMore
+  parent: CratePlastic
+  name: Getmore Bakemore crate
+  description: GetMore branded snacks and baking supplies for the creative chef, all without the need of emptying your station's GetMore machines!
+  components:
+  - type: StorageFill
+    contents:
+    - id: FoodSnackRaisins
+      amount: 6
+    - id: FoodSnackChocolate
+      amount: 6
+    - id: FoodSnackPistachios
+      amount: 6
+    - id: ReagentContainerFlour
+      amount: 3
+    - id: ReagentContainerSugar
+      amount: 2
+    - id: FoodCondimentPacketSalt
+      amount: 3
+    - id: DrinkMilkCarton
+      amount: 2
+    - id: FoodContainerEgg
+      amount: 2
+
+- type: entity
+  id: CrateFoodCannibal
+  parent: CrateFreezer
+  name: black market meats freezer
+  description: Some meat for the kitchen, just don't ask where it came from. Includes 8 pieces of meat.
+  components:
+  - type: StorageFill
+    contents:
+    - id: FoodMeatHuman
+      amount: 4
+    - id: FoodMeatLizard
+      amount: 2
+    - id: FoodMeatPlant
+      amount: 2
+
+- type: entity
+  id: CrateFoodPizzaMoth
+  parent: CratePlastic
+  name: moth pizza delivery
+  description: Help feed your station's hungry moths with some tasty cotton pizzas! Includes 4 pizzas.
+  components:
+  - type: StorageFill
+    contents:
+    - id: FoodBoxPizzaFilledMoth
+      amount: 4
+    - id: LidSalami
+      prob: 0.01
+
+- type: entity
+  id: CrateFoodSurprise
+  parent: CratePlastic
+  name: personnel surprise crate
+  description: A tasty surprise for a special person on the station. Not made for sharing!
+  components:
+  - type: StorageFill
+    contents:
+    - id: FoodBurgerCrazy
+      amount: 1
+    - id: FoodMealFriesCheesy
+      amount: 1
+    - id: DrinkColaBottleFull
+      amount: 1
+    - id: FoodCakeBirthdaySlice
+      amount: 1
+    - id: ClothingHeadHatPartyWaterCup
+      amount: 1
+    - id: MysteryFigureBox
+      amount: 1
+
+- type: entity
+  id: CrateFoodIceCream
+  parent: CratePlastic
+  name: ice cream delivery
+  description: An assortment of ice cream delights for any occasion! Includes 16 frozen treats.
+  components:
+  - type: StorageFill
+    contents:
+    - id: FoodFrozenSandwich
+      amount: 3
+    - id: FoodFrozenSandwichStrawberry
+      amount: 2
+    - id: FoodFrozenPopsicleOrange
+      amount: 2
+    - id: FoodFrozenPopsicleBerry
+      amount: 2
+    - id: FoodFrozenPopsicleJumbo
+      amount: 3
+    - id: FoodFrozenCornuto
+      amount: 2
+    - id: FoodFrozenSundae
+      amount: 2
+
+- type: entity
+  id: CrateFoodSnowcone
+  parent: CratePlastic
+  name: snowcone delivery
+  description: A packed crate of refreshing snowcones for a hard working crew, or even a lazy one! Includes 16 snowcones.
+  components:
+  - type: StorageFill
+    contents:
+    - id: FoodFrozenSnowconeBase
+      amount: 3
+    - id: FoodFrozenSnowconeBerry
+      amount: 3
+    - id: FoodFrozenSnowconeFruit
+      amount: 3
+    - id: FoodFrozenSnowconeRainbow
+      amount: 3
+    - id: FoodFrozenSnowconeClown
+      amount: 2
+    - id: FoodFrozenSnowconeMime
+      amount: 2

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -768,6 +768,81 @@
         orGroup: GiftPool
 
 - type: entity
+  id: FoodMealHappyHonkBigBite
+  parent: HappyHonk
+  name: Happy Honk Big Bite Meal
+  description: Someone paid good money to get this fast food meal shipped out this way. It smells fresh, somehow.
+  components:
+  - type: StorageFill
+    contents:
+      - id: FoodBurgerBig
+        amount: 1
+      - id: FoodMealFriesCheesy
+        amount: 1
+      - id: DrinkColaBottleFull
+        amount: 1
+      - id: FoodPieAppleSlice
+        amount: 1
+      - id: ToyMouse
+        orGroup: GiftPool
+      - id: ToyAi
+        orGroup: GiftPool
+      - id: ToyNuke
+        orGroup: GiftPool
+      - id: ToyFigurinePassenger
+        orGroup: GiftPool
+      - id: ToyGriffin
+        orGroup: GiftPool
+      - id: ToyHonk
+        orGroup: GiftPool
+      - id: ToyIan
+        orGroup: GiftPool
+      - id: ToyMarauder
+        orGroup: GiftPool
+      - id: ToyMauler
+        orGroup: GiftPool
+      - id: ToyGygax
+        orGroup: GiftPool
+      - id: ToyOdysseus
+        orGroup: GiftPool
+      - id: ToyOwlman
+        orGroup: GiftPool
+      - id: ToyDeathRipley
+        orGroup: GiftPool
+      - id: ToyPhazon
+        orGroup: GiftPool
+      - id: ToyFireRipley
+        orGroup: GiftPool
+      - id: ToyReticence
+        orGroup: GiftPool
+      - id: ToyRipley
+        orGroup: GiftPool
+      - id: ToySeraph
+        orGroup: GiftPool
+      - id: ToyDurand
+        orGroup: GiftPool
+      - id: ToySkeleton
+        orGroup: GiftPool
+      - id: FoamBlade
+        orGroup: GiftPool
+      - id: ClothingHeadHatBunny
+        orGroup: GiftPool
+      - id: PersonalAI
+        orGroup: GiftPool
+      - id: ToySword
+        orGroup: GiftPool
+      - id: RevolverCapGun
+        orGroup: GiftPool
+      - id: ToyRubberDuck
+        orGroup: GiftPool
+      - id: BikeHorn
+        prob: 0.5
+        orGroup: GiftPool
+      - id: GoldenBikeHorn
+        prob: 0.1
+        orGroup: GiftPool
+
+- type: entity
   parent: BoxCardboard
   id: FoodBoxCloth
   name: box of FlutterSoft-brand cloth

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -286,6 +286,23 @@
     - id: FoodPizzaCotton
     - id: KnifePlastic
 
+- type: entity
+  name: pizza box
+  parent: FoodBoxPizza
+  id: FoodBoxPizzaFilledMoth
+  suffix: Filled
+  components:
+  - type: Sprite
+    layers:
+    - state: box
+    - state: box-open
+      map: ["enum.StorageVisualLayers.Door"]
+  - type: StorageFill
+    contents:
+    - id: FoodPizzaCotton
+      amount: 1
+    - id: KnifePlastic
+      amount: 1
 # Nugget
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -286,23 +286,6 @@
     - id: FoodPizzaCotton
     - id: KnifePlastic
 
-- type: entity
-  name: pizza box
-  parent: FoodBoxPizza
-  id: FoodBoxPizzaFilledMoth
-  suffix: Filled
-  components:
-  - type: Sprite
-    layers:
-    - state: box
-    - state: box-open
-      map: ["enum.StorageVisualLayers.Door"]
-  - type: StorageFill
-    contents:
-    - id: FoodPizzaCotton
-      amount: 1
-    - id: KnifePlastic
-      amount: 1
 # Nugget
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -178,7 +178,7 @@
   - type: Item
 
 - type: entity
-  name: sweetie's pistachios
+  name: Sweetie's Pistachios
   parent: FoodSnackBase
   id: FoodSnackPistachios
   description: Sweeties's name-brand pistachios. Probably won't give you diseases. Probably.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -196,7 +196,7 @@
   - type: Tag
     tags:
     - Fruit # Seed of a fruit, you can yell at me
--   - Pistachios # Added tag due to CrateFoodGetMore interaction with BountyFruit.
+    - Pistachios # Added tag due to CrateFoodGetMore interaction with BountyFruit.
 
 - type: entity
   name: popcorn

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -181,7 +181,7 @@
   name: sweetie's pistachios
   parent: FoodSnackBase
   id: FoodSnackPistachios
-  description: Sweeties's name-brand pistachios. probably won't give you diseases. Probably.
+  description: Sweeties's name-brand pistachios. Probably won't give you diseases. Probably.
   components:
   - type: FlavorProfile
     flavors:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -196,6 +196,7 @@
   - type: Tag
     tags:
     - Fruit # Seed of a fruit, you can yell at me
+-   - Pistachios # Added tag due to CrateFoodGetMore interaction with BountyFruit.
 
 - type: entity
   name: popcorn

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -178,7 +178,7 @@
   - type: Item
 
 - type: entity
-  name: Sweetie's Pistachios
+  name: Sweetie's pistachios
   parent: FoodSnackBase
   id: FoodSnackPistachios
   description: Sweeties's name-brand pistachios. Probably won't give you diseases. Probably.

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -979,6 +979,9 @@
   id: Pipe
 
 - type: Tag
+  id: Pistachios
+
+- type: Tag
   id: Pizza
 
 - type: Tag


### PR DESCRIPTION
## About the PR
I've added ~~six~~ new food crates available for purchase from the ATS. A brief summary:

1. **Getmore Bakemore Crate** - A slimmed down kitchen supplies crate with 4-6 of each Getmore baking ingredient (raisins/chocolate/pistachios).
2. ~~**Black Market Meats Freezer** - Freezer containing 4 human meat, 2 lizard meat and 2 plant meat.~~
3. ~~**Moth Pizza Delivery** - 4 cotton pizzas for stations that want to accommodate moths, otherwise identical to a normal pizza delivery crate. They spawn properly in pizza boxes with plastic knives.~~
4. ~~**Personnel Surprise Crate** - High-end hamburger and fries meal with cake, bottle of space cola, water cup party hat and mystery figure box, a way to reward/celebrate/cheer up a crew member. Not made for sharing.~~
5. **Ice Cream Delivery** - 16 pieces of assorted ice cream food items, probably going to be very popular if implemented.
6. **Snowcone Delivery** - 16 assorted snowcones for _slightly less_ than the ice cream delivery, because they deserve representation too.
7. NEW: **Happy Honk Meal Delivery** - Big bite burger, bottle of space cola, cheesy fries, a slice of apple pie, and a random toy, all in an official Happy Honk box! Now you can literally ask your QM to buy you McDonalds. Two meals per crate.

Also, while you're here, please see [my other pull request on hacked vending machine contrabandInventory menus.](https://github.com/space-wizards/space-station-14/pull/32934)

EDIT: Minor bonus updates. Capitalized the start of a sentence on Sweetie's Pistachio's description, and removed it as a possible item in the cargo fruit bounty for $5k. They're seemingly a fruit so Reptilians can eat them, but I've never even heard of them being used in the bounty before, so I've removed it as a possible item.

EDIT: Removed Black Market Meats Freezer from PR.
EDIT 2: Removed Moth Pizza Delivery as cotton pizzas are now guaranteed in normal pizza delivery orders.
EDIT 3: Made sweeping changes. Ice Cream and Snowcones now come in freezers to fit their theming. Getmore Bakemore now gets one of the new cloth boxes for moth cooking, and had its raisins and pistachios cut down to 4. Added Happy Honk Meal Delivery to replace Personnel Surprise Crate, which generates with a random Happy Honk toy (crayon box excluded, due to size). I also capitalized Sweetie's Pistachios, following how other branded products are now being treated as proper nouns. New video in description.

## Why / Balance
The food category that cargo has access to is rather limited, with the most exciting things on there being the pizza delivery crates. My basic reasoning is as follows:

The Getmore Bakemore crate is to provide an answer for making things like Raisin Cookies, Baklava and Chocolate Cake without having to raid vending machines as a chef, or necessarily make chocolate. I view the Getmore items inside as candy/junk food, and this is a fun way to combine these specific items which have recipes into a kit that encourages chefs to actually make these sorts of foods. I'm not sure if it's necessarily competitive with a kitchen supplies crate in the current meta, but I could see it being of about equal appeal with a ChefVend restock.

~~Black Market Meats is a way to get cannibal meats onto the station in a marginally less (or more?) morally questionable way. Some people like exploring this topic, and I see no real reason not to enable it. NanoTransen isn't exactly portrayed as that moral of a corporation. It's also a way to get an extra Freezer, which isn't usually a thing that's in demand, but it's a thing.~~

~~The Moth Pizza Delivery is a way to give something edible to moth players, who are often unfed by chefs (even with the new cotton bread and cotton pizza recipes), and they have to resort to eating clothing. This seems like a fun thing for a group of moths to order together from Cargo, or for Cargo to buy in an attempt to support their moth crewmates. Otherwise, it follows the same logic as the other pizza deliveries.~~

Personnel Surprise Crate contains some high-end food. Crazy Hamburger, Cheesy Fries, Slice of Birthday Cake, Bottle of Space Cola, it's an absolute feast. The mystery figure box and the water cup party hat are a bonus so the recipient has visible keepsakes of getting this crate. None of these items are actually powerful or impact the round in any real way, but they're not the most common foods while being very appealing to receive. This is rife with some fun roleplaying opportunities, and I'd argue that getting one of these has the same appeal as getting a medal from the Captain.

Ice Cream Delivery and Snowcone Delivery are functionally identical, 16 appealing treat-type items to spoil the crew with, or for a few crewmembers to gorge on. I expect the ice cream one in particular to become very popular, and any vanity item being requested from Cargo instead of required/meta/grand lottery is a win in my book. As an added bonus, it gives us something appropriate to put into the Chef's ice cream cart for once.

## Technical details
Edits to box.yml, cargo_food.yml and food.yml. Box.yml was to get the cotton pizzas to spawn in their own dedicated pizza boxes, cargo_food.yml and food.yml was to actually get the crates into the cargo menu as spawnable entities. I only added content, nothing was removed. I then learned that the cargo fruit bounty (BountyFruit) worked with pistachios and it was throwing an error, so I made changes to snacks.yml and bounties.yml to remove pistachios from that bounty, it feels off to include them in that as it is. I then added a "pistachios" tag to tags.yml.

## Media
[Here's a YouTube video showcasing the crates, and showing them on the Cargo request console.](https://www.youtube.com/watch?v=Ci9jTEiO7i0)

[NEW VIDEO](https://youtu.be/H6SB8KnWdqw?si=n7YTJcP9Od9aJaCF)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
I don't forsee any issues with this beyond possible merge conflicts. All of these crates worked when tested.

**Changelog**
:cl: AgentSmithRadio
- add: New food crates are now available for purchase from the automated trade station!
- remove: You can no longer use Sweetie's Pistachios to fulfill cargo's generic fruit bounty.

