### PR TITLE
making the sawn-off minor contraband

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -181,7 +181,7 @@
 
 - type: entity
   name: sawn-off shotgun
-  parent: BaseWeaponShotgun
+  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseMinorContraband]
   id: WeaponShotgunSawn
   description: Groovy! Uses .50 shotgun shells.
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The sawn off is now minor contraband, matching the double-barrel

## Why / Balance
 Cutting off part of the barrel of the shotgun does not make it less lethal, and should not make it an innocuous item. If a tider steals a DB and cuts it, it shouldn't suddenly become ok for them to have it. Requested in (https://github.com/space-wizards/space-station-14/issues/31047)

## Technical details
 Changed the YAML to inherit BaseMinorContraband as a parent

## Media
![image](https://github.com/user-attachments/assets/215a4745-a0a2-4b30-b07f-da1ac4e8299f)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!--
:cl:
- fix: Sawn-off shotgun is now properly marked as minor contra.
-->
