### PR TITLE
Change MaskComponent to accommodate sprites namings

### DIFF
--- a/Content.Shared/Clothing/Components/MaskComponent.cs
+++ b/Content.Shared/Clothing/Components/MaskComponent.cs
@@ -20,8 +20,11 @@ public sealed partial class MaskComponent : Component
     [DataField, AutoNetworkedField]
     public bool IsToggled;
 
+    /// <summary>
+    /// Equipped prefix to use after the mask was pulled down.
+    /// </summary>
     [DataField, AutoNetworkedField]
-    public string EquippedPrefix = "toggled";
+    public string EquippedPrefix = "up";
 
     /// <summary>
     /// When <see langword="true"/> will function normally, otherwise will not react to events


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title.

## Why / Balance
All of the sprites use up- prefix for their pulled down sprites. Fixes #30701.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/5c4a6ca0-27ee-498e-b53b-11404c294def

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑
- add: Some masks can now be seen when pulled down.