### PR TITLE
Blind toxin

### DIFF
--- a/Content.Server/EntityEffects/Effects/ChemChangeEyeDamage.cs
+++ b/Content.Server/EntityEffects/Effects/ChemChangeEyeDamage.cs
@@ -2,7 +2,6 @@ using Content.Shared.EntityEffects;
 using Content.Shared.Eye.Blinding.Systems;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
-using System.Text.Json.Serialization;
 
 namespace Content.Server.EntityEffects.Effects;
 
@@ -10,17 +9,16 @@ namespace Content.Server.EntityEffects.Effects;
 /// Heal or apply eye damage
 /// </summary>
 [UsedImplicitly]
-public sealed partial class ChemEyeDamageChange : EntityEffect
+public sealed partial class ChemChangeEyeDamage : EntityEffect
 {
     /// <summary>
     /// How much eye damage to add.
     /// </summary>
     [DataField]
-    [JsonPropertyName("amount")]
     public int Amount = -1;
 
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
-        => Loc.GetString("reagent-effect-guidebook-eye-damage-change", ("chance", Probability), ("deltasign", MathF.Sign(Amount)));
+        => Loc.GetString("reagent-effect-guidebook-change-eye-damage", ("chance", Probability), ("deltasign", MathF.Sign(Amount)));
 
     public override void Effect(EntityEffectBaseArgs args)
     {

--- a/Content.Server/EntityEffects/Effects/ChemEyeDamageChange.cs
+++ b/Content.Server/EntityEffects/Effects/ChemEyeDamageChange.cs
@@ -2,6 +2,7 @@ using Content.Shared.EntityEffects;
 using Content.Shared.Eye.Blinding.Systems;
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
+using System.Text.Json.Serialization;
 
 namespace Content.Server.EntityEffects.Effects;
 
@@ -9,37 +10,17 @@ namespace Content.Server.EntityEffects.Effects;
 /// Heal or apply eye damage
 /// </summary>
 [UsedImplicitly]
-public sealed partial class ChemHealEyeDamage : EntityEffect
+public sealed partial class ChemEyeDamageChange : EntityEffect
 {
     /// <summary>
     /// How much eye damage to add.
     /// </summary>
     [DataField]
+    [JsonPropertyName("amount")]
     public int Amount = -1;
 
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
-        => Loc.GetString("reagent-effect-guidebook-cure-eye-damage", ("chance", Probability), ("deltasign", MathF.Sign(Amount)));
-
-    public override void Effect(EntityEffectBaseArgs args)
-    {
-        if (args is EntityEffectReagentArgs reagentArgs)
-            if (reagentArgs.Scale != 1f) // huh?
-                return;
-
-        args.EntityManager.EntitySysManager.GetEntitySystem<BlindableSystem>().AdjustEyeDamage(args.TargetEntity, Amount);
-    }
-}
-
-public sealed partial class ChemDoEyeDamage : EntityEffect
-{
-    /// <summary>
-    /// How much eye damage to add.
-    /// </summary>
-    [DataField]
-    public int Amount = 1;
-
-    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
-        => Loc.GetString("reagent-effect-guidebook-do-eye-damage", ("chance", Probability), ("deltasign", MathF.Sign(Amount)));
+        => Loc.GetString("reagent-effect-guidebook-eye-damage-change", ("chance", Probability), ("deltasign", MathF.Sign(Amount)));
 
     public override void Effect(EntityEffectBaseArgs args)
     {

--- a/Content.Server/EntityEffects/Effects/ChemEyeDamageChange.cs
+++ b/Content.Server/EntityEffects/Effects/ChemEyeDamageChange.cs
@@ -29,3 +29,24 @@ public sealed partial class ChemHealEyeDamage : EntityEffect
         args.EntityManager.EntitySysManager.GetEntitySystem<BlindableSystem>().AdjustEyeDamage(args.TargetEntity, Amount);
     }
 }
+
+public sealed partial class ChemDoEyeDamage : EntityEffect
+{
+    /// <summary>
+    /// How much eye damage to add.
+    /// </summary>
+    [DataField]
+    public int Amount = 1;
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => Loc.GetString("reagent-effect-guidebook-do-eye-damage", ("chance", Probability), ("deltasign", MathF.Sign(Amount)));
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        if (args is EntityEffectReagentArgs reagentArgs)
+            if (reagentArgs.Scale != 1f) // huh?
+                return;
+
+        args.EntityManager.EntitySysManager.GetEntitySystem<BlindableSystem>().AdjustEyeDamage(args.TargetEntity, Amount);
+    }
+}

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -209,7 +209,7 @@ reagent-effect-guidebook-cure-disease =
         *[other] cure
     } diseases
 
-reagent-effect-guidebook-cure-eye-damage =
+reagent-effect-guidebook-eye-damage-change =
     { $chance ->
         [1] { $deltasign ->
                 [1] Deals
@@ -404,16 +404,3 @@ reagent-effect-guidebook-plant-seeds-remove =
         [1] Removes the
         *[other] remove the
     } seeds of the plant
-
-reagent-effect-guidebook-cure-eye-damage =
-    { $chance ->
-        [1] { $deltasign ->
-                [1] Deals
-                *[-1] Heals
-            }
-        *[other]
-            { $deltasign ->
-                [1] deal
-                *[-1] heal
-            }
-    } eye damage

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -404,3 +404,16 @@ reagent-effect-guidebook-plant-seeds-remove =
         [1] Removes the
         *[other] remove the
     } seeds of the plant
+
+reagent-effect-guidebook-cure-eye-damage =
+    { $chance ->
+        [1] { $deltasign ->
+                [1] Deals
+                *[-1] Heals
+            }
+        *[other]
+            { $deltasign ->
+                [1] deal
+                *[-1] heal
+            }
+    } eye damage

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -209,7 +209,7 @@ reagent-effect-guidebook-cure-disease =
         *[other] cure
     } diseases
 
-reagent-effect-guidebook-eye-damage-change =
+reagent-effect-guidebook-change-eye-damage =
     { $chance ->
         [1] { $deltasign ->
                 [1] Deals

--- a/Resources/Locale/en-US/reagents/meta/physical-desc.ftl
+++ b/Resources/Locale/en-US/reagents/meta/physical-desc.ftl
@@ -94,3 +94,4 @@ reagent-physical-desc-reflective = reflective
 reagent-physical-desc-holy = holy
 reagent-physical-desc-slimy = slimy
 reagent-physical-desc-neural = neural
+reagent-physical-desc-blinding = blinding

--- a/Resources/Locale/en-US/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/reagents/meta/toxins.ftl
@@ -81,3 +81,6 @@ reagent-desc-lipolicide = A powerful toxin that will destroy fat cells, massivel
 
 reagent-name-mechanotoxin = mechanotoxin
 reagent-desc-mechanotoxin = A neurotoxin used as venom by some species of spider. Degrades movement when built up.
+
+reagent-name-blind-toxin = blind toxin
+reagent-desc-blind-toxin = A powerful toxin that causes losing of vision.

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -862,7 +862,7 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:ChemHealEyeDamage
+      - !type:ChemEyeDamageChange
 
 - type: reagent
   id: Cognizine
@@ -1160,7 +1160,7 @@
         conditions:
         - !type:ReagentThreshold
           min: 12
-          
+
 - type: reagent
   id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
   name: reagent-name-opporozidone

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -862,7 +862,7 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:ChemEyeDamageChange
+      - !type:ChemChangeEyeDamage
 
 - type: reagent
   id: Cognizine

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -714,4 +714,5 @@
   metabolisms:
     Poison:
       effects:
-      - !type:ChemDoEyeDamage
+      - !type:ChemEyeDamageChange
+        amount: 1

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -714,5 +714,5 @@
   metabolisms:
     Poison:
       effects:
-      - !type:ChemEyeDamageChange
+      - !type:ChemChangeEyeDamage
         amount: 1

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -702,3 +702,16 @@
           shouldHave: false
         walkSpeedModifier: 0.4
         sprintSpeedModifier: 0.4
+
+- type: reagent
+  id: BlindToxin
+  name: reagent-name-blind-toxin
+  desc: reagent-name-blind-toxin
+  group: Medicine
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: medicine
+  color: "#404040"
+  metabolisms:
+    Poison:
+      effects:
+      - !type:ChemDoEyeDamage

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -706,11 +706,11 @@
 - type: reagent
   id: BlindToxin
   name: reagent-name-blind-toxin
-  desc: reagent-name-blind-toxin
-  group: Medicine
-  physicalDesc: reagent-physical-desc-translucent
+  desc: reagent-desc-blind-toxin
+  group: Toxins
+  physicalDesc: reagent-physical-desc-blinding
   flavor: medicine
-  color: "#404040"
+  color: "#848484"
   metabolisms:
     Poison:
       effects:

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -561,7 +561,7 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine: 
+    Cognizine:
       amount: 1
     Plasma:
       amount: 2
@@ -662,3 +662,13 @@
       amount: 1
   products:
     Haloperidol: 5
+
+- type: reaction
+  id: BlindToxin
+  reactants:
+    Vestine:
+      amount: 1
+    Oculine:
+      amount: 1
+  products:
+    BlindToxin: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a new reagent - blind toxin

## Why / Balance
Adding a new way to make someone blind will adds a more way to roleplay and more ways to complete objections as antags

## Technical details
ChemHealEyeDamage has been renamed into ChemEyeDamageChange because it used not only for healing

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added a new toxin - blind toxin. It can be made from vestine and oculine.
