### PR TITLE
Added two N2 lockers to Reach

### DIFF
--- a/Resources/Maps/reach.yml
+++ b/Resources/Maps/reach.yml
@@ -6038,11 +6038,6 @@ entities:
     - type: Transform
       pos: 4.5,-8.5
       parent: 2
-  - uid: 881
-    components:
-    - type: Transform
-      pos: 5.5,-8.5
-      parent: 2
   - uid: 882
     components:
     - type: Transform
@@ -6058,12 +6053,24 @@ entities:
     - type: Transform
       pos: -16.5,6.5
       parent: 2
-- proto: ClosetFireFilled
+- proto: ClosetEmergencyN2FilledRandom
   entities:
+  - uid: 881
+    components:
+    - type: Transform
+      pos: 5.5,-8.5
+      parent: 2
   - uid: 885
     components:
     - type: Transform
       pos: 11.5,13.5
+      parent: 2
+- proto: ClosetFireFilled
+  entities:
+  - uid: 1739
+    components:
+    - type: Transform
+      pos: 12.5,11.5
       parent: 2
 - proto: ClosetJanitorFilled
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added two pre-filled N2 lockers, one replacing an existing O2 locker, another fully added alongside an O2 and fire locker, to the map Reach, to allow N2 breathers to have emergency breathing supplies.

## Why / Balance
Addressing issue #33329, obvious interest for any species that breathes N2 and not O2. Only a single O2 locker was swapped out, in a place where there were two to keep a good amount of O2 canisters on the map.

## Media
![Reach-0](https://github.com/user-attachments/assets/347e35f8-b678-48ca-88b8-85a360dee94f)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
