### PR TITLE
Fix Disposals Ejections

### DIFF
--- a/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
@@ -137,10 +137,10 @@ namespace Content.Server.Disposal.Unit.EntitySystems
                     _xformSystem.AttachToGridOrMap(entity, xform);
                     var direction = holder.CurrentDirection == Direction.Invalid ? holder.PreviousDirection : holder.CurrentDirection;
 
-                    if (direction != Direction.Invalid && _xformQuery.TryGetComponent(gridUid, out var parentXform))
+                    if (direction != Direction.Invalid && _xformQuery.TryGetComponent(gridUid, out var gridXform))
                     {
                         var directionAngle = direction.ToAngle();
-                        directionAngle += _xformSystem.GetWorldRotation(parentXform);
+                        directionAngle += _xformSystem.GetWorldRotation(gridXform);
                         _throwing.TryThrow(entity, directionAngle.ToWorldVec() * 3f, 10f);
                     }
                 }

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
@@ -135,12 +135,13 @@ namespace Content.Server.Disposal.Unit.EntitySystems
                 else
                 {
                     _xformSystem.AttachToGridOrMap(entity, xform);
+                    var direction = holder.CurrentDirection == Direction.Invalid ? holder.PreviousDirection : holder.CurrentDirection;
 
-                    if (holder.PreviousDirection != Direction.Invalid && _xformQuery.TryGetComponent(xform.ParentUid, out var parentXform))
+                    if (direction != Direction.Invalid && _xformQuery.TryGetComponent(gridUid, out var parentXform))
                     {
-                        var direction = holder.PreviousDirection.ToAngle();
-                        direction += _xformSystem.GetWorldRotation(parentXform);
-                        _throwing.TryThrow(entity, direction.ToWorldVec() * 3f, 10f);
+                        var directionAngle = direction.ToAngle();
+                        directionAngle += _xformSystem.GetWorldRotation(parentXform);
+                        _throwing.TryThrow(entity, directionAngle.ToWorldVec() * 3f, 10f);
                     }
                 }
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Disposals had two issues:
1. It did not respect the direction of a bend if it was the last piece in the disposals pipe.
2. The ejection would use the transform of the map instead of the one from the grid and throw into the wrong direction.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Closes #31459, probably.

## Technical details
<!-- Summary of code changes for easier review. -->
DisposableSystem.cs's ExitDisposals now uses CurrentDirection to eject/throw people, unless CurrentDirection is equal to Direction.Invalid in which case it'll use PreviousDirection.
It also uses the grid's xform instead of the parent's, to better handle from-grid ejections rather than from-map.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Old behavior:
https://github.com/user-attachments/assets/bc819d34-cc27-41a9-85b4-02af36476a2a

New behavior:
https://github.com/user-attachments/assets/cadd65a2-1913-4be3-ae2f-a7f166da64bc
https://github.com/user-attachments/assets/6f42ead3-fd6d-4e1c-9ccd-3a6ff21a92a0

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
