### PR TITLE
All hostile turret

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -196,6 +196,15 @@
     - SimpleHostile
 
 - type: entity
+  parent: BaseWeaponTurret
+  id: WeaponTurretAllHostile
+  suffix: All hostile
+  components:
+  - type: NpcFactionMember
+    factions:
+    - AllHostile
+
+- type: entity
   name: xeno turret
   description: Shoots 9mm acid projectiles.
   parent: BaseWeaponTurret

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -7,6 +7,7 @@
     - PetsNT
     - Zombie
     - Revolutionary
+    - AllHostile
 
 - type: npcFaction
   id: NanoTrasen
@@ -16,11 +17,13 @@
   - Xeno
   - Zombie
   - Revolutionary
+  - AllHostile
 
 - type: npcFaction
   id: Mouse
   hostile:
     - PetsNT
+    - AllHostile
 
 - type: npcFaction
   id: Passive
@@ -32,6 +35,7 @@
   - SimpleHostile
   - Zombie
   - Xeno
+  - AllHostile
 
 - type: npcFaction
   id: SimpleHostile
@@ -42,6 +46,7 @@
   - PetsNT
   - Zombie
   - Revolutionary
+  - AllHostile
 
 - type: npcFaction
   id: SimpleNeutral
@@ -54,6 +59,7 @@
   - Xeno
   - PetsNT
   - Zombie
+  - AllHostile
 
 - type: npcFaction
   id: Xeno
@@ -64,6 +70,7 @@
   - PetsNT
   - Zombie
   - Revolutionary
+  - AllHostile
 
 - type: npcFaction
   id: Zombie
@@ -75,6 +82,7 @@
   - Passive
   - PetsNT
   - Revolutionary
+  - AllHostile
 
 - type: npcFaction
   id: Revolutionary
@@ -83,6 +91,7 @@
   - Zombie
   - SimpleHostile
   - Dragon
+  - AllHostile
 
 - type: npcFaction
   id: AllHostile

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -83,3 +83,18 @@
   - Zombie
   - SimpleHostile
   - Dragon
+
+- type: npcFaction
+  id: AllHostile
+  hostile:
+  - NanoTrasen
+  - Dragon
+  - Mouse
+  - Passive
+  - PetsNT
+  - SimpleHostile
+  - SimpleNeutral
+  - Syndicate
+  - Xeno
+  - Zombie
+  - Revolutionary


### PR DESCRIPTION
## About the PR
New AI faction for NPCs and turrets.

## Why / Balance
• As for now, there's no separate NPC faction that wouldn't side with anyone.
• It's especially bad for turrets, because it either must be sided with SimpleHostile (shared by huge majority of hostile NPC's) or with NT/Syndicate.

I'm sure it'll be great seeing these in some high security areas with decent loot (expeditions for example) where it can be a threat both for hostile NPCs (carps etc) and for salvage.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: RatIRL
- add: Added All-Hostile ballistic turret.

