### PR TITLE
Improved French accent (th sound)

### DIFF
--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Speech.Components;
 using System.Text.RegularExpressions;
+using Robust.Shared.Random;
 
 namespace Content.Server.Speech.EntitySystems;
 
@@ -8,6 +9,7 @@ namespace Content.Server.Speech.EntitySystems;
 /// </summary>
 public sealed class FrenchAccentSystem : EntitySystem
 {
+    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
 
     private static readonly Regex RegexTh = new(@"th", RegexOptions.IgnoreCase);
@@ -27,14 +29,38 @@ public sealed class FrenchAccentSystem : EntitySystem
 
         msg = _replacement.ApplyReplacements(msg, "french");
 
-        // replaces th with z
-        msg = RegexTh.Replace(msg, "'z");
-
         // replaces h with ' at the start of words.
         msg = RegexStartH.Replace(msg, "'");
 
         // spaces out ! ? : and ;.
         msg = RegexSpacePunctuation.Replace(msg, " $&");
+        
+        // replaces th with 'z or 's depending on the case
+        var offset = 0;
+        foreach (Match match in RegexTh.Matches(msg))
+        {
+            var i = match.Index + offset;
+
+            var uppercase = msg.Substring(i, 2).Contains("TH");
+            var Z = uppercase ? "Z" : "z";
+            var S = uppercase ? "S" : "s";
+            var idxLetter = i + 2;
+
+            // If th is alone, just do 'zis
+            if (msg.Length <= idxLetter) {
+                msg = msg.Substring(0, i) + "'" + Z;
+            } else {
+                var c = "aeiouy".Contains(msg.Substring(idxLetter, 1).ToLower()) ? Z : S;
+
+                // french people tend to force 'ze s when talking, especially loudly
+                if (c == S && _random.Prob(uppercase ? 0.75f : 0.25f)) {
+                    c += c;
+                    offset += 1;
+                }
+
+                msg = msg.Substring(0, i) + "'" + c + msg.Substring(idxLetter);
+            }
+        }
 
         return msg;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Enhance 'ze `th` part of 'ze French accent

## Why / Balance

2 reasons:
1.  The french accent couldn't have uppercase `'z` characters. While it looks good on the start of sentences, have fully uppercase messages looking like **'zIS IS 'zE WAY** was imo a problem.

2. Most french people use `'s` or `'f` when `th` preceeds a consonna.

Since it varies a lot depending on the people who use it and knowing that `'f` may be confusing (*'free* for *three* sounds confusing), I put `'s` as a general rule. Also, french people tend to force the `'S` consonna, so I doubled it randomly.

It's still imperfect tho, since french people would for example not say *zink* but *sink* for the word *think*, but it's still closer to reality imo.

I'm still not sure if the character `'` should be before the `s` either, but I feel like it makes it clearer that it's an accent artifact.


## Technical details

The RegEx replace for `th` was replaced by a RegEx matching, following the German Accent example.

The scary part of this code may be the `offset` variable which is there to ensure we offset the matching indexes when doubling the `'s`.

The code should be easily readable and testable by just logging to a server and testing the edgecases (which I think I already covered in my own tests).


## Media

![image](https://github.com/user-attachments/assets/e186be9d-48bc-45c5-b595-cbf6f71992d7)
![image](https://github.com/user-attachments/assets/9df71085-35d1-4551-acce-3365a34df038)
![image](https://github.com/user-attachments/assets/7b8604ed-b8e5-4662-a947-0cd1992f3f31)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
No breaking changes
