### PR TITLE
Adds an introductory message to the user-facing ahelp chat window

### DIFF
--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -572,6 +572,10 @@ public sealed class UserAHelpUIHandler : IAHelpUIHandler
         _window.OnClose += () => { OnClose?.Invoke(); };
         _window.OnOpen += () => { OnOpen?.Invoke(); };
         _window.Contents.AddChild(_chatPanel);
+
+        var introText = Loc.GetString("bwoink-system-introductory-message");
+        var introMessage = new SharedBwoinkSystem.BwoinkTextMessage( _ownerId, SharedBwoinkSystem.SystemUserId, introText);
+        Receive(introMessage);
     }
 
     public void Dispose()

--- a/Resources/Locale/en-US/administration/bwoink.ftl
+++ b/Resources/Locale/en-US/administration/bwoink.ftl
@@ -3,8 +3,14 @@ bwoink-user-title = Admin Message
 bwoink-system-starmute-message-no-other-users = *System: Nobody is available to receive your message. Try pinging Game Admins on Discord.
 
 bwoink-system-messages-being-relayed-to-discord =
-    Your messages are being relayed to the admins via Discord.
+    All messages are being relayed to admins via Discord.
     Issues may be handled without a response.
+
+bwoink-system-introductory-message =
+    Please explain issues. Assume admins know nothing about them.
+    Do not ask for events or request bans of other players.
+    Please report bugs and other game issues through Discord or the Github.
+    Misuse of the Admin Message system may result in a ban.
 
 bwoink-system-typing-indicator = {$players} {$count ->
 [one] is

--- a/Resources/Locale/en-US/administration/bwoink.ftl
+++ b/Resources/Locale/en-US/administration/bwoink.ftl
@@ -7,10 +7,10 @@ bwoink-system-messages-being-relayed-to-discord =
     Issues may be handled without a response.
 
 bwoink-system-introductory-message =
-    Please explain issues. Assume admins know nothing about them.
-    Do not ask for events or request bans of other players.
-    Please report bugs and other game issues through Discord or the Github.
-    Misuse of the Admin Message system may result in a ban.
+    Please describe the issue that you have encountered in detail. Assume that the game administrator who is resolving the problem does not have first-hand knowledge of what has occurred.
+    Please do not ask for special events or punishments for other players.
+    Any bugs and other related issues should be reported through Discord or Github.
+    Misuse of this message system may result in disciplinary action.
 
 bwoink-system-typing-indicator = {$players} {$count ->
 [one] is

--- a/Resources/Locale/en-US/administration/bwoink.ftl
+++ b/Resources/Locale/en-US/administration/bwoink.ftl
@@ -3,7 +3,7 @@ bwoink-user-title = Admin Message
 bwoink-system-starmute-message-no-other-users = *System: Nobody is available to receive your message. Try pinging Game Admins on Discord.
 
 bwoink-system-messages-being-relayed-to-discord =
-    All messages are being relayed to admins via Discord.
+    All messages are relayed to game administrators via Discord.
     Issues may be handled without a response.
 
 bwoink-system-introductory-message =


### PR DESCRIPTION
## About the PR
This PR is made at the request of admins. This adds a very straight-forward introductory message to the user-facing ahelp chat window instructing users to, in customer support terms, remember that admins are not omniscient beings. This is a basic step to mitigate some of the admin workload related to ahelps, as this is a fairly prevalent issue caused by the simple lack of reminders for a button that's predominantly only pressed in a state of panic or other strong emotion.

This originates from a conversation in adminchat, and our proposal we whipped up in a few minutes ended up with getting a stamp of approval from the team. 

## Why / Balance
Read above! Admin request!

## Technical details
This just slaps an extra bit into the init of the user-facing ahelp dialogue that injects a system message containing the introductory text. Nothing too fancy, not particularly engineered, just taking the straight-forward if-it-works-it-works approach.

## Media
Here's how ahelps will now look when being messaged by an admin (the introductory message will appear upon the very first time the admin message window is opened):
![image](https://github.com/user-attachments/assets/c950a969-5360-4a15-b551-5b81d2cbd607)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
For codebases with localizations to other languages: be sure to define `bwoink-system-introductory-message` in your equivalent to `administration/bwoink.ftl`. This message gets displayed as the very first message in the ahelp dialogue window.

**Changelog**
:cl: Bhijn and Myr
- add: The Admin Message system now contains an introductory message as the very first message shown to a user, before any messages are written or received. This message serves primarily to remind ahelping players (whom are likely to be experiencing strong emotion) to remember that admins are humans, too.
