### PR TITLE
Signal timer duration limit

### DIFF
--- a/Content.Server/DeviceLinking/Components/SignalTimerComponent.cs
+++ b/Content.Server/DeviceLinking/Components/SignalTimerComponent.cs
@@ -1,53 +1,58 @@
 using Content.Shared.DeviceLinking;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.DeviceLinking.Components;
 
 [RegisterComponent]
 public sealed partial class SignalTimerComponent : Component
 {
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public double Delay = 5;
 
     /// <summary>
     ///     This shows the Label: text box in the UI.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public bool CanEditLabel = true;
 
     /// <summary>
     ///     The label, used for TextScreen visuals currently.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public string Label = string.Empty;
 
     /// <summary>
     ///     Default max width of a label (how many letters can this render?)
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public int MaxLength = 5;
 
     /// <summary>
     ///     The port that gets signaled when the timer triggers.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public ProtoId<SourcePortPrototype> TriggerPort = "Timer";
 
     /// <summary>
     ///     The port that gets signaled when the timer starts.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public ProtoId<SourcePortPrototype> StartPort = "Start";
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public ProtoId<SinkPortPrototype> Trigger = "Trigger";
 
     /// <summary>
     ///     If not null, this timer will play this sound when done.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public SoundSpecifier? DoneSound;
+
+    /// <summary>
+    ///     The maximum duration the timer can be set to (in seconds)
+    /// </summary>
+    [DataField]
+    public Double MaxDuration = 3599;
 }
 

--- a/Content.Server/DeviceLinking/Components/SignalTimerComponent.cs
+++ b/Content.Server/DeviceLinking/Components/SignalTimerComponent.cs
@@ -50,9 +50,9 @@ public sealed partial class SignalTimerComponent : Component
     public SoundSpecifier? DoneSound;
 
     /// <summary>
-    ///     The maximum duration the timer can be set to (in seconds)
+    ///     The maximum duration in seconds
+    ///     When a larger number is in the input box, the display will start counting down from this one instead
     /// </summary>
     [DataField]
-    public Double MaxDuration = 3599;
+    public Double MaxDuration = 3599; // 59m 59s
 }
-

--- a/Content.Server/DeviceLinking/Systems/SignalTimerSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/SignalTimerSystem.cs
@@ -152,7 +152,7 @@ public sealed class SignalTimerSystem : EntitySystem
         if (!IsMessageValid(uid, args))
             return;
 
-        component.Delay = args.Delay.TotalSeconds;
+        component.Delay = Math.Min(args.Delay.TotalSeconds, component.MaxDuration);
         _appearanceSystem.SetData(uid, TextScreenVisuals.TargetTime, component.Delay);
     }
 


### PR DESCRIPTION
## About the PR
Signal Timers (for example Brig Timers on cells) now have a maximum duration. If any number higher than an hour is input, the countdown will start from 59:59 instead. Max duration is on a component and can be modified by individual prototypes, if necessary.

## Why / Balance
(Technically, there already was a practical maximum, since the largest number that could be typed in was 99m 99s, which becomes 1h 40m. I am merely reducing that limit to an hour instead)

if the current remaining time is over 1h 0m 0s, the display shows hh:mm. This is arguably unintuitive, since people expect it to show mm:ss, and can just look like a short timer got stuck, unless you stare at it long enough to see the minutes change.

There is not really a reasonable usecase for a timer counting down from over an hour. Should that need legitimately arise in the future, or in a fork, MaxDuration can be increased in yaml to the original. But it will still be capped by the limitation of the input field.

This change also makes it possible to set more limitations on specific timers through yaml. For example making it so all brig timers can no longer be set to above a universal maximum sentence time.

## Technical details
Maxduration is on the SignalTimerComponent. When the server receives the value that was input on the client, the lower of the two numbers is used to start the countdown.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl: Errant
- tweak: Signal timers now have a maximum countdown duration, which can be specified in yaml. The default maximum is one hour, to prevent the displayed time from overflowing into hh:mm .