### PR TITLE
Fix the PowerCharge menu so that it has correct text wrapping

### DIFF
--- a/Content.Client/Power/PowerCharge/PowerChargeWindow.xaml
+++ b/Content.Client/Power/PowerCharge/PowerChargeWindow.xaml
@@ -1,33 +1,88 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                MinSize="270 130"
-                SetSize="360 180">
-    <BoxContainer Margin="4 0" Orientation="Horizontal">
-        <BoxContainer Orientation="Vertical" HorizontalExpand="True">
-            <GridContainer Margin="2 0 0 0" Columns="2">
+﻿<controls:FancyWindow
+    xmlns="https://spacestation14.io"
+    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+    MinSize="320 180"
+    Resizable="False">
+    <BoxContainer
+        Margin="12 8"
+        Orientation="Horizontal"
+        SeparationOverride="12">
+        <BoxContainer
+            Orientation="Vertical"
+            HorizontalExpand="True">
+            <GridContainer
+                Columns="2"
+                VerticalAlignment="Center">
+
                 <!-- Power -->
-                <Label Text="{Loc 'power-charge-window-power'}" HorizontalExpand="True" StyleClasses="StatusFieldTitle" />
-                <BoxContainer Orientation="Horizontal" MinWidth="120">
-                    <Button Name="OnButton" Text="{Loc 'power-charge-window-power-on'}" StyleClasses="OpenRight" />
-                    <Button Name="OffButton" Text="{Loc 'power-charge-window-power-off'}" StyleClasses="OpenLeft" />
+                <Label
+                    Text="{Loc 'power-charge-window-power'}"
+                    HorizontalExpand="True"
+                    StyleClasses="StatusFieldTitle" />
+
+                <BoxContainer
+                    Orientation="Horizontal"
+                    MinWidth="120"
+                    SetWidth="160">
+
+                    <Button Name="OnButton"
+                        Text="{Loc 'power-charge-window-power-on'}"
+                        StyleClasses="OpenRight"
+                        MinWidth="60"
+                        SetWidth="80"
+                        HorizontalAlignment="Center"/>
+
+                    <Button
+                        Name="OffButton"
+                        Text="{Loc 'power-charge-window-power-off'}"
+                        StyleClasses="OpenLeft"
+                        MinWidth="60"
+                        SetWidth="80"
+                        HorizontalAlignment="Center"/>
                 </BoxContainer>
-                <Control /> <!-- Empty control to act as a spacer in the grid. -->
-                <Label Name="PowerLabel" Text="0 / 0 W" />
+
                 <!-- Status -->
-                <Label Text="{Loc 'power-charge-window-status'}"  StyleClasses="StatusFieldTitle" />
-                <Label Name="StatusLabel" Text="{Loc 'power-charge-window-status-fully-charged'}" />
+                <Label
+                    Text="{Loc 'power-charge-window-status'}"
+                    StyleClasses="StatusFieldTitle" />
+                <Label Name="StatusLabel"
+                    Text="{Loc 'power-charge-window-status-fully-charged'}" />
+
                 <!-- ETA -->
-                <Label Text="{Loc 'power-charge-window-eta'}" StyleClasses="StatusFieldTitle" />
-                <Label Name="EtaLabel" Text="N/A" />
+                <Label
+                    Text="{Loc 'power-charge-window-eta'}"
+                    StyleClasses="StatusFieldTitle" />
+                <Label Name="EtaLabel"
+                    Text="N/A" />
+
                 <!-- Charge -->
-                <Label Text="{Loc 'power-charge-window-charge'}" StyleClasses="StatusFieldTitle" />
-                <ProgressBar Name="ChargeBar" MaxValue="255">
-                    <Label Name="ChargeText" Margin="4 0" Text="0 %" />
+                <Label
+                    Text="{Loc 'power-charge-window-charge'}"
+                    StyleClasses="StatusFieldTitle" />
+
+                <ProgressBar Name="ChargeBar"
+                    MaxValue="255">
+
+                    <Label Name="ChargeText"
+                        HorizontalAlignment="Center"
+                        Margin="4 0"
+                        Text="0 %" />
                 </ProgressBar>
+
+                <Control /> <!-- Empty control to act as a spacer in the grid. -->
+
+                <Label Name="PowerLabel"
+                    Text="0 / 0 W" />                
             </GridContainer>
         </BoxContainer>
-        <PanelContainer Margin="12 0 0 0" StyleClasses="Inset" VerticalAlignment="Center">
-            <SpriteView Name="EntityView" SetSize="96 96" OverrideDirection="South" />
+        <PanelContainer
+            StyleClasses="Inset"
+            VerticalAlignment="Top">
+            
+            <SpriteView Name="EntityView"
+                SetSize="96 96"
+                Margin="0 0 0 26"
+                OverrideDirection="South" />
         </PanelContainer>
     </BoxContainer>
 </controls:FancyWindow>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Subdivision of https://github.com/space-wizards/space-station-14/pull/33632 PR

## About the PR
<!-- What did you change? -->
Fixed and slightly edited the PowerCharge menu. Now on the RU localization, no text will climb where it is not needed.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Before
![2024-11-28_23-45-53](https://github.com/user-attachments/assets/6421ca5d-6fd4-4a1b-81d9-d867137ce10c)

### After
![UIUpdate_PowerCharge](https://github.com/user-attachments/assets/898a88b7-6ea5-49ea-9564-c416c1d94062)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: fix Power Charge (Gravity gen) resizable. Now it looks like it should, in other languages.

