### PR TITLE
Cog/Marathon: Airlock fixes

### DIFF
--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -9815,6 +9815,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,-44.5
       parent: 30
+    - type: DeviceLinkSink
+      invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
         10559:
@@ -9827,6 +9829,12 @@ entities:
       parent: 30
     - type: DeviceLinkSink
       invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        9342:
+        - DoorStatus: DoorBolt
+      lastSignals:
+        DoorStatus: True
   - uid: 20059
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR fixes two airlocks that weren't wired correctly. First is the airlock on the TEG on Marathon, that only had it's exterior airlock hooked up. Second is the exterior atmos airlock which wasn't wired at all.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I'm fairly certain these airlocks weren't hooked up purely by accident, and even then, most engies I've seen have simply wired them themselves.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a link between the exterior TEG airlock on Marathon to it's interior counterpart to trigger it to bolt when the exterior airlock is opened.
Hooks together the interior and exterior airlock that connects atmospherics to space on Cog as all other airlocks are done.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed the link on Marathon's TEG exterior airlock
- fix: Fixed Cog's exterior atmospherics airlock