### PR TITLE
Axe the singulogen emag

### DIFF
--- a/Content.Client/Singularity/Systems/SingularityGeneratorSystem.cs
+++ b/Content.Client/Singularity/Systems/SingularityGeneratorSystem.cs
@@ -9,4 +9,5 @@ namespace Content.Client.Singularity.Systems;
 /// Exists to make relevant signal handlers (ie: <see cref="SharedSingularityGeneratorSystem.OnEmagged"/>) work on the client.
 /// </summary>
 public sealed class SingularityGeneratorSystem : SharedSingularityGeneratorSystem
-{}
+{
+}

--- a/Content.Shared/Singularity/EntitySystems/SharedSingularityGeneratorSystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedSingularityGeneratorSystem.cs
@@ -16,13 +16,5 @@ public abstract class SharedSingularityGeneratorSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-
-        SubscribeLocalEvent<SingularityGeneratorComponent, GotEmaggedEvent>(OnEmagged);
-    }
-
-    private void OnEmagged(EntityUid uid, SingularityGeneratorComponent component, ref GotEmaggedEvent args)
-    {
-        component.FailsafeDisabled = true;
-        args.Handled = true;
     }
 }

--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -3876,7 +3876,7 @@
 - author: SaphireLattice
   changes:
   - message: The Singularity/Tesla generator now requires being surrounded by containment
-      fields to activate. This can be disabled with an Emag.
+      fields to activate.
     type: Tweak
   id: 7631
   time: '2024-11-20T05:55:58.0000000+00:00'


### PR DESCRIPTION
You can wait for the field to go down if you're already shuffling the generator and PA around

## Technical details
Eventn't

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelogn't**
Edited out the previous changelog entry to not mention this existed. Shhh.