### PR TITLE
Removes weh.txt from Textures/Parallaxes

### DIFF
--- a/Resources/Textures/Parallaxes/weh.txt
+++ b/Resources/Textures/Parallaxes/weh.txt
@@ -1,1 +1,0 @@
-spacescape


### PR DESCRIPTION
## About the PR
Removes weh.txt

## Why / Balance
File cleanup, this file doesn't seem to do anything as far as I can tell.

## Technical details
N/A

## Media
![image](https://github.com/user-attachments/assets/cecc787e-88da-4a59-80b1-fda20b1f7e79)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
No CL.
