### PR TITLE
FIX: Uranium, Cak, and BreadDog are not garbage!

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -942,8 +942,8 @@
   components:
   - type: FlavorProfile
     flavors:
-      - meaty
-      - bread
+    - meaty
+    - bread
   - type: SliceableFood
     slice: FoodBreadSausageSlice
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -940,6 +940,23 @@
   parent: EdibleBase
   description: It's a bread. It's a dog. It's a... breaddog?
   components:
+  - type: FlavorProfile
+    flavors:
+      - meaty
+      - bread
+  - type: SliceableFood
+    slice: FoodBreadSausageSlice
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 45
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 10
+        - ReagentId: Vitamin
+          Quantity: 5
+        - ReagentId: Protein
+          Quantity: 5
   - type: Sprite
     noRot: true
     drawdepth: Mobs
@@ -999,20 +1016,3 @@
     damage:
       groups:
         Brute: 1
-  - type: FlavorProfile
-    flavors:
-      - meaty
-      - bread
-  - type: SliceableFood
-    slice: FoodBreadSausageSlice
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 45
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 10
-        - ReagentId: Vitamin
-          Quantity: 5
-        - ReagentId: Protein
-          Quantity: 5

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -937,7 +937,7 @@
 - type: entity
   name: bread dog
   id: MobBreadDog
-  parent: FoodBreadSausage
+  parent: EdibleBase
   description: It's a bread. It's a dog. It's a... breaddog?
   components:
   - type: Sprite
@@ -984,6 +984,7 @@
     - VimPilot
     - DoorBumpOpener
     - Bread
+    - Meat
   - type: CanEscapeInventory
     baseResistTime: 2
   - type: Puller
@@ -998,3 +999,20 @@
     damage:
       groups:
         Brute: 1
+    - type: FlavorProfile
+    flavors:
+      - meaty
+      - bread
+  - type: SliceableFood
+    slice: FoodBreadSausageSlice
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 45
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 10
+        - ReagentId: Vitamin
+          Quantity: 5
+        - ReagentId: Protein
+          Quantity: 5

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -999,7 +999,7 @@
     damage:
       groups:
         Brute: 1
-    - type: FlavorProfile
+  - type: FlavorProfile
     flavors:
       - meaty
       - bread

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -701,7 +701,7 @@
   components:
   - type: FlavorProfile
     flavors:
-      - sweet
+    - sweet
   - type: InjectableSolution
     solution: food
   - type: RefillableSolution

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -696,9 +696,25 @@
 - type: entity
   name: cak
   id: MobCatCake
-  parent: FoodCakeBase
+  parent: EdibleBase
   description: It's a cake. It's a cat. It's a cak.
   components:
+  - type: FlavorProfile
+    flavors:
+      - sweet
+  - type: InjectableSolution
+    solution: food
+  - type: RefillableSolution
+    solution: food
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 30
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 20
+        - ReagentId: Vitamin
+          Quantity: 5
   - type: Sprite
     noRot: true
     drawdepth: Mobs

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
@@ -1,16 +1,26 @@
 #
 # Base component for consumable food
+# that should be cleaned up in space
+#
+- type: entity
+  parent: EdibleBase
+  id: FoodBase
+  abstract: true
+  components:
+  - type: SpaceGarbage
+
+#
+# Base component for edible food-like items
 #
 - type: entity
   parent: BaseItem
-  id: FoodBase
+  id: EdibleBase
   abstract: true
   components:
   - type: FlavorProfile
     flavors:
       - food
   - type: Food
-  - type: SpaceGarbage
   - type: Sprite
   - type: StaticPrice
     price: 0

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
@@ -1,15 +1,4 @@
 #
-# Base component for consumable food
-# that should be cleaned up in space
-#
-- type: entity
-  parent: EdibleBase
-  id: FoodBase
-  abstract: true
-  components:
-  - type: SpaceGarbage
-
-#
 # Base component for edible food-like items
 #
 - type: entity
@@ -24,6 +13,17 @@
   - type: Sprite
   - type: StaticPrice
     price: 0
+
+#
+# Base component for consumable food
+# that should be cleaned up in space
+#
+- type: entity
+  parent: EdibleBase
+  id: FoodBase
+  abstract: true
+  components:
+  - type: SpaceGarbage
 
 # This base type is used to cover all of the "obvious" things that should be doable to open-package food.
 # Practically this means injection.

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -196,7 +196,7 @@
     count: 1
 
 - type: entity
-  parent: [SheetOtherBase, FoodBase]
+  parent: [SheetOtherBase, EdibleBase]
   id: SheetUranium
   name: uranium
   suffix: Full


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Uranium and Cak no longer have the SpaceGarbage component.

## Why / Balance
The SpaceGarbage component was causing some unwanted interactions with some food-types where they would be destroyed in space when interacting with grids.
Discord: https://discord.com/channels/310555209753690112/1321122013514960968

## Technical details
Most of FoodBase has been refactored into "EdibleBase", which FoodBase inherits. Things that inherit FoodBase should be unaffected.

Uranium, Cak, and BreadDog inherit EdibleBase instead of FoodBase or their previous parent.

## Media
none

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Uranium, Cak, and BreadDog are no longer space garbage.
