### PR TITLE
Fixed clothing items with explicitly defined states not using species variants

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -104,17 +104,28 @@ public sealed class ClientClothingSystem : ClothingSystem
             return;
 
         List<PrototypeLayerData>? layers = null;
+        List<PrototypeLayerData>? specifiedLayers = null;
+
 
         // first attempt to get species specific data.
         if (inventory.SpeciesId != null)
             item.ClothingVisuals.TryGetValue($"{args.Slot}-{inventory.SpeciesId}", out layers);
 
-        // if that returned nothing, attempt to find generic data
-        if (layers == null && !item.ClothingVisuals.TryGetValue(args.Slot, out layers))
+        if (layers == null && !item.ClothingVisuals.TryGetValue(args.Slot, out _))
         {
-            // No generic data either. Attempt to generate defaults from the item's RSI & item-prefixes
+            // If that returned nothing and there was not a speficied state in the yaml, attempt to generate defaults from the item's RSI & item-prefixes
             if (!TryGetDefaultVisuals(uid, item, args.Slot, inventory.SpeciesId, out layers))
                 return;
+        }
+        else if (item.ClothingVisuals.TryGetValue(args.Slot, out specifiedLayers))
+        {
+            //even if a state was specified we still need to check for species specific variant
+            if (!TryGetSpeciesVariant(uid, item, inventory.SpeciesId, specifiedLayers, out layers)) //This will always return true since specifiedLayers is used as a fallback if species variant isnt found, and that value is not null
+                return;
+        }
+        else
+        {
+            return;
         }
 
         // add each layer to the visuals
@@ -131,6 +142,63 @@ public sealed class ClientClothingSystem : ClothingSystem
 
             item.MappedLayer = key;
             args.Layers.Add((key, layer));
+        }
+    }
+
+    private bool TryGetSpeciesVariant(EntityUid uid, ClothingComponent clothing, string? speciesId, List<PrototypeLayerData> specifiedLayers,
+        [NotNullWhen(true)] out List<PrototypeLayerData>? layers)
+    {
+        if (speciesId != null)
+        {
+            layers = null;
+
+            //even if a state was specified we still need to check for species specific variant
+            foreach (var specifiedLayer in specifiedLayers)
+            {
+                RSI? rsi = null;
+
+                //It would be better if this derived the RSI from the specifiedLayer so that custom sprites can use more than one RSI, but I wasnt able to figure out how to do that
+                if (TryComp(uid, out SpriteComponent? sprite))
+                    rsi = sprite.BaseRSI;
+
+                if (rsi == null)
+                {
+                    continue;
+                }
+
+                var layer = new PrototypeLayerData();
+
+                //Its possible that additional layer properties will need to be added here to make the species variant use them
+                layer.RsiPath = rsi.Path.ToString();
+                layer.Color = specifiedLayer.Color;
+                layer.Shader = specifiedLayer.Shader;
+
+                // Species specific state is used if one exists, otherwise fall back to the specified state
+                if (rsi.TryGetState($"{specifiedLayer.State}-{speciesId}", out _))
+                    layer.State = $"{specifiedLayer.State}-{speciesId}";
+                else
+                    layer.State = specifiedLayer.State;
+
+                if (layers == null)
+                {
+                    layers = new() { layer };
+                }
+                else
+                {
+                    layers.Add(layer);
+                }
+
+            }
+
+            if (layers != null)
+                return true;
+            else
+                return false;
+        }
+        else
+        {
+            layers = specifiedLayers;
+            return true;
         }
     }
 


### PR DESCRIPTION
## About the PR
Patched an oversight where species alt sprites would fail to be used for sprites that specified a custom state in the item's yaml.

## Why / Balance
This oversight was causing at least dozens, possibly hundreds, of clothing items to not render correctly. Specifically, this was observed with the Atmos and Spationaut voidsuit helmets, and all winter coats except the plain one.

## Technical details
Modified ClientClothingSystem's OnGetVisuals function to check for species alts for layers specified in ClothingVisuals

## Media
Previously, all of these items (and more) failed to use their vox alt sprites
![Screenshot 2024-12-18 171949](https://github.com/user-attachments/assets/d04324c0-20db-488b-8100-98b88e0ed17e)
![Screenshot 2024-12-18 172104](https://github.com/user-attachments/assets/165cfb4c-c290-4cbe-8ac3-997f1801964d)
![Screenshot 2024-12-18 172142](https://github.com/user-attachments/assets/6452ddbd-8d81-4d55-a9ea-5d0a68985876)
![Screenshot 2024-12-18 172231](https://github.com/user-attachments/assets/6ffa7d1a-61d8-444d-8210-55f7371a6602)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Modifications made to ClientClothingSystem's OnGetVisuals function, unlikely to cause problems but you never know

**Changelog**
:cl:
- fix: Some clothing items that were previously not using species variants properly due to an oversight, including the atmos and spationaut voidsuit helmets and winter coats, now use species variants. 
