### PR TITLE
Other colour of the binary channel

### DIFF
--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -67,7 +67,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
 
         var msg = Loc.GetString("laws-notify");
         var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", msg));
-        _chatManager.ChatMessageToOne(ChatChannel.Server, msg, wrappedMessage, default, false, actor.PlayerSession.Channel, colorOverride: Color.FromHex("#2ed2fd"));
+        _chatManager.ChatMessageToOne(ChatChannel.Server, msg, wrappedMessage, default, false, actor.PlayerSession.Channel, colorOverride: Color.FromHex("#5ed7aa"));
 
         if (!TryComp<SiliconLawProviderComponent>(uid, out var lawcomp))
             return;

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -69,7 +69,7 @@
   - type: CommunicationsConsole
     canShuttle: false
     title: comms-console-announcement-title-station-ai
-    color: "#2ed2fd"
+    color: "#5ed7aa"
   - type: ShowJobIcons
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -542,7 +542,7 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-ai
-    color: "#2ed2fd"
+    color: "#5ed7aa"
 
 - type: entity
   parent: DefaultStationBeaconAI

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -83,7 +83,7 @@
   name: chat-radio-binary
   keycode: 'b'
   frequency: 1001
-  color: "#2ed2fd"
+  color: "#608994"
   # long range since otherwise it'd defeat the point of a handheld radio independent of telecomms
   longRange: true
 

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -83,7 +83,7 @@
   name: chat-radio-binary
   keycode: 'b'
   frequency: 1001
-  color: "#608994"
+  color: "#5ed7aa"
   # long range since otherwise it'd defeat the point of a handheld radio independent of telecomms
   longRange: true
 


### PR DESCRIPTION
## About the PR
Changes the colour of the binary channel, making it visually different from the medical channel.

## Why / Balance
The binary and medecine channel have virtually the same colour, which is visually indistinguishable. This presents difficulties for AI, cyborg medics and sometimes syndicates. Now the binary channel will have a different tone of blue that will visually distinguish it from the others.

## Media
Before
![изображение](https://github.com/user-attachments/assets/0cc0f061-7053-4c13-ba86-53fe2865e813)
After
![изображение](https://github.com/user-attachments/assets/1213dd3e-4c5a-4b71-aff5-b4200e9513fa)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

:cl:

- tweak: Changes the colour of the Borg binary channel to a different shade of blue.
