### PR TITLE
storedOffset bugfix

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
@@ -160,8 +160,9 @@ public sealed class ItemGridPiece : Control, IEntityControl
         }
 
         // typically you'd divide by two, but since the textures are half a tile, this is done implicitly
-        var iconPosition = new Vector2((boundingGrid.Width + 1) * size.X + itemComponent.StoredOffset.X * 2,
-            (boundingGrid.Height + 1) * size.Y + itemComponent.StoredOffset.Y * 2);
+        var iconPosition = new Vector2(
+            (boundingGrid.Width + 1) * size.X + Location.Rotation.RotateVec(itemComponent.StoredOffset).X * 2,
+            (boundingGrid.Height + 1) * size.Y + Location.Rotation.RotateVec(itemComponent.StoredOffset).Y * 2);
         var iconRotation = Location.Rotation + Angle.FromDegrees(itemComponent.StoredRotation);
 
         if (itemComponent.StoredSprite is { } storageSprite)

--- a/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
@@ -160,10 +160,10 @@ public sealed class ItemGridPiece : Control, IEntityControl
         }
 
         // typically you'd divide by two, but since the textures are half a tile, this is done implicitly
-        var iconOffset = Location.Rotation.RotateVec(itemComponent.StoredOffset);
+        var iconOffset = Location.Rotation.RotateVec(itemComponent.StoredOffset) * 2 * UIScale;
         var iconPosition = new Vector2(
-            (boundingGrid.Width + 1) * size.X + iconOffset.X * 2,
-            (boundingGrid.Height + 1) * size.Y + iconOffset.Y * 2);
+            (boundingGrid.Width + 1) * size.X + iconOffset.X,
+            (boundingGrid.Height + 1) * size.Y + iconOffset.Y);
         var iconRotation = Location.Rotation + Angle.FromDegrees(itemComponent.StoredRotation);
 
         if (itemComponent.StoredSprite is { } storageSprite)

--- a/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/ItemGridPiece.cs
@@ -160,15 +160,16 @@ public sealed class ItemGridPiece : Control, IEntityControl
         }
 
         // typically you'd divide by two, but since the textures are half a tile, this is done implicitly
+        var iconOffset = Location.Rotation.RotateVec(itemComponent.StoredOffset);
         var iconPosition = new Vector2(
-            (boundingGrid.Width + 1) * size.X + Location.Rotation.RotateVec(itemComponent.StoredOffset).X * 2,
-            (boundingGrid.Height + 1) * size.Y + Location.Rotation.RotateVec(itemComponent.StoredOffset).Y * 2);
+            (boundingGrid.Width + 1) * size.X + iconOffset.X * 2,
+            (boundingGrid.Height + 1) * size.Y + iconOffset.Y * 2);
         var iconRotation = Location.Rotation + Angle.FromDegrees(itemComponent.StoredRotation);
 
         if (itemComponent.StoredSprite is { } storageSprite)
         {
             var scale = 2 * UIScale;
-            var offset = (((Box2) boundingGrid).Size - Vector2.One) * size;
+            var offset = (((Box2) boundingGrid).Size - Vector2.One) * size + iconOffset;
             var sprite = _entityManager.System<SpriteSystem>().Frame0(storageSprite);
 
             var spriteBox = new Box2Rotated(new Box2(0f, sprite.Height * scale, sprite.Width * scale, 0f), -iconRotation, Vector2.Zero);

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -55,6 +55,15 @@ public abstract class SharedItemSystem : EntitySystem
         Dirty(uid, component);
     }
 
+    public void SetStoredOffset(EntityUid uid, Vector2i newOffset, ItemComponent? component = null)
+    {
+        if (!Resolve(uid, ref component, false))
+            return;
+        
+        component.StoredOffset = newOffset;
+        Dirty(uid, component);
+    }
+
     public void SetHeldPrefix(EntityUid uid, string? heldPrefix, bool force = false, ItemComponent? component = null)
     {
         if (!Resolve(uid, ref component, false))

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -55,11 +55,16 @@ public abstract class SharedItemSystem : EntitySystem
         Dirty(uid, component);
     }
 
+    /// <summary>
+    /// Sets the offset used for the item's sprite inside the storage UI.
+    /// Dirties.
+    /// </summary>
+    [PublicAPI]
     public void SetStoredOffset(EntityUid uid, Vector2i newOffset, ItemComponent? component = null)
     {
         if (!Resolve(uid, ref component, false))
             return;
-        
+
         component.StoredOffset = newOffset;
         Dirty(uid, component);
     }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
storedOffset datafield now work correctly with in-storage object rotation
also add public API for storedOffset datafield setter, for forks
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bug 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
before:
![image](https://github.com/user-attachments/assets/e80d33e3-0f74-4375-a587-d77c969b2b47)
after:
![image](https://github.com/user-attachments/assets/b7e0d757-075b-4862-bc43-0e74419aa714)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->