### PR TITLE
Rename nitrogen internals crate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
@@ -63,7 +63,7 @@
   icon:
     sprite: Objects/Tanks/red.rsi
     state: icon
-  product: CrateSlimepersonLifeSupport
+  product: CrateNitrogenInternals
   cost: 350
   category: cargoproduct-category-name-emergency
   group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
@@ -76,7 +76,7 @@
   id: CrateNitrogenInternals
   parent: CrateInternals
   name: internals crate (nitrogen)
-  description: Contains four breath masks and four large nitrogen tanks.
+  description: Contains four breath masks and four large nitrogen tanks. Intended for Slimepeople and Vox.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
@@ -73,9 +73,9 @@
           amount: 6
 
 - type: entity
-  id: CrateSlimepersonLifeSupport
+  id: CrateNitrogenInternals
   parent: CrateInternals
-  name: slimeperson life support crate
+  name: internals crate (nitrogen)
   description: Contains four breath masks and four large nitrogen tanks.
   components:
   - type: StorageFill

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -478,5 +478,9 @@ TorsoBorgJanitor: TorsoBorg
 
 # 2024-11-17
 PresentRandomAsh: PresentRandomCoal
+
 # 2024-11-19
 CrateCrewMonitoringBoards: CrateCrewMonitoring
+
+# 2024-11-25
+CrateSlimepersonLifeSupport: CrateNitrogenInternals


### PR DESCRIPTION
## About the PR
Renames "slimeperson life support crate" to "internals crate (nitrogen)". This makes the crate name consistent with other internals crates, and ensures that anyone searching for "nitrogen" (such as a Vox player needing new tanks) can find it easily. This also adds "Intended for Slimepeople and Vox." to the description, which means the crate will show up in searches for either species name.

## Why / Balance
Currently, it's not obvious that someone looking to buy nitrogen tanks from Cargo should be searching for something named "Slimepeople", especially if their character is not a Slimeperson.

## Technical details
- Changes the id of the crate from `CrateSlimepersonLifeSupport` to `CrateNitrogenInternals`.
- Change the name of the crate from "slimeperson life support crate" to "internals crate (nitrogen)"
- Adds an extra sentence to the crate description.

## Media
![internals](https://github.com/user-attachments/assets/7bbd105f-e166-4b9c-84d0-02faffcabf5d)
![vox](https://github.com/user-attachments/assets/7a18351d-78d4-49b8-b3cc-06f15d448c9c)
![description](https://github.com/user-attachments/assets/a529d1c4-cbc1-4098-972a-ef698040537d)
![crate](https://github.com/user-attachments/assets/4c1c1f86-bc41-4f04-9eea-04bb4b9b6d17)
![contents](https://github.com/user-attachments/assets/bec4ea75-7910-421a-ad46-774d4991b1bb)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Rename the "slimeperson life support crate" to "internals crate (nitrogen)".




