### PR TITLE
Fix door animations mispredicting if closing is interrupted

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -200,6 +200,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 break;
         }
 
+        Log.Debug($"Set door state to: {state}");
         door.State = state;
         Dirty(uid, door);
         RaiseLocalEvent(uid, new DoorStateChangedEvent(state));
@@ -461,17 +462,17 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!Resolve(uid, ref door, ref physics))
             return false;
 
-        door.Partial = true;
-
         // Make sure no entity walked into the airlock when it started closing.
         if (!CanClose(uid, door))
         {
             door.NextStateChange = GameTiming.CurTime + door.OpenTimeTwo;
-            door.State = DoorState.Opening;
-            AppearanceSystem.SetData(uid, DoorVisuals.State, DoorState.Opening);
+            door.State = DoorState.Open;
+            AppearanceSystem.SetData(uid, DoorVisuals.State, DoorState.Open);
+            Dirty(uid, door);
             return false;
         }
 
+        door.Partial = true;
         SetCollidable(uid, true, door, physics);
         door.NextStateChange = GameTiming.CurTime + door.CloseTimeTwo;
         Dirty(uid, door);


### PR DESCRIPTION
On master it will flicker states a little bit partially due to it not being predicted.

Instead we'll just set it straight back to opening (no animation is ever played anyway).

Resolves https://github.com/space-wizards/space-station-14/issues/33480

:cl:
- fix: Fix airlock animations mispredicting if the closing animation is interrupted, e.g. via walking into it.