### PR TITLE
Engieborg improvements - New lingering plasteel, reinforced glass, black/white tile stacks for construction module + recharging holofan projector for advanced tool module

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -74,9 +74,6 @@
   suffix: borg
   description: Stops suicidal crew from causing more crew harm during atmos emergencies. Powered by a self-recharing power cell.
   components:
-  - type: HolosignProjector
-    signProto: HoloFan
-    chargeUse: 120
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -54,7 +54,7 @@
   parent: Holoprojector
   id: HolofanProjector
   name: holofan projector
-  description: Stop suicidal passengers from killing everyone during atmos emergencies.
+  description: Stops suicidal passengers from killing everyone during atmos emergencies.
   components:
   - type: HolosignProjector
     signProto: HoloFan
@@ -67,6 +67,23 @@
       - HolofanProjector
   - type: StaticPrice
     price: 80
+
+- type: entity
+  parent: HolofanProjector
+  id: HolofanProjectorBorg
+  suffix: borg
+  description: Stops suicidal crew from causing more crew harm during atmos emergencies. Powered by a self-recharing power cell.
+  components:
+  - type: HolosignProjector
+    signProto: HoloFan
+    chargeUse: 120
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellMicroreactor
+        disableEject: true
+        swap: false
 
 - type: entity
   parent: HolofanProjector

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -174,6 +174,15 @@
 
 - type: entity
   parent: SheetRGlass
+  id: SheetRGlassLingering0
+  suffix: Lingering, 0
+  components:
+  - type: Stack
+    lingering: true
+    count: 0
+
+- type: entity
+  parent: SheetRGlass
   id: SheetRGlass1
   name: reinforced glass
   suffix: Single

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -208,6 +208,15 @@
 
 - type: entity
   parent: SheetPlasteel
+  id: SheetPlasteelLingering0
+  suffix: Lingering, 0
+  components:
+  - type: Stack
+    lingering: true
+    count: 0
+
+- type: entity
+  parent: SheetPlasteel
   id: SheetPlasteel10
   name: plasteel
   suffix: 10

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -114,3 +114,21 @@
   - type: Stack
     lingering: true
     count: 0
+
+- type: entity
+  parent: FloorTileItemWhite
+  id: FloorTileItemWhiteLingering0
+  suffix: Lingering, 0
+  components:
+  - type: Stack
+    lingering: true
+    count: 0
+
+- type: entity
+  parent: FloorTileItemDark
+  id: FloorTileItemDarkLingering0
+  suffix: Lingering, 0
+  components:
+  - type: Stack
+    lingering: true
+    count: 0

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -261,6 +261,7 @@
     - WelderExperimental
     - RemoteSignaller
     - GasAnalyzer
+    - HolofanProjectorBorg
     - GeigerCounter
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: adv-tools-module }
@@ -277,9 +278,13 @@
   - type: ItemBorgModule
     items:
     - SheetSteelLingering0
+    - SheetPlasteelLingering0
     - SheetGlassLingering0
+    - SheetRGlassLingering0
     - PartRodMetalLingering0
     - FloorTileItemSteelLingering0
+    - FloorTileItemWhiteLingering0
+    - FloorTileItemDarkLingering0
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: construction-module }
 


### PR DESCRIPTION
## About the PR
Adds new lingering reinforced glass, plasteel, and white/dark tile stacks. All included in the construction module.

Adds new Holofan Projector borg variant, included in the advanced tool module.

## Why / Balance
Borgs right now don't have the ability to:
- Construct new reinforced walls and reinforced windows, which is suboptimal given the current meteor balance situation.
- Place holofans and assist in atmospheric emergencies, something that an engineering borg should be able to do. Right now, they can't navigate firelocks without causing further gas spread or spacing, which could cause crew harm under the default lawset.

This PR addresses this by adding new lingering variants for reinforced glass, plasteel, dark tiles, and white tiles. This is included in the construction module, which engineering borgs get roundstart.

A self-recharging holofan has also been added to the Advanced Tool Module. I believe it is balanced, but if maintainers disagree, the charge consumed per holofan can be changed to make it so that borgs will have to wait longer in between charges.

I think these changes are good, considering that the engineering borg should be able to specialize and perform station maintenance on reinforced walls and glass.

I *do* understand this is really just increasing borghands spam... but I see this as a necessary compromise before hand whitelisting is coded.

## Technical details
Added new lingering variants and a borg holofan projector, based on previous solutions seen in-game.

## Media
![Content Client_TF2YS0p4dm](https://github.com/user-attachments/assets/5c41906f-428b-444c-bd51-a6cd1758ff85)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: The construction cyborg module can now handle plasteel, reinforced glass, and white/dark tiles.
- add: The advanced tool cyborg module now includes a self-recharging Holofan Projector.