### PR TITLE
Add meat tag to Five Alarm Burger

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -578,9 +578,6 @@
     flavors:
       - meaty
       - spicy
-  - type: Tag
-    tags:
-    - Meat
   - type: Sprite
     state: fivealarm
   - type: SolutionContainerManager
@@ -596,6 +593,9 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 1
+  - type: Tag
+    tags:
+    - Meat
 
 # Tastes like bun, HEAT.
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -578,6 +578,9 @@
     flavors:
       - meaty
       - spicy
+  - type: Tag
+    tags:
+    - Meat
   - type: Sprite
     state: fivealarm
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -31,10 +31,10 @@
   id: FoodBreadBunBottom
   parent: FoodBreadSliceBase
   name: bottom bun
-  description: It's time to start building the burger tower. 
+  description: It's time to start building the burger tower.
   components:
   - type: Item
-    size: Normal #patch until there is an adequate resizing system in place 
+    size: Normal #patch until there is an adequate resizing system in place
   - type: Food
   - type: Sprite
     drawdepth: Mobs
@@ -83,7 +83,7 @@
   - type: FoodSequenceElement
     entries:
       Burger: BunTopBurger
-  
+
 # Base
 
 - type: entity
@@ -578,6 +578,9 @@
     flavors:
       - meaty
       - spicy
+  - type: Tag
+    tags:
+    - Meat
   - type: Sprite
     state: fivealarm
   - type: SolutionContainerManager
@@ -684,7 +687,7 @@
   description: An elusive rib shaped burger with limited availability across the galaxy. Not as good as you remember it.
   components:
   - type: Food
-    trash: 
+    trash:
     - FoodKebabSkewer
   - type: FlavorProfile
     flavors:
@@ -984,4 +987,4 @@
   - type: Tag
     tags:
     - Meat
-    
+

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -31,10 +31,10 @@
   id: FoodBreadBunBottom
   parent: FoodBreadSliceBase
   name: bottom bun
-  description: It's time to start building the burger tower.
+  description: It's time to start building the burger tower. 
   components:
   - type: Item
-    size: Normal #patch until there is an adequate resizing system in place
+    size: Normal #patch until there is an adequate resizing system in place 
   - type: Food
   - type: Sprite
     drawdepth: Mobs
@@ -83,7 +83,7 @@
   - type: FoodSequenceElement
     entries:
       Burger: BunTopBurger
-
+  
 # Base
 
 - type: entity
@@ -578,9 +578,6 @@
     flavors:
       - meaty
       - spicy
-  - type: Tag
-    tags:
-    - Meat
   - type: Sprite
     state: fivealarm
   - type: SolutionContainerManager
@@ -687,7 +684,7 @@
   description: An elusive rib shaped burger with limited availability across the galaxy. Not as good as you remember it.
   components:
   - type: Food
-    trash:
+    trash: 
     - FoodKebabSkewer
   - type: FlavorProfile
     flavors:
@@ -987,4 +984,4 @@
   - type: Tag
     tags:
     - Meat
-
+    


### PR DESCRIPTION
## About the PR
added the meat tag to the yml

## Why / Balance
Closes #33827.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Lizards can now eat the Five Alarm Burger!
