### PR TITLE
Added distinct ad and bye chatter to Dr. Gibb vending

### DIFF
--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -179,11 +179,15 @@ public sealed class HolopadSystem : SharedHolopadSystem
         // AI broadcasting
         if (TryComp<StationAiHeldComponent>(args.Actor, out var stationAiHeld))
         {
+            // Link the AI to the holopad they are broadcasting from
+            LinkHolopadToUser(source, args.Actor);
+
             if (!_stationAiSystem.TryGetStationAiCore((args.Actor, stationAiHeld), out var stationAiCore) ||
                 stationAiCore.Value.Comp.RemoteEntity == null ||
                 !TryComp<HolopadComponent>(stationAiCore, out var stationAiCoreHolopad))
                 return;
 
+            // Execute the broadcast, but have it originate from the AI core
             ExecuteBroadcast((stationAiCore.Value, stationAiCoreHolopad), args.Actor);
 
             // Switch the AI's perspective from free roaming to the target holopad
@@ -611,10 +615,25 @@ public sealed class HolopadSystem : SharedHolopadSystem
             DeleteHologram(entity.Comp.Hologram.Value, entity);
 
         if (entity.Comp.User != null)
-            UnlinkHolopadFromUser(entity, entity.Comp.User.Value);
+        {
+            // Check if the associated holopad user is an AI
+            if (TryComp<StationAiHeldComponent>(entity.Comp.User, out var stationAiHeld) &&
+                _stationAiSystem.TryGetStationAiCore((entity.Comp.User.Value, stationAiHeld), out var stationAiCore))
+            {
+                // Return the AI eye to free roaming
+                _stationAiSystem.SwitchRemoteEntityMode(stationAiCore.Value, true);
 
-        if (TryComp<StationAiCoreComponent>(entity, out var stationAiCore))
-            _stationAiSystem.SwitchRemoteEntityMode((entity.Owner, stationAiCore), true);
+                // If the AI core is still broadcasting, end its calls
+                if (entity.Owner != stationAiCore.Value.Owner &&
+                    TryComp<TelephoneComponent>(stationAiCore, out var stationAiCoreTelephone) &&
+                    _telephoneSystem.IsTelephoneEngaged((stationAiCore.Value.Owner, stationAiCoreTelephone)))
+                {
+                    _telephoneSystem.EndTelephoneCalls((stationAiCore.Value.Owner, stationAiCoreTelephone));
+                }
+            }
+
+            UnlinkHolopadFromUser(entity, entity.Comp.User.Value);
+        }
 
         Dirty(entity);
     }

--- a/Resources/Locale/en-US/advertisements/vending/gibb.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/gibb.ftl
@@ -1,0 +1,12 @@
+﻿advertisement-gibb-1 = Delicious!
+advertisement-gibb-2 = Recommended by at least one doctor!
+advertisement-gibb-3 = Over 1 million drinks sold!
+advertisement-gibb-4 = Dr. Gibb, what's the worst that could happen?
+advertisement-gibb-5 = Dr. Gibb, the flavor explosion!
+advertisement-gibb-6 = Trust me, I'm a doctor!
+advertisement-gibb-7 = The best sugar infusion in the galaxy!
+advertisement-gibb-8 = Space Cola can get Gibbed!
+thankyou-gibb-1 = The Dr. is in... your belly!
+thankyou-gibb-2 = Prognosis: flavor!
+thankyou-gibb-3 = Enjoy the 42 flavors!
+thankyou-gibb-4 = Enjoy the syrupy goodness!

--- a/Resources/Prototypes/Catalog/VendingMachines/advertisements.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/advertisements.yml
@@ -83,6 +83,12 @@
     count: 8
 
 - type: localizedDataset
+  id: GibbSoftdrinksAds
+  values:
+    prefix: advertisement-gibb-
+    count: 8
+
+- type: localizedDataset
   id: CondimentVendAds
   values:
     prefix: advertisement-condiment-

--- a/Resources/Prototypes/Catalog/VendingMachines/advertisements.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/advertisements.yml
@@ -83,7 +83,7 @@
     count: 8
 
 - type: localizedDataset
-  id: GibbSoftdrinksAds
+  id: DrGibbAds
   values:
     prefix: advertisement-gibb-
     count: 8

--- a/Resources/Prototypes/Catalog/VendingMachines/goodbyes.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/goodbyes.yml
@@ -41,6 +41,12 @@
     count: 4
 
 - type: localizedDataset
+  id: GibbSoftdrinksGoodbyes
+  values:
+    prefix: thankyou-gibb-
+    count: 4
+
+- type: localizedDataset
   id: DiscountDansGoodbyes
   values:
     prefix: thankyou-discount-

--- a/Resources/Prototypes/Catalog/VendingMachines/goodbyes.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/goodbyes.yml
@@ -41,7 +41,7 @@
     count: 4
 
 - type: localizedDataset
-  id: GibbSoftdrinksGoodbyes
+  id: DrGibbGoodbyes
   values:
     prefix: thankyou-gibb-
     count: 4

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -669,9 +669,9 @@
     ejectDelay: 1.9
     initialStockQuality: 0.33
   - type: Advertise
-    pack: GibbSoftdrinksAds
+    pack: DrGibbAds
   - type: SpeakOnUIClosed
-    pack: GibbSoftdrinksGoodbyes
+    pack: DrGibbGoodbyes
   - type: Speech
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/gib.rsi

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -669,9 +669,9 @@
     ejectDelay: 1.9
     initialStockQuality: 0.33
   - type: Advertise
-    pack: RobustSoftdrinksAds
+    pack: GibbSoftdrinksAds
   - type: SpeakOnUIClosed
-    pack: GenericVendGoodbyes
+    pack: GibbSoftdrinksGoodbyes
   - type: Speech
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/gib.rsi


### PR DESCRIPTION
## About the PR
Dr. Gibb vending machines now get their own set of advertising and purchase chatter.

## Why / Balance
Dr. Gibb machines no longer self-own with "Way better than Dr. Gibb!" and also get a dis line themselves, against Space Cola. They also get their own chatter for advertising and goodbyes.

## Technical details
* New: `gibb.ftl` for chatter.
* Edit: Prototypes - `advertisements.yml` & `goodbyes.yml` (Catalog\VendingMachines)
* Edit: Entities - `vending_machines.yml` (Structures\Machines)

## Media
![DrGibbChatter](https://github.com/user-attachments/assets/a4a81097-80aa-4007-acc9-393d0c6122ee)
![DrGibbColaDiss](https://github.com/user-attachments/assets/f40f9fe8-a549-4132-81c4-8ac87a1a4c22)

## Requirements
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
I'm still working out what does, but with references changed to point to a new file, maybe?

**Changelog**
No, but hopefully a nice surprise for Dr. Gibb enthusiasts.
