### PR TITLE
Refillable generic storage tank and water cooler

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -107,3 +107,13 @@
   cost: 1000
   category: cargoproduct-category-name-materials
   group: market
+
+- type: cargoProduct
+  id: MaterialGenericTank
+  icon:
+    sprite: Structures/Storage/tanks.rsi
+    state: generictank-1
+  product: GenericTank
+  cost: 500
+  category: cargoproduct-category-name-materials
+  group: market

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
@@ -159,6 +159,8 @@
       - Trash
   - type: ExaminableSolution
     solution: tank
+  - type: DumpableSolution
+    solution: tank
   - type: StaticPrice
     price: 500
 
@@ -215,4 +217,6 @@
       maxFillLevels: 5
       fillBaseName: watertank-2-
     - type: ExaminableSolution
+      solution: tank
+    - type: DumpableSolution
       solution: tank


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the ability to dump solutions into the generic liquid storage tank as well as the water cooler by dragging and dropping the solution container, similar to a floor drain.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Players should be able to fill storage tanks with a desired solution and order more of these tanks from cargo. Currently I think the presence and contents of generic storage tanks is mapping dependent.

Water coolers are included so that they can be refilled with new water as well as poisoned.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/b1030e64-d46c-4409-aa35-8d7684256341

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: SpaceRox1244
- add: Solution storage tanks can now be ordered from cargo and refilled by dragging the container onto the tank.

