### PR TITLE
Station-wide destruction toys

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -667,6 +667,7 @@
     maxSpawns: 1
     spawns:
     - id: Singularity
+    - id: SingularityToy # troll
 
 - type: artifactEffect
   id: EffectTesla
@@ -677,3 +678,4 @@
     maxSpawns: 1
     spawns:
     - id: TeslaEnergyBall
+    - id: TeslaToy # troll


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds 50% chance of getting either an actual singulo/tesla or their corresponding toy when activating a node with station-wide destruction.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Maybe the artifact that was supposed to destroy the galaxy was already 'spent' eons ago, or was just a holographic replica for an ancient museum, or...

We'll never know :trollface: 

## Technical details
<!-- Summary of code changes for easier review. -->
yml changes only
- `Resources/Prototypes/XenoArch/Effects/normal_effects.yml`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] ~~I have added media to this PR or~~ it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: Adds 50% chance of getting either an actual singulo/tesla or their corresponding toy when activating a node with station-wide destruction.