### PR TITLE
Fix hugging buckled mobs instead of unbuckling

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Interaction.cs
@@ -15,11 +15,11 @@ public abstract partial class SharedBuckleSystem
     private void InitializeInteraction()
     {
         SubscribeLocalEvent<StrapComponent, GetVerbsEvent<InteractionVerb>>(AddStrapVerbs);
-        SubscribeLocalEvent<StrapComponent, InteractHandEvent>(OnStrapInteractHand, after: [typeof(InteractionPopupSystem)]);
+        SubscribeLocalEvent<StrapComponent, InteractHandEvent>(OnStrapInteractHand, before: [typeof(InteractionPopupSystem)]);
         SubscribeLocalEvent<StrapComponent, DragDropTargetEvent>(OnStrapDragDropTarget);
         SubscribeLocalEvent<StrapComponent, CanDropTargetEvent>(OnCanDropTarget);
 
-        SubscribeLocalEvent<BuckleComponent, InteractHandEvent>(OnBuckleInteractHand, after: [typeof(InteractionPopupSystem)]);
+        SubscribeLocalEvent<BuckleComponent, InteractHandEvent>(OnBuckleInteractHand, before: [typeof(InteractionPopupSystem)]);
         SubscribeLocalEvent<BuckleComponent, GetVerbsEvent<InteractionVerb>>(AddUnbuckleVerb);
     }
 

--- a/Content.Shared/Interaction/InteractionPopupSystem.cs
+++ b/Content.Shared/Interaction/InteractionPopupSystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Bed.Sleep;
-using Content.Shared.Buckle.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
@@ -66,12 +65,6 @@ public sealed class InteractionPopupSystem : EntitySystem
 
         if (TryComp<MobStateComponent>(uid, out var state)
             && !_mobStateSystem.IsAlive(uid, state))
-        {
-            return;
-        }
-
-        if (TryComp<BuckleComponent>(uid, out var buckle)
-            && buckle.BuckledTo != null)
         {
             return;
         }

--- a/Content.Shared/Interaction/InteractionPopupSystem.cs
+++ b/Content.Shared/Interaction/InteractionPopupSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Bed.Sleep;
+using Content.Shared.Buckle.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
@@ -65,6 +66,12 @@ public sealed class InteractionPopupSystem : EntitySystem
 
         if (TryComp<MobStateComponent>(uid, out var state)
             && !_mobStateSystem.IsAlive(uid, state))
+        {
+            return;
+        }
+
+        if (TryComp<BuckleComponent>(uid, out var buckle)
+            && buckle.BuckledTo != null)
         {
             return;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

Requires #33602

## Why / Balance
Fixes a bug that was discussed  here #29282

## Technical details
Makes InteractHandEvent to be used by SharedBuckleSystem.Interaction before InteractionPopupSystem instead of after

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/6d69109b-68fc-4adb-a35a-846d337893a6

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Clicking on a buckled mob now unbuckles it, rather than hugging/petting it.
