### PR TITLE
Coloured Light Cost Reduction

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/watergun.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: WeaponWaterGunBase
   abstract: true
   parent: BaseItem
@@ -71,7 +71,7 @@
   id: WeaponWaterBlaster
   parent: WeaponWaterGunBase
   name: water blaster
-  description: With this bad boy, you'll be the cooleste kid at the summer barbecue.
+  description: With this bad boy, you'll be the coolest kid at the summer barbecue.
   components:
   - type: Gun
     cameraRecoilScalar: 0 #no recoil

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/lighting.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/lighting.yml
@@ -28,7 +28,7 @@
         - to: icon
           steps:
             - material: Glass
-              amount: 2
+              amount: 1
               doAfter: 1
             - tag: CrystalBlue
               name: blue crystal shard
@@ -48,7 +48,7 @@
         - to: icon
           steps:
             - material: Glass
-              amount: 2
+              amount: 1
               doAfter: 1
             - tag: CrystalPink
               name: pink crystal shard
@@ -68,7 +68,7 @@
         - to: icon
           steps:
             - material: Glass
-              amount: 2
+              amount: 1
               doAfter: 1
             - tag: CrystalOrange
               name: orange crystal shard
@@ -88,7 +88,7 @@
         - to: icon
           steps:
             - material: Glass
-              amount: 2
+              amount: 1
               doAfter: 1
             - tag: CrystalRed
               name: red crystal shard
@@ -108,7 +108,7 @@
         - to: icon
           steps:
             - material: Glass
-              amount: 2
+              amount: 1
               doAfter: 1
             - tag: CrystalGreen
               name: green crystal shard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reduced the costs of the craftable coloured lights by one piece of glass.

## Why / Balance
The cyan light fixture was mistakenly only one piece of glass, while the other colours were two. However, after comparing the two glass cost and one coloured crystal of a coloured light fixture to the 0.5 glass and 0.5 steel cost for a normal light fixture, I decided it made sense to make the coloured lights cheaper. 
For the normal light fixture recipe, I assume the glass cost is for the structure of the light, and the steel cost is for the electronics that produce light. For the coloured lights, I assume the glass cost is also for the structure, and the crystal cost is for the light source. An extra 0.5 glass for the coloured lights seem more reasonable than the extra 1.5 glass cost.

## Media
![image](https://github.com/user-attachments/assets/70634500-cf57-45b8-a7d1-d1147709ca1a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->



**Changelog**
:cl:
- tweak: Reduced crafting costs of colored light tubes.
