### PR TITLE
Fixed doors being blocked with mousetraps, and other Collidable items

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -589,7 +589,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
             if (otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.GlassLayer || otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.GlassAirlockLayer || otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.TableLayer)
                 continue;
 
-            //If the colliding entity is a non-lowImpassible, ignore it by the airlock
+            // Ignore low-passable entities.
             if ((otherPhysics.Comp.CollisionMask & (int)CollisionGroup.LowImpassable) == 0)
                 continue;
 

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -589,8 +589,8 @@ public abstract partial class SharedDoorSystem : EntitySystem
             if (otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.GlassLayer || otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.GlassAirlockLayer || otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.TableLayer)
                 continue;
 
-            //If the colliding entity is a slippable item ignore it by the airlock
-            if (otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.SlipLayer && otherPhysics.Comp.CollisionMask == (int) CollisionGroup.ItemMask)
+            //If the colliding entity is a non-lowImpassible, ignore it by the airlock
+            if ((otherPhysics.Comp.CollisionMask & (int)CollisionGroup.LowImpassable) == 0)
                 continue;
 
             //For when doors need to close over conveyor belts


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The bug this PR fixes is caused by special items like mousetraps having PhysicsComponent.CanCollide equals to true, since they need to collide with other entities (mice for mousetraps, moving beings with soap etc). But as a result of this, doors will see these items as valid items to collide to, because the item would think it was colliding with the door as if it was closed;

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixed #33761 and an error with flare gun shot bullets blocking open doors from closing. This allowed using them to keep command (or any type that the player doesn't have access) doors open, or force spacing with this bug.
Fixing this should prevent not only this exploit from happening, but also make the admins don't need to even think about this meta mechanic existing,

## Technical details
<!-- Summary of code changes for easier review. -->
Changed SharedDoorSystem.GetColliding() to allow non-LowImpassible mask entities to stay in the door while it closes

## Media
<!-- Attach media if the PR makes in game changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Testing a bunch of objects on the doors
https://github.com/user-attachments/assets/7788637f-d751-443f-8a9e-8cdb9883e501
https://github.com/user-attachments/assets/81d22b7c-c5a5-433a-bbe8-7c1390011055
https://github.com/user-attachments/assets/f0e98008-9871-4d5d-8a6e-b87a1e5b6c2c

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No code or API will break, but the behavior of entities in closing doors will change. All non-LowImpassable items will be able to stay bellow doors.

## About the fix
This had two methods to be fixed, either using the CollisionGroup.LowImpassable or CollisionGroup.DoorPassable;
- Using DoorPassable would require retroactively changing every type of entity to make them DoorPassable, or apply it with specific entities, making this not concise with every item. Also, no other item, besides the conveyor, uses this CollisionGroup flag. So I opted for the second option;
- Using LowImpassable, or rather, checking for its non existence in the physics mask, its a weird implementation, but it works great;
I still think using DoorPassable would be the best option long term, but since that would need a long list of things being changed, i opted for LowImpassable. I would greatly appreciate a discussion about a new way to categorize "DoorPassable items", or a discussion if it would be best to manually change each special item to DoorPassable, or keep it like this (using LowImpassable)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Items with collisions (like mousetraps) won't kept doors form opening

