### PR TITLE
SSD sleep take 2

### DIFF
--- a/Content.Shared/CCVar/CCVars.Ic.cs
+++ b/Content.Shared/CCVar/CCVars.Ic.cs
@@ -45,4 +45,17 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> ICShowSSDIndicator =
         CVarDef.Create("ic.show_ssd_indicator", true, CVar.CLIENTONLY);
+
+    /// <summary>
+    ///     Forces SSD characters to sleep after
+    /// </summary>
+    public static readonly CVarDef<bool> ICSSDSleep =
+        CVarDef.Create("ic.ssd_sleep", true, CVar.SERVER);
+
+    /// <summary>
+    ///     Time between character getting SSD status and falling asleep
+    ///     Won't work without ICSSDSleep
+    /// </summary>
+    public static readonly CVarDef<float> ICSSDSleepTime =
+        CVarDef.Create("ic.ssd_sleep_time", 600f, CVar.SERVER);
 }

--- a/Content.Shared/CCVar/CCVars.Ic.cs
+++ b/Content.Shared/CCVar/CCVars.Ic.cs
@@ -47,7 +47,7 @@ public sealed partial class CCVars
         CVarDef.Create("ic.show_ssd_indicator", true, CVar.CLIENTONLY);
 
     /// <summary>
-    ///     Forces SSD characters to sleep after
+    ///     Forces SSD characters to sleep after ICSSDSleepTime seconds
     /// </summary>
     public static readonly CVarDef<bool> ICSSDSleep =
         CVarDef.Create("ic.ssd_sleep", true, CVar.SERVER);

--- a/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.SSDIndicator;
 ///     Shows status icon when player in SSD
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-[AutoGenerateComponentState]
+[AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class SSDIndicatorComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite)]
@@ -23,6 +23,13 @@ public sealed partial class SSDIndicatorComponent : Component
     /// <summary>
     ///     When the entity should fall asleep
     /// </summary>
-    [DataField, Access(typeof(SSDIndicatorSystem))]
+    [DataField, AutoPausedField, Access(typeof(SSDIndicatorSystem))]
     public TimeSpan FallAsleepTime = TimeSpan.Zero;
+
+    /// <summary>
+    ///     Required to don't remove forced sleep from other sources
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [AutoNetworkedField]
+    public bool ForcedSleepAdded = false;
 }

--- a/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.StatusIcon;
+using Content.Shared.StatusIcon;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
@@ -19,4 +19,10 @@ public sealed partial class SSDIndicatorComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
     public ProtoId<SsdIconPrototype> Icon = "SSDIcon";
+
+    /// <summary>
+    ///     When the entity should fall asleep
+    /// </summary>
+    [DataField, Access(typeof(SSDIndicatorSystem))]
+    public TimeSpan FallAsleepTime = TimeSpan.Zero;
 }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -28,7 +28,11 @@ public sealed class SSDIndicatorSystem : EntitySystem
         if (_cfg.GetCVar(CCVars.ICSSDSleep))
         {
             component.FallAsleepTime = TimeSpan.Zero;
-            EntityManager.RemoveComponent<ForcedSleepingComponent>(uid);
+            if (component.ForcedSleepAdded) // Remove component only if it has been added by this system
+            {
+                EntityManager.RemoveComponent<ForcedSleepingComponent>(uid);
+                component.ForcedSleepAdded = false;
+            }
         }
         Dirty(uid, component);
     }
@@ -59,9 +63,11 @@ public sealed class SSDIndicatorSystem : EntitySystem
             // Forces the entity to sleep when the time has come
             if(ssd.IsSSD &&
                 ssd.FallAsleepTime <= _timing.CurTime &&
-                !TerminatingOrDeleted(uid))
+                !TerminatingOrDeleted(uid) &&
+                !TryComp<ForcedSleepingComponent>(uid, out _)) // Don't add the component if the entity has it from another sources
             {
                 EnsureComp<ForcedSleepingComponent>(uid);
+                ssd.ForcedSleepAdded = true;
             }
         }
     }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -57,7 +57,9 @@ public sealed class SSDIndicatorSystem : EntitySystem
         while (query.MoveNext(out var uid, out var ssd))
         {
             // Forces the entity to sleep when the time has come
-            if(ssd.IsSSD && ssd.FallAsleepTime <= _timing.CurTime)
+            if(ssd.IsSSD &&
+                ssd.FallAsleepTime <= _timing.CurTime &&
+                !TerminatingOrDeleted(uid))
             {
                 EnsureComp<ForcedSleepingComponent>(uid);
             }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,4 +1,8 @@
-﻿using Robust.Shared.Player;
+﻿using Content.Shared.Bed.Sleep;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.SSDIndicator;
 
@@ -7,6 +11,9 @@ namespace Content.Shared.SSDIndicator;
 /// </summary>
 public sealed class SSDIndicatorSystem : EntitySystem
 {
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
     public override void Initialize()
     {
         SubscribeLocalEvent<SSDIndicatorComponent, PlayerAttachedEvent>(OnPlayerAttached);
@@ -16,12 +23,44 @@ public sealed class SSDIndicatorSystem : EntitySystem
     private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args)
     {
         component.IsSSD = false;
+
+        // Removes force sleep and resets the time to zero
+        if (_cfg.GetCVar(CCVars.ICSSDSleep))
+        {
+            component.FallAsleepTime = TimeSpan.Zero;
+            EntityManager.RemoveComponent<ForcedSleepingComponent>(uid);
+        }
         Dirty(uid, component);
     }
 
     private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args)
     {
         component.IsSSD = true;
+
+        // Sets the time when the entity should fall asleep
+        if (_cfg.GetCVar(CCVars.ICSSDSleep))
+        {
+            component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.ICSSDSleepTime));
+        }
         Dirty(uid, component);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_cfg.GetCVar(CCVars.ICSSDSleep))
+            return;
+
+        var query = EntityQueryEnumerator<SSDIndicatorComponent>();
+
+        while (query.MoveNext(out var uid, out var ssd))
+        {
+            // Forces the entity to sleep when the time has come
+            if(ssd.IsSSD && ssd.FallAsleepTime <= _timing.CurTime)
+            {
+                EnsureComp<ForcedSleepingComponent>(uid);
+            }
+        }
     }
 }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -18,6 +18,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
     {
         SubscribeLocalEvent<SSDIndicatorComponent, PlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<SSDIndicatorComponent, PlayerDetachedEvent>(OnPlayerDetached);
+        SubscribeLocalEvent<SSDIndicatorComponent, MapInitEvent>(OnMapInit);
     }
 
     private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args)
@@ -47,6 +48,17 @@ public sealed class SSDIndicatorSystem : EntitySystem
             component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.ICSSDSleepTime));
         }
         Dirty(uid, component);
+    }
+
+    // Prevents mapped mobs to go to sleep immediately
+    private void OnMapInit(EntityUid uid, SSDIndicatorComponent component, MapInitEvent args)
+    {
+        if (_cfg.GetCVar(CCVars.ICSSDSleep) &&
+            component.IsSSD &&
+            component.FallAsleepTime == TimeSpan.Zero)
+        {
+            component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.ICSSDSleepTime));
+        }
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -64,7 +64,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
             if(ssd.IsSSD &&
                 ssd.FallAsleepTime <= _timing.CurTime &&
                 !TerminatingOrDeleted(uid) &&
-                !TryComp<ForcedSleepingComponent>(uid, out _)) // Don't add the component if the entity has it from another sources
+                !HasComp<ForcedSleepingComponent>(uid)) // Don't add the component if the entity has it from another sources
             {
                 EnsureComp<ForcedSleepingComponent>(uid);
                 ssd.ForcedSleepAdded = true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
If an entity is SSD, it gets a "timer" from cvar (default 10 mins) and after it, the entity gets forced to sleep
When entity is no longer SSD, it can be awakened

Reopened https://github.com/space-wizards/space-station-14/pull/28902 (was unable to reopen, because force-pushed)
Resolves #21906 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Nice feature

## Technical details
<!-- Summary of code changes for easier review. -->
Not really much, two new cvars, bool for ssd sleep and float for the timer
then some easy checks with time and giving or removing of the ForcedSleepComponent


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/f5471cc0-7287-4514-aefc-60f16d04aaa0


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
no

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: When an entity becomes SSD, it will be forced to sleep after 10 minutes. It can be awakened if no more SSD.

