### PR TITLE
let bagel be played at max pop

### DIFF
--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -3,7 +3,7 @@
   mapName: 'Bagel Station'
   mapPath: /Maps/bagel.yml
   minPlayers: 35
-  maxPlayers: 70
+  maxPlayers: 80
   stations:
     Bagel:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
its 'fine' at 80 and some other maps that were originally 70-75 are 80, this gives more variety when max pop