### PR TITLE
Fix dev server crashes caused by putting pills in drinks, depsiting spesos, making burgers

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -62,6 +62,7 @@ namespace Content.Server.Cargo.Systems
             _audio.PlayPvs(component.ConfirmSound, uid);
             UpdateBankAccount(stationUid.Value, bank, (int) price);
             QueueDel(args.Used);
+            args.Handled = true;
         }
 
         private void OnInit(EntityUid uid, CargoOrderConsoleComponent orderConsole, ComponentInit args)

--- a/Content.Server/Nutrition/EntitySystems/FoodSequenceSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSequenceSystem.cs
@@ -39,7 +39,7 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
     private void OnInteractUsing(Entity<FoodSequenceStartPointComponent> ent, ref InteractUsingEvent args)
     {
         if (TryComp<FoodSequenceElementComponent>(args.Used, out var sequenceElement))
-            TryAddFoodElement(ent, (args.Used, sequenceElement), args.User);
+            args.Handled = TryAddFoodElement(ent, (args.Used, sequenceElement), args.User);
     }
 
     private void OnIngredientAdded(Entity<FoodMetamorphableByAddingComponent> ent, ref FoodSequenceIngredientAddedEvent args)

--- a/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
@@ -24,23 +24,18 @@ public sealed class SolutionSpikerSystem : EntitySystem
         SubscribeLocalEvent<RefillableSolutionComponent, InteractUsingEvent>(OnInteractUsing);
     }
 
-    private void OnInteractUsing(Entity<RefillableSolutionComponent> entity, ref InteractUsingEvent args)
-    {
-        TrySpike(args.Used, args.Target, args.User, entity.Comp);
-    }
-
     /// <summary>
     ///     Immediately transfer all reagents from this entity, to the other entity.
     ///     The source entity will then be acted on by TriggerSystem.
     /// </summary>
-    /// <param name="source">Source of the solution.</param>
-    /// <param name="target">Target to spike with the solution from source.</param>
-    /// <param name="user">User spiking the target solution.</param>
-    private void TrySpike(EntityUid source, EntityUid target, EntityUid user, RefillableSolutionComponent? spikableTarget = null,
-        SolutionSpikerComponent? spikableSource = null,
-        SolutionContainerManagerComponent? managerSource = null,
-        SolutionContainerManagerComponent? managerTarget = null)
+    private void OnInteractUsing(Entity<RefillableSolutionComponent> entity, ref InteractUsingEvent args)
     {
+        var (source, target, user) = (args.Used, args.Target, args.User);
+        SolutionSpikerComponent? spikableSource = null;
+        var spikableTarget = entity.Comp;
+        SolutionContainerManagerComponent? managerSource = null;
+        SolutionContainerManagerComponent? managerTarget = null;
+
         if (!Resolve(source, ref spikableSource, ref managerSource, false)
             || !Resolve(target, ref spikableTarget, ref managerTarget, false)
             || !_solution.TryGetRefillableSolution((target, spikableTarget, managerTarget), out var targetSoln, out var targetSolution)
@@ -60,6 +55,7 @@ public sealed class SolutionSpikerSystem : EntitySystem
 
         _popup.PopupClient(Loc.GetString(spikableSource.Popup, ("spiked-entity", target), ("spike-entity", source)), user, user);
         sourceSolution.RemoveAllSolution();
+
         if (spikableSource.Delete)
             QueueDel(source);
     }

--- a/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
@@ -57,6 +57,9 @@ public sealed class SolutionSpikerSystem : EntitySystem
         sourceSolution.RemoveAllSolution();
 
         if (spikableSource.Delete)
+        {
             QueueDel(source);
+            args.Handled = true;
+        }
     }
 }


### PR DESCRIPTION
## About the PR
Several interactions that delete the in-hand item didn't mark the triggering even as handled, leading to the debug server crashing. This fixes that issue for adding pills to a solution, depositing spesos into the cargo console, and adding ingredients to a custom burger. There's probably other cases of this bug that still need to be fixed.

This PR is basically just https://github.com/space-wizards/space-station-14/issues/33316 applied to another three systems.

## Technical details
- Combined the `TrySpike` and `OnInteractUsing` functions in `SolutionSpikerSystem`, since `OnInteractUsing` was a trivial wrapper and `TrySpike` wasn't used anywhere else.
- Added `Handled = true` to `SolutionSpikerSystem.OnInteractUsing`, though only when the spiking item is actauly removed. There aren't any cases in the game where that item *isn't* deleted, so I'm not 100% sure what the correct behavior would be in that case.
- Added `Handled = true` to `CargoSystem.OnInteractUsing`.
- Assigned the return value of `TryAddFoodElement` to `Handled` in `SharedFoodSequenceSystem.OnInteractUsing`. 

## Media
![burger](https://github.com/user-attachments/assets/69ec9d50-716a-49ba-8c1a-0c211dfc8585)
![lobbying](https://github.com/user-attachments/assets/32a8c9cd-eda4-4d1a-a10b-748a42604073)
![spike](https://github.com/user-attachments/assets/912addc6-020b-45b7-83ae-88020b445ebf)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
No changelog - minor bugfixes.
