### PR TITLE
More robust Particle Accelerator menu (retry)

### DIFF
--- a/Content.Client/ParticleAccelerator/UI/ParticleAcceleratorControlMenu.xaml
+++ b/Content.Client/ParticleAccelerator/UI/ParticleAcceleratorControlMenu.xaml
@@ -1,50 +1,129 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
-            xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-            xmlns:ui="clr-namespace:Content.Client.ParticleAccelerator.UI"
-            xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
-            Title="{Loc 'particle-accelerator-control-menu-device-version-label'}"
-            MinSize="420 320"
-            SetSize="420 320">
-    <BoxContainer Orientation="Vertical" VerticalExpand="True" Margin="0 10 0 0">
-        <BoxContainer Orientation="Horizontal" VerticalExpand="True">
-            <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True" Margin="10 0 10 5">
-                <BoxContainer Orientation="Horizontal">
-                    <RichTextLabel Name="StatusLabel" HorizontalExpand="True"/>
-                    <RichTextLabel Name="StatusStateLabel"/>
+    xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
+    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+    xmlns:ui="clr-namespace:Content.Client.ParticleAccelerator.UI"
+    Title="{Loc 'particle-accelerator-control-menu-device-version-label'}"
+    MinSize="320 120">
+
+    <!-- Main Container -->
+    <BoxContainer Orientation="Vertical"
+        VerticalExpand="True">
+
+        <!-- Sub-Main container -->
+        <BoxContainer Orientation="Horizontal"
+            VerticalExpand="True"
+            HorizontalExpand="True">
+
+            <!-- Info part -->
+            <BoxContainer Orientation="Vertical"
+                HorizontalExpand="True"
+                Margin="8">
+
+                <!-- Info -->
+                <BoxContainer Orientation="Vertical"
+                    SeparationOverride="4">
+
+                    <!-- Status -->
+                    <BoxContainer Orientation="Horizontal">
+                        <RichTextLabel Name="StatusLabel" HorizontalExpand="True"/>
+                        <Control MinWidth="8"/>
+                        <RichTextLabel Name="StatusStateLabel"/>
+                    </BoxContainer>
+
+                    <!-- Power -->
+                    <BoxContainer Orientation="Horizontal">
+                        <RichTextLabel Name="PowerLabel"
+                            HorizontalExpand="True"
+                            VerticalAlignment="Center"/>
+
+                        <Control MinWidth="8"/>
+
+                        <Button Name="OffButton"
+                            ToggleMode="False"
+                            Text="{Loc 'particle-accelerator-control-menu-off-button'}"
+                            StyleClasses="OpenRight"/>
+
+                        <Button Name="OnButton"
+                            ToggleMode="False"
+                            Text="{Loc 'particle-accelerator-control-menu-on-button'}"
+                            StyleClasses="OpenLeft"/>
+                    </BoxContainer>
+
+                    <!-- Strenght -->
+                    <BoxContainer Orientation="Horizontal">
+                        <RichTextLabel Name="StrengthLabel"
+                            HorizontalExpand="True"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"/>
+
+                        <Control MinWidth="8"/>
+
+                        <SpinBox Name="StateSpinBox" Value="0"/>
+                    </BoxContainer>
+
+                    <!-- Power -->
+                    <BoxContainer Orientation="Horizontal">
+                        <RichTextLabel Name="DrawLabel" HorizontalExpand="True"/>
+                        <Control MinWidth="8"/>
+                        <RichTextLabel Name="DrawValueLabel"/>
+                    </BoxContainer>
                 </BoxContainer>
-                <Control MinHeight="5"/>
-                <BoxContainer Orientation="Horizontal">
-                    <RichTextLabel Name="PowerLabel" Margin="0 0 20 0" HorizontalExpand="True" VerticalAlignment="Center"/>
-                    <Button Name="OffButton" ToggleMode="False" Text="{Loc 'particle-accelerator-control-menu-off-button'}" StyleClasses="OpenRight"/>
-                    <Button Name="OnButton" ToggleMode="False" Text="{Loc 'particle-accelerator-control-menu-on-button'}" StyleClasses="OpenLeft"/>
+
+                <Control MinHeight="8" VerticalExpand="True"/> <!-- Filler -->
+
+                <!-- Alarm -->
+                <BoxContainer Name="AlarmControl"
+                    Orientation="Vertical"
+                    VerticalAlignment="Center"
+                    Visible="False">
+
+                    <controls:StripeBack Margin="-8 0">
+                        <BoxContainer Orientation="Vertical">
+                            <RichTextLabel Name="BigAlarmLabel"
+                                HorizontalAlignment="Center"/>
+
+                            <RichTextLabel Name="BigAlarmLabelTwo"
+                                HorizontalAlignment="Center"/>
+                        </BoxContainer>
+                    </controls:StripeBack>
+
+                    <Label Text="{Loc 'particle-accelerator-control-menu-service-manual-reference'}"
+                        HorizontalAlignment="Center"
+                        StyleClasses="LabelSubText"/>
                 </BoxContainer>
-                <Control MinHeight="5"/>
-                <BoxContainer Orientation="Horizontal">
-                    <RichTextLabel Name="StrengthLabel" Margin="0 0 20 0" HorizontalExpand="True" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                    <SpinBox Name="StateSpinBox" Value="0"/>
-                </BoxContainer>
-                <Control MinHeight="5"/>
-                <BoxContainer Orientation="Horizontal">
-                    <RichTextLabel Name="DrawLabel" HorizontalExpand="True"/>
-                    <RichTextLabel Name="DrawValueLabel"/>
-                </BoxContainer>
-                <Control MinHeight="10" VerticalExpand="True"/>
-                <BoxContainer Name="AlarmControl" Orientation="Vertical" VerticalAlignment="Center" Visible="False">
-                    <RichTextLabel Name="BigAlarmLabel" HorizontalAlignment="Center"/>
-                    <RichTextLabel Name="BigAlarmLabelTwo" HorizontalAlignment="Center"/>
-                    <Label Text="{Loc 'particle-accelerator-control-menu-service-manual-reference'}" HorizontalAlignment="Center" StyleClasses="LabelSubText"/>
-                </BoxContainer>
-                <Control MinHeight="10" VerticalExpand="True"/>
             </BoxContainer>
-            <customControls:VSeparator Margin="0 0 0 10"/>
-            <BoxContainer Orientation="Vertical" Margin="20 0 20 0" VerticalAlignment="Center">
-                <PanelContainer Name="BackPanel" HorizontalAlignment="Center">
+
+            <PanelContainer StyleClasses="LowDivider" Margin="0 -8" HorizontalAlignment="Right"/>
+
+            <!-- PA Visual part -->
+            <BoxContainer Orientation="Vertical"
+                VerticalAlignment="Center"
+                Margin="8">
+
+                <PanelContainer Name="BackPanel"
+                    HorizontalAlignment="Center">
+
                     <PanelContainer.PanelOverride>
-                        <gfx:StyleBoxTexture Modulate="#202023" PatchMarginBottom="10" PatchMarginLeft="10" PatchMarginRight="10" PatchMarginTop="10"/>
+                        <gfx:StyleBoxTexture Modulate="#202023"
+                            PatchMarginBottom="8"
+                            PatchMarginLeft="8"
+                            PatchMarginRight="8"
+                            PatchMarginTop="8"/>
                     </PanelContainer.PanelOverride>
-                    <BoxContainer Orientation="Vertical" HorizontalExpand="True" HorizontalAlignment="Center" VerticalExpand="True">
-                        <GridContainer Columns="3" VSeparationOverride="0" HSeparationOverride="0" HorizontalAlignment="Center">
+
+                    <BoxContainer Orientation="Vertical"
+                        SeparationOverride="6"
+                        VerticalExpand="True"
+                        VerticalAlignment="Stretch"
+                        HorizontalExpand="True"
+                        HorizontalAlignment="Center">
+
+                        <!-- PA Visualisation -->
+                        <GridContainer Columns="3"
+                            VSeparationOverride="0"
+                            HSeparationOverride="0"
+                            HorizontalAlignment="Center">
+
                             <Control/>
                             <ui:PASegmentControl Name="EndCapTexture" BaseState="end_cap"/>
                             <Control/>
@@ -58,17 +137,47 @@
                             <ui:PASegmentControl Name="EmitterForeTexture" BaseState="emitter_fore"/>
                             <ui:PASegmentControl Name="EmitterPortTexture" BaseState="emitter_port"/>
                         </GridContainer>
-                        <Control MinHeight="5"/>
-                        <Button Name="ScanButton" Text="{Loc 'particle-accelerator-control-menu-scan-parts-button'}" HorizontalAlignment="Center"/>
+
+                        <Button Name="ScanButton"
+                            Text="{Loc 'particle-accelerator-control-menu-scan-parts-button'}"
+                            HorizontalAlignment="Center"/>
                     </BoxContainer>
                 </PanelContainer>
             </BoxContainer>
         </BoxContainer>
-        <controls:StripeBack>
-            <Label Text="{Loc 'particle-accelerator-control-menu-check-containment-field-warning'}" HorizontalAlignment="Center" StyleClasses="LabelSubText" Margin="4 4 0 4"/>
-        </controls:StripeBack>
-        <BoxContainer Orientation="Horizontal" Margin="12 0 0 0">
-            <Label Text="{Loc 'particle-accelerator-control-menu-foo-bar-baz'}" StyleClasses="LabelSubText"/>
+
+        <!-- Footer -->
+        <BoxContainer Orientation="Vertical"
+            VerticalAlignment="Bottom">
+
+            <controls:StripeBack>
+                <Label Text="{Loc 'particle-accelerator-control-menu-check-containment-field-warning'}"
+                    HorizontalAlignment="Center"
+                    StyleClasses="LabelSubText"
+                    Margin="0 4"/>
+            </controls:StripeBack>
+
+            <BoxContainer Orientation="Horizontal"
+                Margin="12 0 6 2"
+                VerticalAlignment="Bottom">
+
+                <!-- Footer title -->
+                <Label Text="{Loc 'particle-accelerator-control-menu-flavor-left'}"
+                    StyleClasses="WindowFooterText" />
+
+                <!-- Version -->
+                <Label Text="{Loc 'particle-accelerator-control-menu-flavor-right'}"
+                    StyleClasses="WindowFooterText"
+                    HorizontalAlignment="Right"
+                    HorizontalExpand="True"
+                    Margin="0 0 4 0" />
+
+                <TextureRect StyleClasses="NTLogoDark"
+                    Stretch="KeepAspectCentered"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Right"
+                    SetSize="19 19"/>
+            </BoxContainer>
         </BoxContainer>
     </BoxContainer>
 </controls:FancyWindow>

--- a/Resources/Locale/en-US/particle-accelerator/components/ui/particle-accelerator-control-menu.ftl
+++ b/Resources/Locale/en-US/particle-accelerator/components/ui/particle-accelerator-control-menu.ftl
@@ -8,7 +8,6 @@ particle-accelerator-control-menu-alarm-control-1 = [bold][color=red]PARTICLE ST
 particle-accelerator-control-menu-alarm-control-2 = [bold][color=red]LIMITER FAILURE[/bold][/color]
 particle-accelerator-control-menu-scan-parts-button = Scan Parts
 particle-accelerator-control-menu-check-containment-field-warning = Ensure containment field is active before operation
-particle-accelerator-control-menu-foo-bar-baz = FOO-BAR-BAZ
 particle-accelerator-control-menu-status-label = [bold]Status:[/bold]
 particle-accelerator-control-menu-status-unknown = [font="Monospace"][color=red]Unknown[/color][/bold]
 particle-accelerator-control-menu-status-operational = [font="Monospace"][color=green]Operational[/color][/bold]
@@ -16,6 +15,8 @@ particle-accelerator-control-menu-status-incomplete = [font="Monospace"][color=r
 particle-accelerator-control-menu-draw = [bold]Draw:[/bold]
 particle-accelerator-control-menu-draw-value = [font="Monospace"]{$watts}/{$lastReceive}[/font]
 particle-accelerator-control-menu-draw-not-available = [font="Monospace"][color=gray]N/A[/color][/font]
+particle-accelerator-control-menu-flavor-left = Please keep the clown away from this console!
+particle-accelerator-control-menu-flavor-right = v 1.6
 
 particle-accelerator-radio-message-on = PA power has been switched on.
 particle-accelerator-radio-message-off = PA power has been switched off.


### PR DESCRIPTION
## About the PR
See #33652

> I changed a little bit of everything and now in Russian localization, the menu does not look like after bombing

As usual, they've granted permissions (Russian channel):
https://discord.com/channels/310555209753690112/1278342990305300491/1320747429712363521

I'll finish this.

## Why / Balance
Robust UI is good, even if it's a problem only on the other localizations right now.

## Media

Before:
![image](https://github.com/user-attachments/assets/5f7e9db8-d7a5-40b8-b235-baf0c093b915)

After:
![image](https://github.com/user-attachments/assets/fc0c5e20-9af8-4f95-9c38-c76ca4174e59)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
https://github.com/space-wizards/space-station-14/pull/33652#issuecomment-2508710366
> I don't think it needs Changelog. It's not player facing

You say no, I say no
