### PR TITLE
Fix formatting IDE0055 warnings in VS Code

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -258,13 +258,13 @@ namespace Content.Client.Actions
 
         public void LinkAllActions(ActionsComponent? actions = null)
         {
-             if (_playerManager.LocalEntity is not { } user ||
-                 !Resolve(user, ref actions, false))
-             {
-                 return;
-             }
+            if (_playerManager.LocalEntity is not { } user ||
+                !Resolve(user, ref actions, false))
+            {
+                return;
+            }
 
-             LinkActions?.Invoke(actions);
+            LinkActions?.Invoke(actions);
         }
 
         public override void Shutdown()

--- a/Content.Client/Clothing/FlippableClothingVisualizerSystem.cs
+++ b/Content.Client/Clothing/FlippableClothingVisualizerSystem.cs
@@ -7,7 +7,7 @@ using Robust.Client.GameObjects;
 
 namespace Content.Client.Clothing;
 
-public sealed class FlippableClothingVisualizerSystem  : VisualizerSystem<FlippableClothingVisualsComponent>
+public sealed class FlippableClothingVisualizerSystem : VisualizerSystem<FlippableClothingVisualsComponent>
 {
     [Dependency] private readonly SharedItemSystem _itemSys = default!;
 

--- a/Content.Shared/Chemistry/Events/HyposprayEvents.cs
+++ b/Content.Shared/Chemistry/Events/HyposprayEvents.cs
@@ -32,7 +32,7 @@ public sealed class SelfBeforeHyposprayInjectsEvent : BeforeHyposprayInjectsTarg
 ///     This event is raised on the target before the hypospray is injected.
 ///     The event is triggered on the target itself and all its clothing.
 /// </summary>
-public sealed class TargetBeforeHyposprayInjectsEvent  : BeforeHyposprayInjectsTargetEvent
+public sealed class TargetBeforeHyposprayInjectsEvent : BeforeHyposprayInjectsTargetEvent
 {
-    public TargetBeforeHyposprayInjectsEvent (EntityUid user, EntityUid hypospray, EntityUid target) : base(user, hypospray, target) { }
+    public TargetBeforeHyposprayInjectsEvent(EntityUid user, EntityUid hypospray, EntityUid target) : base(user, hypospray, target) { }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fix formatting IDE0055 warnings in VS Code.
All the changes are purely whitespace changes.
Done automatically by VS Code autoformatting.

Fixes identation in one file and extra spaces in two other files

## Why
Leads to more efficient usage of developer's attention to problems and warnings section in VS Code.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->