### PR TITLE
Makes admins not count towards the playercount cap

### DIFF
--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
+using Content.Server.Administration.Managers;
 using Content.Server.Chat.Managers;
 using Content.Server.Database;
 using Content.Server.GameTicking;
@@ -56,6 +57,7 @@ namespace Content.Server.Connection
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly IChatManager _chatManager = default!;
+        [Dependency] private readonly IAdminManager _adminManager = default!;
 
         private ISawmill _sawmill = default!;
         private readonly Dictionary<NetUserId, TimeSpan> _temporaryBypasses = [];
@@ -265,7 +267,14 @@ namespace Content.Server.Connection
                             ticker.PlayerGameStatuses.TryGetValue(userId, out var status) &&
                             status == PlayerGameStatus.JoinedGame;
             var adminBypass = _cfg.GetCVar(CCVars.AdminBypassMaxPlayers) && adminData != null;
-            if ((_plyMgr.PlayerCount >= _cfg.GetCVar(CCVars.SoftMaxPlayers) && !adminBypass) && !wasInGame)
+            var softPlayerCount = _plyMgr.PlayerCount;
+
+            if (!_cfg.GetCVar(CCVars.AdminsCountForMaxPlayers))
+            {
+                softPlayerCount -= _adminManager.ActiveAdmins.Count();
+            }
+
+            if ((softPlayerCount >= _cfg.GetCVar(CCVars.SoftMaxPlayers) && !adminBypass) && !wasInGame)
             {
                 return (ConnectionDenyReason.Full, Loc.GetString("soft-player-cap-full"), null);
             }
@@ -282,7 +291,7 @@ namespace Content.Server.Connection
 
                 foreach (var whitelist in _whitelists)
                 {
-                    if (!IsValid(whitelist, _plyMgr.PlayerCount))
+                    if (!IsValid(whitelist, softPlayerCount))
                     {
                         // Not valid for current player count.
                         continue;

--- a/Content.Shared/CCVar/CCVars.Admin.cs
+++ b/Content.Shared/CCVar/CCVars.Admin.cs
@@ -150,6 +150,15 @@ public sealed partial class CCVars
         CVarDef.Create("admin.bypass_max_players", true, CVar.SERVERONLY);
 
     /// <summary>
+    ///     Determines whether admins count towards the total playercount when determining whether the server is over <see cref="SoftMaxPlayers"/>
+    ///     Ideally this should be used in conjuction with <see cref="AdminBypassPlayers"/>.
+	///     ///     This also applies to playercount limits in whitelist conditions
+	///     If false, then admins will not be considered when checking whether the playercount is already above the soft player cap
+    /// </summary>
+    public static readonly CVarDef<bool> AdminsCountForMaxPlayers =
+        CVarDef.Create("admin.admins_count_for_max_players", false, CVar.SERVERONLY);
+
+    /// <summary>
     ///     Determine if custom rank names are used.
     ///     If it is false, it'd use the actual rank name regardless of the individual's title.
     /// </summary>

--- a/Content.Shared/CCVar/CCVars.Admin.cs
+++ b/Content.Shared/CCVar/CCVars.Admin.cs
@@ -152,7 +152,7 @@ public sealed partial class CCVars
     /// <summary>
     ///     Determines whether admins count towards the total playercount when determining whether the server is over <see cref="SoftMaxPlayers"/>
     ///     Ideally this should be used in conjuction with <see cref="AdminBypassPlayers"/>.
-	///     ///     This also applies to playercount limits in whitelist conditions
+	///     This also applies to playercount limits in whitelist conditions
 	///     If false, then admins will not be considered when checking whether the playercount is already above the soft player cap
     /// </summary>
     public static readonly CVarDef<bool> AdminsCountForMaxPlayers =

--- a/Content.Shared/CCVar/CCVars.Admin.cs
+++ b/Content.Shared/CCVar/CCVars.Admin.cs
@@ -152,8 +152,8 @@ public sealed partial class CCVars
     /// <summary>
     ///     Determines whether admins count towards the total playercount when determining whether the server is over <see cref="SoftMaxPlayers"/>
     ///     Ideally this should be used in conjuction with <see cref="AdminBypassPlayers"/>.
-	///     This also applies to playercount limits in whitelist conditions
-	///     If false, then admins will not be considered when checking whether the playercount is already above the soft player cap
+    ///     This also applies to playercount limits in whitelist conditions
+    ///     If false, then admins will not be considered when checking whether the playercount is already above the soft player cap
     /// </summary>
     public static readonly CVarDef<bool> AdminsCountForMaxPlayers =
         CVarDef.Create("admin.admins_count_for_max_players", false, CVar.SERVERONLY);


### PR DESCRIPTION
## About the PR
This is a straight-forward PR, making it so that admins don't count towards the playercount cap. This is controlled by the new `admin.admins_count_for_max_players` cvar

## Why / Balance
Currently, admins bypass the playercount cap entirely, meaning it's very common to see the servers end up escalating beyond their actual playercount cap. This means that when an admin joins while the server's at the cap, players have to wait for way longer than necessary for more than just one person to leave if they want to join the server, which is immensely frustrating for players. Simple fix: making it so that those who are able to bypass the playercount cap don't count towards it either.

## Technical details
This adds a new CVar controlling whether admins count towards the playercount cap (if true, then it behaves exactly how the playercount cap behaved before).

When that CVar is false, the number of active admins gets subtracted from the current playercount during connection checks that care about the playercount.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**

:cl: Bhijn and Myr
- tweak: Admins no longer count towards the playercount cap, meaning you no longer need to wait for multiple people to leave in order to join after an admin has joined.
