### PR TITLE
SS14-33795 Fix airlocks not being pryable closed.

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -296,6 +296,11 @@ public sealed partial class DoorComponent : Component
 
     [DataField(customTypeSerializer: typeof(ConstantSerializer<DrawDepthTag>))]
     public int ClosedDrawDepth = (int) DrawDepth.DrawDepth.Doors;
+
+    /// <summary>
+    /// Is true if the door is currently opening or closing due to being pried.
+    /// </summary>
+    public bool IsPried;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -300,7 +300,8 @@ public sealed partial class DoorComponent : Component
     /// <summary>
     /// Is true if the door is currently opening or closing due to being pried.
     /// </summary>
-    public bool IsPried;
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
+    public bool IsBeingPried;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -43,7 +43,7 @@ public abstract class SharedAirlockSystem : EntitySystem
 
         if (TryComp(uid, out DoorComponent? door)
             && !door.Partial
-            && !CanChangeState(uid, airlock, door.IsPried))
+            && !CanChangeState(uid, airlock, door.IsBeingPried))
         {
             args.Cancel();
         }

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -173,13 +173,13 @@ public abstract partial class SharedDoorSystem : EntitySystem
         {
             case DoorState.Opening:
                 _activeDoors.Add((uid, door));
-                door.IsPried = isPried;
+                door.IsBeingPried = isPried;
                 door.NextStateChange = GameTiming.CurTime + door.OpenTimeOne;
                 break;
 
             case DoorState.Closing:
                 _activeDoors.Add((uid, door));
-                door.IsPried = isPried;
+                door.IsBeingPried = isPried;
                 door.NextStateChange = GameTiming.CurTime + door.CloseTimeOne;
                 break;
 
@@ -195,14 +195,14 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
             case DoorState.Open:
                 door.Partial = false;
-                door.IsPried = false;
+                door.IsBeingPried = false;
                 if (door.NextStateChange == null)
                     _activeDoors.Remove((uid, door));
                 break;
             case DoorState.Closed:
                 // May want to keep the door around to re-check for opening if we got a contact during closing.
                 door.Partial = false;
-                door.IsPried = false;
+                door.IsBeingPried = false;
                 break;
         }
 
@@ -524,6 +524,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
             door.NextStateChange = GameTiming.CurTime + door.OpenTimeTwo;
             door.State = DoorState.Open;
             AppearanceSystem.SetData(uid, DoorVisuals.State, DoorState.Open);
+            door.IsBeingPried = false;
             Dirty(uid, door);
             return false;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes airlocks not being pryable closed. This fix leaves a couple of lingering bugs due to the layered messy state of the door/airlock code.

## Why / Balance
Not being able to pry airlocks shut is very bad for crew health.

## Technical details
Added a IsPried bool to DoorComponent that is true when a door is Opened/Closed due to being Pried. This allows for the SharedAirlockSystem to only check is a door needs to be powered to shut it if it isn't being pried.

## Media
[<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->](https://github.com/user-attachments/assets/08eb4a41-42fa-4fba-9d04-1b5b67e952f0)

Note the remaining animation bug.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Airlocks can now be pried closed, to the relief of atmospheric technicians everywhere.
