### PR TITLE
Fixed Jazz Instrument for Electric Guitars

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
@@ -8,8 +8,8 @@
     program: 27
   - type: SwappableInstrument
     instrumentList:
-      "Jazz": {26: 0}
       "Clean": {27: 0}
+      "Jazz": {26: 0}
       "Muted": {28: 0}
   - type: Sprite
     sprite: Objects/Fun/Instruments/eguitar.rsi

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
@@ -8,8 +8,8 @@
     program: 27
   - type: SwappableInstrument
     instrumentList:
+      "Jazz": {26: 0}
       "Clean": {27: 0}
-      "Jazz": {25: 0}
       "Muted": {28: 0}
   - type: Sprite
     sprite: Objects/Fun/Instruments/eguitar.rsi


### PR DESCRIPTION
## About the PR
Made the Electric Guitar sound different to the Steel version when on the Jazz intrument mode. 

## Why / Balance
Possible Bug or Typo fix.

## Technical details
Edited instruments_string.yml and rearranged it numerically. Set the Jazz from byte 25 to 26 (it sounds more jazzy, I assume it was meant to be that)

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: The "Jazz" style for the Electric Guitar now uses the correct soundfont.
