### PR TITLE
Only disable panicbunker for admins with AdminFlags.Admin

### DIFF
--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -339,11 +339,13 @@ public sealed class AdminSystem : EntitySystem
     {
         var hasAdmins = false;
         foreach (var admin in _adminManager.AllAdmins)
+        {
             if (_adminManager.HasAdminFlag(admin, AdminFlags.Admin, includeDeAdmin: PanicBunker.CountDeadminnedAdmins))
             {
                 hasAdmins = true;
                 break;
             }
+        }
 
         // TODO Fix order dependent Cvars
         // Please for the sake of my sanity don't make cvars & order dependent.

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -337,10 +337,13 @@ public sealed class AdminSystem : EntitySystem
 
     private void UpdatePanicBunker()
     {
-        var admins = PanicBunker.CountDeadminnedAdmins
-            ? _adminManager.AllAdmins
-            : _adminManager.ActiveAdmins;
-        var hasAdmins = admins.Any();
+        var hasAdmins = false;
+        foreach (var admin in _adminManager.AllAdmins)
+            if (_adminManager.HasAdminFlag(admin, AdminFlags.Admin, includeDeAdmin: PanicBunker.CountDeadminnedAdmins))
+            {
+                hasAdmins = true;
+                break;
+            }
 
         // TODO Fix order dependent Cvars
         // Please for the sake of my sanity don't make cvars & order dependent.

--- a/Content.Shared/Administration/AdminData.cs
+++ b/Content.Shared/Administration/AdminData.cs
@@ -31,10 +31,11 @@ namespace Content.Shared.Administration
         ///     Checks whether this admin has an admin flag.
         /// </summary>
         /// <param name="flag">The flags to check. Multiple flags can be specified, they must all be held.</param>
+        /// <param name="includeDeAdmin">If true then also count flags even if the admin has de-adminned.</param>
         /// <returns>False if this admin is not <see cref="Active"/> or does not have all the flags specified.</returns>
-        public bool HasFlag(AdminFlags flag)
+        public bool HasFlag(AdminFlags flag, bool includeDeAdmin = false)
         {
-            return Active && (Flags & flag) == flag;
+            return (includeDeAdmin || Active) && (Flags & flag) == flag;
         }
 
         /// <summary>

--- a/Content.Shared/Administration/Managers/ISharedAdminManager.cs
+++ b/Content.Shared/Administration/Managers/ISharedAdminManager.cs
@@ -18,7 +18,7 @@ public interface ISharedAdminManager
     /// </param>
     /// <returns><see langword="null" /> if the player is not an admin.</returns>
     AdminData? GetAdminData(EntityUid uid, bool includeDeAdmin = false);
-    
+
     /// <summary>
     ///     Gets the admin data for a player, if they are an admin.
     /// </summary>
@@ -37,24 +37,30 @@ public interface ISharedAdminManager
     /// <remarks>
     ///     When used by the client, this only returns accurate results for the player's own entity.
     /// </remarks>
+    /// <param name="includeDeAdmin">
+    ///     Whether to check flags even for admins that are current de-adminned.
+    /// </param>
     /// <returns>True if the player is and admin and has the specified flags.</returns>
-    bool HasAdminFlag(EntityUid player, AdminFlags flag)
+    bool HasAdminFlag(EntityUid player, AdminFlags flag, bool includeDeAdmin = false)
     {
-        var data = GetAdminData(player);
-        return data != null && data.HasFlag(flag);
+        var data = GetAdminData(player, includeDeAdmin);
+        return data != null && data.HasFlag(flag, includeDeAdmin);
     }
-    
+
     /// <summary>
     ///     See if a player has an admin flag.
     /// </summary>
     /// <remarks>
     ///     When used by the client, this only returns accurate results for the player's own session.
     /// </remarks>
+    /// <param name="includeDeAdmin">
+    ///     Whether to check flags even for admins that are current de-adminned.
+    /// </param>
     /// <returns>True if the player is and admin and has the specified flags.</returns>
-    bool HasAdminFlag(ICommonSession player, AdminFlags flag)
+    bool HasAdminFlag(ICommonSession player, AdminFlags flag, bool includeDeAdmin = false)
     {
-        var data = GetAdminData(player);
-        return data != null && data.HasFlag(flag);
+        var data = GetAdminData(player, includeDeAdmin);
+        return data != null && data.HasFlag(flag, includeDeAdmin);
     }
 
     /// <summary>
@@ -71,7 +77,7 @@ public interface ISharedAdminManager
     {
         return GetAdminData(uid, includeDeAdmin) != null;
     }
-    
+
     /// <summary>
     ///     Checks if a player is an admin.
     /// </summary>

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -154,6 +154,7 @@ public sealed partial class CCVars
 
         /// <summary>
         ///     Whether or not the panic bunker will enable when no admins are online.
+        ///     This counts everyone with the 'Admin' AdminFlag.
         /// </summary>
         public static readonly CVarDef<bool> PanicBunkerEnableWithoutAdmins =
             CVarDef.Create("game.panic_bunker.enable_without_admins", false, CVar.SERVERONLY);


### PR DESCRIPTION
## About the PR
Some maintainers have debug permissions, but currently the auto disable function for the panic bunker does not check if someone is a proper admin, so it gets disabled when a maintainer joins.
Fixes #25260

## Technical details
`HasFlag` did not consider the flags if the admin was de-adminned, so I added the `includeDeAdmin` bool similar to the one other functions have.

I was only able to do limited testing since I was not able to figure out how to start a second client without Host permissions as a localhost. But when using breakpoints it seemed to work as intended.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
ADMIN:
- tweak: The panic bunker now only automatically disables when an admin with the 'Admin' permission is online instead of any permission.
