### PR TITLE
Fix security riot crate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -19,6 +19,16 @@
   group: market
 
 - type: cargoProduct
+  id: SecurityRiot
+  icon:
+    sprite: Clothing/OuterClothing/Armor/riot.rsi
+    state: icon
+  product: CrateSecurityRiot
+  cost: 7500
+  category: cargoproduct-category-name-armory
+  group: market
+
+- type: cargoProduct
   id: TrackingImplant
   icon:
     sprite: Objects/Specific/Medical/implanter.rsi

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -29,16 +29,6 @@
   group: market
 
 - type: cargoProduct
-  id: SecurityRiot
-  icon:
-    sprite: Clothing/OuterClothing/Armor/riot.rsi
-    state: icon
-  product: CrateSecurityRiot
-  cost: 7500
-  category: cargoproduct-category-name-security
-  group: market
-
-- type: cargoProduct
   id: SecuritySupplies
   icon:
     sprite: Objects/Storage/boxes.rsi

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -69,3 +69,22 @@
       amount: 2
     - id: MagazinePistol
       amount: 4
+
+- type: entity
+  id: CrateSecurityRiot
+  parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
+  name: swat crate
+  description: Contains two sets of riot armor, helmets, shields, and enforcers loaded with beanbags. Extra ammo is included. Requires Armory access to open.
+  components:
+  - type: StorageFill
+    contents:
+    - id: ClothingOuterArmorRiot
+      amount: 2
+    - id: ClothingHeadHelmetRiot
+      amount: 2
+    - id: WeaponShotgunEnforcerRubber
+      amount: 2
+    - id: BoxBeanbag
+      amount: 2
+    - id: RiotShield
+      amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/security.yml
@@ -39,26 +39,6 @@
 #      - GrenadeTeargas
 
 - type: entity
-  id: CrateSecurityRiot
-  parent: CrateSecgear
-  name: swat crate
-  description: Contains two sets of riot armor, helmets, shields, and enforcers loaded with beanbags. Extra ammo is included. Requires Armory access to open.
-  components:
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterArmorRiot
-        amount: 2
-      - id: ClothingHeadHelmetRiot
-        amount: 2
-      - id: WeaponShotgunEnforcerRubber
-        amount: 2
-      - id: BoxBeanbag
-        amount: 2
-      - id: RiotShield
-        amount: 2
-#      - SecGasmask
-
-- type: entity
   id: CrateSecuritySupplies
   parent: CrateSecgear
   name: security supplies crate


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Riot crate was moved from the security category to the armory category, it now requires armory access to unlock as indicated by its old description. Previously it only required security access.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
IT WAS WRONG

## Technical details
<!-- Summary of code changes for easier review. -->
yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/8177cc0c-2238-47e1-a772-52a033e654ab)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The SWAT crate from cargo now requires armory access to open.