### PR TITLE
fix PermanentBlindnessComponent to be not so permanent

### DIFF
--- a/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
+++ b/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
@@ -37,7 +37,7 @@ public sealed class PermanentBlindnessSystem : EntitySystem
 
         if (blindable.MinDamage != 0)
         {
-            _blinding.SetMinDamage(new Entity<BlindableComponent?>(blindness.Owner, blindable), 0);
+            _blinding.SetMinDamage((blindness.Owner, blindable), 0);
         }
     }
 

--- a/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
+++ b/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
@@ -50,15 +50,15 @@ public sealed class PermanentBlindnessSystem : EntitySystem
 
     private void OnMapInit(Entity<PermanentBlindnessComponent> blindness, ref MapInitEvent args)
     {
-        if (!_entityManager.TryGetComponent<BlindableComponent>(blindness, out var blindable))
+        if(!TryComp<BlindableComponent>(blindness, out var blindable))
             return;
 
         if (blindness.Comp.Blindness != 0)
-            _blinding.SetMinDamage(new Entity<BlindableComponent?>(blindness.Owner, blindable), blindness.Comp.Blindness);
+            _blinding.SetMinDamage((blindness.Owner, blindable), blindness.Comp.Blindness);
         else
         {
             var maxMagnitudeInt = (int) BlurryVisionComponent.MaxMagnitude;
-            _blinding.SetMinDamage(new Entity<BlindableComponent?>(blindness.Owner, blindable), maxMagnitudeInt);
+            _blinding.SetMinDamage((blindness.Owner, blindable), maxMagnitudeInt);
         }
     }
 }

--- a/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
+++ b/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
@@ -12,7 +12,6 @@ namespace Content.Shared.Traits.Assorted;
 public sealed class PermanentBlindnessSystem : EntitySystem
 {
     [Dependency] private readonly INetManager _net = default!;
-    [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly BlindableSystem _blinding = default!;
 
     /// <inheritdoc/>

--- a/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
+++ b/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
@@ -20,6 +20,7 @@ public sealed class PermanentBlindnessSystem : EntitySystem
     {
         SubscribeLocalEvent<PermanentBlindnessComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<PermanentBlindnessComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<PermanentBlindnessComponent, ComponentRemove>(OnRemove);
         SubscribeLocalEvent<PermanentBlindnessComponent, ExaminedEvent>(OnExamined);
     }
 
@@ -34,6 +35,17 @@ public sealed class PermanentBlindnessSystem : EntitySystem
     private void OnShutdown(Entity<PermanentBlindnessComponent> blindness, ref ComponentShutdown args)
     {
         _blinding.UpdateIsBlind(blindness.Owner);
+    }
+
+    private void OnRemove(Entity<PermanentBlindnessComponent> blindness, ref ComponentRemove args)
+    {
+        if (!_entityManager.TryGetComponent<BlindableComponent>(blindness, out var blindable))
+            return;
+
+        if (blindable.MinDamage != 0)
+        {
+            _blinding.SetMinDamage(new Entity<BlindableComponent?>(blindness.Owner, blindable), 0);
+        }
     }
 
     private void OnMapInit(Entity<PermanentBlindnessComponent> blindness, ref MapInitEvent args)

--- a/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
+++ b/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
@@ -20,7 +20,6 @@ public sealed class PermanentBlindnessSystem : EntitySystem
     {
         SubscribeLocalEvent<PermanentBlindnessComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<PermanentBlindnessComponent, ComponentShutdown>(OnShutdown);
-        //SubscribeLocalEvent<PermanentBlindnessComponent, ComponentRemove>(OnRemove);
         SubscribeLocalEvent<PermanentBlindnessComponent, ExaminedEvent>(OnExamined);
     }
 

--- a/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
+++ b/Content.Shared/Traits/Assorted/PermanentBlindnessSystem.cs
@@ -20,7 +20,7 @@ public sealed class PermanentBlindnessSystem : EntitySystem
     {
         SubscribeLocalEvent<PermanentBlindnessComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<PermanentBlindnessComponent, ComponentShutdown>(OnShutdown);
-        SubscribeLocalEvent<PermanentBlindnessComponent, ComponentRemove>(OnRemove);
+        //SubscribeLocalEvent<PermanentBlindnessComponent, ComponentRemove>(OnRemove);
         SubscribeLocalEvent<PermanentBlindnessComponent, ExaminedEvent>(OnExamined);
     }
 
@@ -34,12 +34,7 @@ public sealed class PermanentBlindnessSystem : EntitySystem
 
     private void OnShutdown(Entity<PermanentBlindnessComponent> blindness, ref ComponentShutdown args)
     {
-        _blinding.UpdateIsBlind(blindness.Owner);
-    }
-
-    private void OnRemove(Entity<PermanentBlindnessComponent> blindness, ref ComponentRemove args)
-    {
-        if (!_entityManager.TryGetComponent<BlindableComponent>(blindness, out var blindable))
+        if (!TryComp<BlindableComponent>(blindness.Owner, out var blindable))
             return;
 
         if (blindable.MinDamage != 0)
@@ -50,7 +45,7 @@ public sealed class PermanentBlindnessSystem : EntitySystem
 
     private void OnMapInit(Entity<PermanentBlindnessComponent> blindness, ref MapInitEvent args)
     {
-        if(!TryComp<BlindableComponent>(blindness, out var blindable))
+        if(!TryComp<BlindableComponent>(blindness.Owner, out var blindable))
             return;
 
         if (blindness.Comp.Blindness != 0)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
partially fixed #33146 by reversing it's effect on component removal

does not fix VV not automatically making changes to the BlindableComponent's eyedamage value visible, but rejuvination and oculine will now be able to fix eyesight when the comp is no longer present

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fix!

## Technical details
<!-- Summary of code changes for easier review. -->
when PermanentBlindnessComponent is removed, now set the minimum eye damage value of BlindableComponent to 0 - leaving the eyedamage value unchanged - allowing eye damage to be healed or rejuvenated (if it's preferable to have eyedamage to be set to 0 as well, that can easily be added)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

no cl no fun