### PR TITLE
HealingSystem: check blood restoration, staunching

### DIFF
--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -135,6 +135,7 @@ public sealed class HealingSystem : EntitySystem
 
         if (TryComp<BloodstreamComponent>(ent, out var bloodstream))
         {
+            // Is ent missing blood that we can restore?
             if (healing.ModifyBloodLevel > 0
                 && _solutionContainerSystem.ResolveSolution(ent.Owner, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution)
                 && bloodSolution.Volume < bloodSolution.MaxVolume)
@@ -142,8 +143,8 @@ public sealed class HealingSystem : EntitySystem
                 return true;
             }
 
-            if (healing.BloodlossModifier < 0
-                && bloodstream.BleedAmount > 0)
+            // Is ent bleeding and can we stop it?
+            if (healing.BloodlossModifier < 0 && bloodstream.BleedAmount > 0)
             {
                 return true;
             }

--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -115,19 +115,35 @@ public sealed class HealingSystem : EntitySystem
         _audio.PlayPvs(healing.HealingEndSound, entity.Owner, AudioHelpers.WithVariation(0.125f, _random).WithVolume(1f));
 
         // Logic to determine the whether or not to repeat the healing action
-        args.Repeat = (HasDamage(entity.Comp, healing) && !dontRepeat);
+        args.Repeat = (HasDamage(entity.Owner, entity.Comp, healing) && !dontRepeat);
         if (!args.Repeat && !dontRepeat)
             _popupSystem.PopupEntity(Loc.GetString("medical-item-finished-using", ("item", args.Used)), entity.Owner, args.User);
         args.Handled = true;
     }
 
-    private bool HasDamage(DamageableComponent component, HealingComponent healing)
+    private bool HasDamage(EntityUid target, DamageableComponent component, HealingComponent healing)
     {
         var damageableDict = component.Damage.DamageDict;
         var healingDict = healing.Damage.DamageDict;
         foreach (var type in healingDict)
         {
             if (damageableDict[type.Key].Value > 0)
+            {
+                return true;
+            }
+        }
+
+        if(TryComp<BloodstreamComponent>(target, out var bloodstream))
+        {
+            if (healing.ModifyBloodLevel > 0
+                && _solutionContainerSystem.ResolveSolution(target, bloodstream!.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution)
+                && bloodSolution.Volume < bloodSolution.MaxVolume)
+            {
+                return true;
+            }
+
+            if (healing.BloodlossModifier < 0
+                && bloodstream!.BleedAmount > 0)
             {
                 return true;
             }
@@ -172,14 +188,7 @@ public sealed class HealingSystem : EntitySystem
         if (TryComp<StackComponent>(uid, out var stack) && stack.Count < 1)
             return false;
 
-        var anythingToDo =
-            HasDamage(targetDamage, component) ||
-            component.ModifyBloodLevel > 0 // Special case if healing item can restore lost blood...
-                && TryComp<BloodstreamComponent>(target, out var bloodstream)
-                && _solutionContainerSystem.ResolveSolution(target, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution)
-                && bloodSolution.Volume < bloodSolution.MaxVolume; // ...and there is lost blood to restore.
-
-        if (!anythingToDo)
+        if (!HasDamage(target, targetDamage, component))
         {
             _popupSystem.PopupEntity(Loc.GetString("medical-item-cant-use", ("item", uid)), uid, user);
             return false;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Healing objects now check for possible blood restoration or bleeding reduction when checking whether or not to allow or repeat healing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes #28831.

Porting https://github.com/new-frontiers-14/frontier-station-14/pull/2457.

## Technical details
<!-- Summary of code changes for easier review. -->

The conditions of HasDamage now check bleeding reduction and target bleeding, and blood restoration and target blood loss.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

A video reproducing the steps for #28831 in the test map.  The moth is struck with a 200 dmg bang stick, and gauze is applied, stopping the moth's bleeding despite the moth having no pierce or slash damage.  The bloodpack is then applied, and repeats successfully, despite the moth having no bloodloss damage.

https://github.com/user-attachments/assets/79e5deb8-b8ea-4436-8f38-4c301a23c45d

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Healing items that reduce bleeding can now be applied to undamaged mobs.