### PR TITLE
Added instant detonation back to Syndicate C4

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -54,9 +54,11 @@
     beepSound: /Audio/Machines/Nuke/general_beep.ogg
     startOnStick: true
     canToggleStartOnStick: true
+  - type: TriggerOnSignal
   - type: TimerStartOnSignal
   - type: DeviceLinkSink
     ports:
+      - Trigger
       - Timer
   - type: Explosive # Powerful explosion in a very small radius. Doesn't break underplating.
     explosionType: DemolitionCharge


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
gave the C4 the instant detonation trigger back, left the timer trigger from #32423 

## Why / Balance
#32429 solves the issue that removing the instant detonation from C4 was intended to fix, and both measures at the same time seem unnecessary.

## Technical details
Gave the Syndie C4 back its old TriggerOnSignal, I left the TimerStartOnSignal option because it might be useful under certain circumstances.


## Requirements
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl:
- tweak: Gave the Syndicate C4 its instant explosion on signal back, alongside the timer trigger.

