### PR TITLE
Merge into master: Derelict icon hotfix (#33768)

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -347,4 +347,4 @@
     ionStormAmount: 3
   - type: IonStormTarget
     chance: 1
-    
+  - type: ShowJobIcons


### PR DESCRIPTION
Merging stable into master for the hotfix #33768

Reminder:
Do not squash merge.
Do not delete stable even if github wants you to.