### PR TITLE
Corrected Cotton Dough Recipe

### DIFF
--- a/Resources/ServerInfo/Guidebook/Service/FoodRecipes.xml
+++ b/Resources/ServerInfo/Guidebook/Service/FoodRecipes.xml
@@ -23,7 +23,8 @@ WARNING: This is not an automatically generated list, things here may become out
 - Uncooked Animal Protein: Grind Raw Meat
 
 Buzz! Don't forget about Moth diet!
-- Cotton Dough = 5 Flour, 10 Fabric, 10 Water
+- Fiber: Juice Fabric in a Reagent Grinder, 3 Fiber per Fabric
+- Cotton Dough = 5 Flour, 10 Fiber, 10 Water
 - Cotton bread baked the same as default but with cotton dough instead
 - Cotton Pizza: Microwave 1 Flat Cotton Dough and 4 Cotton Bolls for 30 Seconds
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the guidebook to clarify how cotton dough is made.

## Why / Balance
The current guidebook could be confusing to someone making cotton dough: it says to use fabric when the actual recipe requires fiber, and it doesn't explain how fiber is made.

## Technical details
Modified the FoodRecipes.xml file.

## Media
![image](https://github.com/user-attachments/assets/00c15ae4-d5a9-4276-a0a7-3cb8922e5c80)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

