### PR TITLE
Fix sink draining sound

### DIFF
--- a/Content.Server/Fluids/EntitySystems/DrainSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/DrainSystem.cs
@@ -141,7 +141,7 @@ public sealed class DrainSystem : SharedDrainSystem
             if (!_solutionContainerSystem.ResolveSolution((uid, manager), DrainComponent.SolutionName, ref drain.Solution, out var drainSolution))
                 continue;
 
-            if (drainSolution.AvailableVolume <= 0)
+            if (drainSolution.Volume <= 0 && !drain.AutoDrain)
             {
                 _ambientSoundSystem.SetAmbience(uid, false);
                 continue;
@@ -158,7 +158,7 @@ public sealed class DrainSystem : SharedDrainSystem
                 _puddles.Clear();
                 _lookup.GetEntitiesInRange(Transform(uid).Coordinates, drain.Range, _puddles);
 
-                if (_puddles.Count == 0)
+                if (_puddles.Count == 0 && drainSolution.Volume <= 0)
                 {
                     _ambientSoundSystem.SetAmbience(uid, false);
                     continue;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This fixes the sink draining sound continuing to play forever.

I also saw that floor drains did not play the draining sound when manually emptying into them, so I fixed that too.

Reported on discord here:
https://discord.com/channels/310555209753690112/1323872026288590889/

## Technical details
<!-- Summary of code changes for easier review. -->

The check was checking for available volume instead of volume, so it would only enter if completely full.

We don't want to exit early if we're a floor drain with puddle logic, and I added a volume check down below so that they can play the sound when emptying manually.

I've tested manually emptying into a sink, manually emptying into a floor drain, and dumping liquid near a floor drain, and it all seems to work as expected.

## Media

Dumping a water bottle into a sink:
<video src='https://github.com/user-attachments/assets/79f70c5d-a6eb-49d3-8719-27a60227f4e6'/>

Dumping a water bottle into a drain:
<video src='https://github.com/user-attachments/assets/f77bcbf1-fd54-4226-9a4d-e41e8e226143'/>

Spilling whiskey near a drain: 
<video src='https://github.com/user-attachments/assets/9a233303-cda8-4f2e-a130-8784bf4a695f'/>

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed sink draining noise continuous playback