### PR TITLE
Add a guaranteed cotton pizza to pizza crates

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -7,7 +7,8 @@
   - type: StorageFill
     contents:
     - id: FoodBoxPizzaFilled
-      amount: 4
+      amount: 3
+    - id: FoodBoxPizzaCotton
     - id: LidSalami
       prob: 0.01
 
@@ -20,7 +21,8 @@
   - type: StorageFill
     contents:
     - id: FoodBoxPizzaFilled
-      amount: 16
+      amount: 15
+    - id: FoodBoxPizzaCotton
     - id: LidSalami
       prob: 0.04
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -279,7 +279,7 @@
   name: pizza box
   parent: FoodBoxPizzaFilled
   id: FoodBoxPizzaCotton
-  suffix: Filled
+  suffix: Cotton Pizza
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -277,15 +277,10 @@
   
 - type: entity
   name: pizza box
-  parent: FoodBoxPizza
+  parent: FoodBoxPizzaFilled
   id: FoodBoxPizzaCotton
   suffix: Filled
   components:
-  - type: Sprite
-    layers:
-    - state: box
-    - state: box-open
-      map: ["enum.StorageVisualLayers.Door"]
   - type: StorageFill
     contents:
     - id: FoodPizzaCotton

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -274,6 +274,22 @@
       prob: 0.10
       orGroup: Pizza
     - id: KnifePlastic
+  
+- type: entity
+  name: pizza box
+  parent: FoodBoxPizza
+  id: FoodBoxPizzaCotton
+  suffix: Filled
+  components:
+  - type: Sprite
+    layers:
+    - state: box
+    - state: box-open
+      map: ["enum.StorageVisualLayers.Door"]
+  - type: StorageFill
+    contents:
+    - id: FoodPizzaCotton
+    - id: KnifePlastic
 
 # Nugget
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Replace one of the random pizzas from emergency/disaster pizza deliveries with a cotton one.

## Why / Balance
Guarantees that all species get something edible from pizza deliveries.

## Technical details
Added a new prototype for cotton pizza boxes and replaced one of the random pizzas in the crates with the cotton one.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Pizza deliveries are now guaranteed to have at least one cotton pizza.