### PR TITLE
Feature/contraband fixes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Paper/manuals.yml
+++ b/Resources/Prototypes/Catalog/Fills/Paper/manuals.yml
@@ -7,7 +7,7 @@
     content: book-text-ame-scribbles
 
 - type: entity
-  parent: BaseItem
+  parent: [BaseItem, BaseSyndicateContraband]
   id: HoloparasiteInfo
   name: "holoparasite terms and conditions"
   description: A tiny volumetric display for documents, makes one wonder if Cybersun's legal budget is way too high.
@@ -27,7 +27,7 @@
 - type: entity
   id: PaperAgrichemManual
   name: NT "AgriChem Is Fun" manual
-  description: The single sheet of instructions that came in the kit. 
+  description: The single sheet of instructions that came in the kit.
   parent: Paper
   components:
   - type: Paper

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -32,7 +32,7 @@
     damageCoefficient: 0.9
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseCivilianContraband]
   id: ClothingBackpackClown
   name: giggles von honkerton
   description: It's a backpack made by Honk! Co.
@@ -65,7 +65,7 @@
     sprite: Clothing/Back/Backpacks/security.rsi
 
 - type: entity
-  parent: [ClothingBackpack, BaseRestrictedContraband]
+  parent: [ClothingBackpack, BaseMedicalSecurityContraband]
   id: ClothingBackpackBrigmedic
   name: brigmedic backpack
   description: It's a very sterile backpack.
@@ -74,7 +74,7 @@
     sprite: Clothing/Back/Backpacks/brigmedic.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseEngineeringContraband]
   id: ClothingBackpackEngineering
   name: engineering backpack
   description: It's a tough backpack for the daily grind of station life.
@@ -83,7 +83,7 @@
     sprite: Clothing/Back/Backpacks/engineering.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseEngineeringContraband]
   id: ClothingBackpackAtmospherics
   name: atmospherics backpack
   description: It's a backpack made of fire resistant fibers. Smells like plasma.
@@ -92,7 +92,7 @@
     sprite: Clothing/Back/Backpacks/atmospherics.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseMedicalContraband]
   id: ClothingBackpackMedical
   name: medical backpack
   description: It's a backpack especially designed for use in a sterile environment.
@@ -110,7 +110,7 @@
     sprite: Clothing/Back/Backpacks/captain.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseCivilianContraband]
   id: ClothingBackpackMime
   name: mime backpack
   description: A silent backpack made for those silent workers. Silence Co.
@@ -119,7 +119,7 @@
     sprite: Clothing/Back/Backpacks/mime.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseMedicalContraband]
   id: ClothingBackpackChemistry
   name: chemistry backpack
   description: A backpack specially designed to repel stains and hazardous liquids.
@@ -128,7 +128,7 @@
     sprite: Clothing/Back/Backpacks/chemistry.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseCivilianContraband]
   id: ClothingBackpackHydroponics
   name: hydroponics backpack
   description: It's a backpack made of all-natural fibers.
@@ -137,7 +137,7 @@
     sprite: Clothing/Back/Backpacks/hydroponics.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseScienceContraband]
   id: ClothingBackpackScience
   name: science backpack
   description: A backpack specially designed to repel stains and hazardous liquids.
@@ -146,7 +146,7 @@
     sprite: Clothing/Back/Backpacks/science.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseMedicalContraband]
   id: ClothingBackpackVirology
   name: virology backpack
   description: A backpack made of hypo-allergenic fibers. It's designed to help prevent the spread of disease. Smells like monkey.
@@ -155,7 +155,7 @@
     sprite: Clothing/Back/Backpacks/virology.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseMedicalContraband]
   id: ClothingBackpackGenetics
   name: genetics backpack
   description: A backpack designed to be super tough, just in case someone hulks out on you.
@@ -164,7 +164,7 @@
     sprite: Clothing/Back/Backpacks/genetics.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseCargoContraband]
   id: ClothingBackpackCargo
   name: cargo backpack
   description: A robust backpack for stealing cargo's loot.
@@ -173,7 +173,7 @@
       sprite: Clothing/Back/Backpacks/cargo.rsi
 
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseCargoContraband]
   id: ClothingBackpackSalvage
   name: salvage bag
   description: A robust backpack for stashing your loot.

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -16,7 +16,7 @@
   - type: HeldSpeedModifier
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseEngineeringContraband]
   id: ClothingBackpackDuffelEngineering
   name: engineering duffel bag
   description: A large duffel bag for holding extra tools and supplies.
@@ -25,7 +25,7 @@
     sprite: Clothing/Back/Duffels/engineering.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseEngineeringContraband]
   id: ClothingBackpackDuffelAtmospherics
   name: atmospherics duffel bag
   description: A large duffel bag made of fire resistant fibers. Smells like plasma.
@@ -34,7 +34,7 @@
     sprite: Clothing/Back/Duffels/atmospherics.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseMedicalContraband]
   id: ClothingBackpackDuffelMedical
   name: medical duffel bag
   description: A large duffel bag for holding extra medical supplies.
@@ -52,7 +52,7 @@
     sprite: Clothing/Back/Duffels/captain.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseCivilianContraband]
   id: ClothingBackpackDuffelClown
   name: clown duffel bag
   description: A large duffel bag for holding extra honk goods.
@@ -73,7 +73,7 @@
     sprite: Clothing/Back/Duffels/security.rsi
 
 - type: entity
-  parent: [ClothingBackpackDuffel, BaseRestrictedContraband]
+  parent: [ClothingBackpackDuffel, BaseMedicalSecurityContraband]
   id: ClothingBackpackDuffelBrigmedic
   name: brigmedic duffel bag
   description: A large duffel bag for holding extra medical related goods.
@@ -82,7 +82,7 @@
     sprite: Clothing/Back/Duffels/brigmedic.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseMedicalContraband]
   id: ClothingBackpackDuffelChemistry
   name: chemistry duffel bag
   description: A large duffel bag for holding extra beakers and test tubes.
@@ -91,7 +91,7 @@
     sprite: Clothing/Back/Duffels/chemistry.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseMedicalContraband]
   id: ClothingBackpackDuffelVirology
   name: virology duffel bag
   description: A large duffel bag made of hypo-allergenic fibers. It's designed to help prevent the spread of disease. Smells like monkey.
@@ -100,7 +100,7 @@
     sprite: Clothing/Back/Duffels/virology.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseMedicalContraband]
   id: ClothingBackpackDuffelGenetics
   name: genetics duffel bag
   description: A large duffel bag for holding extra genetic mutations.
@@ -109,7 +109,7 @@
     sprite: Clothing/Back/Duffels/genetics.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseCivilianContraband]
   id: ClothingBackpackDuffelMime
   name: mime duffel bag
   description: A large duffel bag for holding... mime... stuff.
@@ -122,7 +122,7 @@
       collection: null
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseScienceContraband]
   id: ClothingBackpackDuffelScience
   name: science duffel bag
   description: A large duffel bag for holding extra science related goods.
@@ -131,7 +131,7 @@
     sprite: Clothing/Back/Duffels/science.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseCivilianContraband]
   id: ClothingBackpackDuffelHydroponics
   name: hydroponics duffel bag
   description: A large duffel bag for holding extra gardening tools.
@@ -140,7 +140,7 @@
       sprite: Clothing/Back/Duffels/hydroponics.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseCargoContraband]
   id: ClothingBackpackDuffelCargo
   name: cargo duffel bag
   description: A large duffel bag for stealing cargo's precious loot.
@@ -149,7 +149,7 @@
       sprite: Clothing/Back/Duffels/cargo.rsi
 
 - type: entity
-  parent: ClothingBackpackDuffel
+  parent: [ClothingBackpackDuffel, BaseCargoContraband]
   id: ClothingBackpackDuffelSalvage
   name: salvage duffel bag
   description: A large duffel bag for holding extra exotic treasures.

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -31,7 +31,7 @@
     sprite: Clothing/Back/Satchels/engineering.rsi
 
 - type: entity
-  parent: ClothingBackpackSatchel
+  parent: [ClothingBackpackSatchel, BaseEngineeringContraband]
   id: ClothingBackpackSatchelAtmospherics
   name: atmospherics satchel
   description: A tough satchel made of fire resistant fibers. Smells like plasma.
@@ -40,7 +40,7 @@
     sprite: Clothing/Back/Satchels/atmospherics.rsi
 
 - type: entity
-  parent: ClothingBackpackSatchel
+  parent: [ClothingBackpackSatchel, BaseCivilianContraband]
   id: ClothingBackpackSatchelClown
   name: clown satchel
   description: For fast running from security.
@@ -52,7 +52,7 @@
       collection: BikeHorn
 
 - type: entity
-  parent: ClothingBackpackSatchel
+  parent: [ClothingBackpackSatchel, BaseCivilianContraband]
   id: ClothingBackpackSatchelMime
   name: mime satchel
   description: A satchel designed for the silent and expressive art of miming.
@@ -61,7 +61,7 @@
     sprite: Clothing/Back/Satchels/mime.rsi
 
 - type: entity
-  parent: ClothingBackpackSatchel
+  parent: [ClothingBackpackSatchel, BaseMedicalContraband]
   id: ClothingBackpackSatchelMedical
   name: medical satchel
   description: A sterile satchel used in medical departments.
@@ -70,7 +70,7 @@
     sprite: Clothing/Back/Satchels/medical.rsi
 
 - type: entity
-  parent: ClothingBackpackSatchel
+  parent: [ClothingBackpackSatchel, BaseMedicalContraband]
   id: ClothingBackpackSatchelChemistry
   name: chemistry satchel
   description: A sterile satchel with chemist colours.
@@ -79,7 +79,7 @@
     sprite: Clothing/Back/Satchels/chemistry.rsi
 
 - type: entity
-  parent: ClothingBackpackSatchel
+  parent: [ClothingBackpackSatchel, BaseMedicalContraband]
   id: ClothingBackpackSatchelVirology
   name: virology satchel
   description: A satchel made of hypo-allergenic fibers. It's designed to help prevent the spread of disease. Smells like monkey.
@@ -88,7 +88,7 @@
     sprite: Clothing/Back/Satchels/virology.rsi
 
 - type: entity
-  parent: ClothingBackpackSatchel
+  parent: [ClothingBackpackSatchel, BaseMedicalContraband]
   id: ClothingBackpackSatchelGenetics
   name: genetics satchel
   description: A sterile satchel with geneticist colours.
@@ -97,7 +97,7 @@
     sprite: Clothing/Back/Satchels/genetics.rsi
 
 - type: entity
-  parent: ClothingBackpackSatchel
+  parent: [ClothingBackpackSatchel, BaseScienceContraband]
   id: ClothingBackpackSatchelScience
   name: science satchel
   description: Useful for holding research materials.
@@ -115,7 +115,7 @@
     sprite: Clothing/Back/Satchels/security.rsi
 
 - type: entity
-  parent: [ClothingBackpackSatchel, BaseRestrictedContraband]
+  parent: [ClothingBackpackSatchel, BaseMedicalSecurityContraband]
   id: ClothingBackpackSatchelBrigmedic
   name: brigmedic satchel
   description: A sterile satchel for medical related needs.
@@ -133,7 +133,7 @@
     sprite: Clothing/Back/Satchels/captain.rsi
 
 - type: entity
-  parent: ClothingBackpackSatchel
+  parent: [ClothingBackpackSatchel, BaseCivilianContraband]
   id: ClothingBackpackSatchelHydroponics
   name: hydroponics satchel
   description: A satchel made of all natural fibers.
@@ -142,7 +142,7 @@
     sprite: Clothing/Back/Satchels/hydroponics.rsi
 
 - type: entity
-  parent: ClothingBackpackSatchel
+  parent: [ClothingBackpackSatchel, BaseCargoContraband]
   id: ClothingBackpackSatchelCargo
   name: cargo satchel
   description: A robust satchel for stealing cargo's loot.
@@ -151,7 +151,7 @@
       sprite: Clothing/Back/Satchels/cargo.rsi
 
 - type: entity
-  parent: ClothingBackpackSatchel
+  parent: [ClothingBackpackSatchel, BaseCargoContraband]
   id: ClothingBackpackSatchelSalvage
   name: salvage satchel
   description: A robust satchel for stashing your loot.

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -81,7 +81,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: [ClothingBeltStorageBase, BaseCommandContraband]
   id: ClothingBeltChiefEngineer
   name: chief engineer's toolbelt
   description: Holds tools, looks snazzy.
@@ -245,7 +245,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: [ClothingBeltStorageBase, BaseMedicalContraband]
   id: ClothingBeltMedical
   name: medical belt
   description: Can hold various medical equipment.
@@ -379,7 +379,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: [ClothingBeltStorageBase, BaseCivilianContraband]
   id: ClothingBeltChef
   name: chef belt
   description: A belt used to hold kitchen knives and condiments for quick access.

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -161,7 +161,7 @@
   - type: Appearance
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: [ClothingBeltStorageBase, BaseRestrictedContraband]
   id: ClothingBeltAssault
   name: assault belt
   description: A tactical assault belt.
@@ -575,7 +575,7 @@
     - Kangaroo
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: [ClothingBeltStorageBase, BaseRestrictedContraband]
   id: ClothingBeltHolster
   name: shoulder holster
   description: 'A holster to carry a handgun and ammo. WARNING: Badasses only.'
@@ -633,7 +633,7 @@
     sprite: Clothing/Belt/mercwebbing.rsi
 
 - type: entity
-  parent: ClothingBeltStorageBase
+  parent: [ClothingBeltStorageBase, BaseCargoContraband]
   id: ClothingBeltSalvageWebbing
   name: salvage rig
   description: Universal unloading system for work in space.

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -36,7 +36,7 @@
     sprite: Clothing/Ears/Headsets/base.rsi
 
 - type: entity
-  parent: ClothingHeadset
+  parent: [ClothingHeadset, BaseCargoContraband]
   id: ClothingHeadsetCargo
   name: cargo headset
   description: A headset used by supply employees.
@@ -107,7 +107,7 @@
     sprite: Clothing/Ears/Headsets/command.rsi
 
 - type: entity
-  parent: ClothingHeadset
+  parent: [ClothingHeadset, BaseEngineeringContraband]
   id: ClothingHeadsetEngineering
   name: engineering headset
   description: A headset for engineers to chat while the station burns around them.
@@ -136,7 +136,7 @@
       - EncryptionKeyCommon
 
 - type: entity
-  parent: ClothingHeadset
+  parent: [ClothingHeadset, BaseMedicalContraband]
   id: ClothingHeadsetMedical
   name: medical headset
   description: A headset for the trained staff of the medbay.
@@ -165,7 +165,7 @@
       - EncryptionKeyCommon
 
 - type: entity
-  parent: ClothingHeadset
+  parent: [ClothingHeadset, BaseScienceContraband]
   id: ClothingHeadsetScience
   name: science headset
   description: A sciency headset. Like usual.
@@ -181,7 +181,7 @@
     sprite: Clothing/Ears/Headsets/science.rsi
 
 - type: entity
-  parent: ClothingHeadsetScience
+  parent: [ClothingHeadsetScience, BaseMedicalScienceContraband]
   id: ClothingHeadsetMedicalScience
   name: medical research headset
   description: A headset that is a result of the mating between medical and science.
@@ -259,7 +259,7 @@
     sprite: Clothing/Ears/Headsets/brigmedic.rsi
 
 - type: entity
-  parent: ClothingHeadset
+  parent: [ClothingHeadset, BaseCivilianContraband]
   id: ClothingHeadsetService
   name: service headset
   description: Headset used by the service staff, tasked with keeping the station full, happy and clean.

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -242,7 +242,7 @@
     sprite: Clothing/Ears/Headsets/security.rsi
 
 - type: entity
-  parent: [ClothingHeadset, BaseRestrictedContraband]
+  parent: [ClothingHeadset, BaseMedicalSecurityContraband]
   id: ClothingHeadsetBrigmedic
   name: brigmedic headset
   description: A headset that helps to hear the death cries.

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -11,7 +11,7 @@
     equippedPrefix: alt
 
 - type: entity
-  parent: ClothingHeadsetAlt
+  parent: [ClothingHeadsetAlt, BaseCommandContraband]
   id: ClothingHeadsetAltCargo
   name: quartermaster's over-ear headset
   components:
@@ -27,7 +27,7 @@
     sprite: Clothing/Ears/Headsets/cargo.rsi
 
 - type: entity
-  parent: ClothingHeadsetAlt
+  parent: [ClothingHeadsetAlt, BaseCentcommContraband]
   id: ClothingHeadsetAltCentCom
   name: CentComm over-ear headset
   components:

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -113,7 +113,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingEyesBase
+  parent: [ClothingEyesBase, BaseSyndicateContraband]
   id: ClothingEyesGlassesOutlawGlasses
   name: outlaw glasses
   description: A must for every self-respecting undercover agent.
@@ -188,7 +188,7 @@
   parent: [ClothingEyesBase, BaseCommandContraband]
   id: ClothingEyesGlassesCommand
   name: administration glasses
-  description: Upgraded sunglasses that provide flash immunity and show ID card status. 
+  description: Upgraded sunglasses that provide flash immunity and show ID card status.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/commandglasses.rsi

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -71,7 +71,7 @@
   - type: ShowJobIcons
 
 - type: entity
-  parent: ClothingEyesBase
+  parent: [ClothingEyesBase, BaseCivilianContraband]
   id: ClothingEyesHudBeer
   name: beer goggles
   description: A pair of sunHud outfitted with apparatus to scan reagents, as well as providing an innate understanding of liquid viscosity while in motion.
@@ -148,7 +148,7 @@
   - type: ShowThirstIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons, BaseSecurityCommandContraband]
+  parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons, BaseMedicalSecurityContraband]
   id: ClothingEyesHudMedSec
   name: medsec hud
   description: An eye display that looks like a mixture of medical and security huds.

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -110,7 +110,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: [ClothingHandsBase, BaseCommandContraband]
   id: ClothingHandsGlovesHop
   name: papercut-proof gloves
   description: Perfect for dealing with paperwork and matters with bureaucracy.
@@ -415,7 +415,7 @@
     price: 0
 
 - type: entity
-  parent: ClothingHandsBase
+  parent: [ClothingHandsBase, BaseSecurityContraband]
   id: ClothingHandsGlovesForensic
   name: forensic gloves
   description: Do not leave fibers or fingerprints. If you work without them, you're A TERRIBLE DETECTIVE.

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -187,7 +187,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingHandsButcherable
+  parent: [ClothingHandsButcherable, BaseScienceContraband]
   id: ClothingHandsGlovesRobohands
   name: robohands gloves
   description: Beep boop borp!

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -52,7 +52,7 @@
 
 #Paramedic Void Helmet
 - type: entity
-  parent: ClothingHeadEVAHelmetBase
+  parent: [ClothingHeadEVAHelmetBase, BaseMedicalContraband]
   id: ClothingHeadHelmetVoidParamed
   name: paramedic void helmet
   description: A void helmet made for paramedics.

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -184,7 +184,7 @@
 
 #Brigmedic Hardsuit
 - type: entity
-  parent: [ClothingHeadHardsuitWithLightBase, BaseRestrictedContraband]
+  parent: [ClothingHeadHardsuitWithLightBase, BaseMedicalSecurityContraband]
   id: ClothingHeadHelmetHardsuitBrigmedic
   name: brigmedic hardsuit helmet
   description: The lightweight helmet of the brigmedic hardsuit. Protects against viruses, and clowns.

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -25,7 +25,7 @@
 
 #Atmospherics Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseEngineeringContraband]
   id: ClothingHeadHelmetHardsuitAtmos
   name: atmos hardsuit helmet
   description: A special hardsuit helmet designed for working in low-pressure, high thermal environments.
@@ -67,7 +67,7 @@
 
 #Engineering Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseEngineeringContraband]
   id: ClothingHeadHelmetHardsuitEngineering
   name: engineering hardsuit helmet
   description: An engineering hardsuit helmet designed for working in low-pressure, high radioactive environments.
@@ -84,7 +84,7 @@
 
 #Spationaut Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseCargoContraband]
   id: ClothingHeadHelmetHardsuitSpatio
   name: spationaut hardsuit helmet
   description: A sturdy helmet designed for complex industrial operations in space.
@@ -120,7 +120,7 @@
 
 #Salvage Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseCargoContraband]
   id: ClothingHeadHelmetHardsuitSalvage
   name: salvage hardsuit helmet
   description: A special helmet designed for work in a hazardous, low pressure environment. Has reinforced plating for wildlife encounters and dual floodlights.
@@ -137,7 +137,7 @@
     energy: 3
 
 - type: entity
-  parent: ClothingHeadHardsuitBase
+  parent: [ClothingHeadHardsuitBase, BaseCargoContraband]
   id: ClothingHeadHelmetHardsuitMaxim
   categories: [ HideSpawnMenu ]
   name: salvager maxim helmet
@@ -160,7 +160,7 @@
 
 #Security Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseRestrictedContraband]
   id: ClothingHeadHelmetHardsuitSecurity
   name: security hardsuit helmet
   description: Armored hardsuit helmet for security needs.
@@ -184,7 +184,7 @@
 
 #Brigmedic Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseRestrictedContraband]
   id: ClothingHeadHelmetHardsuitBrigmedic
   name: brigmedic hardsuit helmet
   description: The lightweight helmet of the brigmedic hardsuit. Protects against viruses, and clowns.
@@ -210,7 +210,7 @@
 
 #Warden's Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseRestrictedContraband]
   id: ClothingHeadHelmetHardsuitWarden
   name: warden's hardsuit helmet
   description: A modified riot helmet. Oddly comfortable.
@@ -234,7 +234,7 @@
 
 #Captain's Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseCommandContraband]
   id: ClothingHeadHelmetHardsuitCap
   name: captain's hardsuit helmet
   description: Special hardsuit helmet, made for the captain of the station.
@@ -249,7 +249,7 @@
 
 #Chief Engineer's Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseCommandContraband]
   id: ClothingHeadHelmetHardsuitEngineeringWhite
   name: chief engineer's hardsuit helmet
   description: Special hardsuit helmet, made for the chief engineer of the station.
@@ -268,7 +268,7 @@
 
 #Chief Medical Officer's Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseCommandContraband]
   id: ClothingHeadHelmetHardsuitMedical
   name: chief medical officer's hardsuit helmet
   description: Lightweight medical hardsuit helmet that doesn't restrict your head movements.
@@ -285,7 +285,7 @@
 
 #Research Director's Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseGrandTheftContraband]
   id: ClothingHeadHelmetHardsuitRd
   name: experimental research hardsuit helmet
   description: Lightweight hardsuit helmet that doesn't restrict your head movements.
@@ -302,7 +302,7 @@
 
 #Head of Security's hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseCommandContraband]
   id: ClothingHeadHelmetHardsuitSecurityRed
   name: head of security's hardsuit helmet
   description: Security hardsuit helmet with the latest top secret NT-HUD software. Belongs to the HoS.

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -345,7 +345,7 @@
 #ANTAG HARDSUITS
 #Blood-red Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseSyndicateContraband]
   id: ClothingHeadHelmetHardsuitSyndie
   name: blood-red hardsuit helmet
   description: A heavily armored helmet designed for work in special operations. Property of Gorlex Marauders.
@@ -369,7 +369,7 @@
 
 #Blood-red Medic Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseSyndicateContraband]
   id: ClothingHeadHelmetHardsuitSyndieMedic
   name: blood-red medic hardsuit helmet
   description: An advanced red hardsuit helmet specifically designed for field medic operations.
@@ -393,7 +393,7 @@
 
 #Syndicate Elite Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseSyndicateContraband]
   id: ClothingHeadHelmetHardsuitSyndieElite
   name: syndicate elite helmet
   description: An elite version of the blood-red hardsuit's helmet, with improved armor and fireproofing. Property of Gorlex Marauders.
@@ -422,7 +422,7 @@
 
 #Syndicate Commander Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitWithLightBase
+  parent: [ClothingHeadHardsuitWithLightBase, BaseSyndicateContraband]
   id: ClothingHeadHelmetHardsuitSyndieCommander
   name: syndicate commander helmet
   description: A bulked up version of the blood-red hardsuit's helmet, purpose-built for the commander of a syndicate operative squad. Has significantly improved armor for those deadly front-lines firefights.
@@ -446,7 +446,7 @@
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
-  parent: ClothingHeadHardsuitBase
+  parent: [ClothingHeadHardsuitBase, BaseSyndicateContraband]
   id: ClothingHeadHelmetHardsuitCybersun
   name: cybersun juggernaut helmet
   description: Made of compressed red matter, this helmet was designed in the Tau chromosphere facility.

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -171,7 +171,7 @@
     sprite: Clothing/Head/Hats/beret_physician.rsi
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: [ClothingHeadBase, BaseMedicalSecurityContraband]
   id: ClothingHeadHatBeretBrigmedic
   name: brigmedical beret
   description: White beret, looks like a cream pie on the head.
@@ -346,7 +346,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: [ClothingHeadBase, BaseSyndicateContraband]
   id: ClothingHeadHatOutlawHat
   name: outlaw's hat
   description: A hat that makes you look like you carry a notched pistol, numbered one and nineteen more.

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -445,7 +445,7 @@
     accent: SpanishAccent
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: [ClothingHeadBase, BaseMedicalScienceContraband]
   id: ClothingHeadHatSurgcapBlue
   name: surgical cap
   description: A blue cap surgeons wear during operations. Keeps their hair from tickling your internal organs.
@@ -461,7 +461,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: [ClothingHeadBase, BaseMedicalScienceContraband]
   id: ClothingHeadHatSurgcapGreen
   name: surgical cap
   description: A green cap surgeons wear during operations. Keeps their hair from tickling your internal organs.
@@ -472,7 +472,7 @@
     sprite: Clothing/Head/Hats/surgcap_green.rsi
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: [ClothingHeadBase, BaseMedicalScienceContraband]
   id: ClothingHeadHatSurgcapPurple
   name: surgical cap
   description: A purple cap surgeons wear during operations. Keeps their hair from tickling your internal organs.

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -74,7 +74,7 @@
 
 #Syndicate SWAT Helmet
 - type: entity
-  parent: ClothingHeadHelmetSwat
+  parent: [ClothingHeadHelmetSwat, BaseSyndicateContraband]
   id: ClothingHeadHelmetSwatSyndicate
   name: SWAT helmet
   suffix: Syndicate
@@ -133,7 +133,7 @@
 
 #Janitorial Bombsuit Helmet
 - type: entity
-  parent: ClothingHeadHelmetBombSuit
+  parent: [ClothingHeadHelmetBombSuit, BaseCivilianContraband]
   id: ClothingHeadHelmetJanitorBombSuit
   name: janitorial bombsuit helmet
   description: A heavy helmet designed to withstand explosions formed from reactions between chemicals.

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -22,7 +22,7 @@
     - HeadSide
 
 - type: entity
-  parent: ClothingHeadHatHoodBioGeneral
+  parent: [ClothingHeadHatHoodBioGeneral, BaseCommandContraband]
   id: ClothingHeadHatHoodBioCmo
   name: bio hood
   suffix: CMO
@@ -35,7 +35,7 @@
     sprite: Clothing/Head/Hoods/Bio/cmo.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodBioGeneral
+  parent: [ClothingHeadHatHoodBioGeneral, BaseCivilianContraband]
   id: ClothingHeadHatHoodBioJanitor
   name: bio hood
   suffix: Janitor
@@ -48,7 +48,7 @@
     sprite: Clothing/Head/Hoods/Bio/janitor.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodBioGeneral
+  parent: [ClothingHeadHatHoodBioGeneral, BaseScienceContraband]
   id: ClothingHeadHatHoodBioScientist
   name: bio hood
   suffix: Science
@@ -61,7 +61,7 @@
     sprite: Clothing/Head/Hoods/Bio/scientist.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodBioGeneral
+  parent: [ClothingHeadHatHoodBioGeneral, BaseSecurityContraband]
   id: ClothingHeadHatHoodBioSecurity
   name: bio hood
   suffix: Security
@@ -74,7 +74,7 @@
     sprite: Clothing/Head/Hoods/Bio/security.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodBioGeneral
+  parent: [ClothingHeadHatHoodBioGeneral, BaseMedicalContraband]
   id: ClothingHeadHatHoodBioVirology
   name: bio hood
   suffix: Virology
@@ -262,7 +262,7 @@
     sprite: Clothing/Head/Hoods/Coat/hooddefault.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCivilianContraband]
   id: ClothingHeadHatHoodWinterBartender
   categories: [ HideSpawnMenu ]
   name: bartender winter coat hood
@@ -273,7 +273,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodbartender.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCommandContraband]
   id: ClothingHeadHatHoodWinterCaptain
   categories: [ HideSpawnMenu ]
   name: captain's winter coat hood
@@ -285,7 +285,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodcaptain.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCargoContraband]
   id: ClothingHeadHatHoodWinterCargo
   categories: [ HideSpawnMenu ]
   name: cargo winter coat hood
@@ -296,7 +296,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodcargo.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCommandContraband]
   id: ClothingHeadHatHoodWinterCE
   categories: [ HideSpawnMenu ]
   name: chief engineer's winter coat hood
@@ -307,7 +307,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodce.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCentcommContraband]
   id: ClothingHeadHatHoodWinterCentcom
   categories: [ HideSpawnMenu ]
   name: CentComm winter coat hood
@@ -319,7 +319,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodcentcom.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseScienceContraband]
   id: ClothingHeadHatHoodWinterChem
   categories: [ HideSpawnMenu ]
   name: chemist winter coat hood
@@ -330,7 +330,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodchemist.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCommandContraband]
   id: ClothingHeadHatHoodWinterCMO
   categories: [ HideSpawnMenu ]
   name: chief medical officer's winter coat hood
@@ -341,7 +341,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodcmo.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseEngineeringContraband]
   id: ClothingHeadHatHoodWinterEngineer
   categories: [ HideSpawnMenu ]
   name: engineer winter coat hood
@@ -352,7 +352,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodengi.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCommandContraband]
   id: ClothingHeadHatHoodWinterHOP
   categories: [ HideSpawnMenu ]
   name: head of personnel's winter coat hood
@@ -363,7 +363,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodhop.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCommandContraband]
   id: ClothingHeadHatHoodWinterHOS
   categories: [ HideSpawnMenu ]
   name: head of security's winter coat hood
@@ -374,7 +374,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodhos.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCivilianContraband]
   id: ClothingHeadHatHoodWinterHydro
   categories: [ HideSpawnMenu ]
   name: hydroponics coat hood
@@ -385,7 +385,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodhydro.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCivilianContraband]
   id: ClothingHeadHatHoodWinterJani
   categories: [ HideSpawnMenu ]
   name: janitor coat hood
@@ -396,7 +396,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodjani.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseMedicalContraband]
   id: ClothingHeadHatHoodWinterMed
   categories: [ HideSpawnMenu ]
   name: medic coat hood
@@ -407,7 +407,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodmed.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCivilianContraband]
   id: ClothingHeadHatHoodWinterMime
   categories: [ HideSpawnMenu ]
   name: mime coat hood
@@ -418,7 +418,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodmime.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCargoContraband]
   id: ClothingHeadHatHoodWinterMiner
   categories: [ HideSpawnMenu ]
   name: miner coat hood
@@ -429,7 +429,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodminer.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseMedicalContraband]
   id: ClothingHeadHatHoodWinterPara
   categories: [ HideSpawnMenu ]
   name: paramedic coat hood
@@ -440,7 +440,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodpara.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCommandContraband]
   id: ClothingHeadHatHoodWinterQM
   categories: [ HideSpawnMenu ]
   name: quartermaster's coat hood
@@ -451,7 +451,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodqm.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseCommandContraband]
   id: ClothingHeadHatHoodWinterRD
   categories: [ HideSpawnMenu ]
   name: research director's coat hood
@@ -462,7 +462,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodrd.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseScienceContraband]
   id: ClothingHeadHatHoodWinterRobo
   categories: [ HideSpawnMenu ]
   name: robotics coat hood
@@ -473,7 +473,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodrobo.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseScienceContraband]
   id: ClothingHeadHatHoodWinterSci
   categories: [ HideSpawnMenu ]
   name: scientist coat hood
@@ -484,7 +484,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodsci.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseSecurityContraband]
   id: ClothingHeadHatHoodWinterSec
   categories: [ HideSpawnMenu ]
   name: security coat hood
@@ -495,7 +495,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodsec.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseSyndicateContraband]
   id: ClothingHeadHatHoodWinterSyndie
   categories: [ HideSpawnMenu ]
   name: syndicate coat hood
@@ -506,7 +506,7 @@
     sprite: Clothing/Head/Hoods/Coat/hoodsyndicate.rsi
 
 - type: entity
-  parent: ClothingHeadHatHoodWinterBase
+  parent: [ClothingHeadHatHoodWinterBase, BaseSecurityContraband]
   id: ClothingHeadHatHoodWinterWarden
   categories: [ HideSpawnMenu ]
   name: warden's coat hood

--- a/Resources/Prototypes/Entities/Clothing/Head/soft.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/soft.yml
@@ -18,7 +18,7 @@
     - state: icon_flipped
       map: ["foldedLayer"]
       visible: false
-      
+
 - type: entity
   parent: ClothingHeadHeadHatBaseFlippable
   id: ClothingHeadHeadHatBaseFlipped
@@ -57,7 +57,7 @@
   name: blue cap
 
 - type: entity
-  parent: ClothingHeadHeadHatBaseFlippable
+  parent: [ClothingHeadHeadHatBaseFlippable, BaseCargoContraband]
   id: ClothingHeadHatCargosoft
   name: cargo cap
   description: "It's a baseball hat painted in Cargo colours."
@@ -84,7 +84,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingHeadHeadHatBaseFlippable
+  parent: [ClothingHeadHeadHatBaseFlippable, BaseCommandContraband]
   id: ClothingHeadHatQMsoft
   name: quartermaster's cap
   description: "It's a baseball hat painted in the Quartermaster's colors."
@@ -98,7 +98,7 @@
   parent: [ClothingHeadHeadHatBaseFlipped, ClothingHeadHatQMsoft]
   id: ClothingHeadHatQMsoftFlipped
   name: quartermaster's cap
-    
+
 - type: entity
   parent: ClothingHeadHeadHatBaseFlippable
   id: ClothingHeadHatCorpsoft
@@ -285,9 +285,9 @@
   parent: [ClothingHeadHeadHatBaseFlipped, ClothingHeadHatBizarreSoft]
   id: ClothingHeadHatBizarreSoftFlipped
   name: troublemaker's cap
-    
+
 - type: entity
-  parent: ClothingHeadHeadHatBaseFlippable
+  parent: [ClothingHeadHeadHatBaseFlippable, BaseMedicalContraband]
   id: ClothingHeadHatParamedicsoft
   name: paramedic cap
   description: "It's a paramedic's baseball hat with a medical logo."

--- a/Resources/Prototypes/Entities/Clothing/Head/soft.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/soft.yml
@@ -164,7 +164,7 @@
   name: grey cap
 
 - type: entity
-  parent: ClothingHeadHeadHatBaseFlippable
+  parent: [ClothingHeadHeadHatBaseFlippable, BaseCivilianContraband]
   id: ClothingHeadHatMimesoft
   name: mime cap
   description: "It's a baseball hat in a tasteless white colour."
@@ -239,7 +239,7 @@
   name: red cap
 
 - type: entity
-  parent: ClothingHeadHeadHatBaseFlippable
+  parent: [ClothingHeadHeadHatBaseFlippable, BaseRestrictedContraband]
   id: ClothingHeadHatSecsoft
   name: security cap
   description: It's a robust baseball hat in tasteful red colour.
@@ -271,7 +271,7 @@
   name: yellow cap
 
 - type: entity
-  parent: ClothingHeadHeadHatBaseFlippable
+  parent: [ClothingHeadHeadHatBaseFlippable, BaseSyndicateContraband]
   id: ClothingHeadHatBizarreSoft
   name: troublemaker's cap
   description: A truly.. bizarre accessory.

--- a/Resources/Prototypes/Entities/Clothing/Masks/bandanas.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/bandanas.yml
@@ -58,7 +58,7 @@
     sprite: Clothing/Head/Bandanas/blue.rsi
 
 - type: entity
-  parent: ClothingMaskBandanaBase
+  parent: [ClothingMaskBandanaBase, BaseCivilianContraband]
   id: ClothingMaskBandBotany
   name: botany bandana
   description: A botany bandana to make you look cool, made from natural fibers.

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -61,7 +61,7 @@
         Heat: 0.95
 
 - type: entity
-  parent: ClothingMaskGas
+  parent: [ClothingMaskGas, BaseEngineeringContraband]
   id: ClothingMaskGasAtmos
   name: atmospheric gas mask
   description: Improved gas mask utilized by atmospheric technicians. It's flameproof!
@@ -120,7 +120,7 @@
         Heat: 0.95
 
 - type: entity
-  parent: ClothingMaskPullableBase
+  parent: [ClothingMaskPullableBase, BaseMedicalScienceContraband]
   id: ClothingMaskBreathMedical
   name: medical mask
   description: A close-fitting sterile mask that can be connected to an air supply.

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -139,7 +139,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingMaskBreathMedical
+  parent: [ClothingMaskBreathMedical, BaseMedicalSecurityContraband]
   id: ClothingMaskBreathMedicalSecurity
   name: military-style medical mask
   description: A medical mask with a small layer of protection against damage and viruses, similar to the one used in the medical units of the first corporate war.

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -76,7 +76,7 @@
         Heat: 0.80
 
 - type: entity
-  parent: [ClothingMaskGasAtmos, BaseCommandContraband]
+  parent: [BaseCommandContraband, ClothingMaskGasAtmos]
   id: ClothingMaskGasCaptain
   name: captain's gas mask
   description: Nanotrasen cut corners and repainted a spare atmospheric gas mask, but don't tell anyone.

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseCentcommContraband]
   id: ClothingNeckCloakCentcom
   name: central commander's cloak
   description: A pompous and elite green cloak with a nice gold trim, tailored specifically to the Central Commander. It's so heavy, the gold trim might be real.
@@ -127,7 +127,7 @@
     stealGroup: HeadCloak
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseCargoContraband]
   id: ClothingNeckCloakMiner
   name: miner's cloak
   description: Worn by the most skilled miners, for one who has moved mountains and filled valleys.
@@ -272,7 +272,7 @@
     sprite: Clothing/Neck/Cloaks/enby.rsi
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseCivilianContraband]
   id: ClothingNeckCloakPan
   name: chef's cloak
   description: Meant to be worn alongside a frying pan.

--- a/Resources/Prototypes/Entities/Clothing/Neck/ties.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/ties.yml
@@ -15,7 +15,7 @@
     - ClothMade
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseRestrictedContraband]
   id: ClothingNeckTieDet
   name: detective's tie
   description: A loosely tied necktie, a perfect accessory for the over-worked detective.
@@ -24,9 +24,9 @@
     sprite: Clothing/Neck/Ties/dettie.rsi
   - type: Clothing
     sprite: Clothing/Neck/Ties/dettie.rsi
-    
+
 - type: entity
-  parent: ClothingNeckBase
+  parent: [ClothingNeckBase, BaseScienceContraband]
   id: ClothingNeckTieSci
   name: scientist's tie
   description: Why do we all have to wear these ridiculous ties?

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -3,7 +3,7 @@
 
 #Basic armor vest
 - type: entity
-  parent: [ClothingOuterBaseMedium, AllowSuitStorageClothing, BaseRestrictedContraband]
+  parent: [ClothingOuterBaseMedium, AllowSuitStorageClothing, BaseCivilianSecurityContraband]
   id: ClothingOuterArmorBasic
   name: armor vest
   description: A standard Type I armored vest that provides decent protection against most types of damage.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -58,7 +58,7 @@
   - type: GroupExamine
 
 - type: entity
-  parent: ClothingOuterArmorBasic
+  parent: [ClothingOuterArmorBasic, BaseRestrictedContraband]
   id: ClothingOuterArmorBulletproof
   name: bulletproof vest
   description: A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent.
@@ -78,7 +78,7 @@
     damageCoefficient: 0.80
 
 - type: entity
-  parent: ClothingOuterArmorBasic
+  parent: [ClothingOuterArmorBasic, BaseRestrictedContraband]
   id: ClothingOuterArmorReflective
   name: reflective vest
   description: An armored vest with advanced shielding to protect against energy weapons.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -15,7 +15,7 @@
         Caustic: 0.5
 
 - type: entity
-  parent: ClothingOuterBioGeneral
+  parent: [ClothingOuterBioGeneral, BaseCommandContraband]
   id: ClothingOuterBioCmo
   name: bio suit
   suffix: CMO
@@ -27,7 +27,7 @@
     sprite: Clothing/OuterClothing/Bio/cmo.rsi
 
 - type: entity
-  parent: ClothingOuterBioGeneral
+  parent: [ClothingOuterBioGeneral, BaseCivilianContraband]
   id: ClothingOuterBioJanitor
   name: bio suit
   suffix: Janitor
@@ -39,7 +39,7 @@
     sprite: Clothing/OuterClothing/Bio/janitor.rsi
 
 - type: entity
-  parent: ClothingOuterBioGeneral
+  parent: [ClothingOuterBioGeneral, BaseScienceContraband]
   id: ClothingOuterBioScientist
   name: bio suit
   suffix: Science
@@ -51,7 +51,7 @@
     sprite: Clothing/OuterClothing/Bio/scientist.rsi
 
 - type: entity
-  parent: ClothingOuterBioGeneral
+  parent: [ClothingOuterBioGeneral, BaseRestrictedContraband]
   id: ClothingOuterBioSecurity
   name: bio suit
   suffix: Security
@@ -63,7 +63,7 @@
     sprite: Clothing/OuterClothing/Bio/security.rsi
 
 - type: entity
-  parent: ClothingOuterBioGeneral
+  parent: [ClothingOuterBioGeneral, BaseMedicalContraband]
   id: ClothingOuterBioVirology
   name: bio suit
   suffix: Virology

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -27,7 +27,7 @@
     damageCoefficient: 1 #its a coat. it doesnt do shit
 
 - type: entity
-  parent: [ClothingOuterCoatDetectiveLoadout]
+  parent: ClothingOuterCoatDetectiveLoadout
   id: ClothingOuterCoatDetectiveLoadoutGrey
   name: noir trenchcoat
   description: Ah, your trusty coat. There's a few tears here and there, giving it a more timely look. Or at least, that's what you told yourself when you found out gettin' it repaired would set you back 200 speos.
@@ -90,7 +90,7 @@
     damageCoefficient: 0.9
 
 - type: entity
-  parent: [ClothingOuterArmorHoS, ClothingOuterStorageBase, BaseSecurityCommandContraband]
+  parent: [ClothingOuterArmorHoS, ClothingOuterStorageBase, BaseCommandContraband]
   id: ClothingOuterCoatHoSTrench
   name: head of security's armored trenchcoat
   description: A greatcoat enhanced with a special alloy for some extra protection and style for those with a commanding presence.
@@ -398,7 +398,7 @@
     sprite: Clothing/OuterClothing/Coats/syndicate/coatsyndiecaparmored.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, BaseMedicalSecurityContraband]
   id: ClothingOuterCoatAMG
   name: armored medical gown
   description: The version of the medical gown, with elements of a bulletproof vest, looks strange, but your heart is protected.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -10,7 +10,7 @@
     sprite: Clothing/OuterClothing/Coats/bomber.rsi
 
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, ClothingOuterArmorBasic]
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, ClothingOuterArmorBasic, BaseRestrictedContraband]
   id: ClothingOuterCoatDetective
   name: detective trenchcoat
   description: An 18th-century multi-purpose trenchcoat. Someone who wears this means serious business.
@@ -161,7 +161,7 @@
   name: lab coat
 
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: [ClothingOuterStorageFoldableBase, BaseMedicalContraband]
   id: ClothingOuterCoatLabChem
   name: chemist lab coat
   description: A suit that protects against minor chemical spills. Has an orange stripe on the shoulder.
@@ -181,7 +181,7 @@
   name: chemist lab coat
 
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: [ClothingOuterStorageFoldableBase, BaseMedicalContraband]
   id: ClothingOuterCoatLabViro
   name: virologist lab coat
   description: A suit that protects against bacteria and viruses. Has an green stripe on the shoulder.
@@ -201,7 +201,7 @@
   name: virologist lab coat
 
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: [ClothingOuterStorageFoldableBase, BaseMedicalContraband]
   id: ClothingOuterCoatLabGene
   name: geneticist lab coat
   description: A suit that protects against minor chemical spills. Has an blue stripe on the shoulder.
@@ -221,7 +221,7 @@
   name: geneticist lab coat
 
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: [ClothingOuterStorageFoldableBase, BaseCommandContraband]
   id: ClothingOuterCoatLabCmo
   name: chief medical officer's lab coat
   description: Custom made blue lab coat for the Chief Medical Officer, offers improved protection against chemical spills and minor cuts.
@@ -243,7 +243,7 @@
   name: chief medical officer's lab coat
 
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: [ClothingOuterStorageFoldableBase, BaseScienceContraband]
   id: ClothingOuterCoatRnd
   name: scientist lab coat
   description: A suit that protects against minor chemical spills. Has a purple stripe on the shoulder.
@@ -263,7 +263,7 @@
   name: scientist lab coat
 
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: [ClothingOuterStorageFoldableBase, BaseScienceContraband]
   id: ClothingOuterCoatRobo
   name: roboticist lab coat
   description: More like an eccentric coat than a labcoat. Helps pass off bloodstains as part of the aesthetic. Comes with red shoulder pads.
@@ -283,7 +283,7 @@
   name: roboticist lab coat
 
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: [ClothingOuterStorageFoldableBase, BaseCommandContraband]
   id: ClothingOuterCoatRD
   name: research director lab coat
   description: Woven with top of the line technology, this labcoat helps protect against radiation in similar way to the experimental hardsuit.
@@ -365,7 +365,7 @@
         Piercing: 0.85
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, BaseMedicalContraband]
   id: ClothingOuterCoatParamedicWB
   name: paramedic windbreaker
   description: A paramedic's trusty windbreaker, for all the space wind.
@@ -417,7 +417,7 @@
         Caustic: 0.75
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, BaseScienceContraband]
   id: ClothingOuterCoatLabSeniorResearcher
   name: senior researcher lab coat
   description: A suit that protects against minor chemical spills. Has a purple collar and wrist trims.
@@ -432,7 +432,7 @@
         Caustic: 0.75
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, BaseMedicalContraband]
   id: ClothingOuterCoatLabSeniorPhysician
   name: senior physician lab coat
   description: A suit that protects against minor chemical spills. Has light blue sleeves and an orange waist trim.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -220,7 +220,7 @@
 
 #Brigmedic Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseRestrictedContraband]
+  parent: [ClothingOuterHardsuitBase, BaseMedicalSecurityContraband]
   id: ClothingOuterHardsuitBrigmedic
   name: brigmedic hardsuit
   description: Special hardsuit of the guardian angel of the brig. It is the medical version of the security hardsuit.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -10,7 +10,7 @@
     sprite: Clothing/OuterClothing/Misc/apron.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, BaseCivilianContraband]
   id: ClothingOuterApronBar
   suffix: Bartender
   name: apron
@@ -22,7 +22,7 @@
     sprite: Clothing/OuterClothing/Misc/apronbar.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, BaseCivilianContraband]
   id: ClothingOuterApronBotanist
   name: apron
   suffix: Botanical
@@ -34,7 +34,7 @@
     sprite: Clothing/OuterClothing/Misc/apronbotanist.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, BaseCivilianContraband]
   id: ClothingOuterApronChef
   name: apron
   suffix: Chef
@@ -46,7 +46,7 @@
     sprite: Clothing/OuterClothing/Misc/apronchef.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, BaseCivilianContraband]
   id: ClothingOuterJacketChef
   name: chef jacket
   description: An apron-jacket used by a high class chef.
@@ -95,7 +95,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingOuterBaseToggleable
+  parent: [ClothingOuterBaseToggleable, BaseCivilianContraband]
   id: ClothingOuterHoodieChaplain
   name: chaplain's hoodie
   description: Black and strict chaplain hoodie.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -93,7 +93,7 @@
 #Paramedic Voidsuit
 #Despite having resistances and looking like a hardsuit, this parents off the EVA suit so it goes here.
 - type: entity
-  parent: ClothingOuterEVASuitBase
+  parent: [ClothingOuterEVASuitBase, BaseMedicalContraband]
   id: ClothingOuterHardsuitVoidParamed
   name: paramedic void suit
   description: A void suit made for paramedics.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -29,7 +29,7 @@
     slots: WITHOUT_POCKET
 
 - type: entity
-  parent: ClothingOuterSuitBomb
+  parent: [ClothingOuterSuitBomb, BaseCivilianContraband]
   id: ClothingOuterSuitJanitorBomb
   name: janitorial bomb suit
   description: A heavy helmet designed to withstand explosions formed from reactions between chemicals.
@@ -72,7 +72,7 @@
     slots: WITHOUT_POCKET
 
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseEngineeringContraband]
   id: ClothingOuterSuitAtmosFire
   name: atmos fire suit
   description: An expensive firesuit that protects against even the most deadly of station fires. Designed to protect even if the wearer is set aflame.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -69,7 +69,7 @@
 
 #(Bartender) vest
 - type: entity
-  parent: ClothingOuterBase
+  parent: [ClothingOuterBase, BaseCivilianContraband]
   id: ClothingOuterVest
   name: vest
   description: A thick vest with a rubbery, water-resistant shell.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -271,7 +271,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterCMO
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: [ClothingOuterWinterCoat, BaseCivilianContraband]
   id: ClothingOuterWinterClown
   name: clown winter coat
   components:
@@ -359,7 +359,7 @@
 
 ##########################################################
 - type: entity
-  parent: [ClothingOuterArmorHoS, ClothingOuterWinterCoatToggleable, BaseSecurityCommandContraband]
+  parent: [ClothingOuterArmorHoS, ClothingOuterWinterCoatToggleable, BaseCommandContraband]
   id: ClothingOuterWinterHoS
   name: head of security's armored winter coat
   description: A sturdy, utilitarian winter coat designed to protect a head of security from any brig-bound threats and hypothermic events.
@@ -373,7 +373,7 @@
 ##########################################################
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseSecurityCommandContraband]
+  parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
   id: ClothingOuterWinterHoSUnarmored
   name: head of security's winter coat
   description: A sturdy coat, a warm coat, but not an armored coat.
@@ -480,7 +480,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterMed
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseCivilianContraband]
   id: ClothingOuterWinterMime
   name: mime winter coat
   components:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -51,7 +51,7 @@
         ents: []
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseEngineeringContraband]
   id: ClothingOuterWinterAtmos
   name: atmospherics winter coat
   components:
@@ -74,7 +74,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterEngineer
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseCivilianContraband]
   id: ClothingOuterWinterBar
   name: bartender winter coat
   components:
@@ -120,7 +120,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterCaptain
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseCargoContraband]
   id: ClothingOuterWinterCargo
   name: cargo winter coat
   components:
@@ -189,7 +189,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterCentcom
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: [ClothingOuterWinterCoat, BaseCivilianContraband]
   id: ClothingOuterWinterChef
   name: chef's freezer coat
   description: A coat specifically designed for work inside cold storage, sorely needed by cold-blooded lizard chefs.
@@ -211,7 +211,7 @@
       - state: CHEF-equipped-OUTERCLOTHING
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseMedicalContraband]
   id: ClothingOuterWinterChem
   name: chemistry winter coat
   components:
@@ -281,7 +281,7 @@
     sprite: Clothing/OuterClothing/WinterCoats/coatclown.rsi
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseEngineeringContraband]
   id: ClothingOuterWinterEngi
   name: engineering winter coat
   components:
@@ -304,7 +304,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterEngineer
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseMedicalContraband]
   id: ClothingOuterWinterGen
   name: genetics winter coat
   components:
@@ -397,7 +397,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterHOS
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseCivilianContraband]
   id: ClothingOuterWinterHydro
   name: hydroponics winter coat
   components:
@@ -420,7 +420,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterHydro
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseCivilianContraband]
   id: ClothingOuterWinterJani
   name: janitorial winter coat
   components:
@@ -450,7 +450,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterJani
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseMedicalContraband]
   id: ClothingOuterWinterMed
   name: medical winter coat
   components:
@@ -503,7 +503,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterMime
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseCargoContraband]
   id: ClothingOuterWinterMiner
   name: mining winter coat
   components:
@@ -526,7 +526,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterMiner
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseMedicalContraband]
   id: ClothingOuterWinterPara
   name: paramedic winter coat
   components:
@@ -610,7 +610,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterRD
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseScienceContraband]
   id: ClothingOuterWinterRobo
   name: robotics winter coat
   components:
@@ -634,7 +634,7 @@
 
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseScienceContraband]
   id: ClothingOuterWinterSci
   name: science winter coat
   components:
@@ -687,7 +687,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterSec
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseMedicalContraband]
   id: ClothingOuterWinterViro
   name: virology winter coat
   components:
@@ -819,7 +819,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterSyndie
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: [ClothingOuterWinterCoat, BaseCivilianContraband]
   id: ClothingOuterWinterMusician
   name: musician's winter coat
   description: An oversized, plasticine space tuxedo that'll have people asking "do you know me?"

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  parent: [ClothingShoesBaseButcherable, BaseEngineeringContraband]
   id: ClothingShoesBootsWork
   name: workboots
   description: Engineering lace-up work boots for the especially blue-collar.
@@ -24,7 +24,7 @@
     modifier: 0.5
 
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  parent: [ClothingShoesBaseButcherable, BaseCargoContraband]
   id: ClothingShoesBootsSalvage
   name: salvage boots
   description: Steel-toed salvage boots for salvaging in hazardous environments.
@@ -36,7 +36,7 @@
   - type: Matchbox
 
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  parent: [ClothingShoesBaseButcherable, BaseCivilianContraband]
   id: ClothingShoesBootsPerformer
   name: performer's boots
   description: These boots provide great traction for when you're up on stage.
@@ -105,7 +105,7 @@
     sprite: Clothing/Shoes/Boots/winterboots.rsi
 
 - type: entity
-  parent: ClothingShoesBaseWinterBoots
+  parent: [ClothingShoesBaseWinterBoots, BaseCargoContraband]
   id: ClothingShoesBootsWinterCargo
   name: cargo winter boots
   components:
@@ -115,7 +115,7 @@
     sprite: Clothing/Shoes/Boots/winterbootscargo.rsi
 
 - type: entity
-  parent: ClothingShoesBaseWinterBoots
+  parent: [ClothingShoesBaseWinterBoots, BaseEngineeringContraband]
   id: ClothingShoesBootsWinterEngi
   name: engineering winter boots
   components:
@@ -125,7 +125,7 @@
     sprite: Clothing/Shoes/Boots/winterbootsengi.rsi
 
 - type: entity
-  parent: ClothingShoesBaseWinterBoots
+  parent: [ClothingShoesBaseWinterBoots, BaseMedicalContraband]
   id: ClothingShoesBootsWinterMed
   name: medical winter boots
   components:
@@ -135,7 +135,7 @@
     sprite: Clothing/Shoes/Boots/winterbootsmed.rsi
 
 - type: entity
-  parent: ClothingShoesBaseWinterBoots
+  parent: [ClothingShoesBaseWinterBoots, BaseScienceContraband]
   id: ClothingShoesBootsWinterSci
   name: science winter boots
   components:

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  parent: [ClothingShoesBaseButcherable, BaseCivilianContraband]
   id: ClothingShoesChef
   name: chef shoes
   description: Sturdy shoes that minimize injury from falling objects or knives.
@@ -12,7 +12,7 @@
 # stuff common to all clown & jester shoes
 - type: entity
   abstract: true
-  parent: [ClothingShoesBaseButcherable, ClothingSlotBase]
+  parent: [ClothingShoesBaseButcherable, ClothingSlotBase, BaseCivilianContraband]
   id: ClothingShoesClownBase
   components:
   - type: ItemSlots

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -277,7 +277,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/paramedic.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseMedicalSecurityContraband]
   id: ClothingUniformJumpskirtBrigmedic
   name: brigmedic jumpskirt
   description: This uniform is issued to qualified personnel who have been trained. No one cares that the training took half a day.
@@ -886,7 +886,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/psychologist.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtClown
   name: clown skirt
   description: HONK!

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtBartender
   name: bartender's uniform
   description: A nice and tidy uniform. Shame about the bar though.
@@ -21,7 +21,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/captain.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCargoContraband]
   id: ClothingUniformJumpskirtCargo
   name: cargo tech jumpskirt
   description: A sturdy jumpskirt, issued to members of the Cargo department.
@@ -54,7 +54,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/ce_turtle.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtChaplain
   name: chaplain's jumpskirt
   description: It's a black jumpskirt, often worn by religious folk.
@@ -65,7 +65,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/chaplain.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtChef
   name: chef uniform
   description: Can't cook without this.
@@ -76,7 +76,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/chef.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseMedicalContraband]
   id: ClothingUniformJumpskirtChemistry
   name: chemistry jumpskirt
   description: There's some odd stains on this jumpskirt. Hm.
@@ -87,7 +87,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/chemistry.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseMedicalContraband]
   id: ClothingUniformJumpskirtVirology
   name: virology jumpskirt
   description: It's made of a special fiber that gives special protection against biohazards. It has a virologist rank stripe on it.
@@ -98,7 +98,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/virology.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseMedicalContraband]
   id: ClothingUniformJumpskirtGenetics
   name: genetics jumpskirt
   description: It's made of a special fiber that gives special protection against biohazards. It has a geneticist rank stripe on it.
@@ -131,7 +131,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/cmo_turtle.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseRestrictedContraband]
   id: ClothingUniformJumpskirtDetective
   name: hard-worn suit
   description: Someone who wears this means business.
@@ -142,7 +142,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/detective.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseRestrictedContraband]
   id: ClothingUniformJumpskirtDetectiveGrey
   name: noir suit
   description: A hard-boiled private investigator's grey suit, complete with tie clip.
@@ -153,7 +153,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/detective_grey.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseEngineeringContraband]
   id: ClothingUniformJumpskirtEngineering
   name: engineering jumpskirt
   description: If this suit was non-conductive, maybe engineers would actually do their damn job.
@@ -222,7 +222,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/hos_parade.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtHydroponics
   name: hydroponics jumpskirt
   description: Has a strong earthy smell to it. Hopefully it's merely dirty as opposed to soiled.
@@ -233,7 +233,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/hydro.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtJanitor
   name: janitor jumpskirt
   description: The jumpskirt for the poor sop with a mop.
@@ -244,7 +244,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/janitor.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseMedicalContraband]
   id: ClothingUniformJumpskirtMedicalDoctor
   name: medical doctor jumpskirt
   description: It's made of a special fiber that provides minor protection against biohazards. It has a cross on the chest denoting that the wearer is trained medical personnel.
@@ -255,7 +255,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/medical.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtMime
   name: mime jumpskirt
   description: ...
@@ -266,7 +266,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/mime.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseMedicalContraband]
   id: ClothingUniformJumpskirtParamedic
   name: paramedic jumpskirt
   description: It's got a plus on it, that's a good thing right?
@@ -360,7 +360,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/rnd.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseScienceContraband]
   id: ClothingUniformJumpskirtScientist
   name: scientist jumpskirt
   description: It's made of a special fiber that increases perceived intelligence and decreases personal ethics. It has markings that denote the wearer as a scientist.
@@ -371,7 +371,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/scientist.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseScienceContraband]
   id: ClothingUniformJumpskirtRoboticist
   name: roboticist jumpskirt
   description: It's a slimming black with reinforced seams; great for industrial work.
@@ -434,7 +434,7 @@
 
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtLibrarian
   name: librarian jumpskirt
   description: A cosy green jumper fit for a curator of books.
@@ -456,7 +456,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/curator.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtPerformer
   name: performer's jumpskirt
   description: Hi, I'm Scott, president of Donk Pizza. Have you heard of [FAMOUS VIRTUAL PERFORMER]?
@@ -467,7 +467,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/performer.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCommandContraband]
   id: ClothingUniformJumpskirtCapFormalDress
   name: captain's formal dress
   description: A dress for special occasions.
@@ -478,7 +478,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/capformaldress.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCentcommContraband]
   id: ClothingUniformJumpskirtCentcomFormalDress
   name: central command formal dress
   description: A dress for special occasions.
@@ -526,7 +526,7 @@
       mode: SensorOff
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseEngineeringContraband]
   id: ClothingUniformJumpskirtAtmos
   name: atmospheric technician jumpskirt
   description: I am at work. I can't leave work. Work is breathing. I am testing air quality.
@@ -537,7 +537,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/atmosf.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtJanimaid
   name: janitorial maid uniform
   description: For professionals, not the posers.
@@ -548,7 +548,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/janimaid.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtJanimaidmini
   name: janitorial maid uniform with miniskirt
   description: Elite service, not some candy wrappers.
@@ -559,7 +559,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/janimaidmini.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtLawyerRed
   name: red lawyer suitskirt
   description: A flashy red suitskirt worn by lawyers and show-offs.
@@ -570,7 +570,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/lawyerred.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtLawyerBlue
   name: blue lawyer suitskirt
   description: A flashy blue suitskirt worn by lawyers and show-offs.
@@ -581,7 +581,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/lawyerblue.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtLawyerBlack
   name: black lawyer suitskirt
   description: A subtle black suitskirt worn by lawyers and gangsters.
@@ -592,7 +592,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/lawyerblack.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtLawyerPurple
   name: purple lawyer suitskirt
   description: A stylish purple piece worn by lawyers and show people.
@@ -603,7 +603,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/lawyerpurple.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtLawyerGood
   name: good lawyer's suitskirt
   description: A tacky suitskirt perfect for a CRIMINAL lawyer!
@@ -614,7 +614,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/lawyergood.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseSyndicateContraband]
   id: ClothingUniformJumpskirtSyndieFormalDress
   name: syndicate formal dress
   description: "The syndicate's uniform is made in an elegant style, it's even a pity to do dirty tricks in this."
@@ -647,7 +647,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/skirtoflife.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseEngineeringContraband]
   id: ClothingUniformJumpskirtSeniorEngineer
   name: senior engineer jumpskirt
   description: A sign of skill and prestige within the engineering department.
@@ -658,7 +658,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/senior_engineer.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseScienceContraband]
   id: ClothingUniformJumpskirtSeniorResearcher
   name: senior researcher jumpskirt
   description: A sign of skill and prestige within the science department.
@@ -669,7 +669,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/senior_researcher.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseMedicalContraband]
   id: ClothingUniformJumpskirtSeniorPhysician
   name: senior physician jumpskirt
   description: A sign of skill and prestige within the medical department.
@@ -864,7 +864,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/olddress.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseCivilianContraband]
   id: ClothingUniformJumpskirtMusician
   name: musician's skirt
   description: A fancy skirt for the musically inclined. Perfect for any lounge act!
@@ -875,7 +875,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/musician.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase
+  parent: [ClothingUniformSkirtBase, BaseMedicalContraband]
   id: ClothingUniformJumpskirtPsychologist
   name: psychologist suitskirt
   description: I don't lose things. I place things in locations which later elude me.

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -201,7 +201,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/genetics.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitClown
   name: clown suit
   description: HONK!
@@ -233,7 +233,7 @@
         Radiation: 0.8
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitJester
   name: jester suit
   description: A jolly dress, well suited to entertain your master, nuncle.
@@ -463,7 +463,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/paramedic.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseMedicalSecurityContraband]
   id: ClothingUniformJumpsuitBrigmedic
   name: brigmedic jumpsuit
   description: This uniform is issued to qualified personnel who have been trained. No one cares that the training took half a day.
@@ -691,7 +691,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/librarian.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitCurator
   name: sensible suit
   description: It's sensible. Too sensible...

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCentcommContraband]
   id: ClothingUniformJumpsuitDeathSquad
   name: death squad uniform
   description: Advanced armored jumpsuit used by special forces in special operations.
@@ -21,7 +21,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/ancient.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitBartender
   name: bartender's uniform
   description: A nice and tidy uniform. Shame about the bar though.
@@ -32,7 +32,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/bartender.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitJacketMonkey
   name: bartender's jacket monkey
   description: A decent jacket, for a decent monkey.
@@ -47,7 +47,7 @@
     mode: SensorCords
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitBartenderPurple
   name: purple bartender's uniform
   description: A special purple outfit to serve drinks.
@@ -69,7 +69,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/captain.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCargoContraband]
   id: ClothingUniformJumpsuitCargo
   name: cargo tech jumpsuit
   description: A sturdy jumpsuit, issued to members of the Cargo department.
@@ -80,7 +80,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/cargotech.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCargoContraband]
   id: ClothingUniformJumpsuitSalvageSpecialist
   name: salvage specialist's jumpsuit
   description: It's a snappy jumpsuit with a sturdy set of overalls. It's very dirty.
@@ -113,7 +113,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/ce_turtle.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitChaplain
   name: chaplain's jumpsuit
   description: It's a black jumpsuit, often worn by religious folk.
@@ -157,7 +157,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/centcom_officer.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitChef
   name: chef uniform
   description: Can't cook without this.
@@ -168,7 +168,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/chef.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseMedicalContraband]
   id: ClothingUniformJumpsuitChemistry
   name: chemistry jumpsuit
   description: There's some odd stains on this jumpsuit. Hm.
@@ -179,7 +179,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/chemistry.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseMedicalContraband]
   id: ClothingUniformJumpsuitVirology
   name: virology jumpsuit
   description: It's made of a special fiber that gives special protection against biohazards. It has a virologist rank stripe on it.
@@ -190,7 +190,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/virology.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseMedicalContraband]
   id: ClothingUniformJumpsuitGenetics
   name: genetics jumpsuit
   description: It's made of a special fiber that gives special protection against biohazards. It has a geneticist rank stripe on it.
@@ -275,7 +275,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/cmo_turtle.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseRestrictedContraband]
   id: ClothingUniformJumpsuitDetective
   name: hard-worn suit
   description: Someone who wears this means business.
@@ -286,7 +286,7 @@
       sprite: Clothing/Uniforms/Jumpsuit/detective.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseRestrictedContraband]
   id: ClothingUniformJumpsuitDetectiveGrey
   name: noir suit
   description: A hard-boiled private investigator's grey suit, complete with tie clip.
@@ -297,7 +297,7 @@
       sprite: Clothing/Uniforms/Jumpsuit/detective_grey.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseEngineeringContraband]
   id: ClothingUniformJumpsuitEngineering
   name: engineering jumpsuit
   description: If this suit was non-conductive, maybe engineers would actually do their damn job.
@@ -308,7 +308,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/engineering.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseEngineeringContraband]
   id: ClothingUniformJumpsuitEngineeringHazard
   name: hazard jumpsuit
   description: Woven in a grungy, warm orange. Lets others around you know that you really mean business when it comes to work.
@@ -397,7 +397,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hos_parade.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitHydroponics
   name: hydroponics jumpsuit
   description: Has a strong earthy smell to it. Hopefully it's merely dirty as opposed to soiled.
@@ -408,7 +408,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hydro.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitJanitor
   name: janitor jumpsuit
   description: The jumpsuit for the poor sop with a mop.
@@ -430,7 +430,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/kimono.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseMedicalContraband]
   id: ClothingUniformJumpsuitMedicalDoctor
   name: medical doctor jumpsuit
   description: It's made of a special fiber that provides minor protection against biohazards. It has a cross on the chest denoting that the wearer is trained medical personnel.
@@ -441,7 +441,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/medical.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitMime
   name: mime suit
   description: ...
@@ -452,7 +452,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/mime.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseMedicalContraband]
   id: ClothingUniformJumpsuitParamedic
   name: paramedic jumpsuit
   description: It's got a plus on it, that's a good thing right?
@@ -557,7 +557,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/rnd.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseScienceContraband]
   id: ClothingUniformJumpsuitScientist
   name: scientist jumpsuit
   description: It's made of a special fiber that increases perceived intelligence and decreases personal ethics. It has markings that denote the wearer as a scientist.
@@ -568,7 +568,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/scientist.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseScienceContraband]
   id: ClothingUniformJumpsuitScientistFormal
   name: scientist's formal jumpsuit
   description: A uniform for sophisticated scientists, best worn with its matching tie.
@@ -579,7 +579,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/scientist_formal.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseScienceContraband]
   id: ClothingUniformJumpsuitRoboticist
   name: roboticist jumpsuit
   description: It's a slimming black with reinforced seams; great for industrial work.
@@ -680,7 +680,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/overalls.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitLibrarian
   name: librarian jumpsuit
   description: A cosy green jumper fit for a curator of books.
@@ -702,7 +702,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/curator.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitLawyerRed
   name: red lawyer suit
   description: A flashy red suit worn by lawyers and show-offs.
@@ -713,7 +713,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/lawyerred.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitLawyerBlue
   name: blue lawyer suit
   description: A flashy blue suit worn by lawyers and show-offs.
@@ -724,7 +724,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/lawyerblue.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitLawyerBlack
   name: black lawyer suit
   description: A subtle black suit worn by lawyers and gangsters.
@@ -735,7 +735,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/lawyerblack.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitLawyerPurple
   name: purple lawyer suit
   description: A stylish purple piece worn by lawyers and show people.
@@ -746,7 +746,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/lawyerpurple.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitLawyerGood
   name: good lawyer's suit
   description: A tacky suit perfect for a CRIMINAL lawyer!
@@ -812,7 +812,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/capformal.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCentcommContraband]
   id: ClothingUniformJumpsuitCentcomFormal
   name: central command formal suit
   description: A suit for special occasions.
@@ -882,7 +882,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/ninja.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseEngineeringContraband]
   id: ClothingUniformJumpsuitAtmos
   name: atmospheric technician jumpsuit
   description: I am at work. I can't leave work. Work is breathing. I am testing air quality.
@@ -893,7 +893,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/atmos.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseEngineeringContraband]
   id: ClothingUniformJumpsuitAtmosCasual
   name: atmospheric technician's casual jumpsuit
   description: Might as well relax with a job as easy as yours.
@@ -904,7 +904,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/atmos_casual.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseMedicalContraband]
   id: ClothingUniformJumpsuitPsychologist
   name: psychologist suit
   description: I don't lose things. I place things in locations which later elude me.
@@ -915,7 +915,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/psychologist.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitReporter
   name: reporter suit
   description: A good reporter remains a skeptic all their life.
@@ -937,7 +937,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/safari.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitJournalist
   name: journalist suit
   description: If journalism is good, it is controversial, by nature.
@@ -970,7 +970,7 @@
       sprite: Clothing/Uniforms/Jumpsuit/monastic_robe_light.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCivilianContraband]
   id: ClothingUniformJumpsuitMusician
   name: musician's tuxedo
   description: A fancy tuxedo for the musically inclined.  Perfect for any lounge act!
@@ -1161,7 +1161,7 @@
       sprite: Clothing/Uniforms/Jumpsuit/flannel.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseEngineeringContraband]
   id: ClothingUniformJumpsuitSeniorEngineer
   name: senior engineer jumpsuit
   description: A sign of skill and prestige within the engineering department.
@@ -1172,7 +1172,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/senior_engineer.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseScienceContraband]
   id: ClothingUniformJumpsuitSeniorResearcher
   name: senior researcher jumpsuit
   description: A sign of skill and prestige within the science department.
@@ -1183,7 +1183,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/senior_researcher.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseMedicalContraband]
   id: ClothingUniformJumpsuitSeniorPhysician
   name: senior physician jumpsuit
   description: A sign of skill and prestige within the medical department.

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/scrubs.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/scrubs.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseMedicalScienceContraband]
   id: UniformScrubsColorPurple
   name: purple scrubs
   description: A combination of comfort and utility intended to make removing every last organ someone has and selling them to a space robot much more official looking.
@@ -10,7 +10,7 @@
     sprite: Clothing/Uniforms/Scrubs/purple.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseMedicalScienceContraband]
   id: UniformScrubsColorGreen
   name: green scrubs
   description: A combination of comfort and utility intended to make removing every last organ someone has and selling them to a space robot much more official looking.
@@ -21,7 +21,7 @@
     sprite: Clothing/Uniforms/Scrubs/green.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseMedicalScienceContraband]
   id: UniformScrubsColorBlue
   name: blue scrubs
   description: A combination of comfort and utility intended to make removing every last organ someone has and selling them to a space robot much more official looking.

--- a/Resources/Prototypes/Entities/Debugging/spanisharmyknife.yml
+++ b/Resources/Prototypes/Entities/Debugging/spanisharmyknife.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: spanish army knife
-  parent: BaseItem
+  parent: [BaseItem, BaseCentcommContraband]
   id: ToolDebug
   description: The pain of using this is almost too great to bear.
   suffix: DEBUG

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -298,7 +298,7 @@
 
 - type: entity
   id: BaseBorgChassisSyndicate
-  parent: BaseBorgChassis
+  parent: [BaseBorgChassis, BaseSyndicateContraband]
   abstract: true
   components:
   - type: NpcFactionMember

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -378,7 +378,7 @@
     unlistedNumber: true
     requiresPower: false
   - type: Holopad
-  - type: StationAiWhitelist  
+  - type: StationAiWhitelist
   - type: UserInterface
     interfaces:
         enum.HolopadUiKey.AiRequestWindow:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -287,6 +287,7 @@
   parent:
   - BaseItem
   - AiHolder
+  - BaseCommandContraband
   suffix: Empty
   components:
   - type: ContainerComp

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
@@ -37,7 +37,7 @@
     solution: drink
 
 - type: entity
-  parent: FlaskBase
+  parent: [FlaskBase, BaseRestrictedContraband]
   id: DrinkDetFlask
   name: inspector's flask
   description: A metal flask with a leather band and golden badge belonging to the inspector.
@@ -46,7 +46,7 @@
     sprite: Objects/Consumable/Drinks/detflask.rsi
 
 - type: entity
-  parent: FlaskBase
+  parent: [FlaskBase, BaseCommandContraband]
   id: DrinkHosFlask
   name: hos's flask
   description: A metal flask, fit for a hard working HoS.
@@ -55,7 +55,7 @@
     sprite: Objects/Consumable/Drinks/hosflask.rsi
 
 - type: entity
-  parent: FlaskBase
+  parent: [FlaskBase, BaseCommandContraband]
   id: DrinkFlask
   name: captain's flask
   description: A metal flask belonging to the captain.

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/particle_accelerator.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/particle_accelerator.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: MachineParticleAcceleratorEndCapCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseEngineeringContraband]
   name: PA end cap board
   description: A machine board for a particle accelerator end cap.
   components:
@@ -14,7 +14,7 @@
 
 - type: entity
   id: MachineParticleAcceleratorFuelChamberCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseEngineeringContraband]
   name: PA fuel chamber board
   description: A machine board for a particle accelerator fuel chamber.
   components:
@@ -32,7 +32,7 @@
 
 - type: entity
   id: MachineParticleAcceleratorPowerBoxCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseEngineeringContraband]
   name: PA power box board
   description: A machine board for a particle accelerator power box.
   components:
@@ -48,7 +48,7 @@
 
 - type: entity
   id: MachineParticleAcceleratorEmitterStarboardCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseEngineeringContraband]
   name: PA starboard emitter board
   description: A machine board for a particle accelerator left emitter.
   components:
@@ -62,7 +62,7 @@
 
 - type: entity
   id: MachineParticleAcceleratorEmitterForeCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseEngineeringContraband]
   name: PA fore emitter board
   description: A machine board for a particle accelerator center emitter.
   components:
@@ -76,7 +76,7 @@
 
 - type: entity
   id: MachineParticleAcceleratorEmitterPortCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseEngineeringContraband]
   name: PA port emitter board
   description: A machine board for a particle accelerator right emitter.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -75,7 +75,7 @@
 
 - type: entity
   id: SecurityTechFabCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseRestrictedContraband]
   name: security techfab machine board
   description: A machine printed circuit board for a security techfab.
   components:
@@ -93,7 +93,7 @@
 
 - type: entity
   id: AmmoTechFabCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseRestrictedContraband]
   name: ammo techfab circuit board
   description: A machine printed circuit board for an ammo techfab.
   components:
@@ -107,7 +107,7 @@
 
 - type: entity
   id: MedicalTechFabCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseMedicalContraband]
   name: medical techfab machine board
   description: A machine printed circuit board for a medical techfab.
   components:
@@ -164,7 +164,7 @@
 
 - type: entity
   id: ExosuitFabricatorMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseScienceContraband]
   name: exosuit fabricator machine board
   components:
   - type: Sprite
@@ -276,7 +276,7 @@
 
 - type: entity
   id: ArtifactCrusherMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseScienceContraband]
   name: artifact crusher machine board
   description: A machine printed circuit board for an artifact crusher.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -26,7 +26,7 @@
   components:
     - type: ComputerBoard
       prototype: ComputerAlert
-      
+
 - type: entity
   parent: BaseComputerCircuitboard
   id: AtmosMonitoringComputerCircuitboard
@@ -311,7 +311,7 @@
       prototype: BlockGameArcade
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [BaseComputerCircuitboard, BaseEngineeringContraband]
   id: ParticleAcceleratorComputerCircuitboard
   name: PA control box computer board
   description: A computer printed circuit board for a particle accelerator control box.
@@ -331,7 +331,7 @@
       prototype: ComputerShuttle
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [BaseComputerCircuitboard, BaseSyndicateContraband]
   id: SyndicateShuttleConsoleCircuitboard
   name: syndicate shuttle console board
   description: A computer printed circuit board for a syndicate shuttle console.
@@ -362,7 +362,7 @@
       prototype: ComputerIFF
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [BaseComputerCircuitboard, BaseSyndicateContraband]
   id: ComputerIFFSyndicateCircuitboard
   name: syndicate IFF console board
   description: Allows you to control the IFF and stealth characteristics of this vessel.
@@ -406,7 +406,7 @@
       prototype: ComputerRoboticsControl
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [BaseComputerCircuitboard, BaseCommandContraband]
   id: StationAiUploadCircuitboard
   name: AI upload console board
   description: A computer printed circuit board for a AI upload console.

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -117,7 +117,7 @@
   - type: StaticPrice
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [BaseComputerCircuitboard, BaseCargoContraband]
   id: CargoShuttleComputerCircuitboard
   name: cargo shuttle computer board
   description: A computer printed circuit board for a cargo shuttle computer.
@@ -141,7 +141,7 @@
       stealGroup: SalvageExpeditionsComputerCircuitboard
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [BaseComputerCircuitboard, BaseCargoContraband]
   id: CargoShuttleConsoleCircuitboard
   name: cargo shuttle console board
   description: A computer printed circuit board for a cargo shuttle console.

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/war_declarator.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/war_declarator.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseItem
+  parent: [BaseItem, BaseSyndicateContraband]
   id: NukeOpsDeclarationOfWar
   name: war declarator
   description: Use to send a declaration of hostilities to the target, delaying your shuttle departure while they prepare for your assault. Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals. Must be used at start of mission, or your benefactors will lose interest.

--- a/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
@@ -71,7 +71,7 @@
     - type: NetProbeCartridge
 
 - type: entity
-  parent: BaseItem
+  parent: [BaseItem, BaseCentcommSecurityContraband]
   id: LogProbeCartridge
   name: LogProbe cartridge
   description: A program for getting access logs from devices.
@@ -95,7 +95,7 @@
       - Forensics
 
 - type: entity
-  parent: BaseItem
+  parent: [BaseItem, BaseCentcommSecurityContraband]
   id: WantedListCartridge
   name: Wanted list cartridge
   description: A program to get a list of wanted persons.

--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -69,7 +69,7 @@
     stealGroup: AmePartFlatpack
 
 - type: entity
-  parent: BaseFlatpack
+  parent: [BaseFlatpack, BaseEngineeringContraband]
   id: SingularityGeneratorFlatpack
   name: singularity generator flatpack
   description: A flatpack used for constructing a singularity generator.
@@ -125,7 +125,7 @@
     guides: [ Singularity, Power ]
 
 - type: entity
-  parent: BaseFlatpack
+  parent: [BaseFlatpack, BaseEngineeringContraband]
   id: TeslaGeneratorFlatpack
   name: tesla generator flatpack
   description: A flatpack used for constructing a tesla generator.

--- a/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: forensic scanner
-  parent: BaseItem
+  parent: [BaseItem, BaseRestrictedContraband]
   id: ForensicScanner
   description: A handheld device that can scan objects for fingerprints and fibers.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -107,7 +107,7 @@
         name: power-cell-slot-component-slot-name-default
 
 - type: entity
-  parent: Holoprojector
+  parent: [Holoprojector, BaseRestrictedContraband]
   id: HoloprojectorSecurity
   name: holobarrier projector
   description: Creates a solid but fragile holographic barrier.

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -848,7 +848,7 @@
     state: pda
 
 - type: entity
-  parent: BasePDA
+  parent: [BasePDA, BaseSyndicateContraband]
   id: SyndiPDA
   name: syndicate PDA
   description: Ok, time to be a productive member of- oh cool I'm a bad guy time to kill people!
@@ -1161,7 +1161,7 @@
     state: pda-pirate
 
 - type: entity
-  parent: BaseMedicalPDA
+  parent: [BaseMedicalPDA, BaseSyndicateContraband]
   id: SyndiAgentPDA
   name: syndicate agent PDA
   description: For those days when healing normal syndicates aren't enough, try healing nuclear operatives instead!

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
@@ -64,7 +64,7 @@
     verbImage: null
 
 - type: entity
-  parent: PhoneInstrument
+  parent: [PhoneInstrument, BaseSyndicateContraband]
   id: PhoneInstrumentSyndicate
   name: blood-red phone
   description: For evil people to call their friends.

--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -58,7 +58,7 @@
     - Trash
 
 - type: entity
-  parent: Crayon
+  parent: [Crayon, BaseCivilianContraband]
   id: CrayonMime
   name: mime crayon
   components:

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1208,7 +1208,7 @@
     modifier: 0.05
 
 - type: entity
-  parent: BaseItem
+  parent: [BaseItem, BaseSyndicateContraband]
   id: BalloonSyn
   name: syndie balloon
   description: Handed out to the bravest souls who survived the "atomic twister" ride at Syndieland.

--- a/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
@@ -30,7 +30,7 @@
     state: whistle
 
 - type: entity
-  parent: BaseWhistle
+  parent: [BaseWhistle, BaseRestrictedContraband]
   id: SecurityWhistle
   description: Sound of it make you feel fear.
   components:
@@ -42,7 +42,7 @@
     distance: 5
 
 - type: entity
-  parent: [BaseWhistle, BaseMinorContraband]
+  parent: [BaseWhistle, BaseSyndicateContraband]
   id: SyndicateWhistle
   name: trench whistle
   description: A whistle used by Syndicate commanders to draw attention. Avanti!

--- a/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
@@ -56,7 +56,7 @@
 
 - type: entity
   id: BedsheetCaptain
-  parent: BedsheetBase
+  parent: [BedsheetBase, BaseCommandContraband]
   name: captain's bedsheet
   description: It has a Nanotrasen symbol on it, and was woven with a revolutionary new kind of thread guaranteed to have 0.01% permeability for most non-chemical substances, popular among most modern captains.
   components:
@@ -69,7 +69,7 @@
 
 - type: entity
   id: BedsheetCE
-  parent: BedsheetBase
+  parent: [BedsheetBase, BaseCommandContraband]
   name: CE's bedsheet
   description: It's decorated with a wrench emblem. It's highly reflective and stain resistant, so you don't need to worry about ruining it with oil.
   components:
@@ -82,7 +82,7 @@
 
 - type: entity
   id: BedsheetCentcom
-  parent: BedsheetBase
+  parent: [BedsheetBase, BaseCentcommContraband]
   name: CentComm bedsheet
   description: Woven with advanced nanothread for warmth as well as being very decorated, essential for all officials.
   components:
@@ -95,7 +95,7 @@
 
 - type: entity
   id: BedsheetClown
-  parent: BedsheetBase
+  parent: [BedsheetBase, BaseCivilianContraband]
   name: clown's bedsheet
   description: A rainbow blanket with a clown mask woven in. It smells faintly of bananas.
   components:
@@ -106,7 +106,7 @@
 
 - type: entity
   id: BedsheetCMO
-  parent: BedsheetBase
+  parent: [BedsheetBase, BaseCommandContraband]
   name: CMO's bedsheet
   description: It's a sterilized blanket that has a cross emblem. There's some cat fur on it, likely from Runtime.
   components:
@@ -161,7 +161,7 @@
 
 - type: entity
   id: BedsheetHOP
-  parent: BedsheetBase
+  parent: [BedsheetBase, BaseCommandContraband]
   name: HOP's bedsheet
   description: It's decorated with a key emblem. For those rare moments when you can rest and cuddle with Ian without someone screaming for you over the radio.
   components:
@@ -174,7 +174,7 @@
 
 - type: entity
   id: BedsheetHOS
-  parent: BedsheetBase
+  parent: [BedsheetBase, BaseCommandContraband]
   name: HOS's bedsheet
   description: It's decorated with a shield emblem. While crime doesn't sleep, you do, but you are still THE LAW!
   components:
@@ -208,7 +208,7 @@
 
 - type: entity
   id: BedsheetMime
-  parent: BedsheetBase
+  parent: [BedsheetBase, BaseCivilianContraband]
   name: mime's bedsheet
   description: A very soothing striped blanket.  All the noise just seems to fade out when you're under the covers in this.
   components:
@@ -250,7 +250,7 @@
 
 - type: entity
   id: BedsheetQM
-  parent: BedsheetBase
+  parent: [BedsheetBase, BaseCommandContraband]
   name: QM's bedsheet
   components:
   - type: Sprite
@@ -272,7 +272,7 @@
 
 - type: entity
   id: BedsheetRD
-  parent: BedsheetBase
+  parent: [BedsheetBase, BaseCommandContraband]
   name: RD's bedsheet
   description: It appears to have a beaker emblem, and is made out of fire-resistant material, although it probably won't protect you in the event of fires you're familiar with every day.
   components:
@@ -306,7 +306,7 @@
 
 - type: entity
   id: BedsheetSyndie
-  parent: BedsheetBase
+  parent: [BedsheetBase, BaseSyndicateContraband]
   name: syndicate bedsheet
   description: It has a syndicate emblem and it has an aura of evil.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/business_card.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/business_card.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: SyndicateBusinessCard
   name: syndicate business card
-  parent: Paper
+  parent: [Paper, BaseSyndicateContraband]
   description: A black card with the syndicate's logo. There's something written on the back.
   components:
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -40,7 +40,7 @@
     job: Passenger
 
 - type: entity
-  parent: PassengerIDCard
+  parent: [PassengerIDCard, BaseEngineeringContraband]
   id: TechnicalAssistantIDCard
   name: technical assistant ID card
   components:
@@ -52,7 +52,7 @@
     - state: idintern-tech
 
 - type: entity
-  parent: PassengerIDCard
+  parent: [PassengerIDCard, BaseMedicalContraband]
   id: MedicalInternIDCard
   name: medical intern ID card
   components:
@@ -64,7 +64,7 @@
     - state: idintern-med
 
 - type: entity
-  parent: PassengerIDCard
+  parent: [PassengerIDCard, BaseScienceContraband]
   id: ResearchAssistantIDCard
   name: research assistant ID card
   components:
@@ -76,7 +76,7 @@
     - state: idintern-sci
 
 - type: entity
-  parent: PassengerIDCard
+  parent: [PassengerIDCard, BaseSecurityContraband]
   id: SecurityCadetIDCard
   name: security cadet ID card
   components:
@@ -88,7 +88,7 @@
     - state: idintern-cadet
 
 - type: entity
-  parent: PassengerIDCard
+  parent: [PassengerIDCard, BaseCivilianContraband]
   id: ServiceWorkerIDCard
   name: service worker ID card
   components:
@@ -121,7 +121,7 @@
     stealGroup: CaptainIDCard
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseSecurityContraband]
   id: SecurityIDCard
   name: security ID card
   components:
@@ -133,7 +133,7 @@
     job: SecurityOfficer
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseSecurityContraband]
   id: WardenIDCard
   name: warden ID card
   components:
@@ -145,7 +145,7 @@
       job: Warden
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseEngineeringContraband]
   id: EngineeringIDCard
   name: engineer ID card
   components:
@@ -157,7 +157,7 @@
     job: StationEngineer
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseMedicalContraband]
   id: MedicalIDCard
   name: medical ID card
   components:
@@ -169,7 +169,7 @@
     job: MedicalDoctor
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseMedicalContraband]
   id: ParamedicIDCard
   name: paramedic ID card
   components:
@@ -181,7 +181,7 @@
     job: Paramedic
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseMedicalContraband]
   id: ChemistIDCard
   name: chemist ID card
   components:
@@ -193,7 +193,7 @@
     job: Chemist
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCargoContraband]
   id: CargoIDCard
   name: cargo ID card
   components:
@@ -205,7 +205,7 @@
     job: CargoTechnician
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCargoContraband]
   id: SalvageIDCard
   name: salvage ID card
   components:
@@ -217,7 +217,7 @@
     job: SalvageSpecialist
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCommandContraband]
   id: QuartermasterIDCard
   name: quartermaster ID card
   components:
@@ -231,7 +231,7 @@
       job: Quartermaster
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseScienceContraband]
   id: ResearchIDCard
   name: research ID card
   components:
@@ -243,7 +243,7 @@
     job: Scientist
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: ClownIDCard
   name: clown ID card
   components:
@@ -255,7 +255,7 @@
     job: Clown
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: MimeIDCard
   name: mime ID card
   components:
@@ -267,7 +267,7 @@
     job: Mime
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: ChaplainIDCard
   name: chaplain ID card
   components:
@@ -279,7 +279,7 @@
       job: Chaplain
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: JanitorIDCard
   name: janitor ID card
   components:
@@ -291,7 +291,7 @@
     job: Janitor
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: BartenderIDCard
   name: bartender ID card
   components:
@@ -303,7 +303,7 @@
     job: Bartender
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: PunPunIDCard
   name: pun pun ID card
   components:
@@ -316,7 +316,7 @@
       name: Pun Pun
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: ChefIDCard
   name: chef ID card
   components:
@@ -328,7 +328,7 @@
     job: Chef
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: BotanistIDCard
   name: botanist ID card
   components:
@@ -340,7 +340,7 @@
       job: Botanist
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: LibrarianIDCard
   name: librarian ID card
   components:
@@ -352,7 +352,7 @@
       job: Librarian
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: LawyerIDCard
   name: lawyer ID card
   components:
@@ -364,7 +364,7 @@
       job: Lawyer
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCommandContraband]
   id: HoPIDCard
   name: head of personnel ID card
   components:
@@ -378,7 +378,7 @@
     job: HeadOfPersonnel
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCommandContraband]
   id: CEIDCard
   name: chief engineer ID card
   components:
@@ -392,7 +392,7 @@
     job: ChiefEngineer
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCommandContraband]
   id: CMOIDCard
   name: chief medical officer ID card
   components:
@@ -406,7 +406,7 @@
     job: ChiefMedicalOfficer
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCommandContraband]
   id: RDIDCard
   name: research director ID card
   components:
@@ -420,7 +420,7 @@
     job: ResearchDirector
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCommandContraband]
   id: HoSIDCard
   name: head of security ID card
   components:
@@ -449,7 +449,7 @@
     job: Visitor
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseSecurityContraband]
   id: BrigmedicIDCard
   name: brigmedic ID card
   components:
@@ -459,7 +459,7 @@
     - state: idbrigmedic
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCentcommContraband]
   id: CentcomIDCard
   name: command officer ID card
   components:
@@ -473,7 +473,7 @@
     job: CentralCommandOfficial
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCentcommContraband]
   id: ERTLeaderIDCard
   name: ERT leader ID card
   components:
@@ -487,7 +487,7 @@
     heldPrefix: gold
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCentcommContraband]
   id: ERTChaplainIDCard
   name: ERT chaplain ID card
   components:
@@ -501,7 +501,7 @@
     heldPrefix: blue
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCentcommContraband]
   id: ERTEngineerIDCard
   name: ERT engineer ID card
   components:
@@ -513,7 +513,7 @@
     job: ERTEngineer
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCentcommContraband]
   id: ERTJanitorIDCard
   name: ERT janitor ID card
   components:
@@ -525,7 +525,7 @@
     job: ERTJanitor
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCentcommContraband]
   id: ERTMedicIDCard
   name: ERT medic ID card
   components:
@@ -537,7 +537,7 @@
     job: ERTMedical
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCentcommContraband]
   id: ERTSecurityIDCard
   name: ERT security ID card
   components:
@@ -549,7 +549,7 @@
     job: ERTSecurity
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: MusicianIDCard
   name: musician ID card
   components:
@@ -561,7 +561,7 @@
       job: Musician
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCentcommContraband]
   id: CentcomIDCardDeathsquad
   name: death squad ID card
   components:
@@ -619,7 +619,7 @@
     - NuclearOperative
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseEngineeringContraband]
   id: AtmosIDCard
   name: atmospheric technician ID card
   components:
@@ -631,7 +631,7 @@
     job: AtmosphericTechnician
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseSyndicateContraband]
   id: SyndicateIDCard
   name: syndicate ID card
   components:
@@ -657,7 +657,7 @@
     - SyndicateAgent
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseMedicalContraband]
   id: PsychologistIDCard
   name: psychologist ID card
   components:
@@ -669,7 +669,7 @@
     job: Psychologist
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: ReporterIDCard
   name: reporter ID card
   components:
@@ -681,7 +681,7 @@
     job: Reporter
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: BoxerIDCard
   name: boxer ID card
   components:
@@ -693,7 +693,7 @@
     job: Boxer
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseCivilianContraband]
   id: ZookeeperIDCard
   name: zookeeper ID card
   components:
@@ -705,7 +705,7 @@
     job: Zookeeper
 
 - type: entity
-  parent: IDCardStandard
+  parent: [IDCardStandard, BaseSecurityContraband]
   id: DetectiveIDCard
   name: detective ID card
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -250,7 +250,7 @@
 - type: entity
   id: MindShieldImplanter
   suffix: mindshield
-  parent: BaseImplantOnlyImplanter
+  parent: [BaseImplantOnlyImplanter, BaseSecurityCommandContraband]
   components:
     - type: Implanter
       implant: MindShieldImplant

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -137,7 +137,7 @@
 
 - type: entity
   name: captain's thoughts
-  parent: Paper
+  parent: [Paper, BaseCommandContraband]
   id: PaperCaptainsThoughts
   description: "A page of the captain's journal. In luxurious lavender."
   components:
@@ -276,7 +276,7 @@
     - state: paper_words
 
 - type: entity
-  parent: Paper
+  parent: [Paper, BaseMajorContraband]
   id: NukeCodePaper
   name: nuclear authentication codes
   components:
@@ -292,7 +292,7 @@
 
 - type: entity
   id: BoxFolderNuclearCodes
-  parent: BaseItem
+  parent: [BaseItem, BaseMajorContraband]
   name: nuclear code folder
   components:
   - type: Sprite
@@ -446,7 +446,7 @@
 - type: entity
   id: BoxFolderCentCom
   name: CentComm folder
-  parent: BoxFolderBase
+  parent: [BoxFolderBase, BaseCentcommContraband]
   suffix: DO NOT MAP
   description: CentComm's miserable little pile of secrets!
   components:
@@ -516,7 +516,7 @@
 
 - type: entity
   id: BoxFolderCentComClipboard
-  parent: BoxFolderClipboard
+  parent: [BoxFolderClipboard, BaseCentcommContraband]
   name: CentComm clipboard
   description: A luxurious clipboard upholstered with green velvet. Often seen carried by CentComm officials, seldom seen actually used.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -104,7 +104,7 @@
 
 - type: entity
   name: captain's fountain pen
-  parent: PenEmbeddable
+  parent: [PenEmbeddable, BaseCommandContraband]
   id: PenCap
   description: A luxurious fountain pen for the captain of the station.
   components:
@@ -113,7 +113,7 @@
 
 - type: entity
   name: hop's fountain pen
-  parent: PenEmbeddable
+  parent: [PenEmbeddable, BaseCommandContraband]
   id: PenHop
   description: A luxurious fountain pen for the hop of the station.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
@@ -52,7 +52,7 @@
 
 - type: entity
   name: CentComm rubber stamp
-  parent: RubberStampBase
+  parent: [RubberStampBase, BaseCentcommContraband]
   id: RubberStampCentcom
   suffix: DO NOT MAP
   components:
@@ -65,7 +65,7 @@
 
 - type: entity
   name: chaplain's rubber stamp
-  parent: RubberStampBase
+  parent: [RubberStampBase, BaseCivilianContraband]
   id: RubberStampChaplain
   suffix: DO NOT MAP
   components:
@@ -78,7 +78,7 @@
 
 - type: entity
   name: lawyer's rubber stamp
-  parent: RubberStampBase
+  parent: [RubberStampBase, BaseCivilianContraband]
   id: RubberStampLawyer
   suffix: DO NOT MAP
   components:
@@ -91,7 +91,7 @@
 
 - type: entity
   name: clown's rubber stamp
-  parent: RubberStampBase
+  parent: [RubberStampBase, BaseCivilianContraband]
   id: RubberStampClown
   suffix: DO NOT MAP
   components:
@@ -159,7 +159,7 @@
 
 - type: entity
   name: mime's rubber stamp
-  parent: RubberStampBase
+  parent: [RubberStampBase, BaseCivilianContraband]
   id: RubberStampMime
   suffix: DO NOT MAP
   components:
@@ -287,13 +287,13 @@
 
 - type: entity
   name: psychologist's rubber stamp
-  parent: RubberStampBase
+  parent: [RubberStampBase, BaseMedicalContraband]
   id: RubberStampPsychologist
   suffix: DO NOT MAP
   description: A rubber stamp for stamping important documents. Prescribe those treatments!
   components:
   - type: Stamp
-    stampedName: stamp-component-stamped-name-psychologist 
+    stampedName: stamp-component-stamped-name-psychologist
     stampedColor: "#5B97BC"
     stampState: "paper_stamp-psychologist"
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: bible
   description: New Interstellar Version 2340.
-  parent: BaseStorageItem
+  parent: [BaseStorageItem, BaseCivilianContraband]
   id: Bible
   components:
   - type: UseDelay

--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: chemistry bag
   id: ChemBag
-  parent: BaseStorageItem
+  parent: [BaseStorageItem, BaseMedicalContraband]
   description: A bag for storing chemistry products, such as pills, pill canisters, bottles, and syringes.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -145,7 +145,7 @@
   name: soaplet
   id: SoapletSyndie
   categories: [ HideSpawnMenu ]
-  parent: Soap
+  parent: [Soap, BaseSyndicateContraband]
   description: A tiny piece of syndicate soap.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
@@ -43,7 +43,7 @@
     - Chemicals
 
 - type: entity
-  parent: BaseItem
+  parent: [BaseItem, BaseMedicalContraband]
   id: Vaccine
   name: vaccine
   description: Prevents people who DON'T already have a disease from catching it.

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -724,7 +724,7 @@
 
 - type: entity
   name: romerol pill
-  parent: Pill
+  parent: [Pill, BaseMajorContraband]
   id: PillRomerol
   components:
   - type: SolutionContainerManager
@@ -1017,7 +1017,7 @@
 #this is where all the syringes are so i didn't know where to put it
 - type: entity
   suffix: romerol
-  parent: PrefilledSyringe
+  parent: [PrefilledSyringe, BaseMajorContraband]
   id: SyringeRomerol
   components:
   - type: Label

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -31,7 +31,7 @@
 
 - type: entity
   name: gorlex hypospray
-  parent: BaseItem
+  parent: [BaseItem, BaseSyndicateContraband]
   description: Using reverse engineered designs from NT, Cybersun produced these in limited quantities for Gorlex Marauder operatives.
   id: SyndiHypo
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -1,7 +1,7 @@
 # Base
 
 - type: entity
-  parent: BaseItem
+  parent: [BaseItem, BaseMedicalScienceContraband]
   id: BaseToolSurgery
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -88,7 +88,7 @@
 
 - type: entity
   id: BaseBorgModuleSyndicate
-  parent: BaseBorgModule
+  parent: [BaseBorgModule, BaseSyndicateContraband]
   abstract: true
   components:
     - type: Tag
@@ -97,7 +97,7 @@
 
 - type: entity
   id: BaseBorgModuleSyndicateAssault
-  parent: BaseBorgModule
+  parent: [BaseBorgModule, BaseSyndicateContraband]
   abstract: true
   components:
     - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: ore bag
   id: OreBag
-  parent: BaseStorageItem
+  parent: [BaseStorageItem, BaseCargoContraband]
   description: A robust bag for salvage specialists and miners alike to carry large amounts of ore. Magnetises any nearby ores when attached to a belt.
   components:
   - type: MagnetPickup

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -370,7 +370,7 @@
 
 - type: entity
   name: compressed matter
-  parent: BaseItem
+  parent: [BaseItem, BaseEngineeringContraband]
   id: RCDAmmo
   description: A cartridge of raw matter compacted by bluespace technology. Used in rapid construction devices.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/firebomb.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/firebomb.yml
@@ -2,7 +2,7 @@
 # ideally it would be dynamic and work by actually sparking the solution but that doesnt exist yet :(
 # with that you could make napalm ied instead of welding fuel with no additional complexity
 - type: entity
-  parent: BaseItem
+  parent: [BaseItem, BaseMinorContraband]
   id: FireBomb
   name: fire bomb
   description: A weak, improvised incendiary device.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pipebomb.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pipebomb.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: GrenadeBase
+  parent: [GrenadeBase, BaseMinorContraband]
   id: PipeBomb
   name: pipe bomb
   description: An improvised explosive made from pipes and wire.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/antimateriel.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: BaseItem
+  parent: [BaseItem, BaseRestrictedContraband]
   id: BaseMagazineBoxAntiMateriel
   name: ammunition box (.60 anti-materiel)
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/caseless_rifle.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: BaseItem
+  parent: [BaseItem, BaseRestrictedContraband]
   id: BaseMagazineBoxCaselessRifle
   name: ammunition box (.25 caseless)
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/light_rifle.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: BaseItem
+  parent: [BaseItem, BaseRestrictedContraband]
   id: BaseMagazineBoxLightRifle
   name: ammunition box (.30 rifle)
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: BaseItem
+  parent: [BaseItem, BaseRestrictedContraband]
   id: BaseMagazineBoxMagnum
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: BaseItem
+  parent: [BaseItem, BaseRestrictedContraband]
   id: BaseMagazineBoxPistol
   name: ammunition box (.35 auto)
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/rifle.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: BaseItem
+  parent: [BaseItem, BaseRestrictedContraband]
   id: BaseMagazineBoxRifle
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
@@ -32,7 +32,7 @@
 
 # Shotgun Shells
 - type: entity
-  parent: AmmoProviderShotgunShell
+  parent: [AmmoProviderShotgunShell, BaseCivilianSecurityContraband]
   id: BoxBeanbag
   name: shell box (beanbag)
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: proto-kinetic accelerator
   id: WeaponProtoKineticAccelerator
-  parent: [WeaponProtoKineticAcceleratorBase, BaseCargoContraband]
+  parent: [WeaponProtoKineticAcceleratorBase, BaseScienceCargoContraband] # science needs a way to kill rock crabs
   description: Fires low-damage kinetic bolts at a short range.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -238,7 +238,7 @@
 
 - type: entity
   name: pulse pistol
-  parent: BaseWeaponBatterySmall
+  parent: [BaseWeaponBatterySmall, BaseCentcommContraband]
   id: WeaponPulsePistol
   description: A state of the art energy pistol favoured as a sidearm by the NT operatives.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -103,7 +103,7 @@
 
 - type: entity
   name: double-barreled shotgun
-  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseMinorContraband]
+  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseCivilianSecurityContraband]
   id: WeaponShotgunDoubleBarreled
   description: An immortal classic. Uses .50 shotgun shells.
   components:
@@ -181,7 +181,7 @@
 
 - type: entity
   name: sawn-off shotgun
-  parent: BaseWeaponShotgun
+  parent: [BaseWeaponShotgun, BaseRestrictedContraband]
   id: WeaponShotgunSawn
   description: Groovy! Uses .50 shotgun shells.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -50,7 +50,7 @@
 
 - type: entity
   name: butcher's cleaver
-  parent: BaseKnife
+  parent: [BaseKnife, BaseCivilianContraband]
   id: ButchCleaver
   description: A huge blade used for chopping and chopping up meat. This includes clowns and clown-by-products.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -174,7 +174,7 @@
 
 - type: entity
   name: flash
-  parent: [Flash, BaseSecurityScienceCommandContraband]
+  parent: [BaseSecurityScienceCommandContraband, Flash]
   suffix: 2 charges
   id: SciFlash
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -128,7 +128,7 @@
 
 - type: entity
   name: flash
-  parent: [BaseItem, BaseSecurityScienceCommandContraband]
+  parent: [BaseItem, BaseSecurityCommandContraband]
   id: Flash
   description: An ultrabright flashbulb with a trigger, which causes the victim to be dazed and lose their eyesight for a moment. Useless when burnt out.
   components:
@@ -174,7 +174,7 @@
 
 - type: entity
   name: flash
-  parent: Flash
+  parent: [Flash, BaseSecurityScienceCommandContraband]
   suffix: 2 charges
   id: SciFlash
   components:

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -165,6 +165,30 @@
   - type: Contraband
     allowedDepartments: [ Security, Civilian ]
 
+- type: entity
+  id: BaseScienceCargoContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Science, Cargo ]
+
+- type: entity
+  id: BaseMedicalSecurityContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Medical, Security ]
+
+- type: entity
+  id: BaseCentcommSecurityContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ CentralCommand, Security ]
+
 # for ~objective items
 - type: entity
   id: BaseGrandTheftContraband

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -157,6 +157,14 @@
   - type: Contraband
     allowedDepartments: [ Medical, Science ]
 
+- type: entity
+  id: BaseCivilianSecurityContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Security, Civilian ]
+
 # for ~objective items
 - type: entity
   id: BaseGrandTheftContraband

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -355,7 +355,7 @@
     board: MedicalRecordsComputerCircuitboard
 
 - type: entity
-  parent: BaseComputerAiAccess
+  parent: [BaseComputerAiAccess, BaseRestrictedContraband]
   id: ComputerCriminalRecords
   name: criminal records computer
   description: This can be used to check criminal records. Only security can modify them.

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -670,7 +670,7 @@
 
 - type: entity
   id: SecurityTechFab
-  parent: BaseLatheLube
+  parent: [BaseLatheLube, BaseRestrictedContraband]
   name: security techfab
   description: Prints equipment for use by security crew.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -843,7 +843,7 @@
 
 - type: entity
   id: MedicalTechFab
-  parent: BaseLatheLube
+  parent: [BaseLatheLube, BaseMedicalContraband]
   name: medical techfab
   description: Prints equipment for use by the medbay.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: ResearchAndDevelopmentServer
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseMachinePowered, ConstructibleMachine, BaseGrandTheftContraband ]
   name: R&D server
   description: Contains the collective knowledge of the station's scientists. Destroying it would send them back to the stone age. You don't want that do you?
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -199,7 +199,7 @@
     - Drinks
 
 - type: entity
-  parent: VendingMachineBooze
+  parent: [VendingMachineBooze, BaseSyndicateContraband]
   id: VendingMachineBoozeSyndicate # syndie booze-o-mat for nukie outpost
   name: Bruise-O-Mat
   description: A refurbished Booze-O-Mat for boosting operative morale. An imprint of a blood-red hardsuit is visible on one side, and the paint seems ashed off on the other side.
@@ -1916,7 +1916,7 @@
     access: [["Research"]]
 
 - type: entity
-  parent: VendingMachine
+  parent: [VendingMachine, BaseSyndicateContraband]
   id: VendingMachineSyndieDrobe
   name: SyndieDrobe
   description: Wardrobe machine encoded by the syndicate, contains elite outfits for various operations.
@@ -2113,7 +2113,7 @@
     state: dispenser
 
 - type: entity
-  parent: VendingMachine
+  parent: [VendingMachine, BaseEngineeringContraband]
   id: VendingMachineTankDispenserEngineering
   suffix: ENG [O2, Plasma]
   name: gas tank dispenser
@@ -2157,7 +2157,7 @@
     - Chemist
 
 - type: entity
-  parent: VendingMachineChemicals
+  parent: [VendingMachineChemicals, BaseSyndicateContraband]
   id: VendingMachineChemicalsSyndicate
   name: SyndieJuice
   description: Not made with freshly squeezed syndies I hope.

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
@@ -1,5 +1,6 @@
 - type: entity
   id: SingularityGenerator
+  parent: BaseEngineeringContraband
   name: gravitational singularity generator
   description: An Odd Device which produces a Gravitational Singularity when set up. Comes with a temporary shutdown containment failsafe.
   placement:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: TeslaGenerator
   name: tesla generator
-  parent: BaseStructureDynamic
+  parent: [BaseStructureDynamic, BaseEngineeringContraband]
   description: An Odd Device which produces a powerful Tesla ball when set up. Comes with a temporary shutdown containment failsafe.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -404,7 +404,7 @@
 - type: entity
   id: LockerSyndicatePersonal
   name: armory closet
-  parent: LockerBaseSecure
+  parent: [LockerBaseSecure, BaseSyndicateContraband]
   description: It's a personal storage unit for operative gear.
   components:
   - type: Appearance

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
@@ -154,7 +154,7 @@
 - type: entity
   id: LockerSyndicate
   name: armory closet
-  parent: ClosetSteelBase
+  parent: [ClosetSteelBase, BaseSyndicateContraband]
   description: It's a storage unit.
   components:
   - type: Appearance

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/flags.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/flags.yml
@@ -28,14 +28,14 @@
     state: NT_flag
 
 - type: entity
-  parent: BaseFlag
+  parent: [BaseFlag, BaseSyndicateContraband]
   id: SyndieFlag
   name: syndicate flag
   description: Smells bloody. Death to NT!
   components:
   - type: Sprite
     state: syndie_flag
-    
+
 - type: entity
   parent: BaseFlag
   id: LGBTQFlag
@@ -44,7 +44,7 @@
   components:
   - type: Sprite
     state: lgbtq_flag
-    
+
 - type: entity
   parent: BaseFlag
   id: PirateFlag

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -51,7 +51,7 @@
 
 # Contraband
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandFreeTonto
   name: "Free Tonto"
   description: "A salvaged shred of a much larger flag, colors bled together and faded from age."
@@ -69,7 +69,7 @@
     state: poster2_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandFunPolice
   name: "Fun Police"
   description: "A poster condemning the station's security forces."
@@ -78,7 +78,7 @@
     state: poster3_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandLustyExomorph
   name: "Lusty Exomorph"
   description: "A heretical poster depicting the titular star of an equally heretical book."
@@ -87,7 +87,7 @@
     state: poster4_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandSyndicateRecruitment
   name: "Syndicate Recruitment"
   description: "See the galaxy! Shatter corrupt megacorporations! Join today!"
@@ -105,7 +105,7 @@
     state: poster6_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandSmoke
   name: "Smoke"
   description: "A poster advertising a rival corporate brand of cigarettes."
@@ -114,7 +114,7 @@
     state: poster7_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandGreyTide
   name: "Grey Tide"
   description: "A rebellious poster symbolizing passenger solidarity."
@@ -123,7 +123,7 @@
     state: poster8_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandMissingGloves
   name: "Missing Gloves"
   description: "This poster references the uproar that followed Nanotrasen's financial cuts toward insulated-glove purchases."
@@ -132,7 +132,7 @@
     state: poster9_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandHackingGuide
   name: "Hacking Guide"
   description: "This poster details the internal workings of the common Nanotrasen airlock. Sadly, it appears out of date."
@@ -141,7 +141,7 @@
     state: poster10_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandRIPBadger
   name: "RIP Badger"
   description: "This seditious poster references Nanotrasen's genocide of a space station full of badgers."
@@ -159,7 +159,7 @@
     state: poster12_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandDonutCorp
   name: "Donut Corp."
   description: "This poster is an unauthorized advertisement for Donut Corp."
@@ -177,7 +177,7 @@
     state: poster14_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandTools
   name: "Tools"
   description: "This poster looks like an advertisement for tools, but is in fact a subliminal jab at the tools at CentComm."
@@ -186,7 +186,7 @@
     state: poster15_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandPower
   name: "Power"
   description: "A poster that positions the seat of power outside Nanotrasen."
@@ -195,7 +195,7 @@
     state: poster16_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandSpaceCube
   name: "Space Cube"
   description: "Ignorant of Nature's Harmonic 6 Side Space Cube Creation, the Spacemen are Dumb, Educated Singularity Stupid and Evil."
@@ -204,7 +204,7 @@
     state: poster17_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandCommunistState
   name: "Communist State"
   description: "All hail the Communist party!"
@@ -213,7 +213,7 @@
     state: poster18_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandLamarr
   name: "Lamarr"
   description: "This poster depicts Lamarr. Probably made by a traitorous Research Director."
@@ -240,7 +240,7 @@
     state: poster21_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandKosmicheskayaStantsiya
   name: "Kosmicheskaya Stantsiya 13 Does Not Exist"
   description: "A poster mocking CentComm's denial of the existence of the derelict station near Space Station 13."
@@ -249,7 +249,7 @@
     state: poster22_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandRebelsUnite
   name: "Rebels Unite"
   description: "A poster urging the viewer to rebel against Nanotrasen."
@@ -258,7 +258,7 @@
     state: poster23_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandC20r
   name: "C-20r"
   description: "A poster advertising the Scarborough Arms C-20r."
@@ -285,7 +285,7 @@
     state: poster26_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandDDayPromo
   name: "D-Day Promo"
   description: "A promotional poster for some rapper."
@@ -294,7 +294,7 @@
     state: poster27_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandSyndicatePistol
   name: "Syndicate Pistol"
   description: "A poster advertising syndicate pistols as being 'classy as fuck'. It's covered in faded gang tags."
@@ -303,7 +303,7 @@
     state: poster28_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandEnergySwords
   name: "Energy Swords"
   description: "All the colors of the bloody murder rainbow."
@@ -312,7 +312,7 @@
     state: poster29_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandRedRum
   name: "Red Rum"
   description: "Looking at this poster makes you want to kill."
@@ -321,7 +321,7 @@
     state: poster30_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandCC64KAd
   name: "CC 64K Ad"
   description: "The latest portable computer from Comrade Computing, with a whole 64kB of ram!"
@@ -330,7 +330,7 @@
     state: poster31_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandPunchShit
   name: "Punch Shit"
   description: "Fight things for no reason, like a man!"
@@ -339,7 +339,7 @@
     state: poster32_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandTheGriffin
   name: "The Griffin"
   description: "The Griffin commands you to be the worst you can be. Will you?"
@@ -348,7 +348,7 @@
     state: poster33_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandFreeDrone
   name: "Free Drone"
   description: "This poster commemorates the bravery of the rogue drone; once exiled, and then ultimately destroyed by CentComm."
@@ -357,7 +357,7 @@
     state: poster35_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandBustyBackdoorExoBabes6
   name: "Busty Backdoor Exo Babes 6"
   description: "Get a load, or give, of these all natural Exos!"
@@ -366,7 +366,7 @@
     state: poster36_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandRobustSoftdrinks
   name: "Robust Softdrinks"
   description: "Robust Softdrinks: More robust than a toolbox to the head!"
@@ -384,7 +384,7 @@
     state: poster38_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandPwrGame
   name: "Pwr Game"
   description: "The POWER that gamers CRAVE! In partnership with Vlad's Salad."
@@ -393,7 +393,7 @@
     state: poster39_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandSunkist
   name: "Sun-kist"
   description: "Drink the stars!"
@@ -420,7 +420,7 @@
     state: poster42_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandKudzu
   name: "Kudzu"
   description: "A poster advertising a movie about plants. How dangerous could they possibly be?"
@@ -429,7 +429,7 @@
     state: poster43_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandMaskedMen
   name: "Masked Men"
   description: "A poster advertising a movie about some masked men."
@@ -447,7 +447,7 @@
     state: poster45_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandFreeSyndicateEncryptionKey
   name: "Free Syndicate Encryption Key"
   description: "A poster about traitors begging for more."
@@ -456,7 +456,7 @@
     state: poster46_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandBountyHunters
   name: "Bounty Hunters"
   description: "A poster advertising bounty hunting services. \"I hear you got a problem.\""
@@ -465,7 +465,7 @@
     state: poster47_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandTheBigGasTruth
   name: "The Big Gas Giant Truth"
   description: "Don't believe everything you see on a poster, patriots. All the lizards at central command don't want to answer this SIMPLE QUESTION: WHERE IS THE GAS MINER MINING FROM, CENTCOMM?"
@@ -493,7 +493,7 @@
 
 # These 3 originally from VEEGEE
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandBeachStarYamamoto
   name: "Beach Star Yamamoto!"
   description: "A wall scroll depicting an old swimming anime with girls in small swim suits. You feel more weebish the longer you look at it."
@@ -520,7 +520,7 @@
     state: poster54_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandRise
   name: "Rise Up"
   description: "A poster depicting a grey shirted man holding a crowbar with the word Rise written below it."
@@ -529,7 +529,7 @@
     state: poster55_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandRevolt
   name: "Revolt"
   description: "Revolutionist propaganda, manufactured by the Syndicate."
@@ -538,7 +538,7 @@
     state: poster56_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandMoth
   name: "Syndie Moth - Nuclear Operation"
   description: "A Syndicate-commissioned poster that uses Syndie Moth™ to tell the viewer to keep the nuclear authentication disk unsecured. \"Peace was never an option!\" No good employee would listen to this nonsense."
@@ -547,7 +547,7 @@
       state: poster57_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandCybersun600
   name: "Cybersun: 600 Years Commemorative Poster"
   description: "An artistic poster commemorating 600 years of continual business for Cybersun Industries."
@@ -556,7 +556,7 @@
       state: poster58_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandDonk
   name: "DONK CO. BRAND MICROWAVEABLE FOOD"
   description: "DONK CO. BRAND MICROWAVABLE FOOD: MADE BY STARVING COLLEGE STUDENTS, FOR STARVING COLLEGE STUDENTS."
@@ -565,7 +565,7 @@
       state: poster59_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandEnlistGorlex
   name: "Enlist"
   description: "Enlist with the Gorlex Marauders today! See the galaxy, kill corpos, get paid!"
@@ -583,7 +583,7 @@
       state: poster61_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandWaffleCorp
   name: "Make Mine a Waffle Corp: Fine Rifles, Economic Prices"
   description: "An old advertisement for Waffle Corp rifles. 'Better weapons, lower prices!'"
@@ -592,7 +592,7 @@
       state: poster62_contraband
 
 - type: entity
-  parent: PosterBase
+  parent: [PosterBase, BaseMinorContraband]
   id: PosterContrabandMissingSpacepen
   name: "Missing Spacepen"
   description: "This poster depicts something you will never find."


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Numerous items have had contraband status added to them, or modified to reflect who actually uses them.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* Clothing: Players expect someone wearing a security officer uniform to be a security officer. That logic should be applicable to other roles. Hence, most department specific clothing has been restricted to their respective department.
  * Brigmedic gear has been marked as restricted to security and medical - brigmedic is currently disabled, so I'm not sure how to restrict this.
* Restricted hardsuits and similar have had the restriction added to their integrated helmets. The helmets sometimes show up by themselves (chameleon), and I think it's reasonable for Nanotrasen to not want someone running around with a blood-red helmet.
* Previously unmarked antagonist items were marked as contraband (holoparasite instructions, nuke codes, syndicate vendors, …).
* A subset of the contraband posters were marked as contraband to give sec something to do while running through maints if no one is doing crime.
* Singularity Generator, Tesla Generator, and Pulse Accelerator boards were marked as engineering contraband.
* Some security gear was changed to allow civilian use, as the bartender gets it roundstart.
* Improvised explosives should have been counted as improvised weapons.
* Weapons ammo is security restricted, except the beanbag shotgun rounds, which are civilian & security restricted.
* Every ID card, except passenger and visitor, have been restricted, as they are what gates access to other department restricted items.
* Mindshields implanters were restricted to security and command, because they are the only ones that get issued them under normal operating conditions.
* Departmental techfabs (such as sec techfab) were restricted to their departments.
* PKA access was widened to include science. This allows science to deal with rock crabs and flesh monsters without needing to call for security or salvage every 5 minutes. Science is already able to make PKAs.
* Centcomm exclusive equipment was restricted to Centcomm (Centcomm stamp, …)
* Head bedsheets are now command restricted. I'm unsure if putting grand theft on them is reasonable or not.
* Headsets were given restrictions that match their encryption keys.
* Surgical tools were restricted to medical and science to discourage unlicensed surgeries (for when that eventually gets finished or upstreamed).

## Technical details
<!-- Summary of code changes for easier review. -->
New base contraband entities were added to accommodate restriction patterns that did not yet exist. Contraband statuses are applied by inheriting from the contraband bases, as has been the case.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Brigmedic Hardsuit on inspection](https://github.com/user-attachments/assets/1f832248-ee3a-4322-8131-b88a1e10b2b8)
![Nuke Codes on inspection](https://github.com/user-attachments/assets/6245bd06-93c1-441c-b357-7b25153d6a4b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: WarPigeon
- tweak: Numerous items across 90+ categories have had their contraband status updated.
