### PR TITLE
Fix blank newline on empty examine groups

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -409,8 +409,10 @@ namespace Content.Shared.Examine
         private void PopGroup()
         {
             DebugTools.Assert(_currentGroupPart != null);
-            if (_currentGroupPart != null)
+            if (_currentGroupPart != null && !_currentGroupPart.Message.IsEmpty)
+            {
                 Parts.Add(_currentGroupPart);
+            }
 
             _currentGroupPart = null;
         }


### PR DESCRIPTION
Construction always grants a blank newline even if it not currently constructing.

**Changelog**
:cl:
- fix: Fix blank newlines on examine tooltips (e.g. tables).

