### PR TITLE
Buff frezon to acceptable values, pending a frezon rework

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 0.3
+  pricePerMole: 1


### PR DESCRIPTION
## About the PR
Buffs frezon to 1 speso per mol.
For a supercooled canister of frezon, this is ~17,000 spesos per canister.
For a regular canister that you would find in a gambling crate, this is ~1871 spesos per canister.

TLDR? Let's try it out, see how it works.

## Why / Balance
Frezon (and atmos as a whole) is a very complicated subject due to a lot of things. I'm going to try to explain this balance as best I can, mentioning some arguments echoed in design-discussions.

### Background
As we all know, atmospherics (and even engineering in general) is very complex. There are a lot of real-life principles prevalent in atmospherics gameplay, which makes the department hard to learn or get into. Additionally, atmospherics is extremely under documented. If you want to learn something in atmospherics, you basically have to learn it entirely through hear-say, as there is very little external documentation for new players to read.

Because of this, atmospherics (and engineering, but this isn't the PR for it) has developed a gargantuan skill gap.

### Making Frezon
For context, I'll note some facts about frezon (this information was graciously collected by Ilya246):
- Frezon is made by combining tritium/oxygen at a ratio of 1:8
- The reaction only happens below 73.15 K
- Nitrogen is a *catalyst* and is not actually consumed wholly in the reaction
- When the reaction occurs, it consumes 1/50th of the available tritium/oxygen mixture present
- The reaction converts the consumed gas into nitrogen and frezon
- The amount of frezon versus nitrogen generated from the reaction *increases* linearly when it nears 73.15 K, otherwise it decreases. For example, a reaction occuring right at 73.15 K would produce 100% frezon, and a reaction at ~36.6 K would create half frezon, half nitrogen.
- At a certain percentage of available nitrogen, the reaction occurs slower.
- The required percentage of nitrogen is 10% of the available nitrogen and varies linearly depending on the temperature compared to 73.15 K (for example, the percentage would be 5% at ~36.6K and ~3.16% at 23.15K)

None of this is documented in-game which contributes to the previous skill gap I mentioned.

### Balancing Frezon
Due to the complexity behind frezon, there are a *lot* of different ways to increase the efficiency at which the gas is created. Reactions bordering 73.15 K will see a LOT of frezon whereas reactions bordering ~20-40 K will see very little frezon. New players will often create setups that hang around the lower end of the efficiency scale, compared to elite atmosians, who create high efficiency/throughput setups by:
- Making a mixing/burning setup that intentionally borders the 70K range due to how it mixes gas.
- Using sheer plasma burning numbers to brute force the amount of tritium created, making more frezon in the process.

Because of the above skill gap, you have two routes you can go for when you balance frezon:
1. If you balance around the efficiencies seen by newer players, newer players will made the "balanced" amount of spesos whereas elite players will make an absurd amount of spesos.
2. If you balance around the efficiencies seen by elite players, newer players will make absolutely nothing, whereas elite players will make the "balanced" amount of spesos.

Option 1 is Fun. Newer players will *see some results* and be encouraged to optimize their setup further, as they'll either know or be told by elder atmosians where they can improve. Elder atmosians are rewarded for being gigantic nerds, being able to have as much fun as they want with the setups that they spent some time optimizing though lots of testing.

Option 2 is Not Fun. Newer players will see *absolutely nothing* in their efforts and wonder why they bothered at all. Elder atmosians will see *something*, but it's nothing compared to what they *used* to see, and deem the effort not worth pursuing anymore. With no elders doing frezon, nobody learns anything new, and atmos content starves because nobody wants to make frezon anymore. This is where we are at right now.

### So Why Didn't You Change The Trit To Oxygen Ratio?
The reason why is to decrease the skill gap by requiring a large amount of plasma in order to make frezon. I agree with Ilya changing the ratio, and this is my reasoning:

Engineers will be motivated to design *efficient* burn chambers that extract every mol of tritium out of the burned gas. They'll also be motivated to design burn chambers that burn *more gas* to get *more tritium* to make *more frezon*.

This also strengthens the tie between atmospherics and cargo. Fostering this relationship might promote more interaction, and give engineering some much needed tools and equipment (materials, RCD charges, etc) to do their job. Previously, it was just "hah here's some frezon, have fun with those gamba crates".

The idea is that:
- Atmosian setups up frezon mixing device and burn chamber
- Atmosian goes to cargo with a trade deal: you give me plasma can, I turn it into frezon
- Cargo agrees and purchases a 4000 spesos plasma can for atmospherics to turn into frezon.
- Atmosian comes back, some time later, with frezon cans, which can be sold for profit. Cycle repeats.

Note that you will run out of plasma much quicker than you think! You should think about getting canned plasma quite often, to refill your station's plasma tank.

This also promotes more efficient TEG setups, and TEG-Tritium hybrid setups, in order to save plasma for potentially being converted into frezon.

This also promotes frezon for being used for much more than a quick cash grab or for huffing. Frezon is a hilariously excellent working gas, with a very high specific heat. You might find the gas useful in your more complex TEG setups.

### Future Balancing
This balance intentionally leans towards the liberal side of the potential buff. My plan is to monitor how things go and adjust the price accordingly. If I find that frezon setups aren't being as promoted, I might buff it even higher.

The greater idea is to actually make frezon require plasma in order to potentially strengthen the back and fourth between cargo, as well as lower the skill gap. The price would be hiked up massively to accommodate this, with the frezon process being inherently plasma in -> frezon out.

**We've tried out the original balance, and we all said in the original PR we can buff it later. This is the buff.**

### Numbers
From the setup shown below:
- Temperature, trit in, etc, varied greatly, however the burn chamber was an open-door design with the mixer trailing towards the middle end of the temperature efficiency scale
- Used up all ~26667 mol plasma to make 113,132 mol frezon, which would sell for same price
- Time tool around 1hr30min, possibly more

### Yelling At You Tangent
Optimize your setups! Find something interesting! Combine stuff together, try new things!

Way too many of you build an open loop regenerative cooling TEG (Gar-TEG), turn 3 pumps on for distro/waste, never optimize or explore beyond that, and then say "atmospherics has no content". It has more content than that!

Engineering and atmospherics is all about *optimization* and *solving a problem that has multiple solutions, given the constraints of the game and the tools you have to work with*. So go out and solve that puzzle.

## Technical details
frezon pricepermol -> 1

## Media
Setup I used for testing. Burn chamber is 3x3. Unmarked 10nitro/90oxy mixer is outputting at 1200, with slight tuning all around during production (as one would).
![Content Client_Rb7bpSDjWm](https://github.com/user-attachments/assets/077c5297-5da7-47c2-819c-8cd6eabdde9e)
![frezon3 drawio](https://github.com/user-attachments/assets/75652b9d-1540-4492-9df0-ce4c5864c8df)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Frezon prices have been tweaked to be much more worth it for new players and elder atmosians alike.