### PR TITLE
Firearm Description Accuracy Fix

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -2,7 +2,7 @@
   id: CrateArmorySMG
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: SMG crate
-  description: Contains two high-powered, semiautomatic rifles with four mags. Requires Armory access to open.
+  description: Contains two high-powered, automatic carbines with four extra magazines. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:
@@ -15,7 +15,7 @@
   id: CrateArmoryShotgun
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: shotgun crate
-  description: For when the enemy absolutely needs to be replaced with lead. Contains two Enforcer Combat Shotguns, and some standard shotgun shells. Requires Armory access to open.
+  description: For when the enemy absolutely needs to be replaced with lead. Contains two Enforcer Shotguns, and three pellet shell boxes. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:
@@ -74,7 +74,7 @@
   id: CrateSecurityRiot
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: swat crate
-  description: Contains two sets of riot armor, helmets, shields, and enforcers loaded with beanbags. Extra ammo is included. Requires Armory access to open.
+  description: Contains two sets of riot armor, helmets, shields, and Enforcers loaded with beanbags. Two beanbag shell boxes are included. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -2,7 +2,7 @@
   id: CrateArmorySMG
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: SMG crate
-  description: Contains two high-powered, automatic carbines with four extra magazines. Requires Armory access to open.
+  description: Contains two WT550 submachine guns and four top-mounted magazines. Requires Armory access to open.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -138,7 +138,7 @@
   name: Enforcer
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseRestrictedContraband]
   id: WeaponShotgunEnforcer
-  description: A premium combat shotgun based on the Kammerer design, featuring an upgraded clip capacity. .50 shotgun shells.
+  description: A premium combat shotgun based on the Kammerer platform, featuring an upgraded tube capacity. Uses .50 shotgun shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi


### PR DESCRIPTION
## About the PR
Firearm descriptions (mostly shotguns) have been updated to be more term-accurate to actual firearms.

## Why / Balance
It makes me want to rip my eyes out every time I see the description of the enforcer

## Media

Before
![image](https://github.com/user-attachments/assets/dc146be8-510b-4e5e-a5af-e1c8cf4a656e)
![image](https://github.com/user-attachments/assets/e6f031a3-aa25-428c-acec-39e7c0c0de8e)
![image](https://github.com/user-attachments/assets/61acc820-4eb2-401a-b236-28247d009354)

After
![image](https://github.com/user-attachments/assets/e8d71e00-efd7-4d1e-9166-6a1c1b2ac046)
![image](https://github.com/user-attachments/assets/4e97bff5-306f-4e6a-9faa-56deaaab2128)
![image](https://github.com/user-attachments/assets/ce0cfa7d-3100-47bc-9e9c-b0ecd0790309)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Various firearm descriptions have been updated to be more accurate. Additionally, cargo weapon crates now state the amount of extra ammunition included.
