### PR TITLE
Prevent Digiboard recycling

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -597,6 +597,9 @@
     damage:
       types:
         Blunt: 10
+  - type: Tag
+    tags:
+    - HighRiskItem
   - type: StealTarget
     stealGroup: BoxFolderQmClipboard
 

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -599,6 +599,7 @@
         Blunt: 10
   - type: Tag
     tags:
+    - Folder
     - HighRiskItem
   - type: StealTarget
     stealGroup: BoxFolderQmClipboard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Add the necessary tag to the requisition digi-board in order to prevent it from being recycled

## Why / Balance
Fix #33301 and prevent a high value target from being recycled

## Technical details
Adds the `HighRiskItem` tag to the requisition digi board to prevent it from being recycled

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The Quartermaster's requisition digi-board can no longer be recycled.
