### PR TITLE
Block shuttle recall after high zombie percentage

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/ZombieRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/ZombieRuleComponent.cs
@@ -25,4 +25,21 @@ public sealed partial class ZombieRuleComponent : Component
     /// </summary>
     [DataField]
     public float ZombieShuttleCallPercentage = 0.7f;
+
+    /// <summary>
+    /// Is the automatical shuttle called.
+    /// </summary>
+    public bool? ZombieShuttleCalled;
+
+    /// <summary>
+    /// The reason when shuttle called.
+    /// </summary>
+    [DataField]
+    public string ShuttleCallReason = "zombie-shuttle-call";
+
+    /// <summary>
+    /// The reason why shuttle can be recalled after certain zombie percentage.
+    /// </summary>
+    [DataField]
+    public string ShuttleCallUnavailableReason = "zombie-shuttle-unavailable";
 }

--- a/Content.Server/GameTicking/Rules/Components/ZombieRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/ZombieRuleComponent.cs
@@ -29,7 +29,7 @@ public sealed partial class ZombieRuleComponent : Component
     /// <summary>
     /// Is the automatical shuttle called.
     /// </summary>
-    public bool? ZombieShuttleCalled;
+    public bool ZombieShuttleCalled = false;
 
     /// <summary>
     /// The reason when shuttle called.

--- a/Content.Server/GameTicking/Rules/Components/ZombieRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/ZombieRuleComponent.cs
@@ -35,11 +35,11 @@ public sealed partial class ZombieRuleComponent : Component
     /// The reason why the emergency shuttle is called.
     /// </summary>
     [DataField]
-    public string ShuttleCallReason = "zombie-shuttle-call";
+    public LocId ShuttleCallReason = "zombie-shuttle-call";
 
     /// <summary>
     /// The reason why the emergency shuttle cannot be recalled after certain a zombie percentage.
     /// </summary>
     [DataField]
-    public string ShuttleCallUnavailableReason = "zombie-shuttle-unavailable";
+    public LocId ShuttleCallUnavailableReason = "zombie-shuttle-unavailable";
 }

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -143,7 +143,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         {
             if (zombie is { ZombieShuttleCalled: false })
             {
-                if (zombie.ZombieShuttleCalled.Value)
+                if (zombie.ZombieShuttleCalled)
                 {
                     ev.Cancelled = true;
                     ev.Reason = Loc.GetString(zombie.ShuttleCallUnavailableReason);

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -134,7 +134,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
     }
 
     /// <summary>
-    ///     Doesn't let to recall the shuttle. No roundstalling
+    ///     Doesn't let the shuttle be recalled, stopping round-stalling.
     /// </summary>
     private void OnShuttleCallAttempt(ref CommunicationConsoleCallShuttleAttemptEvent ev)
     {

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -141,7 +141,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         var query = QueryActiveRules();
         while (query.MoveNext(out _, out _, out var zombie, out _))
         {
-            if (zombie is { ZombieShuttleCalled: not null })
+            if (zombie is { ZombieShuttleCalled: false })
             {
                 if (zombie.ZombieShuttleCalled.Value)
                 {

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -150,7 +150,6 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         }
     }
 
-
     protected override void Started(EntityUid uid, ZombieRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         base.Started(uid, component, gameRule, args);

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -141,17 +141,15 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         var query = QueryActiveRules();
         while (query.MoveNext(out _, out _, out var zombie, out _))
         {
-            if (zombie is { ZombieShuttleCalled: false })
-            {
-                if (zombie.ZombieShuttleCalled)
-                {
-                    ev.Cancelled = true;
-                    ev.Reason = Loc.GetString(zombie.ShuttleCallUnavailableReason);
-                    return;
-                }
-            }
+            if (!zombie.ZombieShuttleCalled)
+                continue;
+
+            ev.Cancelled = true;
+            ev.Reason = Loc.GetString(zombie.ShuttleCallUnavailableReason);
+            return;
         }
     }
+
 
     protected override void Started(EntityUid uid, ZombieRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Antag;
 using Content.Server.Chat.Systems;
+using Content.Server.Communications;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Popups;
 using Content.Server.Roles;
@@ -41,6 +42,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         SubscribeLocalEvent<InitialInfectedRoleComponent, GetBriefingEvent>(OnGetBriefing);
         SubscribeLocalEvent<ZombieRoleComponent, GetBriefingEvent>(OnGetBriefing);
         SubscribeLocalEvent<IncurableZombieComponent, ZombifySelfActionEvent>(OnZombifySelf);
+        SubscribeLocalEvent<CommunicationConsoleCallShuttleAttemptEvent>(OnShuttleCallAttempt);
     }
 
     private void OnGetBriefing(Entity<InitialInfectedRoleComponent> role, ref GetBriefingEvent args)
@@ -119,8 +121,9 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         {
             foreach (var station in _station.GetStations())
             {
-                _chat.DispatchStationAnnouncement(station, Loc.GetString("zombie-shuttle-call"), colorOverride: Color.Crimson);
+                _chat.DispatchStationAnnouncement(station, Loc.GetString(zombieRuleComponent.ShuttleCallReason), colorOverride: Color.Crimson);
             }
+            zombieRuleComponent.ZombieShuttleCalled = true;
             _roundEnd.RequestRoundEnd(null, false);
         }
 
@@ -128,6 +131,26 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         // when everyone gets on the shuttle.
         if (GetInfectedFraction() >= 1) // Oops, all zombies
             _roundEnd.EndRound();
+    }
+
+    /// <summary>
+    ///     Doesn't let to recall the shuttle. No roundstalling
+    /// </summary>
+    private void OnShuttleCallAttempt(ref CommunicationConsoleCallShuttleAttemptEvent ev)
+    {
+        var query = QueryActiveRules();
+        while (query.MoveNext(out _, out _, out var zombie, out _))
+        {
+            if (zombie is { ZombieShuttleCalled: not null })
+            {
+                if (zombie.ZombieShuttleCalled.Value)
+                {
+                    ev.Cancelled = true;
+                    ev.Reason = Loc.GetString(zombie.ShuttleCallUnavailableReason);
+                    return;
+                }
+            }
+        }
     }
 
     protected override void Started(EntityUid uid, ZombieRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-zombies.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-zombies.ftl
@@ -15,6 +15,7 @@ zombie-infection-underway = Your blood begins to thicken
 zombie-alone = You feel entirely alone.
 
 zombie-shuttle-call = We have detected that the undead have overtaken the station. Dispatching an emergency shuttle to collect remaining personnel.
+zombie-shuttle-unavailable = Shuttle unavailable due to high undead percentage.
 
 zombie-round-end-initial-count = {$initialCount ->
     [one] There was one initial infected:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
recalling shuttle is unavailable after it's been called automatically cause of high zombie percentage

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
less roundstalling

## Technical details
<!-- Summary of code changes for easier review. -->
loc strings moved to the component
added new method just a copy from NukeopsRuleSystem
new bool to check if shuttle has been called

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
couldn't reproduce, even when set shuttle call percentage to 0.1

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
no i suppose

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Automatic shuttle for high zombie percentage now cannot be recalled.