### PR TITLE
Rolling joints no longer requires a filter

### DIFF
--- a/Resources/Prototypes/Recipes/Crafting/Graphs/smokeables.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/smokeables.yml
@@ -7,12 +7,11 @@
         - to: joint
           steps:
             - material: PaperRolling
-            - material: CigaretteFilter
             - material: GroundCannabis
               doAfter: 2
     - node: joint
       entity: Joint
-      
+
 - type: constructionGraph
   id: smokeableJointRainbow
   start: start
@@ -22,7 +21,6 @@
         - to: jointRainbow
           steps:
             - material: PaperRolling
-            - material: CigaretteFilter
             - material: GroundCannabisRainbow
               doAfter: 2
     - node: jointRainbow

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/smokeables.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/smokeables.yml
@@ -21,7 +21,6 @@
         - to: jointRainbow
           steps:
             - material: PaperRolling
-            - material: CigaretteFilter
             - material: GroundCannabisRainbow
               doAfter: 2
     - node: jointRainbow

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/smokeables.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/smokeables.yml
@@ -21,6 +21,7 @@
         - to: jointRainbow
           steps:
             - material: PaperRolling
+            - material: CigaretteFilter
             - material: GroundCannabisRainbow
               doAfter: 2
     - node: jointRainbow

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/smokeables.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/smokeables.yml
@@ -11,7 +11,7 @@
               doAfter: 2
     - node: joint
       entity: Joint
-
+      
 - type: constructionGraph
   id: smokeableJointRainbow
   start: start

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/smokeables.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/smokeables.yml
@@ -7,11 +7,12 @@
         - to: joint
           steps:
             - material: PaperRolling
+            - material: CigaretteFilter
             - material: GroundCannabis
               doAfter: 2
     - node: joint
       entity: Joint
-
+      
 - type: constructionGraph
   id: smokeableJointRainbow
   start: start
@@ -21,6 +22,7 @@
         - to: jointRainbow
           steps:
             - material: PaperRolling
+            - material: CigaretteFilter
             - material: GroundCannabisRainbow
               doAfter: 2
     - node: jointRainbow


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Because no one puts a cig filter in their joints. Also, what's the point of having packs of papers without filters? Answer: They're for the potheads 😉

## Technical details
n/n

## Media
n/a

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- tweak: Rolling joints no longer requires a cigarette filter.
