### PR TITLE
Mild annoyance fixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -583,7 +583,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
@@ -883,7 +883,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 55
+        maxVol: 90
         reagents:
         - ReagentId: Nutriment
           Quantity: 44

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -710,7 +710,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 6
+        maxVol: 18
         reagents:
         - ReagentId: Protein
           Quantity: 9

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -518,7 +518,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 18
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
@@ -543,7 +543,7 @@
     - type: SolutionContainerManager
       solutions:
         food:
-          maxVol: 10
+          maxVol: 15
           reagents:
           - ReagentId: Nutriment
             Quantity: 8

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -144,7 +144,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 7
+        maxVol: 13
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
@@ -598,7 +598,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 18
+        maxVol: 20
         reagents:
         - ReagentId: Vitamin
           Quantity: 4

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -683,7 +683,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 40
         reagents:
         - ReagentId: Fiber
           Quantity: 40

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -108,7 +108,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
@@ -591,7 +591,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 30
         reagents:
         - ReagentId: Nutriment
           Quantity: 7
@@ -620,7 +620,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 1
@@ -646,7 +646,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
@@ -701,7 +701,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
@@ -727,7 +727,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
@@ -754,7 +754,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 30.5
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
@@ -1083,7 +1083,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 25
         reagents:
           - ReagentId: Nutriment
             Quantity: 15
@@ -1137,7 +1137,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 15
         reagents:
           - ReagentId: Nutriment
             Quantity: 1
@@ -1214,7 +1214,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
           - ReagentId: Nutriment
             Quantity: 6


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Increased the container size of all foods (that I could find, anyways) which had their reagents go over the container size.
Each container is at the nearest multiple of 5, with the exception of:

- Nettle soup, increased to 30.5 as it has .5 Histamine in it, this means that you wont end up with having .5 of the reagent you had spare. It's purely so it looks pretty.
- Super bite burger, it's a big burger, so it can hold a lot of flavouring reagents.
- Tofu, made it consistent with it's slices.
- Laughin' pea pod and Lemoon, made it exactly the amount because that's a thing that produce has. Presumably for mutagen or something, idk.

## Why / Balance
Some foods would have less food then they should have, and things like soups and salads which take bowls would actually  _spill_ when made.

## Technical details
Changed the max container size of a bunch of food items. Not sure if this will cause the universe to explode.

## Media
Do you want a screenshot of bungo curry? get it yourself 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

