### PR TITLE
Nerf stun baton

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -38,10 +38,10 @@
     angle: 60
     animation: WeaponArcSlash
   - type: StaminaDamageOnHit
-    damage: 35
+    damage: 25
     sound: /Audio/Weapons/egloves.ogg
   - type: StaminaDamageOnCollide
-    damage: 35
+    damage: 25
     sound: /Audio/Weapons/egloves.ogg
   - type: LandAtCursor # it deals stamina damage when thrown
   - type: Battery


### PR DESCRIPTION

## About the PR
Nerfed the security stun baton.
It now 4 hits stamcrit instead of 3 hit (you can no longer insta stun by throwing 2 batons after hitting once)

## Why / Balance
Stun meta is a little too strong right now so hopefully this will bring it on par with actual guns.
Tested in game and it seems pretty fair compared to what it used to be.

## Technical details
yaml change

## Media
not needed

## Requirements
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes


**Changelog**
:cl:
- tweak: Stun baton has been nerfed to do 25 stamina damage per hit.


