### PR TITLE
Refactors The GhostUI Warp Menu

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -16,7 +16,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
         /// <summary>
         /// Dictionary where the key is the department, and the value is a list of warp data.
         /// </summary>
-        private Dictionary<string, List<(string, NetEntity, string)>> _categories = new();
+        private Dictionary<string, List<(string, NetEntity, Color)>> _categories = new();
 
         public event Action<NetEntity>? WarpClicked;
         public event Action? OnGhostnadoClicked;
@@ -41,7 +41,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
             {
                 if (!_categories.ContainsKey(warp.CategoryName))
                 {
-                    _categories[warp.CategoryName] = new List<(string, NetEntity, string)>();
+                    _categories[warp.CategoryName] = new List<(string, NetEntity, Color)>();
                 }
 
                 var warpName = warp.IsWarpPoint
@@ -83,11 +83,11 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                         HorizontalAlignment = HAlignment.Center,
                         VerticalAlignment = VAlignment.Center,
                         SizeFlagsStretchRatio = 1,
-                        ModulateSelfOverride = Color.FromHex(colorHex),
+                        ModulateSelfOverride = colorHex,
                         MinSize = new Vector2(340, 20),
                     };
 
-                    currentButtonRef.OnMouseEntered += _ => currentButtonRef.Label.FontColorOverride = Color.InterpolateBetween(Color.White, Color.FromHex(colorHex), 0.35f);
+                    currentButtonRef.OnMouseEntered += _ => currentButtonRef.Label.FontColorOverride = Color.InterpolateBetween(Color.White, colorHex, 0.35f);
 
                     currentButtonRef.OnMouseExited += _ =>
                     {
@@ -98,7 +98,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                     currentButtonRef.OnPressed += _ =>
                     {
                         WarpClicked?.Invoke(warpTarget);
-                        currentButtonRef.Modulate = Color.FromHex(colorHex);
+                        currentButtonRef.Modulate = colorHex;
                     };
                     currentButtonRef.Visible = ButtonIsVisible(currentButtonRef);
 

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -83,12 +83,23 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                         HorizontalAlignment = HAlignment.Center,
                         VerticalAlignment = VAlignment.Center,
                         SizeFlagsStretchRatio = 1,
-                        Modulate = Color.FromHex(colorHex),
+                        ModulateSelfOverride = Color.FromHex(colorHex),
                         MinSize = new Vector2(340, 20),
-                        ClipText = true,
                     };
 
-                    currentButtonRef.OnPressed += _ => WarpClicked?.Invoke(warpTarget);
+                    currentButtonRef.OnMouseEntered += _ => currentButtonRef.Label.FontColorOverride = Color.InterpolateBetween(Color.White, Color.FromHex(colorHex), 0.35f);
+
+                    currentButtonRef.OnMouseExited += args =>
+                    {
+                        currentButtonRef.Modulate = Color.White;
+                        currentButtonRef.Label.FontColorOverride = Color.White;
+                    };
+
+                    currentButtonRef.OnPressed += _ =>
+                    {
+                        WarpClicked?.Invoke(warpTarget);
+                        currentButtonRef.Modulate = Color.FromHex(colorHex);
+                    };
                     currentButtonRef.Visible = ButtonIsVisible(currentButtonRef);
 
                     ButtonContainer.AddChild(currentButtonRef);

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -89,7 +89,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
 
                     currentButtonRef.OnMouseEntered += _ => currentButtonRef.Label.FontColorOverride = Color.InterpolateBetween(Color.White, Color.FromHex(colorHex), 0.35f);
 
-                    currentButtonRef.OnMouseExited += args =>
+                    currentButtonRef.OnMouseExited += _ =>
                     {
                         currentButtonRef.Modulate = Color.White;
                         currentButtonRef.Label.FontColorOverride = Color.White;

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -11,8 +11,12 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
     [GenerateTypedNameReferences]
     public sealed partial class GhostTargetWindow : DefaultWindow
     {
-        private List<(string, NetEntity)> _warps = new();
         private string _searchText = string.Empty;
+
+        /// <summary>
+        /// Dictionary where the key is the department, and the value is a list of warp data.
+        /// </summary>
+        private Dictionary<string, List<(string, NetEntity, string)>> _categories = new();
 
         public event Action<NetEntity>? WarpClicked;
         public event Action? OnGhostnadoClicked;
@@ -25,22 +29,27 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
             GhostnadoButton.OnPressed += _ => OnGhostnadoClicked?.Invoke();
         }
 
+        /// <summary>
+        /// Categorizes the warps based on departments.
+        /// </summary>
+        /// <param name="warps"></param>
         public void UpdateWarps(IEnumerable<GhostWarp> warps)
         {
-            // Server COULD send these sorted but how about we just use the client to do it instead
-            _warps = warps
-                .OrderBy(w => w.IsWarpPoint)
-                .ThenBy(w => w.DisplayName, Comparer<string>.Create(
-                    (x, y) => string.Compare(x, y, StringComparison.Ordinal)))
-                .Select(w =>
-                {
-                    var name = w.IsWarpPoint
-                        ? Loc.GetString("ghost-target-window-current-button", ("name", w.DisplayName))
-                        : w.DisplayName;
+            _categories.Clear();
 
-                    return (name, w.Entity);
-                })
-                .ToList();
+            foreach (var warp in warps)
+            {
+                if (!_categories.ContainsKey(warp.CategoryName))
+                {
+                    _categories[warp.CategoryName] = new List<(string, NetEntity, string)>();
+                }
+
+                var warpName = warp.IsWarpPoint
+                    ? Loc.GetString("ghost-target-window-current-button", ("name", warp.DisplayName))
+                    : warp.DisplayName;
+
+                _categories[warp.CategoryName].Add((warpName, warp.Entity, warp.WarpColor));
+            }
         }
 
         public void Populate()
@@ -51,23 +60,39 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
 
         private void AddButtons()
         {
-            foreach (var (name, warpTarget) in _warps)
+            foreach (var (categoryName, warps) in _categories)
             {
-                var currentButtonRef = new Button
+                if (warps.Count == 0)
+                    continue;
+
+                var categoryLabel = new Label
                 {
-                    Text = name,
-                    TextAlign = Label.AlignMode.Right,
+                    Text = categoryName,
                     HorizontalAlignment = HAlignment.Center,
                     VerticalAlignment = VAlignment.Center,
-                    SizeFlagsStretchRatio = 1,
-                    MinSize = new Vector2(340, 20),
-                    ClipText = true,
                 };
 
-                currentButtonRef.OnPressed += _ => WarpClicked?.Invoke(warpTarget);
-                currentButtonRef.Visible = ButtonIsVisible(currentButtonRef);
+                ButtonContainer.AddChild(categoryLabel);
 
-                ButtonContainer.AddChild(currentButtonRef);
+                foreach (var (name, warpTarget, colorHex) in warps)
+                {
+                    var currentButtonRef = new Button
+                    {
+                        Text = name,
+                        TextAlign = Label.AlignMode.Right,
+                        HorizontalAlignment = HAlignment.Center,
+                        VerticalAlignment = VAlignment.Center,
+                        SizeFlagsStretchRatio = 1,
+                        Modulate = Color.FromHex(colorHex),
+                        MinSize = new Vector2(340, 20),
+                        ClipText = true,
+                    };
+
+                    currentButtonRef.OnPressed += _ => WarpClicked?.Invoke(warpTarget);
+                    currentButtonRef.Visible = ButtonIsVisible(currentButtonRef);
+
+                    ButtonContainer.AddChild(currentButtonRef);
+                }
             }
         }
 
@@ -90,7 +115,6 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
             _searchText = args.Text;
 
             UpdateVisibleButtons();
-            // Reset scroll bar so they can see the relevant results.
             GhostScroll.SetScrollValue(Vector2.Zero);
         }
     }

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -98,7 +98,6 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                     currentButtonRef.OnPressed += _ =>
                     {
                         WarpClicked?.Invoke(warpTarget);
-                        
                         currentButtonRef.Modulate = colorHex;
                     };
                     currentButtonRef.Visible = ButtonIsVisible(currentButtonRef);

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -98,6 +98,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                     currentButtonRef.OnPressed += _ =>
                     {
                         WarpClicked?.Invoke(warpTarget);
+                        
                         currentButtonRef.Modulate = colorHex;
                     };
                     currentButtonRef.Visible = ButtonIsVisible(currentButtonRef);

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -85,6 +85,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                         SizeFlagsStretchRatio = 1,
                         ModulateSelfOverride = colorHex,
                         MinSize = new Vector2(340, 20),
+                        ClipText = true,
                     };
 
                     currentButtonRef.OnMouseEntered += _ => currentButtonRef.Label.FontColorOverride = Color.InterpolateBetween(Color.White, colorHex, 0.35f);

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -345,7 +345,7 @@ namespace Content.Server.Ghost
 
             while (allQuery.MoveNext(out var uid, out var warp))
             {
-                yield return new GhostWarp(GetNetEntity(uid), warp.Location ?? Name(uid), true, null, null);
+                yield return new GhostWarp(GetNetEntity(uid), warp.Location ?? Name(uid), true, null, warp.Color);
             }
         }
 
@@ -373,7 +373,7 @@ namespace Content.Server.Ghost
 
                     if (_jobs.TryGetDepartment(jobProto.ID, out var departmentProto))
                     {
-                        yield return new GhostWarp(GetNetEntity(attached), playerInfo, false, Loc.GetString(departmentProto.Name), departmentProto.Color.ToHex());
+                        yield return new GhostWarp(GetNetEntity(attached), playerInfo, false, Loc.GetString(departmentProto.Name), departmentProto.Color);
                     }
                     else
                     {

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -358,13 +358,16 @@ namespace Content.Server.Ghost
 
                 if (attached == except) continue;
 
-                if (!_mobState.IsAlive(attached) && !_mobState.IsCritical(attached) && !HasComp<GhostComponent>(attached)) continue;
-
                 TryComp<MindContainerComponent>(attached, out var mind);
 
+                TryComp<GhostComponent>(attached, out var ghost);
+
+                if (!_mobState.IsAlive(attached) && !_mobState.IsCritical(attached) && ghost == null) continue;
+
                 var entityName = Name(attached);
-                if (HasComp<GhostComponent>(attached))
+                if (ghost != null)
                 {
+                    if (ghost.HideGhostWarp == true) continue;
                     var playerInfo = Loc.GetString("ghost-target-window-player-warp-name",
                     ("entityName", entityName),
                     ("jobName", Loc.GetString("ghost-target-warp-role")));

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -358,13 +358,20 @@ namespace Content.Server.Ghost
 
                 if (attached == except) continue;
 
-                if (!_mobState.IsAlive(attached) && !_mobState.IsCritical(attached)) continue;
+                if (!_mobState.IsAlive(attached) && !_mobState.IsCritical(attached) && !HasComp<GhostComponent>(attached)) continue;
 
                 TryComp<MindContainerComponent>(attached, out var mind);
 
-                if (_jobs.MindTryGetJob(mind?.Mind, out var jobProto))
+                var entityName = Name(attached);
+                if (HasComp<GhostComponent>(attached))
                 {
-                    var entityName = Name(attached);
+                    var playerInfo = Loc.GetString("ghost-target-window-player-warp-name",
+                    ("entityName", entityName),
+                    ("jobName", Loc.GetString("ghost-target-warp-role")));
+                    yield return new GhostWarp(GetNetEntity(attached), playerInfo, false, Loc.GetString("ghost-target-warp-role"), Color.Gray);
+                }
+                else if (_jobs.MindTryGetJob(mind?.Mind, out var jobProto))
+                {
                     var jobName = _jobs.MindTryGetJobName(mind?.Mind);
 
                     var playerInfo = Loc.GetString("ghost-target-window-player-warp-name",

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.Ghost.Components;
 using Content.Server.Mind;
 using Content.Server.Roles.Jobs;
 using Content.Server.Warps;
+using Content.Server.Ghost.Roles.Components;
 using Content.Shared.Actions;
 using Content.Shared.CCVar;
 using Content.Shared.Damage;
@@ -358,11 +359,11 @@ namespace Content.Server.Ghost
 
                 if (attached == except) continue;
 
+                TryComp<GhostRoleComponent>(attached, out var ghostRole);
                 TryComp<MindContainerComponent>(attached, out var mind);
-
                 TryComp<GhostComponent>(attached, out var ghost);
 
-                if (!_mobState.IsAlive(attached) && !_mobState.IsCritical(attached) && ghost == null) continue;
+                if (!_mobState.IsAlive(attached) && !_mobState.IsCritical(attached) && ghost == null && ghostRole == null) continue;
 
                 var entityName = Name(attached);
                 if (ghost != null)
@@ -387,10 +388,17 @@ namespace Content.Server.Ghost
                     }
                     else
                     {
-                        yield return new GhostWarp(GetNetEntity(attached), playerInfo, false, null, null);
+                        yield return new GhostWarp(GetNetEntity(attached), playerInfo, false, null, null); // there exists some job without a department.
                     }
                 }
+                else if (ghostRole != null)
+                {
+                    var playerInfo = Loc.GetString("ghost-target-window-player-warp-name",
+                    ("entityName", entityName),
+                    ("jobName", ghostRole.RoleName));
 
+                    yield return new GhostWarp(GetNetEntity(attached), playerInfo, false, Loc.GetString("ghost-target-category-ghost-role"), Color.Gray);
+                }
             }
         }
 

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -36,7 +36,6 @@ public sealed class MindSystem : SharedMindSystem
 
         SubscribeLocalEvent<MindContainerComponent, EntityTerminatingEvent>(OnMindContainerTerminating);
         SubscribeLocalEvent<MindComponent, ComponentShutdown>(OnMindShutdown);
-        // SubscribeLocalEvent<MindRoleComponent, MindAddedMessage>(OnMindAdded);
     }
 
     private void OnMindShutdown(EntityUid uid, MindComponent mind, ComponentShutdown args)

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -15,6 +15,7 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 using System.Diagnostics.CodeAnalysis;
+using Content.Server.Ghost.Roles.Components;
 
 namespace Content.Server.Mind;
 
@@ -365,15 +366,15 @@ public sealed class MindSystem : SharedMindSystem
             return;
         }
 
-        var validTargetMind = TryGetMind(target, out var targetMindId, out var targetMind);
+        TryGetMind(target, out var targetMindId, out var targetMind);
         _jobs.MindTryGetJobId(targetMindId, out var targetJobProtoId);
+        _jobs.MindTryGetJobId(mindId, out var originalJobProtoId);
+        TryComp<GhostRoleComponent>(target, out var ghostRole);
+        var targetJob = targetJobProtoId ?? ghostRole?.JobProto ?? originalJobProtoId;
 
         MakeSentientCommand.MakeSentient(target, EntityManager);
         TransferTo(mindId, target, ghostCheckOverride: true, mind: mind);
 
-        if (validTargetMind)
-        {
-            _roleSystem.MindAddJobRole(mindId, mind, silent:false, targetJobProtoId);
-        }
+        _roleSystem.MindAddJobRole(mindId, mind, silent:false, targetJob);
     }
 }

--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -7,6 +7,8 @@ using Content.Shared.Ghost;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Players;
+using Content.Shared.Roles;
+using Content.Server.Roles.Jobs;
 using Robust.Server.GameStates;
 using Robust.Server.Player;
 using Robust.Shared.Network;
@@ -24,13 +26,16 @@ public sealed class MindSystem : SharedMindSystem
     [Dependency] private readonly GhostSystem _ghosts = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly PvsOverrideSystem _pvsOverride = default!;
+    [Dependency] private readonly SharedRoleSystem _roleSystem = default!;
 
+    [Dependency] private readonly JobSystem _jobs = default!;
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<MindContainerComponent, EntityTerminatingEvent>(OnMindContainerTerminating);
         SubscribeLocalEvent<MindComponent, ComponentShutdown>(OnMindShutdown);
+        // SubscribeLocalEvent<MindRoleComponent, MindAddedMessage>(OnMindAdded);
     }
 
     private void OnMindShutdown(EntityUid uid, MindComponent mind, ComponentShutdown args)
@@ -176,32 +181,32 @@ public sealed class MindSystem : SharedMindSystem
         }
     }
 
-    public override void TransferTo(EntityUid mindId, EntityUid? entity, bool ghostCheckOverride = false, bool createGhost = true,
+    public override void TransferTo(EntityUid mindToTransfer, EntityUid? targetEntity, bool ghostCheckOverride = false, bool createGhost = true,
         MindComponent? mind = null)
     {
-        if (mind == null && !Resolve(mindId, ref mind))
+        if (mind == null && !Resolve(mindToTransfer, ref mind))
             return;
 
-        if (entity == mind.OwnedEntity)
+        if (targetEntity == mind.OwnedEntity)
             return;
 
-        Dirty(mindId, mind);
+        Dirty(mindToTransfer, mind);
         MindContainerComponent? component = null;
         var alreadyAttached = false;
 
-        if (entity != null)
+        if (targetEntity != null)
         {
-            component = EnsureComp<MindContainerComponent>(entity.Value);
+            component = EnsureComp<MindContainerComponent>(targetEntity.Value);
 
             if (component.HasMind)
                 _ghosts.OnGhostAttempt(component.Mind.Value, false);
 
-            if (TryComp<ActorComponent>(entity.Value, out var actor))
+            if (TryComp<ActorComponent>(targetEntity.Value, out var actor))
             {
                 // Happens when transferring to your currently visited entity.
                 if (actor.PlayerSession != mind.Session)
                 {
-                    throw new ArgumentException("Visit target already has a session.", nameof(entity));
+                    throw new ArgumentException("Visit target already has a session.", nameof(targetEntity));
                 }
 
                 alreadyAttached = true;
@@ -218,9 +223,9 @@ public sealed class MindSystem : SharedMindSystem
                 ? _gameTicker.GetObserverSpawnPoint().ToMap(EntityManager, _transform)
                 : _transform.GetMapCoordinates(mind.OwnedEntity.Value);
 
-            entity = Spawn(GameTicker.ObserverPrototypeName, position);
-            component = EnsureComp<MindContainerComponent>(entity.Value);
-            var ghostComponent = Comp<GhostComponent>(entity.Value);
+            targetEntity = Spawn(GameTicker.ObserverPrototypeName, position);
+            component = EnsureComp<MindContainerComponent>(targetEntity.Value);
+            var ghostComponent = Comp<GhostComponent>(targetEntity.Value);
             _ghosts.SetCanReturnToBody(ghostComponent, false);
         }
 
@@ -229,10 +234,10 @@ public sealed class MindSystem : SharedMindSystem
         {
             oldContainer.Mind = null;
             mind.OwnedEntity = null;
-            Entity<MindComponent> mindEnt = (mindId, mind);
+            Entity<MindComponent> mindEnt = (mindToTransfer, mind);
             Entity<MindContainerComponent> containerEnt = (oldEntity.Value, oldContainer);
             RaiseLocalEvent(oldEntity.Value, new MindRemovedMessage(mindEnt, containerEnt));
-            RaiseLocalEvent(mindId, new MindGotRemovedEvent(mindEnt, containerEnt));
+            RaiseLocalEvent(mindToTransfer, new MindGotRemovedEvent(mindEnt, containerEnt));
             Dirty(oldEntity.Value, oldContainer);
         }
 
@@ -242,35 +247,35 @@ public sealed class MindSystem : SharedMindSystem
             // Set VisitingEntity null first so the removal of VisitingMind doesn't get through Unvisit() and delete what we're visiting.
             // Yes this control flow sucks.
             mind.VisitingEntity = null;
-            RemComp<VisitingMindComponent>(entity!.Value);
+            RemComp<VisitingMindComponent>(targetEntity!.Value);
         }
         else if (mind.VisitingEntity != null
               && (ghostCheckOverride // to force mind transfer, for example from ControlMobVerb
                   || !TryComp(mind.VisitingEntity!, out GhostComponent? ghostComponent) // visiting entity is not a Ghost
                   || !ghostComponent.CanReturnToBody))  // it is a ghost, but cannot return to body anyway, so it's okay
         {
-            RemoveVisitingEntity(mindId, mind);
+            RemoveVisitingEntity(mindToTransfer, mind);
         }
 
         // Player is CURRENTLY connected.
         var session = GetSession(mind);
         if (session != null && !alreadyAttached && mind.VisitingEntity == null)
         {
-            _players.SetAttachedEntity(session, entity, true);
-            DebugTools.Assert(session.AttachedEntity == entity, $"Failed to attach entity.");
-            Log.Info($"Session {session.Name} transferred to entity {entity}.");
+            _players.SetAttachedEntity(session, targetEntity, true);
+            DebugTools.Assert(session.AttachedEntity == targetEntity, $"Failed to attach entity.");
+            Log.Info($"Session {session.Name} transferred to entity {targetEntity}.");
         }
 
-        if (entity != null)
+        if (targetEntity != null)
         {
-            component!.Mind = mindId;
-            mind.OwnedEntity = entity;
+            component!.Mind = mindToTransfer;
+            mind.OwnedEntity = targetEntity;
             mind.OriginalOwnedEntity ??= GetNetEntity(mind.OwnedEntity);
-            Entity<MindComponent> mindEnt = (mindId, mind);
-            Entity<MindContainerComponent> containerEnt = (entity.Value, component);
-            RaiseLocalEvent(entity.Value, new MindAddedMessage(mindEnt, containerEnt));
-            RaiseLocalEvent(mindId, new MindGotAddedEvent(mindEnt, containerEnt));
-            Dirty(entity.Value, component);
+            Entity<MindComponent> mindEnt = (mindToTransfer, mind);
+            Entity<MindContainerComponent> containerEnt = (targetEntity.Value, component);
+            RaiseLocalEvent(targetEntity.Value, new MindAddedMessage(mindEnt, containerEnt));
+            RaiseLocalEvent(mindToTransfer, new MindGotAddedEvent(mindEnt, containerEnt));
+            Dirty(targetEntity.Value, component);
         }
     }
 
@@ -360,7 +365,15 @@ public sealed class MindSystem : SharedMindSystem
             return;
         }
 
+        var validTargetMind = TryGetMind(target, out var targetMindId, out var targetMind);
+        _jobs.MindTryGetJobId(targetMindId, out var targetJobProtoId);
+
         MakeSentientCommand.MakeSentient(target, EntityManager);
         TransferTo(mindId, target, ghostCheckOverride: true, mind: mind);
+
+        if (validTargetMind)
+        {
+            _roleSystem.MindAddJobRole(mindId, mind, silent:false, targetJobProtoId);
+        }
     }
 }

--- a/Content.Server/Warps/WarpPointComponent.cs
+++ b/Content.Server/Warps/WarpPointComponent.cs
@@ -14,5 +14,12 @@ namespace Content.Server.Warps
         /// </summary>
         [DataField]
         public bool Follow;
+
+        /// <summary>
+        ///     Color of the warp button in the ghost menu.
+        /// </summary>
+        [DataField]
+        public Color Color = Color.LightPurple;
     }
+    
 }

--- a/Content.Server/Warps/WarpPointComponent.cs
+++ b/Content.Server/Warps/WarpPointComponent.cs
@@ -19,7 +19,7 @@ namespace Content.Server.Warps
         ///     Color of the warp button in the ghost menu.
         /// </summary>
         [DataField]
-        public Color Color = new Color(67, 67, 92, 255); // light purple
+        public Color Color = new Color(67, 67, 92, 255); // light purple, TODO add purple preset in the robusttoolbox
     }
     
 }

--- a/Content.Server/Warps/WarpPointComponent.cs
+++ b/Content.Server/Warps/WarpPointComponent.cs
@@ -19,7 +19,7 @@ namespace Content.Server.Warps
         ///     Color of the warp button in the ghost menu.
         /// </summary>
         [DataField]
-        public Color Color = Color.LightPurple;
+        public Color Color = new Color(67, 67, 92, 255); // light purple
     }
     
 }

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -83,7 +83,7 @@ public sealed partial class GhostComponent : Component
     }
 
     /// <summary>
-    ///     Whether the ghost warp is visibile in the ghost menu.
+    ///     Whether the ghost warp is visible in the ghost menu.
     /// </summary>
     /// <remarks>Admin ghosts will not appear in the ghost warp menu for the public.</remarks>
     [DataField("hideGhostWarp"), ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -83,6 +83,13 @@ public sealed partial class GhostComponent : Component
     }
 
     /// <summary>
+    ///     Whether the ghost warp is visibile in the ghost menu.
+    /// </summary>
+    /// <remarks>Admin ghosts will not appear in the ghost warp menu for the public.</remarks>
+    [DataField("hideGhostWarp"), ViewVariables(VVAccess.ReadWrite)]
+    public bool HideGhostWarp = false;
+
+    /// <summary>
     /// Ghost color
     /// </summary>
     /// <remarks>Used to allow admins to change ghost colors. Should be removed if the capability to edit existing sprite colors is ever added back.</remarks>

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -81,7 +81,7 @@ namespace Content.Shared.Ghost
             DisplayName = displayName;
             IsWarpPoint = isWarpPoint;
             CategoryName = categoryName ?? "Other";
-            WarpColor = warpColor ?? Color.LightPurple;
+            WarpColor = warpColor ?? new Color(67, 67, 92, 255); // light purple.
         }
 
         /// <summary>

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -75,13 +75,13 @@ namespace Content.Shared.Ghost
     [Serializable, NetSerializable]
     public struct GhostWarp
     {
-        public GhostWarp(NetEntity entity, string displayName, bool isWarpPoint, string? categoryName, string? warpColor)
+        public GhostWarp(NetEntity entity, string displayName, bool isWarpPoint, string? categoryName, Color? warpColor)
         {
             Entity = entity;
             DisplayName = displayName;
             IsWarpPoint = isWarpPoint;
             CategoryName = categoryName ?? "Other";
-            WarpColor = warpColor ?? "#43435C"; // purple
+            WarpColor = warpColor ?? Color.LightPurple;
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace Content.Shared.Ghost
         /// <summary>
         /// The color of each button in the category, should match the color of the department.
         /// </summary>
-        public string WarpColor { get; }
+        public Color WarpColor { get; }
     }
 
     /// <summary>

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -81,7 +81,7 @@ namespace Content.Shared.Ghost
             DisplayName = displayName;
             IsWarpPoint = isWarpPoint;
             CategoryName = categoryName ?? "Other";
-            WarpColor = warpColor ?? "#D3D3D3"; // light grey
+            WarpColor = warpColor ?? "#43435C"; // purple
         }
 
         /// <summary>

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -75,16 +75,17 @@ namespace Content.Shared.Ghost
     [Serializable, NetSerializable]
     public struct GhostWarp
     {
-        public GhostWarp(NetEntity entity, string displayName, bool isWarpPoint)
+        public GhostWarp(NetEntity entity, string displayName, bool isWarpPoint, string? categoryName, string? warpColor)
         {
             Entity = entity;
             DisplayName = displayName;
             IsWarpPoint = isWarpPoint;
+            CategoryName = categoryName ?? "Other";
+            WarpColor = warpColor ?? "#D3D3D3"; // light grey
         }
 
         /// <summary>
         /// The entity representing the warp point.
-        /// This is passed back to the server in <see cref="GhostWarpToTargetRequestEvent"/>
         /// </summary>
         public NetEntity Entity { get; }
 
@@ -96,7 +97,17 @@ namespace Content.Shared.Ghost
         /// <summary>
         /// Whether this warp represents a warp point or a player
         /// </summary>
-        public bool IsWarpPoint { get;  }
+        public bool IsWarpPoint { get; }
+
+        /// <summary>
+        /// The name of the category to which the warp belongs to, for mobs it's just the department.
+        /// </summary>
+        public string CategoryName { get; }
+
+        /// <summary>
+        /// The color of each button in the category, should match the color of the department.
+        /// </summary>
+        public string WarpColor { get; }
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/ghost/ghost-gui.ftl
+++ b/Resources/Locale/en-US/ghost/ghost-gui.ftl
@@ -11,6 +11,7 @@ ghost-gui-toggle-hearing-popup-off = You can now only hear radio and nearby mess
 
 ghost-target-window-title = Ghost Warp
 ghost-target-window-current-button = Warp: {$name}
+ghost-target-window-player-warp-name = {$entityName} ({$jobName})
 ghost-target-window-warp-to-most-followed = Warp to Most Followed
 
 ghost-roles-window-title = Ghost Roles

--- a/Resources/Locale/en-US/ghost/ghost-gui.ftl
+++ b/Resources/Locale/en-US/ghost/ghost-gui.ftl
@@ -12,6 +12,7 @@ ghost-gui-toggle-hearing-popup-off = You can now only hear radio and nearby mess
 ghost-target-window-title = Ghost Warp
 ghost-target-window-current-button = Warp: {$name}
 ghost-target-window-player-warp-name = {$entityName} ({$jobName})
+ghost-target-warp-role = Ghost
 ghost-target-window-warp-to-most-followed = Warp to Most Followed
 
 ghost-roles-window-title = Ghost Roles

--- a/Resources/Locale/en-US/ghost/ghost-gui.ftl
+++ b/Resources/Locale/en-US/ghost/ghost-gui.ftl
@@ -11,6 +11,7 @@ ghost-gui-toggle-hearing-popup-off = You can now only hear radio and nearby mess
 
 ghost-target-window-title = Ghost Warp
 ghost-target-window-current-button = Warp: {$name}
+ghost-target-category-ghost-role = Ghost Role 
 ghost-target-window-player-warp-name = {$entityName} ({$jobName})
 ghost-target-warp-role = Ghost
 ghost-target-window-warp-to-most-followed = Warp to Most Followed

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -17,6 +17,7 @@
     context: "aghost"
   - type: Ghost
     canInteract: true
+    hideGhostWarp: true
   - type: GhostHearing
   - type: Hands
   - type: ComplexInteraction

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -12,7 +12,7 @@
   id: Civilian
   name: department-Civilian
   description: department-Civilian-description
-  color: "#9FED58"
+  color: "#06D515"
   weight: -10
   roles:
   - Bartender


### PR DESCRIPTION
## About the PR
Refactored the ghost ui warp menu to be more user-friendly and intuitive.

TODO:
- [ ] Utilize the job icons in the warp menu.
- [ ] Refactor the buttons to avoid the color saturation issue seen with brighter department colors.

## Why / Balance
I think it's a decent QOL change for observers.

## Technical details
We now utilize the department name and its associated color to categorize and then color the warp buttons. Any warp without an attached mob and an associated department will fall under the other category. 

## Media

Edit: Latest changes

https://github.com/user-attachments/assets/d8539b19-b06f-4034-a9eb-f42f04220d15

One can now warp to a ghost mob

https://github.com/user-attachments/assets/2e2dbf40-da2d-4198-a73e-40e124e97622

Ghost roles have their category if they don't fall under a department

https://github.com/user-attachments/assets/ce5b0f9b-3e37-47ad-95f4-94e1fb0fb52d



## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
The GhostWarp struct now takes two additional optional arguments in the constructor, `categoryName `and `warpColor`. In addition, the GhostComponent now has an extra field `HideGhostWarp` which can optionally hide the visibility of certain ghost types, such as admin ghosts.  

**Changelog**
:cl:
- tweak: Refactored the ghost ui menu to instead utilize departments when categorizing and sorting warp locations. 

