### PR TITLE
Fix for inspecting entities in hand

### DIFF
--- a/Content.Client/UserInterface/Systems/Hands/HandsUIController.cs
+++ b/Content.Client/UserInterface/Systems/Hands/HandsUIController.cs
@@ -83,22 +83,27 @@ public sealed class HandsUIController : UIController, IOnStateEntered<GameplaySt
         if (args.Function == EngineKeyFunctions.UIClick)
         {
             _handsSystem.UIHandClick(_playerHandsComponent, hand.SlotName);
+            args.Handle();
         }
         else if (args.Function == EngineKeyFunctions.UseSecondary)
         {
             _handsSystem.UIHandOpenContextMenu(hand.SlotName);
+            args.Handle();
         }
         else if (args.Function == ContentKeyFunctions.ActivateItemInWorld)
         {
             _handsSystem.UIHandActivate(hand.SlotName);
+            args.Handle();
         }
         else if (args.Function == ContentKeyFunctions.AltActivateItemInWorld)
         {
             _handsSystem.UIHandAltActivateItem(hand.SlotName);
+            args.Handle();
         }
         else if (args.Function == ContentKeyFunctions.ExamineEntity)
         {
             _handsSystem.UIInventoryExamine(hand.SlotName);
+            args.Handle();
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You can now inspect entities in your hand without it attempting to inspect the entity beneath the hand-slot in the world

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/27221

You weren't able to inspect the entity in your hand if there was any inspectable entity underneath where you clicked

## Technical details
<!-- Summary of code changes for easier review. -->
Handle the click arg on the hand slot instead of letting the click continue on to do whatever other things

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:

https://github.com/user-attachments/assets/4018baad-1c5c-463d-b257-e8e527eff5c3


After:

https://github.com/user-attachments/assets/09d4a78b-9b18-4a96-9dc8-56298dc6da4a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: You can now inspect the entity in your hand instead of the entity that happened to be underneath your hand.