### PR TITLE
Fix admins not being able to health scan slimes

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -360,7 +360,7 @@ public abstract class SharedStorageSystem : EntitySystem
     /// <returns>true if inserted, false otherwise</returns>
     private void OnInteractUsing(EntityUid uid, StorageComponent storageComp, InteractUsingEvent args)
     {
-        if (args.Handled || !CanInteract(args.User, (uid, storageComp), storageComp.ClickInsert, false))
+        if (args.Handled || !storageComp.ClickInsert || !CanInteract(args.User, (uid, storageComp), silent: false))
             return;
 
         var attemptEv = new StorageInteractUsingAttemptEvent();
@@ -380,7 +380,7 @@ public abstract class SharedStorageSystem : EntitySystem
     /// </summary>
     private void OnActivate(EntityUid uid, StorageComponent storageComp, ActivateInWorldEvent args)
     {
-        if (args.Handled || !args.Complex || !CanInteract(args.User, (uid, storageComp), storageComp.ClickInsert))
+        if (args.Handled || !args.Complex || !storageComp.OpenOnActivate || !CanInteract(args.User, (uid, storageComp)))
             return;
 
         // Toggle

--- a/Content.Shared/Storage/StorageComponent.cs
+++ b/Content.Shared/Storage/StorageComponent.cs
@@ -65,8 +65,18 @@ namespace Content.Shared.Storage
         [DataField]
         public TimeSpan OpenUiCooldown = TimeSpan.Zero;
 
+        /// <summary>
+        /// Can insert stuff by clicking the storage entity with it.
+        /// </summary>
         [DataField]
-        public bool ClickInsert = true; // Can insert stuff by clicking the storage entity with it
+        public bool ClickInsert = true;
+
+        /// <summary>
+        /// Open the storage window when pressing E.
+        /// When false you can still open the inventory using verbs.
+        /// </summary>
+        [DataField]
+        public bool OpenOnActivate = true;
 
         /// <summary>
         /// How many entities area pickup can pickup at once.

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -15,6 +15,7 @@
   # they like eat it idk lol
   - type: Storage
     clickInsert: false
+    openOnActivate: false
     grid:
     - 0,0,1,2
     maxItemSize: Large


### PR DESCRIPTION
## About the PR
Fixes a major admin annoyance when trying health scan someone.
Fixes #30114 (the health scanner popup was already made silent for the admin pda)
Fixes #29412
Fixes #28300

## Why / Balance
\>be admin
\>try to use admin pda health analyzer on a slime
\>panic as it inserts into their storage instead

## Technical details
I changed the logic behind the `ClickInsert` storage setting to be no longer affected by the admin's `BypassInteractionChecksComponent` as this should only change *if* you can interact with something, not *how* you interact with it. Additionally I split up the `ClickInsert` datafield into a new `OpenOnActivate` datafield as the former was reused for opening the storage by pressing E for no reason.
Since slimes are the only entity that use `ClickInsert = false` this should have no further gameplay impact.

## Media

https://github.com/user-attachments/assets/8f22f523-a8bb-4b8a-8696-be613028fe4f

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`ClickInsert = false` no longer disables opening a storage by pressing E.
Use  `OpenOnActivate = false` instead.

**Changelog**
:cl:
ADMIN:
- fix: Health scanning a slime as an aghost will no longer insert the scanner into their inventory.
