### PR TITLE
Fixed de powered airlocks/doors not being able to be closed

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -259,6 +259,9 @@ public sealed partial class DoorComponent : Component
     public bool CanPry = true;
 
     [DataField]
+    public bool BeingPried;
+
+    [DataField]
     public ProtoId<ToolQualityPrototype> PryingQuality = "Prying";
 
     /// <summary>

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -258,7 +258,7 @@ public sealed partial class DoorComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool CanPry = true;
 
-    [DataField]
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
     public bool BeingPried;
 
     [DataField]

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -259,7 +259,7 @@ public sealed partial class DoorComponent : Component
     public bool CanPry = true;
 
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
-    public bool BeingPried;
+    public bool IsBeingPried;
 
     [DataField]
     public ProtoId<ToolQualityPrototype> PryingQuality = "Prying";

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -42,7 +42,7 @@ public abstract class SharedAirlockSystem : EntitySystem
         // the initial power-check.
         if (TryComp(uid, out DoorComponent? door)
             && !door.Partial
-            && !CanChangeState(uid, airlock, door.BeingPried))
+            && !CanChangeState(uid, airlock, door.IsBeingPried))
         {
             args.Cancel();
         }

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -40,10 +40,9 @@ public abstract class SharedAirlockSystem : EntitySystem
         // only block based on bolts / power status when initially closing the door, not when its already
         // mid-transition. Particularly relevant for when the door was pried-closed with a crowbar, which bypasses
         // the initial power-check.
-
         if (TryComp(uid, out DoorComponent? door)
             && !door.Partial
-            && !CanChangeState(uid, airlock))
+            && !CanChangeState(uid, airlock, door.BeingPried))
         {
             args.Cancel();
         }
@@ -174,8 +173,8 @@ public abstract class SharedAirlockSystem : EntitySystem
         component.Safety = value;
     }
 
-    public bool CanChangeState(EntityUid uid, AirlockComponent component)
+    public bool CanChangeState(EntityUid uid, AirlockComponent component, bool isBeingPried = false)
     {
-        return component.Powered && !DoorSystem.IsBolted(uid);
+        return component.Powered && !DoorSystem.IsBolted(uid) || !component.Powered && isBeingPried ;
     }
 }

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -245,6 +245,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         }
         else if (door.State == DoorState.Open)
         {
+            door.BeingPried = true;
             _adminLog.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User)} pried {ToPrettyString(uid)} closed");
             StartClosing(uid, door, args.User, true);
         }
@@ -486,11 +487,13 @@ public abstract partial class SharedDoorSystem : EntitySystem
             door.NextStateChange = GameTiming.CurTime + door.OpenTimeTwo;
             door.State = DoorState.Open;
             AppearanceSystem.SetData(uid, DoorVisuals.State, DoorState.Open);
+            door.BeingPried = false;
             Dirty(uid, door);
             return false;
         }
 
         door.Partial = true;
+        door.BeingPried = false;
         SetCollidable(uid, true, door, physics);
         door.NextStateChange = GameTiming.CurTime + door.CloseTimeTwo;
         Dirty(uid, door);

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -245,7 +245,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         }
         else if (door.State == DoorState.Open)
         {
-            door.BeingPried = true;
+            door.IsBeingPried = true;
             _adminLog.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User)} pried {ToPrettyString(uid)} closed");
             StartClosing(uid, door, args.User, true);
         }
@@ -487,13 +487,13 @@ public abstract partial class SharedDoorSystem : EntitySystem
             door.NextStateChange = GameTiming.CurTime + door.OpenTimeTwo;
             door.State = DoorState.Open;
             AppearanceSystem.SetData(uid, DoorVisuals.State, DoorState.Open);
-            door.BeingPried = false;
+            door.IsBeingPried = false;
             Dirty(uid, door);
             return false;
         }
 
         door.Partial = true;
-        door.BeingPried = false;
+        door.IsBeingPried = false;
         SetCollidable(uid, true, door, physics);
         door.NextStateChange = GameTiming.CurTime + door.CloseTimeTwo;
         Dirty(uid, door);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed https://github.com/space-wizards/space-station-14/issues/33795

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes a Bug

## Technical details
<!-- Summary of code changes for easier review. -->
Added new property "BeingPried" in Content.Shared.Doors.DoorComponent

Changed Content.Shared.Doors.Systems.SharedAirlockSystem OnBeforeDoorClosed() and CanChangeState() to check for BeingPried door flag

Changed Content.Shared.Doors.Systems.SharedDoorSystem OnAfterPry to set BeingPried to true when closing

Changed Content.Shared.Doors.Systems.SharedDoorSystem set BeingPried to false after CanClose is called

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/f2714a4b-e590-4a35-a650-d4756a3b4879

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No breaking change is expected

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Airlocks and FireLocks not being able to be closed when de powered
