### PR TITLE
Add build configuration for clean-build

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,6 +22,24 @@
             "problemMatcher": "$msCompile"
         },
         {
+            "label": "clean-build",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "--no-incremental",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:'ForceNoAlign;NoSummary'"
+            ],
+            "group": {
+                "kind": "build"
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
             "label": "build-yaml-linter",
             "command": "dotnet",
             "type": "process",


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds `clean-build` task for VS Code which starts build from scratch. Useful if you want to regenerate all warnings outputted by compiler.

## Technical details
Same as `build` but `isDefault: false` and has extra `--no-incremental` option.
See information about this option here:
https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build#:~:text=specified%20root%20project.-,%2D%2Dno%2Dincremental,-Marks%20the%20build

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it **does not require an ingame showcase**.