### PR TITLE
Fix RA0003 warning for ChatBox

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -16,9 +16,8 @@ using static Robust.Client.UserInterface.Controls.LineEdit;
 namespace Content.Client.UserInterface.Systems.Chat.Widgets;
 
 [GenerateTypedNameReferences]
-#pragma warning disable RA0003
+[Virtual]
 public partial class ChatBox : UIWidget
-#pragma warning restore RA0003
 {
     private readonly ChatUIController _controller;
     private readonly IEntityManager _entManager;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes `RA0003` warning for `ChatBox`.
Warning is:
```
Class must be explicitly marked as [Virtual], abstract, static or sealed
```


## Technical details
This class is definitely not `sealed` because `ResizableChatBox` inherits from it.
This class is definitely not `abstract` because it has public constructor.
This class is definitely not `static` by its' nature, it doesn't contain just utility functions. It represents the actual object.
Thus `[Virtual]` is the correct annotation for this class.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
