### PR TITLE
Trim trailing newlines from examine messages

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -385,7 +385,7 @@ namespace Content.Shared.Examine
                     totalMessage.PushNewline();
             }
 
-            totalMessage.TrimTrailingNewlines();
+            totalMessage.TrimEnd();
 
             return totalMessage;
         }

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -385,6 +385,8 @@ namespace Content.Shared.Examine
                     totalMessage.PushNewline();
             }
 
+            totalMessage.TrimTrailingNewlines();
+
             return totalMessage;
         }
 


### PR DESCRIPTION
## About the PR
Trims trailing newlines from examine messages to avoid inconsistent blank line pop-in after the server response is received.

## Why / Balance
The inconsistent pop-in is meaningless and annoying.

## Technical details
Requires https://github.com/space-wizards/RobustToolbox/pull/5524

## Media

| | Before | After |
| - | - | -
| Radio (no change) | ![image](https://github.com/user-attachments/assets/cc120efb-b4d8-419f-9a6a-9620906430f2) | ![image](https://github.com/user-attachments/assets/cea056e9-5ca3-4eda-8b72-341d23ce8bd5)
| Water tank (server-side blank line from empty group) | ![image](https://github.com/user-attachments/assets/4b59958f-4fe1-4456-ac38-76e5e14a9ce0) | ![image](https://github.com/user-attachments/assets/0242174e-f693-4683-9e86-466ae426ad5d)
| Circuit imprinter (server-side blank line from maintenance panel component) | ![image](https://github.com/user-attachments/assets/bbbdd5ee-5912-4cb6-81bb-3f93b48bb5f6) | ![image](https://github.com/user-attachments/assets/ac969a3b-202e-48ee-9b9d-4cc524924864)
| Human (client-side blank line) | ![image](https://github.com/user-attachments/assets/44b302ce-7ce5-4a8d-abd5-1410a37b0fe8) | ![image](https://github.com/user-attachments/assets/02989d3e-5667-4bdb-bfd0-708885b457d1)


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
