### PR TITLE
Edited Snow White reaction to output proper amount of drink.

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -953,7 +953,7 @@
     LemonLime:
       amount: 1
   products:
-    SnowWhite: 3
+    SnowWhite: 2
 
 - type: reaction
   id: SodaWater


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The drink Snow White uses 1 part Beer, 1 part Lemon-Lime, and makes 3 parts Snow White. I fixed it to make 2 parts Snow White.

## Why / Balance
This was clearly just a typo and was annoying to deal with when mixing the drink in a metamorphic glass as it would cause an overflow and spill the mix onto the floor.

## Technical details
I changed the products line of the Snow White in drinks.yml to be a 2 instead of a 3.

## Media
Not necessary.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I do not believe this breaks anything.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Mixing up a Snow White no longer creates extra liquid out of thin air.
