### PR TITLE
Adds purchase delay to nukie medical bundle, max purchase limt of 1

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -714,6 +714,8 @@
       blacklist:
         components:
           - SurplusBundle
+    - !type:ListingLimitedStockCondition
+      stock: 1
 
 # Deception
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Adds a 15-minute delay and purchase limit of 1 to nukie medical bundle

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

### Blitzops
Reduces the effectiveness of roundstart blitzops, which are already difficult to counter by nature and cause short rounds.

This doesn't stop nukies from buying medical kits, raiding medical or simply getting the drop on crew before they attack back. However, it does mean blitzops become riskier with less available healing chemicals, thus discouraging them.

### Warops
Doubling the TC amount distorts balance, making expensive purchases more readily available (keeping in mind expenses are generally the only balancing factor). This is especially apparent with medical bundles as you stock up on multiple autoinjectors, reducing the need for a nukie medic's hypospray.

A single purchase limit should prevent nukies from stocking up on several autoinjectors at once, making healing more tense and impactful.

## Technical details
<!-- Summary of code changes for easier review. -->
yml changes only

- `Resources/Prototypes/Catalog/uplink_catalog.yml` (adds restockTime to uplink catalog for medical bundle, adds stock condition)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/33637a4d-0777-4ae3-b2a7-4b1dc063bde2)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Nukie medical bundles now have a 15 minute delay before purchase, as well as a stock limit of one.