### PR TITLE
adjust eshotgun recharge delay

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -768,4 +768,4 @@
     autoRecharge: true
     autoRechargeRate: 24
     autoRechargePause: true
-    autoRechargePauseTime: 10
+    autoRechargePauseTime: 30


### PR DESCRIPTION
## About the PR
Energy Shotgun now starts to recharge 30 seconds after firing (from 10)

## Why / Balance
There is not a lot of actual on-hands data for how impactful this recharge will be in the wild. If the intended purpose of the recharge is to be a qol thing between uses, and not so much a tactical buff, then this should not have a big impact on that. Let's play it safe while we see how this works out. It's better to release it too long and reduce it than to release an op gun

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: The energy shotgun's recharge delay is now 30 seconds.