### PR TITLE
Touching up Bagel Security Brig

### DIFF
--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -126855,18 +126855,6 @@ entities:
         - Pressed: Toggle
         16542:
         - Pressed: Toggle
-  - uid: 19130
-    components:
-    - type: MetaData
-      name: Privacy Shutter Button
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-20.5
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        19155:
-        - Pressed: Toggle
   - uid: 19170
     components:
     - type: Transform

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -155117,6 +155117,8 @@ entities:
       parent: 60
   - uid: 12684
     components:
+    - type: MetaData
+      name: Security Substation
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,5.5

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -11112,7 +11112,7 @@ entities:
   - uid: 244
     components:
     - type: MetaData
-      name: Brig
+      name: Security Brig
     - type: Transform
       pos: -27.5,-17.5
       parent: 60
@@ -11126,7 +11126,7 @@ entities:
   - uid: 7901
     components:
     - type: MetaData
-      name: Brig
+      name: Security Brig
     - type: Transform
       pos: -25.5,-17.5
       parent: 60
@@ -12797,7 +12797,7 @@ entities:
   - uid: 1729
     components:
     - type: MetaData
-      name: HOS Office
+      name: Head of Security Office
     - type: Transform
       pos: -21.5,-1.5
       parent: 60
@@ -13008,6 +13008,8 @@ entities:
   entities:
   - uid: 363
     components:
+    - type: MetaData
+      name: Security Maintenance
     - type: Transform
       pos: -26.5,6.5
       parent: 60
@@ -13132,6 +13134,8 @@ entities:
       parent: 60
   - uid: 9151
     components:
+    - type: MetaData
+      name: Security Maintenance
     - type: Transform
       pos: -17.5,4.5
       parent: 60
@@ -13272,7 +13276,7 @@ entities:
   - uid: 1847
     components:
     - type: MetaData
-      name: Sec Maint
+      name: Security Maintenance
     - type: Transform
       pos: -29.5,5.5
       parent: 60
@@ -13559,7 +13563,7 @@ entities:
   - uid: 1889
     components:
     - type: MetaData
-      name: Sec Breakroom
+      name: Security Break Room
     - type: Transform
       pos: -35.5,4.5
       parent: 60

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -17255,6 +17255,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 55.5,5.5
       parent: 60
+  - uid: 23939
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-18.5
+      parent: 60
 - proto: ButtonFrameCautionSecurity
   entities:
   - uid: 766
@@ -17290,6 +17296,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 46.5,5.5
+      parent: 60
+  - uid: 23940
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-14.5
       parent: 60
 - proto: CableApcExtension
   entities:
@@ -111706,27 +111718,9 @@ entities:
   - uid: 315
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+      rot: 1.5707963267948966 rad
       pos: -19.5,-5.5
       parent: 60
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
   - uid: 319
     components:
     - type: Transform
@@ -112751,6 +112745,13 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-31.5
+      parent: 60
+- proto: PaperBin20
+  entities:
+  - uid: 23942
+    components:
+    - type: Transform
+      pos: -33.5,-3.5
       parent: 60
 - proto: PaperBin5
   entities:
@@ -115094,23 +115095,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -22.5,0.5
       parent: 60
-  - uid: 1941
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -34.5,-18.5
-      parent: 60
   - uid: 1978
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -28.5,-20.5
-      parent: 60
-  - uid: 2017
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,-20.5
+      pos: -23.5,-20.5
       parent: 60
   - uid: 2106
     components:
@@ -115659,6 +115648,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 23.5,-38.5
       parent: 60
+  - uid: 9176
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -34.5,-19.5
+      parent: 60
   - uid: 9223
     components:
     - type: Transform
@@ -115980,6 +115975,12 @@ entities:
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 11128
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -34.5,-16.5
+      parent: 60
   - uid: 11726
     components:
     - type: Transform
@@ -116921,6 +116922,12 @@ entities:
     - type: Transform
       pos: -24.5,-2.5
       parent: 60
+  - uid: 23941
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -29.5,-20.5
+      parent: 60
   - uid: 24109
     components:
     - type: Transform
@@ -117565,11 +117572,6 @@ entities:
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 9176
-    components:
-    - type: Transform
-      pos: -30.5,5.5
-      parent: 60
   - uid: 9216
     components:
     - type: Transform
@@ -118235,6 +118237,11 @@ entities:
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 23943
+    components:
+    - type: Transform
+      pos: -31.5,5.5
+      parent: 60
   - uid: 24138
     components:
     - type: Transform
@@ -124981,6 +124988,11 @@ entities:
     - type: Transform
       pos: 41.440662,-10.344523
       parent: 60
+  - uid: 2017
+    components:
+    - type: Transform
+      pos: -19.510386,-4.290659
+      parent: 60
 - proto: RubberStampMime
   entities:
   - uid: 7243
@@ -126437,6 +126449,18 @@ entities:
         7685:
         - Pressed: Toggle
         1932:
+        - Pressed: Toggle
+  - uid: 1941
+    components:
+    - type: MetaData
+      name: Privacy Shutter Button
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-18.5
+      parent: 60
+    - type: DeviceLinkSource
+      linkedPorts:
+        19155:
         - Pressed: Toggle
   - uid: 2287
     components:

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -9705,13 +9705,41 @@ entities:
       parent: 60
     - type: DeviceList
       devices:
-      - 5562
-      - 5565
-      - 5563
-      - 8466
+      - 21734
       - 21733
-      - 9154
-      - 8413
+      - 5565
+      - 5562
+      - 8466
+      - 5563
+      - 6307
+      - 6308
+      - 1902
+      - 1651
+      - 1893
+      - 1682
+      - 5454
+      - 1665
+      - 1850
+      - 1669
+      - 1846
+      - 1652
+      - 1564
+      - 1838
+      - 6759
+      - 7790
+  - uid: 2103
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -31.5,-20.5
+      parent: 60
+    - type: DeviceList
+      devices:
+      - 6648
+      - 8230
+      - 1633
+      - 1636
+      - 1559
   - uid: 4046
     components:
     - type: Transform
@@ -9825,6 +9853,34 @@ entities:
       - 21029
       - 21084
       - 21087
+  - uid: 8260
+    components:
+    - type: Transform
+      pos: -19.5,3.5
+      parent: 60
+    - type: DeviceList
+      devices:
+      - 6762
+      - 5425
+  - uid: 8265
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,-15.5
+      parent: 60
+    - type: DeviceList
+      devices:
+      - 8259
+      - 8269
+  - uid: 8271
+    components:
+    - type: Transform
+      pos: -25.5,3.5
+      parent: 60
+    - type: DeviceList
+      devices:
+      - 3197
+      - 8898
   - uid: 8669
     components:
     - type: Transform
@@ -9832,10 +9888,26 @@ entities:
       parent: 60
     - type: DeviceList
       devices:
-      - 8265
-      - 2793
-      - 9679
-      - 6034
+      - 2861
+      - 8718
+  - uid: 8714
+    components:
+    - type: Transform
+      pos: -18.5,-1.5
+      parent: 60
+    - type: DeviceList
+      devices:
+      - 11978
+      - 9156
+  - uid: 8791
+    components:
+    - type: Transform
+      pos: -32.5,-1.5
+      parent: 60
+    - type: DeviceList
+      devices:
+      - 9034
+      - 2791
   - uid: 11464
     components:
     - type: Transform
@@ -10922,14 +10994,14 @@ entities:
   - uid: 1467
     components:
     - type: MetaData
-      name: Warden's Office
+      name: Warden Office
     - type: Transform
       pos: -26.5,-6.5
       parent: 60
   - uid: 19786
     components:
     - type: MetaData
-      name: Armory
+      name: Secure Armory
     - type: Transform
       pos: -26.5,-1.5
       parent: 60
@@ -11031,10 +11103,12 @@ entities:
   - uid: 144
     components:
     - type: MetaData
-      name: Security Lobby
+      name: Brig Medbay
     - type: Transform
-      pos: -21.5,-18.5
+      pos: -20.5,-3.5
       parent: 60
+    - type: PaintableAirlock
+      department: Medical
   - uid: 244
     components:
     - type: MetaData
@@ -11042,17 +11116,10 @@ entities:
     - type: Transform
       pos: -27.5,-17.5
       parent: 60
-  - uid: 307
-    components:
-    - type: MetaData
-      name: Security Lobby
-    - type: Transform
-      pos: -21.5,-20.5
-      parent: 60
   - uid: 1487
     components:
     - type: MetaData
-      name: Front Desk
+      name: Security Front Desk
     - type: Transform
       pos: -21.5,-15.5
       parent: 60
@@ -12342,6 +12409,26 @@ entities:
       parent: 60
 - proto: AirlockGlass
   entities:
+  - uid: 51
+    components:
+    - type: MetaData
+      name: Security Lobby
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -21.5,-18.5
+      parent: 60
+    - type: PaintableAirlock
+      department: Security
+  - uid: 84
+    components:
+    - type: MetaData
+      name: Security Lobby
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -21.5,-20.5
+      parent: 60
+    - type: PaintableAirlock
+      department: Security
   - uid: 211
     components:
     - type: Transform
@@ -12710,7 +12797,7 @@ entities:
   - uid: 1729
     components:
     - type: MetaData
-      name: HoS's Room
+      name: HOS Office
     - type: Transform
       pos: -21.5,-1.5
       parent: 60
@@ -13453,13 +13540,6 @@ entities:
     - type: Transform
       pos: -31.5,-16.5
       parent: 60
-  - uid: 1970
-    components:
-    - type: MetaData
-      name: Brig Med
-    - type: Transform
-      pos: -20.5,-3.5
-      parent: 60
 - proto: AirlockSecurityLawyerLocked
   entities:
   - uid: 4686
@@ -13486,7 +13566,7 @@ entities:
   - uid: 2086
     components:
     - type: MetaData
-      name: Backroom
+      name: Security Break Room
     - type: Transform
       pos: -30.5,-1.5
       parent: 60
@@ -14010,6 +14090,9 @@ entities:
     - type: Transform
       pos: -25.5,-3.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
   - uid: 21734
     components:
     - type: Transform
@@ -14018,6 +14101,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 21736
+      - 249
   - uid: 21772
     components:
     - type: Transform
@@ -15781,11 +15865,6 @@ entities:
     - type: Transform
       pos: -33.5,-7.5
       parent: 60
-  - uid: 1852
-    components:
-    - type: Transform
-      pos: -18.5,-7.5
-      parent: 60
   - uid: 1857
     components:
     - type: Transform
@@ -16897,10 +16976,10 @@ entities:
       parent: 60
 - proto: BoxHandcuff
   entities:
-  - uid: 178
+  - uid: 1872
     components:
     - type: Transform
-      pos: -26.426329,-14.112597
+      pos: -25.850195,-13.340575
       parent: 60
 - proto: BoxLatexGloves
   entities:
@@ -16923,6 +17002,11 @@ entities:
       parent: 60
 - proto: BoxLightMixed
   entities:
+  - uid: 1940
+    components:
+    - type: Transform
+      pos: -32.45523,-0.43822744
+      parent: 60
   - uid: 3972
     components:
     - type: Transform
@@ -17032,6 +17116,8 @@ entities:
   entities:
   - uid: 1468
     components:
+    - type: MetaData
+      name: Cell 3 Timer
     - type: Transform
       pos: -32.5,-5.5
       parent: 60
@@ -17043,6 +17129,8 @@ entities:
         - Timer: Open
   - uid: 1485
     components:
+    - type: MetaData
+      name: Cell 4 Timer
     - type: Transform
       pos: -32.5,-8.5
       parent: 60
@@ -17054,6 +17142,8 @@ entities:
         - Timer: Open
   - uid: 1486
     components:
+    - type: MetaData
+      name: Cell 5 Timer
     - type: Transform
       pos: -32.5,-11.5
       parent: 60
@@ -17065,6 +17155,8 @@ entities:
         - Timer: Open
   - uid: 1488
     components:
+    - type: MetaData
+      name: Cell 1 Timer
     - type: Transform
       pos: -20.5,-8.5
       parent: 60
@@ -17076,6 +17168,8 @@ entities:
         - Timer: Open
   - uid: 6971
     components:
+    - type: MetaData
+      name: Medical Cell Timer
     - type: Transform
       pos: -20.5,-5.5
       parent: 60
@@ -17087,6 +17181,8 @@ entities:
         - Timer: Open
   - uid: 6972
     components:
+    - type: MetaData
+      name: Cell 2 Timer
     - type: Transform
       pos: -20.5,-11.5
       parent: 60
@@ -17157,6 +17253,11 @@ entities:
       parent: 60
 - proto: ButtonFrameCautionSecurity
   entities:
+  - uid: 766
+    components:
+    - type: Transform
+      pos: -20.5,-14.5
+      parent: 60
   - uid: 5659
     components:
     - type: Transform
@@ -17169,11 +17270,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,-21.5
-      parent: 60
-  - uid: 9176
-    components:
-    - type: Transform
-      pos: -20.5,-14.5
       parent: 60
 - proto: ButtonFrameGrey
   entities:
@@ -42458,6 +42554,11 @@ entities:
     - type: Transform
       pos: 41.5,-18.5
       parent: 60
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -20.5,-2.5
+      parent: 60
   - uid: 241
     components:
     - type: Transform
@@ -42527,11 +42628,6 @@ entities:
     components:
     - type: Transform
       pos: -56.5,-18.5
-      parent: 60
-  - uid: 766
-    components:
-    - type: Transform
-      pos: -31.5,-5.5
       parent: 60
   - uid: 767
     components:
@@ -44958,6 +45054,11 @@ entities:
     - type: Transform
       pos: 41.5,-43.5
       parent: 60
+  - uid: 10829
+    components:
+    - type: Transform
+      pos: -30.5,-6.5
+      parent: 60
   - uid: 10882
     components:
     - type: Transform
@@ -45437,6 +45538,11 @@ entities:
     components:
     - type: Transform
       pos: 29.5,18.5
+      parent: 60
+  - uid: 11759
+    components:
+    - type: Transform
+      pos: -20.5,-4.5
       parent: 60
   - uid: 11890
     components:
@@ -55985,11 +56091,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -32.5,-18.5
       parent: 60
-  - uid: 84
-    components:
-    - type: Transform
-      pos: -28.5,-18.5
-      parent: 60
   - uid: 662
     components:
     - type: Transform
@@ -56228,6 +56329,12 @@ entities:
     - type: Transform
       pos: -11.5,-55.5
       parent: 60
+  - uid: 5971
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -25.5,-20.5
+      parent: 60
   - uid: 6322
     components:
     - type: Transform
@@ -56416,10 +56523,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,-50.5
       parent: 60
-  - uid: 8228
+  - uid: 9042
     components:
     - type: Transform
-      pos: -24.5,-18.5
+      rot: 3.141592653589793 rad
+      pos: -24.5,-20.5
       parent: 60
   - uid: 9079
     components:
@@ -56464,6 +56572,12 @@ entities:
     components:
     - type: Transform
       pos: -48.5,4.5
+      parent: 60
+  - uid: 9680
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,-20.5
       parent: 60
   - uid: 10847
     components:
@@ -57043,6 +57157,18 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 38.514114,2.6323514
       parent: 60
+  - uid: 1924
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.474321,-9.37935
+      parent: 60
+  - uid: 1937
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -28.568071,-9.4106
+      parent: 60
   - uid: 2590
     components:
     - type: Transform
@@ -57088,22 +57214,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 43.634438,14.652265
       parent: 60
-  - uid: 4627
-    components:
-    - type: Transform
-      pos: -27.5,-14.5
-      parent: 60
   - uid: 5547
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -42.5,8.5
-      parent: 60
-  - uid: 5799
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -25.5,-14.5
       parent: 60
   - uid: 6628
     components:
@@ -57196,12 +57311,6 @@ entities:
     components:
     - type: Transform
       pos: -41.5,4.5
-      parent: 60
-  - uid: 10369
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,-6.5
       parent: 60
   - uid: 10807
     components:
@@ -57872,6 +57981,12 @@ entities:
     components:
     - type: Transform
       pos: 2.5348077,-76.44673
+      parent: 60
+  - uid: 9155
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -28.503572,-20.408875
       parent: 60
   - uid: 13678
     components:
@@ -61585,10 +61700,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -26.5,-30.5
       parent: 60
-  - uid: 7685
+  - uid: 9153
     components:
     - type: Transform
-      pos: -25.5,-13.5
+      rot: 3.141592653589793 rad
+      pos: -29.5,-7.5
       parent: 60
   - uid: 13383
     components:
@@ -63961,16 +64077,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: 28.5,-24.5
       parent: 60
+  - uid: 8273
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -26.5,-5.5
+      parent: 60
   - uid: 8710
     components:
     - type: Transform
       pos: -18.5,-19.5
-      parent: 60
-  - uid: 8712
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-5.5
       parent: 60
   - uid: 8947
     components:
@@ -64420,12 +64536,6 @@ entities:
     - type: Transform
       pos: 16.5,12.5
       parent: 60
-  - uid: 8711
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-19.5
-      parent: 60
   - uid: 14089
     components:
     - type: Transform
@@ -64471,6 +64581,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,8.5
+      parent: 60
+  - uid: 23938
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -26.5,-19.5
       parent: 60
 - proto: DisposalPipe
   entities:
@@ -65403,6 +65519,18 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,24.5
+      parent: 60
+  - uid: 1919
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-5.5
+      parent: 60
+  - uid: 1922
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-19.5
       parent: 60
   - uid: 1950
     components:
@@ -66594,6 +66722,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,-44.5
       parent: 60
+  - uid: 8229
+    components:
+    - type: Transform
+      pos: -26.5,-6.5
+      parent: 60
   - uid: 8251
     components:
     - type: Transform
@@ -66648,95 +66781,11 @@ entities:
     - type: Transform
       pos: 16.5,23.5
       parent: 60
-  - uid: 8713
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-6.5
-      parent: 60
-  - uid: 8714
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-7.5
-      parent: 60
-  - uid: 8715
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-8.5
-      parent: 60
-  - uid: 8716
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-9.5
-      parent: 60
-  - uid: 8717
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-10.5
-      parent: 60
-  - uid: 8718
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-11.5
-      parent: 60
-  - uid: 8719
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-12.5
-      parent: 60
-  - uid: 8720
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-13.5
-      parent: 60
-  - uid: 8721
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-14.5
-      parent: 60
-  - uid: 8722
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-15.5
-      parent: 60
-  - uid: 8735
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-16.5
-      parent: 60
-  - uid: 8748
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-17.5
-      parent: 60
-  - uid: 8749
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-18.5
-      parent: 60
   - uid: 8891
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,-19.5
-      parent: 60
-  - uid: 8892
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -26.5,-19.5
       parent: 60
   - uid: 8897
     components:
@@ -67810,6 +67859,66 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-13.5
+      parent: 60
+  - uid: 23926
+    components:
+    - type: Transform
+      pos: -26.5,-7.5
+      parent: 60
+  - uid: 23927
+    components:
+    - type: Transform
+      pos: -26.5,-8.5
+      parent: 60
+  - uid: 23928
+    components:
+    - type: Transform
+      pos: -26.5,-9.5
+      parent: 60
+  - uid: 23929
+    components:
+    - type: Transform
+      pos: -26.5,-10.5
+      parent: 60
+  - uid: 23930
+    components:
+    - type: Transform
+      pos: -26.5,-11.5
+      parent: 60
+  - uid: 23931
+    components:
+    - type: Transform
+      pos: -26.5,-12.5
+      parent: 60
+  - uid: 23932
+    components:
+    - type: Transform
+      pos: -26.5,-13.5
+      parent: 60
+  - uid: 23933
+    components:
+    - type: Transform
+      pos: -26.5,-14.5
+      parent: 60
+  - uid: 23934
+    components:
+    - type: Transform
+      pos: -26.5,-15.5
+      parent: 60
+  - uid: 23935
+    components:
+    - type: Transform
+      pos: -26.5,-16.5
+      parent: 60
+  - uid: 23936
+    components:
+    - type: Transform
+      pos: -26.5,-17.5
+      parent: 60
+  - uid: 23937
+    components:
+    - type: Transform
+      pos: -26.5,-18.5
       parent: 60
   - uid: 24082
     components:
@@ -71460,16 +71569,25 @@ entities:
     - type: Transform
       pos: -22.5,-20.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 2103
   - uid: 1633
     components:
     - type: Transform
       pos: -22.5,-18.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 2103
   - uid: 1636
     components:
     - type: Transform
       pos: -22.5,-19.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 2103
   - uid: 2044
     components:
     - type: Transform
@@ -71661,6 +71779,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 21736
+      - 249
   - uid: 5563
     components:
     - type: Transform
@@ -71669,6 +71788,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 21736
+      - 249
   - uid: 5565
     components:
     - type: Transform
@@ -71677,6 +71797,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 21736
+      - 249
   - uid: 5623
     components:
     - type: Transform
@@ -71918,6 +72039,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 21736
+      - 249
   - uid: 8611
     components:
     - type: Transform
@@ -73442,10 +73564,10 @@ entities:
       parent: 60
 - proto: FoodBoxDonut
   entities:
-  - uid: 1919
+  - uid: 1930
     components:
     - type: Transform
-      pos: -26.46309,-14.295396
+      pos: -25.24082,-13.2937
       parent: 60
   - uid: 24664
     components:
@@ -74361,14 +74483,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 1823
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,-6.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 1836
     components:
     - type: Transform
@@ -74384,64 +74498,10 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1922
-    components:
-    - type: Transform
-      pos: -23.5,-5.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 1926
     components:
     - type: Transform
       pos: -29.5,-12.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 1939
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -30.5,-4.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 1940
-    components:
-    - type: Transform
-      pos: -21.5,-4.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 1941
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -31.5,-5.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 1942
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -30.5,-5.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 1965
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -29.5,-5.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 1966
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,-6.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
@@ -74551,6 +74611,14 @@ entities:
     - type: Transform
       pos: 49.5,-19.5
       parent: 60
+  - uid: 3198
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -25.5,-3.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 3211
     components:
     - type: Transform
@@ -74575,14 +74643,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 4519
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-0.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 4739
     components:
     - type: Transform
@@ -74661,14 +74721,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 5425
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,-15.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 5474
     components:
     - type: Transform
@@ -74854,14 +74906,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 6365
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -33.5,5.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 6401
     components:
     - type: Transform
@@ -74943,13 +74987,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 8271
+  - uid: 8258
     components:
     - type: Transform
-      pos: -30.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF1212FF'
   - uid: 8579
     components:
     - type: Transform
@@ -74966,6 +75011,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 8948
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-0.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 8970
     components:
     - type: Transform
@@ -74979,11 +75032,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: 47.5,-21.5
       parent: 60
+  - uid: 9030
+    components:
+    - type: Transform
+      pos: -30.5,0.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 9032
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,0.5
+      pos: -21.5,1.5
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -75002,14 +75062,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 10829
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -33.5,4.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 11105
     components:
     - type: Transform
@@ -76110,20 +76162,13 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 1932
+  - uid: 2002
     components:
     - type: Transform
-      pos: -25.5,-5.5
+      pos: -22.5,-3.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 1958
-    components:
-    - type: Transform
-      pos: -27.5,-4.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 2361
     components:
     - type: Transform
@@ -76232,20 +76277,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 6761
-    components:
-    - type: Transform
-      pos: -27.5,-2.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 6763
-    components:
-    - type: Transform
-      pos: -25.5,-3.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 6834
     components:
     - type: Transform
@@ -76253,6 +76284,27 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 7563
+    components:
+    - type: Transform
+      pos: -21.5,-2.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 8720
+    components:
+    - type: Transform
+      pos: -18.5,-19.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 8748
+    components:
+    - type: Transform
+      pos: -21.5,-7.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 9232
     components:
     - type: Transform
@@ -76346,14 +76398,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 51
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -30.5,-3.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 88
     components:
     - type: Transform
@@ -78656,14 +78700,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1620
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,-4.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 1629
     components:
     - type: Transform
@@ -79201,14 +79237,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 1908
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,-5.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 1909
     components:
     - type: Transform
@@ -79312,38 +79340,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 1930
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,-4.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 1931
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,-4.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 1933
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -26.5,-4.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 1934
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -25.5,-4.5
+      pos: -23.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF1212FF'
   - uid: 1935
     components:
     - type: Transform
@@ -79354,23 +79358,16 @@ entities:
   - uid: 1936
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,-4.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-2.5
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1937
+  - uid: 1943
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,-4.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 1938
-    components:
-    - type: Transform
-      pos: -31.5,-6.5
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-7.5
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -79390,6 +79387,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 1958
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-3.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 1961
     components:
     - type: Transform
@@ -79398,6 +79403,22 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 1965
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -29.5,-7.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1966
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -23.5,-7.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 1967
     components:
     - type: Transform
@@ -79421,6 +79442,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 1970
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -29.5,-5.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 1974
     components:
     - type: Transform
@@ -79474,6 +79503,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 1990
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -31.5,-4.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 1991
     components:
     - type: Transform
@@ -80414,6 +80451,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 2760
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,-0.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 2783
     components:
     - type: Transform
@@ -80452,6 +80497,13 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 2793
+    components:
+    - type: Transform
+      pos: -21.5,-3.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 2794
     components:
     - type: Transform
@@ -80631,14 +80683,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 2861
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -21.5,-2.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 2862
     components:
     - type: Transform
@@ -80704,8 +80748,8 @@ entities:
   - uid: 2940
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-5.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
@@ -80892,7 +80936,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -22.5,-0.5
+      pos: -21.5,0.5
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -80935,14 +80979,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 3196
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,-3.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 3199
     components:
     - type: Transform
@@ -80980,14 +81016,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 42.5,-10.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 3224
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,0.5
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -81773,18 +81801,26 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 4516
+  - uid: 4519
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: -25.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF1212FF'
   - uid: 4550
     components:
     - type: Transform
       pos: -36.5,-4.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 4627
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-7.5
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -82210,6 +82246,14 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-65.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 5020
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -26.5,-7.5
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -83913,13 +83957,21 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 6762
+  - uid: 6761
     components:
     - type: Transform
-      pos: -25.5,-4.5
+      rot: 3.141592653589793 rad
+      pos: -22.5,-2.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 6763
+    components:
+    - type: Transform
+      pos: -21.5,-0.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 6778
     components:
     - type: Transform
@@ -84060,11 +84112,10 @@ entities:
   - uid: 7166
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,-5.5
+      pos: -22.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF1212FF'
   - uid: 7211
     components:
     - type: Transform
@@ -84178,14 +84229,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 7563
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,-6.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 7601
     components:
     - type: Transform
@@ -84196,7 +84239,8 @@ entities:
   - uid: 7647
     components:
     - type: Transform
-      pos: -27.5,-3.5
+      rot: 1.5707963267948966 rad
+      pos: -20.5,1.5
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -84527,15 +84571,16 @@ entities:
   - uid: 8212
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-7.5
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-8.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 8223
     components:
     - type: Transform
-      pos: -22.5,-8.5
+      rot: 1.5707963267948966 rad
+      pos: -23.5,-8.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
@@ -84547,14 +84592,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 8229
+  - uid: 8228
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -25.5,-8.5
+      pos: -21.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#0335FCFF'
   - uid: 8257
     components:
     - type: Transform
@@ -84563,27 +84608,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 8258
-    components:
-    - type: Transform
-      pos: -32.5,-1.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 8259
-    components:
-    - type: Transform
-      pos: -32.5,-2.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 8261
     components:
     - type: Transform
-      pos: -30.5,-1.5
+      rot: 3.141592653589793 rad
+      pos: -30.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF1212FF'
   - uid: 8263
     components:
     - type: Transform
@@ -84600,36 +84632,30 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 8269
+  - uid: 8267
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,-3.5
+      rot: 3.141592653589793 rad
+      pos: -30.5,-1.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 8270
     components:
     - type: Transform
-      pos: -30.5,-0.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 8273
-    components:
-    - type: Transform
-      pos: -32.5,-0.5
+      rot: 3.141592653589793 rad
+      pos: -30.5,-3.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 8274
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-3.5
+      rot: 1.5707963267948966 rad
+      pos: -28.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#0335FCFF'
   - uid: 8386
     components:
     - type: Transform
@@ -84702,22 +84728,60 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 8790
+  - uid: 8711
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,-3.5
+      pos: -21.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 8791
+      color: '#0335FCFF'
+  - uid: 8712
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -25.5,-6.5
+      pos: -22.5,-1.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 8713
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-0.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 8717
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,0.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 8719
+    components:
+    - type: Transform
+      pos: -18.5,-17.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 8721
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-7.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 8749
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-2.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 8792
     components:
     - type: Transform
@@ -84752,13 +84816,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 8948
-    components:
-    - type: Transform
-      pos: -30.5,-7.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 8949
     components:
     - type: Transform
@@ -84791,11 +84848,11 @@ entities:
   - uid: 9014
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: -32.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF1212FF'
   - uid: 9022
     components:
     - type: Transform
@@ -84803,38 +84860,28 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 9030
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,-2.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 9031
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,-1.5
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 9042
+      color: '#0335FCFF'
+  - uid: 9033
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -27.5,-3.5
+      pos: -18.5,-16.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 9043
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,-7.5
+      pos: -18.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#FF1212FF'
   - uid: 9045
     components:
     - type: Transform
@@ -84851,14 +84898,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 9153
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -26.5,-3.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 9158
     components:
     - type: Transform
@@ -85057,27 +85096,6 @@ entities:
     components:
     - type: Transform
       pos: -54.5,-7.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 9681
-    components:
-    - type: Transform
-      pos: -32.5,0.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 9682
-    components:
-    - type: Transform
-      pos: -32.5,2.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 9683
-    components:
-    - type: Transform
-      pos: -32.5,3.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
@@ -92573,6 +92591,22 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -54.5,51.5
       parent: 60
+  - uid: 23924
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,-7.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 23925
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-7.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 24128
     components:
     - type: Transform
@@ -93568,13 +93602,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 796
-    components:
-    - type: Transform
-      pos: -18.5,-19.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 877
     components:
     - type: Transform
@@ -93898,6 +93925,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 1529
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-5.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 1600
     components:
     - type: Transform
@@ -94011,13 +94046,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1924
-    components:
-    - type: Transform
-      pos: -30.5,-6.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 1927
     components:
     - type: Transform
@@ -94034,10 +94062,11 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 1943
+  - uid: 1933
     components:
     - type: Transform
-      pos: -22.5,-6.5
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-5.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
@@ -94080,14 +94109,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1990
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-7.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 1994
     components:
     - type: Transform
@@ -94096,11 +94117,11 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 2002
+  - uid: 2090
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-7.5
+      rot: 3.141592653589793 rad
+      pos: -22.5,-15.5
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -94235,14 +94256,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 2760
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -30.5,-2.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 2799
     components:
     - type: Transform
@@ -94352,14 +94365,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 3198
+  - uid: 3196
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -26.5,-5.5
+      pos: -27.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#0335FCFF'
   - uid: 3205
     components:
     - type: Transform
@@ -94387,6 +94400,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 3224
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -30.5,-4.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 3367
     components:
     - type: Transform
@@ -94870,6 +94891,13 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 6365
+    components:
+    - type: Transform
+      pos: -31.5,-7.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 6380
     components:
     - type: Transform
@@ -94976,6 +95004,14 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 8233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-8.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 8241
     components:
     - type: Transform
@@ -94984,14 +95020,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 8260
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -32.5,-3.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 8537
     components:
     - type: Transform
@@ -95016,6 +95044,37 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 8715
+    components:
+    - type: Transform
+      pos: -27.5,-7.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 8722
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-6.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 8735
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -30.5,-6.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 8790
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -26.5,-5.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 8884
     components:
     - type: Transform
@@ -95024,22 +95083,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 9033
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,-3.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 9034
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,-2.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 9233
     components:
     - type: Transform
@@ -95070,14 +95113,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 9680
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -32.5,1.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 11153
     components:
     - type: Transform
@@ -97171,6 +97206,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -33.5,-7.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 1652
@@ -97179,6 +97217,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -19.5,-10.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 1665
@@ -97187,6 +97228,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -33.5,-13.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 1669
@@ -97195,6 +97239,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -19.5,-7.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 1682
@@ -97203,6 +97250,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -33.5,-10.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 1780
@@ -97226,6 +97276,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -19.5,-13.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 1996
@@ -97297,14 +97350,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -32.5,-2.5
       parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 2793
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -31.5,0.5
-      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8791
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 2826
@@ -97313,6 +97361,17 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 44.5,-29.5
       parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 2861
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -33.5,4.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8669
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 2984
@@ -97343,6 +97402,9 @@ entities:
     - type: Transform
       pos: -27.5,0.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8271
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 3567
@@ -97404,6 +97466,17 @@ entities:
     - type: Transform
       pos: 12.5,8.5
       parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 5425
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,1.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8260
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 5439
@@ -97578,14 +97651,6 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 6034
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -32.5,5.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 6087
     components:
     - type: Transform
@@ -97615,6 +97680,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -27.5,-9.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 6417
@@ -97639,6 +97707,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -28.5,-19.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 2103
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 6759
@@ -97647,6 +97718,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -26.5,-16.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 6770
@@ -97735,6 +97809,17 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,-46.5
       parent: 60
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 8259
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-15.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8265
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 8388
@@ -97842,20 +97927,15 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 11759
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,0.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 11978
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-3.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8714
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 12589
@@ -98693,6 +98773,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -19.5,-12.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 1771
@@ -98709,6 +98792,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -19.5,-9.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 1850
@@ -98717,6 +98803,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -19.5,-6.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 1893
@@ -98725,6 +98814,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -33.5,-9.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 1902
@@ -98733,6 +98825,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -33.5,-6.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 2026
@@ -98911,6 +99006,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -33.5,-12.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 5581
@@ -99053,6 +99151,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -25.5,-9.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 6474
@@ -99069,6 +99170,17 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,-61.5
       parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 6762
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-0.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8260
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 7177
@@ -99125,6 +99237,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -26.5,-15.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 249
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 8137
@@ -99141,22 +99256,19 @@ entities:
       rot: 3.141592653589793 rad
       pos: -24.5,-19.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 2103
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 8265
+  - uid: 8269
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,1.5
+      pos: -18.5,-15.5
       parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 8267
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -32.5,-4.5
-      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8265
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 8578
@@ -99175,11 +99287,25 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 8718
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -33.5,0.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8669
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 8898
     components:
     - type: Transform
       pos: -25.5,0.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8271
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 8960
@@ -99195,6 +99321,17 @@ entities:
     - type: Transform
       pos: -47.5,3.5
       parent: 60
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 9034
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -32.5,-4.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8791
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 9061
@@ -99220,20 +99357,15 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 9155
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-0.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 9156
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,-3.5
       parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 8714
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 9160
@@ -99295,13 +99427,6 @@ entities:
     components:
     - type: Transform
       pos: -38.5,13.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 9679
-    components:
-    - type: Transform
-      pos: -32.5,4.5
       parent: 60
     - type: AtmosPipeColor
       color: '#FF1212FF'
@@ -110366,29 +110491,6 @@ entities:
         - 0
         - 0
         - 0
-  - uid: 5971
-    components:
-    - type: Transform
-      pos: -29.5,-7.5
-      parent: 60
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 1.6495836
-        - 6.2055764
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
   - uid: 6136
     components:
     - type: Transform
@@ -111312,6 +111414,11 @@ entities:
     - type: Transform
       pos: 30.5,-16.5
       parent: 60
+  - uid: 796
+    components:
+    - type: Transform
+      pos: -18.5,-7.5
+      parent: 60
   - uid: 4746
     components:
     - type: Transform
@@ -111430,6 +111537,11 @@ entities:
     components:
     - type: Transform
       pos: 24.473473,-44.545494
+      parent: 60
+  - uid: 9681
+    components:
+    - type: Transform
+      pos: -19.322544,-2.322325
       parent: 60
   - uid: 21361
     components:
@@ -112349,6 +112461,11 @@ entities:
     - type: Transform
       pos: -10.55104,-28.480585
       parent: 60
+  - uid: 4516
+    components:
+    - type: Transform
+      pos: -33.489323,-3.402731
+      parent: 60
   - uid: 8760
     components:
     - type: Transform
@@ -112804,6 +112921,11 @@ entities:
       parent: 60
 - proto: Pen
   entities:
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -33.739323,-3.465231
+      parent: 60
   - uid: 935
     components:
     - type: Transform
@@ -114484,6 +114606,11 @@ entities:
     - type: ContainerContainer
       containers:
         stash: !type:ContainerSlot {}
+  - uid: 1938
+    components:
+    - type: Transform
+      pos: -28.5,-5.5
+      parent: 60
   - uid: 2774
     components:
     - type: Transform
@@ -114712,6 +114839,12 @@ entities:
     - type: Transform
       pos: 0.5,20.5
       parent: 60
+  - uid: 1620
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -32.5,3.5
+      parent: 60
   - uid: 4698
     components:
     - type: Transform
@@ -114739,11 +114872,6 @@ entities:
     components:
     - type: Transform
       pos: -15.5,26.5
-      parent: 60
-  - uid: 8233
-    components:
-    - type: Transform
-      pos: -28.5,-20.5
       parent: 60
   - uid: 9537
     components:
@@ -114921,13 +115049,6 @@ entities:
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 1529
-    components:
-    - type: Transform
-      pos: -33.5,-15.5
-      parent: 60
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 1536
     components:
     - type: Transform
@@ -114939,14 +115060,6 @@ entities:
     components:
     - type: Transform
       pos: -27.5,-7.5
-      parent: 60
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 1549
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,1.5
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
@@ -114964,12 +115077,6 @@ entities:
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 1872
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -34.5,0.5
-      parent: 60
   - uid: 1881
     components:
     - type: Transform
@@ -114977,6 +115084,18 @@ entities:
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 1939
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,0.5
+      parent: 60
+  - uid: 1941
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -34.5,-18.5
+      parent: 60
   - uid: 1978
     components:
     - type: Transform
@@ -114988,17 +115107,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,-20.5
-      parent: 60
-  - uid: 2090
-    components:
-    - type: Transform
-      pos: -33.5,5.5
-      parent: 60
-  - uid: 2103
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -30.5,0.5
       parent: 60
   - uid: 2106
     components:
@@ -115306,6 +115414,12 @@ entities:
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 5799
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -34.5,1.5
+      parent: 60
   - uid: 5826
     components:
     - type: Transform
@@ -115576,6 +115690,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -56.5,11.5
+      parent: 60
+  - uid: 9679
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -30.5,1.5
       parent: 60
   - uid: 10202
     components:
@@ -115853,14 +115973,6 @@ entities:
     components:
     - type: Transform
       pos: 2.5,-75.5
-      parent: 60
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 11128
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -32.5,-20.5
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
@@ -116800,20 +116912,17 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 55.5,46.5
       parent: 60
+  - uid: 23923
+    components:
+    - type: Transform
+      pos: -24.5,-2.5
+      parent: 60
   - uid: 24109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,-32.5
       parent: 60
-  - uid: 24183
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,-5.5
-      parent: 60
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 24234
     components:
     - type: Transform
@@ -117452,6 +117561,11 @@ entities:
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 9176
+    components:
+    - type: Transform
+      pos: -30.5,5.5
+      parent: 60
   - uid: 9216
     components:
     - type: Transform
@@ -117854,6 +117968,12 @@ entities:
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 18997
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,-3.5
+      parent: 60
   - uid: 19194
     components:
     - type: Transform
@@ -117992,6 +118112,11 @@ entities:
       parent: 60
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 21067
+    components:
+    - type: Transform
+      pos: -19.5,-6.5
+      parent: 60
   - uid: 21246
     components:
     - type: Transform
@@ -125511,6 +125636,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -18.5,1.5
       parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 2
   - uid: 1454
     components:
     - type: Transform
@@ -125521,6 +125648,16 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-26.5
+      parent: 60
+  - uid: 1932
+    components:
+    - type: Transform
+      pos: -27.5,-21.5
+      parent: 60
+  - uid: 1942
+    components:
+    - type: Transform
+      pos: -21.5,-19.5
       parent: 60
   - uid: 2250
     components:
@@ -125554,6 +125691,8 @@ entities:
     - type: Transform
       pos: -18.5,0.5
       parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 2
   - uid: 3844
     components:
     - type: Transform
@@ -125725,6 +125864,11 @@ entities:
     - type: Transform
       pos: 39.5,-15.5
       parent: 60
+  - uid: 7685
+    components:
+    - type: Transform
+      pos: -25.5,-21.5
+      parent: 60
   - uid: 8002
     components:
     - type: Transform
@@ -125740,6 +125884,16 @@ entities:
     components:
     - type: Transform
       pos: -12.5,-52.5
+      parent: 60
+  - uid: 8716
+    components:
+    - type: Transform
+      pos: -21.5,-20.5
+      parent: 60
+  - uid: 8892
+    components:
+    - type: Transform
+      pos: -21.5,-18.5
       parent: 60
   - uid: 9167
     components:
@@ -126261,6 +126415,25 @@ entities:
         - Pressed: Toggle
         4355:
         - Pressed: Toggle
+  - uid: 1931
+    components:
+    - type: MetaData
+      name: Lobby Shutdown
+    - type: Transform
+      pos: -20.5,-14.5
+      parent: 60
+    - type: DeviceLinkSource
+      linkedPorts:
+        8892:
+        - Pressed: Toggle
+        1942:
+        - Pressed: Toggle
+        8716:
+        - Pressed: Toggle
+        7685:
+        - Pressed: Toggle
+        1932:
+        - Pressed: Toggle
   - uid: 2287
     components:
     - type: Transform
@@ -126354,6 +126527,8 @@ entities:
         - Pressed: Toggle
   - uid: 4522
     components:
+    - type: MetaData
+      name: Privacy Shutter Button
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,-1.5
@@ -126654,6 +126829,8 @@ entities:
         - Pressed: Toggle
   - uid: 19130
     components:
+    - type: MetaData
+      name: Privacy Shutter Button
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-20.5
@@ -126916,21 +127093,6 @@ entities:
         397:
         - On: Reverse
         - Off: Forward
-  - uid: 18997
-    components:
-    - type: MetaData
-      name: Front Door Switch
-    - type: Transform
-      pos: -20.5,-14.5
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        144:
-        - On: Open
-        - Off: Close
-        307:
-        - On: Open
-        - Off: Close
   - uid: 19837
     components:
     - type: MetaData
@@ -131834,6 +131996,11 @@ entities:
     - type: Transform
       pos: -6.7018414,-28.567108
       parent: 60
+  - uid: 6034
+    components:
+    - type: Transform
+      pos: -33.1201,-0.48510244
+      parent: 60
 - proto: StairDark
   entities:
   - uid: 2908
@@ -132033,6 +132200,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: -30.5,1.5
       parent: 60
+  - uid: 1823
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -25.531624,-14.186428
+      parent: 60
+  - uid: 1852
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -27.484749,-14.202053
+      parent: 60
   - uid: 3165
     components:
     - type: Transform
@@ -132066,6 +132245,11 @@ entities:
     components:
     - type: Transform
       pos: -44.5,-6.5
+      parent: 60
+  - uid: 9682
+    components:
+    - type: Transform
+      pos: -29.51366,-6.3277454
       parent: 60
   - uid: 14541
     components:
@@ -135037,6 +135221,11 @@ entities:
     - type: Transform
       pos: 9.5,-51.5
       parent: 60
+  - uid: 1908
+    components:
+    - type: Transform
+      pos: -25.5,-13.5
+      parent: 60
   - uid: 2076
     components:
     - type: Transform
@@ -135184,11 +135373,6 @@ entities:
     components:
     - type: Transform
       pos: 3.5,-39.5
-      parent: 60
-  - uid: 5020
-    components:
-    - type: Transform
-      pos: -26.5,-14.5
       parent: 60
   - uid: 5335
     components:
@@ -136600,6 +136784,11 @@ entities:
     components:
     - type: Transform
       pos: -40.5,5.5
+      parent: 60
+  - uid: 10369
+    components:
+    - type: Transform
+      pos: -32.5,-0.5
       parent: 60
   - uid: 11127
     components:
@@ -138417,6 +138606,11 @@ entities:
       parent: 60
 - proto: VendingMachineCoffee
   entities:
+  - uid: 1549
+    components:
+    - type: Transform
+      pos: -28.5,-18.5
+      parent: 60
   - uid: 6139
     components:
     - type: Transform
@@ -138618,10 +138812,10 @@ entities:
     - type: Transform
       pos: -34.5,-15.5
       parent: 60
-  - uid: 21067
+  - uid: 9683
     components:
     - type: Transform
-      pos: -32.5,-0.5
+      pos: -31.5,-0.5
       parent: 60
 - proto: VendingMachineSecDrobe
   entities:
@@ -154340,6 +154534,8 @@ entities:
       parent: 60
   - uid: 4077
     components:
+    - type: MetaData
+      name: Security Desk
     - type: Transform
       pos: -19.5,-17.5
       parent: 60
@@ -154544,12 +154740,16 @@ entities:
   entities:
   - uid: 1466
     components:
+    - type: MetaData
+      name: Warden Desk
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,-9.5
       parent: 60
   - uid: 12188
     components:
+    - type: MetaData
+      name: Warden Desk
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-9.5
@@ -154851,42 +155051,56 @@ entities:
   entities:
   - uid: 72
     components:
+    - type: MetaData
+      name: Cell 2
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-12.5
       parent: 60
   - uid: 151
     components:
+    - type: MetaData
+      name: Cell 1
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-9.5
       parent: 60
   - uid: 230
     components:
+    - type: MetaData
+      name: Cell 3
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-6.5
       parent: 60
   - uid: 243
     components:
+    - type: MetaData
+      name: Cell 5
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-12.5
       parent: 60
   - uid: 268
     components:
+    - type: MetaData
+      name: Cell 4
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-9.5
       parent: 60
   - uid: 843
     components:
+    - type: MetaData
+      name: Medical Cell
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-6.5
       parent: 60
   - uid: 4078
     components:
+    - type: MetaData
+      name: Security Desk
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-17.5
@@ -154905,6 +155119,8 @@ entities:
       parent: 60
   - uid: 24149
     components:
+    - type: MetaData
+      name: Brig Medbay
     - type: Transform
       pos: -18.5,-5.5
       parent: 60


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
General touch-up of Bagel's Security/Brig area (the separate permabrig across the hallway to the right has not been modified) with the following list of (hopefully exhaustive) changes:

- Brig Medbay airlock now is a Brig airlock instead of a Security airlock to allow access to the CMO, Brigmeds and Lawyers. All access to the Medical Cell below is still Security access, including the windoor between both, so Medical staff can't interfere with prison sentences. This fixes #33663
- The bed in the Medical Cell is now a medical bed instead of a normal bed to allow the prisoner to heal a bit better once patched up. Brig Medbay window now electrified to prevent Medical Cell prisoner from breaking out through here via windoor.
- The Brig Medbay now has an O2 medkit to allow Security to stabilize someone in crit while waiting for medical dispatch (Dexalin and Inaprovaline) and a roller bed for evacuations. Moved the Morgue tray to open above the windoor to get more usable space
- Moved a table that was blocking movement in southern Brig, moved a console to a corner in NW Brig by Warden to declutter
- Added paper bin, pen and paper to Interrogation
- Added a bottle of space cleaner and a box of spare lights in Security Break Room (top left)
- Changed Security Lobby to public access. Moved the cell recharger from there to Security Break Room and replaced it with a chess board. Added a hot drinks vending machine.
- Changed the lobby access button in the Security Front Office to an emergency shutdown button. This will drop shutters over all windows and doors out of the lobby into the hallway to allow Security Officers to control a riot.
- Security Locker Room shutter button moved to be easier to use. Added a button frame to this one (Caution) and the Janitorial Button in Brig (Janitorial)
- Massive rework of all the atmospherics layout in Security. All pipes have been rationalized in order to remove all the ones going under walls and generally declutter the pipe layout. Additionally, many rooms now have their own air alarms which link to their vents and scrubbers instead of one mega alarm in the Brig
- Basically none of the vents or scrubbers were linked. Redid everything by hand while adding air alarms. Addresses the security part of  #33488
- Fixed disposals to have a slighty easier path to repair
- Small tweaks to lighting to make things better lit while actually lowering power draw
- A MV power cable that was going under a wall was repathed
- Quality pass on airlock names, added custom naming to all buttons, windoors and the brig timers
- A few chairs and stools moved or added

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Brig Medbay: Need an O2 kit to stabilize crit patients, Brig Meds and CMO should have access to it
Medical Bed in Medical Cell: Was already one in Brig Medbay, allows prisoner to go back to his proper cell and still heal well
Electrifying Brig Medbay: If you break the northern windoor from Medical Cell, you can then break the window to escape into brig lobby, unlike other cells
Space cleaner and spare lights: Standard on some other maps, this helps out the Janitor a fair bit and a partially blacked out or slippery Security is very unsafe
Security Lobby public access: The way it was set up before as a sort of "waiting room", it didn't make sense for it to be locked to Brig access, there's nothing of any value in here
Security Lobby shutdown: Allows Security to shut down their own brig entrance if things are out of control, since Bagel Brig is the easiest brig in the game to breach into (minus Reach I suppose). This also leaves an opening through Front Office for determined attackers. If you shut it down, your only remaining access (minus breaking stuff) is Security Break Room hallway access or maintenance into the same room
Piping and Atmos rework: More air alarms means easier atmospherics control for AI and Atmos Techs. Many were also going under reinforced walls which made it a nightmare to repair if a bomb went off in the Brig. Having all vents and scrubbers linked at roundstart is a no brainer.
Lights: Brig Medbay now matches lower cells with two small lights. Symmetry and redundant lights fixed in some cases. Power draw is similar if not slightly lower and the area was already well lit minus one mistake
Cell Recharger: Since Security Lobby is now all access, Security should be able to recharge their seclights without getting the battery yoinked. Before it was, people could still easily get in and running into the front lobby to recharge your stuff was a bit weird.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Full map render:
![Bagel-0](https://github.com/user-attachments/assets/b3b82adb-5953-4573-80b1-442b59ac2608)

Cropped Bagel Security/Brig area:
![BagelSec](https://github.com/user-attachments/assets/ec6ef37e-e293-46d5-bd7f-4930652576fa)

(I do not know how to render a pipe map)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
