### PR TITLE
Box Power Rebalance + Holopads, Gas Pipe Sensors

### DIFF
--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -369,7 +369,7 @@ entities:
           version: 6
         -2,-5:
           ind: -2,-5
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAwAAAAADAwAAAAACAwAAAAABeQAAAAAAWQAAAAADWQAAAAACDgAAAAACDgAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAwAAAAADAwAAAAABAwAAAAABeQAAAAAAWQAAAAADeQAAAAAAeQAAAAAADgAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAwAAAAAAAwAAAAABAwAAAAAAeQAAAAAAWQAAAAAAWQAAAAACeQAAAAAADgAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAAAeQAAAAAAWQAAAAACWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAeQAAAAAAWQAAAAACWQAAAAAAWQAAAAACWQAAAAACWQAAAAABeQAAAAAAeQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAABWQAAAAACWQAAAAAAeQAAAAAAWQAAAAACWQAAAAACeQAAAAAAWQAAAAABWQAAAAADeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAWQAAAAADWQAAAAAAWQAAAAACWQAAAAABWQAAAAACHQAAAAAAWQAAAAACWQAAAAAAWQAAAAABWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAADHQAAAAACHQAAAAABHQAAAAAAHQAAAAACeQAAAAAAWQAAAAABWQAAAAADeQAAAAAAWQAAAAABWQAAAAADeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAAAHQAAAAACHQAAAAABHQAAAAADHQAAAAAAeQAAAAAAaQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABHQAAAAABHQAAAAABHQAAAAACHQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAHQAAAAADHQAAAAADHQAAAAABHQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADHQAAAAADHQAAAAACHQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAwAAAAADAwAAAAACAwAAAAABeQAAAAAAWQAAAAADWQAAAAACDgAAAAACDgAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAwAAAAADAwAAAAABAwAAAAABeQAAAAAAWQAAAAADeQAAAAAAeQAAAAAADgAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAwAAAAAAAwAAAAABAwAAAAAAeQAAAAAAWQAAAAAAWQAAAAACeQAAAAAADgAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAAAeQAAAAAAWQAAAAACWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAeQAAAAAAWQAAAAACWQAAAAAAWQAAAAACWQAAAAACWQAAAAABeQAAAAAAeQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAABWQAAAAACWQAAAAAAeQAAAAAAWQAAAAACWQAAAAACeQAAAAAAWQAAAAABWQAAAAADeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAWQAAAAADWQAAAAAAWQAAAAACWQAAAAABWQAAAAACHQAAAAAAWQAAAAACWQAAAAAAWQAAAAABWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAADHQAAAAACeQAAAAAAHQAAAAAAHQAAAAACeQAAAAAAWQAAAAABWQAAAAADeQAAAAAAWQAAAAABWQAAAAADeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAAAHQAAAAACeQAAAAAAHQAAAAADHQAAAAAAeQAAAAAAaQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABHQAAAAABeQAAAAAAHQAAAAACHQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAHQAAAAADHQAAAAADHQAAAAABHQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADHQAAAAADHQAAAAACHQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAA
           version: 6
         -3,-4:
           ind: -3,-4
@@ -558,11 +558,6 @@ entities:
           decals:
             3643: 60,-52
         - node:
-            color: '#FFFFFFFF'
-            id: ArrowsGreyscale
-          decals:
-            386: -25,-66
-        - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Bot
@@ -709,9 +704,6 @@ entities:
             color: '#FFFFFFFF'
             id: BotGreyscale
           decals:
-            383: -26,-69
-            384: -26,-68
-            385: -26,-67
             1060: -1,-22
             1061: -2,-21
             1062: -1,-20
@@ -743,7 +735,6 @@ entities:
             color: '#FFFFFFFF'
             id: BotLeftGreyscale
           decals:
-            381: -24,-67
             1058: 0,-20
             1059: -2,-22
         - node:
@@ -763,7 +754,6 @@ entities:
             color: '#FFFFFFFF'
             id: BotRightGreyscale
           decals:
-            382: -24,-69
             1056: 0,-22
             1057: -2,-20
         - node:
@@ -836,6 +826,11 @@ entities:
             3582: 0,36
             3583: 1,36
             3584: 2,36
+            4242: -27,-70
+            4246: -23,-70
+            4276: -26,-70
+            4277: -24,-70
+            4281: -25,-70
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineS
@@ -5409,6 +5404,7 @@ entities:
             2314: -73,-4
             3093: 13,-77
             3512: -13,-63
+            4264: -27,-70
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallNW
@@ -5423,6 +5419,7 @@ entities:
             2313: -76,-4
             3092: 17,-77
             3511: -11,-63
+            4263: -23,-70
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallSE
@@ -5433,6 +5430,7 @@ entities:
             2041: 22,-90
             2317: -73,8
             3091: 13,-75
+            4254: -27,-66
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallSW
@@ -5449,6 +5447,7 @@ entities:
             2316: -76,8
             3094: 17,-75
             3699: -38,-10
+            4259: -23,-66
         - node:
             color: '#FFFFFFFF'
             id: WarnEndGreyscaleN
@@ -5501,6 +5500,9 @@ entities:
             3089: 13,-76
             3510: -13,-62
             3514: 23,18
+            4251: -27,-67
+            4252: -27,-68
+            4253: -27,-69
         - node:
             color: '#334E6DC8'
             id: WarnLineGreyscaleE
@@ -5764,6 +5766,9 @@ entities:
             3086: 14,-75
             3087: 15,-75
             3088: 16,-75
+            4255: -26,-66
+            4258: -24,-66
+            4280: -25,-66
         - node:
             color: '#FFFFFFFF'
             id: WarnLineS
@@ -5830,6 +5835,9 @@ entities:
             3568: -11,35
             3569: -11,36
             3703: -38,-11
+            4260: -23,-67
+            4261: -23,-68
+            4262: -23,-69
         - node:
             color: '#FFFFFFFF'
             id: WarnLineW
@@ -5844,11 +5852,6 @@ entities:
             352: 0,38
             353: -1,38
             354: -2,38
-            376: -23,-70
-            377: -24,-70
-            378: -25,-70
-            379: -26,-70
-            380: -27,-70
             664: 74,-34
             665: 73,-34
             666: 72,-34
@@ -5915,6 +5918,9 @@ entities:
             3084: 15,-77
             3085: 16,-77
             3508: -12,-63
+            4278: -26,-70
+            4279: -24,-70
+            4282: -25,-70
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerNe
@@ -9312,8 +9318,8 @@ entities:
     - type: DeviceList
       devices:
       - 23261
-      - 23260
       - 22587
+      - 16789
   - uid: 22589
     components:
     - type: Transform
@@ -11917,7 +11923,7 @@ entities:
       pos: 24.5,16.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -28068.637
+      secondsUntilStateChange: -29187.068
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13684,6 +13690,11 @@ entities:
     - type: Transform
       pos: -23.5,-67.5
       parent: 8364
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 22588
   - uid: 22591
     components:
     - type: Transform
@@ -14140,7 +14151,12 @@ entities:
   - uid: 16349
     components:
     - type: Transform
-      pos: -12.447352,-72.425316
+      pos: -12.304632,-72.45412
+      parent: 8364
+  - uid: 18727
+    components:
+    - type: Transform
+      pos: -12.664007,-72.46974
       parent: 8364
 - proto: AnomalyScanner
   entities:
@@ -40275,7 +40291,7 @@ entities:
   - uid: 4819
     components:
     - type: Transform
-      pos: -23.5,-64.5
+      pos: -22.5,-66.5
       parent: 8364
   - uid: 4973
     components:
@@ -41070,22 +41086,17 @@ entities:
   - uid: 6316
     components:
     - type: Transform
-      pos: -25.5,-70.5
+      pos: -24.5,-69.5
       parent: 8364
   - uid: 6317
     components:
     - type: Transform
-      pos: -25.5,-68.5
-      parent: 8364
-  - uid: 6319
-    components:
-    - type: Transform
-      pos: -25.5,-67.5
+      pos: -25.5,-64.5
       parent: 8364
   - uid: 6321
     components:
     - type: Transform
-      pos: -25.5,-69.5
+      pos: -24.5,-68.5
       parent: 8364
   - uid: 6322
     components:
@@ -41095,7 +41106,7 @@ entities:
   - uid: 6323
     components:
     - type: Transform
-      pos: -25.5,-66.5
+      pos: -26.5,-66.5
       parent: 8364
   - uid: 6324
     components:
@@ -44570,7 +44581,7 @@ entities:
   - uid: 14368
     components:
     - type: Transform
-      pos: -23.5,-65.5
+      pos: -23.5,-66.5
       parent: 8364
   - uid: 14600
     components:
@@ -44620,7 +44631,7 @@ entities:
   - uid: 14925
     components:
     - type: Transform
-      pos: -24.5,-64.5
+      pos: -22.5,-67.5
       parent: 8364
   - uid: 15105
     components:
@@ -44977,6 +44988,56 @@ entities:
     - type: Transform
       pos: -6.5,-53.5
       parent: 8364
+  - uid: 16592
+    components:
+    - type: Transform
+      pos: -24.5,-66.5
+      parent: 8364
+  - uid: 16593
+    components:
+    - type: Transform
+      pos: -25.5,-66.5
+      parent: 8364
+  - uid: 16594
+    components:
+    - type: Transform
+      pos: -26.5,-68.5
+      parent: 8364
+  - uid: 16595
+    components:
+    - type: Transform
+      pos: -26.5,-67.5
+      parent: 8364
+  - uid: 16596
+    components:
+    - type: Transform
+      pos: -24.5,-67.5
+      parent: 8364
+  - uid: 16606
+    components:
+    - type: Transform
+      pos: -26.5,-64.5
+      parent: 8364
+  - uid: 16617
+    components:
+    - type: Transform
+      pos: -25.5,-67.5
+      parent: 8364
+  - uid: 16790
+    components:
+    - type: Transform
+      pos: -24.5,-64.5
+      parent: 8364
+  - uid: 16791
+    components:
+    - type: Transform
+      pos: -23.5,-64.5
+      parent: 8364
+  - uid: 16877
+    components:
+    - type: Transform
+      pos: -22.5,-64.5
+      parent: 8364
   - uid: 17006
     components:
     - type: Transform
@@ -44995,7 +45056,7 @@ entities:
   - uid: 17012
     components:
     - type: Transform
-      pos: -25.5,-64.5
+      pos: -23.5,-67.5
       parent: 8364
   - uid: 17014
     components:
@@ -45045,22 +45106,17 @@ entities:
   - uid: 17162
     components:
     - type: Transform
-      pos: -23.5,-66.5
+      pos: -23.5,-68.5
       parent: 8364
   - uid: 17163
     components:
     - type: Transform
-      pos: -23.5,-67.5
+      pos: -25.5,-68.5
       parent: 8364
   - uid: 17164
     components:
     - type: Transform
       pos: -22.5,-68.5
-      parent: 8364
-  - uid: 17165
-    components:
-    - type: Transform
-      pos: -23.5,-68.5
       parent: 8364
   - uid: 17167
     components:
@@ -45507,6 +45563,11 @@ entities:
     - type: Transform
       pos: 46.5,-38.5
       parent: 8364
+  - uid: 18596
+    components:
+    - type: Transform
+      pos: -22.5,-65.5
+      parent: 8364
   - uid: 18722
     components:
     - type: Transform
@@ -45516,6 +45577,11 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-56.5
+      parent: 8364
+  - uid: 18728
+    components:
+    - type: Transform
+      pos: -24.5,-71.5
       parent: 8364
   - uid: 18763
     components:
@@ -45581,26 +45647,6 @@ entities:
     components:
     - type: Transform
       pos: -26.5,-65.5
-      parent: 8364
-  - uid: 18979
-    components:
-    - type: Transform
-      pos: -26.5,-64.5
-      parent: 8364
-  - uid: 19017
-    components:
-    - type: Transform
-      pos: -24.5,-68.5
-      parent: 8364
-  - uid: 19018
-    components:
-    - type: Transform
-      pos: -24.5,-67.5
-      parent: 8364
-  - uid: 19019
-    components:
-    - type: Transform
-      pos: -24.5,-66.5
       parent: 8364
   - uid: 19053
     components:
@@ -57637,6 +57683,12 @@ entities:
       parent: 8364
 - proto: CableTerminal
   entities:
+  - uid: 6319
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-67.5
+      parent: 8364
   - uid: 15917
     components:
     - type: Transform
@@ -57649,29 +57701,41 @@ entities:
       rot: 3.141592653589793 rad
       pos: -6.5,-50.5
       parent: 8364
+  - uid: 16597
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-68.5
+      parent: 8364
+  - uid: 16598
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-67.5
+      parent: 8364
+  - uid: 16599
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -24.5,-66.5
+      parent: 8364
+  - uid: 16615
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-66.5
+      parent: 8364
+  - uid: 16616
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-68.5
+      parent: 8364
   - uid: 17346
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -49.5,23.5
-      parent: 8364
-  - uid: 19020
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-68.5
-      parent: 8364
-  - uid: 19021
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-67.5
-      parent: 8364
-  - uid: 19028
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-66.5
       parent: 8364
   - uid: 19131
     components:
@@ -62329,6 +62393,24 @@ entities:
     components:
     - type: Transform
       pos: 49.5,-24.5
+      parent: 8364
+  - uid: 19017
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-66.5
+      parent: 8364
+  - uid: 19018
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-67.5
+      parent: 8364
+  - uid: 19019
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-68.5
       parent: 8364
   - uid: 19189
     components:
@@ -70663,6 +70745,12 @@ entities:
     - type: Transform
       pos: -3.5,-4.5
       parent: 8364
+  - uid: 17165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-71.5
+      parent: 8364
   - uid: 17457
     components:
     - type: Transform
@@ -71308,6 +71396,11 @@ entities:
     components:
     - type: Transform
       pos: -11.5,-72.5
+      parent: 8364
+  - uid: 18724
+    components:
+    - type: Transform
+      pos: -10.5,-72.5
       parent: 8364
 - proto: CrateEngineeringCableBulk
   entities:
@@ -81923,13 +82016,6 @@ entities:
     - type: Transform
       pos: 74.3515,-18.443996
       parent: 8364
-- proto: DungeonMasterCircuitBoard
-  entities:
-  - uid: 27917
-    components:
-    - type: Transform
-      pos: 3.5477152,-12.389968
-      parent: 8364
 - proto: EmergencyLight
   entities:
   - uid: 20300
@@ -85124,7 +85210,7 @@ entities:
       pos: -34.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -22257.174
+      secondsUntilStateChange: -23375.605
       state: Closing
   - uid: 15010
     components:
@@ -85617,7 +85703,7 @@ entities:
       pos: -4.5,-71.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -14004.904
+      secondsUntilStateChange: -15123.337
       state: Closing
 - proto: Fireplace
   entities:
@@ -86742,6 +86828,13 @@ entities:
     - type: Transform
       pos: -37.41171,-48.284546
       parent: 8364
+- proto: GameMasterCircuitBoard
+  entities:
+  - uid: 27917
+    components:
+    - type: Transform
+      pos: 3.5477152,-12.389968
+      parent: 8364
 - proto: GasAnalyzer
   entities:
   - uid: 12259
@@ -86807,7 +86900,7 @@ entities:
       pos: 29.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
 - proto: GasMinerCarbonDioxide
   entities:
   - uid: 16807
@@ -87071,14 +87164,14 @@ entities:
       pos: -4.5,39.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 45
     components:
     - type: Transform
       pos: -4.5,37.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2004
     components:
     - type: Transform
@@ -87253,7 +87346,7 @@ entities:
       pos: -3.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5317
     components:
     - type: Transform
@@ -87261,7 +87354,7 @@ entities:
       pos: -3.5,-66.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5381
     components:
     - type: Transform
@@ -87269,7 +87362,7 @@ entities:
       pos: 52.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5389
     components:
     - type: Transform
@@ -87292,7 +87385,7 @@ entities:
       pos: 57.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5595
     components:
     - type: Transform
@@ -87331,7 +87424,7 @@ entities:
       pos: 69.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7228
     components:
     - type: Transform
@@ -87346,7 +87439,7 @@ entities:
       pos: -5.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7315
     components:
     - type: Transform
@@ -87361,7 +87454,7 @@ entities:
       pos: -4.5,41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8431
     components:
     - type: Transform
@@ -87392,7 +87485,7 @@ entities:
       pos: -18.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8971
     components:
     - type: Transform
@@ -87400,7 +87493,7 @@ entities:
       pos: -5.5,37.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8972
     components:
     - type: Transform
@@ -87408,7 +87501,7 @@ entities:
       pos: -5.5,39.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8975
     components:
     - type: Transform
@@ -87431,7 +87524,7 @@ entities:
       pos: -5.5,41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9094
     components:
     - type: Transform
@@ -87439,7 +87532,7 @@ entities:
       pos: -13.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9097
     components:
     - type: Transform
@@ -87586,7 +87679,7 @@ entities:
       pos: -1.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15367
     components:
     - type: Transform
@@ -87601,7 +87694,7 @@ entities:
       pos: 1.5,-47.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15880
     components:
     - type: Transform
@@ -87734,7 +87827,7 @@ entities:
       pos: 3.5,-63.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17095
     components:
     - type: Transform
@@ -87794,7 +87887,7 @@ entities:
       pos: 4.5,-63.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17203
     components:
     - type: Transform
@@ -87911,7 +88004,7 @@ entities:
       pos: 35.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18659
     components:
     - type: Transform
@@ -87919,7 +88012,7 @@ entities:
       pos: 28.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 19247
     components:
     - type: Transform
@@ -87948,7 +88041,7 @@ entities:
       pos: 58.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21770
     components:
     - type: Transform
@@ -87956,7 +88049,7 @@ entities:
       pos: -5.5,-63.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21809
     components:
     - type: Transform
@@ -88022,14 +88115,14 @@ entities:
       pos: 7.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23128
     components:
     - type: Transform
       pos: 8.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23129
     components:
     - type: Transform
@@ -88068,7 +88161,7 @@ entities:
       pos: 1.5,-65.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23150
     components:
     - type: Transform
@@ -88076,7 +88169,7 @@ entities:
       pos: 1.5,-66.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23329
     components:
     - type: Transform
@@ -88084,14 +88177,14 @@ entities:
       pos: -17.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23432
     components:
     - type: Transform
       pos: -54.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23433
     components:
     - type: Transform
@@ -88099,7 +88192,7 @@ entities:
       pos: -54.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23439
     components:
     - type: Transform
@@ -88107,21 +88200,21 @@ entities:
       pos: -64.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23447
     components:
     - type: Transform
       pos: -64.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23501
     components:
     - type: Transform
       pos: 14.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23567
     components:
     - type: Transform
@@ -88190,7 +88283,7 @@ entities:
       pos: -28.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23984
     components:
     - type: Transform
@@ -88205,7 +88298,7 @@ entities:
       pos: -28.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23986
     components:
     - type: Transform
@@ -88227,7 +88320,7 @@ entities:
       pos: -4.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24149
     components:
     - type: Transform
@@ -88235,14 +88328,14 @@ entities:
       pos: 3.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24151
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24152
     components:
     - type: Transform
@@ -88250,7 +88343,7 @@ entities:
       pos: -4.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24153
     components:
     - type: Transform
@@ -88288,7 +88381,7 @@ entities:
       pos: 8.5,14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24263
     components:
     - type: Transform
@@ -88302,7 +88395,7 @@ entities:
       pos: 20.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24379
     components:
     - type: Transform
@@ -88318,7 +88411,7 @@ entities:
       pos: 20.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24399
     components:
     - type: Transform
@@ -88341,7 +88434,7 @@ entities:
       pos: 22.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24438
     components:
     - type: Transform
@@ -88349,7 +88442,7 @@ entities:
       pos: 20.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24442
     components:
     - type: Transform
@@ -88372,7 +88465,7 @@ entities:
       pos: 29.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24477
     components:
     - type: Transform
@@ -88396,7 +88489,7 @@ entities:
       pos: 24.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24602
     components:
     - type: Transform
@@ -88404,7 +88497,7 @@ entities:
       pos: 24.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24603
     components:
     - type: Transform
@@ -88412,7 +88505,7 @@ entities:
       pos: 20.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24624
     components:
     - type: Transform
@@ -88452,7 +88545,7 @@ entities:
       pos: 40.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24639
     components:
     - type: Transform
@@ -88460,7 +88553,7 @@ entities:
       pos: 41.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24660
     components:
     - type: Transform
@@ -88476,7 +88569,7 @@ entities:
       pos: 40.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24723
     components:
     - type: Transform
@@ -88490,14 +88583,14 @@ entities:
       pos: 39.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24837
     components:
     - type: Transform
       pos: 46.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24854
     components:
     - type: Transform
@@ -88543,7 +88636,7 @@ entities:
       pos: 43.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24902
     components:
     - type: Transform
@@ -88567,14 +88660,14 @@ entities:
       pos: 47.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24960
     components:
     - type: Transform
       pos: 69.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24961
     components:
     - type: Transform
@@ -88588,7 +88681,7 @@ entities:
       pos: 74.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25066
     components:
     - type: Transform
@@ -88596,7 +88689,7 @@ entities:
       pos: 74.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25114
     components:
     - type: Transform
@@ -88611,7 +88704,7 @@ entities:
       pos: 66.5,-50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25200
     components:
     - type: Transform
@@ -88635,7 +88728,7 @@ entities:
       pos: -45.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25435
     components:
     - type: Transform
@@ -88643,7 +88736,7 @@ entities:
       pos: -10.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25436
     components:
     - type: Transform
@@ -88651,7 +88744,7 @@ entities:
       pos: -10.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25561
     components:
     - type: Transform
@@ -88675,7 +88768,7 @@ entities:
       pos: 3.5,28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25564
     components:
     - type: Transform
@@ -88683,7 +88776,7 @@ entities:
       pos: 3.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25600
     components:
     - type: Transform
@@ -88699,7 +88792,7 @@ entities:
       pos: -14.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25750
     components:
     - type: Transform
@@ -88714,7 +88807,7 @@ entities:
       pos: 14.5,38.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25808
     components:
     - type: Transform
@@ -88730,7 +88823,7 @@ entities:
       pos: 16.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25810
     components:
     - type: Transform
@@ -88738,7 +88831,7 @@ entities:
       pos: 16.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25811
     components:
     - type: Transform
@@ -88775,7 +88868,7 @@ entities:
       pos: 5.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 27180
     components:
     - type: Transform
@@ -88811,14 +88904,14 @@ entities:
       pos: -5.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8876
     components:
     - type: Transform
       pos: 2.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 20264
     components:
     - type: Transform
@@ -88844,7 +88937,7 @@ entities:
       pos: -1.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23118
     components:
     - type: Transform
@@ -88858,21 +88951,21 @@ entities:
       pos: -1.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23430
     components:
     - type: Transform
       pos: -64.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23452
     components:
     - type: Transform
       pos: -12.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23550
     components:
     - type: Transform
@@ -88900,14 +88993,14 @@ entities:
       pos: -25.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24346
     components:
     - type: Transform
       pos: 17.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24347
     components:
     - type: Transform
@@ -88921,7 +89014,7 @@ entities:
       pos: 26.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24571
     components:
     - type: Transform
@@ -88935,7 +89028,7 @@ entities:
       pos: 35.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24625
     components:
     - type: Transform
@@ -88949,7 +89042,7 @@ entities:
       pos: 26.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24708
     components:
     - type: Transform
@@ -88968,14 +89061,14 @@ entities:
       pos: 39.5,-39.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24780
     components:
     - type: Transform
       pos: 39.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24781
     components:
     - type: Transform
@@ -88989,7 +89082,7 @@ entities:
       pos: 43.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24867
     components:
     - type: Transform
@@ -89003,7 +89096,7 @@ entities:
       pos: 61.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25094
     components:
     - type: Transform
@@ -89024,14 +89117,14 @@ entities:
       pos: 66.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25187
     components:
     - type: Transform
       pos: 66.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25537
     components:
     - type: Transform
@@ -89045,7 +89138,7 @@ entities:
       pos: -4.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25576
     components:
     - type: Transform
@@ -89073,7 +89166,7 @@ entities:
       pos: 14.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26931
     components:
     - type: Transform
@@ -89098,7 +89191,7 @@ entities:
       pos: -4.5,36.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 42
     components:
     - type: Transform
@@ -89114,7 +89207,7 @@ entities:
       pos: -10.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 44
     components:
     - type: Transform
@@ -89122,7 +89215,7 @@ entities:
       pos: -8.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 46
     components:
     - type: Transform
@@ -89130,7 +89223,7 @@ entities:
       pos: -5.5,38.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 47
     components:
     - type: Transform
@@ -89206,7 +89299,7 @@ entities:
       pos: -2.5,-63.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1625
     components:
     - type: Transform
@@ -89244,7 +89337,7 @@ entities:
       pos: -4.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3771
     components:
     - type: Transform
@@ -89302,7 +89395,7 @@ entities:
       pos: -6.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3861
     components:
     - type: Transform
@@ -89342,7 +89435,7 @@ entities:
       pos: 4.5,-57.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3992
     components:
     - type: Transform
@@ -89350,7 +89443,7 @@ entities:
       pos: 8.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3994
     components:
     - type: Transform
@@ -89358,7 +89451,7 @@ entities:
       pos: 7.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3996
     components:
     - type: Transform
@@ -89412,7 +89505,7 @@ entities:
       pos: 10.5,-74.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4062
     components:
     - type: Transform
@@ -89568,7 +89661,7 @@ entities:
       pos: 3.5,-64.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4501
     components:
     - type: Transform
@@ -89808,7 +89901,7 @@ entities:
       pos: -5.5,50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5075
     components:
     - type: Transform
@@ -89816,7 +89909,7 @@ entities:
       pos: -4.5,50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5079
     components:
     - type: Transform
@@ -89868,14 +89961,14 @@ entities:
       pos: -5.5,-66.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5290
     components:
     - type: Transform
       pos: -5.5,-67.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5392
     components:
     - type: Transform
@@ -89891,7 +89984,7 @@ entities:
       pos: 55.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5394
     components:
     - type: Transform
@@ -89899,7 +89992,7 @@ entities:
       pos: 54.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5395
     components:
     - type: Transform
@@ -89976,7 +90069,7 @@ entities:
       pos: 0.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6251
     components:
     - type: Transform
@@ -89998,14 +90091,14 @@ entities:
       pos: -7.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7041
     components:
     - type: Transform
       pos: 69.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7056
     components:
     - type: Transform
@@ -90019,7 +90112,7 @@ entities:
       pos: 69.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7072
     components:
     - type: Transform
@@ -90034,7 +90127,7 @@ entities:
       pos: 70.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7086
     components:
     - type: Transform
@@ -90049,7 +90142,7 @@ entities:
       pos: 69.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7096
     components:
     - type: Transform
@@ -90065,14 +90158,14 @@ entities:
       pos: 71.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7114
     components:
     - type: Transform
       pos: 69.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7143
     components:
     - type: Transform
@@ -90087,7 +90180,7 @@ entities:
       pos: 72.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7164
     components:
     - type: Transform
@@ -90109,7 +90202,7 @@ entities:
       pos: 69.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7221
     components:
     - type: Transform
@@ -90130,7 +90223,7 @@ entities:
       pos: 69.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7278
     components:
     - type: Transform
@@ -90162,7 +90255,7 @@ entities:
       pos: -13.5,44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7298
     components:
     - type: Transform
@@ -90170,7 +90263,7 @@ entities:
       pos: -13.5,45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7299
     components:
     - type: Transform
@@ -90178,7 +90271,7 @@ entities:
       pos: -13.5,46.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7305
     components:
     - type: Transform
@@ -90186,7 +90279,7 @@ entities:
       pos: -11.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7310
     components:
     - type: Transform
@@ -90230,7 +90323,7 @@ entities:
       pos: -2.5,50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7321
     components:
     - type: Transform
@@ -90238,7 +90331,7 @@ entities:
       pos: -3.5,50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7322
     components:
     - type: Transform
@@ -90246,7 +90339,7 @@ entities:
       pos: -12.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7323
     components:
     - type: Transform
@@ -90254,7 +90347,7 @@ entities:
       pos: -9.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7325
     components:
     - type: Transform
@@ -90310,7 +90403,7 @@ entities:
       pos: 6.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8216
     components:
     - type: Transform
@@ -90356,7 +90449,7 @@ entities:
       pos: -12.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8912
     components:
     - type: Transform
@@ -90364,7 +90457,7 @@ entities:
       pos: -6.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8931
     components:
     - type: Transform
@@ -90372,7 +90465,7 @@ entities:
       pos: -8.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8932
     components:
     - type: Transform
@@ -90380,7 +90473,7 @@ entities:
       pos: -9.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8948
     components:
     - type: Transform
@@ -90404,7 +90497,7 @@ entities:
       pos: -14.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8967
     components:
     - type: Transform
@@ -90412,7 +90505,7 @@ entities:
       pos: -4.5,40.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8968
     components:
     - type: Transform
@@ -90420,7 +90513,7 @@ entities:
       pos: -5.5,42.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8977
     components:
     - type: Transform
@@ -90428,7 +90521,7 @@ entities:
       pos: -15.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8978
     components:
     - type: Transform
@@ -90436,7 +90529,7 @@ entities:
       pos: -16.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8985
     components:
     - type: Transform
@@ -90444,14 +90537,14 @@ entities:
       pos: -11.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8987
     components:
     - type: Transform
       pos: -6.5,44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8988
     components:
     - type: Transform
@@ -90459,7 +90552,7 @@ entities:
       pos: -17.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9000
     components:
     - type: Transform
@@ -90482,35 +90575,35 @@ entities:
       pos: -6.5,45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9065
     components:
     - type: Transform
       pos: -6.5,47.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9066
     components:
     - type: Transform
       pos: -6.5,46.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9067
     components:
     - type: Transform
       pos: -6.5,49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9068
     components:
     - type: Transform
       pos: -6.5,48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9087
     components:
     - type: Transform
@@ -90541,7 +90634,7 @@ entities:
       pos: -13.5,34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9106
     components:
     - type: Transform
@@ -90549,7 +90642,7 @@ entities:
       pos: -5.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9108
     components:
     - type: Transform
@@ -90557,7 +90650,7 @@ entities:
       pos: -7.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9187
     components:
     - type: Transform
@@ -91013,7 +91106,7 @@ entities:
       pos: -41.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13665
     components:
     - type: Transform
@@ -91052,7 +91145,7 @@ entities:
       pos: -41.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14232
     components:
     - type: Transform
@@ -91075,14 +91168,14 @@ entities:
       pos: -1.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15342
     components:
     - type: Transform
       pos: -1.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15345
     components:
     - type: Transform
@@ -91097,7 +91190,7 @@ entities:
       pos: 0.5,-47.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15510
     components:
     - type: Transform
@@ -91105,7 +91198,7 @@ entities:
       pos: 0.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15543
     components:
     - type: Transform
@@ -91374,7 +91467,7 @@ entities:
       pos: 5.5,-47.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16985
     components:
     - type: Transform
@@ -91429,7 +91522,7 @@ entities:
       pos: -9.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17021
     components:
     - type: Transform
@@ -91572,7 +91665,7 @@ entities:
       pos: 4.5,-65.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17115
     components:
     - type: Transform
@@ -91580,7 +91673,7 @@ entities:
       pos: 4.5,-62.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17120
     components:
     - type: Transform
@@ -91588,7 +91681,7 @@ entities:
       pos: 4.5,-59.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17121
     components:
     - type: Transform
@@ -91596,7 +91689,7 @@ entities:
       pos: 4.5,-58.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17126
     components:
     - type: Transform
@@ -91713,7 +91806,7 @@ entities:
       pos: -8.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17166
     components:
     - type: Transform
@@ -92036,7 +92129,7 @@ entities:
       pos: -0.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17333
     components:
     - type: Transform
@@ -92083,7 +92176,7 @@ entities:
       pos: -10.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17521
     components:
     - type: Transform
@@ -92091,7 +92184,7 @@ entities:
       pos: 5.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17523
     components:
     - type: Transform
@@ -92115,7 +92208,7 @@ entities:
       pos: 5.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17564
     components:
     - type: Transform
@@ -92146,7 +92239,7 @@ entities:
       pos: 5.5,-46.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17595
     components:
     - type: Transform
@@ -92161,7 +92254,7 @@ entities:
       pos: 5.5,-65.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17601
     components:
     - type: Transform
@@ -92169,7 +92262,7 @@ entities:
       pos: 9.5,-74.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17633
     components:
     - type: Transform
@@ -92177,7 +92270,7 @@ entities:
       pos: 4.5,-60.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17654
     components:
     - type: Transform
@@ -92256,7 +92349,7 @@ entities:
       pos: -3.5,-67.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18660
     components:
     - type: Transform
@@ -92357,7 +92450,7 @@ entities:
       pos: -69.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 20153
     components:
     - type: Transform
@@ -92372,7 +92465,7 @@ entities:
       pos: -68.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 20213
     components:
     - type: Transform
@@ -92380,7 +92473,7 @@ entities:
       pos: -70.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21382
     components:
     - type: Transform
@@ -92814,7 +92907,7 @@ entities:
       pos: -3.5,-63.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22850
     components:
     - type: Transform
@@ -92884,7 +92977,7 @@ entities:
       pos: 4.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22982
     components:
     - type: Transform
@@ -92892,7 +92985,7 @@ entities:
       pos: 3.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22983
     components:
     - type: Transform
@@ -92900,7 +92993,7 @@ entities:
       pos: 2.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22984
     components:
     - type: Transform
@@ -92908,14 +93001,14 @@ entities:
       pos: 1.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22992
     components:
     - type: Transform
       pos: 5.5,-51.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22999
     components:
     - type: Transform
@@ -92930,7 +93023,7 @@ entities:
       pos: 6.5,-52.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23003
     components:
     - type: Transform
@@ -92938,7 +93031,7 @@ entities:
       pos: 7.5,-52.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23004
     components:
     - type: Transform
@@ -92984,21 +93077,21 @@ entities:
       pos: 5.5,-53.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23015
     components:
     - type: Transform
       pos: 5.5,-54.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23016
     components:
     - type: Transform
       pos: 5.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23018
     components:
     - type: Transform
@@ -93022,7 +93115,7 @@ entities:
       pos: 3.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23022
     components:
     - type: Transform
@@ -93030,7 +93123,7 @@ entities:
       pos: 2.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23023
     components:
     - type: Transform
@@ -93046,7 +93139,7 @@ entities:
       pos: 1.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23025
     components:
     - type: Transform
@@ -93062,7 +93155,7 @@ entities:
       pos: 0.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23029
     components:
     - type: Transform
@@ -93070,35 +93163,35 @@ entities:
       pos: -0.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23030
     components:
     - type: Transform
       pos: -1.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23031
     components:
     - type: Transform
       pos: -1.5,-54.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23032
     components:
     - type: Transform
       pos: -1.5,-53.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23033
     components:
     - type: Transform
       pos: -1.5,-52.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23034
     components:
     - type: Transform
@@ -93133,7 +93226,7 @@ entities:
       pos: -1.5,-51.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23039
     components:
     - type: Transform
@@ -93161,21 +93254,21 @@ entities:
       pos: -1.5,-50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23045
     components:
     - type: Transform
       pos: -1.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23047
     components:
     - type: Transform
       pos: -1.5,-46.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23049
     components:
     - type: Transform
@@ -93197,7 +93290,7 @@ entities:
       pos: 0.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23053
     components:
     - type: Transform
@@ -93205,7 +93298,7 @@ entities:
       pos: -0.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23054
     components:
     - type: Transform
@@ -93213,7 +93306,7 @@ entities:
       pos: -1.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23057
     components:
     - type: Transform
@@ -93221,7 +93314,7 @@ entities:
       pos: -2.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23058
     components:
     - type: Transform
@@ -93229,7 +93322,7 @@ entities:
       pos: -3.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23059
     components:
     - type: Transform
@@ -93237,7 +93330,7 @@ entities:
       pos: -4.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23061
     components:
     - type: Transform
@@ -93293,14 +93386,14 @@ entities:
       pos: -6.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23073
     components:
     - type: Transform
       pos: -5.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23074
     components:
     - type: Transform
@@ -93328,21 +93421,21 @@ entities:
       pos: -5.5,-54.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23078
     components:
     - type: Transform
       pos: -5.5,-53.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23079
     components:
     - type: Transform
       pos: -5.5,-52.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23080
     components:
     - type: Transform
@@ -93358,7 +93451,7 @@ entities:
       pos: -8.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23082
     components:
     - type: Transform
@@ -93366,7 +93459,7 @@ entities:
       pos: -9.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23083
     components:
     - type: Transform
@@ -93390,7 +93483,7 @@ entities:
       pos: -10.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23092
     components:
     - type: Transform
@@ -93473,7 +93566,7 @@ entities:
       pos: -10.5,-64.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23114
     components:
     - type: Transform
@@ -93497,7 +93590,7 @@ entities:
       pos: -9.5,-64.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23122
     components:
     - type: Transform
@@ -93521,35 +93614,35 @@ entities:
       pos: 6.5,-65.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23125
     components:
     - type: Transform
       pos: 7.5,-66.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23126
     components:
     - type: Transform
       pos: 7.5,-67.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23131
     components:
     - type: Transform
       pos: 8.5,-69.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23132
     components:
     - type: Transform
       pos: 8.5,-70.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23134
     components:
     - type: Transform
@@ -93571,7 +93664,7 @@ entities:
       pos: -8.5,-64.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23137
     components:
     - type: Transform
@@ -93579,7 +93672,7 @@ entities:
       pos: -7.5,-64.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23139
     components:
     - type: Transform
@@ -93603,7 +93696,7 @@ entities:
       pos: -11.5,-64.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23145
     components:
     - type: Transform
@@ -93619,7 +93712,7 @@ entities:
       pos: 2.5,-65.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23154
     components:
     - type: Transform
@@ -93635,7 +93728,7 @@ entities:
       pos: 8.5,-71.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23156
     components:
     - type: Transform
@@ -93659,7 +93752,7 @@ entities:
       pos: 8.5,-72.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23159
     components:
     - type: Transform
@@ -93667,7 +93760,7 @@ entities:
       pos: 8.5,-73.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23162
     components:
     - type: Transform
@@ -93675,7 +93768,7 @@ entities:
       pos: 7.5,-74.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23163
     components:
     - type: Transform
@@ -93683,7 +93776,7 @@ entities:
       pos: 6.5,-74.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23164
     components:
     - type: Transform
@@ -93691,7 +93784,7 @@ entities:
       pos: 5.5,-74.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23165
     components:
     - type: Transform
@@ -93699,7 +93792,7 @@ entities:
       pos: 4.5,-74.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23166
     components:
     - type: Transform
@@ -93767,7 +93860,7 @@ entities:
       pos: -0.5,-66.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23187
     components:
     - type: Transform
@@ -93775,7 +93868,7 @@ entities:
       pos: -1.5,-66.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23188
     components:
     - type: Transform
@@ -93783,7 +93876,7 @@ entities:
       pos: -2.5,-66.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23189
     components:
     - type: Transform
@@ -93839,7 +93932,7 @@ entities:
       pos: -5.5,-65.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23198
     components:
     - type: Transform
@@ -93901,7 +93994,7 @@ entities:
       pos: -11.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23217
     components:
     - type: Transform
@@ -93909,7 +94002,7 @@ entities:
       pos: -12.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23218
     components:
     - type: Transform
@@ -93925,7 +94018,7 @@ entities:
       pos: 5.5,-50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23240
     components:
     - type: Transform
@@ -93941,7 +94034,7 @@ entities:
       pos: -14.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23243
     components:
     - type: Transform
@@ -93949,7 +94042,7 @@ entities:
       pos: -15.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23244
     components:
     - type: Transform
@@ -93957,7 +94050,7 @@ entities:
       pos: -16.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23245
     components:
     - type: Transform
@@ -93965,7 +94058,7 @@ entities:
       pos: -17.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23246
     components:
     - type: Transform
@@ -93973,7 +94066,7 @@ entities:
       pos: -18.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23247
     components:
     - type: Transform
@@ -93981,7 +94074,7 @@ entities:
       pos: -19.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23248
     components:
     - type: Transform
@@ -93989,7 +94082,7 @@ entities:
       pos: -20.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23249
     components:
     - type: Transform
@@ -93997,15 +94090,7 @@ entities:
       pos: -21.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 23250
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,-68.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23251
     components:
     - type: Transform
@@ -94117,7 +94202,7 @@ entities:
       pos: -2.5,-43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23277
     components:
     - type: Transform
@@ -94125,42 +94210,42 @@ entities:
       pos: -3.5,-43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23282
     components:
     - type: Transform
       pos: -1.5,-42.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23283
     components:
     - type: Transform
       pos: -1.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23284
     components:
     - type: Transform
       pos: -1.5,-40.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23285
     components:
     - type: Transform
       pos: -1.5,-39.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23287
     components:
     - type: Transform
       pos: -1.5,-37.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23288
     components:
     - type: Transform
@@ -94203,7 +94288,7 @@ entities:
       pos: -2.5,-36.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23297
     components:
     - type: Transform
@@ -94211,7 +94296,7 @@ entities:
       pos: -3.5,-36.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23298
     components:
     - type: Transform
@@ -94251,7 +94336,7 @@ entities:
       pos: -1.5,-35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23307
     components:
     - type: Transform
@@ -94259,7 +94344,7 @@ entities:
       pos: -1.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23308
     components:
     - type: Transform
@@ -94283,7 +94368,7 @@ entities:
       pos: -1.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23311
     components:
     - type: Transform
@@ -94291,7 +94376,7 @@ entities:
       pos: -1.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23312
     components:
     - type: Transform
@@ -94307,7 +94392,7 @@ entities:
       pos: -2.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23315
     components:
     - type: Transform
@@ -94315,7 +94400,7 @@ entities:
       pos: -3.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23316
     components:
     - type: Transform
@@ -94323,7 +94408,7 @@ entities:
       pos: -5.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23317
     components:
     - type: Transform
@@ -94331,7 +94416,7 @@ entities:
       pos: -4.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23318
     components:
     - type: Transform
@@ -94339,7 +94424,7 @@ entities:
       pos: -6.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23319
     components:
     - type: Transform
@@ -94347,7 +94432,7 @@ entities:
       pos: -7.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23321
     components:
     - type: Transform
@@ -94355,7 +94440,7 @@ entities:
       pos: -9.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23322
     components:
     - type: Transform
@@ -94363,7 +94448,7 @@ entities:
       pos: -10.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23323
     components:
     - type: Transform
@@ -94371,7 +94456,7 @@ entities:
       pos: -11.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23325
     components:
     - type: Transform
@@ -94379,7 +94464,7 @@ entities:
       pos: -13.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23326
     components:
     - type: Transform
@@ -94387,7 +94472,7 @@ entities:
       pos: -14.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23327
     components:
     - type: Transform
@@ -94395,7 +94480,7 @@ entities:
       pos: -15.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23328
     components:
     - type: Transform
@@ -94403,7 +94488,7 @@ entities:
       pos: -16.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23330
     components:
     - type: Transform
@@ -94411,7 +94496,7 @@ entities:
       pos: -17.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23331
     components:
     - type: Transform
@@ -94419,7 +94504,7 @@ entities:
       pos: -17.5,-29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23332
     components:
     - type: Transform
@@ -94427,7 +94512,7 @@ entities:
       pos: -17.5,-28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23333
     components:
     - type: Transform
@@ -94435,7 +94520,7 @@ entities:
       pos: -17.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23334
     components:
     - type: Transform
@@ -94443,7 +94528,7 @@ entities:
       pos: -17.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23337
     components:
     - type: Transform
@@ -94451,7 +94536,7 @@ entities:
       pos: -17.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23339
     components:
     - type: Transform
@@ -94459,7 +94544,7 @@ entities:
       pos: -17.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23340
     components:
     - type: Transform
@@ -94467,7 +94552,7 @@ entities:
       pos: -17.5,-20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23341
     components:
     - type: Transform
@@ -94475,7 +94560,7 @@ entities:
       pos: -17.5,-19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23342
     components:
     - type: Transform
@@ -94483,7 +94568,7 @@ entities:
       pos: -17.5,-18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23343
     components:
     - type: Transform
@@ -94491,7 +94576,7 @@ entities:
       pos: -17.5,-17.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23344
     components:
     - type: Transform
@@ -94499,7 +94584,7 @@ entities:
       pos: -17.5,-16.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23346
     components:
     - type: Transform
@@ -94507,7 +94592,7 @@ entities:
       pos: -17.5,-14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23347
     components:
     - type: Transform
@@ -94515,7 +94600,7 @@ entities:
       pos: -17.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23349
     components:
     - type: Transform
@@ -94523,7 +94608,7 @@ entities:
       pos: -17.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23350
     components:
     - type: Transform
@@ -94531,7 +94616,7 @@ entities:
       pos: -17.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23351
     components:
     - type: Transform
@@ -94539,7 +94624,7 @@ entities:
       pos: -17.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23352
     components:
     - type: Transform
@@ -94547,7 +94632,7 @@ entities:
       pos: -17.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23355
     components:
     - type: Transform
@@ -94555,7 +94640,7 @@ entities:
       pos: -17.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23356
     components:
     - type: Transform
@@ -94563,7 +94648,7 @@ entities:
       pos: -17.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23357
     components:
     - type: Transform
@@ -94571,7 +94656,7 @@ entities:
       pos: -17.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23358
     components:
     - type: Transform
@@ -94579,7 +94664,7 @@ entities:
       pos: -17.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23359
     components:
     - type: Transform
@@ -94587,7 +94672,7 @@ entities:
       pos: -17.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23361
     components:
     - type: Transform
@@ -94595,7 +94680,7 @@ entities:
       pos: -18.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23362
     components:
     - type: Transform
@@ -94603,7 +94688,7 @@ entities:
       pos: -19.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23363
     components:
     - type: Transform
@@ -94611,7 +94696,7 @@ entities:
       pos: -20.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23364
     components:
     - type: Transform
@@ -94619,7 +94704,7 @@ entities:
       pos: -21.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23367
     components:
     - type: Transform
@@ -94627,7 +94712,7 @@ entities:
       pos: -24.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23368
     components:
     - type: Transform
@@ -94635,7 +94720,7 @@ entities:
       pos: -25.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23370
     components:
     - type: Transform
@@ -94643,7 +94728,7 @@ entities:
       pos: -27.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23371
     components:
     - type: Transform
@@ -94651,7 +94736,7 @@ entities:
       pos: -28.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23372
     components:
     - type: Transform
@@ -94659,7 +94744,7 @@ entities:
       pos: -29.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23373
     components:
     - type: Transform
@@ -94667,7 +94752,7 @@ entities:
       pos: -30.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23376
     components:
     - type: Transform
@@ -94675,7 +94760,7 @@ entities:
       pos: -33.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23377
     components:
     - type: Transform
@@ -94683,7 +94768,7 @@ entities:
       pos: -34.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23378
     components:
     - type: Transform
@@ -94691,7 +94776,7 @@ entities:
       pos: -35.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23379
     components:
     - type: Transform
@@ -94699,7 +94784,7 @@ entities:
       pos: -36.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23380
     components:
     - type: Transform
@@ -94707,7 +94792,7 @@ entities:
       pos: -37.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23381
     components:
     - type: Transform
@@ -94715,7 +94800,7 @@ entities:
       pos: -38.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23382
     components:
     - type: Transform
@@ -94723,7 +94808,7 @@ entities:
       pos: -39.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23383
     components:
     - type: Transform
@@ -94731,7 +94816,7 @@ entities:
       pos: -40.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23385
     components:
     - type: Transform
@@ -94739,7 +94824,7 @@ entities:
       pos: -42.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23387
     components:
     - type: Transform
@@ -94747,7 +94832,7 @@ entities:
       pos: -44.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23389
     components:
     - type: Transform
@@ -94755,7 +94840,7 @@ entities:
       pos: -46.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23390
     components:
     - type: Transform
@@ -94763,7 +94848,7 @@ entities:
       pos: -47.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23391
     components:
     - type: Transform
@@ -94771,7 +94856,7 @@ entities:
       pos: -48.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23392
     components:
     - type: Transform
@@ -94779,7 +94864,7 @@ entities:
       pos: -49.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23394
     components:
     - type: Transform
@@ -94787,7 +94872,7 @@ entities:
       pos: -51.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23395
     components:
     - type: Transform
@@ -94795,7 +94880,7 @@ entities:
       pos: -52.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23397
     components:
     - type: Transform
@@ -94803,7 +94888,7 @@ entities:
       pos: -53.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23398
     components:
     - type: Transform
@@ -94811,7 +94896,7 @@ entities:
       pos: -55.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23399
     components:
     - type: Transform
@@ -94819,42 +94904,42 @@ entities:
       pos: -55.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23400
     components:
     - type: Transform
       pos: -54.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23401
     components:
     - type: Transform
       pos: -54.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23402
     components:
     - type: Transform
       pos: -54.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23403
     components:
     - type: Transform
       pos: -54.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23404
     components:
     - type: Transform
       pos: -54.5,0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23405
     components:
     - type: Transform
@@ -94862,7 +94947,7 @@ entities:
       pos: -56.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23408
     components:
     - type: Transform
@@ -94870,7 +94955,7 @@ entities:
       pos: -59.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23409
     components:
     - type: Transform
@@ -94878,7 +94963,7 @@ entities:
       pos: -61.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23410
     components:
     - type: Transform
@@ -94886,7 +94971,7 @@ entities:
       pos: -60.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23411
     components:
     - type: Transform
@@ -94894,7 +94979,7 @@ entities:
       pos: -62.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23412
     components:
     - type: Transform
@@ -94902,7 +94987,7 @@ entities:
       pos: -63.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23413
     components:
     - type: Transform
@@ -94910,7 +94995,7 @@ entities:
       pos: -56.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23414
     components:
     - type: Transform
@@ -94918,7 +95003,7 @@ entities:
       pos: -57.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23416
     components:
     - type: Transform
@@ -94926,7 +95011,7 @@ entities:
       pos: -59.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23417
     components:
     - type: Transform
@@ -94934,7 +95019,7 @@ entities:
       pos: -60.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23418
     components:
     - type: Transform
@@ -94942,7 +95027,7 @@ entities:
       pos: -61.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23419
     components:
     - type: Transform
@@ -94950,7 +95035,7 @@ entities:
       pos: -62.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23420
     components:
     - type: Transform
@@ -94958,7 +95043,7 @@ entities:
       pos: -63.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23421
     components:
     - type: Transform
@@ -94966,7 +95051,7 @@ entities:
       pos: -64.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23422
     components:
     - type: Transform
@@ -94974,7 +95059,7 @@ entities:
       pos: -64.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23424
     components:
     - type: Transform
@@ -94982,7 +95067,7 @@ entities:
       pos: -64.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23425
     components:
     - type: Transform
@@ -94990,7 +95075,7 @@ entities:
       pos: -64.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23426
     components:
     - type: Transform
@@ -94998,7 +95083,7 @@ entities:
       pos: -64.5,0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23427
     components:
     - type: Transform
@@ -95006,7 +95091,7 @@ entities:
       pos: -64.5,2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23428
     components:
     - type: Transform
@@ -95014,7 +95099,7 @@ entities:
       pos: -64.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23429
     components:
     - type: Transform
@@ -95022,7 +95107,7 @@ entities:
       pos: -64.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23434
     components:
     - type: Transform
@@ -95030,7 +95115,7 @@ entities:
       pos: -64.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23436
     components:
     - type: Transform
@@ -95038,7 +95123,7 @@ entities:
       pos: -64.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23437
     components:
     - type: Transform
@@ -95046,7 +95131,7 @@ entities:
       pos: -64.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23438
     components:
     - type: Transform
@@ -95054,7 +95139,7 @@ entities:
       pos: -64.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23440
     components:
     - type: Transform
@@ -95062,7 +95147,7 @@ entities:
       pos: -64.5,3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23441
     components:
     - type: Transform
@@ -95070,7 +95155,7 @@ entities:
       pos: -64.5,4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23442
     components:
     - type: Transform
@@ -95078,7 +95163,7 @@ entities:
       pos: -64.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23443
     components:
     - type: Transform
@@ -95086,7 +95171,7 @@ entities:
       pos: -64.5,6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23444
     components:
     - type: Transform
@@ -95094,7 +95179,7 @@ entities:
       pos: -64.5,7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23445
     components:
     - type: Transform
@@ -95102,7 +95187,7 @@ entities:
       pos: -64.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23446
     components:
     - type: Transform
@@ -95110,7 +95195,7 @@ entities:
       pos: -64.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23448
     components:
     - type: Transform
@@ -95118,7 +95203,7 @@ entities:
       pos: -16.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23449
     components:
     - type: Transform
@@ -95126,7 +95211,7 @@ entities:
       pos: -15.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23450
     components:
     - type: Transform
@@ -95134,7 +95219,7 @@ entities:
       pos: -14.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23451
     components:
     - type: Transform
@@ -95142,7 +95227,7 @@ entities:
       pos: -13.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23453
     components:
     - type: Transform
@@ -95150,7 +95235,7 @@ entities:
       pos: -11.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23454
     components:
     - type: Transform
@@ -95158,7 +95243,7 @@ entities:
       pos: -10.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23455
     components:
     - type: Transform
@@ -95166,7 +95251,7 @@ entities:
       pos: -9.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23456
     components:
     - type: Transform
@@ -95174,7 +95259,7 @@ entities:
       pos: -8.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23457
     components:
     - type: Transform
@@ -95182,7 +95267,7 @@ entities:
       pos: -7.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23458
     components:
     - type: Transform
@@ -95190,7 +95275,7 @@ entities:
       pos: -6.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23459
     components:
     - type: Transform
@@ -95198,7 +95283,7 @@ entities:
       pos: -5.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23460
     components:
     - type: Transform
@@ -95206,7 +95291,7 @@ entities:
       pos: -4.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23461
     components:
     - type: Transform
@@ -95214,7 +95299,7 @@ entities:
       pos: -3.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23464
     components:
     - type: Transform
@@ -95222,7 +95307,7 @@ entities:
       pos: -1.5,0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23465
     components:
     - type: Transform
@@ -95230,7 +95315,7 @@ entities:
       pos: -1.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23466
     components:
     - type: Transform
@@ -95238,7 +95323,7 @@ entities:
       pos: -1.5,2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23467
     components:
     - type: Transform
@@ -95246,7 +95331,7 @@ entities:
       pos: -1.5,3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23469
     components:
     - type: Transform
@@ -95254,7 +95339,7 @@ entities:
       pos: -1.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23470
     components:
     - type: Transform
@@ -95262,7 +95347,7 @@ entities:
       pos: -1.5,6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23471
     components:
     - type: Transform
@@ -95270,7 +95355,7 @@ entities:
       pos: -1.5,7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23472
     components:
     - type: Transform
@@ -95278,7 +95363,7 @@ entities:
       pos: -1.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23473
     components:
     - type: Transform
@@ -95286,7 +95371,7 @@ entities:
       pos: -1.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23474
     components:
     - type: Transform
@@ -95294,7 +95379,7 @@ entities:
       pos: -1.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23475
     components:
     - type: Transform
@@ -95302,7 +95387,7 @@ entities:
       pos: -1.5,11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23476
     components:
     - type: Transform
@@ -95310,7 +95395,7 @@ entities:
       pos: -1.5,12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23477
     components:
     - type: Transform
@@ -95318,7 +95403,7 @@ entities:
       pos: -1.5,13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23479
     components:
     - type: Transform
@@ -95326,7 +95411,7 @@ entities:
       pos: -1.5,15.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23480
     components:
     - type: Transform
@@ -95334,7 +95419,7 @@ entities:
       pos: -1.5,16.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23481
     components:
     - type: Transform
@@ -95342,7 +95427,7 @@ entities:
       pos: -1.5,17.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23482
     components:
     - type: Transform
@@ -95350,7 +95435,7 @@ entities:
       pos: -1.5,18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23483
     components:
     - type: Transform
@@ -95358,7 +95443,7 @@ entities:
       pos: -1.5,19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23484
     components:
     - type: Transform
@@ -95366,7 +95451,7 @@ entities:
       pos: -1.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23486
     components:
     - type: Transform
@@ -95374,7 +95459,7 @@ entities:
       pos: -0.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23487
     components:
     - type: Transform
@@ -95382,7 +95467,7 @@ entities:
       pos: 0.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23488
     components:
     - type: Transform
@@ -95390,7 +95475,7 @@ entities:
       pos: 1.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23489
     components:
     - type: Transform
@@ -95398,7 +95483,7 @@ entities:
       pos: 2.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23490
     components:
     - type: Transform
@@ -95406,7 +95491,7 @@ entities:
       pos: 3.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23491
     components:
     - type: Transform
@@ -95414,7 +95499,7 @@ entities:
       pos: 4.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23492
     components:
     - type: Transform
@@ -95422,7 +95507,7 @@ entities:
       pos: 5.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23493
     components:
     - type: Transform
@@ -95430,7 +95515,7 @@ entities:
       pos: 6.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23494
     components:
     - type: Transform
@@ -95438,7 +95523,7 @@ entities:
       pos: 7.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23496
     components:
     - type: Transform
@@ -95446,7 +95531,7 @@ entities:
       pos: 9.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23498
     components:
     - type: Transform
@@ -95454,7 +95539,7 @@ entities:
       pos: 11.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23499
     components:
     - type: Transform
@@ -95462,7 +95547,7 @@ entities:
       pos: 12.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23500
     components:
     - type: Transform
@@ -95470,168 +95555,168 @@ entities:
       pos: 13.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23502
     components:
     - type: Transform
       pos: 14.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23503
     components:
     - type: Transform
       pos: 14.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23504
     components:
     - type: Transform
       pos: 14.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23505
     components:
     - type: Transform
       pos: 14.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23506
     components:
     - type: Transform
       pos: 14.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23509
     components:
     - type: Transform
       pos: 14.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23510
     components:
     - type: Transform
       pos: 14.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23511
     components:
     - type: Transform
       pos: 14.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23512
     components:
     - type: Transform
       pos: 14.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23514
     components:
     - type: Transform
       pos: 14.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23515
     components:
     - type: Transform
       pos: 14.5,-14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23516
     components:
     - type: Transform
       pos: 14.5,-15.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23517
     components:
     - type: Transform
       pos: 14.5,-16.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23518
     components:
     - type: Transform
       pos: 14.5,-17.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23519
     components:
     - type: Transform
       pos: 14.5,-18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23521
     components:
     - type: Transform
       pos: 14.5,-20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23522
     components:
     - type: Transform
       pos: 14.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23523
     components:
     - type: Transform
       pos: 14.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23524
     components:
     - type: Transform
       pos: 14.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23525
     components:
     - type: Transform
       pos: 14.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23527
     components:
     - type: Transform
       pos: 14.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23528
     components:
     - type: Transform
       pos: 14.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23529
     components:
     - type: Transform
       pos: 14.5,-28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23531
     components:
     - type: Transform
@@ -95639,7 +95724,7 @@ entities:
       pos: -0.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23532
     components:
     - type: Transform
@@ -95647,7 +95732,7 @@ entities:
       pos: 0.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23534
     components:
     - type: Transform
@@ -95655,7 +95740,7 @@ entities:
       pos: 2.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23535
     components:
     - type: Transform
@@ -95663,7 +95748,7 @@ entities:
       pos: 3.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23537
     components:
     - type: Transform
@@ -95671,7 +95756,7 @@ entities:
       pos: 5.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23538
     components:
     - type: Transform
@@ -95679,7 +95764,7 @@ entities:
       pos: 6.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23539
     components:
     - type: Transform
@@ -95687,7 +95772,7 @@ entities:
       pos: 7.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23540
     components:
     - type: Transform
@@ -95695,7 +95780,7 @@ entities:
       pos: 8.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23541
     components:
     - type: Transform
@@ -95703,7 +95788,7 @@ entities:
       pos: 9.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23542
     components:
     - type: Transform
@@ -95711,7 +95796,7 @@ entities:
       pos: 11.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23543
     components:
     - type: Transform
@@ -95719,7 +95804,7 @@ entities:
       pos: 10.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23544
     components:
     - type: Transform
@@ -95727,7 +95812,7 @@ entities:
       pos: 13.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23545
     components:
     - type: Transform
@@ -95735,7 +95820,7 @@ entities:
       pos: 12.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23546
     components:
     - type: Transform
@@ -95743,7 +95828,7 @@ entities:
       pos: 14.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23547
     components:
     - type: Transform
@@ -95751,7 +95836,7 @@ entities:
       pos: 14.5,-29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23548
     components:
     - type: Transform
@@ -96959,7 +97044,7 @@ entities:
       pos: 15.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23750
     components:
     - type: Transform
@@ -96967,7 +97052,7 @@ entities:
       pos: 16.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23751
     components:
     - type: Transform
@@ -96975,7 +97060,7 @@ entities:
       pos: 17.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23752
     components:
     - type: Transform
@@ -96983,7 +97068,7 @@ entities:
       pos: 18.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23753
     components:
     - type: Transform
@@ -97199,7 +97284,7 @@ entities:
       pos: 19.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23785
     components:
     - type: Transform
@@ -97207,7 +97292,7 @@ entities:
       pos: 20.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23786
     components:
     - type: Transform
@@ -97215,7 +97300,7 @@ entities:
       pos: 21.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23787
     components:
     - type: Transform
@@ -97487,7 +97572,7 @@ entities:
       pos: 59.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23829
     components:
     - type: Transform
@@ -97495,7 +97580,7 @@ entities:
       pos: 58.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23830
     components:
     - type: Transform
@@ -97503,7 +97588,7 @@ entities:
       pos: 57.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23831
     components:
     - type: Transform
@@ -97511,7 +97596,7 @@ entities:
       pos: 56.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23832
     components:
     - type: Transform
@@ -97519,7 +97604,7 @@ entities:
       pos: 54.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23833
     components:
     - type: Transform
@@ -97527,7 +97612,7 @@ entities:
       pos: 55.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23834
     components:
     - type: Transform
@@ -97535,7 +97620,7 @@ entities:
       pos: 53.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23836
     components:
     - type: Transform
@@ -97543,7 +97628,7 @@ entities:
       pos: 51.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23837
     components:
     - type: Transform
@@ -97551,7 +97636,7 @@ entities:
       pos: 50.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23838
     components:
     - type: Transform
@@ -97559,7 +97644,7 @@ entities:
       pos: 49.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23839
     components:
     - type: Transform
@@ -97567,7 +97652,7 @@ entities:
       pos: 48.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23840
     components:
     - type: Transform
@@ -97575,7 +97660,7 @@ entities:
       pos: 47.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23842
     components:
     - type: Transform
@@ -97583,7 +97668,7 @@ entities:
       pos: 45.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23843
     components:
     - type: Transform
@@ -97591,7 +97676,7 @@ entities:
       pos: 44.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23845
     components:
     - type: Transform
@@ -97599,7 +97684,7 @@ entities:
       pos: 42.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23846
     components:
     - type: Transform
@@ -97607,7 +97692,7 @@ entities:
       pos: 41.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23847
     components:
     - type: Transform
@@ -97615,7 +97700,7 @@ entities:
       pos: 40.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23848
     components:
     - type: Transform
@@ -97623,7 +97708,7 @@ entities:
       pos: 39.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23849
     components:
     - type: Transform
@@ -97631,7 +97716,7 @@ entities:
       pos: 38.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23850
     components:
     - type: Transform
@@ -97639,7 +97724,7 @@ entities:
       pos: 37.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23853
     components:
     - type: Transform
@@ -97647,7 +97732,7 @@ entities:
       pos: 33.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23854
     components:
     - type: Transform
@@ -97655,7 +97740,7 @@ entities:
       pos: 34.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23855
     components:
     - type: Transform
@@ -97663,7 +97748,7 @@ entities:
       pos: 32.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23857
     components:
     - type: Transform
@@ -97671,7 +97756,7 @@ entities:
       pos: 30.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23858
     components:
     - type: Transform
@@ -97679,7 +97764,7 @@ entities:
       pos: 29.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23859
     components:
     - type: Transform
@@ -97687,7 +97772,7 @@ entities:
       pos: 28.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23861
     components:
     - type: Transform
@@ -97695,7 +97780,7 @@ entities:
       pos: 27.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23862
     components:
     - type: Transform
@@ -97703,7 +97788,7 @@ entities:
       pos: 25.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23863
     components:
     - type: Transform
@@ -97711,7 +97796,7 @@ entities:
       pos: 24.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23864
     components:
     - type: Transform
@@ -97719,7 +97804,7 @@ entities:
       pos: 23.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23866
     components:
     - type: Transform
@@ -97823,7 +97908,7 @@ entities:
       pos: 60.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23881
     components:
     - type: Transform
@@ -97831,7 +97916,7 @@ entities:
       pos: 61.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23882
     components:
     - type: Transform
@@ -97839,7 +97924,7 @@ entities:
       pos: 63.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23883
     components:
     - type: Transform
@@ -97847,7 +97932,7 @@ entities:
       pos: 62.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23884
     components:
     - type: Transform
@@ -97855,7 +97940,7 @@ entities:
       pos: 64.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23887
     components:
     - type: Transform
@@ -97863,7 +97948,7 @@ entities:
       pos: 68.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23888
     components:
     - type: Transform
@@ -97871,7 +97956,7 @@ entities:
       pos: 67.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23889
     components:
     - type: Transform
@@ -97879,7 +97964,7 @@ entities:
       pos: 69.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23890
     components:
     - type: Transform
@@ -97887,7 +97972,7 @@ entities:
       pos: 70.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23891
     components:
     - type: Transform
@@ -97895,7 +97980,7 @@ entities:
       pos: 71.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23892
     components:
     - type: Transform
@@ -97903,7 +97988,7 @@ entities:
       pos: 72.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23893
     components:
     - type: Transform
@@ -97911,7 +97996,7 @@ entities:
       pos: 73.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23894
     components:
     - type: Transform
@@ -97927,7 +98012,7 @@ entities:
       pos: 74.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23896
     components:
     - type: Transform
@@ -97935,7 +98020,7 @@ entities:
       pos: 75.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23897
     components:
     - type: Transform
@@ -97975,7 +98060,7 @@ entities:
       pos: 76.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23906
     components:
     - type: Transform
@@ -97983,7 +98068,7 @@ entities:
       pos: 76.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23908
     components:
     - type: Transform
@@ -97991,7 +98076,7 @@ entities:
       pos: 76.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23909
     components:
     - type: Transform
@@ -98023,7 +98108,7 @@ entities:
       pos: 76.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23914
     components:
     - type: Transform
@@ -98031,7 +98116,7 @@ entities:
       pos: 76.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23916
     components:
     - type: Transform
@@ -98039,7 +98124,7 @@ entities:
       pos: 76.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23917
     components:
     - type: Transform
@@ -98079,7 +98164,7 @@ entities:
       pos: 76.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23922
     components:
     - type: Transform
@@ -98087,7 +98172,7 @@ entities:
       pos: 76.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23923
     components:
     - type: Transform
@@ -98095,7 +98180,7 @@ entities:
       pos: -1.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23924
     components:
     - type: Transform
@@ -98103,7 +98188,7 @@ entities:
       pos: -1.5,-29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23925
     components:
     - type: Transform
@@ -98111,7 +98196,7 @@ entities:
       pos: -1.5,-28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23926
     components:
     - type: Transform
@@ -98135,7 +98220,7 @@ entities:
       pos: -1.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23931
     components:
     - type: Transform
@@ -98143,7 +98228,7 @@ entities:
       pos: -1.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23932
     components:
     - type: Transform
@@ -98167,7 +98252,7 @@ entities:
       pos: -1.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23937
     components:
     - type: Transform
@@ -98215,7 +98300,7 @@ entities:
       pos: -18.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23956
     components:
     - type: Transform
@@ -98223,7 +98308,7 @@ entities:
       pos: -19.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23961
     components:
     - type: Transform
@@ -98231,7 +98316,7 @@ entities:
       pos: -21.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23962
     components:
     - type: Transform
@@ -98267,28 +98352,28 @@ entities:
       pos: -22.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23967
     components:
     - type: Transform
       pos: -22.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23968
     components:
     - type: Transform
       pos: -22.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23969
     components:
     - type: Transform
       pos: -22.5,-20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23970
     components:
     - type: Transform
@@ -98302,7 +98387,7 @@ entities:
       pos: -22.5,-19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23972
     components:
     - type: Transform
@@ -98310,7 +98395,7 @@ entities:
       pos: -23.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23973
     components:
     - type: Transform
@@ -98342,7 +98427,7 @@ entities:
       pos: -26.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23980
     components:
     - type: Transform
@@ -98350,7 +98435,7 @@ entities:
       pos: -27.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23981
     components:
     - type: Transform
@@ -98358,7 +98443,7 @@ entities:
       pos: -28.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23982
     components:
     - type: Transform
@@ -98373,7 +98458,7 @@ entities:
       pos: -28.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23988
     components:
     - type: Transform
@@ -98396,7 +98481,7 @@ entities:
       pos: -29.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23991
     components:
     - type: Transform
@@ -98412,7 +98497,7 @@ entities:
       pos: -30.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23993
     components:
     - type: Transform
@@ -98436,7 +98521,7 @@ entities:
       pos: -31.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23996
     components:
     - type: Transform
@@ -98520,7 +98605,7 @@ entities:
       pos: -25.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24016
     components:
     - type: Transform
@@ -98543,7 +98628,7 @@ entities:
       pos: -25.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24021
     components:
     - type: Transform
@@ -98557,7 +98642,7 @@ entities:
       pos: -25.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24023
     components:
     - type: Transform
@@ -98578,14 +98663,14 @@ entities:
       pos: -25.5,-28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24026
     components:
     - type: Transform
       pos: -25.5,-29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24027
     components:
     - type: Transform
@@ -98599,7 +98684,7 @@ entities:
       pos: -25.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24033
     components:
     - type: Transform
@@ -98623,7 +98708,7 @@ entities:
       pos: -24.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24036
     components:
     - type: Transform
@@ -98631,7 +98716,7 @@ entities:
       pos: -23.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24037
     components:
     - type: Transform
@@ -98639,7 +98724,7 @@ entities:
       pos: -22.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24040
     components:
     - type: Transform
@@ -98695,7 +98780,7 @@ entities:
       pos: -26.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24047
     components:
     - type: Transform
@@ -98703,7 +98788,7 @@ entities:
       pos: -27.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24048
     components:
     - type: Transform
@@ -98711,7 +98796,7 @@ entities:
       pos: -28.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24049
     components:
     - type: Transform
@@ -98719,7 +98804,7 @@ entities:
       pos: -29.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24050
     components:
     - type: Transform
@@ -98727,7 +98812,7 @@ entities:
       pos: -30.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24053
     components:
     - type: Transform
@@ -98748,7 +98833,7 @@ entities:
       pos: -25.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24058
     components:
     - type: Transform
@@ -98756,7 +98841,7 @@ entities:
       pos: -16.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24059
     components:
     - type: Transform
@@ -98764,7 +98849,7 @@ entities:
       pos: -15.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24060
     components:
     - type: Transform
@@ -98772,7 +98857,7 @@ entities:
       pos: -14.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24061
     components:
     - type: Transform
@@ -98788,7 +98873,7 @@ entities:
       pos: -8.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24065
     components:
     - type: Transform
@@ -98796,7 +98881,7 @@ entities:
       pos: -8.5,-29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24066
     components:
     - type: Transform
@@ -98804,7 +98889,7 @@ entities:
       pos: -8.5,-28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24067
     components:
     - type: Transform
@@ -98812,7 +98897,7 @@ entities:
       pos: -8.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24068
     components:
     - type: Transform
@@ -98820,7 +98905,7 @@ entities:
       pos: -8.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24069
     components:
     - type: Transform
@@ -98892,7 +98977,7 @@ entities:
       pos: -18.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24080
     components:
     - type: Transform
@@ -98900,7 +98985,7 @@ entities:
       pos: -19.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24081
     components:
     - type: Transform
@@ -98908,28 +98993,28 @@ entities:
       pos: -20.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24088
     components:
     - type: Transform
       pos: 4.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24089
     components:
     - type: Transform
       pos: 4.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24090
     components:
     - type: Transform
       pos: 4.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24091
     components:
     - type: Transform
@@ -99012,7 +99097,7 @@ entities:
       pos: 13.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24106
     components:
     - type: Transform
@@ -99020,7 +99105,7 @@ entities:
       pos: 12.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24107
     components:
     - type: Transform
@@ -99028,7 +99113,7 @@ entities:
       pos: 11.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24112
     components:
     - type: Transform
@@ -99108,7 +99193,7 @@ entities:
       pos: 13.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24123
     components:
     - type: Transform
@@ -99116,7 +99201,7 @@ entities:
       pos: 12.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24124
     components:
     - type: Transform
@@ -99124,7 +99209,7 @@ entities:
       pos: 11.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24125
     components:
     - type: Transform
@@ -99132,7 +99217,7 @@ entities:
       pos: 10.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24126
     components:
     - type: Transform
@@ -99140,7 +99225,7 @@ entities:
       pos: 9.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24127
     components:
     - type: Transform
@@ -99148,7 +99233,7 @@ entities:
       pos: 8.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24129
     components:
     - type: Transform
@@ -99156,7 +99241,7 @@ entities:
       pos: 6.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24130
     components:
     - type: Transform
@@ -99164,7 +99249,7 @@ entities:
       pos: -16.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24131
     components:
     - type: Transform
@@ -99172,7 +99257,7 @@ entities:
       pos: -15.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24132
     components:
     - type: Transform
@@ -99180,7 +99265,7 @@ entities:
       pos: -14.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24133
     components:
     - type: Transform
@@ -99188,7 +99273,7 @@ entities:
       pos: -13.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24134
     components:
     - type: Transform
@@ -99196,7 +99281,7 @@ entities:
       pos: -12.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24135
     components:
     - type: Transform
@@ -99204,7 +99289,7 @@ entities:
       pos: -11.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24136
     components:
     - type: Transform
@@ -99212,7 +99297,7 @@ entities:
       pos: -10.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24137
     components:
     - type: Transform
@@ -99220,7 +99305,7 @@ entities:
       pos: -9.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24139
     components:
     - type: Transform
@@ -99228,7 +99313,7 @@ entities:
       pos: -7.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24140
     components:
     - type: Transform
@@ -99292,7 +99377,7 @@ entities:
       pos: -6.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24157
     components:
     - type: Transform
@@ -99300,7 +99385,7 @@ entities:
       pos: -5.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24159
     components:
     - type: Transform
@@ -99308,7 +99393,7 @@ entities:
       pos: -2.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24160
     components:
     - type: Transform
@@ -99316,7 +99401,7 @@ entities:
       pos: -1.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24161
     components:
     - type: Transform
@@ -99324,7 +99409,7 @@ entities:
       pos: -0.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24163
     components:
     - type: Transform
@@ -99332,7 +99417,7 @@ entities:
       pos: 1.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24165
     components:
     - type: Transform
@@ -99340,7 +99425,7 @@ entities:
       pos: 4.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24166
     components:
     - type: Transform
@@ -99348,7 +99433,7 @@ entities:
       pos: 5.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24167
     components:
     - type: Transform
@@ -99419,21 +99504,21 @@ entities:
       pos: 0.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24183
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24184
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24185
     components:
     - type: Transform
@@ -99475,35 +99560,35 @@ entities:
       pos: 7.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24194
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24195
     components:
     - type: Transform
       pos: 7.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24196
     components:
     - type: Transform
       pos: 7.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24197
     components:
     - type: Transform
       pos: 7.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24200
     components:
     - type: Transform
@@ -99517,7 +99602,7 @@ entities:
       pos: 7.5,-14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24202
     components:
     - type: Transform
@@ -99531,7 +99616,7 @@ entities:
       pos: 7.5,-15.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24204
     components:
     - type: Transform
@@ -99545,7 +99630,7 @@ entities:
       pos: 7.5,-16.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24206
     components:
     - type: Transform
@@ -99559,7 +99644,7 @@ entities:
       pos: 7.5,-17.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24208
     components:
     - type: Transform
@@ -99573,14 +99658,14 @@ entities:
       pos: 7.5,-18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24210
     components:
     - type: Transform
       pos: 7.5,-19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24211
     components:
     - type: Transform
@@ -99618,7 +99703,7 @@ entities:
       pos: 8.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24221
     components:
     - type: Transform
@@ -99626,7 +99711,7 @@ entities:
       pos: 9.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24222
     components:
     - type: Transform
@@ -99634,7 +99719,7 @@ entities:
       pos: 10.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24223
     components:
     - type: Transform
@@ -99642,35 +99727,35 @@ entities:
       pos: 11.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24225
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24226
     components:
     - type: Transform
       pos: -8.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24227
     components:
     - type: Transform
       pos: -8.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24228
     components:
     - type: Transform
       pos: -8.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24229
     components:
     - type: Transform
@@ -99691,28 +99776,28 @@ entities:
       pos: -8.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24232
     components:
     - type: Transform
       pos: -8.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24233
     components:
     - type: Transform
       pos: -8.5,-14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24234
     components:
     - type: Transform
       pos: -8.5,-15.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24235
     components:
     - type: Transform
@@ -99768,14 +99853,14 @@ entities:
       pos: 8.5,0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24251
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24252
     components:
     - type: Transform
@@ -99803,7 +99888,7 @@ entities:
       pos: 8.5,3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24264
     components:
     - type: Transform
@@ -99824,21 +99909,21 @@ entities:
       pos: 8.5,4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24267
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24268
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24269
     components:
     - type: Transform
@@ -99877,7 +99962,7 @@ entities:
       pos: 8.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24275
     components:
     - type: Transform
@@ -99891,7 +99976,7 @@ entities:
       pos: 8.5,12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24278
     components:
     - type: Transform
@@ -99907,7 +99992,7 @@ entities:
       pos: 8.5,13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24280
     components:
     - type: Transform
@@ -99939,7 +100024,7 @@ entities:
       pos: 7.5,14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24284
     components:
     - type: Transform
@@ -99955,7 +100040,7 @@ entities:
       pos: 7.5,11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24286
     components:
     - type: Transform
@@ -99971,7 +100056,7 @@ entities:
       pos: 7.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24288
     components:
     - type: Transform
@@ -99987,7 +100072,7 @@ entities:
       pos: 7.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24290
     components:
     - type: Transform
@@ -100011,7 +100096,7 @@ entities:
       pos: -12.5,0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24305
     components:
     - type: Transform
@@ -100019,7 +100104,7 @@ entities:
       pos: -12.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24306
     components:
     - type: Transform
@@ -100050,7 +100135,7 @@ entities:
       pos: -12.5,2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24311
     components:
     - type: Transform
@@ -100064,7 +100149,7 @@ entities:
       pos: -12.5,4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24314
     components:
     - type: Transform
@@ -100085,21 +100170,21 @@ entities:
       pos: -12.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24319
     components:
     - type: Transform
       pos: -12.5,6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24320
     components:
     - type: Transform
       pos: -12.5,7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24321
     components:
     - type: Transform
@@ -100107,7 +100192,7 @@ entities:
       pos: -11.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24322
     components:
     - type: Transform
@@ -100115,7 +100200,7 @@ entities:
       pos: -10.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24323
     components:
     - type: Transform
@@ -100123,7 +100208,7 @@ entities:
       pos: -9.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24324
     components:
     - type: Transform
@@ -100131,7 +100216,7 @@ entities:
       pos: -8.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24325
     components:
     - type: Transform
@@ -100139,7 +100224,7 @@ entities:
       pos: -7.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24326
     components:
     - type: Transform
@@ -100147,7 +100232,7 @@ entities:
       pos: -6.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24327
     components:
     - type: Transform
@@ -100187,7 +100272,7 @@ entities:
       pos: 9.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24340
     components:
     - type: Transform
@@ -100195,7 +100280,7 @@ entities:
       pos: 10.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24341
     components:
     - type: Transform
@@ -100235,7 +100320,7 @@ entities:
       pos: 12.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24352
     components:
     - type: Transform
@@ -100243,7 +100328,7 @@ entities:
       pos: 14.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24353
     components:
     - type: Transform
@@ -100251,7 +100336,7 @@ entities:
       pos: 15.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24354
     components:
     - type: Transform
@@ -100259,7 +100344,7 @@ entities:
       pos: 16.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24355
     components:
     - type: Transform
@@ -100283,28 +100368,28 @@ entities:
       pos: 18.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24358
     components:
     - type: Transform
       pos: 17.5,11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24359
     components:
     - type: Transform
       pos: 17.5,12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24360
     components:
     - type: Transform
       pos: 17.5,13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24361
     components:
     - type: Transform
@@ -100339,21 +100424,21 @@ entities:
       pos: 13.5,11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24366
     components:
     - type: Transform
       pos: 13.5,12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24367
     components:
     - type: Transform
       pos: 13.5,13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24380
     components:
     - type: Transform
@@ -100433,7 +100518,7 @@ entities:
       pos: 21.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24390
     components:
     - type: Transform
@@ -100441,7 +100526,7 @@ entities:
       pos: 22.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24391
     components:
     - type: Transform
@@ -100449,7 +100534,7 @@ entities:
       pos: 23.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24392
     components:
     - type: Transform
@@ -100457,7 +100542,7 @@ entities:
       pos: 24.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24393
     components:
     - type: Transform
@@ -100465,7 +100550,7 @@ entities:
       pos: 25.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24394
     components:
     - type: Transform
@@ -100473,7 +100558,7 @@ entities:
       pos: 26.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24395
     components:
     - type: Transform
@@ -100481,7 +100566,7 @@ entities:
       pos: 27.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24396
     components:
     - type: Transform
@@ -100489,7 +100574,7 @@ entities:
       pos: 28.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24397
     components:
     - type: Transform
@@ -100505,7 +100590,7 @@ entities:
       pos: 17.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24403
     components:
     - type: Transform
@@ -100537,7 +100622,7 @@ entities:
       pos: 17.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24407
     components:
     - type: Transform
@@ -100545,7 +100630,7 @@ entities:
       pos: 17.5,7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24408
     components:
     - type: Transform
@@ -100561,7 +100646,7 @@ entities:
       pos: 17.5,6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24412
     components:
     - type: Transform
@@ -100569,7 +100654,7 @@ entities:
       pos: 16.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24413
     components:
     - type: Transform
@@ -100585,7 +100670,7 @@ entities:
       pos: 15.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24415
     components:
     - type: Transform
@@ -100593,7 +100678,7 @@ entities:
       pos: 14.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24416
     components:
     - type: Transform
@@ -100617,7 +100702,7 @@ entities:
       pos: 13.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24423
     components:
     - type: Transform
@@ -100649,7 +100734,7 @@ entities:
       pos: 22.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24427
     components:
     - type: Transform
@@ -100657,7 +100742,7 @@ entities:
       pos: 22.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24429
     components:
     - type: Transform
@@ -100673,7 +100758,7 @@ entities:
       pos: 22.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24432
     components:
     - type: Transform
@@ -100697,7 +100782,7 @@ entities:
       pos: 21.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24443
     components:
     - type: Transform
@@ -100718,14 +100803,14 @@ entities:
       pos: 20.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24446
     components:
     - type: Transform
       pos: 20.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24447
     components:
     - type: Transform
@@ -100747,14 +100832,14 @@ entities:
       pos: 20.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24450
     components:
     - type: Transform
       pos: 20.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24451
     components:
     - type: Transform
@@ -100775,21 +100860,21 @@ entities:
       pos: 20.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24454
     components:
     - type: Transform
       pos: 20.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24455
     components:
     - type: Transform
       pos: 20.5,0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24456
     components:
     - type: Transform
@@ -100817,14 +100902,14 @@ entities:
       pos: 20.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24460
     components:
     - type: Transform
       pos: 20.5,2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24461
     components:
     - type: Transform
@@ -100879,7 +100964,7 @@ entities:
       pos: 23.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24471
     components:
     - type: Transform
@@ -100887,7 +100972,7 @@ entities:
       pos: 24.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24472
     components:
     - type: Transform
@@ -100895,7 +100980,7 @@ entities:
       pos: 25.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24473
     components:
     - type: Transform
@@ -100903,7 +100988,7 @@ entities:
       pos: 26.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24474
     components:
     - type: Transform
@@ -100911,7 +100996,7 @@ entities:
       pos: 27.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24475
     components:
     - type: Transform
@@ -100919,7 +101004,7 @@ entities:
       pos: 28.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24478
     components:
     - type: Transform
@@ -100943,7 +101028,7 @@ entities:
       pos: 29.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24481
     components:
     - type: Transform
@@ -100951,7 +101036,7 @@ entities:
       pos: 29.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24482
     components:
     - type: Transform
@@ -100975,7 +101060,7 @@ entities:
       pos: 29.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24485
     components:
     - type: Transform
@@ -100983,7 +101068,7 @@ entities:
       pos: 29.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24486
     components:
     - type: Transform
@@ -101007,7 +101092,7 @@ entities:
       pos: 29.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24489
     components:
     - type: Transform
@@ -101015,7 +101100,7 @@ entities:
       pos: 29.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24490
     components:
     - type: Transform
@@ -101039,7 +101124,7 @@ entities:
       pos: 29.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24495
     components:
     - type: Transform
@@ -101047,7 +101132,7 @@ entities:
       pos: 36.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24496
     components:
     - type: Transform
@@ -101087,7 +101172,7 @@ entities:
       pos: 36.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24501
     components:
     - type: Transform
@@ -101095,7 +101180,7 @@ entities:
       pos: 36.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24502
     components:
     - type: Transform
@@ -101117,42 +101202,42 @@ entities:
       pos: 36.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24509
     components:
     - type: Transform
       pos: 36.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24510
     components:
     - type: Transform
       pos: 36.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24511
     components:
     - type: Transform
       pos: 36.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24512
     components:
     - type: Transform
       pos: 36.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24513
     components:
     - type: Transform
       pos: 36.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24514
     components:
     - type: Transform
@@ -101376,126 +101461,126 @@ entities:
       pos: 35.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24552
     components:
     - type: Transform
       pos: 35.5,-14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24553
     components:
     - type: Transform
       pos: 35.5,-15.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24554
     components:
     - type: Transform
       pos: 35.5,-16.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24555
     components:
     - type: Transform
       pos: 35.5,-17.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24557
     components:
     - type: Transform
       pos: 35.5,-19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24558
     components:
     - type: Transform
       pos: 35.5,-20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24559
     components:
     - type: Transform
       pos: 35.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24560
     components:
     - type: Transform
       pos: 35.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24561
     components:
     - type: Transform
       pos: 26.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24562
     components:
     - type: Transform
       pos: 26.5,-14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24563
     components:
     - type: Transform
       pos: 26.5,-15.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24564
     components:
     - type: Transform
       pos: 26.5,-16.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24566
     components:
     - type: Transform
       pos: 26.5,-18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24567
     components:
     - type: Transform
       pos: 26.5,-19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24568
     components:
     - type: Transform
       pos: 26.5,-20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24569
     components:
     - type: Transform
       pos: 26.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24570
     components:
     - type: Transform
       pos: 26.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24573
     components:
     - type: Transform
@@ -101503,7 +101588,7 @@ entities:
       pos: 27.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24574
     components:
     - type: Transform
@@ -101511,7 +101596,7 @@ entities:
       pos: 28.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24575
     components:
     - type: Transform
@@ -101519,7 +101604,7 @@ entities:
       pos: 29.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24576
     components:
     - type: Transform
@@ -101527,7 +101612,7 @@ entities:
       pos: 30.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24578
     components:
     - type: Transform
@@ -101535,7 +101620,7 @@ entities:
       pos: 32.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24579
     components:
     - type: Transform
@@ -101543,7 +101628,7 @@ entities:
       pos: 33.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24580
     components:
     - type: Transform
@@ -101551,7 +101636,7 @@ entities:
       pos: 34.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24589
     components:
     - type: Transform
@@ -101631,7 +101716,7 @@ entities:
       pos: 25.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24604
     components:
     - type: Transform
@@ -101639,7 +101724,7 @@ entities:
       pos: 23.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24605
     components:
     - type: Transform
@@ -101647,7 +101732,7 @@ entities:
       pos: 22.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24606
     components:
     - type: Transform
@@ -101655,28 +101740,28 @@ entities:
       pos: 21.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24607
     components:
     - type: Transform
       pos: 20.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24608
     components:
     - type: Transform
       pos: 20.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24609
     components:
     - type: Transform
       pos: 20.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24612
     components:
     - type: Transform
@@ -101684,7 +101769,7 @@ entities:
       pos: 35.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24613
     components:
     - type: Transform
@@ -101692,7 +101777,7 @@ entities:
       pos: 35.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24614
     components:
     - type: Transform
@@ -101700,7 +101785,7 @@ entities:
       pos: 35.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24615
     components:
     - type: Transform
@@ -101716,7 +101801,7 @@ entities:
       pos: 36.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24617
     components:
     - type: Transform
@@ -101724,7 +101809,7 @@ entities:
       pos: 37.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24619
     components:
     - type: Transform
@@ -101732,7 +101817,7 @@ entities:
       pos: 38.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24620
     components:
     - type: Transform
@@ -101740,7 +101825,7 @@ entities:
       pos: 38.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24621
     components:
     - type: Transform
@@ -101748,7 +101833,7 @@ entities:
       pos: 38.5,-20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24622
     components:
     - type: Transform
@@ -101756,7 +101841,7 @@ entities:
       pos: 38.5,-19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24623
     components:
     - type: Transform
@@ -101764,7 +101849,7 @@ entities:
       pos: 39.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24626
     components:
     - type: Transform
@@ -101847,35 +101932,35 @@ entities:
       pos: 41.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24647
     components:
     - type: Transform
       pos: 26.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24648
     components:
     - type: Transform
       pos: 26.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24649
     components:
     - type: Transform
       pos: 26.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24650
     components:
     - type: Transform
       pos: 26.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24651
     components:
     - type: Transform
@@ -101897,7 +101982,7 @@ entities:
       pos: 40.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24656
     components:
     - type: Transform
@@ -101913,7 +101998,7 @@ entities:
       pos: 40.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24658
     components:
     - type: Transform
@@ -101961,7 +102046,7 @@ entities:
       pos: 42.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24668
     components:
     - type: Transform
@@ -101969,7 +102054,7 @@ entities:
       pos: 43.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24669
     components:
     - type: Transform
@@ -101977,7 +102062,7 @@ entities:
       pos: 44.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24670
     components:
     - type: Transform
@@ -102027,28 +102112,28 @@ entities:
       pos: 26.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24683
     components:
     - type: Transform
       pos: 26.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24684
     components:
     - type: Transform
       pos: 26.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24685
     components:
     - type: Transform
       pos: 26.5,-29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24686
     components:
     - type: Transform
@@ -102056,7 +102141,7 @@ entities:
       pos: 27.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24693
     components:
     - type: Transform
@@ -102064,7 +102149,7 @@ entities:
       pos: 26.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24694
     components:
     - type: Transform
@@ -102104,7 +102189,7 @@ entities:
       pos: 25.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24699
     components:
     - type: Transform
@@ -102112,7 +102197,7 @@ entities:
       pos: 24.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24700
     components:
     - type: Transform
@@ -102120,7 +102205,7 @@ entities:
       pos: 23.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24701
     components:
     - type: Transform
@@ -102128,7 +102213,7 @@ entities:
       pos: 22.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24702
     components:
     - type: Transform
@@ -102136,7 +102221,7 @@ entities:
       pos: 21.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24703
     components:
     - type: Transform
@@ -102152,7 +102237,7 @@ entities:
       pos: 20.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24713
     components:
     - type: Transform
@@ -102255,35 +102340,35 @@ entities:
       pos: 35.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24729
     components:
     - type: Transform
       pos: 35.5,-28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24730
     components:
     - type: Transform
       pos: 35.5,-29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24731
     components:
     - type: Transform
       pos: 35.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24732
     components:
     - type: Transform
       pos: 35.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24734
     components:
     - type: Transform
@@ -102291,7 +102376,7 @@ entities:
       pos: 36.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24735
     components:
     - type: Transform
@@ -102299,7 +102384,7 @@ entities:
       pos: 37.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24736
     components:
     - type: Transform
@@ -102307,14 +102392,14 @@ entities:
       pos: 38.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24738
     components:
     - type: Transform
       pos: 39.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24740
     components:
     - type: Transform
@@ -102322,7 +102407,7 @@ entities:
       pos: 40.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24741
     components:
     - type: Transform
@@ -102330,7 +102415,7 @@ entities:
       pos: 41.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24742
     components:
     - type: Transform
@@ -102338,7 +102423,7 @@ entities:
       pos: 42.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24743
     components:
     - type: Transform
@@ -102346,7 +102431,7 @@ entities:
       pos: 43.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24744
     components:
     - type: Transform
@@ -102354,7 +102439,7 @@ entities:
       pos: 44.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24748
     components:
     - type: Transform
@@ -102386,7 +102471,7 @@ entities:
       pos: 39.5,-36.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24754
     components:
     - type: Transform
@@ -102402,7 +102487,7 @@ entities:
       pos: 39.5,-37.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24756
     components:
     - type: Transform
@@ -102418,7 +102503,7 @@ entities:
       pos: 39.5,-38.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24758
     components:
     - type: Transform
@@ -102442,7 +102527,7 @@ entities:
       pos: 39.5,-40.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24764
     components:
     - type: Transform
@@ -102450,7 +102535,7 @@ entities:
       pos: 39.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24765
     components:
     - type: Transform
@@ -102458,7 +102543,7 @@ entities:
       pos: 39.5,-42.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24767
     components:
     - type: Transform
@@ -102506,7 +102591,7 @@ entities:
       pos: 38.5,-39.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24773
     components:
     - type: Transform
@@ -102514,7 +102599,7 @@ entities:
       pos: 37.5,-39.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24774
     components:
     - type: Transform
@@ -102522,14 +102607,14 @@ entities:
       pos: 36.5,-39.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24779
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24784
     components:
     - type: Transform
@@ -102569,7 +102654,7 @@ entities:
       pos: 37.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24789
     components:
     - type: Transform
@@ -102577,7 +102662,7 @@ entities:
       pos: 38.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24790
     components:
     - type: Transform
@@ -102585,7 +102670,7 @@ entities:
       pos: 38.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24791
     components:
     - type: Transform
@@ -102593,7 +102678,7 @@ entities:
       pos: 37.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24792
     components:
     - type: Transform
@@ -102633,7 +102718,7 @@ entities:
       pos: 39.5,-47.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24797
     components:
     - type: Transform
@@ -102641,7 +102726,7 @@ entities:
       pos: 39.5,-46.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24798
     components:
     - type: Transform
@@ -102649,7 +102734,7 @@ entities:
       pos: 39.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24799
     components:
     - type: Transform
@@ -102657,7 +102742,7 @@ entities:
       pos: 39.5,-43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24800
     components:
     - type: Transform
@@ -102705,7 +102790,7 @@ entities:
       pos: 40.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24806
     components:
     - type: Transform
@@ -102713,7 +102798,7 @@ entities:
       pos: 41.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24807
     components:
     - type: Transform
@@ -102721,7 +102806,7 @@ entities:
       pos: 42.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24808
     components:
     - type: Transform
@@ -102729,7 +102814,7 @@ entities:
       pos: 43.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24809
     components:
     - type: Transform
@@ -102753,7 +102838,7 @@ entities:
       pos: 39.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24818
     components:
     - type: Transform
@@ -102761,7 +102846,7 @@ entities:
       pos: 39.5,-50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24819
     components:
     - type: Transform
@@ -102769,7 +102854,7 @@ entities:
       pos: 39.5,-51.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24820
     components:
     - type: Transform
@@ -102784,7 +102869,7 @@ entities:
       pos: 39.5,-52.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24824
     components:
     - type: Transform
@@ -102812,7 +102897,7 @@ entities:
       pos: 39.5,-54.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24829
     components:
     - type: Transform
@@ -102827,7 +102912,7 @@ entities:
       pos: 38.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24833
     components:
     - type: Transform
@@ -102835,7 +102920,7 @@ entities:
       pos: 37.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24835
     components:
     - type: Transform
@@ -102843,7 +102928,7 @@ entities:
       pos: 41.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24836
     components:
     - type: Transform
@@ -102851,49 +102936,49 @@ entities:
       pos: 42.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24839
     components:
     - type: Transform
       pos: 43.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24840
     components:
     - type: Transform
       pos: 43.5,-57.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24841
     components:
     - type: Transform
       pos: 43.5,-58.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24842
     components:
     - type: Transform
       pos: 46.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24843
     components:
     - type: Transform
       pos: 46.5,-57.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24844
     components:
     - type: Transform
       pos: 46.5,-58.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24845
     components:
     - type: Transform
@@ -102901,7 +102986,7 @@ entities:
       pos: 44.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24846
     components:
     - type: Transform
@@ -102909,7 +102994,7 @@ entities:
       pos: 45.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24847
     components:
     - type: Transform
@@ -102917,7 +103002,7 @@ entities:
       pos: 43.5,-54.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24858
     components:
     - type: Transform
@@ -103043,7 +103128,7 @@ entities:
       pos: 43.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24884
     components:
     - type: Transform
@@ -103067,7 +103152,7 @@ entities:
       pos: 43.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24887
     components:
     - type: Transform
@@ -103075,7 +103160,7 @@ entities:
       pos: 43.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24888
     components:
     - type: Transform
@@ -103083,7 +103168,7 @@ entities:
       pos: 43.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24889
     components:
     - type: Transform
@@ -103091,7 +103176,7 @@ entities:
       pos: 43.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24890
     components:
     - type: Transform
@@ -103113,7 +103198,7 @@ entities:
       pos: 43.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24895
     components:
     - type: Transform
@@ -103121,7 +103206,7 @@ entities:
       pos: 44.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24896
     components:
     - type: Transform
@@ -103153,7 +103238,7 @@ entities:
       pos: 43.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24900
     components:
     - type: Transform
@@ -103161,7 +103246,7 @@ entities:
       pos: 43.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24903
     components:
     - type: Transform
@@ -103185,7 +103270,7 @@ entities:
       pos: 47.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24908
     components:
     - type: Transform
@@ -103217,7 +103302,7 @@ entities:
       pos: 44.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24912
     components:
     - type: Transform
@@ -103225,7 +103310,7 @@ entities:
       pos: 45.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24913
     components:
     - type: Transform
@@ -103233,7 +103318,7 @@ entities:
       pos: 46.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24922
     components:
     - type: Transform
@@ -103241,7 +103326,7 @@ entities:
       pos: 75.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24923
     components:
     - type: Transform
@@ -103273,7 +103358,7 @@ entities:
       pos: 74.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24927
     components:
     - type: Transform
@@ -103321,7 +103406,7 @@ entities:
       pos: 52.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24937
     components:
     - type: Transform
@@ -103329,7 +103414,7 @@ entities:
       pos: 52.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24938
     components:
     - type: Transform
@@ -103337,7 +103422,7 @@ entities:
       pos: 52.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24939
     components:
     - type: Transform
@@ -103345,7 +103430,7 @@ entities:
       pos: 53.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24940
     components:
     - type: Transform
@@ -103353,14 +103438,14 @@ entities:
       pos: 56.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24951
     components:
     - type: Transform
       pos: 69.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24952
     components:
     - type: Transform
@@ -103381,21 +103466,21 @@ entities:
       pos: 69.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24955
     components:
     - type: Transform
       pos: 69.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24956
     components:
     - type: Transform
       pos: 69.5,0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24957
     components:
     - type: Transform
@@ -103432,7 +103517,7 @@ entities:
       pos: 68.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24964
     components:
     - type: Transform
@@ -103448,7 +103533,7 @@ entities:
       pos: 67.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24966
     components:
     - type: Transform
@@ -103532,7 +103617,7 @@ entities:
       pos: 66.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25029
     components:
     - type: Transform
@@ -103540,7 +103625,7 @@ entities:
       pos: 66.5,-14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25030
     components:
     - type: Transform
@@ -103548,7 +103633,7 @@ entities:
       pos: 66.5,-15.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25031
     components:
     - type: Transform
@@ -103556,7 +103641,7 @@ entities:
       pos: 66.5,-17.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25032
     components:
     - type: Transform
@@ -103564,7 +103649,7 @@ entities:
       pos: 66.5,-16.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25033
     components:
     - type: Transform
@@ -103572,7 +103657,7 @@ entities:
       pos: 66.5,-19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25036
     components:
     - type: Transform
@@ -103580,7 +103665,7 @@ entities:
       pos: 66.5,-20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25037
     components:
     - type: Transform
@@ -103604,7 +103689,7 @@ entities:
       pos: 66.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25043
     components:
     - type: Transform
@@ -103625,7 +103710,7 @@ entities:
       pos: 66.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25047
     components:
     - type: Transform
@@ -103665,7 +103750,7 @@ entities:
       pos: 67.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25052
     components:
     - type: Transform
@@ -103673,7 +103758,7 @@ entities:
       pos: 68.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25053
     components:
     - type: Transform
@@ -103681,7 +103766,7 @@ entities:
       pos: 69.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25056
     components:
     - type: Transform
@@ -103737,7 +103822,7 @@ entities:
       pos: 71.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25063
     components:
     - type: Transform
@@ -103745,7 +103830,7 @@ entities:
       pos: 72.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25064
     components:
     - type: Transform
@@ -103753,7 +103838,7 @@ entities:
       pos: 73.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25067
     components:
     - type: Transform
@@ -103761,7 +103846,7 @@ entities:
       pos: 75.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25068
     components:
     - type: Transform
@@ -103769,14 +103854,14 @@ entities:
       pos: 76.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25074
     components:
     - type: Transform
       pos: 66.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25077
     components:
     - type: Transform
@@ -103784,7 +103869,7 @@ entities:
       pos: 66.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25078
     components:
     - type: Transform
@@ -103800,7 +103885,7 @@ entities:
       pos: 65.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25080
     components:
     - type: Transform
@@ -103808,7 +103893,7 @@ entities:
       pos: 64.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25081
     components:
     - type: Transform
@@ -103824,7 +103909,7 @@ entities:
       pos: 63.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25083
     components:
     - type: Transform
@@ -103840,7 +103925,7 @@ entities:
       pos: 62.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25086
     components:
     - type: Transform
@@ -103854,7 +103939,7 @@ entities:
       pos: 66.5,-28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25088
     components:
     - type: Transform
@@ -103868,7 +103953,7 @@ entities:
       pos: 66.5,-29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25090
     components:
     - type: Transform
@@ -103882,7 +103967,7 @@ entities:
       pos: 66.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25092
     components:
     - type: Transform
@@ -103896,7 +103981,7 @@ entities:
       pos: 66.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25095
     components:
     - type: Transform
@@ -103920,7 +104005,7 @@ entities:
       pos: 60.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25098
     components:
     - type: Transform
@@ -103928,7 +104013,7 @@ entities:
       pos: 59.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25099
     components:
     - type: Transform
@@ -103944,7 +104029,7 @@ entities:
       pos: 58.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25101
     components:
     - type: Transform
@@ -103974,28 +104059,28 @@ entities:
       pos: 57.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25105
     components:
     - type: Transform
       pos: 61.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25106
     components:
     - type: Transform
       pos: 61.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25107
     components:
     - type: Transform
       pos: 61.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25108
     components:
     - type: Transform
@@ -104016,7 +104101,7 @@ entities:
       pos: 61.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25111
     components:
     - type: Transform
@@ -104058,21 +104143,21 @@ entities:
       pos: 56.5,-28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25122
     components:
     - type: Transform
       pos: 56.5,-29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25123
     components:
     - type: Transform
       pos: 56.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25126
     components:
     - type: Transform
@@ -104088,7 +104173,7 @@ entities:
       pos: 55.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25128
     components:
     - type: Transform
@@ -104096,7 +104181,7 @@ entities:
       pos: 54.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25129
     components:
     - type: Transform
@@ -104112,21 +104197,21 @@ entities:
       pos: 55.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25137
     components:
     - type: Transform
       pos: 61.5,-28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25138
     components:
     - type: Transform
       pos: 61.5,-29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25139
     components:
     - type: Transform
@@ -104163,7 +104248,7 @@ entities:
       pos: 66.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25148
     components:
     - type: Transform
@@ -104179,7 +104264,7 @@ entities:
       pos: 65.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25152
     components:
     - type: Transform
@@ -104187,7 +104272,7 @@ entities:
       pos: 64.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25153
     components:
     - type: Transform
@@ -104195,7 +104280,7 @@ entities:
       pos: 63.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25154
     components:
     - type: Transform
@@ -104235,7 +104320,7 @@ entities:
       pos: 67.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25159
     components:
     - type: Transform
@@ -104243,7 +104328,7 @@ entities:
       pos: 68.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25160
     components:
     - type: Transform
@@ -104258,7 +104343,7 @@ entities:
       pos: 66.5,-35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25162
     components:
     - type: Transform
@@ -104272,7 +104357,7 @@ entities:
       pos: 66.5,-36.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25172
     components:
     - type: Transform
@@ -104304,7 +104389,7 @@ entities:
       pos: 65.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25176
     components:
     - type: Transform
@@ -104360,7 +104445,7 @@ entities:
       pos: 66.5,-37.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25184
     components:
     - type: Transform
@@ -104368,7 +104453,7 @@ entities:
       pos: 66.5,-38.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25185
     components:
     - type: Transform
@@ -104376,7 +104461,7 @@ entities:
       pos: 66.5,-39.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25186
     components:
     - type: Transform
@@ -104384,7 +104469,7 @@ entities:
       pos: 66.5,-40.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25188
     components:
     - type: Transform
@@ -104392,7 +104477,7 @@ entities:
       pos: 66.5,-42.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25189
     components:
     - type: Transform
@@ -104400,7 +104485,7 @@ entities:
       pos: 66.5,-43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25190
     components:
     - type: Transform
@@ -104408,7 +104493,7 @@ entities:
       pos: 66.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25192
     components:
     - type: Transform
@@ -104416,7 +104501,7 @@ entities:
       pos: 66.5,-46.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25193
     components:
     - type: Transform
@@ -104424,7 +104509,7 @@ entities:
       pos: 66.5,-47.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25194
     components:
     - type: Transform
@@ -104440,7 +104525,7 @@ entities:
       pos: 66.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25196
     components:
     - type: Transform
@@ -104448,7 +104533,7 @@ entities:
       pos: 66.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25197
     components:
     - type: Transform
@@ -104496,7 +104581,7 @@ entities:
       pos: 67.5,-50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25205
     components:
     - type: Transform
@@ -104504,7 +104589,7 @@ entities:
       pos: 68.5,-50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25208
     components:
     - type: Transform
@@ -104520,7 +104605,7 @@ entities:
       pos: 64.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25210
     components:
     - type: Transform
@@ -104528,7 +104613,7 @@ entities:
       pos: 63.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25211
     components:
     - type: Transform
@@ -104544,7 +104629,7 @@ entities:
       pos: 62.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25213
     components:
     - type: Transform
@@ -104560,7 +104645,7 @@ entities:
       pos: 61.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25215
     components:
     - type: Transform
@@ -104576,7 +104661,7 @@ entities:
       pos: 60.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25217
     components:
     - type: Transform
@@ -104592,7 +104677,7 @@ entities:
       pos: 59.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25219
     components:
     - type: Transform
@@ -104631,7 +104716,7 @@ entities:
       pos: 58.5,-40.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25245
     components:
     - type: Transform
@@ -104639,7 +104724,7 @@ entities:
       pos: 67.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25246
     components:
     - type: Transform
@@ -104647,7 +104732,7 @@ entities:
       pos: 68.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25247
     components:
     - type: Transform
@@ -104655,7 +104740,7 @@ entities:
       pos: 69.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25248
     components:
     - type: Transform
@@ -104663,7 +104748,7 @@ entities:
       pos: 70.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25249
     components:
     - type: Transform
@@ -104671,7 +104756,7 @@ entities:
       pos: 71.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25250
     components:
     - type: Transform
@@ -104679,7 +104764,7 @@ entities:
       pos: 72.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25251
     components:
     - type: Transform
@@ -104687,7 +104772,7 @@ entities:
       pos: 73.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25252
     components:
     - type: Transform
@@ -104807,7 +104892,7 @@ entities:
       pos: -65.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25270
     components:
     - type: Transform
@@ -104815,7 +104900,7 @@ entities:
       pos: -66.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25271
     components:
     - type: Transform
@@ -104823,7 +104908,7 @@ entities:
       pos: -67.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25277
     components:
     - type: Transform
@@ -104879,7 +104964,7 @@ entities:
       pos: -65.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25284
     components:
     - type: Transform
@@ -104887,7 +104972,7 @@ entities:
       pos: -66.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25285
     components:
     - type: Transform
@@ -104895,7 +104980,7 @@ entities:
       pos: -67.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25286
     components:
     - type: Transform
@@ -104903,7 +104988,7 @@ entities:
       pos: -68.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25287
     components:
     - type: Transform
@@ -104911,7 +104996,7 @@ entities:
       pos: -69.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25288
     components:
     - type: Transform
@@ -104919,7 +105004,7 @@ entities:
       pos: -70.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25291
     components:
     - type: Transform
@@ -104927,7 +105012,7 @@ entities:
       pos: -65.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25292
     components:
     - type: Transform
@@ -104935,7 +105020,7 @@ entities:
       pos: -66.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25293
     components:
     - type: Transform
@@ -104943,7 +105028,7 @@ entities:
       pos: -67.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25294
     components:
     - type: Transform
@@ -104951,7 +105036,7 @@ entities:
       pos: -68.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25295
     components:
     - type: Transform
@@ -104959,7 +105044,7 @@ entities:
       pos: -69.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25296
     components:
     - type: Transform
@@ -104967,7 +105052,7 @@ entities:
       pos: -70.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25297
     components:
     - type: Transform
@@ -105047,7 +105132,7 @@ entities:
       pos: -63.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25311
     components:
     - type: Transform
@@ -105055,7 +105140,7 @@ entities:
       pos: -62.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25312
     components:
     - type: Transform
@@ -105063,7 +105148,7 @@ entities:
       pos: -61.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25319
     components:
     - type: Transform
@@ -105095,7 +105180,7 @@ entities:
       pos: -57.5,2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25323
     components:
     - type: Transform
@@ -105103,21 +105188,21 @@ entities:
       pos: -57.5,3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25326
     components:
     - type: Transform
       pos: -50.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25327
     components:
     - type: Transform
       pos: -50.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25328
     components:
     - type: Transform
@@ -105131,7 +105216,7 @@ entities:
       pos: -50.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25330
     components:
     - type: Transform
@@ -105145,7 +105230,7 @@ entities:
       pos: -50.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25332
     components:
     - type: Transform
@@ -105159,7 +105244,7 @@ entities:
       pos: -50.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25334
     components:
     - type: Transform
@@ -105173,35 +105258,35 @@ entities:
       pos: -50.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25338
     components:
     - type: Transform
       pos: -41.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25339
     components:
     - type: Transform
       pos: -41.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25340
     components:
     - type: Transform
       pos: -41.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25341
     components:
     - type: Transform
       pos: -41.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25342
     components:
     - type: Transform
@@ -105229,14 +105314,14 @@ entities:
       pos: -41.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25349
     components:
     - type: Transform
       pos: -41.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25353
     components:
     - type: Transform
@@ -105268,7 +105353,7 @@ entities:
       pos: -42.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25357
     components:
     - type: Transform
@@ -105276,7 +105361,7 @@ entities:
       pos: -43.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25358
     components:
     - type: Transform
@@ -105284,7 +105369,7 @@ entities:
       pos: -44.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25359
     components:
     - type: Transform
@@ -105305,7 +105390,7 @@ entities:
       pos: -45.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25362
     components:
     - type: Transform
@@ -105319,7 +105404,7 @@ entities:
       pos: -45.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25368
     components:
     - type: Transform
@@ -105327,7 +105412,7 @@ entities:
       pos: -45.5,0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25369
     components:
     - type: Transform
@@ -105335,7 +105420,7 @@ entities:
       pos: -45.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25370
     components:
     - type: Transform
@@ -105343,7 +105428,7 @@ entities:
       pos: -45.5,2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25371
     components:
     - type: Transform
@@ -105396,28 +105481,28 @@ entities:
       pos: -32.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25381
     components:
     - type: Transform
       pos: -32.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25382
     components:
     - type: Transform
       pos: -32.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25383
     components:
     - type: Transform
       pos: -32.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25384
     components:
     - type: Transform
@@ -105445,56 +105530,56 @@ entities:
       pos: -26.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25388
     components:
     - type: Transform
       pos: -26.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25389
     components:
     - type: Transform
       pos: -26.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25390
     components:
     - type: Transform
       pos: -26.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25391
     components:
     - type: Transform
       pos: -26.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25398
     components:
     - type: Transform
       pos: -31.5,0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25399
     components:
     - type: Transform
       pos: -31.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25400
     components:
     - type: Transform
       pos: -31.5,2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25401
     components:
     - type: Transform
@@ -105536,35 +105621,35 @@ entities:
       pos: -22.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25411
     components:
     - type: Transform
       pos: -22.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25412
     components:
     - type: Transform
       pos: -22.5,-3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25413
     components:
     - type: Transform
       pos: -22.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25414
     components:
     - type: Transform
       pos: -22.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25415
     components:
     - type: Transform
@@ -105625,7 +105710,7 @@ entities:
       pos: -2.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25429
     components:
     - type: Transform
@@ -105633,7 +105718,7 @@ entities:
       pos: -3.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25430
     components:
     - type: Transform
@@ -105641,7 +105726,7 @@ entities:
       pos: -4.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25439
     components:
     - type: Transform
@@ -105673,7 +105758,7 @@ entities:
       pos: -17.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25443
     components:
     - type: Transform
@@ -105681,7 +105766,7 @@ entities:
       pos: -17.5,22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25444
     components:
     - type: Transform
@@ -105713,7 +105798,7 @@ entities:
       pos: -11.5,19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25448
     components:
     - type: Transform
@@ -105721,7 +105806,7 @@ entities:
       pos: -11.5,18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25449
     components:
     - type: Transform
@@ -105729,7 +105814,7 @@ entities:
       pos: -11.5,17.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25450
     components:
     - type: Transform
@@ -105737,7 +105822,7 @@ entities:
       pos: -11.5,16.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25451
     components:
     - type: Transform
@@ -105769,7 +105854,7 @@ entities:
       pos: -5.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25455
     components:
     - type: Transform
@@ -105777,7 +105862,7 @@ entities:
       pos: -5.5,19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25456
     components:
     - type: Transform
@@ -105785,7 +105870,7 @@ entities:
       pos: -5.5,18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25457
     components:
     - type: Transform
@@ -105793,7 +105878,7 @@ entities:
       pos: -5.5,17.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25458
     components:
     - type: Transform
@@ -105801,7 +105886,7 @@ entities:
       pos: -5.5,16.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25459
     components:
     - type: Transform
@@ -105841,7 +105926,7 @@ entities:
       pos: -6.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25466
     components:
     - type: Transform
@@ -105849,7 +105934,7 @@ entities:
       pos: -8.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25467
     components:
     - type: Transform
@@ -105857,7 +105942,7 @@ entities:
       pos: -9.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25468
     components:
     - type: Transform
@@ -105905,7 +105990,7 @@ entities:
       pos: -12.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25474
     components:
     - type: Transform
@@ -105913,7 +105998,7 @@ entities:
       pos: -13.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25475
     components:
     - type: Transform
@@ -105921,7 +106006,7 @@ entities:
       pos: -14.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25476
     components:
     - type: Transform
@@ -105929,7 +106014,7 @@ entities:
       pos: -15.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25477
     components:
     - type: Transform
@@ -105937,7 +106022,7 @@ entities:
       pos: -16.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25478
     components:
     - type: Transform
@@ -106033,7 +106118,7 @@ entities:
       pos: -0.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25503
     components:
     - type: Transform
@@ -106041,7 +106126,7 @@ entities:
       pos: 0.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25504
     components:
     - type: Transform
@@ -106049,7 +106134,7 @@ entities:
       pos: 1.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25505
     components:
     - type: Transform
@@ -106057,7 +106142,7 @@ entities:
       pos: 2.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25506
     components:
     - type: Transform
@@ -106065,7 +106150,7 @@ entities:
       pos: 3.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25507
     components:
     - type: Transform
@@ -106081,7 +106166,7 @@ entities:
       pos: 5.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25509
     components:
     - type: Transform
@@ -106089,7 +106174,7 @@ entities:
       pos: 6.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25510
     components:
     - type: Transform
@@ -106097,7 +106182,7 @@ entities:
       pos: 7.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25512
     components:
     - type: Transform
@@ -106105,7 +106190,7 @@ entities:
       pos: 9.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25513
     components:
     - type: Transform
@@ -106113,7 +106198,7 @@ entities:
       pos: 10.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25514
     components:
     - type: Transform
@@ -106121,7 +106206,7 @@ entities:
       pos: 11.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25515
     components:
     - type: Transform
@@ -106129,7 +106214,7 @@ entities:
       pos: 12.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25520
     components:
     - type: Transform
@@ -106153,7 +106238,7 @@ entities:
       pos: 4.5,22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25523
     components:
     - type: Transform
@@ -106161,7 +106246,7 @@ entities:
       pos: 4.5,23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25524
     components:
     - type: Transform
@@ -106176,7 +106261,7 @@ entities:
       pos: 4.5,25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25528
     components:
     - type: Transform
@@ -106190,14 +106275,14 @@ entities:
       pos: 4.5,26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25530
     components:
     - type: Transform
       pos: 4.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25531
     components:
     - type: Transform
@@ -106213,7 +106298,7 @@ entities:
       pos: 8.5,28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25540
     components:
     - type: Transform
@@ -106229,7 +106314,7 @@ entities:
       pos: 6.5,28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25542
     components:
     - type: Transform
@@ -106237,7 +106322,7 @@ entities:
       pos: 5.5,28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25543
     components:
     - type: Transform
@@ -106269,7 +106354,7 @@ entities:
       pos: 7.5,29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25547
     components:
     - type: Transform
@@ -106277,7 +106362,7 @@ entities:
       pos: 7.5,30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25548
     components:
     - type: Transform
@@ -106285,7 +106370,7 @@ entities:
       pos: 7.5,31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25549
     components:
     - type: Transform
@@ -106293,7 +106378,7 @@ entities:
       pos: 9.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25550
     components:
     - type: Transform
@@ -106309,7 +106394,7 @@ entities:
       pos: 9.5,26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25552
     components:
     - type: Transform
@@ -106325,7 +106410,7 @@ entities:
       pos: 9.5,25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25554
     components:
     - type: Transform
@@ -106341,7 +106426,7 @@ entities:
       pos: 9.5,24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25556
     components:
     - type: Transform
@@ -106380,7 +106465,7 @@ entities:
       pos: -8.5,25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25569
     components:
     - type: Transform
@@ -106411,7 +106496,7 @@ entities:
       pos: -8.5,26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25573
     components:
     - type: Transform
@@ -106458,7 +106543,7 @@ entities:
       pos: -0.5,26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25581
     components:
     - type: Transform
@@ -106489,7 +106574,7 @@ entities:
       pos: 1.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25585
     components:
     - type: Transform
@@ -106497,14 +106582,14 @@ entities:
       pos: 0.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25586
     components:
     - type: Transform
       pos: -4.5,26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25587
     components:
     - type: Transform
@@ -106512,7 +106597,7 @@ entities:
       pos: -1.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25588
     components:
     - type: Transform
@@ -106520,7 +106605,7 @@ entities:
       pos: -2.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25589
     components:
     - type: Transform
@@ -106528,14 +106613,14 @@ entities:
       pos: -3.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25590
     components:
     - type: Transform
       pos: -4.5,25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25591
     components:
     - type: Transform
@@ -106543,7 +106628,7 @@ entities:
       pos: -5.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25592
     components:
     - type: Transform
@@ -106551,7 +106636,7 @@ entities:
       pos: -6.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25593
     components:
     - type: Transform
@@ -106559,7 +106644,7 @@ entities:
       pos: -7.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25594
     components:
     - type: Transform
@@ -106574,7 +106659,7 @@ entities:
       pos: -9.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25596
     components:
     - type: Transform
@@ -106582,7 +106667,7 @@ entities:
       pos: -10.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25598
     components:
     - type: Transform
@@ -106590,7 +106675,7 @@ entities:
       pos: -12.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25599
     components:
     - type: Transform
@@ -106598,28 +106683,28 @@ entities:
       pos: -13.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25602
     components:
     - type: Transform
       pos: -14.5,26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25603
     components:
     - type: Transform
       pos: -14.5,25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25604
     components:
     - type: Transform
       pos: -14.5,24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25605
     components:
     - type: Transform
@@ -106640,7 +106725,7 @@ entities:
       pos: -0.5,25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25608
     components:
     - type: Transform
@@ -106654,14 +106739,14 @@ entities:
       pos: 2.5,25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25610
     components:
     - type: Transform
       pos: 2.5,26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25629
     components:
     - type: Transform
@@ -106701,7 +106786,7 @@ entities:
       pos: 2.5,28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25634
     components:
     - type: Transform
@@ -106709,7 +106794,7 @@ entities:
       pos: 2.5,29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25635
     components:
     - type: Transform
@@ -106717,7 +106802,7 @@ entities:
       pos: 2.5,30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25638
     components:
     - type: Transform
@@ -106752,28 +106837,28 @@ entities:
       pos: 2.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25643
     components:
     - type: Transform
       pos: 2.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25644
     components:
     - type: Transform
       pos: 2.5,34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25645
     components:
     - type: Transform
       pos: 2.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25646
     components:
     - type: Transform
@@ -106794,14 +106879,14 @@ entities:
       pos: -4.5,28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25651
     components:
     - type: Transform
       pos: -4.5,30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25654
     components:
     - type: Transform
@@ -106817,7 +106902,7 @@ entities:
       pos: -5.5,31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25656
     components:
     - type: Transform
@@ -106825,7 +106910,7 @@ entities:
       pos: -6.5,31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25657
     components:
     - type: Transform
@@ -106865,7 +106950,7 @@ entities:
       pos: -4.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25662
     components:
     - type: Transform
@@ -106873,7 +106958,7 @@ entities:
       pos: -4.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25663
     components:
     - type: Transform
@@ -106881,7 +106966,7 @@ entities:
       pos: -4.5,34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25695
     components:
     - type: Transform
@@ -106934,7 +107019,7 @@ entities:
       pos: -13.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25746
     components:
     - type: Transform
@@ -106942,7 +107027,7 @@ entities:
       pos: -13.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25748
     components:
     - type: Transform
@@ -106965,28 +107050,28 @@ entities:
       pos: 7.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25766
     components:
     - type: Transform
       pos: 7.5,34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25767
     components:
     - type: Transform
       pos: 7.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25768
     components:
     - type: Transform
       pos: 7.5,36.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25769
     components:
     - type: Transform
@@ -107022,7 +107107,7 @@ entities:
       pos: 8.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25774
     components:
     - type: Transform
@@ -107030,7 +107115,7 @@ entities:
       pos: 9.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25775
     components:
     - type: Transform
@@ -107054,7 +107139,7 @@ entities:
       pos: 10.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25778
     components:
     - type: Transform
@@ -107062,7 +107147,7 @@ entities:
       pos: 11.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25779
     components:
     - type: Transform
@@ -107086,7 +107171,7 @@ entities:
       pos: 12.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25782
     components:
     - type: Transform
@@ -107094,7 +107179,7 @@ entities:
       pos: 13.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25783
     components:
     - type: Transform
@@ -107166,7 +107251,7 @@ entities:
       pos: 14.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25795
     components:
     - type: Transform
@@ -107174,7 +107259,7 @@ entities:
       pos: 14.5,34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25796
     components:
     - type: Transform
@@ -107182,7 +107267,7 @@ entities:
       pos: 14.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25797
     components:
     - type: Transform
@@ -107190,14 +107275,14 @@ entities:
       pos: 14.5,36.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25799
     components:
     - type: Transform
       pos: 14.5,37.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25806
     components:
     - type: Transform
@@ -107205,7 +107290,7 @@ entities:
       pos: 15.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25812
     components:
     - type: Transform
@@ -107253,7 +107338,7 @@ entities:
       pos: 17.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25818
     components:
     - type: Transform
@@ -107261,7 +107346,7 @@ entities:
       pos: 18.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25819
     components:
     - type: Transform
@@ -107269,7 +107354,7 @@ entities:
       pos: 19.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25820
     components:
     - type: Transform
@@ -107277,7 +107362,7 @@ entities:
       pos: 20.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25821
     components:
     - type: Transform
@@ -107285,7 +107370,7 @@ entities:
       pos: 21.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25822
     components:
     - type: Transform
@@ -107293,7 +107378,7 @@ entities:
       pos: 22.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25966
     components:
     - type: Transform
@@ -107371,7 +107456,7 @@ entities:
       pos: -4.5,-63.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26676
     components:
     - type: Transform
@@ -107411,7 +107496,7 @@ entities:
       pos: -5.5,-72.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26681
     components:
     - type: Transform
@@ -107419,7 +107504,7 @@ entities:
       pos: -5.5,-71.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26682
     components:
     - type: Transform
@@ -107427,7 +107512,7 @@ entities:
       pos: -5.5,-70.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26683
     components:
     - type: Transform
@@ -107435,7 +107520,7 @@ entities:
       pos: -5.5,-69.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26684
     components:
     - type: Transform
@@ -107443,7 +107528,7 @@ entities:
       pos: -4.5,-73.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26685
     components:
     - type: Transform
@@ -107451,7 +107536,7 @@ entities:
       pos: -3.5,-73.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26686
     components:
     - type: Transform
@@ -107491,7 +107576,7 @@ entities:
       pos: -7.5,-73.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26691
     components:
     - type: Transform
@@ -107499,7 +107584,7 @@ entities:
       pos: -8.5,-73.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26921
     components:
     - type: Transform
@@ -107985,7 +108070,7 @@ entities:
       pos: -6.5,50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 953
     components:
     - type: Transform
@@ -108008,7 +108093,7 @@ entities:
       pos: 5.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3860
     components:
     - type: Transform
@@ -108040,7 +108125,7 @@ entities:
       pos: 8.5,-74.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4145
     components:
     - type: Transform
@@ -108117,14 +108202,14 @@ entities:
       pos: -13.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7710
     components:
     - type: Transform
       pos: -11.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8524
     components:
     - type: Transform
@@ -108138,14 +108223,14 @@ entities:
       pos: -0.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8668
     components:
     - type: Transform
       pos: -8.5,27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8672
     components:
     - type: Transform
@@ -108175,7 +108260,7 @@ entities:
       pos: -10.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8949
     components:
     - type: Transform
@@ -108183,7 +108268,7 @@ entities:
       pos: -6.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8965
     components:
     - type: Transform
@@ -108207,7 +108292,7 @@ entities:
       pos: -7.5,43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9107
     components:
     - type: Transform
@@ -108215,7 +108300,7 @@ entities:
       pos: -4.5,35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9439
     components:
     - type: Transform
@@ -108264,7 +108349,7 @@ entities:
       pos: -1.5,-47.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16134
     components:
     - type: Transform
@@ -108272,7 +108357,7 @@ entities:
       pos: -41.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16338
     components:
     - type: Transform
@@ -108334,7 +108419,7 @@ entities:
       pos: 5.5,-52.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17042
     components:
     - type: Transform
@@ -108342,7 +108427,7 @@ entities:
       pos: -0.5,-47.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17051
     components:
     - type: Transform
@@ -108371,7 +108456,7 @@ entities:
       pos: 4.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17119
     components:
     - type: Transform
@@ -108379,7 +108464,7 @@ entities:
       pos: 4.5,-61.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17149
     components:
     - type: Transform
@@ -108387,7 +108472,7 @@ entities:
       pos: 3.5,-65.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17160
     components:
     - type: Transform
@@ -108395,7 +108480,7 @@ entities:
       pos: -5.5,-64.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17183
     components:
     - type: Transform
@@ -108494,7 +108579,7 @@ entities:
       pos: 28.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18036
     components:
     - type: Transform
@@ -108509,7 +108594,7 @@ entities:
       pos: 7.5,-65.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 19101
     components:
     - type: Transform
@@ -108563,7 +108648,7 @@ entities:
       pos: -2.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22556
     components:
     - type: Transform
@@ -108571,7 +108656,7 @@ entities:
       pos: 76.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22557
     components:
     - type: Transform
@@ -108594,7 +108679,7 @@ entities:
       pos: -6.5,-64.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23017
     components:
     - type: Transform
@@ -108610,7 +108695,7 @@ entities:
       pos: -1.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23043
     components:
     - type: Transform
@@ -108634,7 +108719,7 @@ entities:
       pos: -1.5,-43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23056
     components:
     - type: Transform
@@ -108642,7 +108727,7 @@ entities:
       pos: -1.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23060
     components:
     - type: Transform
@@ -108650,7 +108735,7 @@ entities:
       pos: -5.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23069
     components:
     - type: Transform
@@ -108665,7 +108750,7 @@ entities:
       pos: -7.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23071
     components:
     - type: Transform
@@ -108680,7 +108765,7 @@ entities:
       pos: 0.5,-66.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23183
     components:
     - type: Transform
@@ -108696,14 +108781,14 @@ entities:
       pos: 5.5,-44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23252
     components:
     - type: Transform
       pos: -13.5,-68.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23271
     components:
     - type: Transform
@@ -108727,7 +108812,7 @@ entities:
       pos: -1.5,-38.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23294
     components:
     - type: Transform
@@ -108735,7 +108820,7 @@ entities:
       pos: -1.5,-36.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23295
     components:
     - type: Transform
@@ -108751,7 +108836,7 @@ entities:
       pos: -8.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23324
     components:
     - type: Transform
@@ -108759,7 +108844,7 @@ entities:
       pos: -12.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23335
     components:
     - type: Transform
@@ -108783,7 +108868,7 @@ entities:
       pos: -17.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23345
     components:
     - type: Transform
@@ -108791,7 +108876,7 @@ entities:
       pos: -17.5,-15.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23348
     components:
     - type: Transform
@@ -108807,7 +108892,7 @@ entities:
       pos: -17.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23354
     components:
     - type: Transform
@@ -108822,7 +108907,7 @@ entities:
       pos: -17.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23365
     components:
     - type: Transform
@@ -108852,7 +108937,7 @@ entities:
       pos: -31.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23375
     components:
     - type: Transform
@@ -108873,7 +108958,7 @@ entities:
       pos: -43.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23388
     components:
     - type: Transform
@@ -108896,7 +108981,7 @@ entities:
       pos: -54.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23406
     components:
     - type: Transform
@@ -108904,7 +108989,7 @@ entities:
       pos: -57.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23407
     components:
     - type: Transform
@@ -108935,7 +109020,7 @@ entities:
       pos: -64.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23435
     components:
     - type: Transform
@@ -108951,7 +109036,7 @@ entities:
       pos: -1.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23468
     components:
     - type: Transform
@@ -108974,7 +109059,7 @@ entities:
       pos: -1.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23495
     components:
     - type: Transform
@@ -108982,7 +109067,7 @@ entities:
       pos: 8.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23497
     components:
     - type: Transform
@@ -108998,7 +109083,7 @@ entities:
       pos: 14.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23508
     components:
     - type: Transform
@@ -109006,7 +109091,7 @@ entities:
       pos: 14.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23513
     components:
     - type: Transform
@@ -109014,7 +109099,7 @@ entities:
       pos: 14.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23520
     components:
     - type: Transform
@@ -109022,7 +109107,7 @@ entities:
       pos: 14.5,-19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23526
     components:
     - type: Transform
@@ -109030,7 +109115,7 @@ entities:
       pos: 14.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23530
     components:
     - type: Transform
@@ -109038,7 +109123,7 @@ entities:
       pos: 14.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23533
     components:
     - type: Transform
@@ -109060,7 +109145,7 @@ entities:
       pos: 1.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23558
     components:
     - type: Transform
@@ -109091,7 +109176,7 @@ entities:
       pos: -17.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23572
     components:
     - type: Transform
@@ -109099,7 +109184,7 @@ entities:
       pos: -17.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23581
     components:
     - type: Transform
@@ -109115,7 +109200,7 @@ entities:
       pos: -17.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23586
     components:
     - type: Transform
@@ -109131,7 +109216,7 @@ entities:
       pos: -17.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23593
     components:
     - type: Transform
@@ -109145,21 +109230,21 @@ entities:
       pos: -22.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23605
     components:
     - type: Transform
       pos: -23.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23606
     components:
     - type: Transform
       pos: -32.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23609
     components:
     - type: Transform
@@ -109174,7 +109259,7 @@ entities:
       pos: -26.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23617
     components:
     - type: Transform
@@ -109182,7 +109267,7 @@ entities:
       pos: -45.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23619
     components:
     - type: Transform
@@ -109197,14 +109282,14 @@ entities:
       pos: -41.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23630
     components:
     - type: Transform
       pos: -50.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23632
     components:
     - type: Transform
@@ -109219,7 +109304,7 @@ entities:
       pos: -58.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23641
     components:
     - type: Transform
@@ -109235,7 +109320,7 @@ entities:
       pos: -64.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23662
     components:
     - type: Transform
@@ -109243,7 +109328,7 @@ entities:
       pos: -64.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23669
     components:
     - type: Transform
@@ -109251,7 +109336,7 @@ entities:
       pos: -58.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23678
     components:
     - type: Transform
@@ -109291,7 +109376,7 @@ entities:
       pos: -1.5,4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23718
     components:
     - type: Transform
@@ -109299,7 +109384,7 @@ entities:
       pos: -1.5,14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23721
     components:
     - type: Transform
@@ -109321,7 +109406,7 @@ entities:
       pos: 10.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23738
     components:
     - type: Transform
@@ -109368,7 +109453,7 @@ entities:
       pos: 4.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23782
     components:
     - type: Transform
@@ -109383,28 +109468,28 @@ entities:
       pos: 22.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23793
     components:
     - type: Transform
       pos: 35.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23797
     components:
     - type: Transform
       pos: 31.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23802
     components:
     - type: Transform
       pos: 26.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23805
     components:
     - type: Transform
@@ -109444,14 +109529,14 @@ entities:
       pos: 52.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23841
     components:
     - type: Transform
       pos: 46.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23844
     components:
     - type: Transform
@@ -109459,7 +109544,7 @@ entities:
       pos: 43.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23851
     components:
     - type: Transform
@@ -109467,7 +109552,7 @@ entities:
       pos: 36.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23852
     components:
     - type: Transform
@@ -109511,14 +109596,14 @@ entities:
       pos: 66.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23885
     components:
     - type: Transform
       pos: 65.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23886
     components:
     - type: Transform
@@ -109542,7 +109627,7 @@ entities:
       pos: 76.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23928
     components:
     - type: Transform
@@ -109550,7 +109635,7 @@ entities:
       pos: -1.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23929
     components:
     - type: Transform
@@ -109565,7 +109650,7 @@ entities:
       pos: -20.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23958
     components:
     - type: Transform
@@ -109589,21 +109674,21 @@ entities:
       pos: -22.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23975
     components:
     - type: Transform
       pos: -24.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23976
     components:
     - type: Transform
       pos: -25.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23978
     components:
     - type: Transform
@@ -109632,7 +109717,7 @@ entities:
       pos: 7.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24128
     components:
     - type: Transform
@@ -109653,14 +109738,14 @@ entities:
       pos: -8.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24158
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24162
     components:
     - type: Transform
@@ -109674,7 +109759,7 @@ entities:
       pos: -3.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24170
     components:
     - type: Transform
@@ -109689,7 +109774,7 @@ entities:
       pos: 0.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24174
     components:
     - type: Transform
@@ -109713,7 +109798,7 @@ entities:
       pos: 7.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24213
     components:
     - type: Transform
@@ -109729,7 +109814,7 @@ entities:
       pos: 8.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24257
     components:
     - type: Transform
@@ -109745,7 +109830,7 @@ entities:
       pos: 8.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24259
     components:
     - type: Transform
@@ -109761,7 +109846,7 @@ entities:
       pos: 8.5,11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24261
     components:
     - type: Transform
@@ -109777,7 +109862,7 @@ entities:
       pos: 8.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24276
     components:
     - type: Transform
@@ -109801,7 +109886,7 @@ entities:
       pos: -12.5,3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24312
     components:
     - type: Transform
@@ -109823,14 +109908,14 @@ entities:
       pos: -12.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24342
     components:
     - type: Transform
       pos: 11.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24343
     components:
     - type: Transform
@@ -109854,14 +109939,14 @@ entities:
       pos: 13.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24374
     components:
     - type: Transform
       pos: 19.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24375
     components:
     - type: Transform
@@ -109885,7 +109970,7 @@ entities:
       pos: 17.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24428
     components:
     - type: Transform
@@ -109901,7 +109986,7 @@ entities:
       pos: 22.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24433
     components:
     - type: Transform
@@ -109909,7 +109994,7 @@ entities:
       pos: 22.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24439
     components:
     - type: Transform
@@ -109924,7 +110009,7 @@ entities:
       pos: 36.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24504
     components:
     - type: Transform
@@ -109948,7 +110033,7 @@ entities:
       pos: 35.5,-18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24541
     components:
     - type: Transform
@@ -109963,7 +110048,7 @@ entities:
       pos: 31.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24556
     components:
     - type: Transform
@@ -109979,7 +110064,7 @@ entities:
       pos: 26.5,-17.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24577
     components:
     - type: Transform
@@ -110003,7 +110088,7 @@ entities:
       pos: 38.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24637
     components:
     - type: Transform
@@ -110011,7 +110096,7 @@ entities:
       pos: 40.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24653
     components:
     - type: Transform
@@ -110027,14 +110112,14 @@ entities:
       pos: 26.5,-28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24662
     components:
     - type: Transform
       pos: 41.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24663
     components:
     - type: Transform
@@ -110050,7 +110135,7 @@ entities:
       pos: 39.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24751
     components:
     - type: Transform
@@ -110058,7 +110143,7 @@ entities:
       pos: 39.5,-35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24761
     components:
     - type: Transform
@@ -110082,7 +110167,7 @@ entities:
       pos: 39.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24783
     components:
     - type: Transform
@@ -110106,7 +110191,7 @@ entities:
       pos: 39.5,-53.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24828
     components:
     - type: Transform
@@ -110114,14 +110199,14 @@ entities:
       pos: 39.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24834
     components:
     - type: Transform
       pos: 40.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24859
     components:
     - type: Transform
@@ -110152,7 +110237,7 @@ entities:
       pos: 43.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24928
     components:
     - type: Transform
@@ -110167,7 +110252,7 @@ entities:
       pos: 73.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25026
     components:
     - type: Transform
@@ -110183,7 +110268,7 @@ entities:
       pos: 66.5,-18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25041
     components:
     - type: Transform
@@ -110191,7 +110276,7 @@ entities:
       pos: 66.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25042
     components:
     - type: Transform
@@ -110207,7 +110292,7 @@ entities:
       pos: 66.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25054
     components:
     - type: Transform
@@ -110223,7 +110308,7 @@ entities:
       pos: 70.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25073
     components:
     - type: Transform
@@ -110247,14 +110332,14 @@ entities:
       pos: 66.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25117
     components:
     - type: Transform
       pos: 56.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25118
     components:
     - type: Transform
@@ -110269,7 +110354,7 @@ entities:
       pos: 56.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25125
     components:
     - type: Transform
@@ -110293,7 +110378,7 @@ entities:
       pos: 66.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25179
     components:
     - type: Transform
@@ -110301,7 +110386,7 @@ entities:
       pos: 66.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25191
     components:
     - type: Transform
@@ -110325,7 +110410,7 @@ entities:
       pos: -41.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25431
     components:
     - type: Transform
@@ -110339,7 +110424,7 @@ entities:
       pos: -5.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25433
     components:
     - type: Transform
@@ -110353,7 +110438,7 @@ entities:
       pos: -11.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25437
     components:
     - type: Transform
@@ -110369,7 +110454,7 @@ entities:
       pos: -17.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25460
     components:
     - type: Transform
@@ -110384,7 +110469,7 @@ entities:
       pos: -7.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25493
     components:
     - type: Transform
@@ -110400,14 +110485,14 @@ entities:
       pos: 4.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25498
     components:
     - type: Transform
       pos: 8.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25511
     components:
     - type: Transform
@@ -110431,14 +110516,14 @@ entities:
       pos: 4.5,24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25532
     components:
     - type: Transform
       pos: 4.5,28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25535
     components:
     - type: Transform
@@ -110453,14 +110538,14 @@ entities:
       pos: 7.5,28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25538
     components:
     - type: Transform
       pos: 9.5,28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25636
     components:
     - type: Transform
@@ -110476,7 +110561,7 @@ entities:
       pos: 2.5,31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25647
     components:
     - type: Transform
@@ -110484,7 +110569,7 @@ entities:
       pos: -4.5,29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25650
     components:
     - type: Transform
@@ -110508,7 +110593,7 @@ entities:
       pos: -4.5,31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25763
     components:
     - type: Transform
@@ -110524,7 +110609,7 @@ entities:
       pos: 7.5,32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26672
     components:
     - type: Transform
@@ -110540,7 +110625,7 @@ entities:
       pos: -5.5,-73.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26674
     components:
     - type: Transform
@@ -110555,7 +110640,7 @@ entities:
       pos: -6.5,-73.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26920
     components:
     - type: Transform
@@ -110660,7 +110745,7 @@ entities:
       pos: 1.5,-49.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15506
     components:
     - type: Transform
@@ -110668,7 +110753,7 @@ entities:
       pos: 1.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15641
     components:
     - type: Transform
@@ -111034,7 +111119,7 @@ entities:
       pos: 9.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25004
     components:
     - type: Transform
@@ -111509,6 +111594,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -23.5,-69.5
       parent: 8364
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 22588
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 23279
@@ -112712,14 +112802,14 @@ entities:
       pos: 11.5,-74.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5383
     components:
     - type: Transform
       pos: 57.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5463
     components:
     - type: Transform
@@ -112730,28 +112820,28 @@ entities:
       deviceLists:
       - 26707
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7284
     components:
     - type: Transform
       pos: -7.5,44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7294
     components:
     - type: Transform
       pos: -13.5,47.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7295
     components:
     - type: Transform
       pos: -18.5,44.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7301
     components:
     - type: Transform
@@ -112759,7 +112849,7 @@ entities:
       pos: -7.5,50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8953
     components:
     - type: Transform
@@ -112767,7 +112857,7 @@ entities:
       pos: -10.5,34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9185
     components:
     - type: Transform
@@ -112775,7 +112865,7 @@ entities:
       pos: -1.5,50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14226
     components:
     - type: Transform
@@ -112786,7 +112876,7 @@ entities:
       deviceLists:
       - 22970
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15347
     components:
     - type: Transform
@@ -112794,14 +112884,27 @@ entities:
       pos: -2.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
+  - uid: 16789
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-68.5
+      parent: 8364
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 22588
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 16832
     components:
     - type: Transform
       pos: -0.5,-46.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17122
     components:
     - type: Transform
@@ -112809,7 +112912,7 @@ entities:
       pos: 3.5,-61.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17187
     components:
     - type: Transform
@@ -112817,21 +112920,21 @@ entities:
       pos: 0.5,-67.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17630
     components:
     - type: Transform
       pos: 5.5,-43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 19123
     components:
     - type: Transform
       pos: 28.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 20132
     components:
     - type: Transform
@@ -112839,14 +112942,14 @@ entities:
       pos: -71.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22459
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22695
     components:
     - type: Transform
@@ -112854,7 +112957,7 @@ entities:
       pos: 77.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22778
     components:
     - type: Transform
@@ -112862,7 +112965,7 @@ entities:
       pos: -6.5,-65.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22800
     components:
     - type: Transform
@@ -112870,7 +112973,7 @@ entities:
       pos: -1.5,-63.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22828
     components:
     - type: Transform
@@ -112878,7 +112981,7 @@ entities:
       pos: -12.5,-64.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22951
     components:
     - type: Transform
@@ -112893,7 +112996,7 @@ entities:
       pos: 8.5,-52.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23067
     components:
     - type: Transform
@@ -112901,7 +113004,7 @@ entities:
       pos: -1.5,-57.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23086
     components:
     - type: Transform
@@ -112909,7 +113012,7 @@ entities:
       pos: -7.5,-57.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23087
     components:
     - type: Transform
@@ -112917,14 +113020,14 @@ entities:
       pos: -11.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23088
     components:
     - type: Transform
       pos: -5.5,-51.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23120
     components:
     - type: Transform
@@ -112932,7 +113035,7 @@ entities:
       pos: 8.5,-65.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23177
     components:
     - type: Transform
@@ -112940,15 +113043,7 @@ entities:
       pos: 3.5,-74.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 23260
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,-68.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23278
     components:
     - type: Transform
@@ -112956,7 +113051,7 @@ entities:
       pos: -4.5,-43.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23302
     components:
     - type: Transform
@@ -112964,7 +113059,7 @@ entities:
       pos: -4.5,-36.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23305
     components:
     - type: Transform
@@ -112972,7 +113067,7 @@ entities:
       pos: -0.5,-38.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23941
     components:
     - type: Transform
@@ -112980,21 +113075,21 @@ entities:
       pos: -0.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23948
     components:
     - type: Transform
       pos: 1.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 23950
     components:
     - type: Transform
       pos: -12.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24012
     components:
     - type: Transform
@@ -113002,14 +113097,14 @@ entities:
       pos: -32.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24013
     components:
     - type: Transform
       pos: -22.5,-18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24014
     components:
     - type: Transform
@@ -113017,7 +113112,7 @@ entities:
       pos: -20.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24032
     components:
     - type: Transform
@@ -113025,7 +113120,7 @@ entities:
       pos: -24.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24039
     components:
     - type: Transform
@@ -113033,7 +113128,7 @@ entities:
       pos: -21.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24051
     components:
     - type: Transform
@@ -113041,7 +113136,7 @@ entities:
       pos: -31.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24056
     components:
     - type: Transform
@@ -113049,7 +113144,7 @@ entities:
       pos: -25.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24062
     components:
     - type: Transform
@@ -113057,14 +113152,14 @@ entities:
       pos: -13.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24073
     components:
     - type: Transform
       pos: -8.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24083
     components:
     - type: Transform
@@ -113072,7 +113167,7 @@ entities:
       pos: -21.5,-12.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24084
     components:
     - type: Transform
@@ -113080,7 +113175,7 @@ entities:
       pos: -16.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24087
     components:
     - type: Transform
@@ -113088,7 +113183,7 @@ entities:
       pos: -16.5,-15.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24097
     components:
     - type: Transform
@@ -113096,7 +113191,7 @@ entities:
       pos: 4.5,-35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24099
     components:
     - type: Transform
@@ -113104,7 +113199,7 @@ entities:
       pos: 15.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24109
     components:
     - type: Transform
@@ -113112,7 +113207,7 @@ entities:
       pos: 10.5,-25.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24111
     components:
     - type: Transform
@@ -113120,7 +113215,7 @@ entities:
       pos: 15.5,-19.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24180
     components:
     - type: Transform
@@ -113128,7 +113223,7 @@ entities:
       pos: -3.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24181
     components:
     - type: Transform
@@ -113136,7 +113231,7 @@ entities:
       pos: 2.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24188
     components:
     - type: Transform
@@ -113144,7 +113239,7 @@ entities:
       pos: 0.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24219
     components:
     - type: Transform
@@ -113152,7 +113247,7 @@ entities:
       pos: 7.5,-20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24224
     components:
     - type: Transform
@@ -113160,7 +113255,7 @@ entities:
       pos: 12.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24239
     components:
     - type: Transform
@@ -113168,7 +113263,7 @@ entities:
       pos: -8.5,-16.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24242
     components:
     - type: Transform
@@ -113176,7 +113271,7 @@ entities:
       pos: -16.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24244
     components:
     - type: Transform
@@ -113184,14 +113279,14 @@ entities:
       pos: 15.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24245
     components:
     - type: Transform
       pos: 76.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24295
     components:
     - type: Transform
@@ -113199,7 +113294,7 @@ entities:
       pos: 6.5,14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24296
     components:
     - type: Transform
@@ -113207,7 +113302,7 @@ entities:
       pos: 6.5,11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24297
     components:
     - type: Transform
@@ -113215,7 +113310,7 @@ entities:
       pos: 6.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24298
     components:
     - type: Transform
@@ -113223,7 +113318,7 @@ entities:
       pos: 6.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24300
     components:
     - type: Transform
@@ -113231,7 +113326,7 @@ entities:
       pos: 10.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24332
     components:
     - type: Transform
@@ -113239,7 +113334,7 @@ entities:
       pos: -11.5,3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24335
     components:
     - type: Transform
@@ -113247,7 +113342,7 @@ entities:
       pos: -12.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24337
     components:
     - type: Transform
@@ -113255,7 +113350,7 @@ entities:
       pos: -13.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24338
     components:
     - type: Transform
@@ -113263,21 +113358,21 @@ entities:
       pos: -5.5,8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24371
     components:
     - type: Transform
       pos: 13.5,14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24372
     components:
     - type: Transform
       pos: 17.5,14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24373
     components:
     - type: Transform
@@ -113285,7 +113380,7 @@ entities:
       pos: 11.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24377
     components:
     - type: Transform
@@ -113293,7 +113388,7 @@ entities:
       pos: 19.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24401
     components:
     - type: Transform
@@ -113301,7 +113396,7 @@ entities:
       pos: 29.5,9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24421
     components:
     - type: Transform
@@ -113309,7 +113404,7 @@ entities:
       pos: 12.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24422
     components:
     - type: Transform
@@ -113317,7 +113412,7 @@ entities:
       pos: 18.5,5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24436
     components:
     - type: Transform
@@ -113325,21 +113420,21 @@ entities:
       pos: 21.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24464
     components:
     - type: Transform
       pos: 20.5,3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24494
     components:
     - type: Transform
       pos: 29.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24506
     components:
     - type: Transform
@@ -113347,14 +113442,14 @@ entities:
       pos: 35.5,-8.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24520
     components:
     - type: Transform
       pos: 36.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24581
     components:
     - type: Transform
@@ -113362,7 +113457,7 @@ entities:
       pos: 27.5,-17.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24582
     components:
     - type: Transform
@@ -113370,7 +113465,7 @@ entities:
       pos: 34.5,-18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24586
     components:
     - type: Transform
@@ -113378,7 +113473,7 @@ entities:
       pos: 31.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24587
     components:
     - type: Transform
@@ -113386,28 +113481,28 @@ entities:
       pos: 31.5,-24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24610
     components:
     - type: Transform
       pos: 20.5,-20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24644
     components:
     - type: Transform
       pos: 41.5,-20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24646
     components:
     - type: Transform
       pos: 38.5,-18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24673
     components:
     - type: Transform
@@ -113415,7 +113510,7 @@ entities:
       pos: 41.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24674
     components:
     - type: Transform
@@ -113423,7 +113518,7 @@ entities:
       pos: 45.5,-26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24709
     components:
     - type: Transform
@@ -113431,7 +113526,7 @@ entities:
       pos: 26.5,-35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24711
     components:
     - type: Transform
@@ -113439,7 +113534,7 @@ entities:
       pos: 19.5,-33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24712
     components:
     - type: Transform
@@ -113447,7 +113542,7 @@ entities:
       pos: 27.5,-28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24747
     components:
     - type: Transform
@@ -113455,7 +113550,7 @@ entities:
       pos: 45.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24752
     components:
     - type: Transform
@@ -113463,7 +113558,7 @@ entities:
       pos: 40.5,-35.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24777
     components:
     - type: Transform
@@ -113471,7 +113566,7 @@ entities:
       pos: 40.5,-39.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24778
     components:
     - type: Transform
@@ -113479,7 +113574,7 @@ entities:
       pos: 35.5,-39.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24814
     components:
     - type: Transform
@@ -113487,7 +113582,7 @@ entities:
       pos: 36.5,-48.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24815
     components:
     - type: Transform
@@ -113495,7 +113590,7 @@ entities:
       pos: 36.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24816
     components:
     - type: Transform
@@ -113503,7 +113598,7 @@ entities:
       pos: 44.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24830
     components:
     - type: Transform
@@ -113511,7 +113606,7 @@ entities:
       pos: 40.5,-53.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24850
     components:
     - type: Transform
@@ -113519,7 +113614,7 @@ entities:
       pos: 46.5,-59.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24851
     components:
     - type: Transform
@@ -113527,7 +113622,7 @@ entities:
       pos: 43.5,-59.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24852
     components:
     - type: Transform
@@ -113535,7 +113630,7 @@ entities:
       pos: 36.5,-55.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24853
     components:
     - type: Transform
@@ -113543,21 +113638,21 @@ entities:
       pos: 40.5,-56.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24878
     components:
     - type: Transform
       pos: 43.5,-53.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24916
     components:
     - type: Transform
       pos: 47.5,-0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24917
     components:
     - type: Transform
@@ -113565,7 +113660,7 @@ entities:
       pos: 45.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24918
     components:
     - type: Transform
@@ -113573,7 +113668,7 @@ entities:
       pos: 46.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24919
     components:
     - type: Transform
@@ -113581,7 +113676,7 @@ entities:
       pos: 65.5,-13.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24930
     components:
     - type: Transform
@@ -113589,7 +113684,7 @@ entities:
       pos: 73.5,-10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24967
     components:
     - type: Transform
@@ -113597,7 +113692,7 @@ entities:
       pos: 66.5,1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25035
     components:
     - type: Transform
@@ -113605,7 +113700,7 @@ entities:
       pos: 67.5,-18.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25071
     components:
     - type: Transform
@@ -113613,21 +113708,21 @@ entities:
       pos: 77.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25072
     components:
     - type: Transform
       pos: 70.5,-21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25116
     components:
     - type: Transform
       pos: 61.5,-22.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25134
     components:
     - type: Transform
@@ -113635,7 +113730,7 @@ entities:
       pos: 53.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25135
     components:
     - type: Transform
@@ -113643,7 +113738,7 @@ entities:
       pos: 57.5,-31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25136
     components:
     - type: Transform
@@ -113651,7 +113746,7 @@ entities:
       pos: 54.5,-27.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25143
     components:
     - type: Transform
@@ -113659,7 +113754,7 @@ entities:
       pos: 61.5,-30.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25166
     components:
     - type: Transform
@@ -113667,7 +113762,7 @@ entities:
       pos: 62.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25167
     components:
     - type: Transform
@@ -113675,7 +113770,7 @@ entities:
       pos: 69.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25169
     components:
     - type: Transform
@@ -113683,7 +113778,7 @@ entities:
       pos: 67.5,-32.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25171
     components:
     - type: Transform
@@ -113691,7 +113786,7 @@ entities:
       pos: 67.5,-23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25207
     components:
     - type: Transform
@@ -113699,7 +113794,7 @@ entities:
       pos: 69.5,-50.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25223
     components:
     - type: Transform
@@ -113707,14 +113802,14 @@ entities:
       pos: 67.5,-41.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25241
     components:
     - type: Transform
       pos: 58.5,-39.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25261
     components:
     - type: Transform
@@ -113722,7 +113817,7 @@ entities:
       pos: 74.5,-45.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25290
     components:
     - type: Transform
@@ -113730,7 +113825,7 @@ entities:
       pos: -71.5,10.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25305
     components:
     - type: Transform
@@ -113738,7 +113833,7 @@ entities:
       pos: -71.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25306
     components:
     - type: Transform
@@ -113746,7 +113841,7 @@ entities:
       pos: -63.5,-2.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25313
     components:
     - type: Transform
@@ -113754,14 +113849,14 @@ entities:
       pos: -60.5,-9.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25317
     components:
     - type: Transform
       pos: -58.5,-4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25318
     components:
     - type: Transform
@@ -113769,14 +113864,14 @@ entities:
       pos: -58.5,0.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25324
     components:
     - type: Transform
       pos: -57.5,4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25337
     components:
     - type: Transform
@@ -113784,7 +113879,7 @@ entities:
       pos: -50.5,-7.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25364
     components:
     - type: Transform
@@ -113792,7 +113887,7 @@ entities:
       pos: -40.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25365
     components:
     - type: Transform
@@ -113800,14 +113895,14 @@ entities:
       pos: -45.5,-11.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25377
     components:
     - type: Transform
       pos: -45.5,3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25392
     components:
     - type: Transform
@@ -113815,7 +113910,7 @@ entities:
       pos: -26.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25393
     components:
     - type: Transform
@@ -113823,7 +113918,7 @@ entities:
       pos: -32.5,-5.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25397
     components:
     - type: Transform
@@ -113831,14 +113926,14 @@ entities:
       pos: -43.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25406
     components:
     - type: Transform
       pos: -31.5,3.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25408
     components:
     - type: Transform
@@ -113846,7 +113941,7 @@ entities:
       pos: -23.5,-1.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25419
     components:
     - type: Transform
@@ -113854,7 +113949,7 @@ entities:
       pos: -22.5,-6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25422
     components:
     - type: Transform
@@ -113862,7 +113957,7 @@ entities:
       pos: -0.5,14.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25423
     components:
     - type: Transform
@@ -113870,7 +113965,7 @@ entities:
       pos: -0.5,4.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25479
     components:
     - type: Transform
@@ -113878,7 +113973,7 @@ entities:
       pos: -5.5,15.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25480
     components:
     - type: Transform
@@ -113886,7 +113981,7 @@ entities:
       pos: -11.5,15.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25481
     components:
     - type: Transform
@@ -113894,14 +113989,14 @@ entities:
       pos: -18.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25482
     components:
     - type: Transform
       pos: -17.5,23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25487
     components:
     - type: Transform
@@ -113909,7 +114004,7 @@ entities:
       pos: -7.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25516
     components:
     - type: Transform
@@ -113917,7 +114012,7 @@ entities:
       pos: 13.5,21.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25518
     components:
     - type: Transform
@@ -113925,7 +114020,7 @@ entities:
       pos: 8.5,20.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25534
     components:
     - type: Transform
@@ -113933,7 +114028,7 @@ entities:
       pos: 5.5,24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25559
     components:
     - type: Transform
@@ -113941,7 +114036,7 @@ entities:
       pos: 9.5,23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25560
     components:
     - type: Transform
@@ -113949,7 +114044,7 @@ entities:
       pos: 10.5,28.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25624
     components:
     - type: Transform
@@ -113957,7 +114052,7 @@ entities:
       pos: -14.5,23.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25625
     components:
     - type: Transform
@@ -113965,7 +114060,7 @@ entities:
       pos: -8.5,24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25626
     components:
     - type: Transform
@@ -113973,7 +114068,7 @@ entities:
       pos: -4.5,24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25627
     components:
     - type: Transform
@@ -113981,7 +114076,7 @@ entities:
       pos: -0.5,24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25628
     components:
     - type: Transform
@@ -113989,7 +114084,7 @@ entities:
       pos: 2.5,24.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25752
     components:
     - type: Transform
@@ -113997,7 +114092,7 @@ entities:
       pos: -13.5,31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25754
     components:
     - type: Transform
@@ -114005,7 +114100,7 @@ entities:
       pos: -7.5,31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25756
     components:
     - type: Transform
@@ -114013,7 +114108,7 @@ entities:
       pos: -11.5,26.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25758
     components:
     - type: Transform
@@ -114021,7 +114116,7 @@ entities:
       pos: -5.5,29.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25759
     components:
     - type: Transform
@@ -114029,14 +114124,14 @@ entities:
       pos: 3.5,31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25760
     components:
     - type: Transform
       pos: 2.5,36.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25800
     components:
     - type: Transform
@@ -114044,14 +114139,14 @@ entities:
       pos: 14.5,31.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25801
     components:
     - type: Transform
       pos: 7.5,37.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25802
     components:
     - type: Transform
@@ -114059,7 +114154,7 @@ entities:
       pos: 13.5,38.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25823
     components:
     - type: Transform
@@ -114067,7 +114162,7 @@ entities:
       pos: 23.5,33.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26695
     components:
     - type: Transform
@@ -114075,14 +114170,14 @@ entities:
       pos: -2.5,-73.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26696
     components:
     - type: Transform
       pos: -6.5,-72.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 26697
     components:
     - type: Transform
@@ -114090,7 +114185,7 @@ entities:
       pos: -9.5,-73.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
 - proto: GasVolumePump
   entities:
   - uid: 4577
@@ -139949,7 +140044,7 @@ entities:
   - uid: 27556
     components:
     - type: Transform
-      pos: -24.410706,-71.44174
+      pos: -23.7492,-71.4955
       parent: 8364
 - proto: SheetPlasma1
   entities:
@@ -140167,7 +140262,7 @@ entities:
   - uid: 27557
     components:
     - type: Transform
-      pos: -23.566956,-71.37924
+      pos: -23.2492,-71.39133
       parent: 8364
 - proto: ShellShotgunPractice
   entities:
@@ -142764,6 +142859,38 @@ entities:
     - type: Transform
       pos: -3.5,51.5
       parent: 8364
+- proto: SMESAdvanced
+  entities:
+  - uid: 17701
+    components:
+    - type: Transform
+      pos: -25.5,-66.5
+      parent: 8364
+  - uid: 18594
+    components:
+    - type: Transform
+      pos: -25.5,-68.5
+      parent: 8364
+  - uid: 18595
+    components:
+    - type: Transform
+      pos: -25.5,-67.5
+      parent: 8364
+  - uid: 18730
+    components:
+    - type: Transform
+      pos: -23.5,-67.5
+      parent: 8364
+  - uid: 18731
+    components:
+    - type: Transform
+      pos: -23.5,-66.5
+      parent: 8364
+  - uid: 18979
+    components:
+    - type: Transform
+      pos: -23.5,-68.5
+      parent: 8364
 - proto: SMESBasic
   entities:
   - uid: 865
@@ -142820,27 +142947,6 @@ entities:
     components:
     - type: Transform
       pos: -9.5,-65.5
-      parent: 8364
-  - uid: 19013
-    components:
-    - type: MetaData
-      name: SMES Bank 3
-    - type: Transform
-      pos: -24.5,-66.5
-      parent: 8364
-  - uid: 19014
-    components:
-    - type: MetaData
-      name: SMES Bank 2
-    - type: Transform
-      pos: -24.5,-67.5
-      parent: 8364
-  - uid: 19029
-    components:
-    - type: MetaData
-      name: SMES Bank 1
-    - type: Transform
-      pos: -24.5,-68.5
       parent: 8364
   - uid: 22090
     components:
@@ -149677,40 +149783,38 @@ entities:
     - type: Transform
       pos: 36.5,-36.5
       parent: 8364
-  - uid: 18594
-    components:
-    - type: Transform
-      pos: -25.5,-64.5
-      parent: 8364
-  - uid: 18595
-    components:
-    - type: Transform
-      pos: -24.5,-64.5
-      parent: 8364
-  - uid: 18596
-    components:
-    - type: Transform
-      pos: -23.5,-64.5
-      parent: 8364
   - uid: 18655
     components:
     - type: Transform
       pos: 37.5,-36.5
-      parent: 8364
-  - uid: 18724
-    components:
-    - type: Transform
-      pos: -24.5,-71.5
       parent: 8364
   - uid: 18725
     components:
     - type: Transform
       pos: -23.5,-71.5
       parent: 8364
+  - uid: 18729
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,-64.5
+      parent: 8364
   - uid: 18751
     components:
     - type: Transform
       pos: 9.5,-60.5
+      parent: 8364
+  - uid: 19013
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-64.5
+      parent: 8364
+  - uid: 19014
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -25.5,-64.5
       parent: 8364
   - uid: 19047
     components:
@@ -173552,16 +173656,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,-42.5
       parent: 8364
-  - uid: 18727
-    components:
-    - type: Transform
-      pos: -23.5,-68.5
-      parent: 8364
-  - uid: 18730
-    components:
-    - type: Transform
-      pos: -25.5,-68.5
-      parent: 8364
 - proto: WindoorSecureHeadOfPersonnelLocked
   entities:
   - uid: 6248
@@ -175014,21 +175108,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-21.5
-      parent: 8364
-  - uid: 18728
-    components:
-    - type: Transform
-      pos: -26.5,-68.5
-      parent: 8364
-  - uid: 18729
-    components:
-    - type: Transform
-      pos: -24.5,-68.5
-      parent: 8364
-  - uid: 18731
-    components:
-    - type: Transform
-      pos: -22.5,-68.5
       parent: 8364
   - uid: 21305
     components:

--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -137,7 +137,7 @@ entities:
           version: 6
         1,-3:
           ind: 1,-3
-          tiles: eQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAATQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAATQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAATQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAATQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAATQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdQAAAAACdQAAAAADdQAAAAABdQAAAAACdQAAAAAAeQAAAAAALAAAAAAALAAAAAAALAAAAAAAeQAAAAAAbAAAAAACbAAAAAABbAAAAAADbAAAAAACeQAAAAAAeQAAAAAAdQAAAAACdQAAAAABdQAAAAABdQAAAAAAdQAAAAACWQAAAAABLAAAAAAALAAAAAAALAAAAAAAeQAAAAAAbAAAAAAAbAAAAAACbAAAAAABbAAAAAACeQAAAAAAaQAAAAAAdQAAAAAAdQAAAAABdQAAAAAAdQAAAAAAdQAAAAADeQAAAAAALAAAAAAALAAAAAAALAAAAAAAeQAAAAAAbAAAAAACWQAAAAADWQAAAAACWQAAAAAAaQAAAAAAeQAAAAAAJgAAAAADJgAAAAABdQAAAAADJgAAAAACJgAAAAADeQAAAAAALAAAAAAALAAAAAAALAAAAAAAbAAAAAABbAAAAAABWQAAAAABWQAAAAAAWQAAAAACHQAAAAABeQAAAAAAJgAAAAABJgAAAAADdQAAAAACJgAAAAADJgAAAAAAeQAAAAAAUgAAAAABLAAAAAAALAAAAAAAeQAAAAAAbAAAAAADWQAAAAAAWQAAAAACWQAAAAAB
+          tiles: eQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAATQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAATQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAATQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAATQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAATQAAAAAATQAAAAAATQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdQAAAAACdQAAAAADdQAAAAABdQAAAAACdQAAAAAAeQAAAAAALAAAAAAALAAAAAAALAAAAAAAeQAAAAAAbAAAAAACbAAAAAABbAAAAAADbAAAAAACeQAAAAAAeQAAAAAAdQAAAAACdQAAAAABdQAAAAABdQAAAAAAdQAAAAACWQAAAAABLAAAAAAALAAAAAAALAAAAAAAeQAAAAAAbAAAAAAAbAAAAAACbAAAAAABbAAAAAACeQAAAAAAaQAAAAAAdQAAAAAAdQAAAAABdQAAAAAAdQAAAAAAdQAAAAADeQAAAAAALAAAAAAALAAAAAAALAAAAAAAeQAAAAAAbAAAAAACWQAAAAADWQAAAAACWQAAAAAAaQAAAAAAeQAAAAAAJgAAAAADJgAAAAABdQAAAAADJgAAAAACJgAAAAADeQAAAAAALAAAAAAALAAAAAAALAAAAAAAbAAAAAABbAAAAAABWQAAAAABWQAAAAAAWQAAAAADHQAAAAABeQAAAAAAJgAAAAABJgAAAAADdQAAAAACJgAAAAADJgAAAAAAeQAAAAAAUgAAAAABLAAAAAAALAAAAAAAeQAAAAAAbAAAAAADWQAAAAAAWQAAAAACWQAAAAAB
           version: 6
         1,0:
           ind: 1,0
@@ -1698,7 +1698,6 @@ entities:
             id: Caution
           decals:
             1680: 66,-22
-            2436: 31,-34
             2615: 9,-74
         - node:
             color: '#3B393B85'
@@ -11923,7 +11922,7 @@ entities:
       pos: 24.5,16.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -29187.068
+      secondsUntilStateChange: -32469.803
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13691,8 +13690,6 @@ entities:
       pos: -23.5,-67.5
       parent: 8364
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 22588
   - uid: 22591
@@ -64596,11 +64593,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 54.5,1.5
       parent: 8364
-  - uid: 10817
-    components:
-    - type: Transform
-      pos: 56.5,2.5
-      parent: 8364
   - uid: 10818
     components:
     - type: Transform
@@ -64790,6 +64782,11 @@ entities:
     components:
     - type: Transform
       pos: 2.7203026,-11.488351
+      parent: 8364
+  - uid: 28111
+    components:
+    - type: Transform
+      pos: 56.5,2.5
       parent: 8364
 - proto: ChairOfficeLight
   entities:
@@ -70507,6 +70504,18 @@ entities:
       linkedPorts:
         21199:
         - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+- proto: ComputerAtmosMonitoring
+  entities:
+  - uid: 19021
+    components:
+    - type: Transform
+      pos: -7.5,-61.5
+      parent: 8364
+  - uid: 19028
+    components:
+    - type: Transform
+      pos: 7.5,-46.5
+      parent: 8364
 - proto: computerBodyScanner
   entities:
   - uid: 2390
@@ -85210,7 +85219,7 @@ entities:
       pos: -34.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -23375.605
+      secondsUntilStateChange: -26658.34
       state: Closing
   - uid: 15010
     components:
@@ -85703,7 +85712,7 @@ entities:
       pos: -4.5,-71.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -15123.337
+      secondsUntilStateChange: -18406.07
       state: Closing
 - proto: Fireplace
   entities:
@@ -86900,7 +86909,7 @@ entities:
       pos: 29.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#03FCD3FF'
 - proto: GasMinerCarbonDioxide
   entities:
   - uid: 16807
@@ -87325,6 +87334,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 33.5,-33.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 5258
     components:
     - type: Transform
@@ -87657,6 +87668,8 @@ entities:
     - type: Transform
       pos: 40.5,8.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 10443
     components:
     - type: Transform
@@ -88019,6 +88032,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 29.5,-35.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 20067
     components:
     - type: Transform
@@ -88056,12 +88071,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 30.5,-35.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 22545
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,-33.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 22744
     components:
     - type: Transform
@@ -88854,6 +88873,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 32.5,-34.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 26099
     components:
     - type: Transform
@@ -88924,6 +88945,8 @@ entities:
     - type: Transform
       pos: 30.5,-33.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 23026
     components:
     - type: Transform
@@ -89048,6 +89071,8 @@ entities:
     - type: Transform
       pos: 32.5,-33.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 24724
     components:
     - type: Transform
@@ -89174,6 +89199,81 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
+- proto: GasPipeSensor
+  entities:
+  - uid: 17381
+    components:
+    - type: MetaData
+      name: gas pipe sensor (Cryogenics)
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-33.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+    - type: Label
+      currentLabel: Cryogenics
+    - type: NameModifier
+      baseName: gas pipe sensor
+  - uid: 19020
+    components:
+    - type: MetaData
+      name: gas pipe sensor (TEG Mix)
+    - type: Transform
+      pos: 17.5,-58.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#947507FF'
+    - type: Label
+      currentLabel: TEG Mix
+    - type: NameModifier
+      baseName: gas pipe sensor
+- proto: GasPipeSensorDistribution
+  entities:
+  - uid: 10817
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-47.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeSensorMixedAir
+  entities:
+  - uid: 17864
+    components:
+    - type: Transform
+      pos: 20.5,-62.5
+      parent: 8364
+- proto: GasPipeSensorTEGCold
+  entities:
+  - uid: 7418
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-72.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+- proto: GasPipeSensorTEGHot
+  entities:
+  - uid: 16396
+    components:
+    - type: Transform
+      pos: 14.5,-77.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+- proto: GasPipeSensorWaste
+  entities:
+  - uid: 16914
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-48.5
+      parent: 8364
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeStraight
   entities:
   - uid: 3
@@ -89647,14 +89747,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 4228
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,-72.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
   - uid: 4498
     components:
     - type: Transform
@@ -89932,6 +90024,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 30.5,-34.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 5255
     components:
     - type: Transform
@@ -90396,14 +90490,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 7418
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-48.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 8216
     components:
     - type: Transform
@@ -91437,14 +91523,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 16914
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-77.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
   - uid: 16915
     components:
     - type: Transform
@@ -92153,14 +92231,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 17381
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-47.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 17383
     components:
     - type: Transform
@@ -92357,12 +92427,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 19060
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 31.5,-33.5
-      parent: 8364
   - uid: 19066
     components:
     - type: Transform
@@ -92517,13 +92581,6 @@ entities:
     components:
     - type: Transform
       pos: 20.5,-63.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 22740
-    components:
-    - type: Transform
-      pos: 20.5,-62.5
       parent: 8364
     - type: AtmosPipeColor
       color: '#03FCD3FF'
@@ -107426,13 +107483,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 26071
-    components:
-    - type: Transform
-      pos: 17.5,-58.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 26082
     components:
     - type: Transform
@@ -108318,6 +108368,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 40.5,7.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 14212
     components:
     - type: Transform
@@ -110691,6 +110743,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 39.5,8.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 3798
     components:
     - type: Transform
@@ -110728,6 +110782,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 39.5,7.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 15045
     components:
     - type: Transform
@@ -110993,7 +111049,7 @@ entities:
       pos: 40.5,6.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 13813
     components:
     - type: Transform
@@ -111139,7 +111195,7 @@ entities:
       pos: 33.5,-34.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#03FCD3FF'
   - uid: 26081
     components:
     - type: MetaData
@@ -111162,6 +111218,8 @@ entities:
     - type: Transform
       pos: 33.5,-32.5
       parent: 8364
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 20141
     components:
     - type: Transform
@@ -111595,8 +111653,6 @@ entities:
       pos: -23.5,-69.5
       parent: 8364
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 22588
     - type: AtmosPipeColor
@@ -112892,8 +112948,6 @@ entities:
       pos: -22.5,-68.5
       parent: 8364
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 22588
     - type: AtmosPipeColor
@@ -113859,12 +113913,15 @@ entities:
       color: '#990000FF'
   - uid: 25318
     components:
+    - type: MetaData
+      name: air scrubber
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -58.5,0.5
       parent: 8364
     - type: AtmosPipeColor
       color: '#990000FF'
+    - type: Label
   - uid: 25324
     components:
     - type: Transform
@@ -121936,6 +121993,681 @@ entities:
     - type: Transform
       pos: 10.513089,-49.606483
       parent: 8364
+- proto: Holopad
+  entities:
+  - uid: 4228
+    components:
+    - type: MetaData
+      name: holopad (Library Meeting)
+    - type: Transform
+      pos: 56.5,2.5
+      parent: 8364
+    - type: Label
+      currentLabel: Library Meeting
+    - type: NameModifier
+      baseName: holopad
+  - uid: 19029
+    components:
+    - type: MetaData
+      name: holopad (Brig)
+    - type: Transform
+      pos: -1.5,27.5
+      parent: 8364
+    - type: Label
+      currentLabel: Brig
+    - type: NameModifier
+      baseName: holopad
+  - uid: 19060
+    components:
+    - type: MetaData
+      name: holopad (Captain's Office)
+    - type: Transform
+      pos: 9.5,-14.5
+      parent: 8364
+    - type: Label
+      currentLabel: Captain's Office
+    - type: NameModifier
+      baseName: holopad
+  - uid: 19079
+    components:
+    - type: MetaData
+      name: holopad (AI Upload)
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 8364
+    - type: Label
+      currentLabel: AI Upload
+    - type: NameModifier
+      baseName: holopad
+  - uid: 22740
+    components:
+    - type: MetaData
+      name: holopad (Bridge)
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 8364
+    - type: Label
+      currentLabel: Bridge
+    - type: NameModifier
+      baseName: holopad
+  - uid: 23046
+    components:
+    - type: MetaData
+      name: holopad (Command Conference)
+    - type: Transform
+      pos: -10.5,-14.5
+      parent: 8364
+    - type: Label
+      currentLabel: Command Conference
+    - type: NameModifier
+      baseName: holopad
+  - uid: 23250
+    components:
+    - type: MetaData
+      name: holopad (HoP's Office)
+    - type: Transform
+      pos: -9.5,-23.5
+      parent: 8364
+    - type: Label
+      currentLabel: HoP's Office
+    - type: NameModifier
+      baseName: holopad
+  - uid: 23260
+    components:
+    - type: MetaData
+      name: holopad (Cargo)
+    - type: Transform
+      pos: -26.5,-23.5
+      parent: 8364
+    - type: Label
+      currentLabel: Cargo
+    - type: NameModifier
+      baseName: holopad
+  - uid: 25350
+    components:
+    - type: MetaData
+      name: holopad (QM's Office)
+    - type: Transform
+      pos: -32.5,-29.5
+      parent: 8364
+    - type: Label
+      currentLabel: QM's Office
+    - type: NameModifier
+      baseName: holopad
+  - uid: 26071
+    components:
+    - type: MetaData
+      name: holopad (Cargo Loading Dock)
+    - type: Transform
+      pos: -38.5,-29.5
+      parent: 8364
+    - type: Label
+      currentLabel: Cargo Loading Dock
+    - type: NameModifier
+      baseName: holopad
+  - uid: 27921
+    components:
+    - type: MetaData
+      name: holopad (Salvage)
+    - type: Transform
+      pos: -26.5,-34.5
+      parent: 8364
+    - type: Label
+      currentLabel: Salvage
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28084
+    components:
+    - type: MetaData
+      name: holopad (CE's Office)
+    - type: Transform
+      pos: -3.5,-64.5
+      parent: 8364
+    - type: Label
+      currentLabel: CE's Office
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28085
+    components:
+    - type: MetaData
+      name: holopad (Engineering Proper)
+    - type: Transform
+      pos: 2.5,-68.5
+      parent: 8364
+    - type: Label
+      currentLabel: Engineering Proper
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28086
+    components:
+    - type: MetaData
+      name: holopad (Engineering Locker Room)
+    - type: Transform
+      pos: 3.5,-62.5
+      parent: 8364
+    - type: Label
+      currentLabel: Engineering Locker Room
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28087
+    components:
+    - type: MetaData
+      name: holopad (Engineering Break Room)
+    - type: Transform
+      pos: 6.5,-53.5
+      parent: 8364
+    - type: Label
+      currentLabel: Engineering Break Room
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28090
+    components:
+    - type: MetaData
+      name: holopad (Engineering Front Desk)
+    - type: Transform
+      pos: 5.5,-42.5
+      parent: 8364
+    - type: Label
+      currentLabel: Engineering Front Desk
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28091
+    components:
+    - type: MetaData
+      name: holopad (Atmospherics)
+    - type: Transform
+      pos: 16.5,-56.5
+      parent: 8364
+    - type: Label
+      currentLabel: Atmospherics
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28092
+    components:
+    - type: MetaData
+      name: holopad (TEG)
+    - type: Transform
+      pos: 15.5,-73.5
+      parent: 8364
+    - type: Label
+      currentLabel: TEG
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28093
+    components:
+    - type: MetaData
+      name: holopad (Warden's Office)
+    - type: Transform
+      pos: 1.5,32.5
+      parent: 8364
+    - type: Label
+      currentLabel: Warden's Office
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28094
+    components:
+    - type: MetaData
+      name: holopad (Security Break Room)
+    - type: Transform
+      pos: 14.5,33.5
+      parent: 8364
+    - type: Label
+      currentLabel: Security Break Room
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28095
+    components:
+    - type: MetaData
+      name: holopad (HoS's Office)
+    - type: Transform
+      pos: 14.5,38.5
+      parent: 8364
+    - type: Label
+      currentLabel: HoS's Office
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28096
+    components:
+    - type: MetaData
+      name: holopad (Courtroom)
+    - type: Transform
+      pos: 15.5,25.5
+      parent: 8364
+    - type: Label
+      currentLabel: Courtroom
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28097
+    components:
+    - type: MetaData
+      name: holopad (Interrogation)
+    - type: Transform
+      pos: -14.5,32.5
+      parent: 8364
+    - type: Label
+      currentLabel: Interrogation
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28098
+    components:
+    - type: MetaData
+      name: holopad (Detective's Office)
+    - type: Transform
+      pos: -4.5,15.5
+      parent: 8364
+    - type: Label
+      currentLabel: Detective's Office
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28099
+    components:
+    - type: MetaData
+      name: holopad (Lawyer's Office)
+    - type: Transform
+      pos: -12.5,15.5
+      parent: 8364
+    - type: Label
+      currentLabel: Lawyer's Office
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28100
+    components:
+    - type: MetaData
+      name: holopad (EVA)
+    - type: Transform
+      pos: -11.5,4.5
+      parent: 8364
+    - type: Label
+      currentLabel: EVA
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28101
+    components:
+    - type: MetaData
+      name: holopad (Showroom)
+    - type: Transform
+      pos: 9.5,-26.5
+      parent: 8364
+    - type: Label
+      currentLabel: Showroom
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28102
+    components:
+    - type: MetaData
+      name: holopad (Chemistry)
+    - type: Transform
+      pos: 20.5,-19.5
+      parent: 8364
+    - type: Label
+      currentLabel: Chemistry
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28103
+    components:
+    - type: MetaData
+      name: holopad (Medical Front Desk)
+    - type: Transform
+      pos: 30.5,-20.5
+      parent: 8364
+    - type: Label
+      currentLabel: Medical Front Desk
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28104
+    components:
+    - type: MetaData
+      name: holopad (Medical Examination)
+    - type: Transform
+      pos: 31.5,-28.5
+      parent: 8364
+    - type: Label
+      currentLabel: Medical Examination
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28105
+    components:
+    - type: MetaData
+      name: holopad (Medical Cryogenics)
+    - type: Transform
+      pos: 31.5,-34.5
+      parent: 8364
+    - type: Label
+      currentLabel: Medical Cryogenics
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28106
+    components:
+    - type: MetaData
+      name: holopad (CMO's Office)
+    - type: Transform
+      pos: 35.5,-42.5
+      parent: 8364
+    - type: Label
+      currentLabel: CMO's Office
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28107
+    components:
+    - type: MetaData
+      name: holopad (Virology)
+    - type: Transform
+      pos: 42.5,-56.5
+      parent: 8364
+    - type: Label
+      currentLabel: Virology
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28108
+    components:
+    - type: MetaData
+      name: holopad (Bar)
+    - type: Transform
+      pos: 30.5,-5.5
+      parent: 8364
+    - type: Label
+      currentLabel: Bar
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28109
+    components:
+    - type: MetaData
+      name: holopad (Theatre)
+    - type: Transform
+      pos: 21.5,4.5
+      parent: 8364
+    - type: Label
+      currentLabel: Theatre
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28110
+    components:
+    - type: MetaData
+      name: holopad (Botany)
+    - type: Transform
+      pos: 46.5,-7.5
+      parent: 8364
+    - type: Label
+      currentLabel: Botany
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28112
+    components:
+    - type: MetaData
+      name: holopad (Library)
+    - type: Transform
+      pos: 59.5,-9.5
+      parent: 8364
+    - type: Label
+      currentLabel: Library
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28113
+    components:
+    - type: MetaData
+      name: holopad (Chapel)
+    - type: Transform
+      pos: 69.5,-6.5
+      parent: 8364
+    - type: Label
+      currentLabel: Chapel
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28114
+    components:
+    - type: MetaData
+      name: holopad (R&D)
+    - type: Transform
+      pos: 71.5,-22.5
+      parent: 8364
+    - type: Label
+      currentLabel: R&D
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28115
+    components:
+    - type: MetaData
+      name: holopad (Robotics)
+    - type: Transform
+      pos: 60.5,-21.5
+      parent: 8364
+    - type: Label
+      currentLabel: Robotics
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28116
+    components:
+    - type: MetaData
+      name: holopad (RD's Office)
+    - type: Transform
+      pos: 71.5,-36.5
+      parent: 8364
+    - type: Label
+      currentLabel: RD's Office
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28117
+    components:
+    - type: MetaData
+      name: holopad (North Artifacts)
+    - type: Transform
+      pos: 79.5,-24.5
+      parent: 8364
+    - type: Label
+      currentLabel: North Artifacts
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28118
+    components:
+    - type: MetaData
+      name: holopad (South Artifacts)
+    - type: Transform
+      pos: 75.5,-45.5
+      parent: 8364
+    - type: Label
+      currentLabel: South Artifacts
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28119
+    components:
+    - type: MetaData
+      name: holopad (Anomaly Lab)
+    - type: Transform
+      pos: 71.5,-51.5
+      parent: 8364
+    - type: Label
+      currentLabel: Anomaly Lab
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28120
+    components:
+    - type: MetaData
+      name: holopad (Kitchen)
+    - type: Transform
+      pos: 36.5,-8.5
+      parent: 8364
+    - type: Label
+      currentLabel: Kitchen
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28121
+    components:
+    - type: MetaData
+      name: holopad (Mailroom)
+    - type: Transform
+      pos: -21.5,-17.5
+      parent: 8364
+    - type: Label
+      currentLabel: Mailroom
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28122
+    components:
+    - type: MetaData
+      name: holopad (Morgue)
+    - type: Transform
+      pos: 44.5,-19.5
+      parent: 8364
+    - type: Label
+      currentLabel: Morgue
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28123
+    components:
+    - type: MetaData
+      name: holopad (Perma)
+    - type: Transform
+      pos: -7.5,49.5
+      parent: 8364
+    - type: Label
+      currentLabel: Perma
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28124
+    components:
+    - type: MetaData
+      name: holopad (AI Sat Airlock)
+    - type: Transform
+      pos: 28.5,-80.5
+      parent: 8364
+    - type: Label
+      currentLabel: AI Sat Airlock
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28125
+    components:
+    - type: MetaData
+      name: holopad (AI Sat Lobby)
+    - type: Transform
+      pos: 28.5,-85.5
+      parent: 8364
+    - type: Label
+      currentLabel: AI Sat Lobby
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28126
+    components:
+    - type: MetaData
+      name: holopad (AI Core)
+    - type: Transform
+      pos: 28.5,-108.5
+      parent: 8364
+    - type: Label
+      currentLabel: AI Core
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28127
+    components:
+    - type: MetaData
+      name: holopad (Tools)
+    - type: Transform
+      pos: -42.5,3.5
+      parent: 8364
+    - type: Label
+      currentLabel: Tools
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28128
+    components:
+    - type: MetaData
+      name: holopad (Security Arrivals Checkpoint)
+    - type: Transform
+      pos: -59.5,4.5
+      parent: 8364
+    - type: Label
+      currentLabel: Security Arrivals Checkpoint
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28129
+    components:
+    - type: MetaData
+      name: holopad (Vault)
+    - type: Transform
+      pos: -31.5,4.5
+      parent: 8364
+    - type: Label
+      currentLabel: Vault
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28130
+    components:
+    - type: MetaData
+      name: holopad (Janitor)
+    - type: Transform
+      pos: 4.5,-34.5
+      parent: 8364
+    - type: Label
+      currentLabel: Janitor
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28131
+    components:
+    - type: MetaData
+      name: holopad (Tech Vault)
+    - type: Transform
+      pos: -6.5,-36.5
+      parent: 8364
+    - type: Label
+      currentLabel: Tech Vault
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28134
+    components:
+    - type: MetaData
+      name: holopad (Telecoms)
+    - type: Transform
+      pos: -13.5,-53.5
+      parent: 8364
+    - type: Label
+      currentLabel: Telecoms
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28135
+    components:
+    - type: MetaData
+      name: holopad (Security Evac)
+    - type: Transform
+      pos: 79.5,-2.5
+      parent: 8364
+    - type: Label
+      currentLabel: Security Evac
+    - type: NameModifier
+      baseName: holopad
+  - uid: 28136
+    components:
+    - type: MetaData
+      name: holopad (Surgery)
+    - type: Transform
+      pos: 20.5,-35.5
+      parent: 8364
+    - type: Label
+      currentLabel: Surgery
+    - type: NameModifier
+      baseName: holopad
+- proto: HolopadLongRange
+  entities:
+  - uid: 28088
+    components:
+    - type: MetaData
+      name: long-range holopad (Cargo Loading Dock)
+    - type: Transform
+      pos: -38.5,-25.5
+      parent: 8364
+    - type: Label
+      currentLabel: Cargo Loading Dock
+    - type: NameModifier
+      baseName: long-range holopad
+  - uid: 28089
+    components:
+    - type: MetaData
+      name: long-range holopad (Bridge)
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 8364
+    - type: Label
+      currentLabel: Bridge
+    - type: NameModifier
+      baseName: long-range holopad
 - proto: HospitalCurtainsOpen
   entities:
   - uid: 2213
@@ -126413,12 +127145,12 @@ entities:
   - uid: 17674
     components:
     - type: Transform
-      pos: 7.542186,-46.412346
+      pos: 12.267465,-49.63015
       parent: 8364
   - uid: 17765
     components:
     - type: Transform
-      pos: 7.542186,-46.412346
+      pos: 12.18934,-49.50515
       parent: 8364
   - uid: 19346
     components:
@@ -126444,12 +127176,12 @@ entities:
   - uid: 22564
     components:
     - type: Transform
-      pos: 7.542186,-46.412346
+      pos: 12.236215,-49.50515
       parent: 8364
   - uid: 22686
     components:
     - type: Transform
-      pos: 7.542186,-46.412346
+      pos: 12.236215,-49.5989
       parent: 8364
   - uid: 26640
     components:
@@ -127334,6 +128066,14 @@ entities:
     - type: Transform
       pos: 11.5,-37.5
       parent: 8364
+- proto: PosterLegitJustAWeekAway
+  entities:
+  - uid: 28137
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-28.5
+      parent: 8364
 - proto: PosterLegitLoveIan
   entities:
   - uid: 5776
@@ -127668,10 +128408,10 @@ entities:
       parent: 8364
 - proto: PottedPlant27
   entities:
-  - uid: 19079
+  - uid: 28133
     components:
     - type: Transform
-      pos: -7.5,-61.5
+      pos: -5.5,-65.5
       parent: 8364
 - proto: PottedPlant29
   entities:
@@ -133065,11 +133805,6 @@ entities:
     - type: Transform
       pos: -12.5,-72.5
       parent: 8364
-  - uid: 16396
-    components:
-    - type: Transform
-      pos: 7.5,-46.5
-      parent: 8364
   - uid: 16450
     components:
     - type: Transform
@@ -133219,6 +133954,11 @@ entities:
     components:
     - type: Transform
       pos: 34.5,-90.5
+      parent: 8364
+  - uid: 28132
+    components:
+    - type: Transform
+      pos: 12.5,-49.5
       parent: 8364
 - proto: RadiationCollector
   entities:
@@ -140205,12 +140945,12 @@ entities:
   - uid: 17672
     components:
     - type: Transform
-      pos: 7.510936,-46.443596
+      pos: 12.704965,-49.520775
       parent: 8364
   - uid: 17691
     components:
     - type: Transform
-      pos: 7.510936,-46.443596
+      pos: 12.673715,-49.520775
       parent: 8364
   - uid: 19345
     components:
@@ -140240,12 +140980,12 @@ entities:
   - uid: 22559
     components:
     - type: Transform
-      pos: 7.510936,-46.443596
+      pos: 12.68934,-49.489525
       parent: 8364
   - uid: 22567
     components:
     - type: Transform
-      pos: 7.510936,-46.443596
+      pos: 12.68934,-49.50515
       parent: 8364
   - uid: 22927
     components:
@@ -141507,11 +142247,6 @@ entities:
     components:
     - type: Transform
       pos: 42.5,-43.5
-      parent: 8364
-  - uid: 17864
-    components:
-    - type: Transform
-      pos: 37.5,-25.5
       parent: 8364
 - proto: SignConference
   entities:

--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -11922,7 +11922,7 @@ entities:
       pos: 24.5,16.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -32550.387
+      secondsUntilStateChange: -32560.857
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -85219,7 +85219,7 @@ entities:
       pos: -34.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -26738.924
+      secondsUntilStateChange: -26749.395
       state: Closing
   - uid: 15010
     components:
@@ -85712,7 +85712,7 @@ entities:
       pos: -4.5,-71.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -18486.654
+      secondsUntilStateChange: -18497.125
       state: Closing
 - proto: Fireplace
   entities:

--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -11922,7 +11922,7 @@ entities:
       pos: 24.5,16.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -32469.803
+      secondsUntilStateChange: -32550.387
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -85219,7 +85219,7 @@ entities:
       pos: -34.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -26658.34
+      secondsUntilStateChange: -26738.924
       state: Closing
   - uid: 15010
     components:
@@ -85712,7 +85712,7 @@ entities:
       pos: -4.5,-71.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -18406.07
+      secondsUntilStateChange: -18486.654
       state: Closing
 - proto: Fireplace
   entities:
@@ -89263,7 +89263,7 @@ entities:
       pos: 14.5,-77.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#990000FF'
 - proto: GasPipeSensorWaste
   entities:
   - uid: 16914
@@ -91300,7 +91300,7 @@ entities:
       pos: 14.5,-76.5
       parent: 8364
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#990000FF'
   - uid: 15876
     components:
     - type: Transform


### PR DESCRIPTION
## About the PR
Rebalanced Box station power. It now complies with the engineering design document for power roundflow.

Added holopads all around.

Added gas sensors, and the pipenet network monitor in desired places.

## Why / Balance
Power was unbalanced.

New content needs to be mapped.

## Media
![Box-0](https://github.com/user-attachments/assets/a237547c-56fd-4849-912f-b9e1d0814ff6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.