### PR TITLE
Removes Revolutionaries Pending Redesign

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -3,8 +3,7 @@
   weights:
     Nukeops: 0.20
     Traitor: 0.60
-    Zombie: 0.04
+    Zombie: 0.08
     Zombieteors: 0.01
     Survival: 0.09
-    KesslerSyndrome: 0.01
-    Revolutionary: 0.05
+    KesslerSyndrome: 0.02


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Revolutionaries was always a problematic gamemode since it's initial implementation from the player side and on the administrative side of the game. As a result Revolutionaries become a mode full of ginormous grey administrative areas, and meta issues. This PR is going to remove Revolutionary from the secret pool and replace the gamemode with zombies in the interim. The mode will still be able to be run by an admin. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Revolutionaries usually has 2 or 3 stages.
1. Round start, headrevs are chosen, and given a limited use flash where they choose up to 5 other targets that they can convert. This is problematic because the head Revolutionaries tend to focus on converting the most robust players on the station through meta info carried over through many rounds.
2. Revs start to find a way to source additional flashes, such as killing security, going to science and printing more off, or straight up killing command and getting more flashes. This isn't really a problem.
3. Sometimes, the mode culminates in a gigantic TDM with sec specifically against everyone because they don't know who is a revolutionary. This is usually a source of many, many ahelps, as players that are unaware of the active revolution tend to see that "sec killed me for no reason" because sec is justifiably scared of the crew once revs kicks off in full swing.

Sometimes, the round ends quickly, sometimes the Revolutionaries stall the shift for another hour (usually seen on late night, lower pop rev rounds) because a single member of command is hiding from the Revolutionaries looking to escape or survive. This usually requires admin intervention after ahelps.

Zombies doesn't have any of these problems. II are given a clock to attempt to damage the station and crew in a way to create more zombies. They by design are much harder to metagame since they are normal crew until the 30 minute timer expires, and don't have any metagameable items like the flash. II target robust players based on meta information in order to kill them first instead of picking the best player on the field. Zombies typically can't stall rounds by simply existing and hunting down a single survivor as the mode has built in safeguards to call evac once a large percentage of the crew is turned instead of only firing once the kill objective of the revs is 100% complete.

Many other servers have disabled or rejected Revolutionaries for the reasons outlined above, and I'm proposing it here (again).

## Technical details
<!-- Summary of code changes for easier review. -->
Moved the revolutionary percent into zombies 4% and kessler 1% because it's funny.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Nah.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed Revolutionaries from the secret pool and made zombies more common.