### PR TITLE
Added small candles to the birthday cake microwave recipe.

### DIFF
--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1474,6 +1474,7 @@
     Cream: 5
   solids:
     FoodCakePlain: 1
+    CandleSmall: 3
 
 - type: microwaveMealRecipe
   id: RecipeChocolateCake


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I changed the microwave recipe for birthday cake so that it now requires three small candles.

## Why / Balance
The birthday cake sprite pictures three lit candles but the recipe did not require candles. The recipe now matches the sprite as three small candles are required to complete the recipe.

## Technical details
I added CandleSmall: 3 to the solids section of the recipeBirthdayCake microwaveMealRecipe in meal_recipes.yml.

## Media
New recipe in action:
![MicrowaveRecipe](https://github.com/user-attachments/assets/3703f142-1671-43d6-a37a-449e3ef9a309)
It even lit the candles!
![ItsACake](https://github.com/user-attachments/assets/9f467919-936f-4ba1-9783-5e08f13541ce)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Birthday cake recipe now requires 3 small candles.
