### PR TITLE
Throwing Knife description tweak

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -269,7 +269,7 @@
   name: throwing knife
   parent: [BaseKnife, BaseSyndicateContraband]
   id: ThrowingKnife
-  description: This bloodred knife is very aerodynamic and easy to throw, but good luck trying to fight someone hand-to-hand.
+  description: This blood-red knife is very aerodynamic and easy to throw, but good luck trying to fight someone hand-to-hand.
   components:
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Tweaked description of the throwing knife item.

## Why
It previously used 'bloodred' to describe its color, which doesn't match the naming convention of all other 'blood-red' items.

## Technical details
Line 272 in 'knife.yml', changed "bloodred" to "blood-red"

## Media
OLD
![image](https://github.com/user-attachments/assets/a820f293-d5c0-45ae-8eff-1ac7aa1c9f22)
NEW
![image](https://github.com/user-attachments/assets/bcab853e-7d2f-4fb4-807d-df481431ce9d)
REFERENCE
![image](https://github.com/user-attachments/assets/9179de00-82b0-4910-9f1f-d594a26299ac)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->