### PR TITLE
Fix gas pipe leaking when unanchoring or breaking them

### DIFF
--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosUnsafeUnanchorSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosUnsafeUnanchorSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Piping.Components;
 using Content.Server.NodeContainer;
+using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.Popups;
 using Content.Shared.Atmos;
@@ -8,7 +9,6 @@ using Content.Shared.Construction.Components;
 using Content.Shared.Destructible;
 using Content.Shared.Popups;
 using JetBrains.Annotations;
-using Robust.Shared.Player;
 
 namespace Content.Server.Atmos.Piping.EntitySystems
 {
@@ -16,11 +16,12 @@ namespace Content.Server.Atmos.Piping.EntitySystems
     public sealed class AtmosUnsafeUnanchorSystem : EntitySystem
     {
         [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
+        [Dependency] private readonly NodeGroupSystem _group = default!;
         [Dependency] private readonly PopupSystem _popup = default!;
 
         public override void Initialize()
         {
-            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, BeforeUnanchoredEvent>(OnBeforeUnanchored);
+            SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UserUnanchoredEvent>(OnUserUnanchored);
             SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
             SubscribeLocalEvent<AtmosUnsafeUnanchorComponent, BreakageEventArgs>(OnBreak);
         }
@@ -30,15 +31,12 @@ namespace Content.Server.Atmos.Piping.EntitySystems
             if (!component.Enabled || !EntityManager.TryGetComponent(uid, out NodeContainerComponent? nodes))
                 return;
 
-            if (_atmosphere.GetContainingMixture(uid, true) is not {} environment)
-                return;
-
             foreach (var node in nodes.Nodes.Values)
             {
                 if (node is not PipeNode pipe)
                     continue;
 
-                if (pipe.Air.Pressure - environment.Pressure > 2 * Atmospherics.OneAtmosphere)
+                if (pipe.Air.Pressure > Atmospherics.OneAtmosphere)
                 {
                     args.Delay += 2f;
                     _popup.PopupEntity(Loc.GetString("comp-atmos-unsafe-unanchor-warning"), pipe.Owner,
@@ -48,15 +46,23 @@ namespace Content.Server.Atmos.Piping.EntitySystems
             }
         }
 
-        private void OnBeforeUnanchored(EntityUid uid, AtmosUnsafeUnanchorComponent component, BeforeUnanchoredEvent args)
+        // When unanchoring a pipe, leak the gas that was inside the pipe element.
+        // At this point the pipe has been scheduled to be removed from the group, but that won't happen until the next Update() call in NodeGroupSystem,
+        // so we have to force an update.
+        // This way the gas inside other connected pipes stays unchanged, while the removed pipe is completely emptied.
+        private void OnUserUnanchored(EntityUid uid, AtmosUnsafeUnanchorComponent component, UserUnanchoredEvent args)
         {
             if (component.Enabled)
+            {
+                _group.ForceUpdate();
                 LeakGas(uid);
+            }
         }
 
         private void OnBreak(EntityUid uid, AtmosUnsafeUnanchorComponent component, BreakageEventArgs args)
         {
-            LeakGas(uid);
+            _group.ForceUpdate();
+            LeakGas(uid, false);
             // Can't use DoActsBehavior["Destruction"] in the same trigger because that would prevent us
             // from leaking. So we make up for this by queueing deletion here.
             QueueDel(uid);
@@ -64,32 +70,17 @@ namespace Content.Server.Atmos.Piping.EntitySystems
 
         /// <summary>
         /// Leak gas from the uid's NodeContainer into the tile atmosphere.
+        /// Setting removeFromPipe to false will duplicate the gas inside the pipe intead of moving it.
+        /// This is needed to properly handle the gas in the pipe getting deleted with the pipe.
         /// </summary>
-        public void LeakGas(EntityUid uid)
+        public void LeakGas(EntityUid uid, bool removeFromPipe = true)
         {
             if (!EntityManager.TryGetComponent(uid, out NodeContainerComponent? nodes))
                 return;
 
-            if (_atmosphere.GetContainingMixture(uid, true, true) is not {} environment)
+            if (_atmosphere.GetContainingMixture(uid, true, true) is not { } environment)
                 environment = GasMixture.SpaceGas;
 
-            var lost = 0f;
-            var timesLost = 0;
-
-            foreach (var node in nodes.Nodes.Values)
-            {
-                if (node is not PipeNode pipe)
-                    continue;
-
-                var difference = pipe.Air.Pressure - environment.Pressure;
-                lost += Math.Min(
-                            pipe.Volume / pipe.Air.Volume * pipe.Air.TotalMoles,
-                            difference * environment.Volume / (environment.Temperature * Atmospherics.R)
-                        );
-                timesLost++;
-            }
-
-            var sharedLoss = lost / timesLost;
             var buffer = new GasMixture();
 
             foreach (var node in nodes.Nodes.Values)
@@ -97,7 +88,13 @@ namespace Content.Server.Atmos.Piping.EntitySystems
                 if (node is not PipeNode pipe)
                     continue;
 
-                _atmosphere.Merge(buffer, pipe.Air.Remove(sharedLoss));
+                if (removeFromPipe)
+                    _atmosphere.Merge(buffer, pipe.Air.RemoveVolume(pipe.Volume));
+                else
+                {
+                    var copy = new GasMixture(pipe.Air); //clone, then remove to keep the original untouched
+                    _atmosphere.Merge(buffer, copy.RemoveVolume(pipe.Volume));
+                }
             }
 
             _atmosphere.Merge(environment, buffer);

--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosUnsafeUnanchorSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosUnsafeUnanchorSystem.cs
@@ -61,7 +61,6 @@ namespace Content.Server.Atmos.Piping.EntitySystems
 
         private void OnBreak(EntityUid uid, AtmosUnsafeUnanchorComponent component, BreakageEventArgs args)
         {
-            _group.ForceUpdate();
             LeakGas(uid, false);
             // Can't use DoActsBehavior["Destruction"] in the same trigger because that would prevent us
             // from leaking. So we make up for this by queueing deletion here.

--- a/Content.Server/NodeContainer/EntitySystems/NodeGroupSystem.cs
+++ b/Content.Server/NodeContainer/EntitySystems/NodeGroupSystem.cs
@@ -149,6 +149,13 @@ namespace Content.Server.NodeContainer.EntitySystems
             }
         }
 
+        // used to manually force an update for the groups
+        // the VisDoUpdate will be done with the next scheduled update
+        public void ForceUpdate()
+        {
+            DoGroupUpdates();
+        }
+
         private void DoGroupUpdates()
         {
             // "Why is there a separate queue for group remakes and node refloods when they both cause eachother"


### PR DESCRIPTION
## About the PR
Currently when unanchoring a pipe some of the gas will leak from it, but not all of it. This means you can pick it up as a small 200L tank in your backpack and release the gas into the atmosphere by anchoring and unachoring it a second time, which can be potentially abused.
This PR solves this by making the leak amount equal to $V_{pipe} / V_{total}$ which was suggested by @Partmedia in #29574.
The removed pipe will then always be completely empty.

## Why / Balance
Fixes #32632

## Technical details
I simplified the way the leak amount is calculated, removing the pressure dependency and making it only volume dependend, which makes more sense. The warning popup will now show up when the pipes pressure is above standard atmospheric pressure, below that the gas still leaks, but the amount is insignificant.

When the pipe is unanchored, the node group update will be scheduled for next tick. However, this will mean we cannot yet remove the gas from the pipe element since it is still connected with its neighbors. We cannot do this in the next tick either, because the information about the pipe entity and its node is lost by then. To solve this we force a manual update for the scheduled node groups. This should be fine performance-wise since it only happens once when a player unanchors it and the update won't be repeated in the next tick.

## Media

https://github.com/user-attachments/assets/482efc56-0b86-4e92-b69c-cfa0d15e85e7

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed pipes still containing gas after unanchoring them.