### PR TITLE
Increase syndicate uplink discount amount to 6.

### DIFF
--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -79,11 +79,11 @@ public sealed class StoreTests
             var discountComponent = entManager.GetComponent<StoreDiscountComponent>(pda);
             Assert.That(
                 discountComponent.Discounts,
-                Has.Exactly(7).Items,
-                $"After applying discount total discounted items count was expected to be '7' "
+                Has.Exactly(6).Items,
+                $"After applying discount total discounted items count was expected to be '6' "
                 + $"but was actually {discountComponent.Discounts.Count}- this can be due to discount "
                 + $"categories settings (maxItems, weight) not being realistically set, or default "
-                + $"discounted count being changed from '7' in StoreDiscountSystem.InitializeDiscounts."
+                + $"discounted count being changed from '6' in StoreDiscountSystem.InitializeDiscounts."
             );
             var discountedListingItems = storeComponent.FullListingsCatalog
                                                        .Where(x => x.IsCostModified)

--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -79,11 +79,11 @@ public sealed class StoreTests
             var discountComponent = entManager.GetComponent<StoreDiscountComponent>(pda);
             Assert.That(
                 discountComponent.Discounts,
-                Has.Exactly(3).Items,
-                $"After applying discount total discounted items count was expected to be '3' "
+                Has.Exactly(7).Items,
+                $"After applying discount total discounted items count was expected to be '7' "
                 + $"but was actually {discountComponent.Discounts.Count}- this can be due to discount "
                 + $"categories settings (maxItems, weight) not being realistically set, or default "
-                + $"discounted count being changed from '3' in StoreDiscountSystem.InitializeDiscounts."
+                + $"discounted count being changed from '7' in StoreDiscountSystem.InitializeDiscounts."
             );
             var discountedListingItems = storeComponent.FullListingsCatalog
                                                        .Where(x => x.IsCostModified)

--- a/Content.Server/StoreDiscount/Systems/StoreDiscountSystem.cs
+++ b/Content.Server/StoreDiscount/Systems/StoreDiscountSystem.cs
@@ -71,7 +71,7 @@ public sealed class StoreDiscountSystem : EntitySystem
 
     private IReadOnlyList<StoreDiscountData> InitializeDiscounts(
         IReadOnlyCollection<ListingDataWithCostModifiers> listings,
-        int totalAvailableDiscounts = 3
+        int totalAvailableDiscounts = 7
     )
     {
         // Get list of categories with cumulative weights.

--- a/Content.Server/StoreDiscount/Systems/StoreDiscountSystem.cs
+++ b/Content.Server/StoreDiscount/Systems/StoreDiscountSystem.cs
@@ -71,7 +71,7 @@ public sealed class StoreDiscountSystem : EntitySystem
 
     private IReadOnlyList<StoreDiscountData> InitializeDiscounts(
         IReadOnlyCollection<ListingDataWithCostModifiers> listings,
-        int totalAvailableDiscounts = 7
+        int totalAvailableDiscounts = 6
     )
     {
         // Get list of categories with cumulative weights.

--- a/Resources/Prototypes/Catalog/discount_categories.yml
+++ b/Resources/Prototypes/Catalog/discount_categories.yml
@@ -1,7 +1,7 @@
 - type: discountCategory
   id: rareDiscounts # Dirty-cheap items that are rarely used and can be discounted to 0-ish cost to encourage usage.
   weight: 18
-  maxItems: 2
+  maxItems: 4
 
 - type: discountCategory
   id: usualDiscounts # Cheap items that are used not very often.
@@ -10,4 +10,4 @@
 - type: discountCategory
   id: veryRareDiscounts # Casually used items that are widely used but can be (rarely) discounted for epic lulz.
   weight: 2
-  maxItems: 1
+  maxItems: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Increased the amount of discounted items syndicate agents have from 3 to 6.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The point of the discounts was to encourage trying new items and strategies, however having the amount be only 3 almost never gave anything worth using. I believe this change will help syndie agents actually make cool things with the discounts instead of never looking at the tab.
Chance to roll different discount categories remains unchanged.

## Technical details
<!-- Summary of code changes for easier review. -->
Increased amount of uplink discounts to 6 and modified the tests to account for that.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/40e6e478-c2a5-48da-aaeb-b524c03ca05b)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Syndicate uplinks now have 6 discounts instead of 3.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
