### PR TITLE
Fix for arrivals deleting nuke

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -1002,6 +1002,7 @@ public sealed partial class ShuttleSystem
                     continue;
                 }
 
+                // If it has the FTLSmashImmuneComponent ignore it.
                 if (_immuneQuery.HasComponent(ent))
                 {
                     continue;

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -110,6 +110,7 @@
   - type: WarpPoint
     follow: true
     location: nuclear bomb
+  - type: FTLSmashImmune
 
 - type: entity
   parent: NuclearBomb


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes #30555 by adding the FTLSmashImmuneComponent to the nuke prototype, also adds a comment to indicate where this component is checked in ShuttleSystem.FasterThanLight.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Deletion of the nuke could be rather problematic for certain gamemodes / objectives so this just attempts to prevent one of the known ways of doing so.

## Technical details
<!-- Summary of code changes for easier review. -->
The FTLSmashImmuneComponent was initially added to prevent the AI observer from getting smashed by arrivals and adding it here seems to cause no issues as far as I was able to tell. Worst case I found is the nuke gets stuck in the shuttle wall while it's docked but can be retrieved immediately upon the shuttle's departure, a more elegant solution may be possible but this works to prevent the main issue.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: The arrival shuttle will no longer smash the nuke

