### PR TITLE
Add missing nacho recipes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -109,12 +109,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 11
         reagents:
         - ReagentId: Nutriment
-          Quantity: 6
+          Quantity: 4
         - ReagentId: Vitamin
-          Quantity: 2
+          Quantity: 1
         - ReagentId: TableSalt
           Quantity: 1
 # Tastes like nachos.
@@ -159,21 +159,21 @@
   - type: FlavorProfile
     flavors:
       - nachos
-      - cheesy
+      - tomato
       - spicy
   - type: Sprite
     state: nachos-cuban
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
-          Quantity: 7
-        - ReagentId: CapsaicinOil
           Quantity: 8
+        - ReagentId: CapsaicinOil
+          Quantity: 7
         - ReagentId: Vitamin
-          Quantity: 4
+          Quantity: 5
 # Tastes like nachos, hot pepper.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -98,11 +98,25 @@
   id: FoodMealNachos
   description: Chips from Space Mexico.
   components:
+  - type: Food
+    trash:
+    - FoodPlateSmall
   - type: FlavorProfile
     flavors:
       - nachos
   - type: Sprite
     state: nachos
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 6
+        - ReagentId: Vitamin
+          Quantity: 2
+        - ReagentId: TableSalt
+          Quantity: 1
 # Tastes like nachos.
 
 - type: entity
@@ -111,6 +125,9 @@
   id: FoodMealNachosCheesy
   description: The delicious combination of nachos and melting cheese.
   components:
+  - type: Food
+    trash:
+    - FoodPlateSmall
   - type: FlavorProfile
     flavors:
       - nachos
@@ -136,6 +153,9 @@
   id: FoodMealNachosCuban
   description: That's some dangerously spicy nachos.
   components:
+  - type: Food
+    trash:
+    - FoodPlateSmall
   - type: FlavorProfile
     flavors:
       - nachos

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1221,6 +1221,41 @@
     FoodCarrot: 1
 
 - type: microwaveMealRecipe
+  id: RecipeNachos
+  name: nachos recipe
+  result: FoodMealNachos
+  time: 10
+  reagents:
+    TableSalt: 1
+  solids:
+    FoodDoughTortillaFlat: 1
+    FoodPlateSmall: 1
+
+- type: microwaveMealRecipe
+  id: RecipeNachosCheesy
+  name: cheesy nachos recipe
+  result: FoodMealNachosCheesy
+  time: 10
+  reagents:
+    TableSalt: 1
+  solids:
+    FoodCheeseSlice: 1
+    FoodDoughTortillaFlat: 1
+    FoodPlateSmall: 1
+
+- type: microwaveMealRecipe
+  id: RecipeNachosCuban
+  name: cuban nachos recipe
+  result: FoodMealNachosCuban
+  time: 10
+  reagents:
+    Ketchup: 5
+  solids:
+    FoodChiliPepper: 2
+    FoodDoughTortillaFlat: 1
+    FoodPlateSmall: 1
+
+- type: microwaveMealRecipe
   id: RecipePopcorn
   name: popcorn recipe
   result: FoodSnackPopcorn

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1251,7 +1251,7 @@
   reagents:
     Ketchup: 5
   solids:
-    FoodChiliPepper: 2
+    FoodChiliPepper: 1
     FoodDoughTortillaFlat: 1
     FoodPlateSmall: 1
 


### PR DESCRIPTION
## About the PR
This adds recipes for three types of nachos. They're in the game via spawner, just not able to be cooked until now.

## Why / Balance
These foods are practically implemented outside of missing a cooking recipe.

## Technical details
In meal_recipes.yml: Add recipes for Nachos, Cheesy Nachos, and Cuban Nachos.
In meals.yml: Add a solutions container to regular nachos so it lines up with the others, and add a small plate as trash to each one.

## Media
Nachos
https://github.com/user-attachments/assets/fb98f43c-9350-43c8-8e71-b556594fb540
Cheesy Nachos
https://github.com/user-attachments/assets/4d0faf25-752c-4a3f-a43d-be7e8faa7821
Cuban Nachos
https://github.com/user-attachments/assets/2a7a39a7-7bb5-44a8-b52a-8120c33c420a

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added recipes for Nachos, Cheesy Nachos, and Cuban Nachos.