### PR TITLE
Content-side fixturescomp removal

### DIFF
--- a/Content.Client/Pinpointer/UI/NavMapControl.cs
+++ b/Content.Client/Pinpointer/UI/NavMapControl.cs
@@ -83,7 +83,6 @@ public partial class NavMapControl : MapGridControl
     private MapGridComponent? _grid;
     private TransformComponent? _xform;
     private PhysicsComponent? _physics;
-    private FixturesComponent? _fixtures;
 
     // TODO: https://github.com/space-wizards/RobustToolbox/issues/3818
     private readonly Label _zoom = new()
@@ -184,7 +183,6 @@ public partial class NavMapControl : MapGridControl
         EntManager.TryGetComponent(MapUid, out _grid);
         EntManager.TryGetComponent(MapUid, out _xform);
         EntManager.TryGetComponent(MapUid, out _physics);
-        EntManager.TryGetComponent(MapUid, out _fixtures);
 
         UpdateNavMap();
     }
@@ -277,7 +275,6 @@ public partial class NavMapControl : MapGridControl
         EntManager.TryGetComponent(MapUid, out _grid);
         EntManager.TryGetComponent(MapUid, out _xform);
         EntManager.TryGetComponent(MapUid, out _physics);
-        EntManager.TryGetComponent(MapUid, out _fixtures);
 
         if (_navMap == null || _grid == null || _xform == null)
             return;
@@ -477,12 +474,12 @@ public partial class NavMapControl : MapGridControl
 
     private void UpdateNavMapFloorTiles()
     {
-        if (_fixtures == null)
+        if (_physics == null)
             return;
 
         var verts = new Vector2[8];
 
-        foreach (var fixture in _fixtures.Fixtures.Values)
+        foreach (var fixture in _physics.Fixtures.Values)
         {
             if (fixture.Shape is not PolygonShape poly)
                 continue;

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -139,7 +139,6 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
         }
 
         var xformQuery = EntManager.GetEntityQuery<TransformComponent>();
-        var fixturesQuery = EntManager.GetEntityQuery<FixturesComponent>();
         var bodyQuery = EntManager.GetEntityQuery<PhysicsComponent>();
 
         if (!xformQuery.TryGetComponent(_coordinates.Value.EntityId, out var xform)
@@ -158,8 +157,7 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
 
         // Draw our grid in detail
         var ourGridId = xform.GridUid;
-        if (EntManager.TryGetComponent<MapGridComponent>(ourGridId, out var ourGrid) &&
-            fixturesQuery.HasComponent(ourGridId.Value))
+        if (EntManager.TryGetComponent<MapGridComponent>(ourGridId, out var ourGrid))
         {
             var ourGridToWorld = _transform.GetWorldMatrix(ourGridId.Value);
             var ourGridToShuttle = Matrix3x2.Multiply(ourGridToWorld, worldToShuttle);
@@ -193,7 +191,7 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
         foreach (var grid in _grids)
         {
             var gUid = grid.Owner;
-            if (gUid == ourGridId || !fixturesQuery.HasComponent(gUid))
+            if (gUid == ourGridId || !bodyQuery.HasComponent(gUid))
                 continue;
 
             var gridBody = bodyQuery.GetComponent(gUid);

--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
@@ -89,7 +89,7 @@ namespace Content.IntegrationTests.Tests.Disposal
     damageContainer: Biological
   - type: Physics
     bodyType: KinematicController
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -107,7 +107,6 @@ namespace Content.IntegrationTests.Tests.Disposal
       - Anchoring
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -127,7 +126,6 @@ namespace Content.IntegrationTests.Tests.Disposal
   - type: ApcPowerReceiver
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
@@ -89,7 +89,6 @@ namespace Content.IntegrationTests.Tests.Disposal
     damageContainer: Biological
   - type: Physics
     bodyType: KinematicController
-  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockTest.cs
@@ -21,7 +21,6 @@ namespace Content.IntegrationTests.Tests.Doors
   components:
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -41,7 +40,6 @@ namespace Content.IntegrationTests.Tests.Doors
     needsPower: false
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
+++ b/Content.IntegrationTests/Tests/Interaction/Click/InteractionSystemTests.cs
@@ -25,7 +25,6 @@ namespace Content.IntegrationTests.Tests.Interaction.Click
   components:
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
@@ -7,6 +7,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager;
@@ -118,7 +119,7 @@ public sealed class PrototypeSaveTest
                         var compName = compFact.GetComponentName(compType);
                         compNames.Add(compName);
 
-                        if (compType == typeof(MetaDataComponent) || compType == typeof(TransformComponent) || compType == typeof(FixturesComponent))
+                        if (compType == typeof(MetaDataComponent) || compType == typeof(TransformComponent) || compType == typeof(PhysicsComponent))
                             continue;
 
                         MappingDataNode compMapping;

--- a/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/EntitySystemExtensionsTest.cs
@@ -19,7 +19,6 @@ namespace Content.IntegrationTests.Tests.Utility
   name: {BlockerDummyId}
   components:
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -63,7 +63,6 @@ public sealed partial class AdminVerbSystem
     [Dependency] private readonly ElectrocutionSystem _electrocutionSystem = default!;
     [Dependency] private readonly EntityStorageSystem _entityStorageSystem = default!;
     [Dependency] private readonly ExplosionSystem _explosionSystem = default!;
-    [Dependency] private readonly FixtureSystem _fixtures = default!;
     [Dependency] private readonly FlammableSystem _flammableSystem = default!;
     [Dependency] private readonly GhostKickManager _ghostKickManager = default!;
     [Dependency] private readonly SharedGodmodeSystem _sharedGodmodeSystem = default!;
@@ -420,24 +419,23 @@ public sealed partial class AdminVerbSystem
                 Act = () =>
                 {
                     var xform = Transform(args.Target);
-                    var fixtures = Comp<FixturesComponent>(args.Target);
                     xform.Anchored = false; // Just in case.
-                    _physics.SetBodyType(args.Target, BodyType.Dynamic, manager: fixtures, body: physics);
+                    _physics.SetBodyType(args.Target, BodyType.Dynamic, body: physics);
                     _physics.SetBodyStatus(args.Target, physics, BodyStatus.InAir);
-                    _physics.WakeBody(args.Target, manager: fixtures, body: physics);
+                    _physics.WakeBody(args.Target, body: physics);
 
-                    foreach (var fixture in fixtures.Fixtures.Values)
+                    foreach (var fixture in physics.Fixtures.Values)
                     {
                         if (!fixture.Hard)
                             continue;
 
-                        _physics.SetRestitution(args.Target, fixture, 1.1f, false, fixtures);
+                        _physics.SetRestitution(args.Target, fixture, 1.1f, false, physics);
                     }
 
-                    _fixtures.FixtureUpdate(args.Target, manager: fixtures, body: physics);
+                    _physics.FixtureUpdate(args.Target, body: physics);
 
-                    _physics.SetLinearVelocity(args.Target, _random.NextVector2(1.5f, 1.5f), manager: fixtures, body: physics);
-                    _physics.SetAngularVelocity(args.Target, MathF.PI * 12, manager: fixtures, body: physics);
+                    _physics.SetLinearVelocity(args.Target, _random.NextVector2(1.5f, 1.5f), body: physics);
+                    _physics.SetAngularVelocity(args.Target, MathF.PI * 12, body: physics);
                     _physics.SetLinearDamping(args.Target, physics, 0f);
                     _physics.SetAngularDamping(args.Target, physics, 0f);
                 },
@@ -455,20 +453,19 @@ public sealed partial class AdminVerbSystem
                 Act = () =>
                 {
                     var xform = Transform(args.Target);
-                    var fixtures = Comp<FixturesComponent>(args.Target);
                     xform.Anchored = false; // Just in case.
 
                     _physics.SetBodyType(args.Target, BodyType.Dynamic, body: physics);
                     _physics.SetBodyStatus(args.Target, physics, BodyStatus.InAir);
-                    _physics.WakeBody(args.Target, manager: fixtures, body: physics);
+                    _physics.WakeBody(args.Target, body: physics);
 
-                    foreach (var fixture in fixtures.Fixtures.Values)
+                    foreach (var fixture in physics.Fixtures.Values)
                     {
-                        _physics.SetHard(args.Target, fixture, false, manager: fixtures);
+                        _physics.SetHard(args.Target, fixture, false, body: physics);
                     }
 
-                    _physics.SetLinearVelocity(args.Target, _random.NextVector2(8.0f, 8.0f), manager: fixtures, body: physics);
-                    _physics.SetAngularVelocity(args.Target, MathF.PI * 12, manager: fixtures, body: physics);
+                    _physics.SetLinearVelocity(args.Target, _random.NextVector2(8.0f, 8.0f), body: physics);
+                    _physics.SetAngularVelocity(args.Target, MathF.PI * 12, body: physics);
                     _physics.SetLinearDamping(args.Target, physics, 0f);
                     _physics.SetAngularDamping(args.Target, physics, 0f);
                 },

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -56,11 +56,11 @@ namespace Content.Server.Atmos.EntitySystems
                     _physics.SetBodyStatus(uid, body, BodyStatus.OnGround);
                 }
 
-                if (TryComp<FixturesComponent>(uid, out var fixtures))
+                if (TryComp<PhysicsComponent>(uid, out var fixtures))
                 {
                     foreach (var (id, fixture) in fixtures.Fixtures)
                     {
-                        _physics.AddCollisionMask(uid, id, fixture, (int) CollisionGroup.TableLayer, manager: fixtures);
+                        _physics.AddCollisionMask(uid, id, fixture, (int) CollisionGroup.TableLayer, body: fixtures);
                     }
                 }
             }
@@ -73,14 +73,11 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void AddMobMovedByPressure(EntityUid uid, MovedByPressureComponent component, PhysicsComponent body)
         {
-            if (!TryComp<FixturesComponent>(uid, out var fixtures))
-                return;
-
             _physics.SetBodyStatus(uid, body, BodyStatus.InAir);
 
-            foreach (var (id, fixture) in fixtures.Fixtures)
+            foreach (var (id, fixture) in body.Fixtures)
             {
-                _physics.RemoveCollisionMask(uid, id, fixture, (int) CollisionGroup.TableLayer, manager: fixtures);
+                _physics.RemoveCollisionMask(uid, id, fixture, (int) CollisionGroup.TableLayer, body: body);
             }
 
             // TODO: Make them dynamic type? Ehh but they still want movement so uhh make it non-predicted like weightless?

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -40,10 +40,10 @@ namespace Content.Server.Atmos.EntitySystems
         [Dependency] private readonly IgnitionSourceSystem _ignitionSourceSystem = default!;
         [Dependency] private readonly DamageableSystem _damageableSystem = default!;
         [Dependency] private readonly AlertsSystem _alertsSystem = default!;
-        [Dependency] private readonly FixtureSystem _fixture = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly InventorySystem _inventory = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly UseDelaySystem _useDelay = default!;
         [Dependency] private readonly AudioSystem _audio = default!;
@@ -135,7 +135,7 @@ namespace Content.Server.Atmos.EntitySystems
             if (!TryComp<PhysicsComponent>(uid, out var body))
                 return;
 
-            _fixture.TryCreateFixture(uid, component.FlammableCollisionShape, component.FlammableFixtureID, hard: false,
+            _physics.TryCreateFixture(uid, component.FlammableCollisionShape, component.FlammableFixtureID, hard: false,
                 collisionMask: (int) CollisionGroup.FullTileLayer, body: body);
         }
 

--- a/Content.Server/Beam/BeamSystem.cs
+++ b/Content.Server/Beam/BeamSystem.cs
@@ -16,7 +16,6 @@ namespace Content.Server.Beam;
 
 public sealed class BeamSystem : SharedBeamSystem
 {
-    [Dependency] private readonly FixtureSystem _fixture = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
@@ -83,20 +82,18 @@ public sealed class BeamSystem : SharedBeamSystem
         if (!TryComp<PhysicsComponent>(ent, out var physics) || !TryComp<BeamComponent>(ent, out var beam))
             return;
 
-        FixturesComponent? manager = null;
-        _fixture.TryCreateFixture(
+        _physics.TryCreateFixture(
             ent,
             shape,
             "BeamBody",
             hard: false,
             collisionMask: (int)CollisionGroup.ItemMask,
             collisionLayer: (int)CollisionGroup.MobLayer,
-            manager: manager,
             body: physics);
 
-        _physics.SetBodyType(ent, BodyType.Dynamic, manager: manager, body: physics);
-        _physics.SetCanCollide(ent, true, manager: manager, body: physics);
-        _broadphase.RegenerateContacts(ent, physics, manager);
+        _physics.SetBodyType(ent, BodyType.Dynamic, body: physics);
+        _physics.SetCanCollide(ent, true, body: physics);
+        _broadphase.RegenerateContacts(ent, physics);
 
         var distanceLength = distanceCorrection.Length();
 

--- a/Content.Server/Botany/Systems/BotanySystem.Seed.cs
+++ b/Content.Server/Botany/Systems/BotanySystem.Seed.cs
@@ -25,10 +25,8 @@ public sealed partial class BotanySystem : EntitySystem
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
-    [Dependency] private readonly SharedPointLightSystem _light = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
-    [Dependency] private readonly FixtureSystem _fixtureSystem = default!;
     [Dependency] private readonly RandomHelperSystem _randomHelper = default!;
 
     public override void Initialize()

--- a/Content.Server/EntityEffects/Effects/Slipify.cs
+++ b/Content.Server/EntityEffects/Effects/Slipify.cs
@@ -16,16 +16,15 @@ public sealed partial class Slipify : EntityEffect
 {
     public override void Effect(EntityEffectBaseArgs args)
     {
-        var fixtureSystem = args.EntityManager.System<FixtureSystem>();
+        var fixtureSystem = args.EntityManager.System<SharedPhysicsSystem>();
         var colWakeSystem = args.EntityManager.System<CollisionWakeSystem>();
         var slippery = args.EntityManager.EnsureComponent<SlipperyComponent>(args.TargetEntity);
         args.EntityManager.Dirty(args.TargetEntity, slippery);
         args.EntityManager.EnsureComponent<StepTriggerComponent>(args.TargetEntity);
         // Need a fixture with a slip layer in order to actually do the slipping
-        var fixtures = args.EntityManager.EnsureComponent<FixturesComponent>(args.TargetEntity);
         var body = args.EntityManager.EnsureComponent<PhysicsComponent>(args.TargetEntity);
-        var shape = fixtures.Fixtures["fix1"].Shape;
-        fixtureSystem.TryCreateFixture(args.TargetEntity, shape, "slips", 1, false, (int)CollisionGroup.SlipLayer, manager: fixtures, body: body);
+        var shape = body.Fixtures["fix1"].Shape;
+        fixtureSystem.TryCreateFixture(args.TargetEntity, shape, "slips", 1, false, (int)CollisionGroup.SlipLayer, body: body);
         // Need to disable collision wake so that mobs can collide with and slip on it
         var collisionWake = args.EntityManager.EnsureComponent<CollisionWakeComponent>(args.TargetEntity);
         colWakeSystem.SetEnabled(args.TargetEntity, false, collisionWake);

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.Proximity.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.Proximity.cs
@@ -9,9 +9,6 @@ namespace Content.Server.Explosion.EntitySystems;
 
 public sealed partial class TriggerSystem
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-
     private void InitializeProximity()
     {
         SubscribeLocalEvent<TriggerOnProximityComponent, StartCollideEvent>(OnProximityStartCollide);
@@ -55,7 +52,7 @@ public sealed partial class TriggerSystem
         if (!TryComp<PhysicsComponent>(uid, out var body))
             return;
 
-        _fixtures.TryCreateFixture(
+        _physics.TryCreateFixture(
             uid,
             component.Shape,
             TriggerOnProximityComponent.FixtureID,

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -62,22 +62,24 @@ namespace Content.Server.Explosion.EntitySystems
     [UsedImplicitly]
     public sealed partial class TriggerSystem : EntitySystem
     {
-        [Dependency] private readonly ExplosionSystem _explosions = default!;
-        [Dependency] private readonly FixtureSystem _fixtures = default!;
-        [Dependency] private readonly FlashSystem _flashSystem = default!;
-        [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
-        [Dependency] private readonly SharedContainerSystem _container = default!;
+        [Dependency] private readonly IGameTiming _timing = default!;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly BodySystem _body = default!;
-        [Dependency] private readonly SharedAudioSystem _audio = default!;
-        [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+        [Dependency] private readonly ElectrocutionSystem _electrocution = default!;
+        [Dependency] private readonly ExplosionSystem _explosions = default!;
+        [Dependency] private readonly FlashSystem _flashSystem = default!;
+        [Dependency] private readonly InventorySystem _inventory = default!;
         [Dependency] private readonly NavMapSystem _navMap = default!;
         [Dependency] private readonly RadioSystem _radioSystem = default!;
-        [Dependency] private readonly IRobustRandom _random = default!;
-        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+        [Dependency] private readonly SharedAudioSystem _audio = default!;
+        [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
+        [Dependency] private readonly SharedContainerSystem _container = default!;
+        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
         [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
-        [Dependency] private readonly InventorySystem _inventory = default!;
-        [Dependency] private readonly ElectrocutionSystem _electrocution = default!;
+        [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
 
         public override void Initialize()
         {

--- a/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
@@ -223,12 +223,12 @@ public sealed class SmokeSystem : EntitySystem
         Dirty(uid, component);
         EnsureComp<ActiveEdgeSpreaderComponent>(uid);
 
-        if (TryComp<PhysicsComponent>(uid, out var body) && TryComp<FixturesComponent>(uid, out var fixtures))
+        if (TryComp<PhysicsComponent>(uid, out var body))
         {
             var xform = Transform(uid);
-            _physics.SetBodyType(uid, BodyType.Dynamic, fixtures, body, xform);
-            _physics.SetCanCollide(uid, true, manager: fixtures, body: body);
-            _broadphase.RegenerateContacts(uid, body, fixtures, xform);
+            _physics.SetBodyType(uid, BodyType.Dynamic, body, xform);
+            _physics.SetCanCollide(uid, true, body: body);
+            _broadphase.RegenerateContacts(uid, body, xform);
         }
 
         var timer = EnsureComp<TimedDespawnComponent>(uid);

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Collections;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -219,9 +220,9 @@ public sealed partial class PathfindingSystem
         }
     }
 
-    private bool IsBodyRelevant(FixturesComponent fixtures)
+    private bool IsBodyRelevant(PhysicsComponent body)
     {
-        foreach (var fixture in fixtures.Fixtures.Values)
+        foreach (var fixture in body.Fixtures.Values)
         {
             if (!fixture.Hard)
                 continue;
@@ -271,7 +272,7 @@ public sealed partial class PathfindingSystem
 
     private void OnMoveEvent(ref MoveEvent ev)
     {
-        if (!_fixturesQuery.TryGetComponent(ev.Sender, out var fixtures) ||
+        if (!_physicsQuery.TryGetComponent(ev.Sender, out var fixtures) ||
             !IsBodyRelevant(fixtures) ||
             _gridQuery.HasComponent(ev.Sender))
         {
@@ -436,7 +437,7 @@ public sealed partial class PathfindingSystem
                 foreach (var ent in available)
                 {
                     // Irrelevant for pathfinding
-                    if (!_fixturesQuery.TryGetComponent(ent, out var fixtures) ||
+                    if (!_physicsQuery.TryGetComponent(ent, out var fixtures) ||
                         !IsBodyRelevant(fixtures))
                     {
                         continue;
@@ -468,7 +469,7 @@ public sealed partial class PathfindingSystem
 
                         foreach (var ent in tileEntities)
                         {
-                            if (!_fixturesQuery.TryGetComponent(ent, out var fixtures))
+                            if (!_physicsQuery.TryGetComponent(ent, out var fixtures))
                                 continue;
 
                             var colliding = false;
@@ -500,7 +501,7 @@ public sealed partial class PathfindingSystem
                                     continue;
                                 }
 
-                                if (!_fixtures.TestPoint(fixture.Shape, new Transform(xform.LocalPosition, xform.LocalRotation), localPos))
+                                if (!_physics.TestPoint(fixture.Shape, new Transform(xform.LocalPosition, xform.LocalRotation), localPos))
                                 {
                                     continue;
                                 }

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
@@ -16,6 +16,7 @@ using Robust.Shared.Enums;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
@@ -47,7 +48,6 @@ namespace Content.Server.NPC.Pathfinding
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly DestructibleSystem _destructible = default!;
         [Dependency] private readonly EntityLookupSystem _lookup = default!;
-        [Dependency] private readonly FixtureSystem _fixtures = default!;
         [Dependency] private readonly NPCSystem _npc = default!;
         [Dependency] private readonly SharedMapSystem _maps = default!;
         [Dependency] private readonly SharedPhysicsSystem _physics = default!;
@@ -72,8 +72,8 @@ namespace Content.Server.NPC.Pathfinding
         private EntityQuery<DestructibleComponent> _destructibleQuery;
         private EntityQuery<DoorComponent> _doorQuery;
         private EntityQuery<ClimbableComponent> _climbableQuery;
-        private EntityQuery<FixturesComponent> _fixturesQuery;
         private EntityQuery<MapGridComponent> _gridQuery;
+        private EntityQuery<PhysicsComponent> _physicsQuery;
         private EntityQuery<TransformComponent> _xformQuery;
 
         public override void Initialize()
@@ -84,7 +84,7 @@ namespace Content.Server.NPC.Pathfinding
             _destructibleQuery = GetEntityQuery<DestructibleComponent>();
             _doorQuery = GetEntityQuery<DoorComponent>();
             _climbableQuery = GetEntityQuery<ClimbableComponent>();
-            _fixturesQuery = GetEntityQuery<FixturesComponent>();
+            _physicsQuery = GetEntityQuery<PhysicsComponent>();
             _gridQuery = GetEntityQuery<MapGridComponent>();
             _xformQuery = GetEntityQuery<TransformComponent>();
 
@@ -270,9 +270,9 @@ namespace Content.Server.NPC.Pathfinding
             var layer = 0;
             var mask = 0;
 
-            if (TryComp<FixturesComponent>(entity, out var fixtures))
+            if (TryComp<PhysicsComponent>(entity, out var body))
             {
-                (layer, mask) = _physics.GetHardCollision(entity, fixtures);
+                (layer, mask) = _physics.GetHardCollision(entity, body);
             }
 
             var request = new BFSPathRequest(maxRange, limit, start.Coordinates, flags, layer, mask, cancelToken);
@@ -430,9 +430,9 @@ namespace Content.Server.NPC.Pathfinding
             var layer = 0;
             var mask = 0;
 
-            if (TryComp<FixturesComponent>(entity, out var fixtures))
+            if (TryComp<PhysicsComponent>(entity, out var body))
             {
-                (layer, mask) = _physics.GetHardCollision(entity, fixtures);
+                (layer, mask) = _physics.GetHardCollision(entity, body);
             }
 
             return new AStarPathRequest(start, end, flags, range, layer, mask, cancelToken);

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -63,12 +63,11 @@ public sealed partial class NPCSteeringSystem
 
         if (ents.Count > 0)
         {
-            var fixtures = _fixturesQuery.GetComponent(uid);
             var physics = _physicsQuery.GetComponent(uid);
 
             foreach (var intersecting in ents)
             {
-                if (!_physics.IsCurrentlyHardCollidable((uid, fixtures, physics), intersecting))
+                if (!_physics.IsCurrentlyHardCollidable((uid, physics), intersecting))
                 {
                     continue;
                 }

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Obstacles.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Obstacles.cs
@@ -46,9 +46,9 @@ public sealed partial class NPCSteeringSystem
         var layer = 0;
         var mask = 0;
 
-        if (TryComp<FixturesComponent>(uid, out var manager))
+        if (TryComp<PhysicsComponent>(uid, out var body))
         {
-            (layer, mask) = _physics.GetHardCollision(uid, manager);
+            (layer, mask) = _physics.GetHardCollision(uid, body);
         }
         else
         {

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -63,7 +63,6 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedCombatModeSystem _combat = default!;
 
-    private EntityQuery<FixturesComponent> _fixturesQuery;
     private EntityQuery<MovementSpeedModifierComponent> _modifierQuery;
     private EntityQuery<NpcFactionMemberComponent> _factionQuery;
     private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -92,7 +91,6 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
         base.Initialize();
 
         Log.Level = LogLevel.Info;
-        _fixturesQuery = GetEntityQuery<FixturesComponent>();
         _modifierQuery = GetEntityQuery<MovementSpeedModifierComponent>();
         _factionQuery = GetEntityQuery<NpcFactionMemberComponent>();
         _physicsQuery = GetEntityQuery<PhysicsComponent>();

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -24,6 +24,7 @@ using Robust.Shared.Console;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -51,8 +52,8 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
     [Dependency] private readonly ShuttleSystem _shuttles = default!;
 
     private EntityQuery<BiomeComponent> _biomeQuery;
-    private EntityQuery<FixturesComponent> _fixturesQuery;
     private EntityQuery<GhostComponent> _ghostQuery;
+    private EntityQuery<PhysicsComponent> _physicsQuery;
     private EntityQuery<TransformComponent> _xformQuery;
 
     private readonly HashSet<EntityUid> _handledEntities = new();
@@ -82,7 +83,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         base.Initialize();
         Log.Level = LogLevel.Debug;
         _biomeQuery = GetEntityQuery<BiomeComponent>();
-        _fixturesQuery = GetEntityQuery<FixturesComponent>();
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
         _ghostQuery = GetEntityQuery<GhostComponent>();
         _xformQuery = GetEntityQuery<TransformComponent>();
         SubscribeLocalEvent<BiomeComponent, MapInitEvent>(OnBiomeMapInit);
@@ -135,7 +136,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
 
             foreach (var grid in _mapManager.GetAllGrids(mapId))
             {
-                if (!_fixturesQuery.TryGetComponent(grid.Owner, out var fixtures))
+                if (!_physicsQuery.TryGetComponent(grid.Owner, out var fixtures))
                     continue;
 
                 // Don't want shuttles flying around now do we.

--- a/Content.Server/Physics/Controllers/ConveyorController.cs
+++ b/Content.Server/Physics/Controllers/ConveyorController.cs
@@ -17,11 +17,11 @@ namespace Content.Server.Physics.Controllers;
 
 public sealed class ConveyorController : SharedConveyorController
 {
-    [Dependency] private readonly FixtureSystem _fixtures = default!;
     [Dependency] private readonly DeviceLinkSystem _signalSystem = default!;
     [Dependency] private readonly MaterialReclaimerSystem _materialReclaimer = default!;
     [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
     public override void Initialize()
     {
@@ -45,7 +45,7 @@ public sealed class ConveyorController : SharedConveyorController
             var shape = new PolygonShape();
             shape.SetAsBox(0.55f, 0.55f);
 
-            _fixtures.TryCreateFixture(uid, shape, ConveyorFixture,
+            _physics.TryCreateFixture(uid, shape, ConveyorFixture,
                 collisionLayer: (int) (CollisionGroup.LowImpassable | CollisionGroup.MidImpassable |
                                        CollisionGroup.Impassable), hard: false, body: physics);
 
@@ -60,7 +60,7 @@ public sealed class ConveyorController : SharedConveyorController
         if (!TryComp<PhysicsComponent>(uid, out var physics))
             return;
 
-        _fixtures.DestroyFixture(uid, ConveyorFixture, body: physics);
+        _physics.DestroyFixture(uid, ConveyorFixture, body: physics);
     }
 
     private void OnBreakage(Entity<ConveyorComponent> ent, ref BreakageEventArgs args)

--- a/Content.Server/Salvage/RestrictedRangeSystem.cs
+++ b/Content.Server/Salvage/RestrictedRangeSystem.cs
@@ -11,7 +11,6 @@ namespace Content.Server.Salvage;
 
 public sealed class RestrictedRangeSystem : SharedRestrictedRangeSystem
 {
-    [Dependency] private readonly FixtureSystem _fixtures = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
     public override void Initialize()
@@ -32,7 +31,7 @@ public sealed class RestrictedRangeSystem : SharedRestrictedRangeSystem
         var cShape = new ChainShape();
         // Don't need it to be a perfect circle, just need it to be loosely accurate.
         cShape.CreateLoop(Vector2.Zero, range + 0.25f, false, count: 4);
-        _fixtures.TryCreateFixture(
+        _physics.TryCreateFixture(
             boundaryUid,
             cShape,
             "boundary",

--- a/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
@@ -43,7 +43,7 @@ public sealed partial class DockingSystem
         TransformComponent gridDockXform,
         Box2 shuttleAABB,
         Angle targetGridRotation,
-        FixturesComponent shuttleFixtures,
+        PhysicsComponent shuttleFixtures,
         Entity<MapGridComponent> gridEntity,
         bool isMap,
         out Matrix3x2 matty,
@@ -160,7 +160,7 @@ public sealed partial class DockingSystem
         var targetGridGrid = _gridQuery.GetComponent(targetGrid);
         var targetGridXform = _xformQuery.GetComponent(targetGrid);
         var targetGridAngle = _transform.GetWorldRotation(targetGridXform).Reduced();
-        var shuttleFixturesComp = Comp<FixturesComponent>(shuttleUid);
+        var shuttleBodyComp = Comp<PhysicsComponent>(shuttleUid);
         var shuttleAABB = _gridQuery.GetComponent(shuttleUid).LocalAABB;
 
         var isMap = HasComp<MapComponent>(targetGrid);
@@ -182,7 +182,7 @@ public sealed partial class DockingSystem
                             gridDock, gridXform,
                             shuttleAABB,
                             targetGridAngle,
-                            shuttleFixturesComp,
+                            shuttleBodyComp,
                             (targetGrid, targetGridGrid),
                             isMap,
                             out var matty,
@@ -235,7 +235,7 @@ public sealed partial class DockingSystem
                                     _xformQuery.GetComponent(otherGridUid),
                                     shuttleAABB,
                                     targetGridAngle,
-                                    shuttleFixturesComp,
+                                    shuttleBodyComp,
                                     (targetGrid, targetGridGrid),
                                     isMap,
                                     out _,
@@ -309,12 +309,12 @@ public sealed partial class DockingSystem
     /// <summary>
     /// Checks whether the shuttle can warp to the specified position.
     /// </summary>
-    private bool ValidSpawn(Entity<MapGridComponent> gridEntity, Matrix3x2 matty, Angle angle, FixturesComponent shuttleFixturesComp, bool isMap)
+    private bool ValidSpawn(Entity<MapGridComponent> gridEntity, Matrix3x2 matty, Angle angle, PhysicsComponent shuttleBodyComp, bool isMap)
     {
         var transform = new Transform(Vector2.Transform(Vector2.Zero, matty), angle);
 
         // Because some docking bounds are tight af need to check each chunk individually
-        foreach (var fix in shuttleFixturesComp.Fixtures.Values)
+        foreach (var fix in shuttleBodyComp.Fixtures.Values)
         {
             var polyShape = (PolygonShape)fix.Shape;
             var aabb = polyShape.ComputeAABB(transform, 0);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -956,9 +956,9 @@ public sealed partial class ShuttleSystem
     /// <summary>
     /// Flattens / deletes everything under the grid upon FTL.
     /// </summary>
-    private void Smimsh(EntityUid uid, FixturesComponent? manager = null, MapGridComponent? grid = null, TransformComponent? xform = null)
+    private void Smimsh(EntityUid uid, PhysicsComponent? body = null, MapGridComponent? grid = null, TransformComponent? xform = null)
     {
-        if (!Resolve(uid, ref manager, ref grid, ref xform) || xform.MapUid == null)
+        if (!Resolve(uid, ref body, ref grid, ref xform) || xform.MapUid == null)
             return;
 
         if (!TryComp(xform.MapUid, out BroadphaseComponent? lookup))
@@ -966,10 +966,10 @@ public sealed partial class ShuttleSystem
 
         // Flatten anything not parented to a grid.
         var transform = _physics.GetRelativePhysicsTransform((uid, xform), xform.MapUid.Value);
-        var aabbs = new List<Box2>(manager.Fixtures.Count);
+        var aabbs = new List<Box2>(body.Fixtures.Count);
         var tileSet = new List<(Vector2i, Tile)>();
 
-        foreach (var fixture in manager.Fixtures.Values)
+        foreach (var fixture in body.Fixtures.Values)
         {
             if (!fixture.Hard)
                 continue;

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -29,9 +29,9 @@ public sealed class ThrusterSystem : EntitySystem
     [Dependency] private readonly ITileDefinitionManager _tileDefManager = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly AmbientSoundSystem _ambient = default!;
-    [Dependency] private readonly FixtureSystem _fixtureSystem = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedPointLightSystem _light = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
     // Essentially whenever thruster enables we update the shuttle's available impulses which are used for movement.
@@ -295,7 +295,7 @@ public sealed class ThrusterSystem : EntitySystem
                 {
                     var shape = new PolygonShape();
                     shape.Set(component.BurnPoly);
-                    _fixtureSystem.TryCreateFixture(uid, shape, BurnFixture, hard: false, collisionLayer: (int)CollisionGroup.FullTileMask, body: physicsComponent);
+                    _physics.TryCreateFixture(uid, shape, BurnFixture, hard: false, collisionLayer: (int)CollisionGroup.FullTileMask, body: physicsComponent);
                 }
 
                 break;
@@ -410,7 +410,7 @@ public sealed class ThrusterSystem : EntitySystem
 
         if (EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent))
         {
-            _fixtureSystem.DestroyFixture(uid, BurnFixture, body: physicsComponent);
+            _physics.DestroyFixture(uid, BurnFixture, body: physicsComponent);
         }
 
         component.Colliding.Clear();

--- a/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
@@ -178,7 +178,7 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
                 continue;
 
             // See TODO above
-            if (_physicsQuery.TryComp(entity, out var otherBody) && !_physics.IsHardCollidable((uid, null, body), (entity, null, otherBody)))
+            if (_physicsQuery.TryComp(entity, out var otherBody) && !_physics.IsHardCollidable((uid, body), (entity, otherBody)))
                 continue;
 
             AttemptConsumeEntity(uid, entity, eventHorizon);

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/PhasingArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Systems/PhasingArtifactSystem.cs
@@ -25,12 +25,12 @@ public sealed class PhasingArtifactSystem : EntitySystem
 
     private void OnActivate(EntityUid uid, PhasingArtifactComponent component, ArtifactActivatedEvent args)
     {
-        if (!TryComp<FixturesComponent>(uid, out var fixtures))
+        if (!TryComp<PhysicsComponent>(uid, out var body))
             return;
 
-        foreach (var fixture in fixtures.Fixtures.Values)
+        foreach (var fixture in body.Fixtures.Values)
         {
-            _physics.SetHard(uid, fixture, false, fixtures);
+            _physics.SetHard(uid, fixture, false, body);
         }
     }
 }

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -29,7 +29,6 @@ public sealed partial class BlockingSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
     [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
-    [Dependency] private readonly FixtureSystem _fixtureSystem = default!;
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
@@ -206,7 +205,7 @@ public sealed partial class BlockingSystem : EntitySystem
 
         if (TryComp<PhysicsComponent>(user, out var physicsComponent))
         {
-            _fixtureSystem.TryCreateFixture(user,
+            _physics.TryCreateFixture(user,
                 component.Shape,
                 BlockingComponent.BlockFixtureID,
                 hard: true,
@@ -262,7 +261,7 @@ public sealed partial class BlockingSystem : EntitySystem
                 _transformSystem.Unanchor(user, xform);
 
             _actionsSystem.SetToggled(component.BlockingToggleActionEntity, false);
-            _fixtureSystem.DestroyFixture(user, BlockingComponent.BlockFixtureID, body: physicsComponent);
+            _physics.DestroyFixture(user, BlockingComponent.BlockFixtureID, body: physicsComponent);
             _physics.SetBodyType(user, blockingUserComponent.OriginalBodyType, body: physicsComponent);
             if (_gameTiming.IsFirstTimePredicted)
             {

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -74,7 +74,6 @@ namespace Content.Shared.Interaction
         [Dependency] private readonly ISharedChatManager _chat = default!;
 
         private EntityQuery<IgnoreUIRangeComponent> _ignoreUiRangeQuery;
-        private EntityQuery<FixturesComponent> _fixtureQuery;
         private EntityQuery<ItemComponent> _itemQuery;
         private EntityQuery<PhysicsComponent> _physicsQuery;
         private EntityQuery<HandsComponent> _handsQuery;
@@ -96,7 +95,6 @@ namespace Content.Shared.Interaction
         public override void Initialize()
         {
             _ignoreUiRangeQuery = GetEntityQuery<IgnoreUIRangeComponent>();
-            _fixtureQuery = GetEntityQuery<FixturesComponent>();
             _itemQuery = GetEntityQuery<ItemComponent>();
             _physicsQuery = GetEntityQuery<PhysicsComponent>();
             _handsQuery = GetEntityQuery<HandsComponent>();
@@ -740,12 +738,12 @@ namespace Content.Shared.Interaction
             // Alternatively we could check centre distances first though
             // that means we wouldn't be able to easily check overlap interactions.
             if (range > 0f &&
-                _fixtureQuery.TryComp(origin, out var fixtureA) &&
+                _physicsQuery.TryComp(origin, out var fixtureA) &&
                 // These fixture counts are stuff that has the component but no fixtures for <reasons> (e.g. buttons).
                 // At least until they get removed.
-                fixtureA.FixtureCount > 0 &&
-                _fixtureQuery.TryComp(other, out var fixtureB) &&
-                fixtureB.FixtureCount > 0 &&
+                fixtureA.Fixtures.Count > 0 &&
+                _physicsQuery.TryComp(other, out var fixtureB) &&
+                fixtureB.Fixtures.Count > 0 &&
                 Resolve(origin, ref origin.Comp))
             {
                 var (worldPosA, worldRotA) = origin.Comp.GetWorldPositionRotation();

--- a/Content.Shared/Maps/TurfSystem.cs
+++ b/Content.Shared/Maps/TurfSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Physics;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 
 namespace Content.Shared.Maps;
 
@@ -52,10 +53,10 @@ public sealed class TurfSystem : EntitySystem
         tileAabb = tileAabb.Translated(localPos);
 
         var intersectionArea = 0f;
-        var fixtureQuery = GetEntityQuery<FixturesComponent>();
+        var physicsQuery = GetEntityQuery<PhysicsComponent>();
         foreach (var ent in _entityLookup.GetEntitiesIntersecting(gridUid, worldBox, LookupFlags.Dynamic | LookupFlags.Static))
         {
-            if (!fixtureQuery.TryGetComponent(ent, out var fixtures))
+            if (!physicsQuery.TryGetComponent(ent, out var body))
                 continue;
 
             // get grid local coordinates
@@ -65,7 +66,7 @@ public sealed class TurfSystem : EntitySystem
 
             var xform = new Transform(pos, (float) rot.Theta);
 
-            foreach (var fixture in fixtures.Fixtures.Values)
+            foreach (var fixture in body.Fixtures.Values)
             {
                 if (!fixture.Hard)
                     continue;

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -25,6 +25,7 @@ using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Robust.Shared.Physics.Components;
 
 namespace Content.Shared.RCD.Systems;
 
@@ -419,9 +420,9 @@ public class RCDSystem : EntitySystem
                 return false;
             }
 
-            if (component.CachedPrototype.CollisionMask != CollisionGroup.None && TryComp<FixturesComponent>(ent, out var fixtures))
+            if (component.CachedPrototype.CollisionMask != CollisionGroup.None && TryComp<PhysicsComponent>(ent, out var body))
             {
-                foreach (var fixture in fixtures.Fixtures.Values)
+                foreach (var fixture in body.Fixtures.Values)
                 {
                     // Continue if no collision is possible
                     if (!fixture.Hard || fixture.CollisionLayer <= 0 || (fixture.CollisionLayer & (int) component.CachedPrototype.CollisionMask) == 0)

--- a/Content.Shared/Revenant/EntitySystems/SharedCorporealSystem.cs
+++ b/Content.Shared/Revenant/EntitySystems/SharedCorporealSystem.cs
@@ -3,6 +3,7 @@ using Robust.Shared.Physics;
 using System.Linq;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Revenant.Components;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared.Revenant.EntitySystems;
@@ -36,7 +37,7 @@ public abstract class SharedCorporealSystem : EntitySystem
     {
         _appearance.SetData(uid, RevenantVisuals.Corporeal, true);
 
-        if (TryComp<FixturesComponent>(uid, out var fixtures) && fixtures.FixtureCount >= 1)
+        if (TryComp<PhysicsComponent>(uid, out var fixtures) && fixtures.Fixtures.Count >= 1)
         {
             var fixture = fixtures.Fixtures.First();
 
@@ -50,7 +51,7 @@ public abstract class SharedCorporealSystem : EntitySystem
     {
         _appearance.SetData(uid, RevenantVisuals.Corporeal, false);
 
-        if (TryComp<FixturesComponent>(uid, out var fixtures) && fixtures.FixtureCount >= 1)
+        if (TryComp<PhysicsComponent>(uid, out var fixtures) && fixtures.Fixtures.Count >= 1)
         {
             var fixture = fixtures.Fixtures.First();
 

--- a/Content.Shared/Security/Systems/DeployableBarrierSystem.cs
+++ b/Content.Shared/Security/Systems/DeployableBarrierSystem.cs
@@ -8,7 +8,6 @@ namespace Content.Shared.Security.Systems;
 
 public sealed class DeployableBarrierSystem : EntitySystem
 {
-    [Dependency] private readonly FixtureSystem _fixtures = default!;
     [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly PullingSystem _pulling = default!;
@@ -39,7 +38,7 @@ public sealed class DeployableBarrierSystem : EntitySystem
             return;
 
         var transform = Transform(uid);
-        var fixture = _fixtures.GetFixtureOrNull(uid, component.FixtureId);
+        var fixture = _physics.GetFixtureOrNull(uid, component.FixtureId);
 
         if (isDeployed && transform.GridUid != null)
         {

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Rotation;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared.Standing
@@ -69,15 +70,15 @@ namespace Content.Shared.Standing
             _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Horizontal, appearance);
 
             // Change collision masks to allow going under certain entities like flaps and tables
-            if (TryComp(uid, out FixturesComponent? fixtureComponent))
+            if (TryComp(uid, out PhysicsComponent? body))
             {
-                foreach (var (key, fixture) in fixtureComponent.Fixtures)
+                foreach (var (key, fixture) in body.Fixtures)
                 {
                     if ((fixture.CollisionMask & StandingCollisionLayer) == 0)
                         continue;
 
                     standingState.ChangedFixtures.Add(key);
-                    _physics.SetCollisionMask(uid, key, fixture, fixture.CollisionMask & ~StandingCollisionLayer, manager: fixtureComponent);
+                    _physics.SetCollisionMask(uid, key, fixture, fixture.CollisionMask & ~StandingCollisionLayer, body: body);
                 }
             }
 
@@ -124,12 +125,12 @@ namespace Content.Shared.Standing
 
             _appearance.SetData(uid, RotationVisuals.RotationState, RotationState.Vertical, appearance);
 
-            if (TryComp(uid, out FixturesComponent? fixtureComponent))
+            if (TryComp(uid, out PhysicsComponent? body))
             {
                 foreach (var key in standingState.ChangedFixtures)
                 {
-                    if (fixtureComponent.Fixtures.TryGetValue(key, out var fixture))
-                        _physics.SetCollisionMask(uid, key, fixture, fixture.CollisionMask | StandingCollisionLayer, fixtureComponent);
+                    if (body.Fixtures.TryGetValue(key, out var fixture))
+                        _physics.SetCollisionMask(uid, key, fixture, fixture.CollisionMask | StandingCollisionLayer, body);
                 }
             }
             standingState.ChangedFixtures.Clear();

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -30,7 +30,7 @@ public sealed class StepTriggerSystem : EntitySystem
         if (!component.Active)
             return;
 
-        if (!TryComp(uid, out FixturesComponent? fixtures) || fixtures.FixtureCount == 0)
+        if (!TryComp(uid, out PhysicsComponent? fixtures) || fixtures.Fixtures.Count == 0)
             Log.Warning($"{ToPrettyString(uid)} has an active step trigger without any fixtures.");
 #endif
     }

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -23,6 +23,7 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -472,25 +473,25 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (!ResolveStorage(uid, ref component))
             return;
 
-        if (!component.IsCollidableWhenOpen && TryComp<FixturesComponent>(uid, out var fixtures) &&
-            fixtures.Fixtures.Count > 0)
+        if (!component.IsCollidableWhenOpen && TryComp<PhysicsComponent>(uid, out var body) &&
+            body.Fixtures.Count > 0)
         {
             // currently only works for single-fixture entities. If they have more than one fixture, then
             // RemovedMasks needs to be tracked separately for each fixture, using a fixture Id Dictionary. Also the
             // fixture IDs probably cant be automatically generated without causing issues, unless there is some
             // guarantee that they will get deserialized with the same auto-generated ID when saving+loading the map.
-            var fixture = fixtures.Fixtures.First();
+            var fixture = body.Fixtures.First();
 
             if (component.Open)
             {
                 component.RemovedMasks = fixture.Value.CollisionLayer & component.MasksToRemove;
                 _physics.SetCollisionLayer(uid, fixture.Key, fixture.Value, fixture.Value.CollisionLayer & ~component.MasksToRemove,
-                    manager: fixtures);
+                    body: body);
             }
             else
             {
                 _physics.SetCollisionLayer(uid, fixture.Key, fixture.Value, fixture.Value.CollisionLayer | component.RemovedMasks,
-                    manager: fixtures);
+                    body: body);
                 component.RemovedMasks = 0;
             }
         }

--- a/Content.Shared/Tools/Systems/WeldableSystem.cs
+++ b/Content.Shared/Tools/Systems/WeldableSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Tools.Components;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using LayerChangeOnWeldComponent = Content.Shared.Tools.Components.LayerChangeOnWeldComponent;
 
@@ -95,7 +96,7 @@ public sealed class WeldableSystem : EntitySystem
 
     private void OnWeldChanged(EntityUid uid, LayerChangeOnWeldComponent component, ref WeldableChangedEvent args)
     {
-        if (!TryComp<FixturesComponent>(uid, out var fixtures))
+        if (!TryComp<PhysicsComponent>(uid, out var fixtures))
             return;
 
         foreach (var (id, fixture) in fixtures.Fixtures)
@@ -103,11 +104,11 @@ public sealed class WeldableSystem : EntitySystem
             switch (args.IsWelded)
             {
                 case true when fixture.CollisionLayer == (int) component.UnWeldedLayer:
-                    _physics.SetCollisionLayer(uid, id, fixture, (int) component.WeldedLayer);
+                    _physics.SetCollisionLayer(uid, id, fixture, (int) component.WeldedLayer, body: fixtures);
                     break;
 
                 case false when fixture.CollisionLayer == (int) component.WeldedLayer:
-                    _physics.SetCollisionLayer(uid, id, fixture, (int) component.UnWeldedLayer);
+                    _physics.SetCollisionLayer(uid, id, fixture, (int) component.UnWeldedLayer, body: fixtures);
                     break;
             }
         }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedFlyBySoundSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedFlyBySoundSystem.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Weapons.Ranged.Systems;
 
 public abstract class SharedFlyBySoundSystem : EntitySystem
 {
-    [Dependency] private readonly FixtureSystem _fixtures = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
     public const string FlyByFixture = "fly-by";
 
@@ -31,7 +31,7 @@ public abstract class SharedFlyBySoundSystem : EntitySystem
 
         var shape = new PhysShapeCircle(component.Range);
 
-        _fixtures.TryCreateFixture(uid, shape, FlyByFixture, collisionLayer: (int) CollisionGroup.MobMask, hard: false, body: body);
+        _physics.TryCreateFixture(uid, shape, FlyByFixture, collisionLayer: (int) CollisionGroup.MobMask, hard: false, body: body);
     }
 
     private void OnShutdown(EntityUid uid, FlyBySoundComponent component, ComponentShutdown args)
@@ -42,6 +42,6 @@ public abstract class SharedFlyBySoundSystem : EntitySystem
             return;
         }
 
-        _fixtures.DestroyFixture(uid, FlyByFixture, body: body);
+        _physics.DestroyFixture(uid, FlyByFixture, body: body);
     }
 }

--- a/Resources/Maps/Dungeon/Templates/17x17.yml
+++ b/Resources/Maps/Dungeon/Templates/17x17.yml
@@ -37,8 +37,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/17x5.yml
+++ b/Resources/Maps/Dungeon/Templates/17x5.yml
@@ -29,8 +29,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/3x5.yml
+++ b/Resources/Maps/Dungeon/Templates/3x5.yml
@@ -25,8 +25,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/3x7.yml
+++ b/Resources/Maps/Dungeon/Templates/3x7.yml
@@ -25,8 +25,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/5x11.yml
+++ b/Resources/Maps/Dungeon/Templates/5x11.yml
@@ -37,8 +37,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/5x17.yml
+++ b/Resources/Maps/Dungeon/Templates/5x17.yml
@@ -29,8 +29,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/5x5.yml
+++ b/Resources/Maps/Dungeon/Templates/5x5.yml
@@ -25,8 +25,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/LargeArea2.yml
+++ b/Resources/Maps/Dungeon/Templates/LargeArea2.yml
@@ -38,8 +38,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/LargeArea3.yml
+++ b/Resources/Maps/Dungeon/Templates/LargeArea3.yml
@@ -38,8 +38,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/LargeArea4.yml
+++ b/Resources/Maps/Dungeon/Templates/LargeArea4.yml
@@ -38,8 +38,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/MediumArea2.yml
+++ b/Resources/Maps/Dungeon/Templates/MediumArea2.yml
@@ -30,8 +30,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/MediumArea3.yml
+++ b/Resources/Maps/Dungeon/Templates/MediumArea3.yml
@@ -30,8 +30,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/Templates/MediumArea4.yml
+++ b/Resources/Maps/Dungeon/Templates/MediumArea4.yml
@@ -30,8 +30,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Dungeon/experiment.yml
+++ b/Resources/Maps/Dungeon/experiment.yml
@@ -6840,28 +6840,28 @@ entities:
     - type: Transform
       pos: 0.5,47.5
       parent: 1653
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 718
     components:
     - type: Transform
       pos: 4.5,25.5
       parent: 1653
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 796
     components:
     - type: Transform
       pos: 8.5,24.5
       parent: 1653
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 896
     components:
     - type: Transform
       pos: 0.5,22.5
       parent: 1653
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FoamedAluminiumMetal
   entities:

--- a/Resources/Maps/Dungeon/lava_brig.yml
+++ b/Resources/Maps/Dungeon/lava_brig.yml
@@ -8082,7 +8082,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 8.5,28.5
       parent: 588
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 945
     components:
@@ -8090,7 +8090,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 10.5,28.5
       parent: 588
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloorLavaEntity
   entities:

--- a/Resources/Maps/Dungeon/snowy_labs.yml
+++ b/Resources/Maps/Dungeon/snowy_labs.yml
@@ -7652,7 +7652,7 @@ entities:
     - type: Transform
       pos: 0.5,22.5
       parent: 1653
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloraTreeSnow01
   entities:

--- a/Resources/Maps/Misc/terminal.yml
+++ b/Resources/Maps/Misc/terminal.yml
@@ -55,8 +55,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Empty

--- a/Resources/Maps/Nonstations/meteor-arena.yml
+++ b/Resources/Maps/Nonstations/meteor-arena.yml
@@ -59,8 +59,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Arena
@@ -515,7 +513,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 226
     components:
@@ -523,7 +521,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 227
     components:
@@ -531,7 +529,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 228
     components:
@@ -539,7 +537,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 229
     components:
@@ -547,7 +545,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -7.5,-2.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 230
     components:
@@ -555,7 +553,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 231
     components:
@@ -563,7 +561,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 6.5,-2.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 232
     components:
@@ -571,7 +569,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 233
     components:
@@ -579,7 +577,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 234
     components:
@@ -587,7 +585,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 235
     components:
@@ -595,7 +593,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -2.5,-7.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 236
     components:
@@ -603,7 +601,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 237
     components:
@@ -611,7 +609,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -6.5,-6.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 238
     components:
@@ -619,7 +617,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 5.5,-6.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 239
     components:
@@ -627,7 +625,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 240
     components:
@@ -635,7 +633,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -6.5,5.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloorLavaEntity
   entities:

--- a/Resources/Maps/Nonstations/nukieplanet.yml
+++ b/Resources/Maps/Nonstations/nukieplanet.yml
@@ -129,8 +129,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -10493,21 +10491,21 @@ entities:
     - type: Transform
       pos: -4.5,-2.5
       parent: 104
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 2438
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 104
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 2443
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 104
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloraRockSolid01
   entities:

--- a/Resources/Maps/Ruins/abandoned_outpost.yml
+++ b/Resources/Maps/Ruins/abandoned_outpost.yml
@@ -60,8 +60,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -921,7 +919,7 @@ entities:
     - type: Transform
       pos: 8.5,2.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FoodBowlBigTrash
   entities:

--- a/Resources/Maps/Ruins/biodome_satellite.yml
+++ b/Resources/Maps/Ruins/biodome_satellite.yml
@@ -62,8 +62,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Ruins/chunked_tcomms.yml
+++ b/Resources/Maps/Ruins/chunked_tcomms.yml
@@ -36,8 +36,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Ruins/derelict.yml
+++ b/Resources/Maps/Ruins/derelict.yml
@@ -165,8 +165,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Empty
@@ -5321,7 +5319,7 @@ entities:
       parent: 2
     - type: Lock
       locked: False
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -5354,7 +5352,7 @@ entities:
       parent: 2
     - type: Lock
       locked: False
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -5387,7 +5385,7 @@ entities:
       parent: 2
     - type: Lock
       locked: False
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -5420,7 +5418,7 @@ entities:
       parent: 2
     - type: Lock
       locked: False
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape

--- a/Resources/Maps/Ruins/djstation.yml
+++ b/Resources/Maps/Ruins/djstation.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Empty

--- a/Resources/Maps/Ruins/empty_flagship.yml
+++ b/Resources/Maps/Ruins/empty_flagship.yml
@@ -141,8 +141,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Ruins/old_ai_sat.yml
+++ b/Resources/Maps/Ruins/old_ai_sat.yml
@@ -71,8 +71,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Ruins/syndicate_dropship.yml
+++ b/Resources/Maps/Ruins/syndicate_dropship.yml
@@ -33,8 +33,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Ruins/whiteship_ancient.yml
+++ b/Resources/Maps/Ruins/whiteship_ancient.yml
@@ -45,8 +45,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Empty

--- a/Resources/Maps/Ruins/whiteship_bluespacejumper.yml
+++ b/Resources/Maps/Ruins/whiteship_bluespacejumper.yml
@@ -51,8 +51,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/asteroid-base.yml
+++ b/Resources/Maps/Salvage/asteroid-base.yml
@@ -45,8 +45,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/cargo-1.yml
+++ b/Resources/Maps/Salvage/cargo-1.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/engineering-chunk.yml
+++ b/Resources/Maps/Salvage/engineering-chunk.yml
@@ -59,8 +59,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/hauling-shuttle.yml
+++ b/Resources/Maps/Salvage/hauling-shuttle.yml
@@ -49,8 +49,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/meatball.yml
+++ b/Resources/Maps/Salvage/meatball.yml
@@ -38,8 +38,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/medium-1.yml
+++ b/Resources/Maps/Salvage/medium-1.yml
@@ -44,8 +44,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -654,7 +652,7 @@ entities:
     - type: Transform
       pos: 5.5,-1.5
       parent: 85
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: GasPassiveVent
   entities:

--- a/Resources/Maps/Salvage/medium-crashed-shuttle.yml
+++ b/Resources/Maps/Salvage/medium-crashed-shuttle.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/medium-dock.yml
+++ b/Resources/Maps/Salvage/medium-dock.yml
@@ -39,8 +39,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/medium-library.yml
+++ b/Resources/Maps/Salvage/medium-library.yml
@@ -43,8 +43,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/medium-pet-hospital.yml
+++ b/Resources/Maps/Salvage/medium-pet-hospital.yml
@@ -43,8 +43,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/medium-pirate.yml
+++ b/Resources/Maps/Salvage/medium-pirate.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/medium-ruined-emergency-shuttle.yml
+++ b/Resources/Maps/Salvage/medium-ruined-emergency-shuttle.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/medium-silent-orchestra.yml
+++ b/Resources/Maps/Salvage/medium-silent-orchestra.yml
@@ -43,8 +43,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/medium-template.yml
+++ b/Resources/Maps/Salvage/medium-template.yml
@@ -38,8 +38,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/medium-vault-1.yml
+++ b/Resources/Maps/Salvage/medium-vault-1.yml
@@ -43,8 +43,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/outpost-arm.yml
+++ b/Resources/Maps/Salvage/outpost-arm.yml
@@ -53,8 +53,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/ruin-cargo-salvage.yml
+++ b/Resources/Maps/Salvage/ruin-cargo-salvage.yml
@@ -50,8 +50,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/security-chunk.yml
+++ b/Resources/Maps/Salvage/security-chunk.yml
@@ -45,8 +45,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/small-1.yml
+++ b/Resources/Maps/Salvage/small-1.yml
@@ -41,8 +41,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/small-2.yml
+++ b/Resources/Maps/Salvage/small-2.yml
@@ -40,8 +40,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/small-3.yml
+++ b/Resources/Maps/Salvage/small-3.yml
@@ -39,8 +39,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/small-4.yml
+++ b/Resources/Maps/Salvage/small-4.yml
@@ -39,8 +39,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/small-a-1.yml
+++ b/Resources/Maps/Salvage/small-a-1.yml
@@ -40,8 +40,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/small-ai-survey-drone.yml
+++ b/Resources/Maps/Salvage/small-ai-survey-drone.yml
@@ -41,8 +41,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/small-cargo.yml
+++ b/Resources/Maps/Salvage/small-cargo.yml
@@ -45,8 +45,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/small-chapel.yml
+++ b/Resources/Maps/Salvage/small-chapel.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/small-chef.yml
+++ b/Resources/Maps/Salvage/small-chef.yml
@@ -44,8 +44,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/small-party.yml
+++ b/Resources/Maps/Salvage/small-party.yml
@@ -43,8 +43,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/small-ship-1.yml
+++ b/Resources/Maps/Salvage/small-ship-1.yml
@@ -37,8 +37,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/small-syndicate.yml
+++ b/Resources/Maps/Salvage/small-syndicate.yml
@@ -45,8 +45,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/small-template.yml
+++ b/Resources/Maps/Salvage/small-template.yml
@@ -38,8 +38,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/small-tesla.yml
+++ b/Resources/Maps/Salvage/small-tesla.yml
@@ -39,8 +39,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/stationstation.yml
+++ b/Resources/Maps/Salvage/stationstation.yml
@@ -77,8 +77,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -1338,7 +1336,7 @@ entities:
     - type: Transform
       pos: 25.5,7.5
       parent: 179
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FoodTinBeansTrash
   entities:

--- a/Resources/Maps/Salvage/tick-colony.yml
+++ b/Resources/Maps/Salvage/tick-colony.yml
@@ -40,8 +40,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Salvage/vegan-meatball.yml
+++ b/Resources/Maps/Salvage/vegan-meatball.yml
@@ -39,8 +39,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Salvage/wh-salvage.yml
+++ b/Resources/Maps/Salvage/wh-salvage.yml
@@ -44,8 +44,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Shuttles/ShuttleEvent/cruiser.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/cruiser.yml
@@ -54,8 +54,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/ShuttleEvent/cryptid.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/cryptid.yml
@@ -45,8 +45,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/disaster_evacpod.yml
@@ -40,8 +40,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/ShuttleEvent/eternal.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/eternal.yml
@@ -44,8 +44,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/ShuttleEvent/flatline.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/flatline.yml
@@ -44,8 +44,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -960,7 +958,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: GasPassiveVent
   entities:

--- a/Resources/Maps/Shuttles/ShuttleEvent/gym.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/gym.yml
@@ -47,8 +47,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/ShuttleEvent/honki.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/honki.yml
@@ -41,8 +41,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/ShuttleEvent/incorporation.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/incorporation.yml
@@ -60,8 +60,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -904,7 +902,7 @@ entities:
         - 0
       open: True
       removedMasks: 20
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape

--- a/Resources/Maps/Shuttles/ShuttleEvent/instigator.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/instigator.yml
@@ -43,8 +43,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/ShuttleEvent/joe.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/joe.yml
@@ -44,8 +44,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -1338,7 +1336,7 @@ entities:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FoodBakedBunHoney
   entities:

--- a/Resources/Maps/Shuttles/ShuttleEvent/lambordeere.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/lambordeere.yml
@@ -46,8 +46,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -615,7 +613,7 @@ entities:
     - type: EntityStorage
       open: True
       removedMasks: 28
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape

--- a/Resources/Maps/Shuttles/ShuttleEvent/lost_cargo.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/lost_cargo.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Shuttles/ShuttleEvent/manowar.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/manowar.yml
@@ -43,8 +43,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/ShuttleEvent/meatzone.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/meatzone.yml
@@ -46,8 +46,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -1325,7 +1323,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 9.5,-1.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FoodBreadBun
   entities:

--- a/Resources/Maps/Shuttles/ShuttleEvent/microshuttle.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/microshuttle.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/ShuttleEvent/quark.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/quark.yml
@@ -46,8 +46,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -709,7 +707,7 @@ entities:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -1479,8 +1477,8 @@ entities:
 
                                            [bold]Crew of the NT-Quark[/bold]
 
-             [bold]Nuclear containment breach detected on long range 
-                 halcyon scanners. Seek immediate shelter. Avoid 
+             [bold]Nuclear containment breach detected on long range
+                 halcyon scanners. Seek immediate shelter. Avoid
                          contaminated materials. Do not panic.[/bold]
 
                               [color=red][bold]Alpha decay rates indicate estimated
@@ -1496,7 +1494,7 @@ entities:
       solutions: null
       containers:
       - food
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape

--- a/Resources/Maps/Shuttles/ShuttleEvent/spacebus.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/spacebus.yml
@@ -43,8 +43,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -336,7 +334,7 @@ entities:
     - type: EntityStorage
       open: True
       removedMasks: 20
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape

--- a/Resources/Maps/Shuttles/ShuttleEvent/striker.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/striker.yml
@@ -43,8 +43,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Shuttles/ShuttleEvent/syndie_evacpod.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/syndie_evacpod.yml
@@ -43,8 +43,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/traveling_china_cuisine.yml
@@ -51,8 +51,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/arrivals.yml
+++ b/Resources/Maps/Shuttles/arrivals.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Empty

--- a/Resources/Maps/Shuttles/briggle.yml
+++ b/Resources/Maps/Shuttles/briggle.yml
@@ -44,8 +44,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/cargo.yml
+++ b/Resources/Maps/Shuttles/cargo.yml
@@ -43,8 +43,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Shuttles/cargo_core.yml
+++ b/Resources/Maps/Shuttles/cargo_core.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/cargo_fland.yml
+++ b/Resources/Maps/Shuttles/cargo_fland.yml
@@ -35,8 +35,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/dart.yml
+++ b/Resources/Maps/Shuttles/dart.yml
@@ -61,8 +61,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle
@@ -3130,14 +3128,14 @@ entities:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 786
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FoodBoxPizzaFilled
   entities:

--- a/Resources/Maps/Shuttles/emergency.yml
+++ b/Resources/Maps/Shuttles/emergency.yml
@@ -44,8 +44,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: DeviceNetwork
       configurators: []

--- a/Resources/Maps/Shuttles/emergency_accordia.yml
+++ b/Resources/Maps/Shuttles/emergency_accordia.yml
@@ -63,8 +63,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -3061,7 +3059,7 @@ entities:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FolderSpawner
   entities:

--- a/Resources/Maps/Shuttles/emergency_amber.yml
+++ b/Resources/Maps/Shuttles/emergency_amber.yml
@@ -44,8 +44,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -2396,7 +2394,7 @@ entities:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FoodBoxDonut
   entities:

--- a/Resources/Maps/Shuttles/emergency_box.yml
+++ b/Resources/Maps/Shuttles/emergency_box.yml
@@ -51,8 +51,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/emergency_cluster.yml
+++ b/Resources/Maps/Shuttles/emergency_cluster.yml
@@ -54,8 +54,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/emergency_courser.yml
+++ b/Resources/Maps/Shuttles/emergency_courser.yml
@@ -52,8 +52,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle

--- a/Resources/Maps/Shuttles/emergency_delta.yml
+++ b/Resources/Maps/Shuttles/emergency_delta.yml
@@ -57,8 +57,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/emergency_lox.yml
+++ b/Resources/Maps/Shuttles/emergency_lox.yml
@@ -60,8 +60,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Shuttles/emergency_meta.yml
+++ b/Resources/Maps/Shuttles/emergency_meta.yml
@@ -57,8 +57,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -4239,8 +4237,7 @@ entities:
     - type: Transform
       parent: 122
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -4279,8 +4276,7 @@ entities:
     - type: Transform
       parent: 125
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -4319,8 +4315,7 @@ entities:
     - type: Transform
       parent: 125
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -4359,8 +4354,7 @@ entities:
     - type: Transform
       parent: 129
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -4399,8 +4393,7 @@ entities:
     - type: Transform
       parent: 129
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -4439,8 +4432,7 @@ entities:
     - type: Transform
       parent: 726
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -4479,8 +4471,7 @@ entities:
     - type: Transform
       parent: 726
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -4519,8 +4510,7 @@ entities:
     - type: Transform
       parent: 726
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -4559,8 +4549,7 @@ entities:
     - type: Transform
       parent: 726
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -4599,8 +4588,7 @@ entities:
     - type: Transform
       parent: 726
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -4666,8 +4654,7 @@ entities:
     - type: Transform
       parent: 122
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -4706,8 +4693,7 @@ entities:
     - type: Transform
       parent: 125
     - type: Physics
-      canCollide: False
-    - type: Fixtures
+      canCollide: false
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -6451,7 +6437,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 22.5,-5.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -6513,7 +6499,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 22.5,-2.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -6575,7 +6561,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 22.5,-3.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -6648,7 +6634,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 22.5,-0.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -6775,7 +6761,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -6837,7 +6823,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,-8.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -6921,7 +6907,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape

--- a/Resources/Maps/Shuttles/emergency_omega.yml
+++ b/Resources/Maps/Shuttles/emergency_omega.yml
@@ -45,8 +45,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Shuttles/emergency_raven.yml
+++ b/Resources/Maps/Shuttles/emergency_raven.yml
@@ -62,8 +62,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle
@@ -7880,7 +7878,7 @@ entities:
     - type: Transform
       pos: 9.5,-13.5
       parent: 1
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloraTree03
   entities:

--- a/Resources/Maps/Shuttles/emergency_rod.yml
+++ b/Resources/Maps/Shuttles/emergency_rod.yml
@@ -56,8 +56,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/emergency_wode.yml
+++ b/Resources/Maps/Shuttles/emergency_wode.yml
@@ -57,8 +57,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/escape_pod_small.yml
+++ b/Resources/Maps/Shuttles/escape_pod_small.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Empty

--- a/Resources/Maps/Shuttles/infiltrator.yml
+++ b/Resources/Maps/Shuttles/infiltrator.yml
@@ -55,7 +55,6 @@ entities:
       linearDamping: 0.05
       fixedRotation: False
       bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -1875,7 +1874,6 @@ entities:
       parent: 1
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 252
     components:
@@ -1885,7 +1883,6 @@ entities:
       parent: 1
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
 - proto: Carpet
   entities:

--- a/Resources/Maps/Shuttles/mining.yml
+++ b/Resources/Maps/Shuttles/mining.yml
@@ -42,8 +42,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: SalvageShuttle
     - type: Gravity

--- a/Resources/Maps/Shuttles/pirate.yml
+++ b/Resources/Maps/Shuttles/pirate.yml
@@ -49,8 +49,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -1677,7 +1675,6 @@ entities:
       parent: 1
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
 - proto: CarpetBlack
   entities:

--- a/Resources/Maps/Shuttles/shittle.yml
+++ b/Resources/Maps/Shuttles/shittle.yml
@@ -36,8 +36,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/trading_outpost.yml
+++ b/Resources/Maps/Shuttles/trading_outpost.yml
@@ -59,8 +59,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/Shuttles/wizard.yml
+++ b/Resources/Maps/Shuttles/wizard.yml
@@ -61,8 +61,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle
@@ -2139,7 +2137,7 @@ entities:
     - type: Transform
       pos: 4.5,-11.5
       parent: 768
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloraRockSolid01
   entities:

--- a/Resources/Maps/Test/Breathing/3by3-20oxy-80nit.yml
+++ b/Resources/Maps/Test/Breathing/3by3-20oxy-80nit.yml
@@ -36,8 +36,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: GridAtmosphere
       version: 2

--- a/Resources/Maps/Test/admin_test_arena.yml
+++ b/Resources/Maps/Test/admin_test_arena.yml
@@ -39,8 +39,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Test/dev_map.yml
+++ b/Resources/Maps/Test/dev_map.yml
@@ -84,8 +84,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -5200,7 +5198,7 @@ entities:
     - type: Transform
       pos: -8.5,7.5
       parent: 179
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
     - type: Airtight
       noAirWhenFullyAirBlocked: True
@@ -5211,7 +5209,7 @@ entities:
     - type: Transform
       pos: -10.5,7.5
       parent: 179
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
     - type: Airtight
       noAirWhenFullyAirBlocked: True
@@ -5222,7 +5220,7 @@ entities:
     - type: Transform
       pos: -9.5,7.5
       parent: 179
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
     - type: Airtight
       noAirWhenFullyAirBlocked: True
@@ -5242,7 +5240,7 @@ entities:
     - type: Transform
       pos: -13.5,2.5
       parent: 179
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
     missingComponents:
     - TimedDespawn
@@ -5251,7 +5249,7 @@ entities:
     - type: Transform
       pos: -13.5,1.5
       parent: 179
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
     missingComponents:
     - TimedDespawn

--- a/Resources/Maps/Test/empty.yml
+++ b/Resources/Maps/Test/empty.yml
@@ -24,8 +24,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Empty

--- a/Resources/Maps/Test/floor3x3.yml
+++ b/Resources/Maps/Test/floor3x3.yml
@@ -37,8 +37,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Test/npc_test_map.yml
+++ b/Resources/Maps/Test/npc_test_map.yml
@@ -65,8 +65,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -286,8 +284,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier

--- a/Resources/Maps/Test/test_teg.yml
+++ b/Resources/Maps/Test/test_teg.yml
@@ -51,8 +51,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid

--- a/Resources/Maps/amber.yml
+++ b/Resources/Maps/amber.yml
@@ -427,8 +427,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -56699,7 +56697,7 @@ entities:
     - type: Transform
       pos: -2.5,-32.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -67159,21 +67157,21 @@ entities:
     - type: Transform
       pos: -51.5,-33.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 297
     components:
     - type: Transform
       pos: -51.5,-27.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 712
     components:
     - type: Transform
       pos: -43.5,-47.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 2688
     components:
@@ -67181,21 +67179,21 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,-31.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 3142
     components:
     - type: Transform
       pos: -47.5,-31.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 4108
     components:
     - type: Transform
       pos: -30.5,-35.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 4366
     components:
@@ -67203,14 +67201,14 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 38.5,-28.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 4655
     components:
     - type: Transform
       pos: -17.5,-34.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 8162
     components:
@@ -67218,14 +67216,14 @@ entities:
       rot: 3.141592653589793 rad
       pos: -49.5,-45.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 9416
     components:
     - type: Transform
       pos: 28.5,0.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 9834
     components:
@@ -67233,21 +67231,21 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -22.5,-55.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 13041
     components:
     - type: Transform
       pos: -36.5,-2.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 14495
     components:
     - type: Transform
       pos: -40.5,1.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 15897
     components:
@@ -67255,7 +67253,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,-43.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloorTileItemBar
   entities:

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -489,8 +489,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Bagel
@@ -9484,8 +9482,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: Shuttle
@@ -49150,7 +49146,6 @@ entities:
       parent: 60
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 3725
     components:
@@ -49177,7 +49172,6 @@ entities:
       parent: 60
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 15732
     components:
@@ -49186,7 +49180,6 @@ entities:
       parent: 60
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 15733
     components:
@@ -49195,7 +49188,6 @@ entities:
       parent: 60
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 16345
     components:
@@ -49205,7 +49197,6 @@ entities:
       parent: 60
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 17936
     components:
@@ -72842,63 +72833,63 @@ entities:
     - type: Transform
       pos: 24.5,-27.5
       parent: 60
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 9044
     components:
     - type: Transform
       pos: -6.5,-27.5
       parent: 60
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 12634
     components:
     - type: Transform
       pos: 39.5,-28.5
       parent: 60
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 13492
     components:
     - type: Transform
       pos: 20.5,14.5
       parent: 60
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 13567
     components:
     - type: Transform
       pos: -10.5,-20.5
       parent: 60
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 18254
     components:
     - type: Transform
       pos: -2.5,-11.5
       parent: 60
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 19872
     components:
     - type: Transform
       pos: 40.5,-5.5
       parent: 60
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 19874
     components:
     - type: Transform
       pos: -3.5,-26.5
       parent: 60
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 24158
     components:
     - type: Transform
       pos: -41.5,-1.5
       parent: 60
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloorTileItemArcadeBlue
   entities:

--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -489,8 +489,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Boxstation
@@ -9045,8 +9043,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -86050,56 +86046,56 @@ entities:
     - type: Transform
       pos: 24.5,-32.5
       parent: 8364
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 3267
     components:
     - type: Transform
       pos: 20.5,-18.5
       parent: 8364
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 10643
     components:
     - type: Transform
       pos: 18.5,6.5
       parent: 8364
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 10645
     components:
     - type: Transform
       pos: 10.5,-22.5
       parent: 8364
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 10742
     components:
     - type: Transform
       pos: 17.5,5.5
       parent: 8364
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 14459
     components:
     - type: Transform
       pos: -50.5,-6.5
       parent: 8364
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 26044
     components:
     - type: Transform
       pos: 38.5,-1.5
       parent: 8364
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 26631
     components:
     - type: Transform
       pos: 5.5,-34.5
       parent: 8364
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloorTileItemArcadeBlue2
   entities:

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -157,8 +157,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: centcomm
@@ -21248,35 +21246,35 @@ entities:
     - type: Transform
       pos: -20.5,15.5
       parent: 1668
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 6622
     components:
     - type: Transform
       pos: 12.5,-16.5
       parent: 1668
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 6623
     components:
     - type: Transform
       pos: -16.5,-33.5
       parent: 1668
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 6718
     components:
     - type: Transform
       pos: -8.5,-22.5
       parent: 1668
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 6876
     components:
     - type: Transform
       pos: 20.5,-25.5
       parent: 1668
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FoodBoxDonkpocketPizza
   entities:

--- a/Resources/Maps/core.yml
+++ b/Resources/Maps/core.yml
@@ -357,8 +357,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -11740,8 +11738,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -75919,7 +75915,7 @@ entities:
     - type: Transform
       pos: 37.5,-22.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 1073
     components:
@@ -75927,28 +75923,28 @@ entities:
       rot: 3.141592653589793 rad
       pos: -14.5,-23.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 1074
     components:
     - type: Transform
       pos: -34.5,-17.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 4769
     components:
     - type: Transform
       pos: -43.5,16.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 5276
     components:
     - type: Transform
       pos: -0.5,50.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 5287
     components:
@@ -75956,7 +75952,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -4.5,40.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 5288
     components:
@@ -75964,7 +75960,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,40.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 6801
     components:
@@ -75972,42 +75968,42 @@ entities:
       rot: 3.141592653589793 rad
       pos: 52.5,-9.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 6927
     components:
     - type: Transform
       pos: 59.5,17.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 8241
     components:
     - type: Transform
       pos: 14.5,26.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 15990
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 16473
     components:
     - type: Transform
       pos: -55.5,-35.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 16619
     components:
     - type: Transform
       pos: 64.5,-25.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 17482
     components:
@@ -76015,14 +76011,14 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 43.5,14.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 17589
     components:
     - type: Transform
       pos: 45.5,-30.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloorTileItemCarpetClown
   entities:
@@ -106161,11 +106157,11 @@ entities:
         After several simulations where Superconducting Magnetic Energy Storage units were drained from the main system from [italic]a variety[/italic] of user errors and other shenanigans, it has been determined that the Singularity should be put on its own power loop, disconnected from the main station. The upsides of this include but are not limited to:
 
 
-        [bold]1.[/bold] Limited external forces from the containments power. 
+        [bold]1.[/bold] Limited external forces from the containments power.
 
-        [bold]2.[/bold] An "early warning" system, if you see JUST the PA room run out of power, you know there is an issue. 
+        [bold]2.[/bold] An "early warning" system, if you see JUST the PA room run out of power, you know there is an issue.
 
-        [bold]3.[/bold] Due to being on its own small loop, its much easier to spot faults in the system. 
+        [bold]3.[/bold] Due to being on its own small loop, its much easier to spot faults in the system.
 
 
         [italic]While we have listed the upsides we also acknowledge the downside,[/italic] for it being on its own loop you will need an external force if the system "runs out of juice". Our recommendation for this is simply attaching a generator to said SMES and letting it get to full charge before continuing operations but as said from another of our technicians... "just attach it to the main grid for like, a hot moment, and kickstart the thing!"
@@ -106177,7 +106173,7 @@ entities:
       solutions: null
       containers:
       - food
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -106248,7 +106244,7 @@ entities:
       solutions: null
       containers:
       - food
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape

--- a/Resources/Maps/loop.yml
+++ b/Resources/Maps/loop.yml
@@ -335,8 +335,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -49377,28 +49375,28 @@ entities:
     - type: Transform
       pos: -37.5,31.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 7433
     components:
     - type: Transform
       pos: -59.5,31.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 7634
     components:
     - type: Transform
       pos: -48.5,51.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 9696
     components:
     - type: Transform
       pos: -34.5,67.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloraTreeChristmas01
   entities:

--- a/Resources/Maps/marathon.yml
+++ b/Resources/Maps/marathon.yml
@@ -426,8 +426,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -44237,7 +44235,6 @@ entities:
       parent: 30
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 16264
     components:
@@ -44247,7 +44244,6 @@ entities:
       parent: 30
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 21949
     components:
@@ -65634,14 +65630,14 @@ entities:
     - type: Transform
       pos: -23.5,-5.5
       parent: 30
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 8547
     components:
     - type: Transform
       pos: -25.5,39.5
       parent: 30
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 10592
     components:
@@ -65649,7 +65645,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -15.5,-47.5
       parent: 30
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 13752
     components:
@@ -65657,7 +65653,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -43.5,64.5
       parent: 30
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 14330
     components:
@@ -65665,35 +65661,35 @@ entities:
       rot: 3.141592653589793 rad
       pos: 12.5,10.5
       parent: 30
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 20458
     components:
     - type: Transform
       pos: -17.5,15.5
       parent: 30
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 20459
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 30
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 20460
     components:
     - type: Transform
       pos: -8.5,-11.5
       parent: 30
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 20461
     components:
     - type: Transform
       pos: -31.5,9.5
       parent: 30
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloorTileItemEighties
   entities:

--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -472,8 +472,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -8674,8 +8672,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -75483,49 +75479,49 @@ entities:
     - type: Transform
       pos: 6.5,2.5
       parent: 5350
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 3157
     components:
     - type: Transform
       pos: 35.5,-16.5
       parent: 5350
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 5342
     components:
     - type: Transform
       pos: -16.5,-44.5
       parent: 5350
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 7100
     components:
     - type: Transform
       pos: -14.5,57.5
       parent: 5350
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 9500
     components:
     - type: Transform
       pos: -26.5,27.5
       parent: 5350
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 10401
     components:
     - type: Transform
       pos: -17.5,-24.5
       parent: 5350
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 12708
     components:
     - type: Transform
       pos: 28.5,34.5
       parent: 5350
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloorTileItemEighties
   entities:

--- a/Resources/Maps/oasis.yml
+++ b/Resources/Maps/oasis.yml
@@ -425,8 +425,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -8648,8 +8646,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -36723,23 +36719,23 @@ entities:
         [head=2][color=darkgrey][bold]Troubleshooting[/bold][/color][/head]
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The dock doesn’t respond when you approach.[/bolditalic]  
+        The dock doesn’t respond when you approach.[/bolditalic]
 
         Solution: It’s just being shy. Give it some encouragement by knocking lightly on the hull, or jostling the [color=darkorange][bolditalic]Aether Coil Modulator[/bolditalic][/color]. If no response, consult the  [color=blue][bold]Technical Support AI[/bold][/color] (usually known as "Door Stuck").
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The shuttle is stuck halfway through the docking process.[/bolditalic]  
+        The shuttle is stuck halfway through the docking process.[/bolditalic]
 
         Solution: This is an unfortunate but expected outcome. Reboot the dock, reattempt the process, and pray. Alternatively, try "tugging" the shuttle out, but be prepared for the consequences.
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The dock has *disengaged itself* mid-operation.[/bolditalic]  
+        The dock has *disengaged itself* mid-operation.[/bolditalic]
 
         Solution: This is a feature of the  [color=darkblue][bold]NanoTrasen Smart Dock Mk VII™[/bold][/color], called the  [color=darkorange][bolditalic]Premature Release Safety Protocol™[/bolditalic][/color]. It's designed to keep you on your toes. Simply re-dock and hope it doesn’t happen again (spoiler: it will).
 
@@ -36770,17 +36766,17 @@ entities:
         [head=2][color=darkgrey][bold]FAQ: Frequently Avoided Questions[/bold][/color][/head]
 
 
-        [bolditalic]Q: What do I do if the dock’s lights go out suddenly?[/bolditalic]  
+        [bolditalic]Q: What do I do if the dock’s lights go out suddenly?[/bolditalic]
 
         A: Nothing. Just accept the darkness. The dock has either entered [color=darkorange][bolditalic]Sleep Mode™[/bolditalic][/color], or something unspeakable is about to happen.
 
 
-        [bolditalic]Q: Why does the dock occasionally whisper my name?[/bolditalic]  
+        [bolditalic]Q: Why does the dock occasionally whisper my name?[/bolditalic]
 
         A: The dock is semi-sentient and enjoys toying with your mental state. We suggest playing along until it decides you’re no longer amusing.
 
 
-        [bolditalic]Q: How do I know if the docking process is complete?[/bolditalic]  
+        [bolditalic]Q: How do I know if the docking process is complete?[/bolditalic]
 
         A: You'll know it's done when your shuttle stops shaking violently and the alarms stop blaring. Or when you black out—whichever comes first.
 
@@ -36829,23 +36825,23 @@ entities:
         [head=2][color=darkgrey][bold]Troubleshooting[/bold][/color][/head]
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The dock doesn’t respond when you approach.[/bolditalic]  
+        The dock doesn’t respond when you approach.[/bolditalic]
 
         Solution: It’s just being shy. Give it some encouragement by knocking lightly on the hull, or jostling the [color=darkorange][bolditalic]Aether Coil Modulator[/bolditalic][/color]. If no response, consult the  [color=blue][bold]Technical Support AI[/bold][/color] (usually known as "Door Stuck").
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The shuttle is stuck halfway through the docking process.[/bolditalic]  
+        The shuttle is stuck halfway through the docking process.[/bolditalic]
 
         Solution: This is an unfortunate but expected outcome. Reboot the dock, reattempt the process, and pray. Alternatively, try "tugging" the shuttle out, but be prepared for the consequences.
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The dock has *disengaged itself* mid-operation.[/bolditalic]  
+        The dock has *disengaged itself* mid-operation.[/bolditalic]
 
         Solution: This is a feature of the  [color=darkblue][bold]NanoTrasen Smart Dock Mk VII™[/bold][/color], called the  [color=darkorange][bolditalic]Premature Release Safety Protocol™[/bolditalic][/color]. It's designed to keep you on your toes. Simply re-dock and hope it doesn’t happen again (spoiler: it will).
 
@@ -36876,17 +36872,17 @@ entities:
         [head=2][color=darkgrey][bold]FAQ: Frequently Avoided Questions[/bold][/color][/head]
 
 
-        [bolditalic]Q: What do I do if the dock’s lights go out suddenly?[/bolditalic]  
+        [bolditalic]Q: What do I do if the dock’s lights go out suddenly?[/bolditalic]
 
         A: Nothing. Just accept the darkness. The dock has either entered [color=darkorange][bolditalic]Sleep Mode™[/bolditalic][/color], or something unspeakable is about to happen.
 
 
-        [bolditalic]Q: Why does the dock occasionally whisper my name?[/bolditalic]  
+        [bolditalic]Q: Why does the dock occasionally whisper my name?[/bolditalic]
 
         A: The dock is semi-sentient and enjoys toying with your mental state. We suggest playing along until it decides you’re no longer amusing.
 
 
-        [bolditalic]Q: How do I know if the docking process is complete?[/bolditalic]  
+        [bolditalic]Q: How do I know if the docking process is complete?[/bolditalic]
 
         A: You'll know it's done when your shuttle stops shaking violently and the alarms stop blaring. Or when you black out—whichever comes first.
 
@@ -36935,23 +36931,23 @@ entities:
         [head=2][color=darkgrey][bold]Troubleshooting[/bold][/color][/head]
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The dock doesn’t respond when you approach.[/bolditalic]  
+        The dock doesn’t respond when you approach.[/bolditalic]
 
         Solution: It’s just being shy. Give it some encouragement by knocking lightly on the hull, or jostling the [color=darkorange][bolditalic]Aether Coil Modulator[/bolditalic][/color]. If no response, consult the  [color=blue][bold]Technical Support AI[/bold][/color] (usually known as "Door Stuck").
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The shuttle is stuck halfway through the docking process.[/bolditalic]  
+        The shuttle is stuck halfway through the docking process.[/bolditalic]
 
         Solution: This is an unfortunate but expected outcome. Reboot the dock, reattempt the process, and pray. Alternatively, try "tugging" the shuttle out, but be prepared for the consequences.
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The dock has *disengaged itself* mid-operation.[/bolditalic]  
+        The dock has *disengaged itself* mid-operation.[/bolditalic]
 
         Solution: This is a feature of the  [color=darkblue][bold]NanoTrasen Smart Dock Mk VII™[/bold][/color], called the  [color=darkorange][bolditalic]Premature Release Safety Protocol™[/bolditalic][/color]. It's designed to keep you on your toes. Simply re-dock and hope it doesn’t happen again (spoiler: it will).
 
@@ -36982,17 +36978,17 @@ entities:
         [head=2][color=darkgrey][bold]FAQ: Frequently Avoided Questions[/bold][/color][/head]
 
 
-        [bolditalic]Q: What do I do if the dock’s lights go out suddenly?[/bolditalic]  
+        [bolditalic]Q: What do I do if the dock’s lights go out suddenly?[/bolditalic]
 
         A: Nothing. Just accept the darkness. The dock has either entered [color=darkorange][bolditalic]Sleep Mode™[/bolditalic][/color], or something unspeakable is about to happen.
 
 
-        [bolditalic]Q: Why does the dock occasionally whisper my name?[/bolditalic]  
+        [bolditalic]Q: Why does the dock occasionally whisper my name?[/bolditalic]
 
         A: The dock is semi-sentient and enjoys toying with your mental state. We suggest playing along until it decides you’re no longer amusing.
 
 
-        [bolditalic]Q: How do I know if the docking process is complete?[/bolditalic]  
+        [bolditalic]Q: How do I know if the docking process is complete?[/bolditalic]
 
         A: You'll know it's done when your shuttle stops shaking violently and the alarms stop blaring. Or when you black out—whichever comes first.
 
@@ -37043,23 +37039,23 @@ entities:
         [head=2][color=darkgrey][bold]Troubleshooting[/bold][/color][/head]
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The dock doesn’t respond when you approach.[/bolditalic]  
+        The dock doesn’t respond when you approach.[/bolditalic]
 
         Solution: It’s just being shy. Give it some encouragement by knocking lightly on the hull, or jostling the [color=darkorange][bolditalic]Aether Coil Modulator[/bolditalic][/color]. If no response, consult the  [color=blue][bold]Technical Support AI[/bold][/color] (usually known as "Door Stuck").
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The shuttle is stuck halfway through the docking process.[/bolditalic]  
+        The shuttle is stuck halfway through the docking process.[/bolditalic]
 
         Solution: This is an unfortunate but expected outcome. Reboot the dock, reattempt the process, and pray. Alternatively, try "tugging" the shuttle out, but be prepared for the consequences.
 
 
-        [bolditalic]Problem: 
+        [bolditalic]Problem:
 
-        The dock has *disengaged itself* mid-operation.[/bolditalic]  
+        The dock has *disengaged itself* mid-operation.[/bolditalic]
 
         Solution: This is a feature of the  [color=darkblue][bold]NanoTrasen Smart Dock Mk VII™[/bold][/color], called the  [color=darkorange][bolditalic]Premature Release Safety Protocol™[/bolditalic][/color]. It's designed to keep you on your toes. Simply re-dock and hope it doesn’t happen again (spoiler: it will).
 
@@ -37090,17 +37086,17 @@ entities:
         [head=2][color=darkgrey][bold]FAQ: Frequently Avoided Questions[/bold][/color][/head]
 
 
-        [bolditalic]Q: What do I do if the dock’s lights go out suddenly?[/bolditalic]  
+        [bolditalic]Q: What do I do if the dock’s lights go out suddenly?[/bolditalic]
 
         A: Nothing. Just accept the darkness. The dock has either entered [color=darkorange][bolditalic]Sleep Mode™[/bolditalic][/color], or something unspeakable is about to happen.
 
 
-        [bolditalic]Q: Why does the dock occasionally whisper my name?[/bolditalic]  
+        [bolditalic]Q: Why does the dock occasionally whisper my name?[/bolditalic]
 
         A: The dock is semi-sentient and enjoys toying with your mental state. We suggest playing along until it decides you’re no longer amusing.
 
 
-        [bolditalic]Q: How do I know if the docking process is complete?[/bolditalic]  
+        [bolditalic]Q: How do I know if the docking process is complete?[/bolditalic]
 
         A: You'll know it's done when your shuttle stops shaking violently and the alarms stop blaring. Or when you black out—whichever comes first.
 
@@ -80319,7 +80315,7 @@ entities:
     - type: EntityStorage
       open: True
       removedMasks: 28
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -80774,7 +80770,7 @@ entities:
     - type: Transform
       pos: 28.5,-5.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -97443,7 +97439,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -6.5,20.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 1108
     components:
@@ -97451,7 +97447,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -4.5,-27.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 1577
     components:
@@ -97459,7 +97455,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -24.5,-40.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 1578
     components:
@@ -97467,14 +97463,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -14.5,-40.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 2153
     components:
     - type: Transform
       pos: -13.5,23.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 2659
     components:
@@ -97482,7 +97478,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 36.5,22.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 3074
     components:
@@ -97490,28 +97486,28 @@ entities:
       rot: 3.141592653589793 rad
       pos: 20.5,-3.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 10266
     components:
     - type: Transform
       pos: -12.5,-46.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 11838
     components:
     - type: Transform
       pos: -37.5,-5.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 19080
     components:
     - type: Transform
       pos: 30.5,-38.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloraTreeChristmas02
   entities:
@@ -97520,7 +97516,7 @@ entities:
     - type: Transform
       pos: 14.0161085,13.966308
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape

--- a/Resources/Maps/omega.yml
+++ b/Resources/Maps/omega.yml
@@ -274,8 +274,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -40517,7 +40515,7 @@ entities:
     - type: Transform
       pos: -15.5,27.5
       parent: 4812
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 2491
     components:
@@ -40525,56 +40523,56 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 10.5,30.5
       parent: 4812
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 3383
     components:
     - type: Transform
       pos: -21.5,-8.5
       parent: 4812
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 3465
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 4812
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 4458
     components:
     - type: Transform
       pos: 16.5,6.5
       parent: 4812
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 7383
     components:
     - type: Transform
       pos: -10.5,-16.5
       parent: 4812
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 7446
     components:
     - type: Transform
       pos: -19.5,-17.5
       parent: 4812
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 8245
     components:
     - type: Transform
       pos: -19.5,29.5
       parent: 4812
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 13785
     components:
     - type: Transform
       pos: 19.5,36.5
       parent: 4812
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloorTileItemGold
   entities:

--- a/Resources/Maps/packed.yml
+++ b/Resources/Maps/packed.yml
@@ -292,8 +292,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Packed
@@ -46751,63 +46749,63 @@ entities:
     - type: Transform
       pos: 30.5,-11.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 1859
     components:
     - type: Transform
       pos: 12.5,12.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 5254
     components:
     - type: Transform
       pos: 78.5,-0.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 8960
     components:
     - type: Transform
       pos: 102.5,-13.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 10447
     components:
     - type: Transform
       pos: 51.5,15.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 11900
     components:
     - type: Transform
       pos: 78.5,10.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 12288
     components:
     - type: Transform
       pos: 51.5,-5.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 12290
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 13606
     components:
     - type: Transform
       pos: 59.5,36.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 15199
     components:
@@ -46815,7 +46813,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 77.5,10.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloraTreeChristmas02
   entities:

--- a/Resources/Maps/reach.yml
+++ b/Resources/Maps/reach.yml
@@ -97,8 +97,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Reach
@@ -7521,14 +7519,14 @@ entities:
     - type: Transform
       pos: -4.5,3.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 1108
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FuelDispenser
   entities:

--- a/Resources/Maps/saltern.yml
+++ b/Resources/Maps/saltern.yml
@@ -231,8 +231,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: BecomesStation
       id: Saltern
@@ -21741,7 +21739,6 @@ entities:
       parent: 31
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 4328
     components:
@@ -21751,7 +21748,6 @@ entities:
       parent: 31
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 6414
     components:
@@ -21760,7 +21756,6 @@ entities:
       parent: 31
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 6930
     components:
@@ -21769,7 +21764,6 @@ entities:
       parent: 31
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 6941
     components:
@@ -21778,7 +21772,6 @@ entities:
       parent: 31
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 7913
     components:
@@ -21794,7 +21787,6 @@ entities:
       parent: 31
     - type: Physics
       canCollide: False
-    - type: Fixtures
       fixtures: {}
   - uid: 10255
     components:
@@ -26629,7 +26621,7 @@ entities:
     - type: Transform
       pos: -27.5,-15.5
       parent: 31
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape: !type:PolygonShape
@@ -33597,28 +33589,28 @@ entities:
     - type: Transform
       pos: 15.5,-17.5
       parent: 31
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 2300
     components:
     - type: Transform
       pos: -18.5,-11.5
       parent: 31
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 4337
     components:
     - type: Transform
       pos: 12.5,27.5
       parent: 31
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 9108
     components:
     - type: Transform
       pos: 17.5,-0.5
       parent: 31
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 9109
     components:
@@ -33626,7 +33618,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -10.5,-4.5
       parent: 31
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloorTileItemArcadeBlue
   entities:

--- a/Resources/Maps/train.yml
+++ b/Resources/Maps/train.yml
@@ -510,8 +510,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5354,8 +5352,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5395,8 +5391,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5436,8 +5430,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5477,8 +5469,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5518,8 +5508,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5559,8 +5547,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5600,8 +5586,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5641,8 +5625,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5682,8 +5664,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5723,8 +5703,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5764,8 +5742,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5805,8 +5781,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5846,8 +5820,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5887,8 +5859,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5928,8 +5898,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -5969,8 +5937,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6010,8 +5976,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6051,8 +6015,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6092,8 +6054,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6133,8 +6093,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6174,8 +6132,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6215,8 +6171,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6256,8 +6210,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6297,8 +6249,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6338,8 +6288,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6379,8 +6327,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6420,8 +6366,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6462,8 +6406,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6503,8 +6445,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6544,8 +6484,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -6585,8 +6523,6 @@ entities:
       angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
-      bodyType: Dynamic
-    - type: Fixtures
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
@@ -49449,7 +49385,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,-91.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 7523
     components:
@@ -49457,7 +49393,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,-54.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 7524
     components:
@@ -49465,7 +49401,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,-174.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 7525
     components:
@@ -49473,21 +49409,21 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 5.5,-167.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 7526
     components:
     - type: Transform
       pos: 15.5,-61.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
   - uid: 7527
     components:
     - type: Transform
       pos: -1.5,-172.5
       parent: 2
-    - type: Fixtures
+    - type: Physics
       fixtures: {}
 - proto: FloraTree01
   entities:

--- a/Resources/Prototypes/Entities/Effects/acidifier.yml
+++ b/Resources/Prototypes/Entities/Effects/acidifier.yml
@@ -6,12 +6,11 @@
   - type: Transform
     anchored: True
   - type: InteractionOutline
-  - type: Physics
-    bodyType: Static
   - type: Sprite
     sprite: /Textures/Effects/acidifier.rsi
     state: acid
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       portalFixture:
         shape:

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -11,7 +11,6 @@
     anchored: true
   - type: Clickable
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         hard: false
@@ -142,7 +141,6 @@
   - type: Sprite
     drawdepth: Walls
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Effects/mobspawn.yml
+++ b/Resources/Prototypes/Entities/Effects/mobspawn.yml
@@ -6,12 +6,11 @@
   - type: Transform
     anchored: True
   - type: InteractionOutline
-  - type: Physics
-    bodyType: Static
   - type: Sprite
     sprite: /Textures/Effects/mobspawn.rsi
     state: crab_quartz
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       portalFixture:
         shape:

--- a/Resources/Prototypes/Entities/Effects/portal.yml
+++ b/Resources/Prototypes/Entities/Effects/portal.yml
@@ -8,11 +8,10 @@
     anchored: True
   - type: InteractionOutline
   - type: Clickable
-  - type: Physics
-    bodyType: Static
   - type: Sprite
     sprite: /Textures/Effects/portal.rsi
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       portalFixture:
         shape:
@@ -51,7 +50,7 @@
     radius: 3
     energy: 1
     netsync: false
-    
+
 - type: entity
   id: PortalArtifact
   parent: BasePortal

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -124,7 +124,6 @@
     color: "#FFFFFF80"
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       slipFixture:
         shape:

--- a/Resources/Prototypes/Entities/Effects/wallspawn.yml
+++ b/Resources/Prototypes/Entities/Effects/wallspawn.yml
@@ -5,12 +5,11 @@
   - type: Transform
     anchored: True
   - type: InteractionOutline
-  - type: Physics
-    bodyType: Static
   - type: Sprite
     sprite: /Textures/Effects/rockspawn.rsi
     state: asteroid
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       portalFixture:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -19,7 +19,7 @@
   - type: NoSlip
   - type: StaticPrice
     price: 1250
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -17,7 +17,7 @@
     speechSounds: Squeak
     speechVerb: SmallMob
     allowedEmotes: ['Squeak']
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -81,7 +81,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: 0
       sprite: Mobs/Animals/bee.rsi
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -174,7 +174,7 @@
     noMovementLayers:
       movement:
         state: chicken-0
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -322,7 +322,6 @@
     rootTask:
       task: MouseCompound
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -443,7 +442,7 @@
     name: ghost-role-information-mothroach-name
     description: ghost-role-information-mothroach-description
     rules: ghost-role-information-freeagent-rules
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -609,7 +608,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: duck-0
     sprite: Mobs/Animals/duck.rsi
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -739,7 +738,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: butterfly
       sprite: Mobs/Animals/butterfly.rsi
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -796,7 +795,6 @@
     - id: MobCow
   - type: ReproductivePartner
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -876,7 +874,6 @@
       movement:
         state: crab
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -936,7 +933,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: goat
       sprite: Mobs/Animals/goat.rsi
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -1030,7 +1027,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: goose
       sprite: Mobs/Animals/goose.rsi
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -1079,7 +1076,6 @@
       state: crawling
       sprite: Mobs/Animals/gorilla.rsi
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -1139,7 +1135,7 @@
       - map: ["enum.DamageStateVisualLayers.Base"]
         state: kangaroo
         sprite: Mobs/Animals/kangaroo.rsi
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -1150,7 +1146,6 @@
         - MobMask
         layer:
         - MobLayer
-  - type: Physics
   - type: Inventory
     speciesId: kangaroo
     templateId: kangaroo
@@ -1236,7 +1231,7 @@
   - type: RotationVisuals
     defaultRotation: 90
     horizontalRotation: 90
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -1634,10 +1629,9 @@
   - type: HTN
     rootTask:
       task: MouseCompound
-  - type: Physics
   - type: FaxableObject
     insertingState: inserting_mouse
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -1898,7 +1892,6 @@
       state: lizard
       sprite: Mobs/Animals/lizard.rsi
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -1954,7 +1947,6 @@
       state: slug
       sprite: Mobs/Animals/slug.rsi
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -2008,7 +2000,6 @@
       movement:
         state: frog
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -2060,7 +2051,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: parrot
       sprite: Mobs/Animals/parrot.rsi
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -2113,7 +2104,6 @@
       state: penguin
       sprite: Mobs/Animals/penguin.rsi
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -2184,7 +2174,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: penguin
       sprite: Mobs/Animals/grenadepenguin.rsi
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -2246,7 +2236,6 @@
       state: snake
       sprite: Mobs/Animals/snake.rsi
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -2288,7 +2277,6 @@
   abstract: true
   components:
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -2508,7 +2496,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: possum
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -2581,7 +2568,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: raccoon
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -2641,7 +2627,6 @@
       movement:
         state: fox
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -2711,10 +2696,9 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: corgi
-  - type: Physics
   - type: Speech
     speechVerb: Canine
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -2860,7 +2844,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: cat
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -3089,7 +3072,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: sloth
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -3142,7 +3124,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: ferret
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -3216,10 +3197,9 @@
         state: hamster-0
   - type: Item
     size: Tiny
-  - type: Physics
   - type: FaxableObject
     insertingState: inserting_hamster
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -3338,7 +3318,7 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: pig
       sprite: Mobs/Animals/pig.rsi
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -3410,7 +3390,6 @@
       state: nymph
       sprite: Mobs/Animals/nymph.rsi
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -3506,7 +3485,6 @@
 #      movement:
 #        state: reindeer_buck_still
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/argocyte.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/argocyte.yml
@@ -104,7 +104,7 @@
     thresholds:
       0: Alive
       30: Dead
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -140,7 +140,7 @@
     thresholds:
       0: Alive
       30: Dead
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -356,7 +356,7 @@
         Base: founder
       Dead:
         Base: founder_dead
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -397,7 +397,7 @@
         Base: leviathing
       Dead:
         Base: leviathing_dead
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -116,9 +116,6 @@
   components:
   - type: Transform
     anchored: True
-  - type: Physics
-    bodyType: Static
-    canCollide: true
   - type: InteractionOutline
   - type: Sprite
     sprite: Mobs/Aliens/Asteroid/goliath.rsi
@@ -129,6 +126,8 @@
       tags:
       - Goliath
   - type: Physics
+    bodyType: Static
+    canCollide: true
     fixtures:
       fix:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -128,7 +128,7 @@
     blacklist:
       tags:
       - Goliath
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -61,7 +61,6 @@
           Base: dead
     - type: Physics
       bodyType: KinematicController
-    - type: Fixtures
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -123,7 +123,6 @@
     - type: Sprite
       sprite: Mobs/Aliens/Carps/holo.rsi
     - type: Physics
-    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -24,7 +24,6 @@
         state: alive
     - type: CombatMode
     - type: Physics
-    - type: Fixtures
       fixtures:
         fix1:
           shape:
@@ -124,7 +123,7 @@
     - type: Sprite
       sprite: Mobs/Aliens/Carps/holo.rsi
     - type: Physics
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:
@@ -208,7 +207,7 @@
       - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
         state: mouth
         shader: unshaded
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -10,7 +10,8 @@
   - type: Damageable
     damageContainer: Inorganic
   - type: InteractionOutline
-  - type: Fixtures
+  - type: Physics
+    bodyType: KinematicController # Same for all inheritors
     fixtures:
       fix1:
         shape:
@@ -31,8 +32,6 @@
     factions:
     - SimpleNeutral
   - type: MovedByPressure
-  - type: Physics
-    bodyType: KinematicController # Same for all inheritors
   - type: StatusEffects
     allowed:
     - Stun

--- a/Resources/Prototypes/Entities/Mobs/NPCs/hellspawn.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/hellspawn.yml
@@ -58,7 +58,7 @@
     reflectProb: 0.7
     reflects:
       - Energy
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
@@ -20,7 +20,7 @@
     - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
       state: unshaded
       shader: unshaded
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
@@ -52,7 +52,7 @@
     - Corporeal
     - Electrocution
     - StaminaModifier
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
@@ -19,7 +19,7 @@
   - type: Icon
     sprite: Structures/Machines/VendingMachines/cola.rsi
     state: normal
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -16,7 +16,7 @@
       layers:
         - map: [ "enum.DamageStateVisualLayers.Base" ]
           state: laser_raptor
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:
@@ -176,7 +176,7 @@
     thresholds:
       0: Alive
       35: Dead
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -175,7 +175,7 @@
   parent: MobCatCaracal
   description: He out here.
   components:
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -224,7 +224,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: bingus
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -281,7 +280,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: mcgriff
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -374,7 +372,6 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: walter
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -31,7 +31,6 @@
       shader: unshaded
   - type: Physics
     bodyType: KinematicController
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -209,7 +208,7 @@
         state: rat
   - type: Physics
     bodyType: KinematicController
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -208,7 +208,6 @@
         state: rat
   - type: Physics
     bodyType: KinematicController
-  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/shadows.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/shadows.yml
@@ -11,7 +11,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 2
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -36,7 +36,7 @@
     speedModifierThresholds:
       60: 0.7
       80: 0.5
-      
+
 - type: entity
   name: shadow cat
   parent: BaseShadowMob

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -11,7 +11,8 @@
   - type: Damageable
     damageContainer: Inorganic
   - type: InteractionOutline
-  - type: Fixtures
+  - type: Physics
+    bodyType: KinematicController
     fixtures:
       fix1:
         shape:
@@ -44,8 +45,6 @@
     - Shock
     locPrefix: silicon
   - type: MovedByPressure
-  - type: Physics
-    bodyType: KinematicController # Same for all inheritors
   - type: StatusEffects
     allowed:
     - Stun
@@ -180,7 +179,7 @@
     speechVerb: Cluwne
   - type: StepTrigger
     intersectRatio: 0.2
-  - type: Fixtures
+  - type: Physics
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -11,7 +11,7 @@
     layers:
     - map: [ "enum.DamageStateVisualLayers.Base" ]
       state: blue_adult_slime
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -20,7 +20,7 @@
     - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
       state: glow
       shader: unshaded
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -213,7 +213,7 @@
   - type: Bloodstream
     bloodMaxVolume: 250
     bloodReagent: Cryoxadone
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -316,7 +316,7 @@
     - type: Bloodstream
       bloodMaxVolume: 200
       bloodReagent: Cryoxadone
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:
@@ -402,7 +402,6 @@
     rootTask:
       task: MouseCompound
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -19,11 +19,10 @@
       state: alive
       sprite: Mobs/Aliens/Xenos/spacetick.rsi
       scale: 0.8, 0.8
-  - type: Physics
   - type: MovementSpeedModifier
     baseWalkSpeed : 4
     baseSprintSpeed : 6
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -42,7 +42,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: running
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -141,7 +141,7 @@
   - type: SlowOnDamage
     speedModifierThresholds:
       50: 0.7
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -178,7 +178,7 @@
         Brute: 6
   - type: MovementSpeedModifier
     baseSprintSpeed: 4
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -214,7 +214,7 @@
     damage:
      groups:
        Brute: 12
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -254,7 +254,7 @@
   - type: SlowOnDamage
     speedModifierThresholds:
       50: 0.7
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -284,7 +284,7 @@
     damage:
      groups:
        Brute: 5
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -346,7 +346,7 @@
     availableModes:
       - FullAuto
     soundGunshot: /Audio/Weapons/Xeno/alien_spitacid.ogg
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -408,7 +408,7 @@
           Quantity: 50
   - type: MeleeChemicalInjector
     solution: melee
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -66,7 +66,6 @@
         BaseUnshaded: dead-unshaded
   - type: Physics
     bodyType: KinematicController
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -152,7 +151,7 @@
     - DoorBumpOpener
   - type: Puller
     needsHands: false
-    
+
 - type: entity
   parent: BaseMobDragon
   id: MobDragon

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -59,7 +59,6 @@
     - type: InteractionOutline
     - type: Physics
       bodyType: KinematicController
-    - type: Fixtures
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Mobs/Player/narsie.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/narsie.yml
@@ -42,7 +42,9 @@
   # big nar'sie needs to see the universe
   - type: ContentEye
     maxZoom: 2.0,2.0
-  - type: Fixtures
+  - type: Physics
+    bodyType: Dynamic
+    bodyStatus: InAir
     fixtures:
       EventHorizonCollider:
         shape:
@@ -83,9 +85,6 @@
     - Supply
     - Syndicate
     globalReceive: true
-  - type: Physics
-    bodyType: Dynamic
-    bodyStatus: InAir
   - type: CanMoveInAir
   # singulose components
   - type: EventHorizon

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -14,11 +14,10 @@
     baseSprintSpeed: 12
     baseWalkSpeed: 8
   - type: MovementIgnoreGravity
+  - type: CanMoveInAir
   - type: Physics
     bodyType: KinematicController
     bodyStatus: InAir
-  - type: CanMoveInAir
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/Player/ratvar.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ratvar.yml
@@ -39,7 +39,9 @@
   - type: CargoSellBlacklist
   - type: ContentEye
     maxZoom: 2.0,2.0
-  - type: Fixtures
+  - type: Physics
+    bodyType: Dynamic
+    bodyStatus: InAir
     fixtures:
       EventHorizonCollider:
         shape:
@@ -79,9 +81,6 @@
     - Supply
     - Syndicate
     globalReceive: true
-  - type: Physics
-    bodyType: Dynamic
-    bodyStatus: InAir
   - type: CanMoveInAir
   - type: EventHorizon
     radius: 5

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -83,7 +83,7 @@
     speedModifierThresholds:
       60: 0.7
       80: 0.5
-  - type: Fixtures
+  - type: Physics
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -72,7 +72,7 @@
         visualType: Large
         messages: [ "diona-hurt-by-herbicide-popup" ]
         probability: 0.66
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -29,7 +29,7 @@
     spawned:
     - id: FoodMeatHuman
       amount: 5
-  - type: Fixtures
+  - type: Physics
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
@@ -30,7 +30,7 @@
         amount: 5
   - type: Bloodstream
     bloodReagent: Sugar
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -53,7 +53,7 @@
       Female: Skeleton
       Unsexed: Skeleton
   - type: SkeletonAccent
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -10,7 +10,6 @@
     drawdepth: Mobs
   - type: Physics
     bodyType: KinematicController
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cans.yml
@@ -169,7 +169,7 @@
     sprite: Objects/Consumable/Drinks/lemon-lime-cranberry.rsi
   - type: Item
     sprite: Objects/Consumable/Drinks/lemon-lime-cranberry.rsi
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape: !type:PhysShapeCircle

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -876,7 +876,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: base
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -706,7 +706,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: cak
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -536,7 +536,6 @@
     enabled: false
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -25,7 +25,7 @@
           Quantity: 5
   - type: Item
     size: Tiny
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -364,7 +364,6 @@
     enabled: false
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
@@ -9,14 +9,14 @@
   components:
   - type: Sprite
     sprite: Objects/Consumable/Food/skewer.rsi
-    state: 
+    state:
     layers:
     - state: skewer
     - map: ["foodSequenceLayers"]
   - type: LandAtCursor
-  - type: Fixtures
+  - type: Physics
     fixtures:
-      fix1: 
+      fix1:
         shape: !type:PolygonShape
           vertices:
             - -0.40,-0.20
@@ -50,7 +50,7 @@
     - Trash
     - Skewer
   - type: Food
-    trash: 
+    trash:
     - FoodKebabSkewer
   - type: SolutionContainerManager
     solutions:
@@ -61,7 +61,7 @@
     key: Skewer
     maxLayers: 4
     startPosition: -0.27, -0.19
-    inverseLayers: true 
+    inverseLayers: true
     offset: 0.2, 0.1
     nameGeneration: food-sequence-skewer-gen
     contentSeparator: ", "

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -10,7 +10,6 @@
     sprite: Objects/Decoration/Flora/flora_rockssolid.rsi
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -47,7 +46,6 @@
     offset: 0,0.9
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -99,7 +97,7 @@
   - type: Sprite
     sprite: Objects/Decoration/Flora/flora_treessnow.rsi
     offset: 0,0.7
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -117,7 +115,7 @@
   - type: Sprite
     sprite: Objects/Decoration/Flora/flora_treeslarge.rsi
     offset: 0,1.55
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -135,7 +133,7 @@
   - type: Sprite
     sprite: Objects/Decoration/Flora/flora_treesconifer.rsi
     offset: 0,1.15
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -308,7 +306,7 @@
   components:
   - type: Sprite
     state: treechristmas02
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Decoration/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/mining.yml
@@ -10,7 +10,6 @@
     state: sign_left
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -70,7 +69,6 @@
     damageModifierSet: Wood
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -109,7 +107,7 @@
   - type: Sprite
     sprite: Objects/Decoration/mines.rsi
     state: support_beams
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         hard: false
@@ -145,7 +143,6 @@
     damageModifierSet: Wood
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
@@ -10,7 +10,7 @@
     - state: icon
   - type: Item
     size: Huge
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Devices/mousetrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/mousetrap.yml
@@ -33,11 +33,10 @@
           base:
             Armed: { state: mousetraparmed }
             Unarmed: { state: mousetrap }
-    - type: Physics
-      bodyType: Dynamic
     - type: CollisionWake
       enabled: false
-    - type: Fixtures
+    - type: Physics
+      bodyType: Dynamic
       fixtures:
         slips:
           shape:

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -288,7 +288,6 @@
     enabled: false
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/base_instruments.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/base_instruments.yml
@@ -53,7 +53,7 @@
     interfaces:
       enum.InstrumentUiKey.Key:
         type: InstrumentBoundUserInterface
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
@@ -165,7 +165,7 @@
   - type: StepTrigger
   - type: CollisionWake
     enabled: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_structures.yml
@@ -108,7 +108,7 @@
     program: 43
   - type: Sprite
     state: contrabass
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -11,7 +11,7 @@
   - type: ThrowingAngle
     angle: 315
   - type: LandAtCursor
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape: !type:PolygonShape
@@ -139,7 +139,7 @@
     sprite: Objects/Fun/Darts/target.rsi
     state: target_dart
     noRot: true
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -151,7 +151,6 @@
         layer:
         - WallLayer
   - type: InteractionOutline
-  - type: Physics
   - type: Damageable
   - type: DamageRandomPopup
     popups:

--- a/Resources/Prototypes/Entities/Objects/Fun/dice.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/dice.yml
@@ -102,7 +102,7 @@
     state: d4_4
   - type: CollisionWake
     enabled: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Fun/error.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/error.yml
@@ -24,7 +24,6 @@
     enabled: false
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -11,14 +11,13 @@
     state: icon
     noRot: false
   - type: ImmovableRod
-  - type: Physics
-    bodyType: Dynamic
-    linearDamping: 0
   - type: PointLight
     radius: 3
     color: red
     energy: 2.0
-  - type: Fixtures
+  - type: Physics
+    bodyType: Dynamic
+    linearDamping: 0
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -99,7 +99,11 @@
       state: icon
       noRot: true
     - type: Item
-    - type: Fixtures
+    - type: Physics
+      angularDamping: 0.02
+      linearDamping: 0.02
+      fixedRotation: true
+      bodyType: Dynamic
       fixtures:
         fix1:
           shape:
@@ -110,11 +114,6 @@
             - ItemMask
           restitution: 0.98
           friction: 0.01
-    - type: Physics
-      angularDamping: 0.02
-      linearDamping: 0.02
-      fixedRotation: true
-      bodyType: Dynamic
     - type: TileFrictionModifier
       modifier: 0.1
     - type: Tag
@@ -526,7 +525,7 @@
           effects:
             - !type:AddToSolutionReaction
               solution: plushie
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:
@@ -1547,7 +1546,6 @@
     enabled: false
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -12,7 +12,7 @@
   - type: Tag
     tags:
     - Ore
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -54,7 +54,6 @@
     noRot: true
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -28,7 +28,7 @@
     size: Tiny
   - type: CollisionWake
     enabled: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Misc/candy_bowl.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/candy_bowl.yml
@@ -49,7 +49,7 @@
       - !type:EmptyAllContainersBehaviour
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -199,7 +199,6 @@
         map: [ "light" ]
   - type: Physics
     canCollide: true
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -274,7 +273,6 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Misc/ice_crust.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/ice_crust.yml
@@ -23,7 +23,6 @@
     - type: Tag
       tags: [ Ice ]
     - type: Physics
-    - type: Physics
       fixtures:
         fix1:
           hard: false

--- a/Resources/Prototypes/Entities/Objects/Misc/ice_crust.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/ice_crust.yml
@@ -23,7 +23,7 @@
     - type: Tag
       tags: [ Ice ]
     - type: Physics
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           hard: false

--- a/Resources/Prototypes/Entities/Objects/Misc/inflatable_wall.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/inflatable_wall.yml
@@ -10,7 +10,6 @@
     state: inflatable_wall
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -52,7 +51,6 @@
     state: closed
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -33,7 +33,7 @@
       drawdepth: Overdoors
     - type: KudzuVisuals
     - type: Clickable
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           hard: false
@@ -181,7 +181,7 @@
       drawdepth: Overdoors
     - type: KudzuVisuals
     - type: Clickable
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           hard: false

--- a/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/land_mine.yml
@@ -10,7 +10,6 @@
   - type: Physics
     bodyType: Static
     fixedRotation: true
-  - type: Fixtures
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
@@ -20,9 +20,8 @@
     sprite: Objects/Storage/petcarrier.rsi
     state: icon
   - type: InteractionOutline
-  - type: Physics
   - type: MultiHandedItem
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
@@ -34,7 +34,6 @@
       map: ["base"]
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         density: 30

--- a/Resources/Prototypes/Entities/Objects/Misc/spaceshroom.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spaceshroom.yml
@@ -12,7 +12,6 @@
       anchored: true
     - type: Physics
       bodyType: Static
-    - type: Fixtures
       fixtures:
         fix1:
           shape:
@@ -76,7 +75,7 @@
     weightedRandomId: RandomFillSpaceshroom
   - type: StaticPrice
     price: 20
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
@@ -29,7 +29,7 @@
     - type: Transform
       anchored: true
     - type: Physics
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           hard: false
@@ -111,7 +111,7 @@
     - type: StepTrigger
       intersectRatio: 0.2
     - type: Physics
-    - type: Fixtures
+    - type: Physics
       fixtures:
         slips:
           shape:

--- a/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
@@ -29,7 +29,6 @@
     - type: Transform
       anchored: true
     - type: Physics
-    - type: Physics
       fixtures:
         fix1:
           hard: false
@@ -110,7 +109,6 @@
     - type: Slippery
     - type: StepTrigger
       intersectRatio: 0.2
-    - type: Physics
     - type: Physics
       fixtures:
         slips:

--- a/Resources/Prototypes/Entities/Objects/Power/powersink.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powersink.yml
@@ -15,7 +15,6 @@
     - type: Transform
       anchored: true
     - type: Physics
-    - type: Fixtures
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
@@ -11,7 +11,6 @@
   - type: CollideOnAnchor
   - type: Physics
     canCollide: false
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -150,7 +150,6 @@
     enabled: false
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       slips:
         shape:
@@ -217,7 +216,7 @@
       head:
         - state: equipped-HELMET
           offset: "0, 0.15625"
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape: !type:PhysShapeCircle

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -27,7 +27,6 @@
     enabled: false
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       slips:
         shape:
@@ -158,7 +157,7 @@
     intersectRatio: 0.04
   - type: Item
     heldPrefix: syndie
-  - type: Fixtures
+  - type: Physics
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -120,7 +120,6 @@
       map: ["enum.VaporVisualLayers.Base"]
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -145,7 +144,7 @@
     - state: chempuff
       scale: 2, 2
       map: ["enum.VaporVisualLayers.Base"]
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
@@ -9,7 +9,7 @@
       netsync: false
     - type: Rotatable
     - type: InteractionOutline
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mech_construction.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mech_construction.yml
@@ -10,7 +10,6 @@
   - type: Physics
     bodyType: Dynamic
     fixedRotation: false
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -62,11 +62,10 @@
     - DoorBumpOpener
     - FootstepSound
   - type: Pullable
-  - type: Physics
-    bodyType: KinematicController
   - type: Clickable
   - type: WiresPanel
-  - type: Fixtures
+  - type: Physics
+    bodyType: KinematicController
     fixtures:
       fix1:
         shape:
@@ -253,7 +252,7 @@
     layers:
     - map: [ "enum.MechVisualLayers.Base" ]
       state: vim
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -28,11 +28,10 @@
   - type: Clickable
   - type: InteractionOutline
   - type: MovedByPressure
-  - type: Physics
-    bodyType: Dynamic
   - type: Transform
     noRot: true
-  - type: Fixtures
+  - type: Physics
+    bodyType: Dynamic
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/endoskeleton.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/endoskeleton.yml
@@ -8,7 +8,6 @@
   - type: Physics
     bodyType: Dynamic
     fixedRotation: false
-  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/endoskeleton.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/endoskeleton.yml
@@ -8,7 +8,7 @@
   - type: Physics
     bodyType: Dynamic
     fixedRotation: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
@@ -19,7 +19,6 @@
   - type: Physics
     bodyType: Dynamic
     canCollide: false
-  - type: Fixtures
     fixtures:
       base:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Security/target.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/target.yml
@@ -11,7 +11,7 @@
   - type: DamagePopup
     allowTypeChange: true
     damagePopupType: Combined
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -23,7 +23,6 @@
         layer:
         - WallLayer
   - type: InteractionOutline
-  - type: Physics
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -28,7 +28,6 @@
         map: ["enum.PaperLabelVisuals.Layer"]
     - type: InteractionOutline
     - type: Physics
-    - type: Fixtures
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
@@ -14,15 +14,14 @@
       map: [ "enum.ArtifactsVisualLayers.Effect" ]
       visible: false
   - type: Damageable
-  - type: Physics
-    bodyType: Dynamic
   - type: CollisionWake
     enabled: false
   - type: InteractionOutline
   - type: Reactive
     groups:
       Acidic: [Touch]
-  - type: Fixtures
+  - type: Physics
+    bodyType: Dynamic
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
@@ -16,8 +16,6 @@
       map: [ "enum.ArtifactsVisualLayers.Effect" ]
       visible: false
   - type: Damageable
-  - type: Physics
-    bodyType: Dynamic
   - type: Transform
     noRot: true
   - type: UserInterface #needs to be here for certain effects
@@ -33,7 +31,8 @@
   - type: Reactive
     groups:
       Acidic: [Touch]
-  - type: Fixtures
+  - type: Physics
+    bodyType: Dynamic
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -417,7 +417,7 @@
   - type: SolutionInjectOnEmbed
     transferAmount: 2
     solution: injector
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape: !type:PhysShapeCircle
@@ -589,7 +589,7 @@
     areaInsertRadius: 1
     storageInsertSound: /Audio/Effects/pill_insert.ogg
     storageRemoveSound: /Audio/Effects/pill_remove.ogg
-    whitelist: 
+    whitelist:
       tags:
       - Pill
   - type: Dumpable

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -37,7 +37,7 @@
     - MobMonkey
   - type: CollisionWake
     enabled: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -184,7 +184,6 @@
     enabled: false
   - type: Physics
     bodyType: KinematicController
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -258,7 +257,7 @@
     - MobTick
   - type: CollisionWake
     enabled: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Tools/fulton.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/fulton.yml
@@ -17,7 +17,6 @@
   components:
     - type: Physics
       bodyType: Dynamic
-    - type: Fixtures
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Objects/Tools/thief_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/thief_beacon.yml
@@ -11,7 +11,6 @@
       size: Normal
     - type: Physics
       bodyType: Dynamic
-    - type: Fixtures
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
@@ -5,7 +5,7 @@
   components:
   - type: Sprite
     drawdepth: Items
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -165,7 +165,7 @@
     fixedRotation: false
   - type: EmbeddableProjectile
     deleteOnRemove: true
-  - type: Fixtures
+  - type: Physics
     fixtures:
       projectile:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -160,12 +160,11 @@
   name: pellet (.50 flare)
   categories: [ HideSpawnMenu ]
   components:
-  - type: Physics
-    bodyType: Dynamic
-    fixedRotation: false
   - type: EmbeddableProjectile
     deleteOnRemove: true
   - type: Physics
+    bodyType: Dynamic
+    fixedRotation: false
     fixtures:
       projectile:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/toy.yml
@@ -4,7 +4,7 @@
   name: foam dart
   parent: BaseItem
   components:
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape: !type:PolygonShape

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/arrows.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/arrows.yml
@@ -7,7 +7,7 @@
     size: Small
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/arrows.rsi
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape: !type:PhysShapeCircle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/magic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/magic.yml
@@ -130,7 +130,7 @@
     stateBaseClosed: decursed
     stateDoorOpen: decursed_open
     stateDoorClosed: decursed_door
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -22,7 +22,6 @@
     bodyStatus: InAir
     angularDamping: 0
     linearDamping: 0
-  - type: Fixtures
     fixtures:
       projectile:
         shape:
@@ -53,7 +52,7 @@
   components:
   - type: Sprite
     state: space_dust
-  - type: Fixtures
+  - type: Physics
     fixtures:
       projectile:
         shape:
@@ -88,7 +87,7 @@
   components:
   - type: Sprite
     state: small
-  - type: Fixtures
+  - type: Physics
     fixtures:
       projectile:
         shape:
@@ -128,7 +127,7 @@
   components:
   - type: Sprite
     state: medium
-  - type: Fixtures
+  - type: Physics
     fixtures:
       projectile:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -806,10 +806,6 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Clickable
-  - type: Physics
-    bodyType: Dynamic
-    linearDamping: 0
-    angularDamping: 0
   - type: TimedDespawn
     lifetime: 10
   - type: Projectile
@@ -828,6 +824,9 @@
       vapor:
         maxVol: 50
   - type: Physics
+    bodyType: Dynamic
+    linearDamping: 0
+    angularDamping: 0
     fixtures:
       projectile:
         shape:
@@ -878,16 +877,15 @@
       sprite: Objects/Weapons/Guns/Launchers/grappling_gun.rsi
       layers:
         - state: hook
-    - type: Physics
-      bodyType: Dynamic
-      linearDamping: 0
-      angularDamping: 0
     - type: Projectile
       deleteOnCollide: false
       damage:
         types:
           Blunt: 0
     - type: Physics
+      bodyType: Dynamic
+      linearDamping: 0
+      angularDamping: 0
       fixtures:
         projectile:
           shape:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -37,7 +37,6 @@
     bodyType: Dynamic
     linearDamping: 0
     angularDamping: 0
-  - type: Fixtures
     fixtures:
       projectile:
         shape:
@@ -77,7 +76,7 @@
     damage:
       types:
         Blunt: 7 # more damage than a punch.
-  - type: Fixtures
+  - type: Physics
     fixtures:
       projectile:
         shape:
@@ -173,7 +172,6 @@
     - state: spark
       shader: unshaded
   - type: Physics
-  - type: Fixtures
     fixtures:
       projectile:
         shape:
@@ -216,7 +214,6 @@
     - state: omnilaser
       shader: unshaded
   - type: Physics
-  - type: Fixtures
     fixtures:
       projectile:
         shape:
@@ -256,7 +253,6 @@
     - state: omnilaser
       shader: unshaded
   - type: Physics
-  - type: Fixtures
     fixtures:
       projectile:
         shape:
@@ -293,7 +289,6 @@
   - type: Ammo
     muzzleFlash: null
   - type: Physics
-  - type: Fixtures
     fixtures:
       projectile:
         shape:
@@ -335,7 +330,6 @@
   - type: Ammo
     muzzleFlash: null
   - type: Physics
-  - type: Fixtures
     fixtures:
       projectile:
         shape:
@@ -486,7 +480,6 @@
   - type: Ammo
     muzzleFlash: null
   - type: Physics
-  - type: Fixtures
     fixtures:
       projectile:
         shape:
@@ -834,7 +827,7 @@
     solutions:
       vapor:
         maxVol: 50
-  - type: Fixtures
+  - type: Physics
     fixtures:
       projectile:
         shape:
@@ -894,7 +887,7 @@
       damage:
         types:
           Blunt: 0
-    - type: Fixtures
+    - type: Physics
       fixtures:
         projectile:
           shape:
@@ -926,7 +919,6 @@
     - state: omnilaser
       shader: unshaded
   - type: Physics
-  - type: Fixtures
     fixtures:
       projectile:
         shape:
@@ -1002,7 +994,6 @@
     - state: heavylaser
       shader: unshaded
   - type: Physics
-  - type: Fixtures
     fixtures:
       projectile:
         shape:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -39,7 +39,7 @@
     - type: Clickable
     - type: InteractionOutline
     - type: Actions
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -12,7 +12,7 @@
   - type: Tag
     tags:
     - Spear
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape: !type:PolygonShape

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/croissant.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/croissant.yml
@@ -3,7 +3,7 @@
   id: WeaponCroissant
   suffix: Weapon
   components:
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape: !type:PhysShapeCircle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/throwing_stars.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/throwing_stars.yml
@@ -19,7 +19,7 @@
       enum.HolidayVisuals.Holiday:
         base:
           festive: { state: festive }
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape: !type:PhysShapeCircle

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -205,7 +205,7 @@
       layers:
         - state: "off"
           map: ["enum.ProximityTriggerVisualLayers.Base"]
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -26,7 +26,6 @@
   - type: Physics
     bodyType: Dynamic
     fixedRotation: false
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
@@ -11,7 +11,7 @@
     noRot: true
   - type: Transform
     noRot: true
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Decoration/crystals.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/crystals.yml
@@ -19,7 +19,6 @@
       delay: 2
     - type: Physics
       bodyType: Static
-    - type: Fixtures
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Decoration/curtains.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/curtains.yml
@@ -9,7 +9,7 @@
   components:
   - type: Occluder
   - type: AnimationPlayer
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Decoration/flesh_blockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/flesh_blockers.yml
@@ -11,7 +11,7 @@
     layers:
     - state: closed
       map: [ "enum.DamageStateVisualLayers.Base" ]
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Decoration/mannequin.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/mannequin.yml
@@ -21,7 +21,7 @@
     - map: [ "mask" ]
     - map: [ "head" ]
   - type: Rotatable
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -12,7 +12,6 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
@@ -37,7 +37,7 @@
     - Chemist
   - type: StealTarget
     stealGroup: ChemDispenser
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_assembly.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_assembly.yml
@@ -10,7 +10,6 @@
     sprite: Structures/Doors/Airlocks/Standard/basic.rsi
     state: "assembly"
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -38,7 +38,6 @@
       map: ["enum.ElectrifiedLayers.HUD"]
   - type: AnimationPlayer
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -190,7 +189,7 @@
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/glass.rsi
   - type: AnimationPlayer
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
@@ -35,7 +35,7 @@
     sprite: Structures/Doors/Airlocks/Glass/external.rsi
   - type: PaintableAirlock
     group: ExternalGlass
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -34,7 +34,6 @@
       map: ["enum.ElectrifiedLayers.HUD"]
   - type: AnimationPlayer
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -11,7 +11,7 @@
     ports:
       - DoorStatus
       - DockStatus
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -76,7 +76,7 @@
     group: ShuttleGlass
   - type: Door
     occludes: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         layer:     #removed opaque from the layer, allowing lasers to pass through glass airlocks

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -50,7 +50,8 @@
         - state: panel_open
           map: ["enum.WiresVisualLayers.MaintenancePanel"]
     - type: AnimationPlayer
-    - type: Fixtures
+    - type: Physics
+      canCollide: false
       fixtures:
         fix1:
           shape:
@@ -92,8 +93,6 @@
       interfaces:
         enum.WiresUiKey.Key:
           type: WiresBoundUserInterface
-    - type: Physics
-      canCollide: false
     - type: Airtight
       airBlocked: false
       noAirWhenFullyAirBlocked: true
@@ -144,7 +143,7 @@
       sprite: Structures/Doors/Airlocks/Glass/firelock.rsi
     - type: Occluder
       enabled: false
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:
@@ -174,7 +173,8 @@
       noAirWhenFullyAirBlocked: false
       airBlockedDirection:
         - South
-    - type: Fixtures
+    - type: Physics
+      canCollide: false
       fixtures:
         fix1:
           shape:
@@ -189,8 +189,6 @@
       enabled: false
     - type: Door
       occludes: false
-    - type: Physics
-      canCollide: false
     - type: StaticPrice
       price: 100
     - type: Construction

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/frame.yml
@@ -39,7 +39,6 @@
         acts: ["Destruction"]
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
@@ -13,7 +13,6 @@
       map: ["enum.DoorVisualLayers.Base"]
   - type: AnimationPlayer
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -13,7 +13,6 @@
       map: ["enum.DoorVisualLayers.Base"]
   - type: AnimationPlayer
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -81,7 +80,6 @@
     sprite: Structures/Doors/secret_door.rsi
     state: assembly
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -78,7 +78,6 @@
         acts: ["Destruction"]
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -16,7 +16,6 @@
       map: ["enum.DoorVisualLayers.Base"]
   - type: AnimationPlayer
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -224,7 +223,6 @@
         acts: ["Destruction"]
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/assembly.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/assembly.yml
@@ -10,7 +10,6 @@
     layers:
     - state: assembly
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -13,7 +13,6 @@
   - type: InteractionOutline
   - type: StationAiWhitelist
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
@@ -9,7 +9,7 @@
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic
   - type: PlaceableSurface
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -43,7 +43,7 @@
   name: counter
   abstract: true
   components:
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -10,7 +10,7 @@
   - type: Icon
     sprite: Structures/Furniture/Tables/frame.rsi
     state: full
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -67,7 +67,7 @@
   - type: Icon
     sprite: Structures/Furniture/Tables/frame.rsi
     state: full
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Furniture/altar.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/altar.yml
@@ -12,7 +12,7 @@
     damageContainer: StructuralInorganic
     damageModifierSet: Wood
   - type: PlaceableSurface
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -11,7 +11,6 @@
         Blunt: -0.1
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Furniture/carpets.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/carpets.yml
@@ -17,7 +17,6 @@
     tags: [ Carpet ]
   - type: Physics
     canCollide: false
-  - type: Fixtures
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -351,7 +350,6 @@
     tags: [ Carpet ]
   - type: Physics
     canCollide: false
-  - type: Fixtures
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -10,7 +10,6 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Furniture/memorial.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/memorial.yml
@@ -9,7 +9,7 @@
     state: memorial
   - type: Transform
     noRot: true
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
@@ -11,7 +11,6 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
@@ -26,7 +26,6 @@
         collection: MetalThud
     - type: InteractionOutline
     - type: Physics
-    - type: Fixtures
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -51,7 +51,6 @@
       disposals: !type:Container
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -35,7 +35,7 @@
   - type: Sprite
     sprite: Structures/Holo/holofan.rsi
     state: icon
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -52,13 +52,11 @@
   name: holographic barrier
   description: A barrier of hard light that blocks movement, but pretty weak.
   components:
-    - type: Physics
-      bodyType: Static
-      canCollide: true
     - type: Sprite
       sprite: Structures/Holo/security.rsi
       state: icon
-    - type: Fixtures
+    - type: Physics
+      canCollide: true
       fixtures:
         fix1:
           shape:
@@ -83,13 +81,11 @@
   name: holographic force field
   description: A powerful temporal containment field that doesn't let anything through, not even a tesla or singularity.
   components:
-  - type: Physics
-    bodyType: Static
-    canCollide: true
   - type: Sprite
     sprite: Structures/Holo/field.rsi
     state: icon
-  - type: Fixtures
+  - type: Physics
+    canCollide: true
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -17,7 +17,7 @@
       state: glow
       shader: unshaded
     state: base
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
@@ -5,7 +5,6 @@
   components:
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/chemistry_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/chemistry_machines.yml
@@ -12,7 +12,6 @@
     snapCardinals: true
   - type: Appearance
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
@@ -25,7 +25,7 @@
   - type: InteractionOutline
   - type: Transform
     noRot: true
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -140,7 +140,7 @@
       map: ["enum.LockVisualLayers.Lock"]
   - type: Transform
     noRot: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -257,8 +257,6 @@
     volume: -6
     sound:
       path: /Audio/Ambience/Objects/anomaly_generator.ogg
-  - type: Physics
-    bodyType: Static
   - type: AnomalyGenerator
     generatingSound:
       path: /Audio/Machines/anomaly_generate.ogg
@@ -270,7 +268,8 @@
         - Sheet
     materialWhiteList:
     - Plasma
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_sync.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_sync.yml
@@ -33,7 +33,7 @@
       path: /Audio/Machines/scan_loop.ogg
     range: 5
     volume: -8
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -41,7 +41,7 @@
           bounds: "-0.35,-0.35,0.35,0.35"
         density: 100
         mask:
-        - ItemMask 
+        - ItemMask
         hard: True
   - type: Transform
     anchored: true

--- a/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
@@ -13,16 +13,15 @@
     - state: unshaded
       shader: unshaded
       map: ["enum.PowerDeviceVisualLayers.Powered"]
-  - type: Physics
-    bodyType: Static
-    canCollide: true
   - type: AmbientSound
     enabled: false
     sound:
       path: /Audio/Machines/scan_loop.ogg
     range: 5
     volume: -8
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
+    canCollide: true
     fixtures:
       fix1:
         shape:
@@ -112,7 +111,7 @@
     - state: lights
       map: ["enum.PowerDeviceVisualLayers.Powered"]
       shader: unshaded
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/base_structuremachines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/base_structuremachines.yml
@@ -6,11 +6,10 @@
   - type: InteractionOutline
   - type: Anchorable
     delay: 2
-  - type: Physics
-    bodyType: Static
   - type: Transform
     noRot: true
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -32,7 +32,7 @@
       beepSound: /Audio/Machines/timer.ogg
     - type: Anchorable
       delay: 5
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -21,7 +21,6 @@
     pillDosageLimit: 20
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -16,7 +16,6 @@
   - type: Appearance
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/frame.yml
@@ -10,7 +10,6 @@
       anchored: true
     - type: Physics
       bodyType: Static
-    - type: Physics
       fixtures:
         fix1:
           shape:
@@ -68,7 +67,6 @@
       anchored: true
     - type: Physics
       bodyType: Static
-    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/frame.yml
@@ -10,7 +10,7 @@
       anchored: true
     - type: Physics
       bodyType: Static
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:
@@ -68,7 +68,7 @@
       anchored: true
     - type: Physics
       bodyType: Static
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/gateway.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gateway.yml
@@ -27,11 +27,9 @@
           True: { visible: true }
           False: { visible: false }
   - type: InteractionOutline
-  - type: Physics
-    bodyType: Static
   - type: Transform
     noRot: true
-  - type: Fixtures
+  - type: Physics
     fixtures:
       portalFixture:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -29,7 +29,6 @@
   - type: ExtensionCableReceiver
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -99,7 +98,7 @@
         map: ["enum.GravityGeneratorVisualLayers.Core"]
         scale: "0.4,0.4"
         offset: "0,0.2"
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -6,7 +6,7 @@
   components:
   - type: Transform
     anchored: true
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -104,7 +104,7 @@
         node: machineFrame
       - !type:DoActsBehavior
         acts: ["Destruction"]
- 
+
 - type: entity
   name: long-range holopad
   description: "A floor-mounted device for projecting holographic images to similar devices that are far away."
@@ -117,7 +117,7 @@
     - Map
     - Unlimited
     ignoreTelephonesOnSameGrid: true
-    
+
 - type: entity
   name: quantum entangling holopad
   description: "An floor-mounted device for projecting holographic images to similar devices at extreme distances."

--- a/Resources/Prototypes/Entities/Structures/Machines/hotplate.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/hotplate.yml
@@ -6,7 +6,7 @@
   components:
   - type: Transform
     anchored: true
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/jukebox.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/jukebox.yml
@@ -53,7 +53,6 @@
             max: 2
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -6,7 +6,7 @@
   components:
   - type: Appearance
   - type: WiresVisuals
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -47,7 +47,6 @@
       enum.MicrowaveUiKey.Key:
         type: MicrowaveBoundUserInterface
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -50,7 +50,6 @@
           YoureFucked: { state: nuclearbomb_exploding }
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -158,7 +157,6 @@
           pride: { visible: true }
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
@@ -22,7 +22,6 @@
           True: {state: "juicer1"}
           False: {state: "juicer0"}
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -11,7 +11,7 @@
     sound:
       # TODO: https://freesound.org/people/derjuli/sounds/448133/ CC-NC-
       path: /Audio/Ambience/Objects/circular_saw.ogg
-  - type: Fixtures
+  - type: Physics
     fixtures:
       brrt:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/seed_extractor.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/seed_extractor.yml
@@ -14,7 +14,6 @@
       map: ["enum.PowerDeviceVisualLayers.Powered"]
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/smartfridge.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/smartfridge.yml
@@ -43,12 +43,11 @@
     delay: 1
   - type: AntiRottingContainer
   - type: ResistLocker
-  - type: Physics
-    bodyType: Static
   - type: Transform
     noRot: true
     anchored: True
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
@@ -47,7 +47,6 @@
     board: StasisBedMachineCircuitboard
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -30,7 +30,6 @@
   - type: WiresVisuals
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -19,11 +19,10 @@
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/empty.rsi
     snapCardinals: true
-  - type: Physics
-    bodyType: Static
   - type: Transform
     noRot: true
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       fix1:
         shape:
@@ -117,7 +116,7 @@
     layers:
     - state: "off"
       map: ["enum.VendingMachineVisualLayers.Base"]
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Machines/wireless_surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/wireless_surveillance_camera.yml
@@ -14,7 +14,7 @@
       damageModifierSet: Metallic
     - type: Rotatable
       rotateWhileAnchored: true
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -10,7 +10,6 @@
     - type: InteractionOutline
     - type: Physics
       canCollide: false
-    - type: Fixtures
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/portable.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/portable.yml
@@ -10,7 +10,7 @@
     bodyType: Dynamic
   - type: AtmosDevice
     joinSystem: true
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -105,11 +105,10 @@
   - type: StationAiWhitelist
   - type: Transform
     anchored: false
-  - type: Physics
-    bodyType: Dynamic
   - type: AtmosDevice
     joinSystem: true
-  - type: Fixtures
+  - type: Physics
+    bodyType: Dynamic
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/portable.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/portable.yml
@@ -6,11 +6,10 @@
   components:
   - type: Transform
     anchored: false
-  - type: Physics
-    bodyType: Dynamic
   - type: AtmosDevice
     joinSystem: true
   - type: Physics
+    bodyType: Dynamic
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
@@ -13,7 +13,7 @@
   - type: Sprite
     sprite: Structures/Piping/Atmospherics/tinyfan.rsi
     state: icon
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -40,7 +40,7 @@
   - type: Sprite
     sprite: Structures/Piping/Atmospherics/directionalfan.rsi
     state: icon
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
@@ -8,12 +8,11 @@
   components:
   - type: Transform
     anchored: true
-  - type: Physics
-    bodyType: Static
   - type: Sprite
     sprite: Structures/Piping/Atmospherics/tinyfan.rsi
     state: icon
   - type: Physics
+    bodyType: Static
     fixtures:
       fix1:
         shape:
@@ -35,12 +34,11 @@
   components:
   - type: Transform
     anchored: true
-  - type: Physics
-    bodyType: Static
   - type: Sprite
     sprite: Structures/Piping/Atmospherics/directionalfan.rsi
     state: icon
   - type: Physics
+    bodyType: Static
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/high_pressure_machine_frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/high_pressure_machine_frame.yml
@@ -10,7 +10,7 @@
       noRot: true
     - type: Physics
       bodyType: Static
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/high_pressure_machine_frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/high_pressure_machine_frame.yml
@@ -10,7 +10,6 @@
       noRot: true
     - type: Physics
       bodyType: Static
-    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
@@ -17,7 +17,6 @@
   - type: Physics
     bodyType: Static
     canCollide: false
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -173,7 +172,7 @@
         pipe:
           Free: { state: conpipe-t }
           Anchored: { state: pipe-t }
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -221,7 +220,7 @@
     interfaces:
       enum.DisposalRouterUiKey.Key:
         type: DisposalRouterBoundUserInterface
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -263,7 +262,7 @@
           Anchored: { state: pipe-j2s }
   - type: Flippable
     mirrorEntity: DisposalRouter
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -305,7 +304,7 @@
           Anchored: { state: pipe-j1 }
   - type: Flippable
     mirrorEntity: DisposalJunctionFlipped
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -347,7 +346,7 @@
           Anchored: { state: pipe-j2 }
   - type: Flippable
     mirrorEntity: DisposalJunction
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -386,7 +385,7 @@
         pipe:
           Free: { state: conpipe-y }
           Anchored: { state: pipe-y }
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -422,7 +421,7 @@
         pipe:
           Free: { state: conpipe-c }
           Anchored: { state: pipe-c }
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/base_particleaccelerator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/base_particleaccelerator.yml
@@ -9,7 +9,6 @@
   - type: Rotatable
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -20,7 +20,6 @@
         types:
           Radiation: 25
     - type: Physics
-    - type: Fixtures
       fixtures:
         projectile:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
@@ -10,7 +10,6 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
@@ -4,7 +4,7 @@
   name: containment field generator
   description: A machine that generates a containment field when powered by an emitter. Keeps the Singularity docile.
   components:
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -79,7 +79,6 @@
   - type: Clickable
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -10,7 +10,6 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/generator.yml
@@ -13,7 +13,6 @@
   - type: Clickable
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -21,7 +21,7 @@
   - type: GravityWell # To make the singularity attract things.
     baseRadialAcceleration: 10
     maxRange: 4
-  - type: Fixtures
+  - type: Physics
     fixtures:
       EventHorizonCollider:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -9,9 +9,6 @@
     range: 14
     sound:
       path: /Audio/Effects/singularity.ogg
-  - type: Physics
-    bodyType: Dynamic
-    bodyStatus: InAir
   - type: CanMoveInAir
   - type: EventHorizon # To make the singularity consume things.
     radius: 0.5
@@ -22,6 +19,8 @@
     baseRadialAcceleration: 10
     maxRange: 4
   - type: Physics
+    bodyType: Dynamic
+    bodyStatus: InAir
     fixtures:
       EventHorizonCollider:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -9,7 +9,6 @@
     anchored: true
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -114,7 +113,6 @@
     anchored: true
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
@@ -38,7 +38,7 @@
   name: ball lightning
   description: A giant ball of pure energy. The space around it is humming and melting.
   components:
-  - type: Fixtures
+  - type: Physics
     fixtures:
       EventHorizonCollider:
         shape:
@@ -120,7 +120,7 @@
     maxSpeed: 3
     chasingComponent:
     - type: TeslaEnergyBall
-  - type: Fixtures
+  - type: Physics
     fixtures:
       TeslaCollider:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/generator.yml
@@ -11,7 +11,7 @@
   - type: SingularityGenerator # TODO: rename the generator
     spawnId: TeslaEnergyBall
   - type: InteractionOutline
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
@@ -17,7 +17,6 @@
       map: ["display"]
       visible: false
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -141,7 +140,6 @@
       shader: unshaded
       visible: false
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -16,7 +16,6 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -111,7 +110,6 @@
     color: "#3db83b"
     castShadows: false
     netsync: false
-  - type: Fixtures
   - type: Transform
     anchored: true
   - type: Physics
@@ -155,7 +153,6 @@
   - type: InteractionOutline
   - type: Physics
     canCollide: false
-  - type: Fixtures
   - type: Transform
     anchored: true
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
@@ -11,8 +11,6 @@
     # Basic properties
     - type: Transform
       anchored: False
-    - type: Physics
-      bodyType: Dynamic
     - type: StaticPrice
       price: 500
     - type: AmbientSound
@@ -21,7 +19,8 @@
       sound:
         path: /Audio/Ambience/Objects/engine_hum.ogg
       enabled: false
-    - type: Fixtures
+    - type: Physics
+      bodyType: Dynamic
       fixtures:
         fix1:
           shape:
@@ -256,7 +255,7 @@
       range: 4
       volume: -8
 
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
@@ -15,7 +15,6 @@
     anchored: true
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -124,7 +123,6 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -171,7 +169,6 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -15,7 +15,6 @@
   - type: Physics
     bodyType: Static
     canCollide: false
-  - type: Fixtures
   - type: Sprite
     drawdepth: ThinWire
     visible: false

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -49,7 +49,7 @@
     - map: ["enum.PowerChargerVisualLayers.Light"]
       state: "light-off"
       shader: "unshaded"
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -111,7 +111,7 @@
   id: PowerCageRecharger
   name: cage recharger
   components:
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/debug_power.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/debug_power.yml
@@ -24,7 +24,6 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -69,7 +68,6 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -103,7 +101,6 @@
   - type: PowerNetworkBattery
   - type: InteractionOutline
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -164,7 +161,6 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -266,7 +266,6 @@
   - type: Physics
     bodyType: Static
     canCollide: false
-  - type: Physics
   - type: Transform
     anchored: true
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -144,7 +144,6 @@
   - type: Physics
     bodyType: Static
     canCollide: false
-  - type: Fixtures
   - type: Transform
     anchored: true
   - type: Sprite # TODO: add sprite for maintenance panel open
@@ -267,7 +266,7 @@
   - type: Physics
     bodyType: Static
     canCollide: false
-  - type: Fixtures
+  - type: Physics
   - type: Transform
     anchored: true
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -13,14 +13,13 @@
   - type: Anchorable
   - type: Pullable
   - type: Rotatable
-  - type: Physics
-    bodyType: Static
   - type: ContainerContainer
   - type: Gun
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
@@ -10,8 +10,6 @@
   - type: StationAnchor
   - type: Transform
     anchored: true
-  - type: Physics
-    bodyType: Static
   - type: AmbientSound
     enabled: false
     range: 4
@@ -34,7 +32,8 @@
           True: { visible: True }
           False: { visible: False }
   - type: Appearance
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -5,7 +5,8 @@
   description: A thruster that allows a shuttle to move.
   abstract: true
   components:
-    - type: Fixtures
+    - type: Physics
+      bodyType: Static
       fixtures:
         fix1:
           shape:
@@ -24,8 +25,6 @@
         path: /Audio/Effects/shuttle_thruster.ogg
     - type: Transform
       anchored: true
-    - type: Physics
-      bodyType: Static
     - type: Rotatable
       rotateWhileAnchored: true
     - type: Thruster

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -20,7 +20,6 @@
   - type: Physics
     bodyType: Static
     bodyStatus: InAir
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -283,7 +282,7 @@
     castShadows: false
   - type: BluespaceAnomaly
   - type: Portal
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -670,7 +669,6 @@
     anchored: true
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injectors.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injectors.yml
@@ -4,15 +4,14 @@
   id: BaseAnomalyInjector
   abstract: true
   components:
-  - type: Physics
-    bodyType: Static
-    fixedRotation: true
   - type: AmbientSound
     range: 5
     volume: -5
     sound:
       path: /Audio/Ambience/anomaly_drone.ogg
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
+    fixedRotation: true
     fixtures:
       anom:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -52,7 +52,6 @@
             acts: ["Destruction"]
     - type: Physics
       canCollide: false
-    - type: Fixtures
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Janitor/janicart.yml
@@ -96,7 +96,7 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: DnaSubstanceTrace
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -216,7 +216,7 @@
             tags:
               - TrashBag
           priority: 3 # Higher than drinking priority
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Specific/church-bell.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/church-bell.yml
@@ -24,7 +24,6 @@
   - type: Physics
     canCollide: false
     bodyType: Static
-  - type: Physics
   - type: InteractionOutline
   - type: Damageable
     damageContainer: Inorganic

--- a/Resources/Prototypes/Entities/Structures/Specific/church-bell.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/church-bell.yml
@@ -24,7 +24,7 @@
   - type: Physics
     canCollide: false
     bodyType: Static
-  - type: Fixtures
+  - type: Physics
   - type: InteractionOutline
   - type: Damageable
     damageContainer: Inorganic

--- a/Resources/Prototypes/Entities/Structures/Specific/dragon.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/dragon.yml
@@ -11,7 +11,7 @@
   - type: Physics
     bodyType: Static
     canCollide: false
-  - type: Fixtures
+  - type: Physics
   - type: Sprite
     layers:
     - sprite: Structures/Specific/carp_rift.rsi

--- a/Resources/Prototypes/Entities/Structures/Specific/dragon.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/dragon.yml
@@ -11,7 +11,6 @@
   - type: Physics
     bodyType: Static
     canCollide: false
-  - type: Physics
   - type: Sprite
     layers:
     - sprite: Structures/Specific/carp_rift.rsi

--- a/Resources/Prototypes/Entities/Structures/Specific/xeno.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/xeno.yml
@@ -30,7 +30,6 @@
     damageModifierSet: Metallic
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -66,7 +65,7 @@
       shader: unshaded
     - state: teeth_unshaded
       shader: unshaded
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -66,7 +66,6 @@
       damageModifierSet: Metallic
     - type: Physics
       bodyType: Dynamic
-    - type: Fixtures
       fixtures:
         fix1:
           shape:
@@ -677,7 +676,6 @@
       state: grey-1
     - type: Physics
       bodyType: Dynamic
-    - type: Fixtures
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -43,7 +43,6 @@
       collection: MetalThud
   - type: InteractionOutline
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -262,7 +261,6 @@
       collection: MetalThud
   - type: InteractionOutline
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -9,7 +9,6 @@
     - type: Clickable
     - type: Physics
       bodyType: KinematicController
-    - type: Fixtures
       fixtures:
         fix1:
           shape:
@@ -95,7 +94,7 @@
   name: ghost box
   description: Beware!
   components:
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -26,7 +26,6 @@
       map: ["enum.PaperLabelVisuals.Layer"]
   - type: InteractionOutline
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -353,7 +353,6 @@
         acts: [ "Destruction" ]
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -405,12 +404,11 @@
             max: 2
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: Physics
-    bodyType: Dynamic
   - type: EntityStorage
     capacity: 1
     airtight: false
-  - type: Fixtures
+  - type: Physics
+    bodyType: Dynamic
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
@@ -9,7 +9,6 @@
     noRot: true
   - type: InteractionOutline
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -72,7 +71,7 @@
   parent: StorageTank
   abstract: true
   components:
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
@@ -24,7 +24,7 @@
         type: StorageBoundUserInterface
   - type: Transform
     noRot: true
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -106,7 +106,7 @@
     - state: chestdrawer
     - state: chestdrawer-open
       map: ["openLayer"]
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/glass_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/glass_box.yml
@@ -5,10 +5,9 @@
   components:
   - type: Transform
     anchored: true
+  - type: InteractionOutline
   - type: Physics
     bodyType: Static
-  - type: InteractionOutline
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -43,7 +42,7 @@
     - state: locked
       shader: unshaded
       map: ["enum.LockVisualLayers.Lock"]
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -24,7 +24,6 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -101,7 +100,6 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -66,7 +66,7 @@
     containers:
       storagebase: !type:Container
         ents: [ ]
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/paper_bin.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/paper_bin.yml
@@ -19,7 +19,7 @@
           tags:
           - Document
           - Write
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Storage/storage.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/storage.yml
@@ -19,7 +19,7 @@
     sprite: Structures/Furniture/furniture.rsi
     state: rack
     snapCardinals: true
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/atmos_plaque.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/atmos_plaque.yml
@@ -5,7 +5,6 @@
   components:
   - type: WallMount
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
@@ -13,7 +13,6 @@
   - type: Physics
     bodyType: Static
     canCollide: false
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/bell.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/bell.yml
@@ -31,7 +31,6 @@
   - type: Physics
     canCollide: false
     bodyType: Static
-  - type: Physics
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/bell.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/bell.yml
@@ -31,7 +31,7 @@
   - type: Physics
     canCollide: false
     bodyType: Static
-  - type: Fixtures
+  - type: Physics
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/monitors_televisions.yml
@@ -18,7 +18,7 @@
     radius: 1.5
     energy: 1.6
     color: "#b89f25"
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -47,7 +47,7 @@
         state: telescreen_frame
       - map: ["computerLayerScreen"]
         state: telescreen
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -122,7 +122,7 @@
   name: television frame
   description: Finally, some decent reception around here...
   components:
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
@@ -6,7 +6,6 @@
   components:
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       light:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -25,7 +25,6 @@
   - type: Construction
     graph: SignalSwitchGraph
     node: SignalSwitchNode
-  - type: Fixtures
   - type: DeviceNetwork
     deviceNetId: Wireless
   - type: WirelessNetworkConnection
@@ -71,7 +70,6 @@
   - type: Construction
     graph: SignalButtonGraph
     node: SignalButtonNode
-  - type: Fixtures
   - type: DeviceNetwork
     deviceNetId: Wireless
   - type: WirelessNetworkConnection
@@ -136,7 +134,6 @@
     - type: Construction
       graph: LightSwitchGraph
       node: LightSwitchNode
-    - type: Fixtures
     - type: Tag
       tags:
       - Structure
@@ -516,7 +513,6 @@
     sprite: Structures/Wallmounts/switch_frame.rsi
     state: grey
   - type: Rotatable
-  - type: Fixtures
 
 - type: entity
   id: ButtonFrameGrey

--- a/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/fence_metal.yml
@@ -96,7 +96,6 @@
       visible: false
   - type: Physics
     canCollide: false
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -154,7 +153,7 @@
       map: ["enum.ElectrifiedLayers.Sparks"]
       shader: unshaded
       visible: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -212,7 +211,7 @@
       map: ["enum.ElectrifiedLayers.Sparks"]
       shader: unshaded
       visible: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       # needs two shapes to properly handle a triangle corner without weirdness
       fix1:
@@ -259,7 +258,7 @@
       map: ["enum.ElectrifiedLayers.Sparks"]
       shader: unshaded
       visible: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -295,7 +294,7 @@
       map: [ "enum.ElectrifiedLayers.Sparks" ]
       shader: unshaded
       visible: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Walls/fence_wood.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/fence_wood.yml
@@ -86,7 +86,7 @@
   - type: Sprite
     layers:
     - state: straight
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -115,7 +115,7 @@
   - type: Sprite
     layers:
     - state: end
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -144,7 +144,7 @@
   - type: Sprite
     layers:
     - state: corner
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -182,7 +182,7 @@
   - type: Sprite
     layers:
     - state: tjunction
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -219,7 +219,7 @@
     layers:
     - state: end
       map: ["enum.DoorVisualLayers.Base"]
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -269,7 +269,7 @@
   - type: Sprite
     layers:
     - state: straight_small
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -297,7 +297,7 @@
   - type: Sprite
     layers:
     - state: end_small
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -325,7 +325,7 @@
   - type: Sprite
     layers:
     - state: corner_small
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -362,7 +362,7 @@
   - type: Sprite
     layers:
     - state: tjunction_small
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -398,7 +398,7 @@
     layers:
     - state: end_small
       map: ["enum.DoorVisualLayers.Base"]
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Walls/girders.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/girders.yml
@@ -9,7 +9,6 @@
     noRot: false
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -55,7 +55,6 @@
           nodeGroupID: Apc
     - type: Physics
       bodyType: Static
-    - type: Fixtures
       fixtures:
         fix1:
           shape:
@@ -182,7 +181,7 @@
     - type: Icon
       sprite: Structures/Walls/grille.rsi
       state: grille_diagonal
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:
@@ -217,7 +216,7 @@
     - type: Icon
       sprite: Structures/Walls/clockwork_grille.rsi
       state: ratvargrille_diagonal
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -128,7 +128,6 @@
       graph: Grille
       node: grilleBroken
       deconstructionTarget: start
-    - type: Fixtures # overwrite BaseStructure parent.
     - type: Physics
       bodyType: Static
       canCollide: false

--- a/Resources/Prototypes/Entities/Structures/Walls/railing.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/railing.yml
@@ -33,7 +33,7 @@
     state: side
   - type: Icon
     state: side
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -79,7 +79,7 @@
     state: corner
   - type: Icon
     state: corner
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -134,7 +134,7 @@
     state: corner_small
   - type: Icon
     state: corner_small
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -180,7 +180,7 @@
     state: round
   - type: Icon
     state: round
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -32,7 +32,6 @@
     damageModifierSet: StructuralMetallic
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -564,7 +563,7 @@
     airBlockedDirection:
     - South
     - East
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -821,8 +820,6 @@
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: StructuralMetallic
-  - type: Physics
-    bodyType: Static
   - type: Reflect
     reflectProb: 1
   - type: Pullable
@@ -831,7 +828,8 @@
     airBlockedDirection:
     - South
     - East
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       fix1:
         shape:
@@ -1324,7 +1322,6 @@
       - Wall
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -1347,7 +1344,7 @@
         - Wall
     - type: Physics
       bodyType: Static
-    - type: Fixtures
+    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -556,14 +556,13 @@
   - type: Icon
     sprite: Structures/Walls/plastitanium_diagonal.rsi
     state: state0
-  - type: Physics
-    bodyType: Static
   - type: Airtight
     noAirWhenFullyAirBlocked: false
     airBlockedDirection:
     - South
     - East
   - type: Physics
+    bodyType: Static
     fixtures:
       fix1:
         shape:
@@ -1344,7 +1343,6 @@
         - Wall
     - type: Physics
       bodyType: Static
-    - type: Physics
       fixtures:
         fix1:
           shape:

--- a/Resources/Prototypes/Entities/Structures/Windows/clockwork.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/clockwork.yml
@@ -129,7 +129,7 @@
   - type: Icon
     sprite: Structures/Windows/clockwork_diagonal.rsi
     state: state0
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Windows/mining.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/mining.yml
@@ -71,7 +71,7 @@
   - type: Icon
     sprite: Structures/Windows/mining_diagonal.rsi
     state: state0
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
@@ -129,7 +129,7 @@
   - type: Icon
     sprite: Structures/Windows/plasma_diagonal.rsi
     state: state0
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
@@ -51,7 +51,7 @@
     key: windows
     base: ptwindow
   - type: Airtight
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:
@@ -128,7 +128,7 @@
     mode: Diagonal
     key: windows
     base: state
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
@@ -136,7 +136,7 @@
   - type: Icon
     sprite: Structures/Windows/reinforced_window_diagonal.rsi
     state: state0
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -132,7 +132,7 @@
   - type: Icon
     sprite: Structures/Windows/reinforced_plasma_diagonal.rsi
     state: state0
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
@@ -129,7 +129,7 @@
   - type: Icon
     sprite: Structures/Windows/reinforced_uranium_diagonal.rsi
     state: state0
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
@@ -74,7 +74,7 @@
   - type: Icon
     sprite: Structures/Windows/shuttle_window_diagonal.rsi
     state: state0
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
@@ -124,7 +124,7 @@
   - type: Icon
     sprite: Structures/Windows/uranium_window_diagonal.rsi
     state: state0
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -26,7 +26,6 @@
     state: full
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -152,7 +151,6 @@
     interactSuccessSound:
       path: /Audio/Effects/glass_knock.ogg
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -261,7 +259,7 @@
   - type: Icon
     sprite: Structures/Windows/window_diagonal.rsi
     state: state0
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/barricades.yml
+++ b/Resources/Prototypes/Entities/Structures/barricades.yml
@@ -17,7 +17,6 @@
     drawdepth: BlastDoors
     noRot: true
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -93,7 +92,6 @@
     graph: BarricadeDirectional
     node: barricadefull
   - type: Physics
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/base_structure.yml
+++ b/Resources/Prototypes/Entities/Structures/base_structure.yml
@@ -9,7 +9,6 @@
   - type: Clickable
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -42,7 +41,6 @@
   - type: Clickable
   - type: Physics
     bodyType: Dynamic
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
+++ b/Resources/Prototypes/Entities/Structures/cargo_telepad.yml
@@ -5,13 +5,12 @@
   description: Beam in the pizzas and dig in.
   components:
   - type: InteractionOutline
-  - type: Physics
-    bodyType: Static
-    canCollide: false
   - type: Transform
     anchored: true
     noRot: true
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
+    canCollide: false
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -19,7 +19,6 @@
   - type: ExtensionCableReceiver
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       conveyor:
         shape: !type:PolygonShape

--- a/Resources/Prototypes/Entities/Structures/hydro_tray.yml
+++ b/Resources/Prototypes/Entities/Structures/hydro_tray.yml
@@ -4,7 +4,7 @@
   id: hydroponicsTray
   description: An interstellar-grade space farmplot allowing for rapid growth and selective breeding of crops. Just... keep in mind the space weeds.
   components:
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -9,11 +9,10 @@
     sprite: Structures/plastic_flaps.rsi
     state: plasticflaps
     drawdepth: Mobs
-  - type: Physics
-    bodyType: Static
   - type: Transform
     anchored: true
-  - type: Fixtures
+  - type: Physics
+    bodyType: Static
     fixtures:
       fix1:
         shape:
@@ -59,7 +58,7 @@
   suffix: Opaque
   description: Heavy duty, plastic flaps. Definitely can't get past those. No way.
   components:
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Structures/soil.yml
+++ b/Resources/Prototypes/Entities/Structures/soil.yml
@@ -8,7 +8,6 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Tiles/bananium.yml
+++ b/Resources/Prototypes/Entities/Tiles/bananium.yml
@@ -48,7 +48,6 @@
     intersectRatio: 0.2
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       slips:
         shape:

--- a/Resources/Prototypes/Entities/Tiles/chasm.yml
+++ b/Resources/Prototypes/Entities/Tiles/chasm.yml
@@ -30,7 +30,6 @@
     base: chasm
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:
@@ -55,7 +54,7 @@
     sprite: Tiles/Planet/Chasms/chromite_chasm.rsi
   - type: Icon
     sprite: Tiles/Planet/Chasms/chromite_chasm.rsi
-    
+
 - type: entity
   parent: FloorChasmEntity
   id: FloorDesertChasm
@@ -65,7 +64,7 @@
     sprite: Tiles/Planet/Chasms/desert_chasm.rsi
   - type: Icon
     sprite: Tiles/Planet/Chasms/desert_chasm.rsi
-    
+
 - type: entity
   parent: FloorChasmEntity
   id: FloorSnowChasm

--- a/Resources/Prototypes/Entities/Tiles/lava.yml
+++ b/Resources/Prototypes/Entities/Tiles/lava.yml
@@ -37,7 +37,6 @@
     base: lava
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
+++ b/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
@@ -37,7 +37,6 @@
     base: plasma
   - type: Physics
     bodyType: Static
-  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
+++ b/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
@@ -37,7 +37,7 @@
     base: plasma
   - type: Physics
     bodyType: Static
-  - type: Fixtures
+  - type: Physics
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Tiles/water.yml
+++ b/Resources/Prototypes/Entities/Tiles/water.yml
@@ -20,7 +20,7 @@
   - type: SolutionContainerManager
     solutions:
       pool:
-        maxVol: 9999999 #.inf seems to break the whole yaml file, but would definitely be preferable. 
+        maxVol: 9999999 #.inf seems to break the whole yaml file, but would definitely be preferable.
         reagents:
         - ReagentId: Water
           Quantity: 9999999
@@ -37,7 +37,6 @@
     sprintSpeedModifier: 0.5
   - type: Physics
     bodyType: Static
-  - type: Fixtures
     fixtures:
       fix1:
         shape:

--- a/Resources/Prototypes/Entities/Virtual/tether.yml
+++ b/Resources/Prototypes/Entities/Virtual/tether.yml
@@ -5,7 +5,6 @@
   - type: Physics
     bodyType: Dynamic
     sleepingAllowed: false
-  - type: Physics
     fixtures:
       tether:
         shape:

--- a/Resources/Prototypes/Entities/Virtual/tether.yml
+++ b/Resources/Prototypes/Entities/Virtual/tether.yml
@@ -5,7 +5,7 @@
   - type: Physics
     bodyType: Dynamic
     sleepingAllowed: false
-  - type: Fixtures
+  - type: Physics
     fixtures:
       tether:
         shape:

--- a/Resources/Prototypes/Magic/Fixtures/runes.yml
+++ b/Resources/Prototypes/Magic/Fixtures/runes.yml
@@ -18,7 +18,7 @@
   name: "collision rune"
   abstract: true
   components:
-    - type: Fixtures
+    - type: Physics
       fixtures:
         rune:
           shape:
@@ -29,7 +29,6 @@
             - ItemMask
           layer:
             - SlipLayer
-    - type: Physics
 
 - type: entity
   parent: CollideRune
@@ -91,7 +90,7 @@
   components:
     - type: TriggerOnCollide
       fixtureID: ignition
-    - type: Fixtures
+    - type: Physics
       fixtures:
         ignition:
           shape:

--- a/Resources/Prototypes/floor_trap.yml
+++ b/Resources/Prototypes/floor_trap.yml
@@ -7,7 +7,7 @@
     - type: Sprite
       sprite: Tiles/Misc/floortrap.rsi
       state: floortrap
-    - type: Fixtures
+    - type: Physics
       fixtures:
         floortrap:
           shape:
@@ -18,7 +18,6 @@
             - ItemMask
           layer:
             - SlipLayer
-    - type: Physics
     - type: Tag
       tags:
         - HideContextMenu


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/5566

## Breaking changes
Boy is there.
Code-side the main nasty one is SetCanCollide having a bool arg removed so hope you were already using named args.

Many many yaml breaking changes.
