### PR TITLE
Add telegram to the server info-links

### DIFF
--- a/Content.Client/Info/LinkBanner.cs
+++ b/Content.Client/Info/LinkBanner.cs
@@ -34,6 +34,7 @@ namespace Content.Client.Info
             AddInfoButton("server-info-website-button", CCVars.InfoLinksWebsite);
             AddInfoButton("server-info-wiki-button", CCVars.InfoLinksWiki);
             AddInfoButton("server-info-forum-button", CCVars.InfoLinksForum);
+            AddInfoButton("server-info-telegram-button", CCVars.InfoLinksTelegram);
 
             var guidebookController = UserInterfaceManager.GetUIController<GuidebookUIController>();
             var guidebookButton = new Button() { Text = Loc.GetString("server-info-guidebook-button") };

--- a/Content.Server/ServerInfo/ServerInfoManager.cs
+++ b/Content.Server/ServerInfo/ServerInfoManager.cs
@@ -13,11 +13,12 @@ public sealed class ServerInfoManager
     private static readonly (CVarDef<string> cVar, string icon, string name)[] Vars =
     {
         // @formatter:off
-        (CCVars.InfoLinksDiscord, "discord", "info-link-discord"),
-        (CCVars.InfoLinksForum,   "forum",   "info-link-forum"),
-        (CCVars.InfoLinksGithub,  "github",  "info-link-github"),
-        (CCVars.InfoLinksWebsite, "web",     "info-link-website"),
-        (CCVars.InfoLinksWiki,    "wiki",    "info-link-wiki")
+        (CCVars.InfoLinksDiscord,  "discord",  "info-link-discord"),
+        (CCVars.InfoLinksForum,    "forum",    "info-link-forum"),
+        (CCVars.InfoLinksGithub,   "github",   "info-link-github"),
+        (CCVars.InfoLinksWebsite,  "web",      "info-link-website"),
+        (CCVars.InfoLinksWiki,     "wiki",     "info-link-wiki"),
+        (CCVars.InfoLinksTelegram, "telegram", "info-link-telegram")
         // @formatter:on
     };
 

--- a/Content.Shared/CCVar/CCVars.Game.Infolinks.cs
+++ b/Content.Shared/CCVar/CCVars.Game.Infolinks.cs
@@ -51,4 +51,10 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<string> InfoLinksAppeal =
         CVarDef.Create("infolinks.appeal", "", CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    ///     Link to Telegram channel to show in the launcher.
+    /// </summary>
+    public static readonly CVarDef<string> InfoLinksTelegram =
+        CVarDef.Create("infolinks.telegram", "", CVar.SERVER | CVar.REPLICATED);
 }

--- a/Resources/Locale/en-US/info/server-info.ftl
+++ b/Resources/Locale/en-US/info/server-info.ftl
@@ -4,5 +4,6 @@ server-info-discord-button = Discord
 server-info-website-button = Website
 server-info-wiki-button = Wiki
 server-info-forum-button = Forum
+server-info-telegram-button = Telegram
 server-info-report-button = Report Bugs
 server-info-credits-button = Credits

--- a/Resources/Locale/en-US/server-info/info-links.ftl
+++ b/Resources/Locale/en-US/server-info/info-links.ftl
@@ -5,3 +5,4 @@ info-link-forum = Forum
 info-link-github = GitHub
 info-link-website = Website
 info-link-wiki = Wiki
+info-link-telegram = Telegram


### PR DESCRIPTION
## About the PR

Adds config variable for the telegram link in the server list on the hub.

Perhaps it should be merged after the launcher is updated, because right now there's no icon.

## Why / Balance

There's already a telegram icon in the launcher https://github.com/space-wizards/SS14.Launcher/commit/373bf9c056d60a80e7128312a4d0b0ceb528ab01 , so I think it should also be in the server code.

## Technical details
Just copied all forum's info-link related parts.

## Media

![image](https://github.com/user-attachments/assets/b92f3f55-aa54-4670-a117-345fd6eca08e)
(Right now without icon, because launcher hasn't been updated yet)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
Not required
