### PR TITLE
[BUGFIX] "Ghost" in the lobby lets you see the whole chat

### DIFF
--- a/Content.Server/Ghost/GhostCommand.cs
+++ b/Content.Server/Ghost/GhostCommand.cs
@@ -23,6 +23,13 @@ namespace Content.Server.Ghost
                 return;
             }
 
+            var gameTicker = _entities.System<GameTicker>();
+            if (!gameTicker.PlayerGameStatuses.TryGetValue(player.UserId, out var status) || status is not PlayerGameStatus.JoinedGame)
+            {
+                shell.WriteLine("ghost-command-error-lobby");
+                return;
+            }
+
             if (player.AttachedEntity is { Valid: true } frozen &&
                 _entities.HasComponent<AdminFrozenComponent>(frozen))
             {

--- a/Content.Server/Ghost/GhostCommand.cs
+++ b/Content.Server/Ghost/GhostCommand.cs
@@ -1,7 +1,9 @@
 using Content.Server.Popups;
 using Content.Shared.Administration;
+using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Robust.Shared.Console;
+using Content.Server.GameTicking;
 
 namespace Content.Server.Ghost
 {

--- a/Content.Server/Ghost/GhostCommand.cs
+++ b/Content.Server/Ghost/GhostCommand.cs
@@ -24,7 +24,8 @@ namespace Content.Server.Ghost
             }
 
             var gameTicker = _entities.System<GameTicker>();
-            if (!gameTicker.PlayerGameStatuses.TryGetValue(player.UserId, out var status) || status is not PlayerGameStatus.JoinedGame)
+            if (!gameTicker.PlayerGameStatuses.TryGetValue(player.UserId, out var playerStatus) ||
+                playerStatus is not PlayerGameStatus.JoinedGame)
             {
                 shell.WriteLine("ghost-command-error-lobby");
                 return;

--- a/Resources/Locale/en-US/chat/commands/ghost-command.ftl
+++ b/Resources/Locale/en-US/chat/commands/ghost-command.ftl
@@ -3,3 +3,4 @@ ghost-command-help-text = The ghost command turns you into a ghost and makes the
                           Please note that you cannot return to your character's body after ghosting.
 ghost-command-no-session = You have no session, you can't ghost.
 ghost-command-denied = You cannot ghost right now.
+ghost-command-error-lobby = You can't ghost right now. You are not in the game!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
When you type "ghost" while being in the lobby, it lets you see the whole chat, like you're an observer. It doesn't make you a ghost, though. Your chat simply modifies.
What this PR does is checks whether the player is in lobby or not.
If he's in lobby - it will show an error that says that you can't use that in the lobby.

## Why / Balance
To simply fix the bug and prevent players from metainfo, maybe

## Technical details
What this PR does is checks whether the player is in lobby or not.
If he's in lobby - it will show an error that says that you can't use that in the lobby.

## Media
Before the fix:
![image](https://github.com/user-attachments/assets/09d9759a-afdc-4142-9a7f-494c56a242ca)
After the fix:
![image](https://github.com/user-attachments/assets/dca8fc6b-4e41-4c8e-be28-839cedaede80)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
I don't think the changes might be called "breaking"

**Changelog**
:cl: Schrodinger71
- fix: Fixed a bug letting players type "ghost" in the console and then see the whole chat while being in the lobby.