### PR TITLE
Panic bunker can now activate automatically if enough ahelps have occured

### DIFF
--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -844,16 +844,19 @@ namespace Content.Server.Administration.Systems
 
             var totalAhelpsPerRound = _config.GetCVar(CCVars.ActivatePanicBunkerAhelpsPerRound);
 
-            var aHelpTime = _config.GetCVar(CCVars.ActivatePanicBunkerAhelpsTime);
-            var aHelpAmount = _config.GetCVar(CCVars.ActivatePanicBunkerAhelpsAmount);
-
-            if (_activeConversations.Count > totalAhelpsPerRound)
+            if (totalAhelpsPerRound > 0 && _activeConversations.Count > totalAhelpsPerRound)
             {
                 _config.SetCVar(CCVars.PanicBunkerEnabled, true);
                 _sawmill.Info($"Panic bunker enabled, total aHelps this round has exceeded {totalAhelpsPerRound}.");
                 _hasPanicBunkerBeenActivatedThisRound = true;
                 return;
             }
+
+            var aHelpTime = _config.GetCVar(CCVars.ActivatePanicBunkerAhelpsTime);
+            var aHelpAmount = _config.GetCVar(CCVars.ActivatePanicBunkerAhelpsAmount);
+
+            if (aHelpTime <= 0 || aHelpAmount <= 0)
+                return;
 
             var aHelpsInTime = 0;
             foreach (var conversationTime in _activeConversations.Values.ToList())

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -942,7 +942,7 @@ namespace Content.Shared.CCVar
         /// If zero or less, the feature is disabled.
         /// </summary>
         public static readonly CVarDef<int> ActivatePanicBunkerAhelpsPerRound =
-            CVarDef.Create("admin.activate_panic_bunker_after_at", 20, CVar.SERVERONLY);
+            CVarDef.Create("admin.activate_panic_bunker_after_ahelps", 20, CVar.SERVERONLY);
 
         /// <summary>
         /// If <see cref="ActivatePanicBunkerAhelpsAmount"/> aHelps have been received in <see cref="ActivatePanicBunkerAhelpsTime"/> many minutes,

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -936,6 +936,25 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> AdminUseCustomNamesAdminRank =
             CVarDef.Create("admin.use_custom_names_admin_rank", true, CVar.SERVERONLY);
 
+        /// <summary>
+        /// If this many aHelps have occured in a round, the server will automatically go into panic bunker mode.
+        /// Will respect <see cref="PanicBunkerDisableWithAdmins"/> and will only ever activate at most once per round.
+        /// </summary>
+        public static readonly CVarDef<int> ActivatePanicBunkerAhelpsPerRound =
+            CVarDef.Create("admin.activate_panic_bunker_after_at", 20, CVar.SERVERONLY);
+
+        /// <summary>
+        /// If <see cref="ActivatePanicBunkerAhelpsAmount"/> aHelps have been received in <see cref="ActivatePanicBunkerAhelpsTime"/> many minutes,
+        /// the server will automatically go into panic bunker mode.
+        /// Will respect <see cref="PanicBunkerDisableWithAdmins"/> and will only ever activate at most once per round.
+        /// </summary>
+        public static readonly CVarDef<int> ActivatePanicBunkerAhelpsTime =
+            CVarDef.Create("admin.activate_panic_bunker_received_ahelps_time", 10, CVar.SERVERONLY);
+
+        /// <inheritdoc cref="ActivatePanicBunkerAhelpsTime"/>
+        public static readonly CVarDef<int> ActivatePanicBunkerAhelpsAmount =
+            CVarDef.Create("admin.activate_panic_bunker_received_ahelps_amount", 10, CVar.SERVERONLY);
+
         /*
          * AHELP
          */
@@ -1562,7 +1581,7 @@ namespace Content.Shared.CCVar
             CVarDef.Create("votekick.ban_duration", 180, CVar.SERVERONLY);
 
         /// <summary>
-        ///     Whether the ghost requirement settings for votekicks should be ignored for the lobby. 
+        ///     Whether the ghost requirement settings for votekicks should be ignored for the lobby.
         /// </summary>
         public static readonly CVarDef<bool> VotekickIgnoreGhostReqInLobby =
             CVarDef.Create("votekick.ignore_ghost_req_in_lobby", true, CVar.SERVERONLY);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -939,6 +939,7 @@ namespace Content.Shared.CCVar
         /// <summary>
         /// If this many aHelps have occured in a round, the server will automatically go into panic bunker mode.
         /// Will respect <see cref="PanicBunkerDisableWithAdmins"/> and will only ever activate at most once per round.
+        /// If zero or less, the feature is disabled.
         /// </summary>
         public static readonly CVarDef<int> ActivatePanicBunkerAhelpsPerRound =
             CVarDef.Create("admin.activate_panic_bunker_after_at", 20, CVar.SERVERONLY);
@@ -947,6 +948,7 @@ namespace Content.Shared.CCVar
         /// If <see cref="ActivatePanicBunkerAhelpsAmount"/> aHelps have been received in <see cref="ActivatePanicBunkerAhelpsTime"/> many minutes,
         /// the server will automatically go into panic bunker mode.
         /// Will respect <see cref="PanicBunkerDisableWithAdmins"/> and will only ever activate at most once per round.
+        /// Set either value to 0 or less to disable.
         /// </summary>
         public static readonly CVarDef<int> ActivatePanicBunkerAhelpsTime =
             CVarDef.Create("admin.activate_panic_bunker_received_ahelps_time", 10, CVar.SERVERONLY);


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Added three CCVars that allow the panic bunker to be automatically enabled if enough ahelps have occurred.
1.) If `activate_panic_bunker_received_ahelps_time` have occurred in a round, the bunker is enabled.
2.) If `activate_panic_bunker_received_ahelps_amount` ahelps have occured in the last `activate_panic_bunker_received_ahelps_time` minutes, the bunker is enabled.

Both will also check for the `disable_with_admins` CCVar and wont activate if its true and there is an admin online. They will also only ever activate once per round.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #23031!

## Technical details
<!-- Summary of code changes for easier review. -->
This stuff is kind of out of my depth in multiple ways 😆
1.) I'm not sure this is the correct location for the CCVars (Should they be in admin or panic bunker?)
2.) The default numbers are literally pulled from thin air. I have ZERO idea what would even be close to making sense! If an admin could chime in and give defaults I'd appreciate it!
3.) I'm not sure this is the correct location for the function either! Should I make a new panic bunker system?

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Beck Thompson
ADMIN:
- add: Panic bunker is automatically enabled if enough ahelps have occurred in a round or a certain amount of time. This can be changed in a CCVar.

