### PR TITLE
Add delay to AutoOrient

### DIFF
--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -5,6 +5,12 @@ namespace Content.Shared.CCVar;
 public sealed partial class CCVars
 {
     /// <summary>
+    ///     Delay for auto-orientation. Used for people arriving via arrivals.
+    /// </summary>
+    public static readonly CVarDef<double> AutoOrientDelay =
+        CVarDef.Create("shuttle.auto_orient_delay", 2.0, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
     ///     If true then the camera will match the grid / map and is unchangeable.
     ///     - When traversing grids it will snap to 0 degrees rotation.
     ///     False means the player has control over the camera rotation.

--- a/Content.Shared/Movement/Components/AutoOrientComponent.cs
+++ b/Content.Shared/Movement/Components/AutoOrientComponent.cs
@@ -5,8 +5,9 @@ namespace Content.Shared.Movement.Components;
 /// <summary>
 /// Automatically rotates eye upon grid traversals.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class AutoOrientComponent : Component
 {
-
+    [DataField, AutoNetworkedField, AutoPausedField]
+    public TimeSpan? NextChange;
 }

--- a/Content.Shared/Movement/Systems/AutoOrientSystem.cs
+++ b/Content.Shared/Movement/Systems/AutoOrientSystem.cs
@@ -1,0 +1,51 @@
+using Content.Shared.CCVar;
+using Content.Shared.Movement.Components;
+using Robust.Shared.Configuration;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.Movement.Systems;
+
+public sealed class AutoOrientSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _cfgManager = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedMoverController _mover = default!;
+
+    private TimeSpan _delay = TimeSpan.Zero;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<AutoOrientComponent, EntParentChangedMessage>(OnEntParentChanged);
+
+        Subs.CVar(_cfgManager, CCVars.AutoOrientDelay, OnAutoOrient, true);
+    }
+
+    private void OnAutoOrient(double obj)
+    {
+        _delay = TimeSpan.FromSeconds(obj);
+    }
+
+    private void OnEntParentChanged(Entity<AutoOrientComponent> ent, ref EntParentChangedMessage args)
+    {
+        ent.Comp.NextChange = _timing.CurTime + _delay;
+        Dirty(ent);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<AutoOrientComponent>();
+
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.NextChange <= _timing.CurTime)
+            {
+                comp.NextChange = null;
+                Dirty(uid, comp);
+                _mover.ResetCamera(uid);
+            }
+        }
+    }
+}

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -57,8 +57,6 @@ namespace Content.Shared.Movement.Systems
             SubscribeLocalEvent<InputMoverComponent, ComponentHandleState>(OnMoverHandleState);
             SubscribeLocalEvent<InputMoverComponent, EntParentChangedMessage>(OnInputParentChange);
 
-            SubscribeLocalEvent<AutoOrientComponent, EntParentChangedMessage>(OnAutoParentChange);
-
             SubscribeLocalEvent<FollowedComponent, EntParentChangedMessage>(OnFollowedParentChange);
 
             Subs.CVar(_configManager, CCVars.CameraRotationLocked, obj => CameraRotationLocked = obj, true);
@@ -145,11 +143,6 @@ namespace Content.Shared.Movement.Systems
         public bool DiagonalMovementEnabled { get; private set; }
 
         protected virtual void HandleShuttleInput(EntityUid uid, ShuttleButtons button, ushort subTick, bool state) {}
-
-        private void OnAutoParentChange(Entity<AutoOrientComponent> entity, ref EntParentChangedMessage args)
-        {
-            ResetCamera(entity.Owner);
-        }
 
         public void RotateCamera(EntityUid uid, Angle angle)
         {


### PR DESCRIPTION
It functions identically to how V1 of orientation worked and it's incredibly annoying.

Fixes https://github.com/space-wizards/space-station-14/issues/19721

:cl:
- tweak: The auto-orientation when showing up on the arrivals shuttle now has a delay to it.
