### PR TITLE
Organize the Sandbox Panel window

### DIFF
--- a/Content.Client/Sandbox/SandboxSystem.cs
+++ b/Content.Client/Sandbox/SandboxSystem.cs
@@ -110,7 +110,7 @@ namespace Content.Client.Sandbox
             }
 
             // Try copy tile.
-            
+
             if (!_map.TryFindGridAt(_transform.ToMapCoordinates(coords), out var gridUid, out var grid) || !_mapSystem.TryGetTileRef(gridUid, grid, coords, out var tileRef))
                 return false;
 
@@ -156,11 +156,6 @@ namespace Content.Client.Sandbox
         public void ShowBb()
         {
             _consoleHost.ExecuteCommand("physics shapes");
-        }
-
-        public void MachineLinking()
-        {
-            _consoleHost.ExecuteCommand("signallink");
         }
     }
 }

--- a/Content.Client/UserInterface/Systems/Sandbox/SandboxUIController.cs
+++ b/Content.Client/UserInterface/Systems/Sandbox/SandboxUIController.cs
@@ -1,4 +1,5 @@
-﻿using Content.Client.Administration.Managers;
+﻿using System.Numerics;
+using Content.Client.Administration.Managers;
 using Content.Client.Gameplay;
 using Content.Client.Markers;
 using Content.Client.Sandbox;
@@ -7,9 +8,7 @@ using Content.Client.UserInterface.Controls;
 using Content.Client.UserInterface.Systems.DecalPlacer;
 using Content.Client.UserInterface.Systems.Sandbox.Windows;
 using Content.Shared.Input;
-using Content.Shared.Silicons.StationAi;
 using JetBrains.Annotations;
-using Robust.Client.Console;
 using Robust.Client.Debugging;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
@@ -109,9 +108,13 @@ public sealed class SandboxUIController : UIController, IOnStateChanged<Gameplay
 
     private void EnsureWindow()
     {
-        if(_window is { Disposed: false })
+        if (_window is { Disposed: false })
             return;
         _window = UIManager.CreateWindow<SandboxWindow>();
+        // Pre-center the window without forcing it to the center every time.
+        _window.OpenCentered();
+        _window.Close();
+
         _window.OnOpen += () => { SandboxButton!.Pressed = true; };
         _window.OnClose += () => { SandboxButton!.Pressed = false; };
         _window.ToggleLightButton.Pressed = !_light.Enabled;
@@ -163,7 +166,7 @@ public sealed class SandboxUIController : UIController, IOnStateChanged<Gameplay
     {
         if (_window != null)
         {
-            _window.Dispose();
+            _window.Close();
             _window = null;
         }
 
@@ -208,7 +211,7 @@ public sealed class SandboxUIController : UIController, IOnStateChanged<Gameplay
         if (_sandbox.SandboxAllowed && _window.IsOpen != true)
         {
             UIManager.ClickSound();
-            _window.OpenCentered();
+            _window.Open();
         }
         else
         {

--- a/Content.Client/UserInterface/Systems/Sandbox/SandboxUIController.cs
+++ b/Content.Client/UserInterface/Systems/Sandbox/SandboxUIController.cs
@@ -149,7 +149,6 @@ public sealed class SandboxUIController : UIController, IOnStateChanged<Gameplay
         _window.ToggleSubfloorButton.OnPressed += _ => _sandbox.ToggleSubFloor();
         _window.ShowMarkersButton.OnPressed += _ => _sandbox.ShowMarkers();
         _window.ShowBbButton.OnPressed += _ => _sandbox.ShowBb();
-        _window.MachineLinkingButton.OnPressed += _ => _sandbox.MachineLinking();
     }
 
     private void CheckSandboxVisibility()

--- a/Content.Client/UserInterface/Systems/Sandbox/Windows/SandboxWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Sandbox/Windows/SandboxWindow.xaml
@@ -8,7 +8,6 @@
         <Button Name="SpawnTilesButton" Access="Public" Text="{Loc sandbox-window-spawn-tiles-button}"/>
         <Button Name="SpawnEntitiesButton" Access="Public" Text="{Loc sandbox-window-spawn-entities-button}"/>
         <Button Name="SpawnDecalsButton" Access="Public" Text="{Loc sandbox-window-spawn-decals-button}"/>
-        <Button Name="MachineLinkingButton" Access="Public" Text="{Loc sandbox-window-link-machines-button}" ToggleMode="True"/>
 
         <Label Text="{Loc sandbox-window-visibility-label}"/>
         <Button Name="ToggleLightButton" Access="Public" Text="{Loc sandbox-window-toggle-lights-button}" ToggleMode="True"/>

--- a/Content.Client/UserInterface/Systems/Sandbox/Windows/SandboxWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Sandbox/Windows/SandboxWindow.xaml
@@ -22,7 +22,7 @@
         <Label Text="{Loc sandbox-window-your-character-label}"/>
         <Button Name="GiveAghostButton" Access="Public" Text="{Loc sandbox-window-ghost-button}"/>
         <Button Name="GiveFullAccessButton" Access="Public" Text="{Loc sandbox-window-grant-full-access-button}"/>
-        <Button Name="SuicideButton" Access="Public" Text="{Loc sandbox-window-toggle-suicide-button}" ToggleMode="True"/>
+        <Button Name="SuicideButton" Access="Public" Text="{Loc sandbox-window-toggle-suicide-button}"/>
         <Button Name="RespawnButton" Access="Public" Text="{Loc sandbox-window-respawn-button}"/>
     </BoxContainer>
 </windows:SandboxWindow>

--- a/Content.Client/UserInterface/Systems/Sandbox/Windows/SandboxWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Sandbox/Windows/SandboxWindow.xaml
@@ -4,20 +4,25 @@
     Title="{Loc sandbox-window-title}"
     Resizable="False">
     <BoxContainer Orientation="Vertical" SeparationOverride="4">
-        <Button Name="AiOverlayButton" Access="Public" Text="{Loc sandbox-window-ai-overlay-button}" ToggleMode="True"/>
-        <Button Name="RespawnButton" Access="Public" Text="{Loc sandbox-window-respawn-button}"/>
-        <Button Name="SpawnEntitiesButton" Access="Public" Text="{Loc sandbox-window-spawn-entities-button}"/>
+        <Label Text="{Loc sandbox-window-map-editing-label}"/>
         <Button Name="SpawnTilesButton" Access="Public" Text="{Loc sandbox-window-spawn-tiles-button}"/>
+        <Button Name="SpawnEntitiesButton" Access="Public" Text="{Loc sandbox-window-spawn-entities-button}"/>
         <Button Name="SpawnDecalsButton" Access="Public" Text="{Loc sandbox-window-spawn-decals-button}"/>
-        <Button Name="GiveFullAccessButton" Access="Public" Text="{Loc sandbox-window-grant-full-access-button}"/>
-        <Button Name="GiveAghostButton" Access="Public" Text="{Loc sandbox-window-ghost-button}"/>
+        <Button Name="MachineLinkingButton" Access="Public" Text="{Loc sandbox-window-link-machines-button}" ToggleMode="True"/>
+
+        <Label Text="{Loc sandbox-window-visibility-label}"/>
         <Button Name="ToggleLightButton" Access="Public" Text="{Loc sandbox-window-toggle-lights-button}" ToggleMode="True"/>
         <Button Name="ToggleFovButton" Access="Public" Text="{Loc sandbox-window-toggle-fov-button}" ToggleMode="True"/>
         <Button Name="ToggleShadowsButton" Access="Public" Text="{Loc sandbox-window-toggle-shadows-button}" ToggleMode="True"/>
         <Button Name="ToggleSubfloorButton" Access="Public" Text="{Loc sandbox-window-toggle-subfloor-button}" ToggleMode="True"/>
-        <Button Name="SuicideButton" Access="Public" Text="{Loc sandbox-window-toggle-suicide-button}" ToggleMode="True"/>
+        <Button Name="AiOverlayButton" Access="Public" Text="{Loc sandbox-window-ai-overlay-button}" ToggleMode="True"/>
         <Button Name="ShowMarkersButton" Access="Public" Text="{Loc sandbox-window-show-spawns-button}" ToggleMode="True"/>
         <Button Name="ShowBbButton" Access="Public" Text="{Loc sandbox-window-show-bb-button}" ToggleMode="True"/>
-        <Button Name="MachineLinkingButton" Access="Public" Text="{Loc sandbox-window-link-machines-button}" ToggleMode="True"/>
+
+        <Label Text="{Loc sandbox-window-your-character-label}"/>
+        <Button Name="GiveAghostButton" Access="Public" Text="{Loc sandbox-window-ghost-button}"/>
+        <Button Name="GiveFullAccessButton" Access="Public" Text="{Loc sandbox-window-grant-full-access-button}"/>
+        <Button Name="SuicideButton" Access="Public" Text="{Loc sandbox-window-toggle-suicide-button}" ToggleMode="True"/>
+        <Button Name="RespawnButton" Access="Public" Text="{Loc sandbox-window-respawn-button}"/>
     </BoxContainer>
 </windows:SandboxWindow>

--- a/Resources/Locale/en-US/sandbox/sandbox-manager.ftl
+++ b/Resources/Locale/en-US/sandbox/sandbox-manager.ftl
@@ -1,4 +1,9 @@
 sandbox-window-title = Sandbox Panel
+
+sandbox-window-map-editing-label = Map Editing
+sandbox-window-visibility-label = Visibility
+sandbox-window-your-character-label = Your Character
+
 sandbox-window-ai-overlay-button = AI Overlay
 sandbox-window-respawn-button = Respawn
 sandbox-window-spawn-entities-button = Spawn Entities

--- a/Resources/Locale/en-US/sandbox/sandbox-manager.ftl
+++ b/Resources/Locale/en-US/sandbox/sandbox-manager.ftl
@@ -16,6 +16,6 @@ sandbox-window-toggle-fov-button = Toggle FOV
 sandbox-window-toggle-shadows-button = Toggle Shadows
 sandbox-window-toggle-subfloor-button = Toggle Subfloor
 sandbox-window-toggle-suicide-button = Suicide
-sandbox-window-show-spawns-button = Shows Spawns
+sandbox-window-show-spawns-button = Show Spawns
 sandbox-window-show-bb-button = Show BB
 sandbox-window-show-npc-button = Show NPC

--- a/Resources/Locale/en-US/sandbox/sandbox-manager.ftl
+++ b/Resources/Locale/en-US/sandbox/sandbox-manager.ftl
@@ -19,4 +19,3 @@ sandbox-window-toggle-suicide-button = Suicide
 sandbox-window-show-spawns-button = Shows Spawns
 sandbox-window-show-bb-button = Show BB
 sandbox-window-show-npc-button = Show NPC
-sandbox-window-link-machines-button = Link machines

--- a/Resources/Locale/en-US/sandbox/sandbox-manager.ftl
+++ b/Resources/Locale/en-US/sandbox/sandbox-manager.ftl
@@ -1,6 +1,6 @@
 sandbox-window-title = Sandbox Panel
 
-sandbox-window-map-editing-label = Map Editing
+sandbox-window-map-editing-label = Editing
 sandbox-window-visibility-label = Visibility
 sandbox-window-your-character-label = Your Character
 


### PR DESCRIPTION
## About the PR
This window was a bit disorganized and had buttons that were misspelled or did nothing. Now it's less so.

## Technical details
- Remember the Sandbox Panel's position like other windows, instead of forcibly centering it on open
- Group buttons into logical sections
- Rename "Shows Spawns" to "Show Spawns"
- Remove "Link Machines" button that has done nothing for 3 years.
  - Related issue #23110
  - Related PR #4323
- Unset ToggleMode on Suicide button

## Media
| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/7a24aeb6-9d22-4718-acb7-46eac37d5fc2) | ![image](https://github.com/user-attachments/assets/b9868253-5fc6-43a1-bbb2-e92bf531eb49) |
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
