### PR TITLE
Bug fixes for Store UIs with multiple currencies

### DIFF
--- a/Content.Client/Store/Ui/StoreMenu.xaml.cs
+++ b/Content.Client/Store/Ui/StoreMenu.xaml.cs
@@ -54,7 +54,7 @@ public sealed partial class StoreMenu : DefaultWindow
         foreach (var ((_, amount), proto) in currency)
         {
             balanceStr += Loc.GetString("store-ui-balance-display", ("amount", amount),
-                ("currency", Loc.GetString(proto.DisplayName, ("amount", 1))));
+                ("currency", Loc.GetString(proto.DisplayName, ("amount", 1)))) + "\n";
         }
 
         BalanceInfo.SetMarkup(balanceStr.TrimEnd());
@@ -63,7 +63,10 @@ public sealed partial class StoreMenu : DefaultWindow
         foreach (var type in currency)
         {
             if (type.Value.CanWithdraw && type.Value.Cash != null && type.Key.Item2 > 0)
+            {
                 disabled = false;
+                break;
+            }
         }
 
         WithdrawButton.Disabled = disabled;

--- a/Content.Client/Store/Ui/StoreWithdrawWindow.xaml.cs
+++ b/Content.Client/Store/Ui/StoreWithdrawWindow.xaml.cs
@@ -18,7 +18,7 @@ public sealed partial class StoreWithdrawWindow : DefaultWindow
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
-    private Dictionary<FixedPoint2, CurrencyPrototype> _validCurrencies = new();
+    private Dictionary<CurrencyPrototype, FixedPoint2> _validCurrencies = new();
     private HashSet<CurrencyWithdrawButton> _buttons = new();
     public event Action<BaseButton.ButtonEventArgs, string, int>? OnWithdrawAttempt;
 
@@ -36,7 +36,7 @@ public sealed partial class StoreWithdrawWindow : DefaultWindow
             if (!_prototypeManager.TryIndex(currency.Key, out var proto))
                 continue;
 
-            _validCurrencies.Add(currency.Value, proto);
+            _validCurrencies.Add(proto, currency.Value);
         }
 
         //this shouldn't ever happen but w/e
@@ -47,14 +47,17 @@ public sealed partial class StoreWithdrawWindow : DefaultWindow
         _buttons.Clear();
         foreach (var currency in _validCurrencies)
         {
+            if (!currency.Key.CanWithdraw)
+                continue;
+
             var button = new CurrencyWithdrawButton()
             {
-                Id = currency.Value.ID,
-                Amount = currency.Key,
+                Id = currency.Key.ID,
+                Amount = currency.Value,
                 MinHeight = 20,
-                Text = Loc.GetString("store-withdraw-button-ui", ("currency",Loc.GetString(currency.Value.DisplayName, ("amount", currency.Key)))),
+                Text = Loc.GetString("store-withdraw-button-ui", ("currency",Loc.GetString(currency.Key.DisplayName, ("amount", currency.Value)))),
+                Disabled = false,
             };
-            button.Disabled = false;
             button.OnPressed += args =>
             {
                 OnWithdrawAttempt?.Invoke(args, button.Id, WithdrawSlider.Value);
@@ -65,7 +68,7 @@ public sealed partial class StoreWithdrawWindow : DefaultWindow
             ButtonContainer.AddChild(button);
         }
 
-        var maxWithdrawAmount = _validCurrencies.Keys.Max().Int();
+        var maxWithdrawAmount = _validCurrencies.Values.Max().Int();
 
         // setup withdraw slider
         WithdrawSlider.MinValue = 1;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR fixes some UI bugs with stores that whitelist multiple currencies. Namely, the formatting of multiple currencies is much more readable, and the withdraw menu no longer throws an error when two currencies have the same amount.

## Why / Balance
Bug fixes

## Technical details
<!-- Summary of code changes for easier review. -->

For some reason, the withdraw UI previously stored all the available currencies in a `Dictionary<FixedPoint2,CurrencyPrototype>`, with the amount of the currency as the key, and the prototype as the value. This has been changed to a `Dictionary<CurrencyPrototype, FixedPoint2>`.

The withdraw screen will also only show withdraw buttons for currencies that can be withdrawn.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/61b2ffdb-be39-43fa-9e9a-7d6fca744a18)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
