### PR TITLE
Adjust inventory size of ginormous scrap

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -37,7 +37,9 @@
       - state: metal-1
         map: [ "base" ]
   - type: Item
-    size: Ginormous
+    size: Large
+    shape:
+    - 0,0,4,4 # 5x5
     heldPrefix: metal
   - type: MultiHandedItem
   - type: RandomSprite
@@ -95,7 +97,9 @@
         junk-airlock-1: ""
         junk-airlock-2: ""
   - type: Item
-    size: Ginormous
+    size: Large
+    shape:
+    - 0,0,4,4 # 5x5
     heldPrefix: "airlock"
   - type: MultiHandedItem
   - type: PhysicalComposition
@@ -233,7 +237,9 @@
     layers:
     - state: junk-firelock-1
   - type: Item
-    size: Ginormous
+    size: Large
+    shape:
+    - 0,0,4,4 # 5x5
     heldPrefix: firelock-1
   - type: MultiHandedItem
   - type: PhysicalComposition
@@ -250,7 +256,9 @@
     layers:
     - state: junk-firelock-2
   - type: Item
-    size: Ginormous
+    size: Large
+    shape:
+    - 0,0,4,4 # 5x5
     heldPrefix: firelock-2
   - type: MultiHandedItem
   - type: PhysicalComposition


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes salvage scrap that is currently "ginormous" to be "large" so that they can fit in grid inventories. Gives them a defined size so that it can have interactions with a bag of holding.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The bag of holding is kind of a novelty item that never really sees any real application because of its late-game availability and expensive material cost and is mostly just mildly entertaining because upgrades are stimulating, but forget all that- 

All of the salvage scrap should be able to fit in a bag of holding so that it could hypothetically have a salvage use. If all major scrap items do not fit in a bag of holding, then a salvager still needs to drag a crate, and so the upgrade fails to change the gameplay experience.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![big scrap](https://github.com/user-attachments/assets/689e83c6-ca07-486b-93d3-7e2eef95cc15)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: SpaceRox1244
- tweak: Massive scrap can now fit in bags of holding.
