### PR TITLE
Fix salvage vendor inventory

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -154,7 +154,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockSalvageEquipmentFilled
-  cost: 1000
+  cost: 1500
   category: cargoproduct-category-name-engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -2,11 +2,11 @@
   id: SalvageEquipmentInventory
   startingInventory:
     Crowbar: 2
-    Pickaxe: 4
+    Pickaxe: 2
     OreBag: 4
     Flare: 4
     FlashlightLantern: 2
-    HandheldGPSBasic: 4
-    RadioHandheld: 4
+    HandheldGPSBasic: 2
+    RadioHandheld: 2
     WeaponGrapplingGun: 4
     WeaponProtoKineticAccelerator: 4

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -3,10 +3,10 @@
   startingInventory:
     Crowbar: 2
     Pickaxe: 4
-    OreBag: 2
+    OreBag: 4
     Flare: 4
     FlashlightLantern: 2
-    HandheldGPSBasic: 2
-    RadioHandheld: 2
-    WeaponGrapplingGun: 2
+    HandheldGPSBasic: 4
+    RadioHandheld: 4
+    WeaponGrapplingGun: 4
     WeaponProtoKineticAccelerator: 4

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -2,7 +2,7 @@
   id: SalvageEquipmentInventory
   startingInventory:
     Crowbar: 2
-    Pickaxe: 2
+    Pickaxe: 4
     OreBag: 4
     Flare: 4
     FlashlightLantern: 2


### PR DESCRIPTION
## About the PR
Salvagers were not provided with enough ore bags or grappling hooks. This PR changes the salvage vendor to have enough for all 3 salvagers

## Why / Balance
The changes made the the salvage vendor did not take into account all maps have 3 salvagers. One salvager would be sitting not helping due to not having an ore bag in particular.

## Technical details
Increased grappling hook and ore bag amount from 2 to 4

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: The salvage vendor now has enough equipment for everyone
