### PR TITLE
Link Core cargo shuttle atmos devices

### DIFF
--- a/Resources/Maps/Shuttles/cargo_core.yml
+++ b/Resources/Maps/Shuttles/cargo_core.yml
@@ -169,6 +169,10 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,-7.5
       parent: 2
+    - type: DeviceList
+      devices:
+      - 144
+      - 95
 - proto: AirCanister
   entities:
   - uid: 147
@@ -647,6 +651,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,-6.5
       parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 145
 - proto: GasVentScrubber
   entities:
   - uid: 144
@@ -655,6 +664,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 145
 - proto: GeneratorBasic15kW
   entities:
   - uid: 96

--- a/Resources/Maps/Shuttles/cargo_core.yml
+++ b/Resources/Maps/Shuttles/cargo_core.yml
@@ -652,8 +652,6 @@ entities:
       pos: 1.5,-6.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 145
 - proto: GasVentScrubber
@@ -665,8 +663,6 @@ entities:
       pos: 1.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 145
 - proto: GeneratorBasic15kW


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The scrubber and vent on the core cargo shuttle have been linked to the air alarm on the shuttle.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The air alarm should either be functional or not present. I think the making it functional option is better.
## Technical details
<!-- Summary of code changes for easier review. -->
The air alarms were just linked in mapping mode.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![The air alarm interface showing the new connections](https://github.com/user-attachments/assets/3dfd6fed-e1af-496c-80c1-fc19960ae73b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->


<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
It's a relatively minor mapping change, so I believe this falls under the guideline to not include a changelog.