### PR TITLE
Printable bedsheets

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1082,8 +1082,29 @@
       - CarpetPurple
       - CarpetCyan
       - CarpetWhite
+      # Bedsheets
+      - BedsheetBlack
+      - BedsheetBlue
+      - BedsheetBrown
+      - BedsheetGreen
+      - BedsheetGrey
+      - BedsheetOrange
+      - BedsheetPurple
+      - BedsheetRed
+      - BedsheetWhite
+      - BedsheetYellow
+      - BedsheetClown
+      - BedsheetCosmos
+      - BedsheetIan
+      - BedsheetMedical
+      - BedsheetMime
+      - BedsheetNT
+      - BedsheetRainbow
+      - BedsheetBrigmedic
+      - BedsheetUSA
   - type: EmagLatheRecipes
     emagStaticRecipes:
+      # Clothing
       - ClothingHeadHatCentcomcap
       - ClothingHeadHatCentcom
       - ClothingUniformJumpsuitCentcomAgent
@@ -1106,6 +1127,8 @@
       - ClothingOuterWinterCentcom
       - ClothingOuterWinterSyndie
       - ClothingOuterWinterSyndieCap
+      # Bedsheet
+      - BedsheetSyndie
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1101,7 +1101,6 @@
       - BedsheetNT
       - BedsheetRainbow
       - BedsheetBrigmedic
-      - BedsheetUSA
   - type: EmagLatheRecipes
     emagStaticRecipes:
       # Clothing
@@ -1127,7 +1126,7 @@
       - ClothingOuterWinterCentcom
       - ClothingOuterWinterSyndie
       - ClothingOuterWinterSyndieCap
-      # Bedsheet
+      # Bedsheets
       - BedsheetSyndie
   - type: MaterialStorage
     whitelist:

--- a/Resources/Prototypes/Recipes/Lathes/bedsheets.yml
+++ b/Resources/Prototypes/Recipes/Lathes/bedsheets.yml
@@ -61,7 +61,7 @@
   result: BedsheetWhite
 
 - type: latheRecipe
-  parent: BaseSpecifiedBedsheetRecipe
+  parent: BaseBedsheetRecipe
   id: BedsheetYellow
   result: BedsheetYellow
 
@@ -106,11 +106,6 @@
   parent: BaseSpecifiedBedsheetRecipe
   id: BedsheetBrigmedic
   result: BedsheetBrigmedic
-
-- type: latheRecipe
-  parent: BaseSpecifiedBedsheetRecipe
-  id: BedsheetUSA
-  result: BedsheetUSA
 
 - type: latheRecipe
   parent: BaseSpecifiedBedsheetRecipe

--- a/Resources/Prototypes/Recipes/Lathes/bedsheets.yml
+++ b/Resources/Prototypes/Recipes/Lathes/bedsheets.yml
@@ -1,0 +1,118 @@
+- type: latheRecipe
+  abstract: true
+  id: BaseBedsheetRecipe
+  completetime: 2
+  materials:
+    Cloth: 150
+
+- type: latheRecipe
+  abstract: true
+  parent: BaseBedsheetRecipe
+  id: BaseSpecifiedBedsheetRecipe
+  materials:
+    Cloth: 150
+    Durathread: 50
+
+  #Base bedsheets
+
+- type: latheRecipe
+  parent: BaseBedsheetRecipe
+  id: BedsheetBlack
+  result: BedsheetBlack
+
+- type: latheRecipe
+  parent: BaseBedsheetRecipe
+  id: BedsheetBlue
+  result: BedsheetBlue
+
+- type: latheRecipe
+  parent: BaseBedsheetRecipe
+  id: BedsheetBrown
+  result: BedsheetBrown
+
+- type: latheRecipe
+  parent: BaseBedsheetRecipe
+  id: BedsheetGreen
+  result: BedsheetGreen
+
+- type: latheRecipe
+  parent: BaseBedsheetRecipe
+  id: BedsheetGrey
+  result: BedsheetGrey
+
+- type: latheRecipe
+  parent: BaseBedsheetRecipe
+  id: BedsheetOrange
+  result: BedsheetOrange
+
+- type: latheRecipe
+  parent: BaseBedsheetRecipe
+  id: BedsheetPurple
+  result: BedsheetPurple
+
+- type: latheRecipe
+  parent: BaseBedsheetRecipe
+  id: BedsheetRed
+  result: BedsheetRed
+
+- type: latheRecipe
+  parent: BaseBedsheetRecipe
+  id: BedsheetWhite
+  result: BedsheetWhite
+
+- type: latheRecipe
+  parent: BaseSpecifiedBedsheetRecipe
+  id: BedsheetYellow
+  result: BedsheetYellow
+
+  #Specified bedsheets
+
+- type: latheRecipe
+  parent: BaseSpecifiedBedsheetRecipe
+  id: BedsheetClown
+  result: BedsheetClown
+
+- type: latheRecipe
+  parent: BaseSpecifiedBedsheetRecipe
+  id: BedsheetCosmos
+  result: BedsheetCosmos
+
+- type: latheRecipe
+  parent: BaseSpecifiedBedsheetRecipe
+  id: BedsheetIan #I'm not sure that that should be here
+  result: BedsheetIan
+
+- type: latheRecipe
+  parent: BaseSpecifiedBedsheetRecipe
+  id: BedsheetMedical
+  result: BedsheetMedical
+
+- type: latheRecipe
+  parent: BaseSpecifiedBedsheetRecipe
+  id: BedsheetMime
+  result: BedsheetMime
+
+- type: latheRecipe
+  parent: BaseSpecifiedBedsheetRecipe
+  id: BedsheetNT
+  result: BedsheetNT
+
+- type: latheRecipe
+  parent: BaseSpecifiedBedsheetRecipe
+  id: BedsheetRainbow
+  result: BedsheetRainbow
+
+- type: latheRecipe
+  parent: BaseSpecifiedBedsheetRecipe
+  id: BedsheetBrigmedic
+  result: BedsheetBrigmedic
+
+- type: latheRecipe
+  parent: BaseSpecifiedBedsheetRecipe
+  id: BedsheetUSA
+  result: BedsheetUSA
+
+- type: latheRecipe
+  parent: BaseSpecifiedBedsheetRecipe
+  id: BedsheetSyndie
+  result: BedsheetSyndie

--- a/Resources/Prototypes/Recipes/Lathes/carpets.yml
+++ b/Resources/Prototypes/Recipes/Lathes/carpets.yml
@@ -1,0 +1,51 @@
+- type: latheRecipe
+  abstract: true
+  id: BaseCarpetRecipe
+  completetime: 1
+  materials:
+    Cloth: 100
+
+- type: latheRecipe
+  parent: BaseCarpetRecipe
+  id: Carpet
+  result: FloorCarpetItemRed
+
+- type: latheRecipe
+  parent: BaseCarpetRecipe
+  id: CarpetBlack
+  result: FloorCarpetItemBlack
+
+- type: latheRecipe
+  parent: BaseCarpetRecipe
+  id: CarpetPink
+  result: FloorCarpetItemPink
+
+- type: latheRecipe
+  parent: BaseCarpetRecipe
+  id: CarpetBlue
+  result: FloorCarpetItemBlue
+
+- type: latheRecipe
+  parent: BaseCarpetRecipe
+  id: CarpetGreen
+  result: FloorCarpetItemGreen
+
+- type: latheRecipe
+  parent: BaseCarpetRecipe
+  id: CarpetOrange
+  result: FloorCarpetItemOrange
+
+- type: latheRecipe
+  parent: BaseCarpetRecipe
+  id: CarpetPurple
+  result: FloorCarpetItemPurple
+
+- type: latheRecipe
+  parent: BaseCarpetRecipe
+  id: CarpetCyan
+  result: FloorCarpetItemCyan
+
+- type: latheRecipe
+  parent: BaseCarpetRecipe
+  id: CarpetWhite
+  result: FloorCarpetItemWhite

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -40,13 +40,6 @@
 
 - type: latheRecipe
   abstract: true
-  id: BaseCarpetRecipe
-  completetime: 1
-  materials:
-    Cloth: 100
-
-- type: latheRecipe
-  abstract: true
   parent: BaseHatRecipe
   id: BaseCommandHatRecipe
   materials:
@@ -916,49 +909,3 @@
   parent: BaseNeckClothingRecipe
   id: ClothingNeckScarfStripedPurple
   result: ClothingNeckScarfStripedPurple
-
-# Carpets
-- type: latheRecipe
-  parent: BaseCarpetRecipe
-  id: Carpet
-  result: FloorCarpetItemRed
-
-- type: latheRecipe
-  parent: BaseCarpetRecipe
-  id: CarpetBlack
-  result: FloorCarpetItemBlack
-
-- type: latheRecipe
-  parent: BaseCarpetRecipe
-  id: CarpetPink
-  result: FloorCarpetItemPink
-
-- type: latheRecipe
-  parent: BaseCarpetRecipe
-  id: CarpetBlue
-  result: FloorCarpetItemBlue
-
-- type: latheRecipe
-  parent: BaseCarpetRecipe
-  id: CarpetGreen
-  result: FloorCarpetItemGreen
-
-- type: latheRecipe
-  parent: BaseCarpetRecipe
-  id: CarpetOrange
-  result: FloorCarpetItemOrange
-
-- type: latheRecipe
-  parent: BaseCarpetRecipe
-  id: CarpetPurple
-  result: FloorCarpetItemPurple
-
-- type: latheRecipe
-  parent: BaseCarpetRecipe
-  id: CarpetCyan
-  result: FloorCarpetItemCyan
-
-- type: latheRecipe
-  parent: BaseCarpetRecipe
-  id: CarpetWhite
-  result: FloorCarpetItemWhite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Bedsheets now can be printed on uniform printer

## Why / Balance
Right now bedsheets can't be created. This PR fixes it

## Technical details
For the recipes of carpets has been created yml file because it isn't clothing

## Media
![Безымянный](https://github.com/user-attachments/assets/7b3a96bc-5f5f-46a8-837f-b81a947c6361)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Bedsheets now can be printed on uniform printer
