### PR TITLE
Grant elevated door access to Janitor

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
@@ -30,7 +30,7 @@
   suffix: Bar, Locked
   components:
   - type: AccessReader
-    access: [["Bar"]]
+    access: [["Bar"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -38,7 +38,7 @@
   suffix: Bar, Locked
   components:
   - type: AccessReader
-    access: [["Bar"], ["Kitchen"]]
+    access: [["Bar"], ["Kitchen"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -46,7 +46,7 @@
   suffix: Hydroponics, Locked
   components:
   - type: AccessReader
-    access: [["Hydroponics"]]
+    access: [["Hydroponics"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -54,7 +54,7 @@
   suffix: Chapel, Locked
   components:
   - type: AccessReader
-    access: [["Chapel"]]
+    access: [["Chapel"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -62,7 +62,7 @@
   suffix: Theatre, Locked
   components:
   - type: AccessReader
-    access: [["Theatre"]]
+    access: [["Theatre"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -70,7 +70,7 @@
   suffix: Kitchen, Locked
   components:
   - type: AccessReader
-    access: [["Kitchen"]]
+    access: [["Kitchen"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -78,7 +78,7 @@
   suffix: Kitchen/Hydroponics, Locked
   components:
   - type: AccessReader
-    access: [["Kitchen"], ["Hydroponics"]]
+    access: [["Kitchen"], ["Hydroponics"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -94,7 +94,7 @@
   suffix: Lawyer, Locked
   components:
   - type: AccessReader
-    access: [["Lawyer"]]
+    access: [["Lawyer"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -119,7 +119,7 @@
   suffix: Salvage, Locked
   components:
   - type: AccessReader
-    access: [["Salvage"]]
+    access: [["Salvage"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -127,7 +127,7 @@
   suffix: Cargo, Locked
   components:
   - type: AccessReader
-    access: [["Cargo"]]
+    access: [["Cargo"], ["Janitor"]]
 
 # Engineering
 - type: entity
@@ -152,7 +152,7 @@
   suffix: Engineering, Locked
   components:
   - type: AccessReader
-    access: [["Engineering"]]
+    access: [["Engineering"], ["Janitor"]]
 
 # Science
 - type: entity
@@ -161,7 +161,7 @@
   suffix: Morgue, Locked
   components:
   - type: AccessReader
-    access: [["Medical"], ["Detective"], ["Chapel"]]
+    access: [["Medical"], ["Detective"], ["Chapel"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -177,7 +177,7 @@
   suffix: Medical/Science, Locked
   components:
   - type: AccessReader
-    access: [["Research"], ["Medical"]]
+    access: [["Research"], ["Medical"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -185,7 +185,7 @@
   suffix: Research, Locked
   components:
   - type: AccessReader
-    access: [["Research"]]
+    access: [["Research"], ["Janitor"]]
 
 # Security
 - type: entity
@@ -226,7 +226,7 @@
   suffix: Security/Lawyer, Locked
   components:
   - type: AccessReader
-    access: [["Security"], ["Lawyer"]]
+    access: [["Security"], ["Lawyer"], ["Janitor"]]
 
 - type: entity
   parent: DoorElectronics
@@ -234,7 +234,7 @@
   suffix: Brig, Locked
   components:
   - type: AccessReader
-    access: [["Brig"]]
+    access: [["Brig"], ["Janitor"]]
 
 # Medical
 - type: entity
@@ -259,7 +259,7 @@
   suffix: Medical, Locked
   components:
   - type: AccessReader
-    access: [["Medical"]]
+    access: [["Medical"], ["Janitor"]]
 
 # Syndicate
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This would significantly increase the access level of the Janitor role on doors only by enabling Janitor access to a large selection of doors for various departments, allowing him into most departments but keeping him out of Command and Security-level areas and some specifically very dangerous areas like Atmospherics or Chemistry.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Since this is a pretty significant change in terms of role balance, I will split this as to why I did this code wise, and why I think this is viable regardless gameplay-wise:

**Code-wise**, it's obvious this is a bit of a brute-force method to allow the Janitor the ability to enter and clean a lot of departments, and gives him elevated access even to areas that are a bit risky like Science's anomaly containment chamber or the Engineering engine and power substations.

However, there is no way to further refine what rooms he has access to without a **major access and mapping refactor**. For example Engineering is a single universal access category, which doesn't hugely make sense where you're thinking of allowing other roles to enter more benign areas like Engineering lobby, to clean, rescue an injured person or arrest a perp.

Some other areas, Security notably, have far more detailed access levels which means the Janitor would have a tightly controlled access level, using what was already set up for the Lawyer so he can't open cells, go into Security equipment rooms or other risky areas.

**Gameplay-wise**, I think this makes sense insofar as what a Janitor is supposed to be. Wherever it is in real life or in tropes, a Janitor by definition has access to a large amount of areas, many containing sensitive equipment or information, because he's the person who is cleaning them. This is currently completely impossible and the Janitor has the same access level as a Passenger minus his own janitorial office.

I believe this hugely detracts from how the job works because having to beg departmental workers to be let into areas to clean them, especially since the station ends up junked up at roundstart, is frankly hugely frustrating, especially otherwise benign areas like Medbay or Cargo. It also puts an unreasonable burden on departments to clean their own departments when we have a dedicated job for cleaning.

While this elevated access could obviously be used for ill-intent, I also believe this isn't crazy roleplay and gameplay wise. Janitors clearly stick out, and departments tend to be territorial and would likely keep an eye on them. This would also make this job special compared to literally any civilian who scavenged a mop and bucket from maintenance by allowing them to be -very- independent and only requiring departmental supervision to access dangerous areas (as current access allows, sadly Engineering and Research only have a single, universal access level)

I will also note on a miscellaneous note that this kind of elevated access makes sense for multiple other roles, notably Paramedics (to rescue injured crew), Security (for arrests and investigations) and Engineering (for repairs). However to keep the PR atomic I am only addressing Janitors here, which I think are the highest priority. Paramedics also don't have their own access type.

## Technical details
<!-- Summary of code changes for easier review. -->
Janitor access can now interact with a much wider array of airlocks, here is a cleaned-up list of affected airlocks. **This access is for airlocks and windoors only, not machinery, buttons, lockers or other access checks**:

Service/Civilian: Bar, Kitchen, Hydroponics, Theatre, Lawyer, Chapel. All mixed access between those.
Cargo: Cargo, Salvage
Medbay: Medical, Morgue
Research: Research
Engineering: Engineering
Security: Brig, Lawyer/Brig

He is excluded from all Command airlocks, external, Chemistry (to avoid mopping up water-reactive materials), Atmospherics (Atmospherics gear like pumps are not ID-locked, so too dangerous) and Security (to not give access to cells or equipment)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Janitor role now has elevated access across the station to allow him to better clean departments.
-->
