### PR TITLE
Give vox health regen for poison below 20 damage

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -32,6 +32,18 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Vox
+  - type: PassiveDamage
+    # Augment normal health regen to be able to tank some Poison damage
+    # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.
+    allowedStates:
+    - Alive
+    damageCap: 20
+    damage:
+      types:
+        Heat: -0.07
+        Poison: -0.2
+      groups:
+        Brute: -0.07
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:


### PR DESCRIPTION
This enables Vox to go about 30 seconds in oxygen and have the damage naturally go away. It's also just a nice species plus for them.

This is done in context of https://github.com/space-wizards/space-station-14/issues/33720

:cl:
- tweak: Vox now have natural poison regeneration, allowing them to go for ~30 seconds in oxygen and heal the damage away.