### PR TITLE
Make storage implant drop items on gibbing

### DIFF
--- a/Content.Server/Implants/ImplantedSystem.cs
+++ b/Content.Server/Implants/ImplantedSystem.cs
@@ -25,9 +25,9 @@ public sealed partial class ImplanterSystem
         _container.CleanContainer(component.ImplantContainer);
     }
 
-    private void OnGibbed(EntityUid uid, ImplantedComponent component, BeingGibbedEvent args)
+    private void OnGibbed(Entity<ImplantedComponent> ent, ref BeingGibbedEvent args)
     {
         //If the entity is gibbed, get rid of the implants
-        _container.CleanContainer(component.ImplantContainer);
+        _container.CleanContainer(ent.Comp.ImplantContainer);
     }
 }

--- a/Content.Server/Implants/ImplantedSystem.cs
+++ b/Content.Server/Implants/ImplantedSystem.cs
@@ -1,14 +1,19 @@
-﻿using Content.Shared.Implants.Components;
+using Content.Server.Body.Components;
+using Content.Shared.Implants;
+using Content.Shared.Implants.Components;
 using Robust.Shared.Containers;
 
 namespace Content.Server.Implants;
 
 public sealed partial class ImplanterSystem
 {
+    [Dependency] private readonly SharedSubdermalImplantSystem _sharedSubdermal = default!;
+
     public void InitializeImplanted()
     {
         SubscribeLocalEvent<ImplantedComponent, ComponentInit>(OnImplantedInit);
         SubscribeLocalEvent<ImplantedComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<ImplantedComponent, BeingGibbedEvent>(OnGibbed);
     }
 
     private void OnImplantedInit(EntityUid uid, ImplantedComponent component, ComponentInit args)
@@ -21,5 +26,10 @@ public sealed partial class ImplanterSystem
     {
         //If the entity is deleted, get rid of the implants
         _container.CleanContainer(component.ImplantContainer);
+    }
+
+    private void OnGibbed(EntityUid uid, ImplantedComponent component, BeingGibbedEvent args)
+    {
+        _sharedSubdermal.WipeImplants(uid);
     }
 }

--- a/Content.Server/Implants/ImplantedSystem.cs
+++ b/Content.Server/Implants/ImplantedSystem.cs
@@ -1,5 +1,4 @@
 using Content.Server.Body.Components;
-using Content.Shared.Implants;
 using Content.Shared.Implants.Components;
 using Robust.Shared.Containers;
 
@@ -7,8 +6,6 @@ namespace Content.Server.Implants;
 
 public sealed partial class ImplanterSystem
 {
-    [Dependency] private readonly SharedSubdermalImplantSystem _sharedSubdermal = default!;
-
     public void InitializeImplanted()
     {
         SubscribeLocalEvent<ImplantedComponent, ComponentInit>(OnImplantedInit);
@@ -30,6 +27,7 @@ public sealed partial class ImplanterSystem
 
     private void OnGibbed(EntityUid uid, ImplantedComponent component, BeingGibbedEvent args)
     {
-        _sharedSubdermal.WipeImplants(uid);
+        //If the entity is gibbed, get rid of the implants
+        _container.CleanContainer(component.ImplantContainer);
     }
 }

--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs;
 using Content.Shared.Tag;
-using Content.Shared.Throwing;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
@@ -22,7 +21,6 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly TagSystem _tag = default!;
-    [Dependency] private readonly ThrowingSystem _throwingSystem = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
 
     public const string BaseStorageId = "storagebase";
@@ -93,11 +91,6 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
         foreach (var entity in containedEntites)
         {
             _transformSystem.DropNextTo(entity, uid);
-
-            _throwingSystem.TryThrow(entity,
-                _random.NextAngle().RotateVec(direction / dropAngle + worldRotation / 50),
-                0.5f * dropAngle * _random.NextFloat(-0.9f, 1.1f),
-                uid, 0);
         }
     }
 

--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
@@ -7,17 +7,13 @@ using Content.Shared.Tag;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
-using Robust.Shared.Physics.Components;
-using Robust.Shared.Random;
 using System.Linq;
-using System.Numerics;
 
 namespace Content.Shared.Implants;
 
 public abstract class SharedSubdermalImplantSystem : EntitySystem
 {
     [Dependency] private readonly INetManager _net = default!;
-    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly TagSystem _tag = default!;

--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
@@ -76,8 +76,6 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
         if (!_container.TryGetContainer(uid, BaseStorageId, out var storageImplant))
             return;
 
-        var entCoords = Transform(component.ImplantedEntity.Value).Coordinates;
-
         var containedEntites = storageImplant.ContainedEntities.ToArray();
 
         foreach (var entity in containedEntites)

--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
@@ -84,10 +84,6 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
 
         var containedEntites = storageImplant.ContainedEntities.ToArray();
 
-        var direction = EntityManager.TryGetComponent(uid, out PhysicsComponent? comp) ? comp.LinearVelocity / 50 : Vector2.Zero;
-        var dropAngle = _random.NextFloat(0.8f, 1.2f);
-        var worldRotation = _transformSystem.GetWorldRotation(uid).ToVec();
-
         foreach (var entity in containedEntites)
         {
             _transformSystem.DropNextTo(entity, uid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title.

## Why / Balance
No more items round removing using storage implant. Resolves #25524.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/02375f14-9027-488f-b3e2-1ec0b0a4dbab

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Now items from the storage implant drop on the floor upon gibbing of the owner.