### PR TITLE
Chem master UI

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -228,11 +228,11 @@ namespace Content.Client.Chemistry.UI
                                     {
                                         Name = "colorPanel",
                                         VerticalExpand = true,
-                                        MinSize = new Vector2(4,8),
+                                        MinWidth = 4,
                                         PanelOverride = new StyleBoxFlat
-                                            {
+                                        {
                                             BackgroundColor = proto.SubstanceColor
-                                            },
+                                        },
                                         Margin = new Thickness(0,1)
                                         
                                     },
@@ -348,11 +348,11 @@ namespace Content.Client.Chemistry.UI
                             {
                                 Name = "colorPanel",
                                 VerticalExpand = true,
-                                MinSize = new Vector2(4,8),
+                                MinWidth = 4,
                                 PanelOverride = new StyleBoxFlat
                                 {
                                     BackgroundColor = proto.SubstanceColor
-                                            },
+                                },
                                 Margin = new Thickness(0,1)
                                         
                             },

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -311,10 +311,10 @@ namespace Content.Client.Chemistry.UI
         private Control BuildReagentRow(Color reagentColor, int rowCount, string name, ReagentId reagent, FixedPoint2 quantity, bool isBuffer, bool isOutput)
         {
             //Colors rows and sets fallback for reagentcolor to the same as background, this will hide colorPanel for entities hopefully
-            var rowColor1 = Color.FromHex("#202025");
-            var rowColor2 = Color.FromHex("#1B1B1E");
+            var rowColor1 = Color.FromHex("#1B1B1E");
+            var rowColor2 = Color.FromHex("#202025");
             var currentRowColor = (rowCount % 2 == 1) ? rowColor1 : rowColor2;
-            if (reagentColor == default(Color))
+            if ((reagentColor == default(Color))|(isOutput))
             {
                 reagentColor = currentRowColor;
             }

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -45,7 +45,7 @@ namespace Content.Client.Chemistry.UI
             PillTypeButtons = new Button[20];
             for (uint i = 0; i < PillTypeButtons.Length; i++)
             {
-                // For every button decide which StyleBase to have
+                // For every button decide which stylebase to have
                 // Every row has 10 buttons
                 String styleBase = StyleBase.ButtonOpenBoth;
                 uint modulo = i % 10;
@@ -184,7 +184,7 @@ namespace Content.Client.Chemistry.UI
             bufferHBox.AddChild(bufferVol); 
             
             // initialises count of loop for purposes of alternating background color each layer,
-            // also initialises the two color values for alternating in the buffer window.
+            // and also initialises the two color values for alternating in the buffer window.
 
             int layerCount = 0;
             Color layerColor1 = Color.FromHex("#202025");

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -168,6 +168,16 @@ namespace Content.Client.Chemistry.UI
             var bufferVolume = castState.BufferCurrentVolume?.Int() ?? 0;
 
             PillDosage.Value = (int)Math.Min(bufferVolume, castState.PillDosageLimit);
+            
+            PillTypeButtons[castState.SelectedPillType].Pressed = true;
+            PillNumber.IsValid = x => x >= 0 && x <= pillNumberMax;
+            PillDosage.IsValid = x => x > 0 && x <= castState.PillDosageLimit;
+            BottleDosage.IsValid = x => x >= 0 && x <= bottleAmountMax;
+
+            if (PillNumber.Value > pillNumberMax)
+                PillNumber.Value = pillNumberMax;
+            if (BottleDosage.Value > bottleAmountMax)
+                BottleDosage.Value = bottleAmountMax;
 
             // Avoid division by zero
             if (PillDosage.Value > 0)

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Utility;
 using System.Linq;
 using System.Numerics;
 using Content.Shared.FixedPoint;
+using Robust.Client.Graphics;
 using static Robust.Client.UserInterface.Controls.BoxContainer;
 
 namespace Content.Client.Chemistry.UI
@@ -44,7 +45,7 @@ namespace Content.Client.Chemistry.UI
             PillTypeButtons = new Button[20];
             for (uint i = 0; i < PillTypeButtons.Length; i++)
             {
-                // For every button decide which stylebase to have
+                // For every button decide which StyleBase to have
                 // Every row has 10 buttons
                 String styleBase = StyleBase.ButtonOpenBoth;
                 uint modulo = i % 10;
@@ -180,38 +181,63 @@ namespace Content.Client.Chemistry.UI
                 Text = $"{state.BufferCurrentVolume}u",
                 StyleClasses = {StyleNano.StyleClassLabelSecondaryColor}
             };
-            bufferHBox.AddChild(bufferVol);
+            bufferHBox.AddChild(bufferVol); 
+            
+            // initialises count of loop for purposes of alternating background color each layer,
+            // also initialises the two color values for alternating in the buffer window.
 
+            int layerCount = 0;
+            Color layerColor1 = Color.FromHex("#202025");
+            Color layerColor2 = Color.FromHex("#1B1B1E");
             foreach (var (reagent, quantity) in state.BufferReagents)
             {
                 // Try to get the prototype for the given reagent. This gives us its name.
                 _prototypeManager.TryIndex(reagent.Prototype, out ReagentPrototype? proto);
                 var name = proto?.LocalizedName ?? Loc.GetString("chem-master-window-unknown-reagent-text");
-
+                
+               
                 if (proto != null)
                 {
-                    BufferInfo.Children.Add(new BoxContainer
+                    // Iterate layerCount and then set backgroundColor accordingly.
+                    layerCount++;
+                    Color currentLayerColor = (layerCount % 2 == 1) ? layerColor1 : layerColor2;
+                    
+                    BufferInfo.Children.Add(new PanelContainer
                     {
-                        Orientation = LayoutOrientation.Horizontal,
+                        // Applies a color tint to the current reagent row
+                        PanelOverride = new StyleBoxFlat(currentLayerColor),
                         Children =
                         {
-                            new Label {Text = $"{name}: "},
-                            new Label
+                            new BoxContainer
                             {
-                                Text = $"{quantity}u",
-                                StyleClasses = {StyleNano.StyleClassLabelSecondaryColor}
-                            },
+                                Orientation = LayoutOrientation.Horizontal,
+                                Children =
+                                {
+                                    new Label { Text = $"{name}: " },
+                                    new Label
+                                    {
+                                        Text = $"{quantity}u",
+                                        StyleClasses = { StyleNano.StyleClassLabelSecondaryColor }
+                                    },
 
-                            // Padding
-                            new Control {HorizontalExpand = true},
-
-                            MakeReagentButton("1", ChemMasterReagentAmount.U1, reagent, true, StyleBase.ButtonOpenRight),
-                            MakeReagentButton("5", ChemMasterReagentAmount.U5, reagent, true, StyleBase.ButtonOpenBoth),
-                            MakeReagentButton("10", ChemMasterReagentAmount.U10, reagent, true, StyleBase.ButtonOpenBoth),
-                            MakeReagentButton("25", ChemMasterReagentAmount.U25, reagent, true, StyleBase.ButtonOpenBoth),
-                            MakeReagentButton("50", ChemMasterReagentAmount.U50, reagent, true, StyleBase.ButtonOpenBoth),
-                            MakeReagentButton("100", ChemMasterReagentAmount.U100, reagent, true, StyleBase.ButtonOpenBoth),
-                            MakeReagentButton(Loc.GetString("chem-master-window-buffer-all-amount"), ChemMasterReagentAmount.All, reagent, true, StyleBase.ButtonOpenLeft),
+                                    // Padding
+                                    new Control { HorizontalExpand = true },
+                                    // Provides a Unicode "medium vertical bar" and colors it based on the reagent.
+                                    new Label
+                                    {
+                                        Text = "\u2759",
+                                        Modulate = proto.SubstanceColor
+                                    },
+                                    
+                                    MakeReagentButton("1", ChemMasterReagentAmount.U1, reagent, true, StyleBase.ButtonOpenRight),
+                                    MakeReagentButton("5", ChemMasterReagentAmount.U5, reagent, true, StyleBase.ButtonOpenBoth),
+                                    MakeReagentButton("10", ChemMasterReagentAmount.U10, reagent, true, StyleBase.ButtonOpenBoth),
+                                    MakeReagentButton("25", ChemMasterReagentAmount.U25, reagent, true, StyleBase.ButtonOpenBoth),
+                                    MakeReagentButton("50", ChemMasterReagentAmount.U50, reagent, true, StyleBase.ButtonOpenBoth),
+                                    MakeReagentButton("100", ChemMasterReagentAmount.U100, reagent, true, StyleBase.ButtonOpenBoth),
+                                    MakeReagentButton(Loc.GetString("chem-master-window-buffer-all-amount"), ChemMasterReagentAmount.All, reagent, true, StyleBase.ButtonOpenLeft),
+                                }
+                            }
                         }
                     });
                 }

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -222,14 +222,21 @@ namespace Content.Client.Chemistry.UI
 
                                     // Padding
                                     new Control { HorizontalExpand = true },
-                                    // Provides a Unicode "medium vertical bar" and colors it based on the reagent.
-                                    new Label
+                                    // Colored panels for reagents, and invocation of proto to choose the correct color.
+                                    new PanelContainer
                                     {
-                                        Text = "\u2759",
-                                        Modulate = proto.SubstanceColor
+                                        Name = "colorPanel",
+                                        VerticalExpand = true,
+                                        MinSize = new Vector2(4,8),
+                                        PanelOverride = new StyleBoxFlat
+                                            {
+                                            BackgroundColor = proto.SubstanceColor
+                                            },
+                                        Margin = new Thickness(0,1)
+                                        
                                     },
                                     
-                                    MakeReagentButton("1", ChemMasterReagentAmount.U1, reagent, true, StyleBase.ButtonOpenRight),
+                                    MakeReagentButton("1", ChemMasterReagentAmount.U1, reagent, true, StyleBase.ButtonOpenBoth),
                                     MakeReagentButton("5", ChemMasterReagentAmount.U5, reagent, true, StyleBase.ButtonOpenBoth),
                                     MakeReagentButton("10", ChemMasterReagentAmount.U10, reagent, true, StyleBase.ButtonOpenBoth),
                                     MakeReagentButton("25", ChemMasterReagentAmount.U25, reagent, true, StyleBase.ButtonOpenBoth),


### PR DESCRIPTION
## About the PR
Added striped rows, as well as a small reagent colored bar for each reagent to the Chem Master buffer and input buffer UI.

Left side of Chem Master Buffer Buttons have been made into plain rectangles, in order to look better with the new colored bars.

Pill and bottle dosages in the output tab will now default to the largest valid value, rather than zero.

## Why / Balance
This should not have an appreciable effect on game balance, but it should make the eyes of myself and other chemists very happy, and should make using Chem Masters to actually make pills slightly more tolerable.

## Technical details
Not counting comments, and lines that seem to have been counted as additions because they were moved slightly, this PR contains probably less than 10 lines of novel code. 

Edit: Changing the input buffer was more involved, and much was restructured, still not a large change, and limited to the one xaml.cs

Edit2: The vast majority of the file has now been desecrated in one manner or another.

## Media!
Visuals as of latest commit:
![ChemMasterInuputUICommit](https://github.com/user-attachments/assets/337840a3-76e2-4cef-95c7-4103ed2389fd)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
It is my fondest hope that this breaks absolutely nothing.

**Changelog**