### PR TITLE
Allow to paint multiple airlocks

### DIFF
--- a/Content.Shared/SprayPainter/Components/SprayPainterComponent.cs
+++ b/Content.Shared/SprayPainter/Components/SprayPainterComponent.cs
@@ -17,13 +17,6 @@ public sealed partial class SprayPainterComponent : Component
     public TimeSpan PipeSprayTime = TimeSpan.FromSeconds(1);
 
     /// <summary>
-    /// DoAfterId for airlock spraying.
-    /// Pipes do not track doafters so you can spray multiple at once.
-    /// </summary>
-    [DataField]
-    public DoAfterId? AirlockDoAfter;
-
-    /// <summary>
     /// Pipe color chosen to spray with.
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/SprayPainter/SharedSprayPainterSystem.cs
+++ b/Content.Shared/SprayPainter/SharedSprayPainterSystem.cs
@@ -60,8 +60,6 @@ public abstract class SharedSprayPainterSystem : EntitySystem
 
     private void OnDoorDoAfter(Entity<SprayPainterComponent> ent, ref SprayPainterDoorDoAfterEvent args)
     {
-        ent.Comp.AirlockDoAfter = null;
-
         if (args.Handled || args.Cancelled)
             return;
 
@@ -116,9 +114,6 @@ public abstract class SharedSprayPainterSystem : EntitySystem
         if (args.Handled)
             return;
 
-        if (!TryComp<SprayPainterComponent>(args.Used, out var painter) || painter.AirlockDoAfter != null)
-            return;
-
         var group = Proto.Index<AirlockGroupPrototype>(ent.Comp.Group);
 
         var style = Styles[painter.Index];
@@ -138,9 +133,6 @@ public abstract class SharedSprayPainterSystem : EntitySystem
         if (!DoAfter.TryStartDoAfter(doAfterEventArgs, out var id))
             return;
 
-        // since we are now spraying an airlock prevent spraying more at the same time
-        // pipes ignore this
-        painter.AirlockDoAfter = id;
         args.Handled = true;
 
         // Log the attempt

--- a/Content.Shared/SprayPainter/SharedSprayPainterSystem.cs
+++ b/Content.Shared/SprayPainter/SharedSprayPainterSystem.cs
@@ -114,6 +114,9 @@ public abstract class SharedSprayPainterSystem : EntitySystem
         if (args.Handled)
             return;
 
+        if (!TryComp<SprayPainterComponent>(args.Used, out var painter))
+            return;
+
         var group = Proto.Index<AirlockGroupPrototype>(ent.Comp.Group);
 
         var style = Styles[painter.Index];


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
title + fixes https://github.com/space-wizards/space-station-14/issues/34000
plus you can now cancel doafter by pressing on the door you are painting

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
why are we allowed to paint multiple pipes but not airlocks?

## Technical details
<!-- Summary of code changes for easier review. -->
not much, just removed check for doafter and the doafter saving

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/28d0b3f2-436e-4556-817f-6b995e62798e



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Removed AirlockDoAfter datafield from SprayPainterComponent

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Now you are allowed to paint multiple airlocks with the spray painter. Along with that you can cancel the doafter by clicking on the door you are painting.
ADMIN:
- fix: Fixed spray painter using while being aghost.
