### PR TITLE
Names camera routers

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/surveillance_camera_routers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/surveillance_camera_routers.yml
@@ -48,6 +48,7 @@
 - type: entity
   parent: SurveillanceCameraRouterBase
   id: SurveillanceCameraRouterEngineering
+  name: engineering camera router
   suffix: Engineering
   components:
     - type: SurveillanceCameraRouter
@@ -56,6 +57,7 @@
 - type: entity
   parent: SurveillanceCameraRouterBase
   id: SurveillanceCameraRouterSecurity
+  name: security camera router
   suffix: Security
   components:
     - type: SurveillanceCameraRouter
@@ -64,6 +66,7 @@
 - type: entity
   parent: SurveillanceCameraRouterBase
   id: SurveillanceCameraRouterScience
+  name: science camera router
   suffix: Science
   components:
     - type: SurveillanceCameraRouter
@@ -72,6 +75,7 @@
 - type: entity
   parent: SurveillanceCameraRouterBase
   id: SurveillanceCameraRouterSupply
+  name: supply camera router
   suffix: Supply
   components:
     - type: SurveillanceCameraRouter
@@ -80,6 +84,7 @@
 - type: entity
   parent: SurveillanceCameraRouterBase
   id: SurveillanceCameraRouterCommand
+  name: command camera router
   suffix: Command
   components:
     - type: SurveillanceCameraRouter
@@ -88,6 +93,7 @@
 - type: entity
   parent: SurveillanceCameraRouterBase
   id: SurveillanceCameraRouterService
+  name: service camera router
   suffix: Service
   components:
     - type: SurveillanceCameraRouter
@@ -96,6 +102,7 @@
 - type: entity
   parent: SurveillanceCameraRouterBase
   id: SurveillanceCameraRouterMedical
+  name: medical camera router
   suffix: Medical
   components:
     - type: SurveillanceCameraRouter
@@ -104,6 +111,7 @@
 - type: entity
   parent: SurveillanceCameraRouterBase
   id: SurveillanceCameraRouterGeneral
+  name: general camera router
   suffix: General
   components:
     - type: SurveillanceCameraRouter
@@ -152,6 +160,7 @@
 - type: entity
   parent: SurveillanceCameraWirelessRouterBase
   id: SurveillanceCameraWirelessRouterEntertainment
+  name: entertainment camera router
   suffix: Entertainment
   components:
     - type: SurveillanceCameraRouter


### PR DESCRIPTION
## About the PR
Small QoL to be able to tell which router is which.

## Why / Balance
They look identical and unless the mapper names them, there is nothing to communicate to the player which is which. 

## Technical details
n/a

## Media
![image](https://github.com/user-attachments/assets/8e6263ad-9c19-47d2-b3ee-9413a8f36a11)
![image](https://github.com/user-attachments/assets/e53bf132-0c43-497f-8047-42ad55e71c60)


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
n/a
