### PR TITLE
Added several variables to make ClumsyComponent more modular for developers.

### DIFF
--- a/Content.Shared/Clumsy/ClumsyComponent.cs
+++ b/Content.Shared/Clumsy/ClumsyComponent.cs
@@ -56,7 +56,7 @@ public sealed partial class ClumsyComponent : Component
     /// <summary>
     ///     Noise to play after failing to shoot a gun. Boom!
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public SoundSpecifier GunShootFailSound = new SoundPathSpecifier("/Audio/Weapons/Guns/Gunshots/bang.ogg");
 
     /// <summary>

--- a/Content.Shared/Clumsy/ClumsyComponent.cs
+++ b/Content.Shared/Clumsy/ClumsyComponent.cs
@@ -56,48 +56,48 @@ public sealed partial class ClumsyComponent : Component
     /// <summary>
     ///     Noise to play after failing to shoot a gun. Boom!
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public SoundSpecifier GunShootFailSound = new SoundPathSpecifier("/Audio/Weapons/Guns/Gunshots/bang.ogg");
-	
-	/// <summary>
-	///		Whether or not to apply Clumsy to hyposprays.
-	/// </summary>
-	[DataField, AutoNetworkedField]
-	public bool ClumsyHypo = true;
-	
-	/// <summary>
-	///		Whether or not to apply Clumsy to defibs.
-	/// </summary>
-	[DataField, AutoNetworkedField]
-	public bool ClumsyDefib = true;
-	
-	/// <summary>
-	///		Whether or not to apply Clumsy to guns.
-	/// </summary>
-	[DataField, AutoNetworkedField]
-	public bool ClumsyGuns = true;
-	
-	/// <summary>
-	///		Whether or not to apply Clumsy to vaulting.
-	/// </summary>
-	[DataField, AutoNetworkedField]
-	public bool ClumsyVaulting = true;
-	
-	/// <summary>
-	///		Lets you define a new "failed" message for each event.
-	/// </summary>
-	[DataField]
-	public LocId HypoFailedMessage = "hypospray-component-inject-self-clumsy-message";
-	
-	[DataField]
-	public LocId GunFailedMessage = "gun-clumsy";
-	
-	[DataField]
-	public LocId VaulingFailedMessageSelf = "bonkable-success-message-user";
-	
-	[DataField]
-	public LocId VaulingFailedMessageOthers = "bonkable-success-message-others";
-	
-	[DataField]
-	public LocId VaulingFailedMessageForced = "forced-bonkable-success-message";
+
+    /// <summary>
+    ///      Whether or not to apply Clumsy to hyposprays.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool ClumsyHypo = true;
+
+    /// <summary>
+    ///      Whether or not to apply Clumsy to defibs.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool ClumsyDefib = true;
+
+    /// <summary>
+    ///      Whether or not to apply Clumsy to guns.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool ClumsyGuns = true;
+
+    /// <summary>
+    ///      Whether or not to apply Clumsy to vaulting.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool ClumsyVaulting = true;
+
+    /// <summary>
+    ///      Lets you define a new "failed" message for each event.
+    /// </summary>
+    [DataField]
+    public LocId HypoFailedMessage = "hypospray-component-inject-self-clumsy-message";
+
+    [DataField]
+    public LocId GunFailedMessage = "gun-clumsy";
+
+    [DataField]
+    public LocId VaulingFailedMessageSelf = "bonkable-success-message-user";
+
+    [DataField]
+    public LocId VaulingFailedMessageOthers = "bonkable-success-message-others";
+
+    [DataField]
+    public LocId VaulingFailedMessageForced = "forced-bonkable-success-message";
 }

--- a/Content.Shared/Clumsy/ClumsyComponent.cs
+++ b/Content.Shared/Clumsy/ClumsyComponent.cs
@@ -62,25 +62,25 @@ public sealed partial class ClumsyComponent : Component
 	/// <summary>
 	///		Whether or not to apply Clumsy to hyposprays.
 	/// </summary>
-	[DataField]
+	[DataField, AutoNetworkedField]
 	public bool ClumsyHypo = true;
 	
 	/// <summary>
 	///		Whether or not to apply Clumsy to defibs.
 	/// </summary>
-	[DataField]
+	[DataField, AutoNetworkedField]
 	public bool ClumsyDefib = true;
 	
 	/// <summary>
 	///		Whether or not to apply Clumsy to guns.
 	/// </summary>
-	[DataField]
+	[DataField, AutoNetworkedField]
 	public bool ClumsyGuns = true;
 	
 	/// <summary>
 	///		Whether or not to apply Clumsy to vaulting.
 	/// </summary>
-	[DataField]
+	[DataField, AutoNetworkedField]
 	public bool ClumsyVaulting = true;
 	
 	/// <summary>

--- a/Content.Shared/Clumsy/ClumsyComponent.cs
+++ b/Content.Shared/Clumsy/ClumsyComponent.cs
@@ -58,4 +58,46 @@ public sealed partial class ClumsyComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier GunShootFailSound = new SoundPathSpecifier("/Audio/Weapons/Guns/Gunshots/bang.ogg");
+	
+	/// <summary>
+	///		Imp. Whether or not to apply Clumsy to hyposprays.
+	/// </summary>
+	[DataField]
+	public bool ClumsyHypo = true;
+	
+	/// <summary>
+	///		Imp. Whether or not to apply Clumsy to defibs.
+	/// </summary>
+	[DataField]
+	public bool ClumsyDefib = true;
+	
+	/// <summary>
+	///		Imp. Whether or not to apply Clumsy to guns.
+	/// </summary>
+	[DataField]
+	public bool ClumsyGuns = true;
+	
+	/// <summary>
+	///		Imp. Whether or not to apply Clumsy to vaulting.
+	/// </summary>
+	[DataField]
+	public bool ClumsyVaulting = true;
+	
+	/// <summary>
+	///		Imp. Lets you define a new "failed" message for each event.
+	/// </summary>
+	[DataField]
+	public string HypoFailedMessage = "hypospray-component-inject-self-clumsy-message";
+	
+	[DataField]
+	public string GunFailedMessage = "gun-clumsy";
+	
+	[DataField]
+	public string VaulingFailedMessageSelf = "bonkable-success-message-user";
+	
+	[DataField]
+	public string VaulingFailedMessageOthers = "bonkable-success-message-others";
+	
+	[DataField]
+	public string VaulingFailedMessageForced = "forced-bonkable-success-message";
 }

--- a/Content.Shared/Clumsy/ClumsyComponent.cs
+++ b/Content.Shared/Clumsy/ClumsyComponent.cs
@@ -60,31 +60,31 @@ public sealed partial class ClumsyComponent : Component
     public SoundSpecifier GunShootFailSound = new SoundPathSpecifier("/Audio/Weapons/Guns/Gunshots/bang.ogg");
 	
 	/// <summary>
-	///		Imp. Whether or not to apply Clumsy to hyposprays.
+	///		Whether or not to apply Clumsy to hyposprays.
 	/// </summary>
 	[DataField]
 	public bool ClumsyHypo = true;
 	
 	/// <summary>
-	///		Imp. Whether or not to apply Clumsy to defibs.
+	///		Whether or not to apply Clumsy to defibs.
 	/// </summary>
 	[DataField]
 	public bool ClumsyDefib = true;
 	
 	/// <summary>
-	///		Imp. Whether or not to apply Clumsy to guns.
+	///		Whether or not to apply Clumsy to guns.
 	/// </summary>
 	[DataField]
 	public bool ClumsyGuns = true;
 	
 	/// <summary>
-	///		Imp. Whether or not to apply Clumsy to vaulting.
+	///		Whether or not to apply Clumsy to vaulting.
 	/// </summary>
 	[DataField]
 	public bool ClumsyVaulting = true;
 	
 	/// <summary>
-	///		Imp. Lets you define a new "failed" message for each event.
+	///		Lets you define a new "failed" message for each event.
 	/// </summary>
 	[DataField]
 	public LocId HypoFailedMessage = "hypospray-component-inject-self-clumsy-message";

--- a/Content.Shared/Clumsy/ClumsyComponent.cs
+++ b/Content.Shared/Clumsy/ClumsyComponent.cs
@@ -87,17 +87,17 @@ public sealed partial class ClumsyComponent : Component
 	///		Imp. Lets you define a new "failed" message for each event.
 	/// </summary>
 	[DataField]
-	public string HypoFailedMessage = "hypospray-component-inject-self-clumsy-message";
+	public LocId HypoFailedMessage = "hypospray-component-inject-self-clumsy-message";
 	
 	[DataField]
-	public string GunFailedMessage = "gun-clumsy";
+	public LocId GunFailedMessage = "gun-clumsy";
 	
 	[DataField]
-	public string VaulingFailedMessageSelf = "bonkable-success-message-user";
+	public LocId VaulingFailedMessageSelf = "bonkable-success-message-user";
 	
 	[DataField]
-	public string VaulingFailedMessageOthers = "bonkable-success-message-others";
+	public LocId VaulingFailedMessageOthers = "bonkable-success-message-others";
 	
 	[DataField]
-	public string VaulingFailedMessageForced = "forced-bonkable-success-message";
+	public LocId VaulingFailedMessageForced = "forced-bonkable-success-message";
 }

--- a/Content.Shared/Clumsy/ClumsySystem.cs
+++ b/Content.Shared/Clumsy/ClumsySystem.cs
@@ -38,12 +38,13 @@ public sealed class ClumsySystem : EntitySystem
     private void BeforeHyposprayEvent(Entity<ClumsyComponent> ent, ref SelfBeforeHyposprayInjectsEvent args)
     {
         // Clumsy people sometimes inject themselves! Apparently syringes are clumsy proof...
-        if (!_random.Prob(ent.Comp.ClumsyDefaultCheck))
-            return;
 		
 		// imp. checks if ClumsyHypo is false, if so, skips.
 		if (!ent.Comp.ClumsyHypo)
 			return;
+
+        if (!_random.Prob(ent.Comp.ClumsyDefaultCheck))
+            return;
 
         args.TargetGettingInjected = args.EntityUsingHypospray;
         args.InjectMessageOverride = "hypospray-component-inject-self-clumsy-message";
@@ -53,12 +54,13 @@ public sealed class ClumsySystem : EntitySystem
     private void BeforeDefibrillatorZapsEvent(Entity<ClumsyComponent> ent, ref SelfBeforeDefibrillatorZapsEvent args)
     {
         // Clumsy people sometimes defib themselves!
-        if (!_random.Prob(ent.Comp.ClumsyDefaultCheck))
-            return;
-
-		// imp. checks if ClumsyDefib is false, if so, skips.
+		
+		// checks if ClumsyDefib is false, if so, skips.
 		if (!ent.Comp.ClumsyDefib)
 			return;
+		
+        if (!_random.Prob(ent.Comp.ClumsyDefaultCheck))
+            return;
 
         args.DefibTarget = args.EntityUsingDefib;
         _audio.PlayPvs(ent.Comp.ClumsySound, ent);
@@ -69,15 +71,15 @@ public sealed class ClumsySystem : EntitySystem
     {
         // Clumsy people sometimes can't shoot :(
 
+		// checks if ClumsyGuns is false, if so, skips.
+		if (!ent.Comp.ClumsyGuns)
+			return;
+
         if (args.Gun.Comp.ClumsyProof)
             return;
 
         if (!_random.Prob(ent.Comp.ClumsyDefaultCheck))
             return;
-
-		// imp. checks if ClumsyGuns is false, if so, skips.
-		if (!ent.Comp.ClumsyGuns)
-			return;
 
         if (ent.Comp.GunShootFailDamage != null)
             _damageable.TryChangeDamage(ent, ent.Comp.GunShootFailDamage, origin: ent);
@@ -94,16 +96,16 @@ public sealed class ClumsySystem : EntitySystem
 
     private void OnBeforeClimbEvent(Entity<ClumsyComponent> ent, ref SelfBeforeClimbEvent args)
     {
+		// checks if ClumsyVaulting is false, if so, skips.
+		if (!ent.Comp.ClumsyVaulting)
+			return;
+		
         // This event is called in shared, thats why it has all the extra prediction stuff.
         var rand = new System.Random((int)_timing.CurTick.Value);
 
         // If someone is putting you on the table, always get past the guard.
         if (!_cfg.GetCVar(CCVars.GameTableBonk) && args.PuttingOnTable == ent.Owner && !rand.Prob(ent.Comp.ClumsyDefaultCheck))
             return;
-
-		// imp special. checks if ClumsyVaulting is false, if so, skips.
-		if (!ent.Comp.ClumsyVaulting)
-			return;
 
         HitHeadClumsy(ent, args.BeingClimbedOn);
 

--- a/Content.Shared/Clumsy/ClumsySystem.cs
+++ b/Content.Shared/Clumsy/ClumsySystem.cs
@@ -38,10 +38,10 @@ public sealed class ClumsySystem : EntitySystem
     private void BeforeHyposprayEvent(Entity<ClumsyComponent> ent, ref SelfBeforeHyposprayInjectsEvent args)
     {
         // Clumsy people sometimes inject themselves! Apparently syringes are clumsy proof...
-		
-		// checks if ClumsyHypo is false, if so, skips.
-		if (!ent.Comp.ClumsyHypo)
-			return;
+    
+        // checks if ClumsyHypo is false, if so, skips.
+        if (!ent.Comp.ClumsyHypo)
+            return;
 
         if (!_random.Prob(ent.Comp.ClumsyDefaultCheck))
             return;
@@ -54,11 +54,11 @@ public sealed class ClumsySystem : EntitySystem
     private void BeforeDefibrillatorZapsEvent(Entity<ClumsyComponent> ent, ref SelfBeforeDefibrillatorZapsEvent args)
     {
         // Clumsy people sometimes defib themselves!
-		
-		// checks if ClumsyDefib is false, if so, skips.
-		if (!ent.Comp.ClumsyDefib)
-			return;
-		
+        
+        // checks if ClumsyDefib is false, if so, skips.
+        if (!ent.Comp.ClumsyDefib)
+            return;
+
         if (!_random.Prob(ent.Comp.ClumsyDefaultCheck))
             return;
 
@@ -71,9 +71,9 @@ public sealed class ClumsySystem : EntitySystem
     {
         // Clumsy people sometimes can't shoot :(
 
-		// checks if ClumsyGuns is false, if so, skips.
-		if (!ent.Comp.ClumsyGuns)
-			return;
+        // checks if ClumsyGuns is false, if so, skips.
+        if (!ent.Comp.ClumsyGuns)
+            return;
 
         if (args.Gun.Comp.ClumsyProof)
             return;
@@ -96,10 +96,10 @@ public sealed class ClumsySystem : EntitySystem
 
     private void OnBeforeClimbEvent(Entity<ClumsyComponent> ent, ref SelfBeforeClimbEvent args)
     {
-		// checks if ClumsyVaulting is false, if so, skips.
-		if (!ent.Comp.ClumsyVaulting)
-			return;
-		
+        // checks if ClumsyVaulting is false, if so, skips.
+        if (!ent.Comp.ClumsyVaulting)
+            return;
+
         // This event is called in shared, thats why it has all the extra prediction stuff.
         var rand = new System.Random((int)_timing.CurTick.Value);
 

--- a/Content.Shared/Clumsy/ClumsySystem.cs
+++ b/Content.Shared/Clumsy/ClumsySystem.cs
@@ -40,6 +40,10 @@ public sealed class ClumsySystem : EntitySystem
         // Clumsy people sometimes inject themselves! Apparently syringes are clumsy proof...
         if (!_random.Prob(ent.Comp.ClumsyDefaultCheck))
             return;
+		
+		// imp. checks if ClumsyHypo is false, if so, skips.
+		if (!ent.Comp.ClumsyHypo)
+			return;
 
         args.TargetGettingInjected = args.EntityUsingHypospray;
         args.InjectMessageOverride = "hypospray-component-inject-self-clumsy-message";
@@ -51,6 +55,10 @@ public sealed class ClumsySystem : EntitySystem
         // Clumsy people sometimes defib themselves!
         if (!_random.Prob(ent.Comp.ClumsyDefaultCheck))
             return;
+
+		// imp. checks if ClumsyDefib is false, if so, skips.
+		if (!ent.Comp.ClumsyDefib)
+			return;
 
         args.DefibTarget = args.EntityUsingDefib;
         _audio.PlayPvs(ent.Comp.ClumsySound, ent);
@@ -66,6 +74,10 @@ public sealed class ClumsySystem : EntitySystem
 
         if (!_random.Prob(ent.Comp.ClumsyDefaultCheck))
             return;
+
+		// imp. checks if ClumsyGuns is false, if so, skips.
+		if (!ent.Comp.ClumsyGuns)
+			return;
 
         if (ent.Comp.GunShootFailDamage != null)
             _damageable.TryChangeDamage(ent, ent.Comp.GunShootFailDamage, origin: ent);
@@ -89,6 +101,10 @@ public sealed class ClumsySystem : EntitySystem
         if (!_cfg.GetCVar(CCVars.GameTableBonk) && args.PuttingOnTable == ent.Owner && !rand.Prob(ent.Comp.ClumsyDefaultCheck))
             return;
 
+		// imp special. checks if ClumsyVaulting is false, if so, skips.
+		if (!ent.Comp.ClumsyVaulting)
+			return;
+
         HitHeadClumsy(ent, args.BeingClimbedOn);
 
         _audio.PlayPredicted(ent.Comp.ClumsySound, ent, ent);
@@ -102,8 +118,8 @@ public sealed class ClumsySystem : EntitySystem
         {
             // You are slamming yourself onto the table.
             _popup.PopupPredicted(
-                Loc.GetString("bonkable-success-message-user", ("bonkable", args.BeingClimbedOn)),
-                Loc.GetString("bonkable-success-message-others", ("victim", gettingPutOnTableName), ("bonkable", args.BeingClimbedOn)),
+                Loc.GetString(ent.Comp.VaulingFailedMessageSelf, ("bonkable", args.BeingClimbedOn)),
+                Loc.GetString(ent.Comp.VaulingFailedMessageOthers, ("victim", gettingPutOnTableName), ("bonkable", args.BeingClimbedOn)),
                 ent,
                 ent);
         }
@@ -112,7 +128,7 @@ public sealed class ClumsySystem : EntitySystem
             // Someone else slamed you onto the table.
             // This is only run in server so you need to use popup entity.
             _popup.PopupPredicted(
-                Loc.GetString("forced-bonkable-success-message",
+                Loc.GetString(ent.Comp.VaulingFailedMessageForced,
                     ("bonker", puttingOnTableName),
                     ("victim", gettingPutOnTableName),
                     ("bonkable", args.BeingClimbedOn)),

--- a/Content.Shared/Clumsy/ClumsySystem.cs
+++ b/Content.Shared/Clumsy/ClumsySystem.cs
@@ -39,7 +39,7 @@ public sealed class ClumsySystem : EntitySystem
     {
         // Clumsy people sometimes inject themselves! Apparently syringes are clumsy proof...
 		
-		// imp. checks if ClumsyHypo is false, if so, skips.
+		// checks if ClumsyHypo is false, if so, skips.
 		if (!ent.Comp.ClumsyHypo)
 			return;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Added nine new variables to ClumsyComponent and its system to allow developers to specify that certain clumsy events should not be applied to a given entity, and to allow developers to have custom per-entity "failed" popup message.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

ClumsyComponent does a lot of different things, and sometimes you only want it to do a few of those things. For example, I was developing a species that is incapable of using guns on my server - I added these variables so that I could disable the hypospray, defibrilator, and table bonk events on those entities. 
In short, these changes allow developers to find more creative uses for this component, without the hassle that would be separating each event into its own system. 

## Technical details
<!-- Summary of code changes for easier review. -->

Very simple. Added a check to each event that, if that event's boolean is false, skips the event, and changed the hardcoded strings in ClumsySystem to public LocIds that are read from ClumsyComponent.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
