### PR TITLE
added basic admin logs for PDA notekeeper notes

### DIFF
--- a/Content.Server/CartridgeLoader/Cartridges/NotekeeperCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/NotekeeperCartridgeSystem.cs
@@ -1,12 +1,14 @@
+using Content.Server.Administration.Logs;
 using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
+using Content.Shared.Database;
 
 namespace Content.Server.CartridgeLoader.Cartridges;
 
 public sealed class NotekeeperCartridgeSystem : EntitySystem
 {
     [Dependency] private readonly CartridgeLoaderSystem? _cartridgeLoaderSystem = default!;
-
+    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -36,10 +38,14 @@ public sealed class NotekeeperCartridgeSystem : EntitySystem
         if (message.Action == NotekeeperUiAction.Add)
         {
             component.Notes.Add(message.Note);
+            _adminLogger.Add(LogType.AdminMessage, LogImpact.Low,
+                $"{ToPrettyString(args.Actor)} added a note to PDA: '{message.Note}' contained on: {ToPrettyString(uid)}");
         }
         else
         {
             component.Notes.Remove(message.Note);
+            _adminLogger.Add(LogType.AdminMessage, LogImpact.Low,
+                $"{ToPrettyString(args.Actor)} removed a note from PDA: '{message.Note}' was contained on: {ToPrettyString(uid)}");
         }
 
         UpdateUiState(uid, GetEntity(args.LoaderUid), component);


### PR DESCRIPTION
## About the PR
Added some basic admin logging functionality to PDA notekeeper.  Logs like this:  user, note, cartridge it is stored on.

## Why / Balance
Improves verbosity(?) of admin logs.

## Technical details
Uses the conditional statement for adding/removing notes, I added separate _adminLogger instances to record notes.

## Media
![image_2024-12-29_173125946](https://github.com/user-attachments/assets/f3059b9c-a611-4a09-a7a2-26c8766b2b06)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines]
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
None
