### PR TITLE
Arrivals blacklist for bluespace lockers and QSIs

### DIFF
--- a/Content.Server/StationEvents/Events/BluespaceLockerRule.cs
+++ b/Content.Server/StationEvents/Events/BluespaceLockerRule.cs
@@ -47,6 +47,8 @@ public sealed class BluespaceLockerRule : StationEventSystem<BluespaceLockerRule
 
             Sawmill.Info($"Converted {ToPrettyString(potentialLink)} to bluespace locker");
 
+            EnsureComp<ArrivalsBlacklistComponent>(potentialLink); // To stop people getting to arrivals terminal
+
             return;
         }
     }

--- a/Content.Server/StationEvents/Events/BluespaceLockerRule.cs
+++ b/Content.Server/StationEvents/Events/BluespaceLockerRule.cs
@@ -6,7 +6,6 @@ using Content.Shared.Access.Components;
 using Content.Shared.Station.Components;
 ﻿using Content.Shared.GameTicking.Components;
 using Content.Shared.Coordinates;
-using Content.Server.Shuttles.Components;
 
 namespace Content.Server.StationEvents.Events;
 
@@ -45,8 +44,6 @@ public sealed class BluespaceLockerRule : StationEventSystem<BluespaceLockerRule
             comp.AutoLinkProperties.BluespaceEffectOnTeleportSource = true;
             _bluespaceLocker.GetTarget(potentialLink, comp, true);
             _bluespaceLocker.BluespaceEffect(potentialLink, comp, comp, true);
-
-            EnsureComp<ArrivalsBlacklistComponent>(potentialLink); // To stop people getting to arrivals terminal
 
             Sawmill.Info($"Converted {ToPrettyString(potentialLink)} to bluespace locker");
 

--- a/Content.Server/StationEvents/Events/BluespaceLockerRule.cs
+++ b/Content.Server/StationEvents/Events/BluespaceLockerRule.cs
@@ -6,6 +6,7 @@ using Content.Shared.Access.Components;
 using Content.Shared.Station.Components;
 ﻿using Content.Shared.GameTicking.Components;
 using Content.Shared.Coordinates;
+using Content.Server.Shuttles.Components;
 
 namespace Content.Server.StationEvents.Events;
 
@@ -45,9 +46,9 @@ public sealed class BluespaceLockerRule : StationEventSystem<BluespaceLockerRule
             _bluespaceLocker.GetTarget(potentialLink, comp, true);
             _bluespaceLocker.BluespaceEffect(potentialLink, comp, comp, true);
 
-            Sawmill.Info($"Converted {ToPrettyString(potentialLink)} to bluespace locker");
-
             EnsureComp<ArrivalsBlacklistComponent>(potentialLink); // To stop people getting to arrivals terminal
+
+            Sawmill.Info($"Converted {ToPrettyString(potentialLink)} to bluespace locker");
 
             return;
         }

--- a/Content.Server/Storage/EntitySystems/BluespaceLockerSystem.cs
+++ b/Content.Server/Storage/EntitySystems/BluespaceLockerSystem.cs
@@ -16,6 +16,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Prototypes;
+using Content.Server.Shuttles.Components;
 
 namespace Content.Server.Storage.EntitySystems;
 
@@ -47,6 +48,8 @@ public sealed class BluespaceLockerSystem : EntitySystem
 
         if (component.BehaviorProperties.BluespaceEffectOnInit)
             BluespaceEffect(uid, component, component, true);
+
+        EnsureComp<ArrivalsBlacklistComponent>(uid); // To stop people getting to arrivals terminal
     }
 
     public void BluespaceEffect(EntityUid effectTargetUid, BluespaceLockerComponent effectSourceComponent, BluespaceLockerComponent? effectTargetComponent, bool bypassLimit = false)

--- a/Resources/Prototypes/Entities/Objects/Devices/swapper.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/swapper.yml
@@ -12,6 +12,7 @@
   - type: Item
     size: Small
   - type: Appearance
+  - type: ArrivalsBlacklist
   - type: SwapTeleporter
     teleporterWhitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -421,6 +421,7 @@
   parent: LockerSyndicatePersonal
   description: Advanced locker technology.
   components:
+    - type: ArrivalsBlacklist
     - type: BluespaceLocker
       minBluespaceLinks: 1
       behaviorProperties:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
@@ -171,6 +171,7 @@
   parent: ClosetMaintenance
   description: It's a storage unit... right?
   components:
+    - type: ArrivalsBlacklist
     - type: BluespaceLocker
       pickLinksFromSameMap: true
       minBluespaceLinks: 1
@@ -189,6 +190,7 @@
   parent: ClosetMaintenance
   description: It's a storage unit... right?
   components:
+    - type: ArrivalsBlacklist
     - type: BluespaceLocker
       pickLinksFromSameMap: true
       minBluespaceLinks: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the arrivals blacklist to bluespace lockers and quantum spin inverters.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Both bluespace lockers and quantum spin inverters could and have been used to get back to the arrivals terminal. This is a problem because players have recently been building "colonies" out on the arrivals planet map.
This change prevents the method commonly used to get to the terminal (bluespace lockers) and another method I knew of (quantum spin inverters).

## Technical details
<!-- Summary of code changes for easier review. -->
In the bluespace locker event, just after the lockers are configured, I made it ensure the locker has the arrivals blacklist component. As for the quantum spin inverter, I just added the component in the yaml.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/5e2cf0be-576a-47bb-b558-8a85f0386f1f)
![image](https://github.com/user-attachments/assets/c894a750-6864-42f0-928a-225203a3f92e)
(QSI worked in exactly the same way so screenshots are pointless)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

~~## Breaking changes~~
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: crazybrain
- tweak: Bluespace lockers and quantum spin inverters can no longer go on the arrivals shuttle.