### PR TITLE
Fixes borgs not being able to check their laws in crit

### DIFF
--- a/Resources/Prototypes/Actions/borgs.yml
+++ b/Resources/Prototypes/Actions/borgs.yml
@@ -4,6 +4,8 @@
   description: View the laws that you must follow.
   components:
   - type: InstantAction
+    checkCanInteract: false
+    checkConsciousness: false
     itemIconStyle: NoItem
     icon:
       sprite: Interface/Actions/actions_borg.rsi

--- a/Resources/Prototypes/Actions/station_ai.yml
+++ b/Resources/Prototypes/Actions/station_ai.yml
@@ -44,6 +44,8 @@
   description: View the laws that you must follow.
   components:
   - type: InstantAction
+    checkCanInteract: false
+    checkConsciousness: false
     priority: -3
     itemIconStyle: NoItem
     icon:

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -65,6 +65,7 @@
     interfaces:
       enum.SiliconLawsUiKey.Key:
         type: SiliconLawBoundUserInterface
+        requireInputValidation: false
       enum.BorgUiKey.Key:
         type: BorgBoundUserInterface
       enum.StrippingUiKey.Key:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -424,6 +424,7 @@
     interfaces:
       enum.SiliconLawsUiKey.Key:
         type: SiliconLawBoundUserInterface
+        requireInputValidation: false
   - type: ComplexInteraction
   - type: Actions
   - type: Access


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

## Why / Balance
Fixes #33514

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: PopGamer46
- fix: Fixed borgs not being able to check their laws in crit
