### PR TITLE
Make kill objectives more common

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -2,10 +2,10 @@
 - type: weightedRandom
   id: TraitorObjectiveGroups
   weights:
-    TraitorObjectiveGroupSteal: 1
+    TraitorObjectiveGroupSteal: 0.5
     TraitorObjectiveGroupKill: 1
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
-    TraitorObjectiveGroupSocial: 1 #Involves helping/harming others without killing them or stealing their stuff
+    TraitorObjectiveGroupSocial: 0.5 #Involves helping/harming others without killing them or stealing their stuff
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSteal

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -42,7 +42,7 @@
   description: One of our undercover agents will debrief you when you arrive. Don't show up in cuffs.
   components:
   - type: Objective
-    difficulty: 1.3
+    difficulty: 1
     icon:
       sprite: Structures/Furniture/chairs.rsi
       state: shuttle
@@ -119,7 +119,7 @@
   description: Identify yourself at your own risk. We just need them alive.
   components:
   - type: Objective
-    difficulty: 1.75
+    difficulty: 1.5
   - type: TargetObjective
     title: objective-condition-other-traitor-alive-title
   - type: RandomTraitorAlive
@@ -130,7 +130,7 @@
   description: Identify yourself at your own risk. We just need them to succeed.
   components:
   - type: Objective
-    difficulty: 2.5
+    difficulty: 2
   - type: TargetObjective
     title: objective-condition-other-traitor-progress-title
   - type: RandomTraitorProgress
@@ -183,7 +183,7 @@
     stealGroup: ClothingOuterHardsuitRd
   - type: Objective
     # This item must be worn or stored in a slowing duffelbag, very hard to hide.
-    difficulty: 3
+    difficulty: 2
 
 - type: entity
   parent: BaseRDStealObjective


### PR DESCRIPTION
## About the PR
This PR adjusts the weight of traitor objectives, reducing the frequency of steal and social objectives.
Also, the difficulty level of escape to centcomm, steal rd-hardsuit, keep alive, help progress is lowered slightly so traitors dont just get 1-2 of those.

## Why / Balance
Currently it's quite common to get only 1-2 steal/social objectives and then escape to centcomm. This PR will throw in more kill objectives in the mix.

Also, by reducing the social objectives it'll be harder for the syndies to group up.