### PR TITLE
Fix race condition causing disconnected admins to appear in adminwho

### DIFF
--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -409,6 +409,17 @@ namespace Content.Server.Administration.Managers
 
         private async Task<(AdminData dat, int? rankId, bool specialLogin)?> LoadAdminData(ICommonSession session)
         {
+            var result = await LoadAdminDataCore(session);
+
+            // Make sure admin didn't disconnect while data was loading.
+            if (session.Status != SessionStatus.InGame)
+                return null;
+
+            return result;
+        }
+
+        private async Task<(AdminData dat, int? rankId, bool specialLogin)?> LoadAdminDataCore(ICommonSession session)
+        {
             var promoteHost = IsLocal(session) && _cfg.GetCVar(CCVars.ConsoleLoginLocal)
                               || _promotedPlayers.Contains(session.UserId)
                               || session.Name == _cfg.GetCVar(CCVars.ConsoleLoginHostUser);


### PR DESCRIPTION
If an admin disconnected during the right part of the connection sequence, they'd be listed in adminwho but be disconnected from the server. This is now checked against.
