### PR TITLE
Minor fixes for the holopad

### DIFF
--- a/Content.Server/Telephone/TelephoneSystem.cs
+++ b/Content.Server/Telephone/TelephoneSystem.cs
@@ -194,7 +194,7 @@ public sealed class TelephoneSystem : SharedTelephoneSystem
 
     private bool TryCallTelephone(Entity<TelephoneComponent> source, Entity<TelephoneComponent> receiver, EntityUid user, TelephoneCallOptions? options = null)
     {
-        if (!IsSourceAbleToReachReceiver(source, receiver))
+        if (!IsSourceAbleToReachReceiver(source, receiver) && options?.IgnoreRange != true)
             return false;
 
         if (IsTelephoneEngaged(receiver) &&

--- a/Content.Shared/Telephone/TelephoneComponent.cs
+++ b/Content.Shared/Telephone/TelephoneComponent.cs
@@ -181,6 +181,7 @@ public readonly record struct TelephoneMessageReceivedEvent(string Message, MsgC
 [Serializable, NetSerializable]
 public struct TelephoneCallOptions
 {
+    public bool IgnoreRange;    // The source can always reach its target
     public bool ForceConnect;   // The source immediately starts a call with the receiver, potentially interrupting a call that is already in progress 
     public bool ForceJoin;      // The source smoothly joins a call in progress, or starts a normal call with the receiver if there is none
     public bool MuteSource;     // Chatter from the source is not transmitted - could be used for eavesdropping when combined with 'ForceJoin'

--- a/Resources/Locale/en-US/holopad/holopad.ftl
+++ b/Resources/Locale/en-US/holopad/holopad.ftl
@@ -39,6 +39,7 @@ holopad-hologram-name = hologram of {THE($name)}
 # Holopad actions
 holopad-activate-projector-verb = Activate holopad projector
 holopad-ai-is-unable-to-reach-holopad = You are unable to interface with the source of the call, it is too far from your core.
+holopad-ai-is-unable-to-activate-projector = You are unable to activate the holopad's projector, it is too far from your core.
 
 # Mapping prototypes
 # General


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A few more minor fixes for holopads

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Popup text should now appear above the holopad to inform AI players that they can't answer when they try to respond to calls that come from a different grid or map to their core
- If an AI starts an emergency broadcast on a bluespace holopad, the bluespace holopad will now activate alongside all the others (note: while the AI might start a broadcast from a specific holopad, the broadcast actually originates from its AI core. So the reach of the broadcast is restricted to the grid that the AI core is on, not the holopad they are using. This is the intended design since the AI is meant to be station-bound, and it makes sense that if the AI can't answer calls coming from off-station they can't call devices off-station either) 
- You can now call for the station AI from long-range and quantum and holopads (provided the holopad are on the same grid as an AI core, of course)
- If all AIs are currently busy (i.e., in calls), if you attempt to call them, the UI will correctly inform you that your call could be connected instead of doing nothing
- You can no longer request an AI that is on another grid or map via a bluespace holopad (the AI would get the popup, but couldn't answer the call)
- Properly fixed an infinite 'ending call' loop when the AI ended a holo-call; this would cause the buttons on the AI holopad UI to periodically flicker

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
N/A
