### PR TITLE
improve GetInStation filter

### DIFF
--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -234,14 +234,14 @@ public sealed class StationSystem : EntitySystem
                 !xformQuery.TryGetComponent(gridUid, out var gridXform))
                 continue;
 
-            var worldRotation = _transform.GetWorldRotation(gridXform, xformQuery);
+            var (worldPos, worldRot) = _transform.GetWorldPositionRotation(gridXform);
             var localBounds = grid.LocalAABB.Enlarged(range);
 
             // Create a rotated box using the grid's transform
             var rotatedBounds = new Box2Rotated(
                 localBounds,
-                worldRotation,
-                _transform.GetWorldPosition(gridXform, xformQuery));
+                worldRot,
+                worldPos);
 
             gridBounds.Add((rotatedBounds, gridXform.MapID));
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
actually checks if you're on the station now, and if not, it checks if you're in the specified range
fixes https://github.com/DeltaV-Station/Delta-v/issues/2228

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bug fix

## Technical details
<!-- Summary of code changes for easier review. -->
removed the initial bounds collection pass and now build bounds only when needed
added a transform parent traversal to check if players are directly on station grids


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no fun