### PR TITLE
Reach/Cargo Update (Holopads & Atmos)

### DIFF
--- a/Resources/Maps/Shuttles/cargo.yml
+++ b/Resources/Maps/Shuttles/cargo.yml
@@ -817,19 +817,13 @@ entities:
     - type: Transform
       pos: -3.5,-2.5
       parent: 173
-- proto: HolopadLongRange
+- proto: HolopadCargoShuttle
   entities:
   - uid: 186
     components:
-    - type: MetaData
-      name: long-range holopad (Cargo Shuttle)
     - type: Transform
       pos: -2.5,5.5
       parent: 173
-    - type: Label
-      currentLabel: Cargo Shuttle
-    - type: NameModifier
-      baseName: long-range holopad
 - proto: LockableButtonCargo
   entities:
   - uid: 182

--- a/Resources/Maps/Shuttles/trading_outpost.yml
+++ b/Resources/Maps/Shuttles/trading_outpost.yml
@@ -4326,19 +4326,13 @@ entities:
     - type: Transform
       pos: 11.5,9.5
       parent: 2
-- proto: HolopadLongRange
+- proto: HolopadCargoAts
   entities:
   - uid: 546
     components:
-    - type: MetaData
-      name: long-range holopad (Automated Trade Station)
     - type: Transform
       pos: 5.5,2.5
       parent: 2
-    - type: Label
-      currentLabel: Automated Trade Station
-    - type: NameModifier
-      baseName: long-range holopad
 - proto: NewtonCradle
   entities:
   - uid: 65

--- a/Resources/Maps/reach.yml
+++ b/Resources/Maps/reach.yml
@@ -61,7 +61,7 @@ entities:
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAfQAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAUAAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAAAfgAAAAAAAgAAAAAAAgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAUAAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAAAXQAAAAABAgAAAAAAAgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAADfgAAAAAAAgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAABfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAACfgAAAAAAcAAAAAAAcAAAAAABcAAAAAACcAAAAAADcAAAAAAAcAAAAAAAcAAAAAABcAAAAAADcAAAAAACcAAAAAADcAAAAAACfgAAAAAAHwAAAAADegAAAAADHwAAAAACfgAAAAAAcAAAAAABcAAAAAADcAAAAAAAcAAAAAACcAAAAAADcAAAAAACcAAAAAADcAAAAAAAcAAAAAACcAAAAAACcAAAAAAAfgAAAAAAHwAAAAADegAAAAABHwAAAAABfgAAAAAAcAAAAAAAcAAAAAADcAAAAAABcAAAAAAAcAAAAAACcAAAAAABcAAAAAACcAAAAAACcAAAAAAAcAAAAAACcAAAAAABfgAAAAAAHwAAAAAAegAAAAADHwAAAAACfgAAAAAAfgAAAAAAcAAAAAADcAAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAcAAAAAADcAAAAAADcAAAAAADfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAcAAAAAABcAAAAAACcAAAAAACfgAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAfgAAAAAAcAAAAAABcAAAAAABcAAAAAADfgAAAAAAHwAAAAABHwAAAAAC
+          tiles: AAAAAAAAAAAAAAAAfQAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAUAAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAAAfgAAAAAAAgAAAAAAAgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAUAAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAAAXQAAAAABAgAAAAAAAgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAADfgAAAAAAAgAAAAAAAgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAABfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfQAAAAAAAAAAAAAAAAAAAAAAHwAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAACfgAAAAAAcAAAAAAAcAAAAAABcAAAAAACcAAAAAADcAAAAAAAcAAAAAAAcAAAAAABcAAAAAADcAAAAAACcAAAAAADcAAAAAACfgAAAAAAHwAAAAADegAAAAADHwAAAAACfgAAAAAAcAAAAAABcAAAAAADcAAAAAAAcAAAAAACcAAAAAADcAAAAAACcAAAAAADcAAAAAAAcAAAAAACcAAAAAACcAAAAAAAfgAAAAAAHwAAAAADegAAAAABHwAAAAABfgAAAAAAcAAAAAAAcAAAAAADcAAAAAABcAAAAAAAcAAAAAACcAAAAAABcAAAAAACcAAAAAACcAAAAAAAcAAAAAACcAAAAAABfgAAAAAAHwAAAAAAegAAAAADHwAAAAACfgAAAAAAfgAAAAAAcAAAAAADcAAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAcAAAAAADcAAAAAADcAAAAAADfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAcAAAAAABcAAAAAACcAAAAAACfgAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAfgAAAAAAcAAAAAABcAAAAAABcAAAAAADfgAAAAAAHwAAAAABHwAAAAAC
           version: 6
         -2,0:
           ind: -2,0
@@ -139,6 +139,16 @@ entities:
             399: -23,-1
             400: -23,1
             413: -24,0
+        - node:
+            color: '#334E6DC8'
+            id: BotGreyscale
+          decals:
+            419: 22,0
+        - node:
+            color: '#A4610696'
+            id: BotGreyscale
+          decals:
+            418: 1,9
         - node:
             color: '#FFFFFFFF'
             id: BotLeft
@@ -612,6 +622,7 @@ entities:
             2: 2,-12
             3: 3,-13
             415: 3,-14
+            417: 3,-12
         - node:
             color: '#FFFFFFFF'
             id: Grasse2
@@ -1031,7 +1042,7 @@ entities:
           -4,-2:
             0: 57344
           -5,-2:
-            0: 57344
+            0: 58368
           -4,-1:
             0: 61166
           -5,-1:
@@ -1064,10 +1075,10 @@ entities:
           -1,-4:
             0: 32768
           0,-4:
-            0: 62720
+            0: 64768
             1: 4
           0,-3:
-            0: 21781
+            0: 21791
           0,-2:
             0: 55805
           0,-1:
@@ -1127,8 +1138,7 @@ entities:
           4,0:
             0: 54783
           4,1:
-            0: 157
-            2: 64
+            0: 221
           -5,0:
             0: 61183
           -4,1:
@@ -1164,8 +1174,8 @@ entities:
           2,-2:
             0: 61687
           2,-4:
-            3: 6
-            4: 1536
+            2: 6
+            3: 1536
           3,-4:
             1: 8737
             0: 256
@@ -1244,21 +1254,6 @@ entities:
           moles:
           - 0
           - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.14975
-          moles:
-          - 20.078888
-          - 75.53487
           - 0
           - 0
           - 0
@@ -1454,18 +1449,17 @@ entities:
       - 1097
       - 1096
       - 1083
-  - uid: 14
+  - uid: 2500
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-11.5
+      pos: 2.5,-10.5
       parent: 2
     - type: DeviceList
       devices:
-      - 1486
-      - 1454
-      - 1453
       - 1514
+      - 1453
+      - 1454
+      - 1486
 - proto: AirCanister
   entities:
   - uid: 15
@@ -6272,7 +6266,7 @@ entities:
   - uid: 915
     components:
     - type: Transform
-      pos: 4.5333743,-11.7164135
+      pos: 5.4690175,-10.51443
       parent: 2
 - proto: ClothingUniformJumpsuitERTJanitor
   entities:
@@ -6397,6 +6391,14 @@ entities:
       rot: 3.141592653589793 rad
       pos: 16.5,3.5
       parent: 2
+- proto: ComputerAlert
+  entities:
+  - uid: 2081
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-13.5
+      parent: 2
 - proto: ComputerAnalysisConsole
   entities:
   - uid: 1801
@@ -6409,6 +6411,14 @@ entities:
       linkedPorts:
         1070:
         - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+- proto: ComputerAtmosMonitoring
+  entities:
+  - uid: 1289
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-13.5
+      parent: 2
 - proto: ComputerCargoBounty
   entities:
   - uid: 936
@@ -8054,6 +8064,25 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+- proto: GasPipeSensorDistribution
+  entities:
+  - uid: 1183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeSensorWaste
+  entities:
+  - uid: 1287
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeStraight
   entities:
   - uid: 1177
@@ -8097,14 +8126,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 7.5,-14.5
       parent: 2
-  - uid: 1183
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1184
     components:
     - type: Transform
@@ -8906,14 +8927,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1287
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1288
     components:
     - type: Transform
@@ -8922,12 +8935,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1289
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-11.5
-      parent: 2
   - uid: 1290
     components:
     - type: Transform
@@ -10208,8 +10215,10 @@ entities:
       pos: 6.5,-11.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
-      - 14
+      - 2500
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1454
@@ -10219,8 +10228,10 @@ entities:
       pos: 10.5,-11.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
-      - 14
+      - 2500
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1455
@@ -10549,8 +10560,10 @@ entities:
       pos: 7.5,-7.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
-      - 14
+      - 2500
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1487
@@ -10836,8 +10849,10 @@ entities:
       pos: 5.5,-14.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
-      - 14
+      - 2500
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1515
@@ -11434,6 +11449,20 @@ entities:
     - type: Transform
       pos: 4.6859074,-10.602916
       parent: 2
+- proto: HolopadCargoBayLongRange
+  entities:
+  - uid: 2171
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 2
+- proto: HolopadCommandBridgeLongRange
+  entities:
+  - uid: 2128
+    components:
+    - type: Transform
+      pos: 22.5,0.5
+      parent: 2
 - proto: HoPIDCard
   entities:
   - uid: 1623
@@ -11571,10 +11600,10 @@ entities:
       parent: 2
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
-  - uid: 1956
+  - uid: 2499
     components:
     - type: Transform
-      pos: 3.5,-13.5
+      pos: 4.5,-11.5
       parent: 2
 - proto: LockerBoozeFilled
   entities:
@@ -12199,6 +12228,13 @@ entities:
     - type: Transform
       pos: 8.5,-4.5
       parent: 2
+- proto: PoweredDimSmallLight
+  entities:
+  - uid: 1783
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 2
 - proto: Poweredlight
   entities:
   - uid: 876
@@ -12531,20 +12567,6 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 1782
-    components:
-    - type: Transform
-      pos: 9.5,-6.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 1783
-    components:
-    - type: Transform
-      pos: 4.5,-6.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 1784
     components:
     - type: Transform
@@ -12600,6 +12622,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,15.5
+      parent: 2
+  - uid: 1956
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
       parent: 2
 - proto: Protolathe
   entities:
@@ -13614,7 +13641,7 @@ entities:
     - type: Transform
       pos: 8.5,-1.5
       parent: 2
-- proto: SMESBasic
+- proto: SMESAdvanced
   entities:
   - uid: 1972
     components:
@@ -14699,10 +14726,10 @@ entities:
       parent: 2
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 2128
+  - uid: 1782
     components:
     - type: Transform
-      pos: 2.5,-13.5
+      pos: 3.5,-11.5
       parent: 2
   - uid: 2129
     components:
@@ -14941,11 +14968,6 @@ entities:
     components:
     - type: Transform
       pos: 3.5,-10.5
-      parent: 2
-  - uid: 2171
-    components:
-    - type: Transform
-      pos: 3.5,-11.5
       parent: 2
   - uid: 2173
     components:
@@ -16442,6 +16464,12 @@ entities:
       parent: 2
 - proto: WindowReinforcedDirectional
   entities:
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-11.5
+      parent: 2
   - uid: 1592
     components:
     - type: Transform

--- a/Resources/Maps/reach.yml
+++ b/Resources/Maps/reach.yml
@@ -10215,8 +10215,6 @@ entities:
       pos: 6.5,-11.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 2500
     - type: AtmosPipeColor
@@ -10228,8 +10226,6 @@ entities:
       pos: 10.5,-11.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 2500
     - type: AtmosPipeColor
@@ -10560,8 +10556,6 @@ entities:
       pos: 7.5,-7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 2500
     - type: AtmosPipeColor
@@ -10849,8 +10843,6 @@ entities:
       pos: 5.5,-14.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 2500
     - type: AtmosPipeColor


### PR DESCRIPTION
## About the PR
To Reach: Added long-range holopads in the bridge and cargo (for contacting cargo/visiting shuttles and the ATS) and added both of the new atmos computers and pipe sensors.
To Cargo Shuttle & ATS: replaced holopads with localized versions.

## Media
![Reach-0](https://github.com/user-attachments/assets/bbdd6103-18f8-4331-88bc-2a28bee71d77)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->