### PR TITLE
Standardize vials

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
@@ -2,20 +2,17 @@
 
 - type: entity
   name: vial
-  parent: BaseItem
+  parent: BaseChemistryEmptyBottle
   id: BaseChemistryEmptyVial
   description: A small vial.
   components:
   - type: Tag
     tags:
     - Trash
+    - Bottle
     - CentrifugeCompatible
-  - type: PhysicalComposition
-    materialComposition:
-      Glass: 25
   - type: FitsInDispenser
-    solution: beaker
-  - type: SpaceGarbage
+    solution: drink
   - type: Sprite
     sprite: Objects/Specific/Chemistry/vial.rsi
     layers:
@@ -23,85 +20,14 @@
       - state: vial-1-1
         map: ["enum.SolutionContainerLayers.Fill"]
         visible: false
-  - type: Appearance
   - type: SolutionContainerVisuals
     maxFillLevels: 6
     fillBaseName: vial-1-
     inHandsMaxFillLevels: 4
     inHandsFillBaseName: -fill-
-  - type: Drink
-    solution: beaker
-  - type: SolutionContainerManager
-    solutions:
-      beaker:
-        maxVol: 30
-  - type: MixableSolution
-    solution: beaker
-  - type: RefillableSolution
-    solution: beaker
-  - type: DrainableSolution
-    solution: beaker
-  - type: ExaminableSolution
-    solution: beaker
-  - type: DrawableSolution
-    solution: beaker
-  - type: SolutionTransfer
-    maxTransferAmount: 30
-    canChangeTransferAmount: true
-  - type: SolutionItemStatus
-    solution: beaker
-  - type: UserInterface
-    interfaces:
-      enum.TransferAmountUiKey.Key:
-        type: TransferAmountBoundUserInterface
   - type: Item
     size: Tiny
     sprite: Objects/Specific/Chemistry/vial.rsi
-    shape:
-    - 0,0,0,0
-  - type: MeleeWeapon
-    soundNoDamage:
-      path: "/Audio/Effects/Fluids/splat.ogg"
-    damage:
-      types:
-        Blunt: 0
-  - type: TrashOnSolutionEmpty
-    solution: beaker
-  - type: StaticPrice
-    price: 100
-  - type: DamageOnLand
-    damage:
-      types:
-        Blunt: 5
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Blunt: 2
-  - type: Damageable
-    damageContainer: Inorganic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 15
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-          params:
-            volume: -4
-      - !type:SpillBehavior { }
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          ShardGlass:
-            min: 0
-            max: 1
-        transferForensics: true
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-  - type: Spillable
-    solution: beaker
-  - type: DnaSubstanceTrace
 
 - type: entity
   id: VestineChemistryVial
@@ -112,7 +38,7 @@
     currentLabel: reagent-name-vestine
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         maxVol: 30
         reagents:
         - ReagentId: Vestine
@@ -129,7 +55,7 @@
     currentLabel: reagent-name-radium
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         maxVol: 5
         reagents:
           - ReagentId: Radium
@@ -144,7 +70,7 @@
     currentLabel: reagent-name-chlorine
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         maxVol: 5
         reagents:
           - ReagentId: Chlorine


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Vials now behave like bottles.

## Why / Balance
Vials previously behaved almost like bottles, but with a lot of weird minor differences such as not fitting in medical belts, not breaking when thrown, etc. 
This has been ironed out, allowing vials to be inserted where you feel like they really should be able to be inserted. Also adjusted the vial health to be in line with the bottle's.

## Technical details
Made `BaseChemistryEmptyVial` inherit from `BaseChemistryEmptyBottle`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The vial's solution was renamed from `beaker` (???) to `drink`. Vials filled with reagents will need to adjust this.

**Changelog**
:cl: Jajsha
- fix: Vials now fit in medical belts and chemsitry shelves.
