### PR TITLE
Fix sinks and toilets not draining

### DIFF
--- a/Content.Shared/Fluids/Components/DrainComponent.cs
+++ b/Content.Shared/Fluids/Components/DrainComponent.cs
@@ -27,8 +27,8 @@ public sealed partial class DrainComponent : Component
     public float Accumulator = 0f;
 
     /// <summary>
-    /// Does this drain automatically absorb surrouding puddles? Or is it a drain designed to empty
-    /// solutions in it manually? 
+    /// If true, automatically transfers solutions from nearby puddles and drains them. True for floor drains;
+    /// false for things like toilets and sinks.
     /// </summary>
     [DataField]
     public bool AutoDrain = true;


### PR DESCRIPTION
## About the PR
Per the system comments, AutoDrain is designed to automatically move puddles into the drain (like a floor drain). Drains without AutoDrain are still supposed to gradually empty the buffer, but not remove puddles (like sinks and toilets).

However, a logic error in the original implementation causes drains with AutoDrain set to false to simply not work. Hence sinks never emptied.

## Why / Balance
Fixes sinks draining.

## Media
https://github.com/user-attachments/assets/972a188a-a7ab-4ce0-8464-7716cae2fc23

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: notafet
- fix: Fix sinks and toilets not draining.