### PR TITLE
Corrected all ghost role names to title case.

### DIFF
--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -64,7 +64,7 @@ ghost-role-information-angry-slimes-description = Everyone around you irritates 
 ghost-role-information-angry-slimes-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all other angry slimes.
 
 ghost-role-information-smile-name = Smile the Slime
-ghost-role-information-smile-description = The sweetest creature in the world. Smile Slime!
+ghost-role-information-smile-description = The sweetest creature in the world. Smile slime!
 
 ghost-role-information-punpun-name = Pun Pun
 ghost-role-information-punpun-description = An honorable member of the monkey society in charge of the bar and helping the bartenders in any way he can.
@@ -99,7 +99,7 @@ ghost-role-information-sentient-carp-name = Sentient Carp
 ghost-role-information-sentient-carp-description = Help the dragon flood the station with carps!
 
 ghost-role-information-willow-name = Willow the Kangaroo
-ghost-role-information-willow-description = You're a kangaroo named willow! Willow likes to box.
+ghost-role-information-willow-description = You're a kangaroo named Willow! Willow likes to box.
 
 ghost-role-information-honkbot-name = Honkbot
 ghost-role-information-honkbot-description = An artificial being of pure evil.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -53,7 +53,7 @@ ghost-role-information-cognizine-description = Made conscious with the magic of 
 ghost-role-information-hamster-name = Hamster
 ghost-role-information-hamster-description = A grumpy little ball of fluff.
 
-ghost-role-information-hamlet-name = Hamlet the Hamster.
+ghost-role-information-hamlet-name = Hamlet the Hamster
 ghost-role-information-hamlet-description = Lives in the station bridge, has a bit of a temper and is always hungry.
 
 ghost-role-information-slimes-name = Slime

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -44,7 +44,7 @@ ghost-role-information-snailspeed-description = A little snail with snailborn th
 ghost-role-information-snoth-name = Snoth
 ghost-role-information-snoth-description = A little snoth who doesn't mind a bit of space. Just stay on grid!
 
-ghost-role-information-giant-spider-name = Giant spider
+ghost-role-information-giant-spider-name = Giant Spider
 ghost-role-information-giant-spider-description = This station's inhabitants look mighty tasty, and your sticky web is perfect to catch them!
 ghost-role-information-giant-spider-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all other giant spiders.
 
@@ -53,7 +53,7 @@ ghost-role-information-cognizine-description = Made conscious with the magic of 
 ghost-role-information-hamster-name = Hamster
 ghost-role-information-hamster-description = A grumpy little ball of fluff.
 
-ghost-role-information-hamlet-name = Hamlet the hamster.
+ghost-role-information-hamlet-name = Hamlet the Hamster.
 ghost-role-information-hamlet-description = Lives in the station bridge, has a bit of a temper and is always hungry.
 
 ghost-role-information-slimes-name = Slime
@@ -92,13 +92,13 @@ ghost-role-information-rat-king-description = You are the Rat King, your interes
 ghost-role-information-rat-servant-name = Rat Servant
 ghost-role-information-rat-servant-description = You are a Rat Servant. You must follow your king's orders.
 
-ghost-role-information-salvage-carp-name = Space carp on salvage wreck
+ghost-role-information-salvage-carp-name = Space Carp on Salvage Wreck
 ghost-role-information-salvage-carp-description = Defend the loot inside the salvage wreck!
 
 ghost-role-information-sentient-carp-name = Sentient Carp
 ghost-role-information-sentient-carp-description = Help the dragon flood the station with carps!
 
-ghost-role-information-willow-name = Willow the kangaroo
+ghost-role-information-willow-name = Willow the Kangaroo
 ghost-role-information-willow-description = You're a kangaroo named willow! Willow likes to box.
 
 ghost-role-information-honkbot-name = Honkbot
@@ -113,7 +113,7 @@ ghost-role-information-mimebot-description = A Mimebot, act like a mime but don'
 ghost-role-information-supplybot-name = SupplyBot
 ghost-role-information-supplybot-description = Deliver goods around the station.
 
-ghost-role-information-space-bear-name = Space bear
+ghost-role-information-space-bear-name = Space Bear
 ghost-role-information-space-bear-description = Your tummy rumbles, and these people look really yummy... What a feast!
 
 # Still exists as a commented out reference for Tropico. Keeping it around. -TsjipTsjip, 2024-06-20
@@ -132,7 +132,7 @@ ghost-role-information-holoclown-description = Listen to your owner. Utilize you
 ghost-role-information-ifrit-name = Ifrit
 ghost-role-information-ifrit-description = Listen to your owner. Don't tank damage. Punch people hard.
 
-ghost-role-information-space-dragon-name = Space dragon
+ghost-role-information-space-dragon-name = Space Dragon
 ghost-role-information-space-dragon-description = Call in 3 carp rifts and take over this quadrant! You have only 5 minutes in between each rift before you will disappear.
 ghost-role-information-space-dragon-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all your summoned carp.
 ghost-role-information-space-dragon-summoned-carp-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with your dragon and its allies.
@@ -152,7 +152,7 @@ ghost-role-information-skeleton-biker-description = Ride around on your sweet ri
 ghost-role-information-closet-skeleton-name = Closet Skeleton
 ghost-role-information-closet-skeleton-description = You are arguably one of the oldest members of the station! Get your old job back, or cause chaos! The world is yours to shape.
 
-ghost-role-information-remilia-name = Remilia, the chaplain's familiar
+ghost-role-information-remilia-name = Remilia, the Chaplain's Familiar
 ghost-role-information-remilia-description = Follow and obey the chaplain. Eat fruit. Screech loudly into people's ears and write it off as echolocation.
 
 ghost-role-information-cerberus-name = Cerberus, Evil Familiar
@@ -179,7 +179,7 @@ ghost-role-information-ert-medical-description = Assist with medical efforts to 
 ghost-role-information-cburn-agent-name = CBURN Agent
 ghost-role-information-cburn-agent-description = A highly trained CentComm agent, capable of dealing with various threats.
 
-ghost-role-information-centcom-official-name = CentComm official
+ghost-role-information-centcom-official-name = CentComm Official
 ghost-role-information-centcom-official-description = Perform CentComm related duties such as inspect the station, jotting down performance reviews for heads of staff, and managing the fax machine.
 
 ghost-role-information-nukeop-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all other nuclear operatives. Covert syndicate agents are not guaranteed to help you.
@@ -296,7 +296,7 @@ ghost-role-information-syndie-soldier-teamlead-description = You are the fire te
 ghost-role-information-blackmarketeer-name = Black Market Trader
 ghost-role-information-blackmarketeer-description = Make trades or take odd jobs to collect the most interesting items by the end of the shift.
 
-ghost-role-information-cossack-name = Ancient traveler
+ghost-role-information-cossack-name = Ancient Traveler
 ghost-role-information-cossack-description = From a history lost to time, you find yourself cast into this day and age.
 
 ghost-role-information-pirate-name = Space Pirate
@@ -308,8 +308,8 @@ ghost-role-information-pirate-captain-description = Argh matey! You are in charg
 ghost-role-information-artifact-name = Sentient Artifact
 ghost-role-information-artifact-description = Enact your eldritch whims. Forcibly activate your nodes for good or for evil.
 
-ghost-role-information-tomatokiller-name = Tomato killer
-ghost-role-information-tomatokiller-description = This little tomato will serve the botanist for the rest of his life... that is, a couple of minutes
+ghost-role-information-tomatokiller-name = Tomato Killer
+ghost-role-information-tomatokiller-description = This little tomato will serve the botanist for the rest of his life... that is, a couple of minutes.
 
 ghost-role-information-gingerbread-name = Gingerbread Man
 ghost-role-information-gingerbread-description = A being of pure holiday spirit.

--- a/Resources/Locale/en-US/pai/pai-system.ftl
+++ b/Resources/Locale/en-US/pai/pai-system.ftl
@@ -3,13 +3,13 @@ pai-system-off = No pAI is installed.
 pai-system-still-searching = Still searching for a pAI.
 pai-system-searching = Now searching for a pAI...
 
-pai-system-role-name = personal ai
+pai-system-role-name = Personal AI
 pai-system-role-description = Be someone's electronic pal!
                               (Memories *not* included.)
-pai-system-role-name-syndicate = Syndicate personal ai
+pai-system-role-name-syndicate = Syndicate Personal AI
 pai-system-role-description-syndicate = Be someone's Syndicate pal!
                                         (Memories *not* included.)
-pai-system-role-name-potato = potato artificial intelligence
+pai-system-role-name-potato = Potato Artificial Intelligence
 pai-system-role-description-potato = It's a toy for children. And now you live in it.
 
 pai-system-wipe-device-verb-text = Remove pAI

--- a/Resources/Locale/en-US/robotics/mmi.ftl
+++ b/Resources/Locale/en-US/robotics/mmi.ftl
@@ -3,7 +3,7 @@ positronic-brain-off = No neural activity detected.
 positronic-brain-still-searching = Synthetic neuron descrambling in progress...
 positronic-brain-searching = Beginning synthetic neuron descrambling...
 
-positronic-brain-role-name = positronic brain
+positronic-brain-role-name = Positronic Brain
 positronic-brain-role-description = Serve the station crew.
 
 positronic-brain-wipe-device-verb-text = Wipe Brain

--- a/Resources/Locale/en-US/ventriloquist/ventriloquist.ftl
+++ b/Resources/Locale/en-US/ventriloquist/ventriloquist.ftl
@@ -4,5 +4,5 @@ ventriloquist-puppet-remove-hand = You remove your hand from the puppet.
 ventriloquist-puppet-cant-speak = You cannot speak without a helping hand.
 ventriloquist-puppet-inserted-hand = You have a helping hand.
 ventriloquist-puppet-removed-hand = you have lost your helping hand.
-ventriloquist-puppet-role-name = A dummy
+ventriloquist-puppet-role-name = A Dummy
 ventriloquist-puppet-role-description = Become a dummy, dummy!


### PR DESCRIPTION
## About the PR
Most, but not all ghost role names used title case, this corrects those that did not.

## Why / Balance
Resolves #34141. A small change, with little impact on the game that just makes things look a little more polished. It also indicates a clear style consistency for future edits.

## Technical details
Edited a few strings in ghost-role-component.ftl and related files.

## Requirements
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
I don't think this breaks anything as it just tweaks the role titles in the localisation files.

**Changelog**
None, purely cosmetic.
