### PR TITLE
Allow map-editor admin-ghosts to toggle doors

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -45,7 +45,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
     [Dependency] protected readonly SharedPopupSystem Popup = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly SharedPowerReceiverSystem _powerReceiver = default!;
-    [Dependency] private readonly TagSystem _tag = default!;
 
 
     [ValidatePrototypeId<TagPrototype>]
@@ -372,7 +371,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         var nextState = DoorState.Opening;
 
         // Admin ghosts in map editor mode can instantly open doors.
-        if (Paused(uid) && user is EntityUid realUser && _tag.HasTag(realUser, "InstantDoAfters"))
+        if (Paused(uid) && user is EntityUid realUser && Tags.HasTag(realUser, "InstantDoAfters"))
             nextState = DoorState.Open;
 
         if (!SetState(uid, nextState, door))
@@ -471,7 +470,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         var nextState = DoorState.Closing;
 
         // Admin ghosts in map editor mode can instantly open doors.
-        if (Paused(uid) && user is EntityUid realUser && _tag.HasTag(realUser, "InstantDoAfters"))
+        if (Paused(uid) && user is EntityUid realUser && Tags.HasTag(realUser, "InstantDoAfters"))
             nextState = DoorState.Closed;
 
         if (!SetState(uid, nextState, door))


### PR DESCRIPTION
## About the PR
Admin ghosts clicking doors on paused maps (map editor) now actually opens them instead of getting them stuck on the first frame of the opening animation for all time.

## Why / Balance
Admin ghosts have the `InstantDoAfters` tag and so can force open doors instantly even on paused maps. The doors then enter the "Opening" state but never go all the way to "Open", don't animate, can't be closed again, and start open when the map is loaded. It's better if they open properly and can be closed again too.

## Technical details
Skip animation if map is paused and doer has `InstantDoAfters` tag, which only aghosts do.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
