### PR TITLE
Makes MultipleToolComponent able to have different speed modifiers per mode

### DIFF
--- a/Content.Shared/Tools/Components/MultipleToolComponent.cs
+++ b/Content.Shared/Tools/Components/MultipleToolComponent.cs
@@ -14,6 +14,9 @@ public sealed partial class MultipleToolComponent : Component
         public PrototypeFlags<ToolQualityPrototype> Behavior = new();
 
         [DataField]
+        public float SpeedModifier = 1;
+
+        [DataField]
         public SoundSpecifier? UseSound;
 
         [DataField]

--- a/Content.Shared/Tools/Systems/SharedToolSystem.MultipleTool.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.MultipleTool.cs
@@ -68,6 +68,7 @@ public abstract partial class SharedToolSystem
         var current = multiple.Entries[multiple.CurrentEntry];
         tool.UseSound = current.UseSound;
         tool.Qualities = current.Behavior;
+        tool.SpeedModifier = current.SpeedModifier;
 
         // TODO: Replace this with a better solution later
         if (TryComp<PryingComponent>(uid, out var pryComp))

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -78,19 +78,6 @@
       - Screwing
     useSound:
       collection: Screwdriver
-  - type: MultipleTool
-    statusShowBehavior: true
-    entries:
-      - behavior: Screwing
-        useSound:
-          collection: Screwdriver
-      - behavior: Prying
-        speedModifier: 0.4
-        useSound:
-          path: /Audio/Items/crowbar.ogg
-  - type: Prying
-    enabled: false
-  - type: ToolTileCompatible
   - type: RandomSprite
     available:
       - enum.DamageStateVisualLayers.Base:

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -78,6 +78,19 @@
       - Screwing
     useSound:
       collection: Screwdriver
+  - type: MultipleTool
+    statusShowBehavior: true
+    entries:
+      - behavior: Screwing
+        useSound:
+          collection: Screwdriver
+      - behavior: Prying
+        speedModifier: 0.4
+        useSound:
+          path: /Audio/Items/crowbar.ogg
+  - type: Prying
+    enabled: false
+  - type: ToolTileCompatible
   - type: RandomSprite
     available:
       - enum.DamageStateVisualLayers.Base:
@@ -252,6 +265,7 @@
     statusShowBehavior: true
     entries:
       - behavior: Screwing
+        speedModifier: 1.5
         sprite:
           sprite: Objects/Tools/drill.rsi
           state: drill_screw
@@ -260,6 +274,7 @@
         changeSound:
           path: /Audio/Items/change_drill.ogg
       - behavior: Anchoring
+        speedModifier: 1.5
         sprite:
           sprite: Objects/Tools/drill.rsi
           state: drill_bolt
@@ -415,6 +430,7 @@
     statusShowBehavior: true
     entries:
       - behavior: Screwing
+        speedModifier: 1.2
         sprite:
           sprite: Objects/Tools/omnitool.rsi
           state: omnitool-screwing
@@ -423,6 +439,7 @@
         changeSound:
           path: /Audio/Items/change_drill.ogg
       - behavior: Prying
+        speedModifier: 1.2
         sprite:
           sprite: Objects/Tools/omnitool.rsi
           state: omnitool-prying
@@ -431,6 +448,7 @@
         changeSound:
           path: /Audio/Items/change_drill.ogg
       - behavior: Anchoring
+        speedModifier: 1.2
         sprite:
           sprite: Objects/Tools/omnitool.rsi
           state: omnitool-wrenching
@@ -439,6 +457,7 @@
         changeSound:
           path: /Audio/Items/change_drill.ogg
       - behavior: Cutting
+        speedModifier: 1.2
         sprite:
           sprite: Objects/Tools/omnitool.rsi
           state: omnitool-snipping
@@ -447,6 +466,7 @@
         changeSound:
           path: /Audio/Items/change_drill.ogg
       - behavior: Pulsing
+        speedModifier: 1.2
         sprite:
           sprite: Objects/Tools/omnitool.rsi
           state: omnitool-pulsing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds optional speed modifiers to tools with multiple modes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This PR was previously adding this optional field so that it could give screwdrivers very bad prying abilities as an alternative toggled mode. The feedback to this change led to the PR being specifically about the change to the component, because why not.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

No CL