### PR TITLE
Don't show drag-drop outline if climbing

### DIFF
--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -151,6 +151,10 @@ public sealed partial class ClimbSystem : VirtualController
         if (args.Handled)
             return;
 
+        // If already climbing then don't show outlines.
+        if (TryComp(args.Dragged, out ClimbingComponent? climbing) && climbing.IsClimbing)
+            return;
+
         var canVault = args.User == args.Dragged
             ? CanVault(component, args.User, uid, out _)
             : CanVault(component, args.User, args.Dragged, uid, out _);


### PR DESCRIPTION
It won't actually do anything.

:cl:
- tweak: Drag-drop outline no longer shows the vaulting outlines if you're vaulting.