### PR TITLE
Welded secret doors no longer say they are welded shut.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -37,6 +37,7 @@
   - type: Appearance
   - type: Weldable
     time: 2
+    weldedExamineMessage: null
   - type: Airtight
   - type: Damageable
     damageContainer: StructuralInorganic


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When examining a welded secret door it no longer says "It is welded shut".

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Secret doors are basically a joke with how easy they are to figure out, even if they are welded it doesnt stop someone from examining walls in a location cause they saw an odd room on the station map.
This gives a bit of a higher chance of not being found as easily.

## Technical details
<!-- Summary of code changes for easier review. -->
Set the weldedExamineMessage to nothing.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
See? Even you can't tell whether its a secret door or a wall now.
![image](https://github.com/user-attachments/assets/78c6821c-b02f-4575-9132-bccf651d43dd)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Secret doors no longer tell you if they're welded shut on examine.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
