### PR TITLE
Fix horrible lag in Zombies mode

### DIFF
--- a/Content.Shared/Whitelist/EntityWhitelistSystem.cs
+++ b/Content.Shared/Whitelist/EntityWhitelistSystem.cs
@@ -49,10 +49,12 @@ public sealed class EntityWhitelistSystem : EntitySystem
     {
         if (list.Components != null)
         {
-            var regs = StringsToRegs(list.Components);
-
-            list.Registrations ??= new List<ComponentRegistration>();
-            list.Registrations.AddRange(regs);
+            if (list.Registrations == null)
+            {
+                var regs = StringsToRegs(list.Components);
+                list.Registrations = new List<ComponentRegistration>();
+                list.Registrations.AddRange(regs);
+            }
         }
 
         if (list.MindRoles != null)


### PR DESCRIPTION
## About the PR
This fixes massive FPS drop in vicinity of zombified players.
Closes #32870.

## Why / Balance
Many FPS = good

## Technical details
With some experimentation I figured out lag is caused specifically by Zombie component, not a "complete" Zombie antag.
I spawned ~30 Urists in a box, gave them the Zombie component, and once lag settled in for real, turned on IDE profiling. Turns out ~75% of CPU time is spent in `Content.Shared.Whitelist.EntityWhitelistSystem.IsValid`, which was called from `StatusIconSystem`.
Logical error here blows up the `EntityWhitelist.Registrations` List to 100k+ duplicate elements which completely chokes the processor in the following loop.
Zombies (and Revolutionaries) are the only prototypes that use component lookup for `factionIcon`, so it didn't blow up anywhere else.
Fix is self-explanatory.

## Media
![image_2024-12-11_03-22-50](https://github.com/user-attachments/assets/e0dc2c57-5a13-46f7-a235-8ee3d6345459)
![image_2024-12-11_03-25-07](https://github.com/user-attachments/assets/38cbc51b-4aa9-4889-b0c1-c4a635c4b1d2)


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Massive FPS drop in vicinity of zombified players
