### PR TITLE
Remove zombie antag role on unzombification

### DIFF
--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -213,7 +213,7 @@ namespace Content.Server.Cloning
             var mob = Spawn(speciesPrototype.Prototype, _transformSystem.GetMapCoordinates(uid));
             _humanoidSystem.CloneAppearance(bodyToClone, mob);
 
-            var ev = new CloningEvent(bodyToClone, mob);
+            var ev = new CloningEvent(bodyToClone, mob, mindEnt);
             RaiseLocalEvent(bodyToClone, ref ev);
 
             if (!ev.NameHandled)

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Body.Systems;
 using Content.Server.Chat;
 using Content.Server.Chat.Systems;
 using Content.Server.Emoting.Systems;
+using Content.Server.Roles;
 using Content.Server.Speech.EntitySystems;
 using Content.Shared.Anomaly.Components;
 using Content.Shared.Bed.Sleep;
@@ -275,7 +276,7 @@ namespace Content.Server.Zombies
         ///     this currently only restore the name and skin/eye color from before zombified
         ///     TODO: completely rethink how zombies are done to allow reversal.
         /// </remarks>
-        public bool UnZombify(EntityUid source, EntityUid target, ZombieComponent? zombiecomp)
+        public bool UnZombify(EntityUid source, EntityUid target, EntityUid mind, ZombieComponent? zombiecomp)
         {
             if (!Resolve(source, ref zombiecomp))
                 return false;
@@ -292,13 +293,16 @@ namespace Content.Server.Zombies
             _humanoidAppearance.SetSkinColor(target, zombiecomp.BeforeZombifiedSkinColor, false);
             _bloodstream.ChangeBloodReagent(target, zombiecomp.BeforeZombifiedBloodReagent);
 
+            // Remove the zombie role from the mind (so the clone won't have zombie role antag status)
+            _roles.MindTryRemoveRole<ZombieRoleComponent>(mind);
+
             _nameMod.RefreshNameModifiers(target);
             return true;
         }
 
         private void OnZombieCloning(EntityUid uid, ZombieComponent zombiecomp, ref CloningEvent args)
         {
-            if (UnZombify(args.Source, args.Target, zombiecomp))
+            if (UnZombify(args.Source, args.Target, args.Mind, zombiecomp))
                 args.NameHandled = true;
         }
     }

--- a/Content.Shared/Cloning/CloningPodComponent.cs
+++ b/Content.Shared/Cloning/CloningPodComponent.cs
@@ -95,9 +95,12 @@ public struct CloningEvent
     public readonly EntityUid Source;
     public readonly EntityUid Target;
 
-    public CloningEvent(EntityUid source, EntityUid target)
+    public readonly EntityUid Mind;
+
+    public CloningEvent(EntityUid source, EntityUid target, EntityUid mind)
     {
         Source = source;
         Target = target;
+        Mind = mind;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Unzombification (e.g. by cloning) now remove the zombie role from the mind of the zombified entity (which, in the case of cloning, usually won't be attached at the time). 

## Why / Balance
Fixes #20162 
This fixes a problem where unzombified entities will still appear as an antagonist in the Player Overlay and to admins.

## Technical details
CloningEvent now also broadcasts a mind EntityUid.
ZombieSystem::UnZombify now affects the mind.

## Media
![za-0](https://github.com/user-attachments/assets/b7a8df09-f3d8-4725-9a8b-c5012142884e)
![za-1](https://github.com/user-attachments/assets/5a8ed806-e706-4340-a20f-d3a90be4c68c)
![za-3](https://github.com/user-attachments/assets/b9eb1f13-04fb-4619-94b6-e79121861074)

The name is wrong due to some pre-existing problem that should only be happening in testing due to cloning myself as an aghost - here's what happens with the current behavior:
![za-none](https://github.com/user-attachments/assets/c6c06d2f-9d94-4b92-a697-a056765436b5)



## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
CloningEvent now should pass the mind EntityUid. This is generally useful because neither the old body nor the new body had the mind before.

**Changelog**
:cl:
- fix: Fixed cloned bodies keeping the zombie antag status
