### PR TITLE
Traitor can no longer get multiple objectives to save/help/kill the same person

### DIFF
--- a/Content.Server/Objectives/Systems/HelpProgressConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/HelpProgressConditionSystem.cs
@@ -45,10 +45,7 @@ public sealed class HelpProgressConditionSystem : EntitySystem
             return;
         }
 
-        var traitors = _traitorRule.GetOtherTraitorMindsAliveAndConnected(args.Mind)
-            .Select(pair => pair.Item1)
-            .ToHashSet();
-        var removeList = new List<EntityUid>();
+        var traitors = _traitorRule.GetOtherTraitorMindsAliveAndConnected(args.Mind).ToHashSet();
 
         // cant help anyone who is tasked with helping:
         // 1. thats boring
@@ -56,19 +53,29 @@ public sealed class HelpProgressConditionSystem : EntitySystem
         foreach (var traitor in traitors)
         {
             // TODO: replace this with TryComp<ObjectivesComponent>(traitor) or something when objectives are moved out of mind
-            if (!TryComp<MindComponent>(traitor, out var mind))
+            if (!TryComp<MindComponent>(traitor.Id, out var mind))
                 continue;
 
             foreach (var objective in mind.Objectives)
             {
                 if (HasComp<HelpProgressConditionComponent>(objective))
-                    removeList.Add(traitor);
+                    traitors.RemoveWhere(x => x.Mind == mind);
             }
         }
 
-        foreach (var tot in removeList)
+        // Can't have multiple objectives to help/save the same person
+        foreach (var objective in args.Mind.Objectives)
         {
-            traitors.Remove(tot);
+            if (HasComp<RandomTraitorAliveComponent>(objective) || HasComp<RandomTraitorProgressComponent>(objective))
+            {
+                if (TryComp<TargetObjectiveComponent>(objective, out var help))
+                {
+                    if (help.Target != null)
+                    {
+                        traitors.RemoveWhere(x => x.Id == help.Target);
+                    }
+                }
+            }
         }
 
         // no more helpable traitors
@@ -78,7 +85,7 @@ public sealed class HelpProgressConditionSystem : EntitySystem
             return;
         }
 
-        _target.SetTarget(uid, _random.Pick(traitors), target);
+        _target.SetTarget(uid, _random.Pick(traitors).Id, target);
     }
 
     private float GetProgress(EntityUid target)

--- a/Content.Server/Objectives/Systems/HelpProgressConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/HelpProgressConditionSystem.cs
@@ -70,10 +70,7 @@ public sealed class HelpProgressConditionSystem : EntitySystem
             {
                 if (TryComp<TargetObjectiveComponent>(objective, out var help))
                 {
-                    if (help.Target != null)
-                    {
-                        traitors.RemoveWhere(x => x.Id == help.Target);
-                    }
+                    traitors.RemoveWhere(x => x.Id == help.Target);
                 }
             }
         }

--- a/Content.Server/Objectives/Systems/KeepAliveCondition.cs
+++ b/Content.Server/Objectives/Systems/KeepAliveCondition.cs
@@ -44,7 +44,19 @@ public sealed class KeepAliveConditionSystem : EntitySystem
             return;
         }
 
-        var traitors = Enumerable.ToList<(EntityUid Id, MindComponent Mind)>(_traitorRule.GetOtherTraitorMindsAliveAndConnected(args.Mind));
+        var traitors = _traitorRule.GetOtherTraitorMindsAliveAndConnected(args.Mind).ToHashSet();
+
+        // Can't have multiple objectives to help/save the same person
+        foreach (var objective in args.Mind.Objectives)
+        {
+            if (HasComp<RandomTraitorAliveComponent>(objective) || HasComp<RandomTraitorProgressComponent>(objective))
+            {
+                if (TryComp<TargetObjectiveComponent>(objective, out var help))
+                {
+                    traitors.RemoveWhere(x => x.Id == help.Target);
+                }
+            }
+        }
 
         // You are the first/only traitor.
         if (traitors.Count == 0)

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Mind;
 using Content.Shared.Objectives.Components;
 using Robust.Shared.Configuration;
 using Robust.Shared.Random;
+using System.Linq;
 
 namespace Content.Server.Objectives.Systems;
 
@@ -52,8 +53,18 @@ public sealed class KillPersonConditionSystem : EntitySystem
         if (target.Target != null)
             return;
 
-        // no other humans to kill
         var allHumans = _mind.GetAliveHumans(args.MindId);
+
+        // Can't have multiple objectives to kill the same person
+        foreach (var objective in args.Mind.Objectives)
+        {
+            if (HasComp<KillPersonConditionComponent>(objective) && TryComp<TargetObjectiveComponent>(objective, out var kill))
+            {
+                allHumans.RemoveWhere(x => x.Owner == kill.Target);
+            }
+        }
+
+        // no other humans to kill
         if (allHumans.Count == 0)
         {
             args.Cancelled = true;


### PR DESCRIPTION
## About the PR
Fixes #21042.
Traitor can no longer get multiple objectives to save/help/kill the same person.

## Why / Balance
More unique traitor objectives = more fun.

## Technical details
Respective traitor objective systems (`HelpProgressCondition`, `KeepAliveCondition`, `KillPersonConditionSystem`) now check that current traitor Mind doesn't already have an objective with the same Target.
If such condition is found, pending objective is rejected and a new one is generated per existing flow.

## Media
See #21042.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Not that I know of.

**Changelog**
:cl:
- fix: Traitor can no longer get multiple objectives to save/help/kill the same person
