### PR TITLE
Display GPS coordinates on their own line

### DIFF
--- a/Resources/Locale/en-US/GPS/handheld-gps.ftl
+++ b/Resources/Locale/en-US/GPS/handheld-gps.ftl
@@ -1,1 +1,3 @@
-handheld-gps-coordinates-title = Coords: {$coordinates}
+handheld-gps-coordinates-title =
+    Coords:
+    {$coordinates}


### PR DESCRIPTION
## About the PR
Moves GPS coordinates to their own line, after the text "Coords:".

## Why / Balance
With the newish action bar, the previous single-line approach frequently resulted in hard-to-read coordinates. In particular, if the Y-coordinate is negative, the minus sign has a tendency to stay on the first line while the rest migrates to the second. It's much too easy to miss it and send people on a wild goose chase. Especially problematic considering coordinates are usually needed when one is lost and time is of the essence.

## Technical details
.ftl change only

## Media
**Before** (from Frontier, where PDAs all come with the AstroNav app):
![image](https://github.com/user-attachments/assets/824ec5a0-bc82-479d-bf36-38b134bcdebc)

**After:**
![image](https://github.com/user-attachments/assets/af01a313-72a9-4502-8597-ad1fe63b4a6f)

The label can easily support ridiculous, unrealistically large offsets even within the limited space afforded to it:
![image](https://github.com/user-attachments/assets/62a5746e-cabf-4cda-b1c9-6c93d7a81fac)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No.

**Changelog**
:cl:
- tweak: GPS coordinates are now more readable.