### PR TITLE
Mercenary gear contraband tweaks.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -184,7 +184,7 @@
 - type: entity
   parent: ClothingBackpack
   id: ClothingBackpackMerc
-  name: merc bag
+  name: mercenary bag
   description: A backpack that has been in many dangerous places, a reliable combat backpack.
   components:
     - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -285,7 +285,7 @@
     fiberColor: fibers-black
 
 - type: entity
-  parent: ClothingHandsGlovesCombat
+  parent: [ ClothingHandsGlovesColorBlack, BaseSecurityCargoContraband ]
   id: ClothingHandsMercGlovesCombat
   name: mercenary combat gloves
   description: High-quality combat gloves to protect hands from mechanical damage during combat.

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -285,7 +285,7 @@
     fiberColor: fibers-black
 
 - type: entity
-  parent: [ ClothingHandsGlovesColorBlack, BaseSecurityCargoContraband ]
+  parent: [ BaseSecurityCargoContraband, ClothingHandsGlovesCombat ]
   id: ClothingHandsMercGlovesCombat
   name: mercenary combat gloves
   description: High-quality combat gloves to protect hands from mechanical damage during combat.

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -182,7 +182,7 @@
     sprite: Clothing/Head/Hats/beret_brigmedic.rsi
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseRestrictedContraband ]
+  parent: [ ClothingHeadBase ]
   id: ClothingHeadHatBeretMerc
   name: mercenary beret
   description: Olive beret, the badge depicts a jackal on a rock.

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -39,7 +39,7 @@
 
 #Mercenary Helmet
 - type: entity
-  parent: [ ClothingHeadHelmetBase, BaseRestrictedContraband ]
+  parent: [ ClothingHeadHelmetBase, BaseMajorContraband ]
   id: ClothingHeadHelmetMerc
   name: mercenary helmet
   description: The combat helmet is commonly used by mercenaries, is strong, light and smells like gunpowder and the jungle.

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -385,7 +385,7 @@
         Heat: 0.95
 
 - type: entity
-  parent: [ ClothingMaskGas, BaseRestrictedContraband ]
+  parent: [ ClothingMaskGas, BaseSecurityCargoContraband ]
   id: ClothingMaskGasMerc
   name: mercenary gas mask
   description: Slightly outdated, but reliable military-style gas mask.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -21,9 +21,9 @@
 
 #Mercenary web vest
 - type: entity
-  parent: [ClothingOuterVestWeb, BaseMinorContraband] #web vest so it should have some pockets for ammo
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing,  BaseMajorContraband] #web vest so it should have some pockets for ammo
   id: ClothingOuterVestWebMerc
-  name: merc web vest
+  name: mercenary web vest
   description: A high-quality armored vest made from a hard synthetic material. It's surprisingly flexible and light, despite formidable armor plating.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -21,7 +21,7 @@
 
 #Mercenary web vest
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing,  BaseMajorContraband] #web vest so it should have some pockets for ammo
+  parent: [ BaseMajorContraband, ClothingOuterVestWeb] #web vest so it should have some pockets for ammo
   id: ClothingOuterVestWebMerc
   name: mercenary web vest
   description: A high-quality armored vest made from a hard synthetic material. It's surprisingly flexible and light, despite formidable armor plating.

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -73,7 +73,7 @@
     sprite: Clothing/Shoes/Boots/highheelboots.rsi
 
 - type: entity
-  parent: [ ClothingShoesMilitaryBase, BaseRestrictedContraband ]
+  parent: [ ClothingShoesMilitaryBase ]
   id: ClothingShoesBootsMerc
   name: mercenary boots
   description: Boots that have gone through many conflicts and that have proven their combat reliability.

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -860,7 +860,7 @@
       mode: SensorOff
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseRestrictedContraband ]
+  parent: [ ClothingUniformBase ]
   id: ClothingUniformJumpsuitMercenary
   name: mercenary jumpsuit
   description: Clothing for real mercenaries who have gone through fire, water and the jungle of planets flooded with dangerous monsters or targets for which a reward has been assigned.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -129,7 +129,7 @@
 
 - type: entity
   name: kukri knife
-  parent: [CombatKnife, BaseMinorContraband]
+  parent: [CombatKnife, BaseSecurityCargoContraband]
   id: KukriKnife
   description: Professionals have standards. Be polite. Be efficient. Have a plan to kill everyone you meet.
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR standardizes the contraband status of Mercenary items.

**Non-Contraband:** Mercenary Bandana, Mercenary Beret, Mercenary Fingerless Gloves, Mercenary Boots, Mercenary Bag, Mercenary Jumpsuit, Mercenary Glasses.

**Security/Cargo Restricted:** Mercenary Gloves, Mercenary Gas Mask, Mercenary Webbing, Kukri.

**Major Contraband:** Mercenary Helmet, Mercenary Web Vest.

I am very open to tweaking the different levels of contraband based on feedback, but my general thoughts were that all cosmetic-only items should be non-contraband, items that provide utility should be Cargo/Sec restricted to allow Salvage to use them without much issue (The Kukri being included as it comes in Mercenary Boots and isn't out of line for a Salvage weapon), and to have the purely armor items as Major Contraband given that they're effectively Security gear. 

## Why / Balance
Mercenary Gear's contraband status is all over the place. Some items were marked as Security only, some as Cargo and Security, some as just Major Contraband, some Syndicate Contraband, some non-contraband, with very little rhyme or reason. This PR standardizes contraband levels (As well as tweaking the names for the Mercenary Bag/Vest).

I've had suggestions that all Mercenary gear should be minor/major contraband across the board, and i've had suggestions to make it all Cargo restricted only, and i've personally gone back and forth on a bunch of items. Please leave your own feedback on the topic, i'd love to hear it.

## Technical details
Changes to the relevant yml files for the items, nothing major. I did have to change some of the parents for the Merc Gloves and Merc Web Vest to change their contra status, please let me know if that causes any issues.

(I also noticed the uh, Kukri's storage sprite seems kinda borked. And is it supposed to be a 1x2 now instead of the curved pistol size? Weird.)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/dc48b889-2e0f-498a-a087-536130fee745)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Redbookcase
- tweak: Standardized Mercenary gear's contraband status.

