### PR TITLE
Make bible recharge popup only show for entities in the same or parent container

### DIFF
--- a/Content.Server/Bible/BibleSystem.cs
+++ b/Content.Server/Bible/BibleSystem.cs
@@ -92,8 +92,8 @@ namespace Content.Server.Bible
                     uid,
                     Filter.PvsExcept(uid, entityManager: EntityManager)
                         .RemoveWhere(e =>
-                            e.AttachedEntity != null && (!_container.IsInSameOrParentContainer((uid, Transform(uid)),
-                                (e.AttachedEntity.Value, Transform(e.AttachedEntity.Value))) && _container.IsEntityInContainer(uid))),
+                            e.AttachedEntity != null && _container.IsEntityInContainer(uid) && !_container.IsInSameOrParentContainer((uid, Transform(uid)),
+                                (e.AttachedEntity.Value, Transform(e.AttachedEntity.Value)))),
                     true,
                     PopupType.Medium);
                 _audio.PlayPvs("/Audio/Effects/radpulse9.ogg", uid, AudioParams.Default.WithVolume(-4f));

--- a/Content.Server/Bible/BibleSystem.cs
+++ b/Content.Server/Bible/BibleSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.Timing;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 
@@ -33,6 +34,7 @@ namespace Content.Server.Bible
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly UseDelaySystem _delay = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
+        [Dependency] private readonly SharedContainerSystem _container = default!;
 
         public override void Initialize()
         {
@@ -83,7 +85,17 @@ namespace Content.Server.Bible
                     summonableComp.Summon = null;
                 }
                 summonableComp.AlreadySummoned = false;
-                _popupSystem.PopupEntity(Loc.GetString("bible-summon-respawn-ready", ("book", uid)), uid, PopupType.Medium);
+                // Only play the popup if the entity is the person holding the book,
+                // if the person is in the same container as the book,
+                // or if the book isn't in a container
+                _popupSystem.PopupEntity(Loc.GetString("bible-summon-respawn-ready", ("book", uid)),
+                    uid,
+                    Filter.PvsExcept(uid, entityManager: EntityManager)
+                        .RemoveWhere(e =>
+                            e.AttachedEntity != null && (!_container.IsInSameOrParentContainer((uid, Transform(uid)),
+                                (e.AttachedEntity.Value, Transform(e.AttachedEntity.Value))) && _container.IsEntityInContainer(uid))),
+                    true,
+                    PopupType.Medium);
                 _audio.PlayPvs("/Audio/Effects/radpulse9.ogg", uid, AudioParams.Default.WithVolume(-4f));
                 // Clean up the accumulator and respawn tracking component
                 summonableComp.Accumulator = 0;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes the bible recharge text to only show the recharge popup if the bible itself isn't in a container, or if the other entities are in the same container as the bible, or if the other entity is the parent container for the bible

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently the recharge text shows for absolutely everyone, it's very awkward when your necronomicon recharges in a public location and everyone just reads the popup text to know that you have one. The necronomicon should at least be visible for people to be able to differentiate it being a bible or a necronomicon.

## Technical details
<!-- Summary of code changes for easier review. -->
Filter out all entities that aren't in the same or parent container as the bible, and only while the bible itself is in a container. If you don't check for the bible itself being in a container, then you wouldn't be able to see the necronomicon popup if it's sitting on the floor while you're in a locker.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Holder in locker

https://github.com/user-attachments/assets/e64b8c76-3a64-4ad0-803f-4eab0ad2646d

Holder not in a locker

https://github.com/user-attachments/assets/cd47374c-c7b4-4131-8f34-00e2b248333d

Not in a container at all

https://github.com/user-attachments/assets/6c75c69a-5184-411d-a211-493f0578c0c5

Observer in locker

https://github.com/user-attachments/assets/cce94de2-1800-4b65-b0ac-4ee10f80e114


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Necronomicon and bible recharge popup now only shows for the person holding the necronomicon.