### PR TITLE
Fix for towels not having a cooldown for cleaning

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -29,6 +29,8 @@
           Quantity: 30
       absorbed:
         maxVol: 30
+  - type: UseDelay
+    delay: 1
   - type: Fiber
     fiberColor: fibers-white
   - type: DnaSubstanceTrace


### PR DESCRIPTION
## About the PR
Added a cooldown to cleaning with towels, similar to mops.

## Why / Balance
Resolves https://github.com/space-wizards/space-station-14/issues/33654

## Technical details
Added a UseDelay type to BaseTowel.

## Media

Before:
https://github.com/user-attachments/assets/4cd8cd56-0746-44ea-97cc-e6c77979349b

After:
https://github.com/user-attachments/assets/0502c131-5736-47c5-8f34-74c9860c420e

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
N/A