### PR TITLE
add locale to Shuttle Console Map tab

### DIFF
--- a/Resources/Locale/en-US/shuttles/console.ftl
+++ b/Resources/Locale/en-US/shuttles/console.ftl
@@ -30,6 +30,7 @@ shuttle-console-ftl-state-Starting = Starting
 shuttle-console-ftl-state-Travelling = Travelling
 shuttle-console-ftl-state-Arriving = Arriving
 shuttle-console-ftl-state-Cooldown = Cooldown
+shuttle-console-ftl-state-Invalid = Invalid
 
 shuttle-console-map-settings = Settings
 shuttle-console-ftl-button = FTL


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
added ftl localization for incorrect FTL status of the shuttle

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![UIUpdate_FixFTL](https://github.com/user-attachments/assets/21f1573b-2b4f-414e-aacc-509a6e752f66)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Locale to shuttle-ftl-status-Invalid

