### PR TITLE
Logic Gate Compatibility with Non-Logic Signals bugfix

### DIFF
--- a/Content.Server/DeviceLinking/Systems/LogicGateSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/LogicGateSystem.cs
@@ -44,7 +44,7 @@ public sealed class LogicGateSystem : EntitySystem
             }
             if (comp.StateB == SignalState.Momentary)
             {
-                comp.StateB = SignalState.High;
+                comp.StateB = SignalState.Low;
             }
 
             // output most likely changed so update it


### PR DESCRIPTION
## About the PR
Fixed a bug where B port inputs to logic gates weren't properly reset to `Low` when a non-logic signal is sent to them.
ie. if you link a Signaller to a Logic Gate's B input, it gets stuck as `High` forever.
Fixes #33716

## Why / Balance
I just spent a whole round trying to make a thing and only once I hooked up the debugger did I understand ):

## Technical details
`High` -> `Low`
:)

## Media
Very small and nothing really to show

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Fixed a bug where the B input on logic gates would get stuck in a high state
