### PR TITLE
Fix empty lines in adminwho with stealthmins.

### DIFF
--- a/Content.Server/Administration/Commands/AdminWhoCommand.cs
+++ b/Content.Server/Administration/Commands/AdminWhoCommand.cs
@@ -33,15 +33,15 @@ public sealed class AdminWhoCommand : IConsoleCommand
         var first = true;
         foreach (var admin in adminMgr.ActiveAdmins)
         {
-            if (!first)
-                sb.Append('\n');
-            first = false;
-
             var adminData = adminMgr.GetAdminData(admin)!;
             DebugTools.AssertNotNull(adminData);
 
             if (adminData.Stealth && !seeStealth)
                 continue;
+
+            if (!first)
+                sb.Append('\n');
+            first = false;
 
             sb.Append(admin.Name);
             if (adminData.Title is { } title)


### PR DESCRIPTION
## About the PR
Don't print newline in the adminwho output if admin is hidden.

## Why / Balance
You can clearly see if there're any stealthmins in the game or not right now.
This doesn't make much sense because it's the main purpose of it.

## Technical details
Moved newline after a stealth check so it first checks if you can even see an admin, and only
then prints something.

## Media
Before (There's an empty line between second `adminwho` and `guest@c4llv07e`):
![image](https://github.com/user-attachments/assets/44de4581-4169-43fe-8710-86311208e6f2)
After:
![image](https://github.com/user-attachments/assets/a80edf7b-99b0-4bc6-9147-2aed4651c325)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl: c4llv07e
ADMIN:
- fix: adminwho doesn't leak stealthmins count now!
