### PR TITLE
Fix: SMES now has wirepanels visuals

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -28,6 +28,8 @@
         - map: ["enum.SmesVisualLayers.Output"]
           state: "smes-op1"
           shader: unshaded
+        - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
+          state: smes-open
     - type: Smes
     - type: Appearance
     - type: Battery
@@ -67,6 +69,7 @@
       color: "#c9c042"
       castShadows: false
     - type: WiresPanel
+    - type: WiresVisuals
     - type: Machine
       board: SMESMachineCircuitboard
     - type: StationInfiniteBatteryTarget


### PR DESCRIPTION
## About the PR
SMES now has visuals for if the maintenance panel is open.

## Why / Balance
SMES had wirepanel sprites but they were never used because missing code in YAML.
Something I noticed when I was working on #33757 (that PR needs this one to be merged before, or else it'll look weird)

## Technical details
Added like 3 lines of YAML. It was missing the `WiresVisuals` type.
## Media
![image](https://github.com/user-attachments/assets/da84c0f5-1bbc-4c19-bbb7-7deac7f8324d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: SMES now gives visual feedback for if the maintenance panel is open.