### PR TITLE
Fix lag spike from stinger grenades

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ClusterGrenadeSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ClusterGrenadeSystem.cs
@@ -97,7 +97,7 @@ public sealed class ClusterGrenadeSystem : EntitySystem
                     switch (clug.GrenadeType)
                     {
                         case GrenadeType.Shoot:
-                            ShootProjectile(grenade, angle, clug, uid);
+                            ShootProjectile(grenade, angle, clug);
                             break;
                         case GrenadeType.Throw:
                             ThrowGrenade(grenade, angle, clug);
@@ -120,14 +120,14 @@ public sealed class ClusterGrenadeSystem : EntitySystem
         }
     }
 
-    private void ShootProjectile(EntityUid grenade, Angle angle, ClusterGrenadeComponent clug, EntityUid clugUid)
+    private void ShootProjectile(EntityUid grenade, Angle angle, ClusterGrenadeComponent clug)
     {
         var direction = angle.ToVec().Normalized();
 
         if (clug.RandomSpread)
             direction = _random.NextVector2().Normalized();
 
-        _gun.ShootProjectile(grenade, direction, Vector2.One.Normalized(), clugUid);
+        _gun.ShootProjectile(grenade, direction, Vector2.One.Normalized());
 
     }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -415,7 +415,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         EntityUid? user = null,
         bool throwItems = false);
 
-    public void ShootProjectile(EntityUid uid, Vector2 direction, Vector2 gunVelocity, EntityUid gunUid, EntityUid? user = null, float speed = 20f)
+    public void ShootProjectile(EntityUid uid, Vector2 direction, Vector2 gunVelocity, EntityUid? gunUid = null, EntityUid? user = null, float speed = 20f)
     {
         var physics = EnsureComp<PhysicsComponent>(uid);
         Physics.SetBodyStatus(uid, physics, BodyStatus.InAir);
@@ -426,7 +426,11 @@ public abstract partial class SharedGunSystem : EntitySystem
         Physics.SetLinearVelocity(uid, finalLinear, body: physics);
 
         var projectile = EnsureComp<ProjectileComponent>(uid);
-        Projectiles.SetShooter(uid, projectile, user ?? gunUid);
+        if (user != null)
+            Projectiles.SetShooter(uid, projectile, user.Value);
+        else if (gunUid != null)
+            Projectiles.SetShooter(uid, projectile, gunUid.Value);
+
         projectile.Weapon = gunUid;
 
         TransformSystem.SetWorldRotation(uid, direction.ToWorldAngle() + projectile.Angle);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`ClusterGrenadeComponent` - specifically the type that spawns bullets - currently causes a lag spike when it goes off. This is because every bullet tries and fails to reference the already deleted grenade. This PR stops the bullets from looking for the grenade.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Lag is bad.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed `ShootProjectile` in `SharedGunSystem` to make the parameter for gun source nullable.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Causes ugly admin logging, but previously there was no admin logging at all.
![image](https://github.com/user-attachments/assets/49bfa29a-d3dd-4458-88d3-3e167e1e8a94)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: aada
- fix: Stinger grenades no longer cause lag spikes.
