### PR TITLE
Make foods reflect their ingredients better

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -15,12 +15,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 55 # flavored cakes have less room for spiking
         reagents:
         - ReagentId: Nutriment
-          Quantity: 20
+          Quantity: 40
         - ReagentId: Vitamin
-          Quantity: 5
+          Quantity: 10
   - type: Item
     size: Normal
   - type: Tag
@@ -40,12 +40,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 12
         reagents:
         - ReagentId: Nutriment
-          Quantity: 4
+          Quantity: 8
         - ReagentId: Vitamin
-          Quantity: 1
+          Quantity: 2
   - type: Item
     size: Tiny
   - type: Tag
@@ -102,6 +102,15 @@
     state: plain
   - type: SliceableFood
     slice: FoodCakePlainSlice
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 55
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 20
+        - ReagentId: Vitamin
+          Quantity: 5
 
 # Added in type lines above
 
@@ -112,6 +121,15 @@
   components:
   - type: Sprite
     state: plain-slice
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 4
+        - ReagentId: Vitamin
+          Quantity: 1
 # Tastes like sweetness, cake.
 
 - type: entity
@@ -322,14 +340,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 70
         reagents:
         - ReagentId: Nutriment
-          Quantity: 15
+          Quantity: 40
         - ReagentId: Vitamin
-          Quantity: 5
+          Quantity: 20
         - ReagentId: Milk
-          Quantity: 5
+          Quantity: 10
   - type: Tag
     tags:
     - Cake
@@ -353,11 +371,11 @@
         maxVol: 15
         reagents:
         - ReagentId: Nutriment
-          Quantity: 3
+          Quantity: 8
         - ReagentId: Vitamin
-          Quantity: 1
+          Quantity: 4
         - ReagentId: Milk
-          Quantity: 1
+          Quantity: 2
   - type: Tag
     tags:
     - Cake
@@ -377,10 +395,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 35
+        maxVol: 55
         reagents:
         - ReagentId: Nutriment
-          Quantity: 20
+          Quantity: 40
         - ReagentId: Theobromine
           Quantity: 5
         - ReagentId: Vitamin
@@ -396,14 +414,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 8
+        maxVol: 15
         reagents:
         - ReagentId: Nutriment
-          Quantity: 4
+          Quantity: 8
         - ReagentId: Theobromine
           Quantity: 1
         - ReagentId: Vitamin
-          Quantity: 1
+          Quantity: 2
 # Tastes like sweetness, cake, chocolate.
 
 - type: entity
@@ -479,12 +497,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 50
+        maxVol: 60
         reagents:
         - ReagentId: Nutriment
-          Quantity: 32
+          Quantity: 35
         - ReagentId: Vitamin
-          Quantity: 11
+          Quantity: 15
   - type: Tag
     tags:
     - Cake
@@ -504,9 +522,9 @@
         maxVol: 15
         reagents:
         - ReagentId: Nutriment
-          Quantity: 6.4
+          Quantity: 7
         - ReagentId: Vitamin
-          Quantity: 2.2
+          Quantity: 3
   - type: Tag
     tags:
     - Cake
@@ -577,10 +595,10 @@
   - type: SolutionContainerManager #TODO Sprinkles
     solutions:
       food:
-        maxVol: 45
+        maxVol: 55
         reagents:
         - ReagentId: Nutriment
-          Quantity: 20
+          Quantity: 25
         - ReagentId: Vitamin
           Quantity: 5
         - ReagentId: Sugar
@@ -597,14 +615,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 45
+        maxVol: 15
         reagents:
         - ReagentId: Nutriment
-          Quantity: 4
+          Quantity: 6
         - ReagentId: Vitamin
-          Quantity: 1
+          Quantity: 2
         - ReagentId: Sugar
-          Quantity: 3
+          Quantity: 5
 # Tastes like sweetness, cake, vanilla.
 
 - type: entity
@@ -620,10 +638,10 @@
   - type: SolutionContainerManager #TODO Sprinkles
     solutions:
       food:
-        maxVol: 45
+        maxVol: 55
         reagents:
         - ReagentId: Nutriment
-          Quantity: 20
+          Quantity: 30
         - ReagentId: Vitamin
           Quantity: 5
         - ReagentId: Sugar
@@ -640,14 +658,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 45
+        maxVol: 15
         reagents:
         - ReagentId: Nutriment
-          Quantity: 4
+          Quantity: 8
         - ReagentId: Vitamin
           Quantity: 1
         - ReagentId: Sugar
-          Quantity: 3
+          Quantity: 5
 # Tastes like sweetness, cake, clown.
 
 - type: entity
@@ -663,10 +681,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 45
+        maxVol: 55
         reagents:
         - ReagentId: Nutriment
-          Quantity: 20
+          Quantity: 30
         - ReagentId: Vitamin
           Quantity: 5
         - ReagentId: PolypyryliumOligomers
@@ -683,10 +701,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 15
         reagents:
         - ReagentId: Nutriment
-          Quantity: 4
+          Quantity: 8
         - ReagentId: Vitamin
           Quantity: 1
         - ReagentId: PolypyryliumOligomers
@@ -782,10 +800,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 48
+        maxVol: 125 # SUPER dense cake
         reagents:
         - ReagentId: Nutriment
-          Quantity: 48
+          Quantity: 80
+        - ReagentId: Sugar
+          Quantity: 30
   - type: Food
     transferAmount: 12
   - type: Item
@@ -806,10 +826,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
-          Quantity: 12
+          Quantity: 10
+        - ReagentId: Sugar
+          Quantity: 5
   - type: Food
     transferAmount: 3
   - type: PointLight

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
@@ -16,10 +16,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 30
         reagents: #Most of these are this with slight variations, not worth changing until we have the rest of the reagents
         - ReagentId: Nutriment
-          Quantity: 11
+          Quantity: 15
         - ReagentId: Vitamin
           Quantity: 5
   - type: Food #All pies here made with a pie tin; unless you're some kind of savage, you're probably not destroying this when you eat or slice the pie!
@@ -47,10 +47,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 6
+        maxVol: 7
         reagents:
         - ReagentId: Nutriment
-          Quantity: 1.2
+          Quantity: 4
         - ReagentId: Vitamin
           Quantity: 1
   - type: Tag
@@ -509,6 +509,17 @@
       - sweet
   - type: Sprite
     state: grape
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 30
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 15
+        - ReagentId: Vitamin
+          Quantity: 5
+        - ReagentId: Sugar
+          Quantity: 5
   - type: Tag
     tags:
     - Fruit
@@ -546,10 +557,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 26
+        maxVol: 35
         reagents:
         - ReagentId: Nutriment
-          Quantity: 15
+          Quantity: 25
         - ReagentId: Theobromine
           Quantity: 2
 # Tastes like tart, dark chocolate.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
@@ -16,11 +16,13 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 50
         reagents: #Most of these are this with slight variations, not worth changing until we have the rest of the reagents
         - ReagentId: Nutriment
-          Quantity: 15
+          Quantity: 30
         - ReagentId: Vitamin
+          Quantity: 14
+        - ReagentId: Sugar
           Quantity: 5
   - type: Food #All pies here made with a pie tin; unless you're some kind of savage, you're probably not destroying this when you eat or slice the pie!
     trash:
@@ -50,9 +52,11 @@
         maxVol: 7
         reagents:
         - ReagentId: Nutriment
-          Quantity: 4
+          Quantity: 7.5
         - ReagentId: Vitamin
-          Quantity: 1
+          Quantity: 3.5
+        - ReagentId: Sugar
+          Quantity: 1.25
   - type: Tag
     tags:
     - Pie

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -844,7 +844,9 @@
         maxVol: 20
         reagents:
         - ReagentId: Nutriment
-          Quantity: 18
+          Quantity: 13
+        - ReagentId: Vitamin
+          Quantity: 5
 # Tastes like bun, redditors.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -254,12 +254,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 33
+        maxVol: 45
         reagents:
         - ReagentId: Nutriment
-          Quantity: 17
+          Quantity: 18
+        - ReagentId: Protein
+          Quantity: 18
         - ReagentId: Vitamin
-          Quantity: 9
+          Quantity: 6
   - type: Sprite
     state: bigbite
   - type: Tag
@@ -339,14 +341,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 26
         reagents:
         - ReagentId: Nutriment
-          Quantity: 3
+          Quantity: 7
         - ReagentId: Vitamin
           Quantity: 7
         - ReagentId: Protein
-          Quantity: 1
+          Quantity: 10
   - type: Tag
     tags:
     - Meat
@@ -375,10 +377,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
-          Quantity: 3
+          Quantity: 5
         - ReagentId: Protein
           Quantity: 7
         - ReagentId: Vitamin
@@ -486,16 +488,18 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 65
         reagents:
         - ReagentId: Nutriment
-          Quantity: 4
+          Quantity: 31
         - ReagentId: Protein
-          Quantity: 6
+          Quantity: 15
         - ReagentId: CapsaicinOil
           Quantity: 3
         - ReagentId: Vitamin
-          Quantity: 6
+          Quantity: 8
+        - ReagentId: Sulfur # What you get for eating something with a flare in it
+          Quantity: 5 
   - type: Tag
     tags:
     - Meat
@@ -515,14 +519,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
-          Quantity: 3
+          Quantity: 15
         - ReagentId: Protein
-          Quantity: 7
-        - ReagentId: Vitamin
-          Quantity: 1
+          Quantity: 5
   - type: Tag
     tags:
     - Meat
@@ -583,16 +585,18 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 55
         reagents:
         - ReagentId: Nutriment
-          Quantity: 6
+          Quantity: 25
+        - ReagentId: Protein
+          Quantity: 5
         - ReagentId: CapsaicinOil
           Quantity: 5
         - ReagentId: Blackpepper
           Quantity: 5
         - ReagentId: Vitamin
-          Quantity: 1
+          Quantity: 12
   - type: Tag
     tags:
     - Meat
@@ -641,10 +645,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
-          Quantity: 2
+          Quantity: 5
         - ReagentId: Protein
           Quantity: 6
         - ReagentId: Vitamin
@@ -668,14 +672,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
-          Quantity: 2
+          Quantity: 5
         - ReagentId: Protein
-          Quantity: 7
+          Quantity: 8
         - ReagentId: Vitamin
-          Quantity: 1
+          Quantity: 3
   - type: Tag
     tags:
     - Meat
@@ -698,16 +702,16 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 30 
         reagents:
         - ReagentId: Nutriment
-          Quantity: 2
+          Quantity: 11
         - ReagentId: Protein
-          Quantity: 7
+          Quantity: 10
         - ReagentId: Vitamin
           Quantity: 4
         - ReagentId: BbqSauce
-          Quantity: 1
+          Quantity: 5
   - type: Tag
     tags:
     - Meat
@@ -782,10 +786,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
-          Quantity: 3
+          Quantity: 6
         - ReagentId: Protein
           Quantity: 6
         - ReagentId: Vitamin
@@ -837,14 +841,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
-          Quantity: 4
-        - ReagentId: Protein
-          Quantity: 6
-        - ReagentId: Vitamin
-          Quantity: 4
+          Quantity: 18
 # Tastes like bun, redditors.
 
 - type: entity
@@ -921,10 +921,8 @@
         maxVol: 15
         reagents:
         - ReagentId: Nutriment
-          Quantity: 3
+          Quantity: 8
         - ReagentId: Protein
-          Quantity: 6
-        - ReagentId: Vitamin
           Quantity: 3
 # Tastes like bun, tofu.
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -109,14 +109,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 11
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
-          Quantity: 4
-        - ReagentId: Vitamin
-          Quantity: 1
+          Quantity: 15
         - ReagentId: TableSalt
-          Quantity: 1
+          Quantity: 2
 # Tastes like nachos.
 
 - type: entity
@@ -137,14 +135,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
-          Quantity: 6
-        - ReagentId: Vitamin
-          Quantity: 3
+          Quantity: 20
         - ReagentId: TableSalt
-          Quantity: 1
+          Quantity: 2
 # Tastes like nachos, cheese.
 
 - type: entity
@@ -166,10 +162,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 40
         reagents:
         - ReagentId: Nutriment
-          Quantity: 8
+          Quantity: 25
         - ReagentId: CapsaicinOil
           Quantity: 7
         - ReagentId: Vitamin
@@ -253,12 +249,16 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 55
         reagents:
         - ReagentId: Nutriment
-          Quantity: 6
+          Quantity: 40
         - ReagentId: CarpoToxin
           Quantity: 3
+        - ReagentId: Vitamin
+          Quantity: 5
+        - ReagentID: CapscaicinOil
+          Quantity: 4
   - type: Tag
     tags:
     - CubanCarp
@@ -361,12 +361,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 35
         reagents:
         - ReagentId: Nutriment
           Quantity: 3
         - ReagentId: Protein
-          Quantity: 10
+          Quantity: 20
         - ReagentId: BbqSauce
           Quantity: 10
   - type: Tag
@@ -563,11 +563,15 @@
     - type: SolutionContainerManager
       solutions:
         food:
-          maxVol: 15
+          maxVol: 35
           reagents:
           - ReagentId: Nutriment
-            Quantity: 8
+            Quantity: 20
+          - ReagentId: Protein
+            Quantity: 5
           - ReagentId: CapsaicinOil
+            Quantity: 6
+          - ReagentId: Vitamin
             Quantity: 6
     - type: Tag
       tags:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -257,7 +257,7 @@
           Quantity: 3
         - ReagentId: Vitamin
           Quantity: 5
-        - ReagentID: CapsaicinOil
+        - ReagentId: CapsaicinOil
           Quantity: 4
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -257,7 +257,7 @@
           Quantity: 3
         - ReagentId: Vitamin
           Quantity: 5
-        - ReagentID: CapscaicinOil
+        - ReagentID: CapsaicinOil
           Quantity: 4
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
@@ -46,6 +46,15 @@
       - tomato
   - type: Sprite
     state: tomato
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 40
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 30
+        - ReagentId: TomatoSauce
+          Quantity: 5
   - type: Tag
     tags:
     - Fruit
@@ -65,12 +74,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 80
         reagents:
         - ReagentId: Nutriment
-          Quantity: 12
-        - ReagentId: Vitamin
-          Quantity: 8
+          Quantity: 60
+        - ReagentId: TomatoSauce
+          Quantity: 15
 # Tastes like pasta, bad humor.
 
 - type: entity
@@ -88,12 +97,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
-          Quantity: 8
-        - ReagentId: Vitamin
-          Quantity: 4
+          Quantity: 15
+        - ReagentId: Protein
+          Quantity: 6
   - type: Tag
     tags:
     - Meat
@@ -139,12 +148,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 50
         reagents:
         - ReagentId: Nutriment
-          Quantity: 7
-        - ReagentId: Vitamin
+          Quantity: 20
+        - ReagentId: Protein
           Quantity: 6
+        - ReagentId: Vitamin
+          Quantity: 20
 # Tastes like pasta, tomato.
 
 - type: entity
@@ -162,10 +173,8 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 25
         reagents:
         - ReagentId: Nutriment
-          Quantity: 8
-        - ReagentId: Vitamin
-          Quantity: 1
+          Quantity: 23
 # Tastes like pasta, butter.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
@@ -52,9 +52,7 @@
         maxVol: 40
         reagents:
         - ReagentId: Nutriment
-          Quantity: 30
-        - ReagentId: TomatoSauce
-          Quantity: 5
+          Quantity: 35
   - type: Tag
     tags:
     - Fruit
@@ -77,9 +75,7 @@
         maxVol: 80
         reagents:
         - ReagentId: Nutriment
-          Quantity: 60
-        - ReagentId: TomatoSauce
-          Quantity: 15
+          Quantity: 70
 # Tastes like pasta, bad humor.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -707,7 +707,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 40
+        maxVol: 55
         reagents:
         - ReagentId: Nutriment
           Quantity: 2

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -138,12 +138,16 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 70
         reagents:
         - ReagentId: Nutriment
-          Quantity: 8
+          Quantity: 20
+        - ReagentId: Kelotane
+          Quantity: 12
+        - ReagentId: Bicardine
+          Quantity: 12
         - ReagentId: Vitamin
-          Quantity: 2
+          Quantity: 20
   - type: Tag
     tags:
     - Fruit
@@ -168,14 +172,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 50
         reagents:
         - ReagentId: Nutriment
-          Quantity: 8
+          Quantity: 10
         - ReagentId: Vitamin
-          Quantity: 2
+          Quantity: 25
         - ReagentId: DoctorsDelight
-          Quantity: 5
+          Quantity: 10
   - type: Tag
     tags:
     - Meat
@@ -200,14 +204,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 45
         reagents:
         - ReagentId: Nutriment
-          Quantity: 8
+          Quantity: 20
         - ReagentId: Vitamin
-          Quantity: 2
+          Quantity: 10
         - ReagentId: Allicin
-          Quantity: 3
+          Quantity: 8
 
 - type: entity
   name: caesar salad
@@ -228,12 +232,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 50
         reagents:
         - ReagentId: Nutriment
-          Quantity: 8
+          Quantity: 15
         - ReagentId: Vitamin
-          Quantity: 6
+          Quantity: 30
 
 - type: entity
   name: kimchi salad
@@ -253,12 +257,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 30
         reagents:
         - ReagentId: Nutriment
           Quantity: 8
         - ReagentId: Vitamin
-          Quantity: 2
+          Quantity: 15
         - ReagentId: Allicin
           Quantity: 2
 
@@ -278,12 +282,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 35
         reagents:
-        - ReagentId: Nutriment
-          Quantity: 2
+        - ReagentId: Sugar
+          Quantity: 10
         - ReagentId: Vitamin
-          Quantity: 4
+          Quantity: 15
   - type: Tag
     tags:
     - Fruit
@@ -306,12 +310,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 35
         reagents:
-        - ReagentId: Nutriment
-          Quantity: 7
+        - ReagentId: Sugar
+          Quantity: 8
         - ReagentId: Vitamin
-          Quantity: 4
+          Quantity: 17 
   - type: Tag
     tags:
     - Fruit
@@ -404,11 +408,13 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 35
         reagents:
         - ReagentId: Nutriment
-          Quantity: 4
+          Quantity: 25
         - ReagentId: Vitamin
+          Quantity: 4
+        - ReagentId: Protein
           Quantity: 4
   - type: Tag
     tags:
@@ -494,12 +500,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 30
         reagents:
         - ReagentId: Nutriment
-          Quantity: 5
+          Quantity: 10
         - ReagentId: Vitamin
-          Quantity: 3
+          Quantity: 15
         - ReagentId: CapsaicinOil
           Quantity: 2
   - type: Tag
@@ -591,14 +597,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 40
         reagents:
         - ReagentId: Nutriment
-          Quantity: 7
-        - ReagentId: Vitamin
           Quantity: 8
+        - ReagentId: Vitamin
+          Quantity: 17
         - ReagentId: Water
-          Quantity: 10
+          Quantity: 5
   - type: Tag
     tags:
     - Meat
@@ -620,7 +626,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 40
         reagents:
         - ReagentId: Nutriment
           Quantity: 1
@@ -646,10 +652,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 40
         reagents:
         - ReagentId: Nutriment
-          Quantity: 3
+          Quantity: 10
         - ReagentId: Iron
           Quantity: 10
         - ReagentId: Blood
@@ -676,14 +682,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 40
         reagents:
         - ReagentId: Protein
-          Quantity: 9
+          Quantity: 15
         - ReagentId: Soysauce
           Quantity: 10
         - ReagentId: Vitamin
-          Quantity: 7
+          Quantity: 10
 
 - type: entity
   name: clown's tears
@@ -701,7 +707,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 40
         reagents:
         - ReagentId: Nutriment
           Quantity: 2
@@ -709,6 +715,8 @@
           Quantity: 9
         - ReagentId: Water
           Quantity: 10
+        - ReagentId: Razorium
+          Quantity: 1 # silly
 
 - type: entity
   name: vegetable soup
@@ -727,16 +735,16 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 40
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
         - ReagentId: Vitamin
-          Quantity: 7
+          Quantity: 15
         - ReagentId: Water
           Quantity: 10
         - ReagentId: Oculine
-          Quantity: 1
+          Quantity: 4
 
 - type: entity
   name: nettle soup
@@ -754,18 +762,18 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30.5
+        maxVol: 40
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
         - ReagentId: Vitamin
-          Quantity: 8
+          Quantity: 15
         - ReagentId: Water
           Quantity: 10
         - ReagentId: Omnizine
           Quantity: 5
         - ReagentId: Histamine
-          Quantity: 0.5
+          Quantity: 4
 
 - type: entity
   name: mystery soup
@@ -797,14 +805,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
             Quantity: 8
           - ReagentId: CapsaicinOil
             Quantity: 5
           - ReagentId: Vitamin
-            Quantity: 4
+            Quantity: 20
           - ReagentId: Allicin
             Quantity: 3
   - type: Tag
@@ -829,12 +837,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
             Quantity: 8
           - ReagentId: Vitamin
-            Quantity: 4
+            Quantity: 25
   - type: Tag
     tags:
     - ChiliBowl
@@ -858,14 +866,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 6
+            Quantity: 12
           - ReagentId: CapsaicinOil
             Quantity: 5
           - ReagentId: Vitamin
-            Quantity: 4
+            Quantity: 20
           - ReagentId: Allicin
             Quantity: 3
   - type: Tag
@@ -889,10 +897,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 10
+            Quantity: 15
           - ReagentId: Vitamin
             Quantity: 5
           - ReagentId: TableSalt
@@ -920,12 +928,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 22
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
             Quantity: 3
           - ReagentId: Vitamin
-            Quantity: 5
+            Quantity: 20
           - ReagentId: Water
             Quantity: 10
   - type: Tag
@@ -950,12 +958,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 5
+            Quantity: 10 # Eyes are yummy
           - ReagentId: Vitamin
-            Quantity: 3
+            Quantity: 15
   - type: Tag
     tags:
     - Meat
@@ -981,7 +989,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
             Quantity: 9
@@ -1010,12 +1018,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 2
+            Quantity: 5
           - ReagentId: Vitamin
-            Quantity: 6
+            Quantity: 20
           - ReagentId: Water
             Quantity: 5
           - ReagentId: Milk
@@ -1034,10 +1042,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 3
+            Quantity: 15
           - ReagentId: Vitamin
             Quantity: 7
           - ReagentId: Water
@@ -1057,12 +1065,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 4
+            Quantity: 15
           - ReagentId: Vitamin
-            Quantity: 6
+            Quantity: 15
 # Tastes like beet.
 
 - type: entity
@@ -1083,14 +1091,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 25
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 15
-          - ReagentId: Protein
             Quantity: 5
+          - ReagentId: Protein
+            Quantity: 20
           - ReagentId: Vitamin
-            Quantity: 2
+            Quantity: 15
   - type: Tag
     tags:
     - Meat
@@ -1113,12 +1121,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 12
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 4
+            Quantity: 15
           - ReagentId: Vitamin
-            Quantity: 5
+            Quantity: 15
 # Tastes like sweet potato.
 
 - type: entity
@@ -1137,12 +1145,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 1
-          - ReagentId: Vitamin
             Quantity: 5
+          - ReagentId: Vitamin
+            Quantity: 25
           - ReagentId: Allicin
             Quantity: 5
 
@@ -1162,14 +1170,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 30
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 6
+            Quantity: 5
           - ReagentId: Vitamin
-            Quantity: 6
+            Quantity: 15
           - ReagentId: Protein
-            Quantity: 6
+            Quantity: 5
           - ReagentId: Water
             Quantity: 5
 # Tastes like crab.
@@ -1191,10 +1199,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 3
+            Quantity: 15
           - ReagentId: Licoxide
             Quantity: 6
 
@@ -1214,12 +1222,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 6
+            Quantity: 10
           - ReagentId: Vitamin
-            Quantity: 5
+            Quantity: 15
           - ReagentId: CapsaicinOil
             Quantity: 5
   - type: Tag
@@ -1245,12 +1253,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 20
+        maxVol: 40
         reagents:
           - ReagentId: Nutriment
-            Quantity: 6
+            Quantity: 15
           - ReagentId: Vitamin
-            Quantity: 6
+            Quantity: 15
           - ReagentId: Allicin
             Quantity: 3
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -144,7 +144,7 @@
           Quantity: 20
         - ReagentId: Kelotane
           Quantity: 12
-        - ReagentId: Bicardine
+        - ReagentId: Bicaridine
           Quantity: 12
         - ReagentId: Vitamin
           Quantity: 20

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/taco.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/taco.yml
@@ -140,10 +140,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 26
+        maxVol: 30
         reagents:
         - ReagentId: Nutriment
-          Quantity: 14
+          Quantity: 22
         - ReagentId: Vitamin
           Quantity: 6
 
@@ -159,10 +159,10 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 26
+        maxVol: 30
         reagents:
         - ReagentId: Nutriment
-          Quantity: 14
+          Quantity: 22
         - ReagentId: Vitamin
           Quantity: 6
 
@@ -180,6 +180,15 @@
       - onion
   - type: Sprite
     state: softtaco
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 30
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 10
+        - ReagentId: Vitamin
+          Quantity: 18
   - type: Tag
     tags:
       - Meat


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR changes the internal reagents that control hunger to better reflect the ingredients that went in them
soups have all been standardized to 55u of max volume, regardless of whats in them, salads have much more vitamin since they are healthier and many more changes. These amounts should better reflect the amount of effort chefs put into food. There are many examples where the microwave would just takes your 30+ nutriment worth of ingredients and reduce it to 12.

## Why / Balance
This needed to be done eventually, a lot of the food protos hadn't been updated since 2021 and many recipes called for several ingredients only for their end result to be lackluster

## Technical details
all of this is YML and almost every bit of it is just reagents.

## Media
There is no good way to display these changes through media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Meals now better reflect the amount of ingredients put into them.
