### PR TITLE
Remove grasshopper from the panic bunker message

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -9,7 +9,7 @@ panic_bunker.enabled = true
 panic_bunker.disable_with_admins = true
 panic_bunker.enable_without_admins = true
 panic_bunker.show_reason = true
-panic_bunker.custom_reason = "You have not played on a Wizard's Den server long enough to connect to this server. Please play on Wizard's Den Lizard or Farm Grass Hopper until you have more playtime."
+panic_bunker.custom_reason = "You have not played on a Wizard's Den server long enough to connect to this server. Please play on Wizard's Den Lizard until you have more playtime."
 
 [infolinks]
 bug_report = "https://github.com/space-wizards/space-station-14/issues/new/choose"


### PR DESCRIPTION
Can be retargetted to stable if preferred, which will then be a hotfix