### PR TITLE
Remove steel sheet hull fixing

### DIFF
--- a/Content.IntegrationTests/Tests/Tiles/TileConstructionTests.cs
+++ b/Content.IntegrationTests/Tests/Tiles/TileConstructionTests.cs
@@ -82,7 +82,7 @@ public sealed class TileConstructionTests : InteractionTest
         AssertGridCount(1);
 
         // Lattice -> Plating
-        await InteractUsing(Steel);
+        await InteractUsing(FloorItem);
         Assert.That(Hands.ActiveHandEntity, Is.Null);
         await AssertTile(Plating);
         AssertGridCount(1);

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -56,9 +56,6 @@
   - type: Item
     heldPrefix: steel
   - type: Appearance
-  - type: FloorTile
-    outputs:
-    - Plating
   - type: Extractable
     grindableSolutionName: steel
   - type: SolutionContainerManager


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes the steel sheets to not be able to place down Plating (base hull tiles)

## Why / Balance
It's unintuitive that it's wasteful, there's not really any systems to NOT make it wasteful, and it's a UX trap. No this is not "noob trap", no. It's an UX issue because if hundreds of people do it over and over again without noticing anything wrong, well, something fails to properly note that there's an issue with what they are doing. Aka user experience issue. Aka not a problem with the user but the design.

Also could be a shitty doafter action that makes you wonder if something's wrong

Personally: I hate this PR and I think we need to fix the part where people avoid the crafting and building menus. Yes, building menus have an issue too. Otherwise people wouldn't be building walls with RCD all the time. "Ran out of materials" might be a common reason, but I suspect a lot of people just never *discover* the damn menu until someone yells at them - which sprinkles an already awful UX sandwich with potential community interaction issues. Because who the hell would be happy to be told that the action they thought was fine and intuitive is actually "bad", or in some cases that can be directed at the player.

So yeah. This PR kinda sucks. I wish I could just fix the UX. The amount of work for that is enormous. For now we can at least axe this whole "feature" to avoid people fighting over "being wasteful"/etc. Because with current system there's **ZERO** discovery on player side that this perfectly quick action they can do is, in fact, not optimal. No messaging at all. No feedback.

Axe the feature, don't blame the people for using it.

## Technical details
YAML

## Media
Imagine a video of an engineer failing to use steel sheets on a lattice here

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- remove: Steel sheets no longer have unintuitively wasteful plating placement that can be done with steel tiles instead
