### PR TITLE
removed obsolete netmessage creator

### DIFF
--- a/Content.Client/Eui/BaseEui.cs
+++ b/Content.Client/Eui/BaseEui.cs
@@ -55,7 +55,7 @@ namespace Content.Client.Eui
         /// </summary>
         protected void SendMessage(EuiMessageBase msg)
         {
-            var netMsg = _netManager.CreateNetMessage<MsgEuiMessage>();
+            var netMsg = new MsgEuiMessage();
             netMsg.Id = Id;
             netMsg.Message = msg;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I spotted this obsolete warning when making an eui, I did not attempt the change due to rule regarding unrelated changes. 
 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
 #33279

## Technical details
<!-- Summary of code changes for easier review. -->
Updates `MsgEuiMessage` in `BaseEui` to use the constructor directly.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
