### PR TITLE
Fix wagging action name and desc

### DIFF
--- a/Resources/Locale/en-US/actions/actions/wagging.ftl
+++ b/Resources/Locale/en-US/actions/actions/wagging.ftl
@@ -1,2 +1,0 @@
-action-name-toggle-wagging = Wagging Tail
-action-description-toggle-wagging = Start or stop wagging tail.

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -319,8 +319,8 @@
 
 - type: entity
   id: ActionToggleWagging
-  name: action-name-toggle-wagging
-  description: action-description-toggle-wagging
+  name: Wagging Tail
+  description: Start or stop wagging your tail.
   components:
     - type: InstantAction
       icon: { sprite: Mobs/Customization/reptilian_parts.rsi, state: tail_smooth_behind }


### PR DESCRIPTION
like there is no need for it to be with locale strings
downstreams can translate it via `ent-ActionToggleWagging` key