### PR TITLE
Hotfix: Fixed Closing Unpowered Airlocks

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -480,6 +480,8 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!Resolve(uid, ref door, ref physics))
             return false;
 
+        door.Partial = true;
+
         // Make sure no entity walked into the airlock when it started closing.
         if (!CanClose(uid, door))
         {
@@ -490,7 +492,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
             return false;
         }
 
-        door.Partial = true;
         SetCollidable(uid, true, door, physics);
         door.NextStateChange = GameTiming.CurTime + door.CloseTimeTwo;
         Dirty(uid, door);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Did a quick bisect, found that #33481 broke unpowered airlocks from being closed. I just reverted the part that broke it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Not being able to close airlocks is bad.

Alternative to #33843, as this one only tries to revert the change while that one changes the logic to make it work. I don't really know which is better.

## Technical details
<!-- Summary of code changes for easier review. -->

The CanClose check fails for unpowered airlocks as it tries to short circuit with `door.Partial`, and as it got moved after, it would be false and cancel the event, and thus fail to close the door.

https://github.com/space-wizards/space-station-14/blob/821ae95dd43ab1e0c18948db36dcce404312be2c/Content.Shared/Doors/Systems/SharedAirlockSystem.cs#L44-L46

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: Unpowered airlocks can now be pried closed again.