### PR TITLE
expanded FillLevelSpriteTest test and fixed found issues

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -148,6 +148,15 @@
   parent: Soap
   description: A tiny piece of syndicate soap.
   components:
+  - type: SolutionContainerManager
+    solutions:
+      soap:
+        maxVol: 1.5 # 50 / 30 = 1.666
+        reagents:
+        - ReagentId: SoapReagent
+          Quantity: 1.5
+  - type: SolutionContainerVisuals
+    maxFillLevels: 0
   - type: Sprite
     layers:
     - state: syndie-soaplet
@@ -180,6 +189,9 @@
       path: "/Audio/Effects/Fluids/splat.ogg"
       params:
         volume: -20
+  - type: Residue
+    residueAdjective: residue-slippery
+    residueColor: residue-red
 
 - type: entity
   name: soap

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
@@ -129,6 +129,7 @@
     sprite: Objects/Specific/Janitorial/soap.rsi
     layers:
     - state: syndie-4
+      map: ["enum.SolutionContainerLayers.Fill"]
   - type: ScatteringGrenade
     fillPrototype: SoapletSyndie
     capacity: 30


### PR DESCRIPTION
## About the PR
This PR expands the FillLevelSpriteTest by:

- Getting the actual RSI for base sprites.
- Checking equipped sprites.

This test then found issues with the clustersoap and the soaplets it produced. Which I also addressed.

## Why / Balance

More (correct) tests and fixes.
I actually found this "incorrect" test because #34159 had it fail when it shouldn't.

## Technical details

- FillLevelSpritesExist expanded.
- SlipocalypseClusterSoap sprite layer now contains the fill map.
- SoapletSyndie now
  - has the correct color of residue.
  - does not multiply soap.
  - has no fill levels.

## Media


https://github.com/user-attachments/assets/ae803fac-ecc2-438a-9b09-ee049bc8de78



## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

None.

**Changelog**

:cl:
- fix: The clustersoap now visually changes when eaten.
- tweak: Soaplets now contain less soap.
