### PR TITLE
Upgrade GitHub actions in Workfows to `node20`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,7 +11,7 @@ jobs:
     name: Run Benchmarks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.6.0
+    - uses: actions/checkout@v4.2.2
       with:
         submodules: 'recursive'
     - name: Get Engine version

--- a/.github/workflows/build-docfx.yml
+++ b/.github/workflows/build-docfx.yml
@@ -8,7 +8,7 @@ jobs:
   docfx:
    runs-on: ubuntu-latest
    steps:
-    - uses: actions/checkout@v3.6.0
+    - uses: actions/checkout@v4.2.2
     - name: Setup submodule
       run: |
         git submodule update --init --recursive
@@ -19,7 +19,7 @@ jobs:
         cd RobustToolbox/
         git submodule update --init --recursive
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3.2.0
+      uses: actions/setup-dotnet@v4.1.0
       with:
         dotnet-version: 8.0.x
 

--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Master
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.2.2
 
       - name: Setup Submodule
         run: |
@@ -34,7 +34,7 @@ jobs:
           git submodule update --init --recursive
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3.2.0
+        uses: actions/setup-dotnet@v4.1.0
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout Master
-      uses: actions/checkout@v3.6.0
+      uses: actions/checkout@v4.2.2
 
     - name: Setup Submodule
       run: |
@@ -34,7 +34,7 @@ jobs:
         git submodule update --init --recursive
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3.2.0
+      uses: actions/setup-dotnet@v4.1.0
       with:
         dotnet-version: 8.0.x
 

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -10,6 +10,6 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.6.0
+    - uses: actions/checkout@v4.2.2
     - name: Check for CRLF
       run: Tools/check_crlf.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,11 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get install -y python3-paramiko python3-lxml
 
-    - uses: actions/checkout@v3.6.0
+    - uses: actions/checkout@v4.2.2
       with:
         submodules: 'recursive'
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3.2.0
+      uses: actions/setup-dotnet@v4.1.0
       with:
         dotnet-version: 8.0.x
 

--- a/.github/workflows/rsi-diff.yml
+++ b/.github/workflows/rsi-diff.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.2.2
 
       - name: Get changed files
         id: files
         uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'space-delimited'
-          filter: | 
+          filter: |
             **.rsi
             **.png
 

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Master
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.2.2
 
       - name: Setup Submodule
         run: |
@@ -49,7 +49,7 @@ jobs:
           git submodule update --init --recursive
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3.2.0
+        uses: actions/setup-dotnet@v4.1.0
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/update-credits.yml
+++ b/.github/workflows/update-credits.yml
@@ -4,19 +4,19 @@ on:
   workflow_dispatch:
   schedule:
     - cron: 0 0 * * 0
-    
+
 jobs:
   get_credits:
     runs-on: ubuntu-latest
     # Hey there fork dev! If you like to include your own contributors in this then you can probably just change this to your own repo
     # Do this in dump_github_contributors.ps1 too into your own repo
     if: github.repository == 'space-wizards/space-station-14'
-    
+
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.2.2
         with:
           ref: master
-        
+
       - name: Get this week's Contributors
         shell: pwsh
         env:
@@ -25,25 +25,25 @@ jobs:
 
       # TODO
       #- name: Get this week's Patreons
-      #  run: Tools/script2dumppatreons > Resources/Credits/Patrons.yml        
-      
+      #  run: Tools/script2dumppatreons > Resources/Credits/Patrons.yml
+
       # MAKE SURE YOU ENABLED "Allow GitHub Actions to create and approve pull requests" IN YOUR ACTIONS, OTHERWISE IT WILL MOST LIKELY FAIL
 
 
-      # For this you can use a pat token of an account with direct push access to the repo if you have protected branches. 
+      # For this you can use a pat token of an account with direct push access to the repo if you have protected branches.
       # Uncomment this and comment the other line if you do this.
       # https://github.com/stefanzweifel/git-auto-commit-action#push-to-protected-branches
-      
+
       #- name: Commit new credit files
       #  uses: stefanzweifel/git-auto-commit-action@v4
       #  with:
       #    commit_message: Update Credits
       #    commit_author: PJBot <pieterjan.briers+bot@gmail.com>
-      
+
       # This will make a PR
       - name: Set current date as env variable
         run: echo "NOW=$(date +'%Y-%m-%dT%H-%M-%S')" >> $GITHUB_ENV
-        
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.actor != 'PJBot' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.6.0
+    - uses: actions/checkout@v4.2.2
     - name: Setup Submodule
       run: git submodule update --init
     - name: Pull engine updates

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -13,7 +13,7 @@ jobs:
     name: Validate RSIs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.2.2
       - name: Setup Submodule
         run: git submodule update --init
       - name: Pull engine updates

--- a/.github/workflows/validate_mapfiles.yml
+++ b/.github/workflows/validate_mapfiles.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.actor != 'PJBot' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.6.0
+    - uses: actions/checkout@v4.2.2
     - name: Setup Submodule
       run: git submodule update --init
     - name: Pull engine updates

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.actor != 'PJBot' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.2.2
       - name: Setup submodule
         run: |
           git submodule update --init --recursive
@@ -24,7 +24,7 @@ jobs:
           cd RobustToolbox/
           git submodule update --init --recursive
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3.2.0
+        uses: actions/setup-dotnet@v4.1.0
         with:
           dotnet-version: 8.0.x
       - name: Install dependencies


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Upgrades Github Actions in Workflows to use `node20` instead of `node16`. These run on `node20` any way since 3rd June 2024 and it throws warnings like this:
> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3.6.0, actions/setup-dotnet@v3.2.0. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

See this for example:
https://github.com/space-wizards/space-station-14/actions/runs/12013279846

Also autoformatted `.yml` files in `.github/workflows` (trimmed spaces in the end of the strings)

## Why
Improves general technical infrastructure

## Technical details
Did the same for `RobustToolbox` (https://github.com/space-wizards/RobustToolbox/pull/5536)
Nothing breaks

## Testing 
Tests in this Pull Request are sufficient as they are run over the updated configuration of actions.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->