### PR TITLE
Ignore audio entities in SpawnAndDeleteEntityCountTest

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Robust.Shared;
+using Robust.Shared.Audio.Components;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
@@ -216,14 +217,17 @@ namespace Content.IntegrationTests.Tests
         /// generally not spawn unrelated / detached entities. Any entities that do get spawned should be parented to
         /// the spawned entity (e.g., in a container). If an entity needs to spawn an entity somewhere in null-space,
         /// it should delete that entity when it is no longer required. This test mainly exists to prevent "entity leak"
-        /// bugs, where spawning some entity starts spawning unrelated entities in null space.
+        /// bugs, where spawning some entity starts spawning unrelated entities in null space that stick around after
+        /// the original entity is gone.
+        ///
+        /// Note that this isn't really a strict requirement, and there are probably quite a few edge cases. Its a pretty
+        /// crude test to try catch issues like this, and possibly should just be disabled.
         /// </remarks>
         [Test]
         public async Task SpawnAndDeleteEntityCountTest()
         {
             var settings = new PoolSettings { Connected = true, Dirty = true };
             await using var pair = await PoolManager.GetServerClient(settings);
-            var mapManager = pair.Server.ResolveDependency<IMapManager>();
             var mapSys = pair.Server.System<SharedMapSystem>();
             var server = pair.Server;
             var client = pair.Client;
@@ -261,6 +265,9 @@ namespace Content.IntegrationTests.Tests
 
             await pair.RunTicksSync(3);
 
+            // We consider only non-audio entities, as some entities will just play sounds when they spawn.
+            int Count(IEntityManager ent) =>  ent.EntityCount - ent.Count<AudioComponent>();
+
             foreach (var protoId in protoIds)
             {
                 // TODO fix ninja
@@ -268,8 +275,8 @@ namespace Content.IntegrationTests.Tests
                 if (protoId == "MobHumanSpaceNinja")
                     continue;
 
-                var count = server.EntMan.EntityCount;
-                var clientCount = client.EntMan.EntityCount;
+                var count = Count(server.EntMan);
+                var clientCount = Count(client.EntMan);
                 EntityUid uid = default;
                 await server.WaitPost(() => uid = server.EntMan.SpawnEntity(protoId, coords));
                 await pair.RunTicksSync(3);
@@ -277,30 +284,30 @@ namespace Content.IntegrationTests.Tests
                 // If the entity deleted itself, check that it didn't spawn other entities
                 if (!server.EntMan.EntityExists(uid))
                 {
-                    if (server.EntMan.EntityCount != count)
+                    if (Count(server.EntMan) != count)
                     {
                         Assert.Fail($"Server prototype {protoId} failed on deleting itself");
                     }
 
-                    if (client.EntMan.EntityCount != clientCount)
+                    if (Count(client.EntMan) != clientCount)
                     {
                         Assert.Fail($"Client prototype {protoId} failed on deleting itself\n" +
-                                    $"Expected {clientCount} and found {client.EntMan.EntityCount}.\n" +
+                                    $"Expected {clientCount} and found {Count(client.EntMan)}.\n" +
                                     $"Server was {count}.");
                     }
                     continue;
                 }
 
                 // Check that the number of entities has increased.
-                if (server.EntMan.EntityCount <= count)
+                if (Count(server.EntMan) <= count)
                 {
                     Assert.Fail($"Server prototype {protoId} failed on spawning as entity count didn't increase");
                 }
 
-                if (client.EntMan.EntityCount <= clientCount)
+                if (Count(client.EntMan) <= clientCount)
                 {
                     Assert.Fail($"Client prototype {protoId} failed on spawning as entity count didn't increase" +
-                                $"Expected at least {clientCount} and found {client.EntMan.EntityCount}. " +
+                                $"Expected at least {clientCount} and found {Count(client.EntMan)}. " +
                                 $"Server was {count}");
                 }
 
@@ -308,15 +315,15 @@ namespace Content.IntegrationTests.Tests
                 await pair.RunTicksSync(3);
 
                 // Check that the number of entities has gone back to the original value.
-                if (server.EntMan.EntityCount != count)
+                if (Count(server.EntMan) != count)
                 {
                     Assert.Fail($"Server prototype {protoId} failed on deletion count didn't reset properly");
                 }
 
-                if (client.EntMan.EntityCount != clientCount)
+                if (Count(client.EntMan) != clientCount)
                 {
                     Assert.Fail($"Client prototype {protoId} failed on deletion count didn't reset properly:\n" +
-                                $"Expected {clientCount} and found {client.EntMan.EntityCount}.\n" +
+                                $"Expected {clientCount} and found {Count(client.EntMan)}.\n" +
                                 $"Server was {count}.");
                 }
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Prevents the test from failing whenever an entity plays detached sounds when it is spawned.

## Why / Balance

The test was written before audio entities existed, and it was just never updated.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

