### PR TITLE
Give silicons proper lobby/character editor previews

### DIFF
--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -455,7 +455,21 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
     {
         EntityUid dummyEnt;
 
-        if (humanoid is not null)
+        EntProtoId? previewEntity = null;
+        if (humanoid != null && jobClothes)
+        {
+            job ??= GetPreferredJob(humanoid);
+
+            previewEntity = job.JobPreviewEntity ?? (EntProtoId?) job?.JobEntity;
+        }
+
+        if (previewEntity != null)
+        {
+            // Special type like borg or AI, do not spawn a human just spawn the entity.
+            dummyEnt = EntityManager.SpawnEntity(previewEntity, MapCoordinates.Nullspace);
+            return dummyEnt;
+        }
+        else if (humanoid is not null)
         {
             var dummy = _prototypeManager.Index<SpeciesPrototype>(humanoid.Species).DollPrototype;
             dummyEnt = EntityManager.SpawnEntity(dummy, MapCoordinates.Nullspace);
@@ -469,7 +483,8 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
 
         if (humanoid != null && jobClothes)
         {
-            job ??= GetPreferredJob(humanoid);
+            DebugTools.Assert(job != null);
+
             GiveDummyJobClothes(dummyEnt, humanoid, job);
 
             if (_prototypeManager.HasIndex<RoleLoadoutPrototype>(LoadoutSystem.GetJobPrototype(job.ID)))

--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -460,7 +460,7 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
         {
             job ??= GetPreferredJob(humanoid);
 
-            previewEntity = job.JobPreviewEntity ?? (EntProtoId?) job?.JobEntity;
+            previewEntity = job.JobPreviewEntity ?? (EntProtoId?)job?.JobEntity;
         }
 
         if (previewEntity != null)

--- a/Content.Client/Lobby/UI/CharacterPickerButton.xaml
+++ b/Content.Client/Lobby/UI/CharacterPickerButton.xaml
@@ -6,6 +6,7 @@
                   SeparationOverride="0"
                   Name="InternalHBox">
         <SpriteView Scale="2 2"
+                    Margin="0 4 4 4"
                     OverrideDirection="South"
                     Name="View"/>
         <Label Name="DescriptionLabel"

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -140,7 +140,7 @@
         </BoxContainer>
         <!-- Right side -->
         <BoxContainer Orientation="Vertical" VerticalExpand="True" VerticalAlignment="Center">
-            <SpriteView Name="SpriteView" Scale="8 8" SizeFlagsStretchRatio="1" />
+            <SpriteView Name="SpriteView" Scale="8 8" Margin="4" SizeFlagsStretchRatio="1" />
             <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 5">
                 <Button Name="SpriteRotateLeft" Text="◀" StyleClasses="OpenRight" />
                 <cc:VSeparator Margin="2 0 3 0" />

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -119,6 +119,13 @@ namespace Content.Shared.Roles
         [DataField("jobEntity", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
         public string? JobEntity = null;
 
+        /// <summary>
+        /// Entity to use as a preview in the lobby/character editor.
+        /// Same restrictions as <see cref="JobEntity"/> apply.
+        /// </summary>
+        [DataField("jobPreviewEntity")]
+        public EntProtoId? JobPreviewEntity = null;
+
         [DataField]
         public ProtoId<JobIconPrototype> Icon { get; private set; } = "JobIconUnknown";
 

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -123,7 +123,7 @@ namespace Content.Shared.Roles
         /// Entity to use as a preview in the lobby/character editor.
         /// Same restrictions as <see cref="JobEntity"/> apply.
         /// </summary>
-        [DataField("jobPreviewEntity")]
+        [DataField]
         public EntProtoId? JobPreviewEntity = null;
 
         [DataField]

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -305,6 +305,18 @@
   - type: Intellicard
 
 - type: entity
+  id: PlayerStationAiPreview
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: Mobs/Silicon/station_ai.rsi
+    layers:
+    - state: base
+    - state: ai
+      map: ["unshaded"]
+      shader: unshaded
+
+- type: entity
   id: PlayerStationAiEmpty
   name: AI Core
   description: The latest in Artificial Intelligences.

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -313,7 +313,6 @@
     layers:
     - state: base
     - state: ai
-      map: ["unshaded"]
       shader: unshaded
 
 - type: entity

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -12,6 +12,7 @@
   icon: JobIconStationAi
   supervisors: job-supervisors-rd
   jobEntity: StationAiBrain
+  jobPreviewEntity: PlayerStationAiPreview
   applyTraits: false
 
 - type: job


### PR DESCRIPTION
No more naked dummies, properly show a borg/AI sprite now.

This means taking the JobEntity into account when spawning the dummy. For AIs I had to add a "JobPreviewEntity" field because they'd look like a posibrain otherwise. AI therefore uses a custom dummy entity I defined.

Also I had to add some margins to the UI, because otherwise the 32x32 sprite of the AI would look bad.

![image](https://github.com/user-attachments/assets/98a95236-ad58-434c-a23f-bd28793ad4e8)
![image](https://github.com/user-attachments/assets/ec642ef2-ae9e-423b-83f4-8fbb0110b6a4)
![image](https://github.com/user-attachments/assets/eaf8897f-b047-4746-99f5-622b51d1c0cc)
![image](https://github.com/user-attachments/assets/a7bd46fc-1d7d-42ac-aa33-06534f205cd3)

:cl:
- tweak: Silicons now have a proper preview in the lobby/character editor.