### PR TITLE
Standardize shotgun ammo in storagefills

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -22,7 +22,7 @@
       - id: WeaponShotgunEnforcer
         amount: 2
       - id: BoxLethalshot
-        amount: 3
+        amount: 4
 
 - type: entity
   id: CrateTrackingImplants

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -208,7 +208,7 @@
     contents:
     - id: WeaponShotgunEnforcer
       amount: 2
-    - id: MagazineShotgun
+    - id: BoxLethalshot
       amount: 4
 
 - type: entity
@@ -220,8 +220,8 @@
     contents:
     - id: WeaponShotgunKammerer
       amount: 2
-    - id: MagazineShotgun
-      amount: 4
+    - id: BoxLethalshot
+      amount: 2
 
 - type: entity
   id: GunSafeSubMachineGunWt550


### PR DESCRIPTION
## About the PR
Changes storagefills in areas to be more sane.
- Kammerer safe now has 2 lethal shotgun shell boxes as opposed to 4 shotgun shell magazines
- Enforcer safe now has 4 lethal shotgun shell boxes as opposed to 4 shotgun shell magazines
- Shotgun crate now contains 4 lethal shotgun shell boxes as opposed to 3

## Why / Balance
It doesn't make sense for the armory to have 4 bulldog magazines when they should have shell boxes.

The shotgun crate that contains enforcers had an uneven amount of ammo boxes per gun, which doesn't make sense. Now each shotgun gets two shell boxes.

These storage fills were pointed out as weird in the cartography channel. Emisse said it was okay to buff the ammo received when purchasing Enforcers as well.

## Technical details
Just changes protos and amounts.

## Media
![image](https://github.com/user-attachments/assets/c7a955e5-ce6f-49be-b22c-001160bc88e2)
![image](https://github.com/user-attachments/assets/1e59846b-1948-456c-9c72-e855e715e0f6)
![image](https://github.com/user-attachments/assets/ae389d77-1795-4e72-b791-cd905fd39154)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Shotgun crate now comes with 4 lethal shell boxes.
- tweak: Enforcer gun safe now comes with 4 lethal shell boxes.
- tweak: Kammerer gun safe now comes with 2 lethal shell boxes.

