### PR TITLE
Fix detective Vox spawning with their chosen outer clothing on the floor, force detective to have a selected outerclothing like all other sec roles

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1070,7 +1070,6 @@
 - type: loadoutGroup
   id: DetectiveOuterClothing
   name: loadout-group-detective-outerclothing
-  minLimit: 0
   loadouts:
   - DetectiveArmorVest
   - DetectiveCoat

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -377,7 +377,6 @@
 - type: roleLoadout
   id: JobDetective
   groups:
-  - GroupTankHarness
   - DetectiveHead
   - DetectiveNeck
   - DetectiveJumpsuit


### PR DESCRIPTION
## About the PR
Detective Vox no longer spawn with their outer clothing on the floor and their tank harness equipped instead.

Detectives are forced to have an outer clothing selected for their loadout. This is for consistency with all other sec roles.

This closes #33741.

## Why / Balance
All other security roles like Secoff and HoS have Vox spawn with their intended armor and tank attached. The Detective, however, spawns with an equipped tank harness, with the player's selected armor on the floor.

## Technical details
Removed the limit for detective armor, it now follows the default minimum and maximum select of 1 (you cannot unselect, and you can't select more than 1)
Removed the tank harness group from the loadout group, as now detective is forced to spawn with their armor, like all other sec roles.
## Media
Tested for all armors, only showing one.
![Content Client_FWUkEtl9Yi](https://github.com/user-attachments/assets/71bf8b5d-ce88-4a4b-aaaf-634aa6ed6722)
![image](https://github.com/user-attachments/assets/9a9878a9-1876-4dec-a5e3-9e387ccd3eb6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Detectives are now required to start with outer clothing (armor) like all other security roles.
- fix: Vox Detectives now spawn with their chosen outer clothing equipped. Previously the tank harness would override this and your armor would start on the floor.

