### PR TITLE
Wood walls from barricades

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -1106,13 +1106,14 @@
   parent: BaseWall
   id: WallWood
   name: wood wall
+  description: A wooden wall. Built by adding wood to a barricade.
   components:
   - type: Sprite
     sprite: Structures/Walls/wood.rsi
   - type: Icon
     sprite: Structures/Walls/wood.rsi
   - type: Construction
-    graph: Girder
+    graph: Barricade
     node: woodWall
   - type: Destructible
     thresholds:
@@ -1133,7 +1134,7 @@
         sound:
           collection: WoodDestroyHeavy
       - !type:ChangeConstructionNodeBehavior
-        node: girder
+        node: Barricade
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: IconSmooth

--- a/Resources/Prototypes/Entities/Structures/barricades.yml
+++ b/Resources/Prototypes/Entities/Structures/barricades.yml
@@ -73,6 +73,9 @@
   - type: Sprite
     sprite: Structures/barricades.rsi
     state: barricade
+  - type: Construction
+    graph: BarricadeCovering
+    node: barricadecover
 
 #Directional Barricade
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/barricades.yml
+++ b/Resources/Prototypes/Entities/Structures/barricades.yml
@@ -38,8 +38,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           MaterialWoodPlank1:
-            min: 2 # The construction graphs that use this all override this value on all trees so it's just a fallback
-            max: 2
+            min: 1
+            max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: AtmosExposed

--- a/Resources/Prototypes/Entities/Structures/barricades.yml
+++ b/Resources/Prototypes/Entities/Structures/barricades.yml
@@ -38,8 +38,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           MaterialWoodPlank1:
-            min: 3
-            max: 3
+            min: 2 # The construction graphs that use this all override this value on all trees so it's just a fallback
+            max: 2
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: AtmosExposed

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
@@ -72,3 +72,30 @@
           steps:
             - tool: Prying
               doAfter: 5
+
+- type: constructionGraph
+  id: BarricadeCovering
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: barricadecover
+          steps:
+            - material: WoodPlank
+              amount: 2
+              doAfter: 3
+    - node: barricadecover
+      entity: BarricadeCover
+      edges:
+        -to: start
+        completed:
+        - !type:SpawnPrototype
+          prototype: MaterialWoodPlank1
+          amount: 1 #returns 1 less as one breaks
+        - !type:DeleteEntity { }
+        conditions:
+        - !type:EntityAnchored
+          anchored: true
+        steps:
+        - tool: Prying
+          doAfter: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
@@ -87,15 +87,15 @@
     - node: barricadecover
       entity: BarricadeCover
       edges:
-        -to: start
-        completed:
-        - !type:SpawnPrototype
-          prototype: MaterialWoodPlank1
-          amount: 1 #returns 1 less as one breaks
-        - !type:DeleteEntity { }
-        conditions:
-        - !type:EntityAnchored
-          anchored: true
-        steps:
-        - tool: Prying
-          doAfter: 2
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: MaterialWoodPlank1
+              amount: 1 #returns 1 less as one breaks
+            - !type:DeleteEntity { }
+          conditions:
+            - !type:EntityAnchored
+              anchored: true
+          steps:
+            - tool: Prying
+              doAfter: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
@@ -91,7 +91,7 @@
           completed:
             - !type:SpawnPrototype
               prototype: MaterialWoodPlank1
-              amount: 1 #returns 1 less as one breaks
+              amount: 2 #returns 1 less as one breaks
             - !type:DeleteEntity { }
           conditions:
             - !type:EntityAnchored

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
@@ -26,17 +26,6 @@
           steps:
             - tool: Prying
               doAfter: 5
-          edges:
-            - to: WoodWall
-              completed:
-              - !type:SnapToGrid
-                southRotation: true
-              conditions:
-              - !type:EntityAnchored { }
-              steps:
-              - material: WoodPlank
-                amount: 2
-                doAfter: 2
         - to: woodWall
           completed:
             - !type:SnapToGrid

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
@@ -85,7 +85,7 @@
               amount: 2
               doAfter: 3
     - node: barricadecover
-      entity: BarricadeCover
+      entity: BarricadeBlock
       edges:
         - to: start
           completed:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
@@ -41,8 +41,6 @@
           completed:
             - !type:SnapToGrid
               southRotation: true
-          conditions:
-            - !type:EntityAnchored {}
           steps:
             - material: WoodPlank
               amount: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
@@ -26,6 +26,38 @@
           steps:
             - tool: Prying
               doAfter: 5
+          edges:
+            - to: WoodWall
+              completed:
+              - !type:SnapToGrid
+                southRotation: true
+              conditions:
+              - !type:EntityAnchored { }
+              steps:
+              - material: WoodPlank
+                amount: 2
+                doAfter: 2
+        - to: woodWall
+          completed:
+            - !type:SnapToGrid
+              southRotation: true
+          conditions:
+            - !type:EntityAnchored {}
+          steps:
+            - material: WoodPlank
+              amount: 2
+              doAfter: 2
+    - node: woodWall
+      entity: WallWood
+      edges:
+      - to: barricadefull
+        completed:
+        - !type:GivePrototype
+          prototype: MaterialWoodPlank1
+          amount: 2
+        steps:
+        - tool: Prying
+          doAfter: 10
 
 - type: constructionGraph
   id: BarricadeDirectional

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -51,17 +51,6 @@
               amount: 2
               doAfter: 1
 
-        - to: woodWall
-          completed:
-            - !type:SnapToGrid
-              southRotation: true
-          conditions:
-            - !type:EntityAnchored {}
-          steps:
-            - material: WoodPlank
-              amount: 2
-              doAfter: 2
-
         - to: uraniumWall
           completed:
             - !type:SnapToGrid
@@ -171,18 +160,6 @@
               amount: 2
           steps:
             - tool: Welding
-              doAfter: 10
-
-    - node: woodWall
-      entity: WallWood
-      edges:
-        - to: girder
-          completed:
-            - !type:GivePrototype
-              prototype: MaterialWoodPlank1
-              amount: 2
-          steps:
-            - tool: Prying
               doAfter: 10
 
     - node: uraniumWall

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -105,11 +105,11 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
-# here
+
 - type: construction
   name: wood wall
   id: WoodWall
-  graph: Girder
+  graph: Barricade
   startNode: start
   targetNode: woodWall
   category: construction-category-structures


### PR DESCRIPTION
## About the PR
Resolves #33866

## Why / Balance
Wooden walls should not have metal as part of their construction cost - SS13 creates a wood wall from a barricade, this change reflects that and allows for niche uses for wood when steel is unavailable.

## Technical details
Wood wall construction graph node moved to barricade construction graph and updated woodwall prototype to reflect this.

## Media
<img width="422" alt="woodwallchange" src="https://github.com/user-attachments/assets/aaf70b58-b438-46ad-8d19-8d0d8e1dafbd" />


## Requirements
- [ x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Wood walls no longer require girders and are built from barricades instead.