### PR TITLE
Added whitelist for sigarrete packs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -48,6 +48,11 @@
     shape: # Yes, this is cursed, but it breaks otherwise, dont question it.
     - 0,0,0,1
   - type: Storage
+    whitelist:
+      tags:
+        - Cigarette
+        - Lighter
+        - Cigar
     grid:
     - 0,0,4,1
   - type: StorageFill
@@ -117,6 +122,11 @@
     shape: # Yes, this is cursed, but it breaks otherwise, dont question it.
     - 0,0,0,1
   - type: Storage
+    whitelist:
+      tags:
+        - Cigarette
+        - Lighter
+        - Cigar
     grid:
     - 0,0,4,1
   - type: StorageFill

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/case.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/case.yml
@@ -36,6 +36,11 @@
       map: ["cigar8"]
       visible: false
   - type: Storage
+    whitelist:
+      tags:
+        - Cigarette
+        - Lighter
+        - Cigar
     grid:
     - 0,0,3,1
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -88,6 +88,9 @@
     radius: 1.1 #smallest possible
     color: orange
   - type: ItemTogglePointLight
+  - type: Tag
+    tags:
+    - Lighter
 
 - type: entity
   name: cheap lighter

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -768,6 +768,9 @@
   id: LightBulb
 
 - type: Tag
+  id: Lighter
+
+- type: Tag
   id: Lime
 
 - type: Tag


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Whitelist added for cigs packs to prevent storing other tiny objects inside

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Preventing stuff like this _(don't mind russian and different texture :p )_
![bf31d716-ea8a-47f6-a07d-9258804d78d6](https://github.com/user-attachments/assets/0697199e-ebb6-4bb7-af94-1fcca974c307)

## Technical details
<!-- Summary of code changes for easier review. -->
Whitelist added for Base cigs packs

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
none
**Changelog**

:cl: Svarshik
- tweak: Whitelist added for cigarette packs to prevent using it as tiny item storage.