### PR TITLE
Admins can now always see encryption keys details

### DIFF
--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared.Administration.Managers;
 using Content.Shared.Chat;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -23,6 +24,7 @@ namespace Content.Shared.Radio.EntitySystems;
 /// </summary>
 public sealed partial class EncryptionKeySystem : EntitySystem
 {
+    [Dependency] private readonly ISharedAdminManager _admin = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly INetManager _net = default!;
@@ -174,7 +176,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
 
     private void OnHolderExamined(EntityUid uid, EncryptionKeyHolderComponent component, ExaminedEvent args)
     {
-        if (!args.IsInDetailsRange)
+        if (!args.IsInDetailsRange && !_admin.IsAdmin(args.Examiner))
             return;
 
         if (component.KeyContainer.ContainedEntities.Count == 0)
@@ -199,7 +201,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
 
     private void OnKeyExamined(EntityUid uid, EncryptionKeyComponent component, ExaminedEvent args)
     {
-        if (!args.IsInDetailsRange)
+        if (!args.IsInDetailsRange && !_admin.IsAdmin(args.Examiner))
             return;
 
         if(component.Channels.Count > 0)


### PR DESCRIPTION
## About the PR
title

## Why / Balance
fix #20805 

## Media

https://github.com/user-attachments/assets/12efb3d4-a7e0-40f5-9995-2cc2fbd3f0f2

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

