### PR TITLE
Turn off PointLights on VendingMachines when broken or off.

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -38,6 +38,7 @@ namespace Content.Server.VendingMachines
         [Dependency] private readonly ThrowingSystem _throwingSystem = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly SpeakOnUIClosedSystem _speakOnUIClosed = default!;
+        [Dependency] private readonly SharedPointLightSystem _light = default!;
 
         private const float WallVendEjectDistanceFromWall = 1f;
 
@@ -332,6 +333,12 @@ namespace Content.Server.VendingMachines
             else if (!this.IsPowered(uid, EntityManager))
             {
                 finalState = VendingMachineVisualState.Off;
+            }
+
+            if (_light.TryGetLight(uid, out var pointlight))
+            {
+                var lightState = finalState != VendingMachineVisualState.Broken && finalState != VendingMachineVisualState.Off;
+                _light.SetEnabled(uid, lightState, pointlight);
             }
 
             _appearanceSystem.SetData(uid, VendingMachineVisuals.VisualState, finalState);


### PR DESCRIPTION
## About the PR
Vendingmachines now turn off their PointLight component when going to either state Off or Broken.

## Why / Balance
Should allow people to hide near broken machines.
Fixes  #33382

## Technical details
Might need to refactor this into something similar to LitOnPowered but then called LitOnWorking.
This probably could allow all sorts of Machines to link their lights into their working ability.

## Media
See original bugreport #33382 for problem screenshot.
![image](https://github.com/user-attachments/assets/1b60aead-c8f8-483a-88f3-adb68fc4688a)
After shooting the NanoMed vending machine:
![image](https://github.com/user-attachments/assets/53043751-04fa-4668-8363-ca6d5e88fa32)

PS: SecTech vending machine light radius is unusually low `1.0` whereas other machines are usually >1.5

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- fix: Vending machine lights turns off when broken.
