### PR TITLE
Remove kessler and zombeteors gamemodes from the secret pool

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -13,6 +13,21 @@
     - BasicRoundstartVariation
 
 - type: gamePreset
+  id: KesslerSyndrome
+  alias:
+    - kessler
+    - junk
+    - meteorhell
+  name: kessler-syndrome-title
+  showInVote: false # secret
+  description: kessler-syndrome-description
+  rules:
+    - KesslerSyndromeScheduler
+    - RampingStationEventScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+
+- type: gamePreset
   id: AllAtOnce
   alias:
   - all
@@ -201,5 +216,21 @@
   - Zombie
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
+  - SpaceTrafficControlEventScheduler
+  - BasicRoundstartVariation
+
+- type: gamePreset
+  id: Zombieteors
+  alias:
+  - zombieteors
+  - zombombies
+  - meteombies
+  name: zombieteors-title
+  description: zombieteors-description
+  showInVote: false
+  rules:
+  - Zombie
+  - BasicStationEventScheduler
+  - KesslerSyndromeScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -13,21 +13,6 @@
     - BasicRoundstartVariation
 
 - type: gamePreset
-  id: KesslerSyndrome
-  alias:
-    - kessler
-    - junk
-    - meteorhell
-  name: kessler-syndrome-title
-  showInVote: false # secret
-  description: kessler-syndrome-description
-  rules:
-    - KesslerSyndromeScheduler
-    - RampingStationEventScheduler
-    - SpaceTrafficControlEventScheduler
-    - BasicRoundstartVariation
-
-- type: gamePreset
   id: AllAtOnce
   alias:
   - all
@@ -91,7 +76,7 @@
   showInVote: false #4boring4vote
   description: greenshift-description
   rules:
-  - SpaceTrafficControlFriendlyEventScheduler 
+  - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
 
 - type: gamePreset
@@ -126,7 +111,7 @@
   showInVote: false #Admin Use
   description: secret-description
   rules:
-  - SpaceTrafficControlFriendlyEventScheduler 
+  - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
 
 - type: gamePreset
@@ -216,21 +201,5 @@
   - Zombie
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
-  - SpaceTrafficControlEventScheduler
-  - BasicRoundstartVariation
-
-- type: gamePreset
-  id: Zombieteors
-  alias:
-  - zombieteors
-  - zombombies
-  - meteombies
-  name: zombieteors-title
-  description: zombieteors-description
-  showInVote: false
-  rules:
-  - Zombie
-  - BasicStationEventScheduler
-  - KesslerSyndromeScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -3,6 +3,6 @@
   weights:
     Nukeops: 0.20
     Traitor: 0.60
-    Zombie: 0.04
-    Survival: 0.11
+    Zombie: 0.05
+    Survival: 0.10
     Revolutionary: 0.05

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -4,7 +4,5 @@
     Nukeops: 0.20
     Traitor: 0.60
     Zombie: 0.04
-    Zombieteors: 0.01
-    Survival: 0.09
-    KesslerSyndrome: 0.01
+    Survival: 0.11
     Revolutionary: 0.05


### PR DESCRIPTION
## About the PR
This PR removes Kesser and Zombeteors from the secret pool, tuning the Survival chance to match the void.

Zombeteors, for those who don't know, is just the Kessler gamemode with an added Zombies gamerule.

## Why / Balance
For context, Kessler and Zombeteors were implemented along with the refactoring of event schedulers to use explicit game rules (PR #29320). The reasoning seen in that PR for adding them was moreso a "showing off" of what the refactor is capable of.

Kessler is unfortunately just an annoying meteor repair simulator. Basically:
- Round progression is very bland. Engineering will just keep repairing ever-increasing waves of meteors until the situation reaches critical mass and the amount of incoming damage outweighs the amount of damage Engineering can repair, and then evac gets called.
- Meteors have this amazing problem where they target structures that have a large surface area (stick out from the station) which usually means Evac or Arrivals. Arrivals shouldn't be targeted (this is a problem for another PR but alas) and usually both structures are made entirely out of glass, which is annoying to repair and takes a while, which is plenty of time for another round to come in before you're done.
- Engineering can do nothing to prevent meteors from coming in, they can only repair the damage once it's done. This leads to a very annoying feeling of fighting against entropy which isn't fun. This is also annoying considering in most other gamemodes there's a real, physical antagonist that the crew can fight against. Engineering can't really fight against meteors other than repairing the constant stream of damage that comes in.
- This affects lowpop engineering to an annoying degree.

I'm more inclined to believe that Kessler and Zombeteors was snuck in as part of the rework, with the benefits not properly evaluated:

- What roleplay does this add to the game?
- What can the crew do to combat this?
- Is this fun for other departments, or just one?

In terms of core design principles,
- Meteors aren't really unique chaos. The same thing happens over and over again. Evac gets hit -> repair, arrivals gets hit -> repair, repeat with other locations over and over again until you can't keep up anymore and call evac. _"Mechanics that [guarantee] a chaotic situation will always occur should be avoid[ed] since this negatively impacts player agency."_
- _"Part of the unique experience of Spacestation 14 is interacting with its indepth simulation gameplay while dealing with the chaos that comes from antagonists and random events."_ While I do agree that meteor damage leads to interaction with the many systems this game has to offer (atmos simulation, construction), the negatives outweigh the benefits.

If I want to cryo if I knew it's Kessler or Zombeteors, then the gamemode shouldn't be included in the pool.

In my opinion, the idea of Kessler would be much more suited if Engineering had a real, potentially station-wide system they could deploy over the course of a round that could intercept incoming meteors, as a form of reactionary measure.

Lacking this, it would be better to not have Kessler (and Zombeteors, as a component of that).


## Technical details
Removed the Zombeteors and Kessler roll chances from the secret gamemode table, increased Survival to compensate, cause that's what should be rolled instead. The gamemodes were kept in the files to enable admin torture.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- remove: Kessler Syndrome and Zombeteors are removed from the possible gamemodes in the Secret pool.
