### PR TITLE
Fix server crash when the seed extractor is used on the dev map

### DIFF
--- a/Content.Server/Botany/Systems/SeedExtractorSystem.cs
+++ b/Content.Server/Botany/Systems/SeedExtractorSystem.cs
@@ -38,6 +38,7 @@ public sealed class SeedExtractorSystem : EntitySystem
             args.User, PopupType.Medium);
 
         QueueDel(args.Used);
+        args.Handled = true;
 
         var amount = _random.Next(seedExtractor.BaseMinSeeds, seedExtractor.BaseMaxSeeds + 1);
         var coords = Transform(uid).Coordinates;


### PR DESCRIPTION
## About the PR
Attempting to use the seed extractor in the dev map would crash the server. This was resolved by marking the `InteractUsingEvent` as handled inside `SeedExtractorSystem`.

Also, thanks to Slartibartfast for walking me through this.

## Technical details
Added a line to `SeedExtractorSystem.OnInteractUsing` to make the event as handled. This prevents the `SharedInteractionSystem.InteractDoAfter` from attempting to access the plant item, which is been queued for deletion.
Since the check that the item isn't deleted is done using a `DebugTools.Assert`, this issue likely only affected the development server.

## Media
![carrot](https://github.com/user-attachments/assets/54bbcac2-5870-411b-aee9-24825feef91b)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
No changelog - minor bugfix.