### PR TITLE
fix EntityWhitelist causing huge performance drop

### DIFF
--- a/Content.Shared/Whitelist/EntityWhitelist.cs
+++ b/Content.Shared/Whitelist/EntityWhitelist.cs
@@ -44,8 +44,15 @@ public sealed partial class EntityWhitelist
     [DataField]
     public List<ProtoId<ItemSizePrototype>>? Sizes;
 
-    [NonSerialized, Access(typeof(EntityWhitelistSystem))]
-    public List<ComponentRegistration>? Registrations;
+    [NonSerialized]
+    private List<ComponentRegistration>? _registrations;
+
+    [Access(typeof(EntityWhitelistSystem))]
+    public List<ComponentRegistration>? Registrations
+    {
+        get => _registrations;
+        set => _registrations = value;
+    }
 
     /// <summary>
     ///     Tags that are allowed in the whitelist.

--- a/Content.Shared/Whitelist/EntityWhitelist.cs
+++ b/Content.Shared/Whitelist/EntityWhitelist.cs
@@ -44,15 +44,8 @@ public sealed partial class EntityWhitelist
     [DataField]
     public List<ProtoId<ItemSizePrototype>>? Sizes;
 
-    [NonSerialized]
-    private List<ComponentRegistration>? _registrations;
-
-    [Access(typeof(EntityWhitelistSystem))]
-    public List<ComponentRegistration>? Registrations
-    {
-        get => _registrations;
-        set => _registrations = value;
-    }
+    [NonSerialized, Access(typeof(EntityWhitelistSystem))]
+    public List<ComponentRegistration>? Registrations;
 
     /// <summary>
     ///     Tags that are allowed in the whitelist.

--- a/Content.Shared/Whitelist/EntityWhitelistSystem.cs
+++ b/Content.Shared/Whitelist/EntityWhitelistSystem.cs
@@ -12,11 +12,78 @@ public sealed class EntityWhitelistSystem : EntitySystem
     [Dependency] private readonly TagSystem _tag = default!;
 
     private EntityQuery<ItemComponent> _itemQuery;
+    private readonly Dictionary<string, (ComponentAvailability availability, ComponentRegistration? registration)> _componentCache = new();
 
     public override void Initialize()
     {
         base.Initialize();
         _itemQuery = GetEntityQuery<ItemComponent>();
+
+        foreach (var registration in _factory.GetAllRegistrations())
+        {
+            _componentCache[registration.Name] = (ComponentAvailability.Available, registration);
+        }
+    }
+
+    /// <summary>
+    /// Converts strings to registrations once and caches the result
+    /// </summary>
+    private void EnsureRegistrations(EntityWhitelist list)
+    {
+        // If we've already converted the Components, no need to do it again
+        if (list.Registrations != null)
+            return;
+
+        // Initialize registrations list
+        var capacity = (list.Components?.Length ?? 0) + (list.MindRoles?.Length ?? 0);
+        list.Registrations = new List<ComponentRegistration>(capacity);
+
+        // Process both component lists
+        ProcessNames(list.Components);
+        ProcessNames(list.MindRoles);
+        return;
+
+        void ProcessNames(string[]? names)
+        {
+            if (names == null)
+                return;
+
+            foreach (var name in names)
+            {
+                // Skip if we already know it's unknown (cached with null registration)
+                if (_componentCache.TryGetValue(name, out var cached))
+                {
+                    if (cached.registration != null && !list.Registrations.Contains(cached.registration))
+                    {
+                        list.Registrations.Add(cached.registration);
+                    }
+                    continue;
+                }
+
+                // First time seeing this component name
+                var availability = _factory.GetComponentAvailability(name);
+                ComponentRegistration? registration = null;
+
+                if (availability == ComponentAvailability.Available)
+                {
+                    _factory.TryGetRegistration(name, out registration);
+                }
+
+                else if (availability == ComponentAvailability.Unknown)
+                {
+                    // Only log unknown components once when we first see them
+                    Log.Error($"Unknown component name {name} passed to EntityWhitelist!");
+                }
+
+                // Cache the result (including nulls for unknown components)
+                _componentCache[name] = (availability, registration);
+
+                if (registration != null && !list.Registrations.Contains(registration))
+                {
+                    list.Registrations.Add(registration);
+                }
+            }
+        }
     }
 
     /// <inheritdoc cref="IsValid(Content.Shared.Whitelist.EntityWhitelist,Robust.Shared.GameObjects.EntityUid)"/>
@@ -47,21 +114,28 @@ public sealed class EntityWhitelistSystem : EntitySystem
     /// </summary>
     public bool IsValid(EntityWhitelist list, EntityUid uid)
     {
-        if (list.Components != null)
+        // Fast path for empty lists
+        if ((list.Components == null || list.Components.Length == 0) &&
+            (list.MindRoles == null || list.MindRoles.Length == 0) &&
+            (list.Tags == null || list.Tags.Count == 0) &&
+            (list.Registrations == null || list.Registrations.Count == 0) &&
+            list.Sizes == null)
         {
-            var regs = StringsToRegs(list.Components);
-
-            list.Registrations ??= new List<ComponentRegistration>();
-            list.Registrations.AddRange(regs);
+            return list.RequireAll;
         }
 
-        if (list.MindRoles != null)
-        {
-            var regs = StringsToRegs(list.MindRoles);
+        // Convert Components and MindRoles to Registrations
+        EnsureRegistrations(list);
 
-            foreach (var role in regs)
+        // Check mind roles first
+        if (list.MindRoles is { Length: > 0 })
+        {
+            foreach (var roleName in list.MindRoles)
             {
-                if ( _roles.MindHasRole(uid, role.Type, out _))
+                if (!_componentCache.TryGetValue(roleName, out var cached) || cached.registration == null)
+                    continue;
+
+                if (_roles.MindHasRole(uid, cached.registration.Type, out _))
                 {
                     if (!list.RequireAll)
                         return true;
@@ -71,6 +145,7 @@ public sealed class EntityWhitelistSystem : EntitySystem
             }
         }
 
+        // Check registrations
         if (list.Registrations != null && list.Registrations.Count > 0)
         {
             foreach (var reg in list.Registrations)
@@ -85,21 +160,35 @@ public sealed class EntityWhitelistSystem : EntitySystem
             }
         }
 
+        // Check sizes
         if (list.Sizes != null && _itemQuery.TryComp(uid, out var itemComp))
         {
             if (list.Sizes.Contains(itemComp.Size))
-                return true;
+            {
+                if (!list.RequireAll)
+                    return true;
+            }
+            else if (list.RequireAll)
+                return false;
         }
 
-        if (list.Tags != null)
-        {
-            return list.RequireAll
-                ? _tag.HasAllTags(uid, list.Tags)
-                : _tag.HasAnyTag(uid, list.Tags);
-        }
+        // Check tags
+        if (list.Tags == null)
+            return list.RequireAll;
+
+        var hasTag = list.RequireAll
+            ? _tag.HasAllTags(uid, list.Tags)
+            : _tag.HasAnyTag(uid, list.Tags);
+
+        if (!list.RequireAll && hasTag)
+            return true;
+
+        if (list.RequireAll && !hasTag)
+            return false;
 
         return list.RequireAll;
     }
+
     /// The following are a list of "helper functions" that are basically the same as each other
     /// to help make code that uses EntityWhitelist a bit more readable because at the moment
     /// it is quite clunky having to write out component.Whitelist == null ? true : _whitelist.IsValid(component.Whitelist, uid)
@@ -183,29 +272,5 @@ public sealed class EntityWhitelistSystem : EntitySystem
     public bool IsBlacklistFailOrNull(EntityWhitelist? blacklist, EntityUid uid)
     {
         return IsWhitelistFailOrNull(blacklist, uid);
-    }
-
-    private List<ComponentRegistration> StringsToRegs(string[]? input)
-    {
-        var list = new List<ComponentRegistration>();
-
-        if (input == null || input.Length == 0)
-            return list;
-
-        foreach (var name in input)
-        {
-            var availability = _factory.GetComponentAvailability(name);
-            if (_factory.TryGetRegistration(name, out var registration)
-                && availability == ComponentAvailability.Available)
-            {
-                list.Add(registration);
-            }
-            else if (availability == ComponentAvailability.Unknown)
-            {
-                Log.Error($"StringsToRegs failed: Unknown component name {name} passed to EntityWhitelist!");
-            }
-        }
-
-        return list;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
optimizes EntityWhitelistSystem by caching component registrations

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
EntityWhitelist would kill server performance the instant you had an entity with an invalid component name

from a trace:
- IsValid method: 98,960ms total time
- Dictionary FindValue: 25,376ms
- FrozenDictionary GetValueRefOrNullRefCore: 40,373ms

## Technical details
<!-- Summary of code changes for easier review. -->
1. component registration caching:
   - new `_componentCache` dict to store component availability and registration
   - cache initialized during system startup with all available registrations

2. improved registration handling:
   - added `EnsureRegistrations` method to convert strings to registrations once and cache results
   - removed redundant `StringsToRegs` method
   - registration lists are now built once and reused

3. optimized validation flow:
   - added fast path for empty lists
   - better structured RequireAll logic across all validation checks

<details><summary>You can test it yourself with this, just put it in Content.Shared:</summary>

```c#
using Content.Shared.Item;
using Content.Shared.Whitelist;
using Robust.Shared.Timing;

public sealed class WhitelistLagTestSystem : EntitySystem
{
    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
    [Dependency] private readonly IGameTiming _timing = default!;

    private EntityWhitelist? _problematicWhitelist;
    private const int EntityCount = 25;
    private bool _initialized;
    private TimeSpan _startTime;

    public override void Initialize()
    {
        base.Initialize();
        _startTime = _timing.CurTime;

        // Create whitelist but don't spawn entities yet
        _problematicWhitelist = new EntityWhitelist
        {
            Components = new[] { "MisspelledComponent", "AnotherTypo" },
            RequireAll = true,
        };
    }

    private void InitializeTest()
    {
        Log.Info("Starting whitelist lag test...");

        // Spawn test entities
        for (var i = 0; i < EntityCount; i++)
        {
            var ent = Spawn("MobHuman");
            AddComp<ItemComponent>(ent);
        }

        _initialized = true;
        Log.Info($"Whitelist lag test initialized with {EntityCount} entities");
    }

    public override void Update(float frameTime)
    {
        base.Update(frameTime);

        if (!_initialized && (_timing.CurTime - _startTime).TotalSeconds >= 15)
        {
            InitializeTest();
            return;
        }

        if (!_initialized)
            return;

        var query = EntityQueryEnumerator<ItemComponent>();
        while (query.MoveNext(out var uid, out _))
        {
            if (_problematicWhitelist != null)
                _whitelist.IsValid(_problematicWhitelist, uid);
        }
    }
}
```

</details>

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
*holy shit*
![image](https://github.com/user-attachments/assets/fc5f04d7-cc1d-478a-a67f-d4754f817cfd)

![image](https://github.com/user-attachments/assets/c0768dd6-a559-439a-b260-7ffcf699c1fa)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

no fun
