### PR TITLE
Fix BuckleSystem always marking InteractHandEvent as Handled

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
@@ -114,14 +114,10 @@ public abstract partial class SharedBuckleSystem
         if (args.Handled)
             return;
 
-        var canUnbuckle = false;
-
         if (ent.Comp.BuckledTo != null)
             args.Handled = TryUnbuckle(ent!, args.User, popup: true);
 
         // TODO BUCKLE add out bool for whether a pop-up was generated or not.
-        if (canUnbuckle)
-            args.Handled = true;
     }
 
     private void AddStrapVerbs(EntityUid uid, StrapComponent component, GetVerbsEvent<InteractionVerb> args)

--- a/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
@@ -114,11 +114,14 @@ public abstract partial class SharedBuckleSystem
         if (args.Handled)
             return;
 
+        var canUnbuckle = false;
+
         if (ent.Comp.BuckledTo != null)
-            TryUnbuckle(ent!, args.User, popup: true);
+            canUnbuckle = TryUnbuckle(ent!, args.User, popup: true);
 
         // TODO BUCKLE add out bool for whether a pop-up was generated or not.
-        args.Handled = true;
+        if (canUnbuckle)
+            args.Handled = true;
     }
 
     private void AddStrapVerbs(EntityUid uid, StrapComponent component, GetVerbsEvent<InteractionVerb> args)

--- a/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
@@ -117,7 +117,7 @@ public abstract partial class SharedBuckleSystem
         var canUnbuckle = false;
 
         if (ent.Comp.BuckledTo != null)
-            canUnbuckle = TryUnbuckle(ent!, args.User, popup: true);
+            args.Handled = TryUnbuckle(ent!, args.User, popup: true);
 
         // TODO BUCKLE add out bool for whether a pop-up was generated or not.
         if (canUnbuckle)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The issue has popped up only recently. Due to #27111 being merged, SharedChameleonSystem required to work with InteractHandEvent before SharedItemSystem, so SharedBuckleSystem.Interaction was working with that event before SharedItemSystem. Because of SharedBuckleSystem.Interaction always marking InteractHandEvent as Handled, it was impossible to pickup the mob.

## Why / Balance
Fixes #33263

## Technical details
This PR adds check for a successful unbuckling before marking InteractHandEvent as Handled

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/e497f9ca-3743-46f3-99aa-6cf7c4b5009b
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Mouses, mothroaches, cockroaches and etc can be picked up once again.
