### PR TITLE
Temporarily Making Cargo Buy and Sell Pallets Indestructible

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
@@ -30,25 +30,25 @@
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic
-  - type: Destructible
-    thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 500
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-      - trigger:
-          !type:DamageTrigger
-          damage: 200
-        behaviors:
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              PartRodMetal: # takes two to construct, so drop less than that
-                min: 0
-                max: 1
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
+  #- type: Destructible
+  #  thresholds:
+  #    - trigger:
+  #        !type:DamageTrigger
+  #        damage: 500
+  #      behaviors:
+  #        - !type:DoActsBehavior
+  #          acts: [ "Destruction" ]
+  #    - trigger:
+  #        !type:DamageTrigger
+  #        damage: 200
+  #      behaviors:
+  #        - !type:SpawnEntitiesBehavior
+  #          spawn:
+  #            PartRodMetal: # takes two to construct, so drop less than that
+  #              min: 0
+  #              max: 1
+  #        - !type:DoActsBehavior
+  #          acts: [ "Destruction" ]
   - type: GuideHelp
     guides:
     - Cargo
@@ -56,7 +56,7 @@
 - type: entity
   id: CargoPalletSell
   name: cargo selling pallet
-  description: Designates valid items to sell.
+  description: Designates valid items to sell. Made of plastitanium to discourage pesky vandals.
   parent: CargoPallet
   components:
   - type: CargoPallet
@@ -74,7 +74,7 @@
 - type: entity
   id: CargoPalletBuy
   name: cargo buying pallet
-  description: Designates where orders will appear when purchased.
+  description: Designates where orders will appear when purchased. Made of plastitanium to discourage pesky vandals.
   parent: CargoPallet
   components:
   - type: CargoPallet


### PR DESCRIPTION
## About the PR

- Made cargo buy and sell pallets indestructible by removing the destructible component.
- I added a note to the pallet descriptions to bring attention to the change in material to plastitanium.

## Why / Balance

- Cargo will no longer be useless when somebody destroys these pallets unable to buy or sell.
- There is currently no way to repair these pallets, so this is a fix until then.

## Technical details

- I just commented out the destructible component.

## Media

- Nothing to show sorry.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

- No breaking changes.

**Changelog**
:cl:

- Cargo buy and sell pallets aboard the ATS can no longer be destroyed, so cargo workers will no longer be unable to perform their job entirely for the rest of the round.
- ATS can still be sabotaged through other less permanent means.
- This is explained in-game by the pallets now having the description that they are made of plastitanium as a means of saving money on frequently destroyed pallets.
