### PR TITLE
Adds bullet collision to station lights

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -44,6 +44,19 @@
     cost: 4
     delay: 2
     fx: EffectRCDDeconstruct2
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,0.5,0.4,0.35"
+        density: 190
+        mask:
+        - TabletopMachineMask
+        layer:
+        - TabletopMachineLayer
   - type: Destructible
     thresholds:
     - trigger:
@@ -253,6 +266,19 @@
       radius: 6
       softness: 1.1
       enabled: true
+    - type: Physics
+      bodyType: Static
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape:
+            !type:PhysShapeAabb
+            bounds: "-0.2,0.5,0.2,0.35"
+          density: 190
+          mask:
+          - TabletopMachineMask
+          layer:
+          - TabletopMachineLayer
     - type: Damageable
       damageContainer: Inorganic
     - type: Destructible

--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -29,6 +29,7 @@
         layer:
         - MidImpassable
         - LowImpassable
+        - BulletImpassable
   - type: PointLight
     radius: 10
     energy: 2.5
@@ -64,6 +65,7 @@
           collection: MetalGlassBreak
   - type: StaticPrice
     price: 75
+  - type: RequireProjectileTarget
 
 - type: entity
   id: PoweredLightPostSmallEmpty

--- a/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
@@ -38,6 +38,19 @@
     softness: 1
     offset: "0, 0.35"
   - type: RotatingLight
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.2,0.5,0.2,0.35"
+        density: 190
+        mask:
+        - TabletopMachineMask
+        layer:
+        - TabletopMachineLayer
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds collision with bullets to wall lights and post lights so that lights can be shot out with guns.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Adds fun escape/stealth opportunities and more environmental consequences to hectic gun fights.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/9130e6cc-1477-40fe-90c1-a50c5b0573ef

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: SpaceRox1244
- add: Station lights can now be destroyed by bullets.
