### PR TITLE
[Hotfix] Disable holopad emotes

### DIFF
--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -76,7 +76,7 @@ public sealed class HolopadSystem : SharedHolopadSystem
         SubscribeLocalEvent<HolopadUserComponent, ComponentShutdown>(OnHolopadUserShutdown);
 
         // Misc events
-        // SubscribeLocalEvent<HolopadUserComponent, EmoteEvent>(OnEmote); Commented out due to a bug with ALL spectators hearing the emotes during broadcasts. All bless chatcode.
+        // SubscribeLocalEvent<HolopadUserComponent, EmoteEvent>(OnEmote); Commented out due to a bug with ALL spectators hearing the emotes during broadcasts. Will be re-enabled after chat refactor.
         SubscribeLocalEvent<HolopadUserComponent, JumpToCoreEvent>(OnJumpToCore);
         SubscribeLocalEvent<HolopadComponent, GetVerbsEvent<AlternativeVerb>>(AddToggleProjectorVerb);
         SubscribeLocalEvent<HolopadComponent, EntRemovedFromContainerMessage>(OnAiRemove);
@@ -368,7 +368,7 @@ public sealed class HolopadSystem : SharedHolopadSystem
 
     #region: Misc events
 
-    // Commented out due to a bug with ALL spectators hearing the emotes during broadcasts. All bless chatcode.
+    // Commented out due to a bug with ALL spectators hearing the emotes during broadcasts. Will be re-enabled after chat refactor.
     /*private void OnEmote(Entity<HolopadUserComponent> entity, ref EmoteEvent args)
     {
         foreach (var linkedHolopad in entity.Comp.LinkedHolopads)

--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -76,7 +76,7 @@ public sealed class HolopadSystem : SharedHolopadSystem
         SubscribeLocalEvent<HolopadUserComponent, ComponentShutdown>(OnHolopadUserShutdown);
 
         // Misc events
-        SubscribeLocalEvent<HolopadUserComponent, EmoteEvent>(OnEmote);
+        // SubscribeLocalEvent<HolopadUserComponent, EmoteEvent>(OnEmote); Commented out due to a bug with ALL spectators hearing the emotes during broadcasts. All bless chatcode.
         SubscribeLocalEvent<HolopadUserComponent, JumpToCoreEvent>(OnJumpToCore);
         SubscribeLocalEvent<HolopadComponent, GetVerbsEvent<AlternativeVerb>>(AddToggleProjectorVerb);
         SubscribeLocalEvent<HolopadComponent, EntRemovedFromContainerMessage>(OnAiRemove);
@@ -368,7 +368,8 @@ public sealed class HolopadSystem : SharedHolopadSystem
 
     #region: Misc events
 
-    private void OnEmote(Entity<HolopadUserComponent> entity, ref EmoteEvent args)
+    // Commented out due to a bug with ALL spectators hearing the emotes during broadcasts. All bless chatcode.
+    /*private void OnEmote(Entity<HolopadUserComponent> entity, ref EmoteEvent args)
     {
         foreach (var linkedHolopad in entity.Comp.LinkedHolopads)
         {
@@ -393,7 +394,7 @@ public sealed class HolopadSystem : SharedHolopadSystem
                 _chatSystem.TryEmoteWithChat(receiver.Comp.Hologram.Value, args.Emote, ChatTransmitRange.Normal, false, name, true, true);
             }
         }
-    }
+    }*/
 
     private void OnJumpToCore(Entity<HolopadUserComponent> entity, ref JumpToCoreEvent args)
     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Holopad emoting is currently broken as all emotes get sent to all spectators at once. Which causes huge issues during emergency broadcasts. This should be reverted once newchat is out and the EmoteEvent supports emoting with custom emotes too.
It was unfinished anyways as it was supposed to support custom emotes to begin with.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
*Kristopher Laborde screams!*
*Kristopher Laborde screams!*
*Kristopher Laborde screams!*
*Kristopher Laborde screams!*
*Kristopher Laborde screams!*
*Kristopher Laborde screams!*

## Technical details
<!-- Summary of code changes for easier review. -->
Just commented out the function.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/0cd13c50-fef9-4237-8551-ed1c484192fe)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
