### PR TITLE
Zombies can see Initial Infected

### DIFF
--- a/Resources/Locale/en-US/zombies/zombie.ftl
+++ b/Resources/Locale/en-US/zombies/zombie.ftl
@@ -1,9 +1,9 @@
 zombie-transform = {CAPITALIZE(THE($target))} turned into a zombie!
-zombie-infection-greeting = You have become a zombie. Your goal is to seek out the living and to try to infect them.  Work together with the other zombies to overtake the station.
+zombie-infection-greeting = You have become a zombie. Your goal is to seek out the living and to try to infect them.  Work together with the other zombies and remaining initial infected to overtake the station.
 
 zombie-generic = zombie
 zombie-name-prefix = zombified {$baseName}
 zombie-role-desc =  A malevolent creature of the dead.
-zombie-role-rules = You are an antagonist. Search out the living and bite them in order to infect them and turn them into zombies. Work together with the other zombies to overtake the station.
+zombie-role-rules = You are an antagonist. Search out the living and bite them in order to infect them and turn them into zombies. Work together with the other zombies and remaining initial infected to overtake the station.
 
 zombie-permadeath = This time, you're dead for real.

--- a/Resources/Prototypes/StatusIcon/faction.yml
+++ b/Resources/Prototypes/StatusIcon/faction.yml
@@ -17,6 +17,7 @@
     components:
     - ShowAntagIcons
     - InitialInfected
+    - Zombie
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: InitialInfected


### PR DESCRIPTION
## About the PR
Zombies can now see initial infected.

## Why / Balance
Many times I've seen Initial Infected's sabotage plans get ruined by another II who's starting to bite people 5 minutes into the match, making the former fight both the living and the agressive turned.
This should improve gameplay as Initial Infected and zombies in general, as they will cooperate better now.

This is kind of controversial in terms of lore, but both options can be justified:
- On one hand, zombies are completely braindead and just attack all living.
- On the other hand, Initial Infected are Syndicate bioterrorists who have/keep the virus since the beginning on the match, and zombies can sense it somehow, just like they can sense each other.

## Technical details
Only prototype change.

## Media
![image](https://github.com/user-attachments/assets/93d79bc5-5d6e-48d6-8586-69fb2988134b)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- add: Zombies can now see initial infected