### PR TITLE
Switches eject priority of pen and ID from PDA

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -30,7 +30,6 @@
         - PAI
     penSlot:
       startingItem: Pen
-      priority: -1
       whitelist:
         tags:
         - Write
@@ -38,6 +37,7 @@
       name: access-id-card-component-default
       ejectSound: /Audio/Machines/id_swipe.ogg
       insertSound: /Audio/Machines/id_insert.ogg
+      priority: -1
       whitelist:
         components:
         - IdCard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes it so that when you alt-click your PDA, you pull out the pen before you pull out the ID.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It feels more natural that a writing utensil would be more casually accessible than a workplace ID. Im hoping that by swapping them around, people will think about their pens more and maybe be more willing to leave notes and engage in some bureaucracy.

## Media
I have attached a video to respond to feedback concerning the ease of accessing an ID in a combat scenario. I understand this concern and wouldnt want to make a change that would disrupt combat, but I dont think that this change affects combat significantly. I think that stealing IDs mid-fight is a bit niche of a scenario to prioritize quality of life for over the general station gameplay experience.

https://github.com/user-attachments/assets/9c94e5fb-7577-4b10-92e3-7f856b6cf6fe

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: SpaceRox1244
- tweak: Pens now eject from PDAs before ID cards.
