### PR TITLE
fix airlocks inconsistently auto-closing after unbolting

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -66,7 +66,7 @@ public sealed partial class DoorComponent : Component
     /// <summary>
     ///     When the door is active, this is the time when the state will next update.
     /// </summary>
-    [AutoNetworkedField]
+    [AutoNetworkedField, ViewVariables]
     public TimeSpan? NextStateChange;
 
     /// <summary>

--- a/Content.Shared/Doors/DoorEvents.cs
+++ b/Content.Shared/Doors/DoorEvents.cs
@@ -16,6 +16,19 @@ namespace Content.Shared.Doors
     }
 
     /// <summary>
+    /// Raised when the door's bolt status was changed.
+    /// </summary>
+    public sealed class DoorBoltsChangedEvent : EntityEventArgs
+    {
+        public readonly bool BoltsDown;
+
+        public DoorBoltsChangedEvent(bool boltsDown)
+        {
+            BoltsDown = boltsDown;
+        }
+    }
+
+    /// <summary>
     /// Raised when the door is determining whether it is able to open.
     /// Cancel to stop the door from being opened.
     /// </summary>

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -22,6 +22,7 @@ public abstract class SharedAirlockSystem : EntitySystem
 
         SubscribeLocalEvent<AirlockComponent, BeforeDoorClosedEvent>(OnBeforeDoorClosed);
         SubscribeLocalEvent<AirlockComponent, DoorStateChangedEvent>(OnStateChanged);
+        SubscribeLocalEvent<AirlockComponent, DoorBoltsChangedEvent>(OnBoltsChanged);
         SubscribeLocalEvent<AirlockComponent, BeforeDoorOpenedEvent>(OnBeforeDoorOpened);
         SubscribeLocalEvent<AirlockComponent, BeforeDoorDeniedEvent>(OnBeforeDoorDenied);
         SubscribeLocalEvent<AirlockComponent, GetPryTimeModifierEvent>(OnGetPryMod);
@@ -68,6 +69,13 @@ public abstract class SharedAirlockSystem : EntitySystem
             component.AutoClose = true;
             Dirty(uid, component);
         }
+    }
+
+    private void OnBoltsChanged(EntityUid uid, AirlockComponent component, DoorBoltsChangedEvent args)
+    {
+        // If unbolted, reset the auto close timer
+        if (!args.BoltsDown)
+            UpdateAutoClose(uid, component);
     }
 
     private void OnBeforeDoorOpened(EntityUid uid, AirlockComponent component, BeforeDoorOpenedEvent args)
@@ -145,7 +153,7 @@ public abstract class SharedAirlockSystem : EntitySystem
         ent.Comp.EmergencyAccess = value;
         Dirty(ent, ent.Comp); // This only runs on the server apparently so we need this.
         UpdateEmergencyLightStatus(ent, ent.Comp);
-		
+
         var sound = ent.Comp.EmergencyAccess ? ent.Comp.EmergencyOnSound : ent.Comp.EmergencyOffSound;
         if (predicted)
             Audio.PlayPredicted(sound, ent, user: user);

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.Bolts.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.Bolts.cs
@@ -96,6 +96,10 @@ public abstract partial class SharedDoorSystem
         Dirty(ent, ent.Comp);
         UpdateBoltLightStatus(ent);
 
+        // used to reset the auto-close timer after unbolting
+        var ev = new DoorBoltsChangedEvent(value);
+        RaiseLocalEvent(ent.Owner, ev);
+
         var sound = value ? ent.Comp.BoltDownSound : ent.Comp.BoltUpSound;
         if (predicted)
             Audio.PlayPredicted(sound, ent, user: user);

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -700,6 +700,8 @@ public abstract partial class SharedDoorSystem : EntitySystem
         }
 
         door.NextStateChange = GameTiming.CurTime + delay.Value;
+        Dirty(uid, door);
+
         _activeDoors.Add((uid, door));
     }
 


### PR DESCRIPTION
## About the PR
The autoclose timer is now correctly being reset after unbolting an opened door.
Two scenarios in which this bug previously occured on master:

A:
- spawn an airlock and emag
- emag the airlock
- open the wirepanel and use a multitool to pulse the bolts wire to unbolt the door
- the door won't autoclose until closed manually

B:
- spawn an airlock and command door remote
- walk into the airlock so it opens, then activate the bolts using the remote so it stays open
- if you wait less than 5 seconds to unbolt again, then the door will wait a while until closing
- if you wait more than 5 seconds to unbolt, the door will close immediately


## Why / Balance
bugfix

## Technical details
Added `DoorBoltsChangedEvent` and raise it in `SetBoltsDown`.
Subscribe to it in `SharedAirlockSystem` to update the auto-close timer.
Added a `Dirty()` into `SetNextStateChange` so the timer is correctly networked.
Added the readonly `ViewVariables` attribute to the `NextStateChange` variable in `DoorComponent` to make debugging it easier.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed doors not auto-closing correctly after being unbolted in an open state.
