### PR TITLE
Lobby chat width and custom lobby titles

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -60,8 +60,7 @@ namespace Content.Client.Lobby
                 : lobbyNameCvar;
 
             var width = _cfg.GetCVar(CCVars.ServerLobbyRightPanelWidth);
-            Lobby.RightSide.MinWidth = width;
-            Lobby.RightSide.MaxWidth = width;
+            Lobby.RightSide.SetWidth = width;
 
             UpdateLobbyUi();
 

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -54,8 +54,10 @@ namespace Content.Client.Lobby
             LayoutContainer.SetAnchorPreset(Lobby, LayoutContainer.LayoutPreset.Wide);
 
             var lobbyNameCvar = _cfg.GetCVar(CCVars.ServerLobbyName);
+            var serverName = _baseClient.GameInfo?.ServerName ?? "";
+
             Lobby.ServerName.Text = string.IsNullOrEmpty(lobbyNameCvar)
-                ? Loc.GetString("ui-lobby-title") + " "  + _baseClient.GameInfo?.ServerName
+                ? Loc.GetString("ui-lobby-title", ("serverName", serverName))
                 : lobbyNameCvar;
 
             var width = _cfg.GetCVar(CCVars.ServerLobbyRightPanelWidth);

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -5,11 +5,13 @@ using Content.Client.Lobby.UI;
 using Content.Client.Message;
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Client.Voting;
+using Content.Shared.CCVar;
 using Robust.Client;
 using Robust.Client.Console;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Configuration;
 using Robust.Shared.Timing;
 
 
@@ -18,6 +20,7 @@ namespace Content.Client.Lobby
     public sealed class LobbyState : Robust.Client.State.State
     {
         [Dependency] private readonly IBaseClient _baseClient = default!;
+        [Dependency] private readonly IConfigurationManager _cfg = default!;
         [Dependency] private readonly IClientConsoleHost _consoleHost = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IResourceCache _resourceCache = default!;
@@ -49,7 +52,12 @@ namespace Content.Client.Lobby
 
             _voteManager.SetPopupContainer(Lobby.VoteContainer);
             LayoutContainer.SetAnchorPreset(Lobby, LayoutContainer.LayoutPreset.Wide);
-            Lobby.ServerName.Text = _baseClient.GameInfo?.ServerName; //The eye of refactor gazes upon you...
+
+            var serverLobbyName = _cfg.GetCVar(CCVars.ServerLobbyName);
+            Lobby.ServerName.Text = string.IsNullOrEmpty(serverLobbyName)
+                ? Loc.GetString("ui-lobby-title") + " "  + _baseClient.GameInfo?.ServerName
+                : serverLobbyName;
+
             UpdateLobbyUi();
 
             Lobby.CharacterPreview.CharacterSetupButton.OnPressed += OnSetupPressed;

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -14,7 +14,6 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Configuration;
 using Robust.Shared.Timing;
 
-
 namespace Content.Client.Lobby
 {
     public sealed class LobbyState : Robust.Client.State.State

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -53,10 +53,14 @@ namespace Content.Client.Lobby
             _voteManager.SetPopupContainer(Lobby.VoteContainer);
             LayoutContainer.SetAnchorPreset(Lobby, LayoutContainer.LayoutPreset.Wide);
 
-            var serverLobbyName = _cfg.GetCVar(CCVars.ServerLobbyName);
-            Lobby.ServerName.Text = string.IsNullOrEmpty(serverLobbyName)
+            var lobbyNameCvar = _cfg.GetCVar(CCVars.ServerLobbyName);
+            Lobby.ServerName.Text = string.IsNullOrEmpty(lobbyNameCvar)
                 ? Loc.GetString("ui-lobby-title") + " "  + _baseClient.GameInfo?.ServerName
-                : serverLobbyName;
+                : lobbyNameCvar;
+
+            var width = _cfg.GetCVar(CCVars.ServerLobbyRightPanelWidth);
+            Lobby.RightSide.MinWidth = width;
+            Lobby.RightSide.MaxWidth = width;
 
             UpdateLobbyUi();
 

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -53,7 +53,7 @@ namespace Content.Client.Lobby
             LayoutContainer.SetAnchorPreset(Lobby, LayoutContainer.LayoutPreset.Wide);
 
             var lobbyNameCvar = _cfg.GetCVar(CCVars.ServerLobbyName);
-            var serverName = _baseClient.GameInfo?.ServerName ?? "";
+            var serverName = _baseClient.GameInfo?.ServerName ?? string.Empty;
 
             Lobby.ServerName.Text = string.IsNullOrEmpty(lobbyNameCvar)
                 ? Loc.GetString("ui-lobby-title", ("serverName", serverName))

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -62,7 +62,7 @@
                 <Control Access="Public" Visible="False" Name="CharacterSetupState" VerticalExpand="True" />
             </BoxContainer>
             <!-- Right Panel -->
-            <PanelContainer Name="RightSide" StyleClasses="AngleRect" HorizontalAlignment="Right" VerticalExpand="True"
+            <PanelContainer Name="RightSide" Access="Public" StyleClasses="AngleRect" HorizontalAlignment="Right" VerticalExpand="True"
                             VerticalAlignment="Stretch">
                 <BoxContainer Orientation="Vertical" HorizontalExpand="True">
                     <!-- Top row -->

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -68,8 +68,6 @@
                     <!-- Top row -->
                     <BoxContainer Orientation="Horizontal" MinSize="0 40" Name="HeaderContainer" Access="Public"
                                   SeparationOverride="4">
-                        <Label Margin="8 0 0 0" StyleClasses="LabelHeadingBigger" VAlign="Center"
-                               Text="{Loc 'ui-lobby-title'}" />
                         <Label Name="ServerName" Access="Public" StyleClasses="LabelHeadingBigger" VAlign="Center"
                                HorizontalExpand="True" HorizontalAlignment="Center" />
                     </BoxContainer>

--- a/Content.Shared/CCVar/CCVars.Interface.cs
+++ b/Content.Shared/CCVar/CCVars.Interface.cs
@@ -21,4 +21,10 @@ public sealed partial class CCVars
 
     public static readonly CVarDef<bool> OutlineEnabled =
         CVarDef.Create("outline.enabled", true, CVar.CLIENTONLY);
+
+    // <summary>
+    //  The width of the right side (chat) panel in the lobby
+    // </summary>
+    public static readonly CVarDef<int> ServerLobbyRightPanelWidth =
+        CVarDef.Create("server.lobby_right_panel_width", 650, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/CCVar/CCVars.Interface.cs
+++ b/Content.Shared/CCVar/CCVars.Interface.cs
@@ -21,10 +21,4 @@ public sealed partial class CCVars
 
     public static readonly CVarDef<bool> OutlineEnabled =
         CVarDef.Create("outline.enabled", true, CVar.CLIENTONLY);
-
-    // <summary>
-    //  The width of the right side (chat) panel in the lobby
-    // </summary>
-    public static readonly CVarDef<int> ServerLobbyRightPanelWidth =
-        CVarDef.Create("server.lobby_right_panel_width", 650, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/CCVar/CCVars.Server.cs
+++ b/Content.Shared/CCVar/CCVars.Server.cs
@@ -47,4 +47,10 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<string> ServerLobbyName =
         CVarDef.Create("server.lobby_name", "", CVar.REPLICATED | CVar.SERVER);
+
+    // <summary>
+    //  The width of the right side (chat) panel in the lobby
+    // </summary>
+    public static readonly CVarDef<int> ServerLobbyRightPanelWidth =
+        CVarDef.Create("server.lobby_right_panel_width", 650, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/CCVar/CCVars.Server.cs
+++ b/Content.Shared/CCVar/CCVars.Server.cs
@@ -48,9 +48,9 @@ public sealed partial class CCVars
     public static readonly CVarDef<string> ServerLobbyName =
         CVarDef.Create("server.lobby_name", "", CVar.REPLICATED | CVar.SERVER);
 
-    // <summary>
-    //  The width of the right side (chat) panel in the lobby
-    // </summary>
+    /// <summary>
+    ///     The width of the right side (chat) panel in the lobby
+    /// </summary>
     public static readonly CVarDef<int> ServerLobbyRightPanelWidth =
         CVarDef.Create("server.lobby_right_panel_width", 650, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/CCVar/CCVars.Server.cs
+++ b/Content.Shared/CCVar/CCVars.Server.cs
@@ -40,4 +40,11 @@ public sealed partial class CCVars
     /// </remarks>
     public static readonly CVarDef<int> ServerUptimeRestartMinutes =
         CVarDef.Create("server.uptime_restart_minutes", 0, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     This will be the title shown in the lobby
+    ///     If empty, the title will be {ui-lobby-title} + the server's full name from the hub
+    /// </summary>
+    public static readonly CVarDef<string> ServerLobbyName =
+        CVarDef.Create("server.lobby_name", "", CVar.REPLICATED | CVar.SERVER);
 }

--- a/Resources/Locale/en-US/lobby/lobby-gui.ftl
+++ b/Resources/Locale/en-US/lobby/lobby-gui.ftl
@@ -1,4 +1,4 @@
-ui-lobby-title = Lobby {$serverName}
+ui-lobby-title = Lobby: {$serverName}
 ui-lobby-ahelp-button = AHelp
 ui-lobby-options-button = Options
 ui-lobby-leave-button = Leave

--- a/Resources/Locale/en-US/lobby/lobby-gui.ftl
+++ b/Resources/Locale/en-US/lobby/lobby-gui.ftl
@@ -1,4 +1,4 @@
-ui-lobby-title = Lobby
+ui-lobby-title = Lobby {$serverName}
 ui-lobby-ahelp-button = AHelp
 ui-lobby-options-button = Options
 ui-lobby-leave-button = Leave


### PR DESCRIPTION
## About the PR
The width of the right side lobby panel is now fixed at 650* or it can be specified via cvar.
(650 was picked somewhat arbitrarily, between Lizard and Salamander. I'm not super attached to it, but it seemed like a reasonable default width.)

Servers can also set a custom title/message to be displayed as the Lobby title via cvar. If it's not specified, then the title will be taken from the server's hub name, similarly* to Live.
(The spacing/layout will theoretically look slightly different for servers with very short names, because the "Lobby" prefix is now part of the same string as the name) 

Having looked at this, ultimately we might want to redesign the layout of lobby chat, so that the vast majority of the screen space does not go wasted while you are actually using it and not basking in the beauty of the lobby art. Or make it draggable so the players can set it.
But quick fix first.

## Why
Currently, the width of the right side panel in the lobby is (in practice) governed by how long a server's name is. This means that basically every server has a slightly different lobby chat width unless their names just happens to be exactly the same lenght.
It turns out some forks already had to modify the layout code because otherwise their exceptionally long names/featurelist would make the chat take up most of the screen. 

The fixed width would now mean that a long server name does not fit onto the panel and runs out of the screen. But why should the lobby title need to be the same as the hub listing, anway? So it can now be specified.

## Live
NOTE! Do not compare the images to anything but each other, as your UI scale and to some degree even Resolution being different from mine will throw off your comparison

![Screenshot_2024-12-08_143654](https://github.com/user-attachments/assets/f6645224-390e-473f-bb10-63869b238172)
![Screenshot_2024-12-08_150254](https://github.com/user-attachments/assets/a84538e0-e817-42cb-a614-244732be7cb6)
(Forgive a bit of necromancy, but the difference here is quite huge)
![Screenshot_2024-12-08_150041](https://github.com/user-attachments/assets/0b0bb7bf-1bff-48c8-b167-f13aad0f113e)
The logical conclusion of the unmodified code
![Screenshot_2024-12-08_143827](https://github.com/user-attachments/assets/91e74790-60c2-4b3c-aa56-799168cc8d86)

## Fixed length at 650 
The same servers with fixed width, no configuration:
![Screenshot_2024-12-08_144341](https://github.com/user-attachments/assets/2b45048e-970d-44bc-beca-8db523588e4f)
![Screenshot_2024-12-08_144644](https://github.com/user-attachments/assets/fe5a922d-6d7a-46d6-b465-17c24a307a8b)
![Screenshot_2024-12-08_181818](https://github.com/user-attachments/assets/0591f457-c676-4b51-8c09-31f92f43495a)
![Screenshot_2024-12-08_144959](https://github.com/user-attachments/assets/6662475a-9ea4-4009-95f7-a9b10aec36cc)

With the lobby_name cvar, servers can fully specify the lobby title as desired.
![Screenshot_2024-12-08_144758](https://github.com/user-attachments/assets/52f49fbc-bb1b-4e22-b130-18084e933a52)
![Screenshot_2024-12-08_144839](https://github.com/user-attachments/assets/252a5410-edfc-4ac5-9f78-9eaa260dcda4)
![Screenshot_2024-12-08_145104](https://github.com/user-attachments/assets/301b5d6e-30e7-45c2-94a9-3a77b10741ad)
![Screenshot_2024-12-08_145545](https://github.com/user-attachments/assets/9a798ad9-3656-4ab8-ab5a-fe66c045b115)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The chat panel's width in the lobby is now fixed. Server names that are longer than the default width will not fit onto the screen and the end will be cut off. Use your server config file to either increase the width or specify a shorter lobby title to be displayed.
[server] 
lobby_right_panel_width = 675
lobby_name = "Lobby MyServer"

**Changelog**
:cl: Errant
- tweak: Lobby chat width is no longer dependent on the server's name.
- tweak: Lobby title of a server can now be different from the Hub listing's name.
