### PR TITLE
Monospace Support for Rich Text

### DIFF
--- a/Content.Client/Paper/UI/PaperWindow.xaml.cs
+++ b/Content.Client/Paper/UI/PaperWindow.xaml.cs
@@ -43,7 +43,8 @@ namespace Content.Client.Paper.UI
             typeof(BulletTag),
             typeof(ColorTag),
             typeof(HeadingTag),
-            typeof(ItalicTag)
+            typeof(ItalicTag),
+            typeof(MonoTag)
         };
 
         public event Action<string>? OnSaved;

--- a/Content.Client/Paper/UI/PaperWindow.xaml.cs
+++ b/Content.Client/Paper/UI/PaperWindow.xaml.cs
@@ -9,6 +9,7 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.Utility;
 using Robust.Client.UserInterface.RichText;
+using Content.Client.UserInterface.RichText;
 using Robust.Shared.Input;
 
 namespace Content.Client.Paper.UI

--- a/Content.Client/UserInterface/RichText/MonoTag.cs
+++ b/Content.Client/UserInterface/RichText/MonoTag.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using Robust.Client.ResourceManagement;
+using Robust.Client.UserInterface.RichText;
+using Robust.Shared.IoC;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Client.UserInterface.RichText;
+
+/// <summary>
+/// Sets the font to a monospaced variant
+/// </summary>
+public sealed class MonoTag : IMarkupTag
+{
+    public const string MonoFont = "Monospace";
+
+    [Dependency] private readonly IResourceCache _resourceCache = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public string Name => "mono";
+
+    /// <inheritdoc/>
+    public void PushDrawContext(MarkupNode node, MarkupDrawingContext context)
+    {
+        var font = FontTag.CreateFont(context.Font, node, _resourceCache, _prototypeManager, MonoFont);
+        context.Font.Push(font);
+    }
+
+    /// <inheritdoc/>
+    public void PopDrawContext(MarkupNode node, MarkupDrawingContext context)
+    {
+        context.Font.Pop();
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Adds the ability to have monospaced text in text documents through the use of the brand new `[mono]` tag.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Anybody doing paperwork wants to be able to have consistent text width, this enables that.

## Technical details
<!-- Summary of code changes for easier review. -->

~~Most of the work here relies upon a change to the engine which has it's own PR here.
https://github.com/space-wizards/RobustToolbox/pull/5556~~

~~However we do need to add the MonoTag to the list of allowed tags client side which is what this PR does.~~

*This PR now contains all of the code required to make this monospace functionality work. It no longer requires the PR from the engine.*

I've added the new [MonoTag.cs](Content.Client/UserInterface/RichText/MonoTag.cs) class into [Content.Client/UserInterface/RichText/](Content.Client/UserInterface/RichText/) and set [PaperWindow.xaml.cs](Content.Client/Paper/UI/PaperWindow.xaml.cs) to import it, also added it to the allowed tags list. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/79d89d5b-4922-49fa-9770-daddc647c88f

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Southbridge
- add: Paper documents now support the [mono] tag.

