### PR TITLE
Dim light bulbs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -151,6 +151,23 @@
     - Trash
 
 - type: entity
+  parent: BaseLightbulb
+  name: dim light bulb
+  id: DimLightBulb
+  description: A dim light bulb for populating the darkness of maintenance.
+  components:
+  - type: LightBulb
+    bulb: Bulb
+    color: "#ba473f"
+    lightEnergy: 0.5
+    lightRadius: 5
+    lightSoftness: 3
+  - type: Tag
+    tags:
+    - LightBulb
+    - Trash
+
+- type: entity
   parent: LightBulb
   name: old incandescent light bulb
   id: LightBulbOld

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -347,6 +347,27 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  id: PoweredDimSmallLight
+  suffix: Dim
+  parent: PoweredSmallLightEmpty
+  components:
+  - type: Sprite
+    state: base
+  - type: PointLight
+    enabled: true
+    radius: 5
+    energy: 0.5
+    softness: 3
+    color: "#ba473f"
+  - type: PoweredLight
+    hasLampOnSpawn: DimLightBulb
+  - type: DamageOnInteract
+    damage:
+      types:
+        Heat: 1
+    popupText: powered-light-component-burn-hand
+
+- type: entity
   id: PoweredSmallLight
   suffix: ""
   parent: PoweredSmallLightEmpty

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -150,6 +150,7 @@
       - ExteriorLightTube
       - LightBulb
       - LedLightBulb
+      - DimLightBulb
       - Bucket
       - DrinkMug
       - DrinkMugMetal

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -53,6 +53,15 @@
     Glass: 50
 
 - type: latheRecipe
+  id: DimLightBulb
+  result: DimLightBulb
+  category: Lights
+  completetime: 2
+  materials:
+    Steel: 50
+    Glass: 50
+
+- type: latheRecipe
   id: GlowstickRed
   result: GlowstickRed
   category: Lights


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Mostly PR'd this for mapping sake, but gave a source of renewability so you can now print these bulbs. Ideally they should be scattered in maintenance replacing the main light sources, but can be used in other run-down areas as well.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/6c700e3b-1a19-427c-a153-6d8c02dac088)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: Ubaser
- add: You can now craft dim light bulbs at an autolathe.