### PR TITLE
Fix space wind layer removal

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -90,10 +90,6 @@ namespace Content.Server.Atmos.EntitySystems
                     component.TableLayerRemoved.Add(id);
                     _physics.RemoveCollisionMask(uid, id, fixture, (int)CollisionGroup.TableLayer, manager: fixtures);
                 }
-                else
-                {
-                    component.TableLayerRemoved.Remove(id); // Ensure it is no longer marked as removed
-                }
             }
             // TODO: Make them dynamic type? Ehh but they still want movement so uhh make it non-predicted like weightless?
             // idk it's hard.

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -61,12 +61,11 @@ namespace Content.Server.Atmos.EntitySystems
                 {
                     foreach (var (id, fixture) in fixtures.Fixtures)
                     {
-                        if (component.TableLayerRemoved.TryGetValue(id, out var wasRemoved) && wasRemoved)
+                        if (component.TableLayerRemoved.Contains(id))
                         {
                             _physics.AddCollisionMask(uid, id, fixture, (int)CollisionGroup.TableLayer, manager: fixtures);
                         }
                     }
-
                 }
             }
 
@@ -85,21 +84,17 @@ namespace Content.Server.Atmos.EntitySystems
 
             foreach (var (id, fixture) in fixtures.Fixtures)
             {
-                // Mark fixtures that has TableLayer removed
+                // Mark fixtures that have TableLayer removed
                 if ((fixture.CollisionMask & (int)CollisionGroup.TableLayer) != 0)
-                    {
-                        component.TableLayerRemoved[id] = true;
-                        _physics.RemoveCollisionMask(uid, id, fixture, (int)CollisionGroup.TableLayer, manager: fixtures);
-                    }
+                {
+                    component.TableLayerRemoved.Add(id);
+                    _physics.RemoveCollisionMask(uid, id, fixture, (int)CollisionGroup.TableLayer, manager: fixtures);
+                }
                 else
-                    {
-                        if (!component.TableLayerRemoved.ContainsKey(id))
-                        {
-                            component.TableLayerRemoved[id] = false;
-                        }
-                    }
+                {
+                    component.TableLayerRemoved.Remove(id); // Ensure it is no longer marked as removed
+                }
             }
-
             // TODO: Make them dynamic type? Ehh but they still want movement so uhh make it non-predicted like weightless?
             // idk it's hard.
 

--- a/Content.Shared/Atmos/Components/MovedByPressureComponent.cs
+++ b/Content.Shared/Atmos/Components/MovedByPressureComponent.cs
@@ -27,5 +27,8 @@ public sealed partial class MovedByPressureComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite)]
     public int LastHighPressureMovementAirCycle { get; set; } = 0;
+
+    [DataField]
+    public Dictionary<string, bool> TableLayerRemoved = new();
 }
 

--- a/Content.Shared/Atmos/Components/MovedByPressureComponent.cs
+++ b/Content.Shared/Atmos/Components/MovedByPressureComponent.cs
@@ -28,6 +28,9 @@ public sealed partial class MovedByPressureComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     public int LastHighPressureMovementAirCycle { get; set; } = 0;
 
+    /// <summary>
+    /// Used to remember which fixtures we have to remove the table mask from and give it back accordingly
+    /// </summary>
     [DataField]
     public HashSet<string> TableLayerRemoved = new();
 }

--- a/Content.Shared/Atmos/Components/MovedByPressureComponent.cs
+++ b/Content.Shared/Atmos/Components/MovedByPressureComponent.cs
@@ -29,6 +29,6 @@ public sealed partial class MovedByPressureComponent : Component
     public int LastHighPressureMovementAirCycle { get; set; } = 0;
 
     [DataField]
-    public Dictionary<string, bool> TableLayerRemoved = new();
+    public HashSet<string> TableLayerRemoved = new();
 }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
fixes https://github.com/space-wizards/space-station-14/issues/31044
more in media and tech details

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bug

## Technical details
<!-- Summary of code changes for easier review. -->
now before we remove the table layer removed, we check if it even was in a fixture and write it down
and before adding it back we check if it was there before

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
what happens on the video:
- a human gets in a flow
- still can't pass through tables
- a mouse gets in a flow
- still can pass under tables

https://github.com/user-attachments/assets/210b2269-3078-45bf-8341-44a6eab1e8d6



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
no

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed breaking small mobs (e.g. mice) mask after getting into an air flow.
