### PR TITLE
Fix auto-updates of RobustToolbox on Windows

### DIFF
--- a/BuildChecker/BuildChecker.csproj
+++ b/BuildChecker/BuildChecker.csproj
@@ -15,7 +15,6 @@ https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Python>python3</Python>
-    <Python Condition="'$(OS)'=='Windows_NT' Or '$(OS)'=='Windows'">py -3</Python>
     <ProjectGuid>{C899FCA4-7037-4E49-ABC2-44DE72487110}</ProjectGuid>
     <TargetFrameworkMoniker>.NETFramework, Version=v4.7.2</TargetFrameworkMoniker>
     <RestorePackages>false</RestorePackages>

--- a/BuildChecker/git_helper.py
+++ b/BuildChecker/git_helper.py
@@ -10,7 +10,7 @@ from typing import List
 
 SOLUTION_PATH = Path("..") / "SpaceStation14.sln"
 # If this doesn't match the saved version we overwrite them all.
-CURRENT_HOOKS_VERSION = "2"
+CURRENT_HOOKS_VERSION = "3"
 QUIET = len(sys.argv) == 2 and sys.argv[1] == "--quiet"
 
 

--- a/BuildChecker/hooks/post-checkout
+++ b/BuildChecker/hooks/post-checkout
@@ -4,10 +4,4 @@ gitroot=`git rev-parse --show-toplevel`
 
 cd "$gitroot/BuildChecker"
 
-if [[ `uname` == MINGW* || `uname` == CYGWIN* ]]; then
-    # Windows
-    py -3 git_helper.py --quiet
-else
-    # Not Windows, so probably some other Unix thing.
-    python3 git_helper.py --quiet
-fi
+python3 git_helper.py --quiet


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Same as https://github.com/space-wizards/space-station-14/pull/26017
But for BuildChecker.csproj

## Technical details
`py` was used as Python launcher for Windows for Python before 3.5 (inclusively). It's no longer the case and both `python` and `python3` work (`py` doesn't work). Python 3.5 reached end-of-life support in October 2020 (4 years ago).

## Testing
Repository compiles on Windows without any errors. Previously it contained a single error related to not being able to execute `py -3 git_helper.py` due to unexistence of `py`.

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

- tweak: developer infrastructure: auto-updating RobustToolbox now works on Windows