### PR TITLE
Better PowerCharge menu wrapping (retry)

### DIFF
--- a/Content.Client/Power/PowerCharge/PowerChargeWindow.xaml
+++ b/Content.Client/Power/PowerCharge/PowerChargeWindow.xaml
@@ -1,4 +1,4 @@
-﻿<controls:FancyWindow
+<controls:FancyWindow
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     MinSize="320 180"
@@ -41,6 +41,11 @@
                         HorizontalAlignment="Center"/>
                 </BoxContainer>
 
+                <Control /> <!-- Empty control to act as a spacer in the grid. -->
+
+                <Label Name="PowerLabel"
+                    Text="0 / 0 W" />
+
                 <!-- Status -->
                 <Label
                     Text="{Loc 'power-charge-window-status'}"
@@ -68,17 +73,12 @@
                         Margin="4 0"
                         Text="0 %" />
                 </ProgressBar>
-
-                <Control /> <!-- Empty control to act as a spacer in the grid. -->
-
-                <Label Name="PowerLabel"
-                    Text="0 / 0 W" />                
             </GridContainer>
         </BoxContainer>
         <PanelContainer
             StyleClasses="Inset"
             VerticalAlignment="Top">
-            
+
             <SpriteView Name="EntityView"
                 SetSize="96 96"
                 Margin="0 0 0 26"

--- a/Content.Client/Power/PowerCharge/PowerChargeWindow.xaml
+++ b/Content.Client/Power/PowerCharge/PowerChargeWindow.xaml
@@ -1,33 +1,88 @@
-﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                MinSize="270 130"
-                SetSize="360 180">
-    <BoxContainer Margin="4 0" Orientation="Horizontal">
-        <BoxContainer Orientation="Vertical" HorizontalExpand="True">
-            <GridContainer Margin="2 0 0 0" Columns="2">
+﻿<controls:FancyWindow
+    xmlns="https://spacestation14.io"
+    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+    MinSize="320 180"
+    Resizable="False">
+    <BoxContainer
+        Margin="12 8"
+        Orientation="Horizontal"
+        SeparationOverride="12">
+        <BoxContainer
+            Orientation="Vertical"
+            HorizontalExpand="True">
+            <GridContainer
+                Columns="2"
+                VerticalAlignment="Center">
+
                 <!-- Power -->
-                <Label Text="{Loc 'power-charge-window-power'}" HorizontalExpand="True" StyleClasses="StatusFieldTitle" />
-                <BoxContainer Orientation="Horizontal" MinWidth="120">
-                    <Button Name="OnButton" Text="{Loc 'power-charge-window-power-on'}" StyleClasses="OpenRight" />
-                    <Button Name="OffButton" Text="{Loc 'power-charge-window-power-off'}" StyleClasses="OpenLeft" />
+                <Label
+                    Text="{Loc 'power-charge-window-power'}"
+                    HorizontalExpand="True"
+                    StyleClasses="StatusFieldTitle" />
+
+                <BoxContainer
+                    Orientation="Horizontal"
+                    MinWidth="120"
+                    SetWidth="160">
+
+                    <Button Name="OnButton"
+                        Text="{Loc 'power-charge-window-power-on'}"
+                        StyleClasses="OpenRight"
+                        MinWidth="60"
+                        SetWidth="80"
+                        HorizontalAlignment="Center"/>
+
+                    <Button
+                        Name="OffButton"
+                        Text="{Loc 'power-charge-window-power-off'}"
+                        StyleClasses="OpenLeft"
+                        MinWidth="60"
+                        SetWidth="80"
+                        HorizontalAlignment="Center"/>
                 </BoxContainer>
-                <Control /> <!-- Empty control to act as a spacer in the grid. -->
-                <Label Name="PowerLabel" Text="0 / 0 W" />
+
                 <!-- Status -->
-                <Label Text="{Loc 'power-charge-window-status'}"  StyleClasses="StatusFieldTitle" />
-                <Label Name="StatusLabel" Text="{Loc 'power-charge-window-status-fully-charged'}" />
+                <Label
+                    Text="{Loc 'power-charge-window-status'}"
+                    StyleClasses="StatusFieldTitle" />
+                <Label Name="StatusLabel"
+                    Text="{Loc 'power-charge-window-status-fully-charged'}" />
+
                 <!-- ETA -->
-                <Label Text="{Loc 'power-charge-window-eta'}" StyleClasses="StatusFieldTitle" />
-                <Label Name="EtaLabel" Text="N/A" />
+                <Label
+                    Text="{Loc 'power-charge-window-eta'}"
+                    StyleClasses="StatusFieldTitle" />
+                <Label Name="EtaLabel"
+                    Text="N/A" />
+
                 <!-- Charge -->
-                <Label Text="{Loc 'power-charge-window-charge'}" StyleClasses="StatusFieldTitle" />
-                <ProgressBar Name="ChargeBar" MaxValue="255">
-                    <Label Name="ChargeText" Margin="4 0" Text="0 %" />
+                <Label
+                    Text="{Loc 'power-charge-window-charge'}"
+                    StyleClasses="StatusFieldTitle" />
+
+                <ProgressBar Name="ChargeBar"
+                    MaxValue="255">
+
+                    <Label Name="ChargeText"
+                        HorizontalAlignment="Center"
+                        Margin="4 0"
+                        Text="0 %" />
                 </ProgressBar>
+
+                <Control /> <!-- Empty control to act as a spacer in the grid. -->
+
+                <Label Name="PowerLabel"
+                    Text="0 / 0 W" />                
             </GridContainer>
         </BoxContainer>
-        <PanelContainer Margin="12 0 0 0" StyleClasses="Inset" VerticalAlignment="Center">
-            <SpriteView Name="EntityView" SetSize="96 96" OverrideDirection="South" />
+        <PanelContainer
+            StyleClasses="Inset"
+            VerticalAlignment="Top">
+            
+            <SpriteView Name="EntityView"
+                SetSize="96 96"
+                Margin="0 0 0 26"
+                OverrideDirection="South" />
         </PanelContainer>
     </BoxContainer>
 </controls:FancyWindow>


### PR DESCRIPTION
## About the PR
See #33656

> Fixed and slightly edited the PowerCharge menu. Now on the RU localization, no text will climb where it is not needed.

They've granted permissions (Russian channel):
https://discord.com/channels/310555209753690112/1278342990305300491/1320747429712363521

So I'll finish this.

## Why / Balance
Looks better

## Media

Before:
![image](https://github.com/user-attachments/assets/86a390cd-f45c-43a7-8b1c-28c99cfa1774)

After:
![image](https://github.com/user-attachments/assets/2415476e-76b7-4c24-bc0e-550f79c147eb)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl: VlaDOS1408
- fix: Fixed Gravity gen menu resizing! Now it looks like it should.
