### PR TITLE
Fix airlocks can't be closed without power.

### DIFF
--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -43,7 +43,7 @@ public abstract class SharedAirlockSystem : EntitySystem
 
         if (TryComp(uid, out DoorComponent? door)
             && !door.Partial
-            && !CanChangeState(uid, airlock))
+            && DoorSystem.IsBolted(uid))
         {
             args.Cancel();
         }

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -221,7 +221,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
     private void OnBeforePry(EntityUid uid, DoorComponent door, ref BeforePryEvent args)
     {
-        if (door.State == DoorState.Welded || !door.CanPry)
+        if (door.State == DoorState.Welded || !door.CanPry || GetColliding(uid).Any())
             args.Cancelled = true;
     }
 


### PR DESCRIPTION
## About the PR
Right now you can't close unpowered airlocks with crowbar or by hands. This PR fixes it.

## Why / Balance
It's a bug, I guess?

## Technical details
Ignore power state when handling airlock closing event.

I can't say for sure if it's good solution, but it works and I can't find any problematic interactions caused by this fix.

Tested with different airlocks configurations (locked, unpowered, bolted), all of them are working as intended.

## Media

https://github.com/user-attachments/assets/b11fbc54-f954-4dd5-85c3-439cc4db743c

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**

:cl: c4llv07e
- fix: Unpowered airlocks can be closed again!
