### PR TITLE
SpiderSystem refactor and rename 

### DIFF
--- a/Content.Server/Spider/SpiderSystem.cs
+++ b/Content.Server/Spider/SpiderSystem.cs
@@ -69,6 +69,12 @@ public sealed class SpiderSystem : SharedSpiderSystem
 
     private bool IsValidTile(EntityCoordinates coords, EntityWhitelist? whitelist, EntityWhitelist? blacklist, EntityUid grid, MapGridComponent gridComp)
     {
+        // Don't place webs on webs
+        if (blacklist != null)
+            foreach (var entity in _lookup.GetEntitiesIntersecting(coords, LookupFlags.Uncontained))
+                if (_whitelistSystem.IsBlacklistPass(blacklist, entity))
+                    return false;
+
         // Only place webs on webs
         if (whitelist != null)
         {
@@ -79,16 +85,10 @@ public sealed class SpiderSystem : SharedSpiderSystem
             return false;
         }
 
-        // Don't place webs on webs
-        if (blacklist != null)
-            foreach (var entity in _lookup.GetEntitiesIntersecting(coords, LookupFlags.Uncontained))
-                if (_whitelistSystem.IsBlacklistPass(blacklist, entity))
-                    return false;
-
         // Don't place webs in space
         if (!_map.TryGetTileRef(grid, gridComp, coords, out var tileRef) ||
             tileRef.IsSpace(_tile))
-                return false;
+            return false;
 
         return true;
     }

--- a/Content.Server/Spider/SpiderSystem.cs
+++ b/Content.Server/Spider/SpiderSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Spider;
 using Content.Shared.Maps;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 
 namespace Content.Server.Spider;
 
@@ -11,6 +12,8 @@ public sealed class SpiderSystem : SharedSpiderSystem
 {
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly ITileDefinitionManager _tile = default!;
 
     public override void Initialize()
     {
@@ -24,39 +27,32 @@ public sealed class SpiderSystem : SharedSpiderSystem
             return;
 
         var transform = Transform(uid);
+        var grid = transform.GridUid;
 
-        if (transform.GridUid == null)
+        if (grid == null || !TryComp<MapGridComponent>(grid, out var gridComp))
         {
             _popup.PopupEntity(Loc.GetString("spider-web-action-nogrid"), args.Performer, args.Performer);
             return;
         }
 
         var coords = transform.Coordinates;
+        List<EntityCoordinates> spawnPos = new();
 
-        // TODO generic way to get certain coordinates
+        var vects = new List<Vector2i>();
+        vects.AddRange(args.OffsetVectors);
 
-        var result = false;
-        // Spawn web in center
-        if (!IsTileBlockedByWeb(coords))
-        {
-            Spawn(component.WebPrototype, coords);
-            result = true;
-        }
+        foreach (var vect in vects)
+            spawnPos.Add(coords.Offset(vect));
 
-        // Spawn web in other directions
-        for (var i = 0; i < 4; i++)
-        {
-            var direction = (DirectionFlag) (1 << i);
-            coords = transform.Coordinates.Offset(direction.AsDir().ToVec());
-
-            if (!IsTileBlockedByWeb(coords))
+        bool success = false;
+        foreach (var pos in spawnPos)
+            if (IsValidTile(pos, grid.Value, gridComp))
             {
-                Spawn(component.WebPrototype, coords);
-                result = true;
+                Spawn(component.WebPrototype, pos);
+                success = true;
             }
-        }
 
-        if (result)
+        if (success)
         {
             _popup.PopupEntity(Loc.GetString("spider-web-action-success"), args.Performer, args.Performer);
             args.Handled = true;
@@ -65,13 +61,19 @@ public sealed class SpiderSystem : SharedSpiderSystem
             _popup.PopupEntity(Loc.GetString("spider-web-action-fail"), args.Performer, args.Performer);
     }
 
-    private bool IsTileBlockedByWeb(EntityCoordinates coords)
+    private bool IsValidTile(EntityCoordinates coords, EntityUid grid, MapGridComponent gridComp)
     {
+        // TODO change this hard coded comp
+        // Don't place webs on top of webs
         foreach (var entity in _lookup.GetEntitiesIntersecting(coords, LookupFlags.Uncontained))
-        {
             if (HasComp<SpiderWebObjectComponent>(entity))
-                return true;
-        }
-        return false;
+                return false;
+
+        // Don't place webs in space
+        if (!_map.TryGetTileRef(grid, gridComp, coords, out var tileRef) ||
+            tileRef.IsSpace(_tile))
+                return false;
+
+        return true;
     }
 }

--- a/Content.Server/Spider/SpiderSystem.cs
+++ b/Content.Server/Spider/SpiderSystem.cs
@@ -10,6 +10,7 @@ namespace Content.Server.Spider;
 public sealed class SpiderSystem : SharedSpiderSystem
 {
     [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
 
     public override void Initialize()
     {
@@ -66,7 +67,7 @@ public sealed class SpiderSystem : SharedSpiderSystem
 
     private bool IsTileBlockedByWeb(EntityCoordinates coords)
     {
-        foreach (var entity in coords.GetEntitiesInTile())
+        foreach (var entity in _lookup.GetEntitiesIntersecting(coords, LookupFlags.Uncontained))
         {
             if (HasComp<SpiderWebObjectComponent>(entity))
                 return true;
@@ -74,4 +75,3 @@ public sealed class SpiderSystem : SharedSpiderSystem
         return false;
     }
 }
-

--- a/Content.Server/WebPlacer/WebPlacerSystem.cs
+++ b/Content.Server/WebPlacer/WebPlacerSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Popups;
 using Content.Shared.Maps;
 using Content.Shared.WebPlacer;

--- a/Content.Shared/Spider/IgnoreSpiderWebComponent.cs
+++ b/Content.Shared/Spider/IgnoreSpiderWebComponent.cs
@@ -1,7 +1,0 @@
-namespace Content.Shared.Spider;
-
-[RegisterComponent]
-public sealed partial class IgnoreSpiderWebComponent : Component
-{
-
-}

--- a/Content.Shared/Spider/SharedSpiderSystem.cs
+++ b/Content.Shared/Spider/SharedSpiderSystem.cs
@@ -7,25 +7,16 @@ namespace Content.Shared.Spider;
 public abstract class SharedSpiderSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _action = default!;
-    [Dependency] private readonly IRobustRandom _robustRandom = default!;
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<SpiderComponent, MapInitEvent>(OnInit);
-        SubscribeLocalEvent<SpiderWebObjectComponent, ComponentStartup>(OnWebStartup);
     }
 
     private void OnInit(EntityUid uid, SpiderComponent component, MapInitEvent args)
     {
         _action.AddAction(uid, ref component.ActionEntity, component.SpawnWebAction, uid);
-    }
-
-    private void OnWebStartup(EntityUid uid, SpiderWebObjectComponent component, ComponentStartup args)
-    {
-        // TODO dont use this. use some general random appearance system
-        _appearance.SetData(uid, SpiderWebVisuals.Variant, _robustRandom.Next(1, 3));
     }
 }

--- a/Content.Shared/Spider/SharedSpiderSystem.cs
+++ b/Content.Shared/Spider/SharedSpiderSystem.cs
@@ -4,6 +4,9 @@ using Robust.Shared.Random;
 
 namespace Content.Shared.Spider;
 
+/// <summary>
+/// Gives entities (probably spiders) an action on init.  Spawning handled by <see cref="ServerSpiderSystem"/>..
+/// </summary>
 public abstract class SharedSpiderSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _action = default!;

--- a/Content.Shared/Spider/SharedSpiderSystem.cs
+++ b/Content.Shared/Spider/SharedSpiderSystem.cs
@@ -20,7 +20,7 @@ public abstract class SharedSpiderSystem : EntitySystem
 
     private void OnInit(EntityUid uid, SpiderComponent component, MapInitEvent args)
     {
-        _action.AddAction(uid, ref component.Action, component.WebAction, uid);
+        _action.AddAction(uid, ref component.ActionEntity, component.SpawnWebAction, uid);
     }
 
     private void OnWebStartup(EntityUid uid, SpiderWebObjectComponent component, ComponentStartup args)

--- a/Content.Shared/Spider/SpiderComponent.cs
+++ b/Content.Shared/Spider/SpiderComponent.cs
@@ -20,4 +20,18 @@ public sealed partial class SpiderComponent : Component
     [DataField] public EntityUid? Action;
 }
 
-public sealed partial class SpiderWebActionEvent : InstantActionEvent { }
+public sealed partial class SpiderWebActionEvent : InstantActionEvent
+{
+        /// <summary>
+    /// Vectors determining where the entities will spawn.
+    /// </summary>
+    [DataField]
+    public List<Vector2i> OffsetVectors = new()
+    {
+        Vector2i.Zero,
+        Vector2i.Up,
+        Vector2i.Down,
+        Vector2i.Left,
+        Vector2i.Right,
+    };
+}

--- a/Content.Shared/Spider/SpiderComponent.cs
+++ b/Content.Shared/Spider/SpiderComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Actions;
+using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
@@ -9,20 +10,37 @@ namespace Content.Shared.Spider;
 [Access(typeof(SharedSpiderSystem))]
 public sealed partial class SpiderComponent : Component
 {
+    /// <summary>
+    /// Id of the entity getting spawned.
+    /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("webPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string WebPrototype = "SpiderWeb";
+    [DataField(required: true,
+               customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string WebPrototype;
 
+    /// <summary>
+    /// List of entities that prevent spawning.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? BlockedByBlacklist;
+
+    /// <summary>
+    /// Id of the action that will be given.
+    /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("webAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string WebAction = "ActionSpiderWeb";
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string SpawnWebAction = "ActionSpiderWeb";
 
-    [DataField] public EntityUid? Action;
+    /// <summary>
+    /// Action given to the player.
+    /// </summary>
+    [ViewVariables]
+    public EntityUid? ActionEntity;
 }
 
 public sealed partial class SpiderWebActionEvent : InstantActionEvent
 {
-        /// <summary>
+    /// <summary>
     /// Vectors determining where the entities will spawn.
     /// </summary>
     [DataField]

--- a/Content.Shared/Spider/SpiderComponent.cs
+++ b/Content.Shared/Spider/SpiderComponent.cs
@@ -6,6 +6,9 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Spider;
 
+/// <summary>
+/// Gives the entity (probably a spider) an ability to spawn webs around itself.
+/// </summary>
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedSpiderSystem))]
 public sealed partial class SpiderComponent : Component
@@ -14,15 +17,8 @@ public sealed partial class SpiderComponent : Component
     /// Id of the entity getting spawned.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField(required: true,
-               customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string WebPrototype;
-
-    /// <summary>
-    /// List of entities that prevent spawning.
-    /// </summary>
-    [DataField]
-    public EntityWhitelist? BlockedByBlacklist;
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string WebPrototype = "SpiderWeb";
 
     /// <summary>
     /// Id of the action that will be given.
@@ -36,6 +32,23 @@ public sealed partial class SpiderComponent : Component
     /// </summary>
     [ViewVariables]
     public EntityUid? ActionEntity;
+
+    /// <summary>
+    /// List of entities proto will spawn on.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? DestinationWhitelist;
+
+    /// <summary>
+    /// List of entities proto won't spawn on.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? DestinationBlacklist;
+
+    /// Popup text
+    [DataField("inSpace")] public string _offGrid = "spider-web-action-nogrid";
+    [DataField("success")] public string _success = "spider-web-action-success";
+    [DataField("failure")] public string _fail = "spider-web-action-fail";
 }
 
 public sealed partial class SpiderWebActionEvent : InstantActionEvent

--- a/Content.Shared/Spider/SpiderComponent.cs
+++ b/Content.Shared/Spider/SpiderComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Actions;
 using Content.Shared.Whitelist;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
@@ -16,14 +17,13 @@ public sealed partial class SpiderComponent : Component
     /// <summary>
     /// Id of the entity getting spawned.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
     [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string WebPrototype = "SpiderWeb";
 
     /// <summary>
     /// Id of the action that will be given.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
+    [ViewVariables(VVAccess.ReadOnly)]
     [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string SpawnWebAction = "ActionSpiderWeb";
 
@@ -34,25 +34,27 @@ public sealed partial class SpiderComponent : Component
     public EntityUid? ActionEntity;
 
     /// <summary>
-    /// List of entities proto will spawn on.
+    /// Whitelist of entities proto will only spawn on.
     /// </summary>
     [DataField]
     public EntityWhitelist? DestinationWhitelist;
 
     /// <summary>
-    /// List of entities proto won't spawn on.
+    /// Blacklist of entities proto won't spawn on.
     /// </summary>
     [DataField]
     public EntityWhitelist? DestinationBlacklist;
 
-    /// Popup text
-    [DataField("inSpace")] public string _offGrid = "spider-web-action-nogrid";
-    [DataField("success")] public string _success = "spider-web-action-success";
-    [DataField("failure")] public string _fail = "spider-web-action-fail";
-}
+    /// <summary>
+    /// Sound played when successfully spawning webs.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? WebSound =
+            new SoundPathSpecifier("/Audio/Effects/spray3.ogg")
+            {
+                Params = AudioParams.Default.WithVariation(0.125f),
+            };
 
-public sealed partial class SpiderWebActionEvent : InstantActionEvent
-{
     /// <summary>
     /// Vectors determining where the entities will spawn.
     /// </summary>
@@ -65,4 +67,13 @@ public sealed partial class SpiderWebActionEvent : InstantActionEvent
         Vector2i.Left,
         Vector2i.Right,
     };
+
+    /// Localization files for popup text.
+    [DataField] public LocId MessageOffGrid = "spider-web-action-nogrid";
+    [DataField] public LocId MessageSuccess = "spider-web-action-success";
+    [DataField] public LocId MessageFail = "spider-web-action-fail";
+}
+
+public sealed partial class SpiderWebActionEvent : InstantActionEvent
+{
 }

--- a/Content.Shared/Spider/SpiderWebObjectComponent.cs
+++ b/Content.Shared/Spider/SpiderWebObjectComponent.cs
@@ -1,9 +1,0 @@
-using Robust.Shared.GameStates;
-
-namespace Content.Shared.Spider;
-
-[RegisterComponent, NetworkedComponent]
-[Access(typeof(SharedSpiderSystem))]
-public sealed partial class SpiderWebObjectComponent : Component
-{
-}

--- a/Content.Shared/Spider/SpiderWebVisualsComponent.cs
+++ b/Content.Shared/Spider/SpiderWebVisualsComponent.cs
@@ -1,9 +1,0 @@
-using Robust.Shared.Serialization;
-
-namespace Content.Shared.Spider;
-
-[Serializable, NetSerializable]
-public enum SpiderWebVisuals
-{
-    Variant
-}

--- a/Content.Shared/WebPlacer/SharedWebPlacerSystem.cs
+++ b/Content.Shared/WebPlacer/SharedWebPlacerSystem.cs
@@ -2,12 +2,12 @@ using Content.Shared.Actions;
 using Robust.Shared.Network;
 using Robust.Shared.Random;
 
-namespace Content.Shared.Spider;
+namespace Content.Shared.WebPlacer;
 
 /// <summary>
-/// Gives entities (probably spiders) an action on init.  Spawning handled by <see cref="ServerSpiderSystem"/>..
+/// Gives entities (probably spiders) an action on init.  Spawning handled by <see cref="WebPlacerSystem"/>..
 /// </summary>
-public abstract class SharedSpiderSystem : EntitySystem
+public abstract class SharedWebPlacerSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _action = default!;
 
@@ -15,10 +15,10 @@ public abstract class SharedSpiderSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<SpiderComponent, MapInitEvent>(OnInit);
+        SubscribeLocalEvent<WebPlacerComponent, MapInitEvent>(OnInit);
     }
 
-    private void OnInit(EntityUid uid, SpiderComponent component, MapInitEvent args)
+    private void OnInit(EntityUid uid, WebPlacerComponent component, MapInitEvent args)
     {
         _action.AddAction(uid, ref component.ActionEntity, component.SpawnWebAction, uid);
     }

--- a/Content.Shared/WebPlacer/SharedWebPlacerSystem.cs
+++ b/Content.Shared/WebPlacer/SharedWebPlacerSystem.cs
@@ -1,11 +1,9 @@
 using Content.Shared.Actions;
-using Robust.Shared.Network;
-using Robust.Shared.Random;
 
 namespace Content.Shared.WebPlacer;
 
 /// <summary>
-/// Gives entities (probably spiders) an action on init.  Spawning handled by <see cref="WebPlacerSystem"/>..
+/// Gives entities (probably spiders) an action on init.  Spawning handled by <see cref="WebPlacerSystem"/>.
 /// </summary>
 public abstract class SharedWebPlacerSystem : EntitySystem
 {

--- a/Content.Shared/WebPlacer/WebPlacerComponent.cs
+++ b/Content.Shared/WebPlacer/WebPlacerComponent.cs
@@ -5,14 +5,14 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
-namespace Content.Shared.Spider;
+namespace Content.Shared.WebPlacer;
 
 /// <summary>
 /// Gives the entity (probably a spider) an ability to spawn webs around itself.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-[Access(typeof(SharedSpiderSystem))]
-public sealed partial class SpiderComponent : Component
+[Access(typeof(SharedWebPlacerSystem))]
+public sealed partial class WebPlacerComponent : Component
 {
     /// <summary>
     /// Id of the entity getting spawned.

--- a/Resources/Locale/en-US/actions/actions/spider.ftl
+++ b/Resources/Locale/en-US/actions/actions/spider.ftl
@@ -1,5 +1,5 @@
 spider-web-action-nogrid = There is no floor under you!
-spider-web-action-success = You place webs around you.
-spider-web-action-fail = You can't place webs here! All cardinal directions already have webs!
+spider-web-action-success = You spin webs around you.
+spider-web-action-fail = There's no room to spin your webs!
 
 sericulture-failure-hunger = Your stomach is too empty to make any more webs!

--- a/Resources/Locale/en-US/actions/actions/spider.ftl
+++ b/Resources/Locale/en-US/actions/actions/spider.ftl
@@ -1,5 +1,5 @@
 spider-web-action-nogrid = There is no floor under you!
 spider-web-action-success = You spin webs around you.
-spider-web-action-fail = There's no room to spin your webs!
+spider-web-action-fail = There is no room to spin your webs!
 
 sericulture-failure-hunger = Your stomach is too empty to make any more webs!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2365,7 +2365,7 @@
     interactSuccessSound:
       path: /Audio/Animals/snake_hiss.ogg
   - type: NoSlip
-  - type: Spider
+  - type: WebPlacer
     webPrototype: SpiderWeb
     destinationBlacklist:
       tags:
@@ -2457,7 +2457,7 @@
       thresholds:
         0: Alive
         180: Dead
-    - type: Spider
+    - type: WebPlacer
       webPrototype: SpiderWebClown
       destinationBlacklist:
         tags:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2367,7 +2367,7 @@
   - type: NoSlip
   - type: Spider
     webPrototype: SpiderWeb
-    blockedByBlacklist:
+    destinationBlacklist:
       components:
       - SpiderWebObject
   - type: IgnoreSpiderWeb
@@ -2459,7 +2459,7 @@
         180: Dead
     - type: Spider
       webPrototype: SpiderWebClown
-      blockedByBlacklist:
+      destinationBlacklist:
         components:
         - SpiderWebObject
     - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2366,6 +2366,10 @@
       path: /Audio/Animals/snake_hiss.ogg
   - type: NoSlip
   - type: Spider
+    webPrototype: SpiderWeb
+    blockedByBlacklist:
+      components:
+      - SpiderWebObject
   - type: IgnoreSpiderWeb
   - type: Bloodstream
     bloodMaxVolume: 150
@@ -2455,6 +2459,9 @@
         180: Dead
     - type: Spider
       webPrototype: SpiderWebClown
+      blockedByBlacklist:
+        components:
+        - SpiderWebObject
     - type: MeleeWeapon
       altDisarm: false
       angle: 0

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2459,6 +2459,10 @@
         180: Dead
     - type: WebPlacer
       webPrototype: SpiderWebClown
+      webSound:
+        collection: BikeHorn
+        params:
+          variation: 0.125
       destinationBlacklist:
         tags:
         - SpiderWeb

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2368,9 +2368,8 @@
   - type: Spider
     webPrototype: SpiderWeb
     destinationBlacklist:
-      components:
-      - SpiderWebObject
-  - type: IgnoreSpiderWeb
+      tags:
+      - SpiderWeb
   - type: Bloodstream
     bloodMaxVolume: 150
     bloodReagent: CopperBlood
@@ -2389,6 +2388,7 @@
     tags:
     - DoorBumpOpener
     - FootstepSound
+    - IgnoreSpiderWeb
   - type: Prying # Open door from xeno.yml.
     pryPowered: true
     force: true
@@ -2460,8 +2460,8 @@
     - type: Spider
       webPrototype: SpiderWebClown
       destinationBlacklist:
-        components:
-        - SpiderWebObject
+        tags:
+        - SpiderWeb
     - type: MeleeWeapon
       altDisarm: false
       angle: 0

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -675,6 +675,7 @@
     - VimPilot
     - DoorBumpOpener
     - FootstepSound
+    - IgnoreSpiderWeb
   - type: StealTarget
     stealGroup: AnimalShiva
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -253,7 +253,6 @@
     energy: 2
     color: "#4faffb"
   - type: NoSlip
-  - type: IgnoreSpiderWeb
   - type: Speech
     speechVerb: Arachnid
     speechSounds: Arachnid
@@ -265,6 +264,11 @@
       Unsexed: UnisexArachnid
   - type: TypingIndicator
     proto: spider
+  - type: Tag
+    tags:
+    - DoorBumpOpener
+    - FootstepSound
+    - IgnoreSpiderWeb
 
 - type: entity
   id: MobSpiderSpaceSalvage

--- a/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
@@ -16,15 +16,14 @@
       sprite: Objects/Misc/spiderweb.rsi
       layers:
         - state: spider_web_1
-          map: ["spiderWebLayer"]
+          map: [ "enum.DamageStateVisualLayers.Base" ]
       drawdepth: WallMountedItems
+    - type: RandomSprite
+      available:
+        - enum.DamageStateVisualLayers.Base:
+            spider_web_1: ""
+            spider_web_2: ""
     - type: Appearance
-    - type: GenericVisualizer
-      visuals:
-        enum.SpiderWebVisuals.Variant:
-          spiderWebLayer:
-            1:  {state: spider_web_1}
-            2:  {state: spider_web_2}
     - type: Clickable
     - type: Transform
       anchored: true
@@ -95,15 +94,14 @@
       sprite: Objects/Misc/spiderweb.rsi
       layers:
         - state: spider_web_clown_1
-          map: ["spiderWebLayer"]
+          map: [ "enum.DamageStateVisualLayers.Base" ]
       drawdepth: WallMountedItems
+    - type: RandomSprite
+      available:
+        - enum.DamageStateVisualLayers.Base:
+            spider_web_clown_1: ""
+            spider_web_clown_2: ""
     - type: Appearance
-    - type: GenericVisualizer
-      visuals:
-        enum.SpiderWebVisuals.Variant:
-          spiderWebLayer:
-            1:  {state: spider_web_clown_1}
-            2:  {state: spider_web_clown_2}
     - type: Clickable
     - type: Transform
       anchored: true

--- a/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
@@ -68,13 +68,15 @@
       groups:
         Flammable: [Touch]
         Extinguish: [Touch]
-    - type: SpiderWebObject
     - type: SpeedModifierContacts
       walkSpeedModifier: 0.5
       sprintSpeedModifier: 0.5
       ignoreWhitelist:
-        components:
+        tags:
             - IgnoreSpiderWeb
+    - type: Tag
+      tags: 
+      - SpiderWeb
 
 - type: entity
   id: SpiderWebClown
@@ -150,7 +152,6 @@
       groups:
         Flammable: [Touch]
         Extinguish: [Touch]
-    - type: SpiderWebObject
     - type: FlavorProfile
       flavors:
         - sweet
@@ -162,3 +163,6 @@
           reagents:
           - ReagentId: Sugar
             Quantity: 2
+    - type: Tag
+      tags: 
+      - SpiderWeb

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -723,6 +723,9 @@
   id: Igniter
 
 - type: Tag
+  id: IgnoreSpiderWeb
+
+- type: Tag
   id: Ingredient
 
 - type: Tag #Drop this innate tool instead of deleting it.
@@ -1173,6 +1176,9 @@
 
 - type: Tag
   id: SpiderCraft
+
+- type: Tag
+  id: SpiderWeb
 
 - type: Tag
   id: SpookyFog


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Refactor of the component and systems that give spiders the ability to spawn webs, and renamed them to a less generic name. Changes include:

- Webs no longer spawn on webs. (bugfix)
- Webs no longer spawn in space.
- Play a sound when webs spawn.
- More yaml control in where webs spawn (still somewhat limited).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The only balance change is that spiderwebs no longer spawn on other spiderwebs. This is a bugfix though, as the code to do this already existed and just didn't work.

## Technical details
<!-- Summary of code changes for easier review. -->
`SpiderSystem`, `SharedSpiderSystem` and `SpiderComponent` renamed to `WebPlacerComponent`, `SharedWebPlacerSystem`, and `WebPlacerSystem`.
`SpiderWebObjectComponent` and `IgnoreSpiderWebComponent` deleted. Both of these existed to be found by a whitelist in yaml, and have been replaced with tags.
`SpiderWebVisuals` enumerator deleted. This was used alongside `SpiderWebObjectComponent` to give webs a random appearance, and has been replaced with `RandomSpriteComponent` and a generic enum.
Minor yaml changes. Changed the renamed component, replaced the deleted components. Clown spiders have a honk horn sound.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
None.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`SpiderComponent` renamed to `WebPlacerComponent`.
`SharedSpiderSystem` renamed to `SharedWebPlacerSystem`.
`SpiderSystem` renamed to `WebPlacerSystem`.
Namespace `Content.Shared.Spider` changed to `Content.Shared.WebPlacer`.
Namespace `Content.Server.Spider` changed to `Content.Server.WebPlacer`.
`SpiderWebObjectComponent` removed. Replaced with `Tag: SpiderWeb`.
`IgnoreSpiderWebComponent` removed. Replaced with `Tag: IgnoreSpiderWeb`.
`SpiderWebVisuals` enumerator removed.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: aada
- fix: Spiderwebs no longer spawn over other spider webs.
- tweak: Spiderwebs no longer spawn in space.
