### PR TITLE
Fix layout on wires UI

### DIFF
--- a/Content.Client/Wires/UI/WiresMenu.cs
+++ b/Content.Client/Wires/UI/WiresMenu.cs
@@ -206,8 +206,7 @@ namespace Content.Client.Wires.UI
                             (_statusContainer = new GridContainer
                             {
                                 Margin = new Thickness(8, 4),
-                                // TODO: automatically change columns count.
-                                Columns = 3
+                                Rows = 2
                             })
                         }
                     }
@@ -227,7 +226,8 @@ namespace Content.Client.Wires.UI
                 PanelOverride = new StyleBoxFlat {BackgroundColor = Color.FromHex("#525252ff")}
             });
             CloseButton.OnPressed += _ => Close();
-            SetSize = new Vector2(320, 200);
+            SetHeight = 200;
+            MinWidth = 320;
         }
 
 
@@ -503,6 +503,8 @@ namespace Content.Client.Wires.UI
 
             public StatusLight(StatusLightData data, IResourceCache resourceCache)
             {
+                HorizontalAlignment = HAlignment.Right;
+
                 var hsv = Color.ToHsv(data.Color);
                 hsv.Z /= 2;
                 var dimColor = Color.FromHsv(hsv);


### PR DESCRIPTION
Layout would break for machines with >6 lights because the column count was hardcoded. Uncap the UI width and fix the rows count instead.

Lights with less than 4 characters of text weren't aligned right, now they are.

Before:
![image](https://github.com/user-attachments/assets/ef1c8a87-95c4-4b5d-9e98-00aa87f7f951)

After:
![image](https://github.com/user-attachments/assets/86936e60-2dc0-48c1-bcad-b7bdcc4b5d3a)

:cl:
- fix: Fixed broken layout on some wire hacking UIs.
