### PR TITLE
Reinforced tables require welding to construct/deconstruct

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/tables.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/tables.yml
@@ -145,10 +145,10 @@
               prototype: SheetPlasteel1
               amount: 1
           steps:
-            - tool: Anchoring
-              doAfter: 1
             - tool: Welding
               doAfter: 3
+            - tool: Anchoring
+              doAfter: 1
 
     - node: TableGlass
       entity: TableGlass

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/tables.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/tables.yml
@@ -55,6 +55,8 @@
             - material: Plasteel
               amount: 1
               doAfter: 1
+            - tool: Welding
+              doAfter: 3
 
         - to: TableGlass
           steps:
@@ -73,7 +75,7 @@
             - material: PlasmaGlass
               amount: 1
               doAfter: 1
-        
+
         - to: TableBrass
           steps:
             - material: Brass
@@ -145,6 +147,8 @@
           steps:
             - tool: Anchoring
               doAfter: 1
+            - tool: Welding
+              doAfter: 3
 
     - node: TableGlass
       entity: TableGlass
@@ -211,73 +215,73 @@
             - material: Cloth
               amount: 1
               doAfter: 1
-              
+
         - to: TableFancyBlack
-          steps: 
+          steps:
             - tag: CarpetBlack
               name: black carpet
               icon:
                 sprite: Objects/Tiles/tile.rsi
                 state: carpet-black
-              
+
         - to: TableFancyBlue
-          steps: 
+          steps:
             - tag: CarpetBlue
               name: blue carpet
               icon:
                 sprite: Objects/Tiles/tile.rsi
                 state: carpet-blue
-              
+
         - to: TableFancyCyan
-          steps: 
+          steps:
             - tag: CarpetCyan
               name: cyan carpet
               icon:
                 sprite: Objects/Tiles/tile.rsi
                 state: carpet-cyan
-              
+
         - to: TableFancyGreen
-          steps: 
+          steps:
             - tag: CarpetGreen
               name: green carpet
               icon:
                 sprite: Objects/Tiles/tile.rsi
                 state: carpet-green
-              
+
         - to: TableFancyOrange
-          steps: 
+          steps:
             - tag: CarpetOrange
               name: orange carpet
               icon:
                 sprite: Objects/Tiles/tile.rsi
                 state: carpet-orange
-              
+
         - to: TableFancyPurple
-          steps: 
+          steps:
             - tag: CarpetPurple
               name: purple carpet
               icon:
                 sprite: Objects/Tiles/tile.rsi
                 state: carpet-purple
-                
+
         - to: TableFancyPink
-          steps: 
+          steps:
             - tag: CarpetPink
               name: pink carpet
               icon:
                 sprite: Objects/Tiles/tile.rsi
                 state: carpet-pink
-              
+
         - to: TableFancyRed
-          steps: 
+          steps:
             - tag: CarpetRed
               name: red carpet
               icon:
                 sprite: Objects/Tiles/tile.rsi
                 state: carpet-red
-              
+
         - to: TableFancyWhite
-          steps: 
+          steps:
             - tag: CarpetWhite
               name: white carpet
               icon:
@@ -295,7 +299,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-              
+
     - node: TableFancyBlack
       entity: TableFancyBlack
       edges:
@@ -307,7 +311,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-              
+
     - node: TableFancyBlue
       entity: TableFancyBlue
       edges:
@@ -319,7 +323,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-              
+
     - node: TableFancyCyan
       entity: TableFancyCyan
       edges:


### PR DESCRIPTION
## About the PR
Reinforced tables now require welding to construct and deconstruct.

## Why / Balance
This is primarily intended to combat this issue raised in #33871.

Chemists often just wrench their own table or someone else's table to steal plasteel for plasma.

I think that the 10u vial solution, while solving the problem, kinda distracts from the point of the game, to be a social and roleplaying game. Giving a 10u vial bypasses one of the few reasons regular chemists leave their department.

Now, chemists will have to talk to departments to get their plasma.

Welding is required for both constructing AND deconstructing to promote a neutral time and resource balance if someone wants to spam reinforced tables for... whatever reason.

## Technical details
Just added 3s doafter welding steps in the construction graph.

## Media

https://github.com/user-attachments/assets/bcc226a1-3db8-4a51-87ef-0a44087716ff


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:

- tweak: Reinforced tables now require welding to construct and deconstruct.