### PR TITLE
Fix broken layer hiding on clothes with multiple equipment slots

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -101,7 +101,8 @@ public abstract class ClothingSystem : EntitySystem
                 {
                     if (comp.Slots.Contains(layer))
                     {
-                        if (TryComp(item, out ClothingComponent? clothing) && clothing.Slots == slot.SlotFlags)
+                        if (TryComp(item, out ClothingComponent? clothing) && clothing.InSlot != null
+                                                                           && clothing.InSlot.Equals(slot.Name))
                         {
                             //Checks for mask toggling. TODO: Make a generic system for this
                             if (comp.HideOnToggle && TryComp(item, out MaskComponent? mask))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adjusted ClothingSystem logic to confirm that a slot to be hidden by a HideLayerComponent matches the slot that an item is equipped in.

Before PR: ClothingSystem compared the sum combination of slots an item can be equipped in to the slot the HideLayerComponent's slot. This would always be false for clothing with more than one equip slot.

After PR: ClothingSystem specifically checks for a match between the item's current equipped slot and the HideLayerComponent's slot.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Addresses issue #33965

## Technical details
<!-- Summary of code changes for easier review. -->
I haven't noticed any problems on local testing, but this logic _is_ somewhat less performant than the old logic. I had initially hoped to use `HasFlag` to keep it simple, but this resulted in goofy things like hiding the snout layer when equipping a mask to suit storage.

I don't think it's going to cause issues at scale, but if anyone has some clever bitshift magic with the slotflags that could do this more performantly I think that would be ideal solution.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
