### PR TITLE
Stop greytide virus spacing

### DIFF
--- a/Content.Server/StationEvents/Events/GreytideVirusRule.cs
+++ b/Content.Server/StationEvents/Events/GreytideVirusRule.cs
@@ -60,6 +60,7 @@ public sealed class GreytideVirusRule : StationEventSystem<GreytideVirusRuleComp
 
         var firelockQuery = GetEntityQuery<FirelockComponent>();
         var accessQuery = GetEntityQuery<AccessReaderComponent>();
+        var externalAccessQuery = GetEntityQuery<ExternalAccessMarkerComponent>();
 
         var lockQuery = AllEntityQuery<LockComponent, TransformComponent>();
         while (lockQuery.MoveNext(out var lockUid, out var lockComp, out var xform))
@@ -86,10 +87,7 @@ public sealed class GreytideVirusRule : StationEventSystem<GreytideVirusRuleComp
         while (airlockQuery.MoveNext(out var airlockUid, out var airlockComp, out var doorComp, out var xform))
         {
             // don't space everything
-            if (firelockQuery.HasComp(airlockUid))
-                continue;
-
-            if (HasComp<ExternalAccessMarkerComponent>(airlockUid))
+            if (firelockQuery.HasComp(airlockUid) || externalAccessQuery.HasComp(airlockUid))
                 continue;
 
             // make sure not to hit CentCom or other maps

--- a/Content.Server/StationEvents/Events/GreytideVirusRule.cs
+++ b/Content.Server/StationEvents/Events/GreytideVirusRule.cs
@@ -89,6 +89,9 @@ public sealed class GreytideVirusRule : StationEventSystem<GreytideVirusRuleComp
             if (firelockQuery.HasComp(airlockUid))
                 continue;
 
+            if (HasComp<ExternalAccessMarkerComponent>(airlockUid))
+                continue;
+
             // make sure not to hit CentCom or other maps
             if (CompOrNull<StationMemberComponent>(xform.GridUid)?.Station != chosenStation)
                 continue;

--- a/Content.Shared/Doors/Components/ExternalAccessMarkerComponent.cs
+++ b/Content.Shared/Doors/Components/ExternalAccessMarkerComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.Doors.Components;
+
+/// <summary>
+/// Marks a door as having access to space.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ExternalAccessMarkerComponent : Component
+{
+
+}

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
@@ -21,6 +21,7 @@
     department: null
   - type: Wires
     layoutId: AirlockExternal
+  - type: ExternalAccessMarker
 
 - type: entity
   parent: AirlockExternal


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed the Greytide virus event spacing the station by opening airlocks with access to space.

## Why / Balance
Resolves #33798

## Technical details
-Created a new ExternalAccessMarker component for airlocks with access to space and added it to the AirlockExternal prototype.
-Added a check in GreytideVirusRule.cs to skip over airlocks with the ExternalAccessMarker component.

## Media
Uneeded(?), but I did test it on a local server and it did fix the problem.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The Greytide virus event is now unable to open external airlocks.
