### PR TITLE
minor fix to "silent footsteps for ninja"

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -137,8 +137,7 @@
     walkModifier: 1.1
     sprintModifier: 1.3
   - type: FootstepModifier
-    footstepSoundCollection:
-      collection: null
+    footstepSoundCollection: null
 
 - type: entity
   parent: ClothingShoesBaseButcherable


### PR DESCRIPTION
Fixes a minor oversight I missed in the review of #33280
The sound specifier itself should be `null`.
Thanks to @deltanedas for noticing.