### PR TITLE
Temporarily Making Cargo Buy and Sell Pallets Indestructible

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
@@ -30,25 +30,25 @@
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic
-  - type: Destructible
-    thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 500
-        behaviors:
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-      - trigger:
-          !type:DamageTrigger
-          damage: 200
-        behaviors:
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              PartRodMetal: # takes two to construct, so drop less than that
-                min: 0
-                max: 1
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
+  #- type: Destructible
+  #  thresholds:
+  #    - trigger:
+  #        !type:DamageTrigger
+  #        damage: 500
+  #      behaviors:
+  #        - !type:DoActsBehavior
+  #          acts: [ "Destruction" ]
+  #    - trigger:
+  #        !type:DamageTrigger
+  #        damage: 200
+  #      behaviors:
+  #        - !type:SpawnEntitiesBehavior
+  #          spawn:
+  #            PartRodMetal: # takes two to construct, so drop less than that
+  #              min: 0
+  #              max: 1
+  #        - !type:DoActsBehavior
+  #          acts: [ "Destruction" ]
   - type: GuideHelp
     guides:
     - Cargo
@@ -56,7 +56,7 @@
 - type: entity
   id: CargoPalletSell
   name: cargo selling pallet
-  description: Designates valid items to sell.
+  description: Designates valid items to sell. Made of plastitanium to discourage pesky vandals.
   parent: CargoPallet
   components:
   - type: CargoPallet
@@ -74,7 +74,7 @@
 - type: entity
   id: CargoPalletBuy
   name: cargo buying pallet
-  description: Designates where orders will appear when purchased.
+  description: Designates where orders will appear when purchased. Made of plastitanium to discourage pesky vandals.
   parent: CargoPallet
   components:
   - type: CargoPallet

--- a/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
@@ -27,28 +27,6 @@
     layers:
     - sprite: Structures/catwalk.rsi
       state: catwalk_preview
-  #- type: Damageable
-  #  damageContainer: StructuralInorganic
-  #  damageModifierSet: Metallic
-  #- type: Destructible
-  #  thresholds:
-  #    - trigger:
-  #        !type:DamageTrigger
-  #        damage: 500
-  #      behaviors:
-  #        - !type:DoActsBehavior
-  #          acts: [ "Destruction" ]
-  #    - trigger:
-  #        !type:DamageTrigger
-  #        damage: 200
-  #      behaviors:
-  #        - !type:SpawnEntitiesBehavior
-  #          spawn:
-  #            PartRodMetal: # takes two to construct, so drop less than that
-  #              min: 0
-  #              max: 1
-  #        - !type:DoActsBehavior
-  #          acts: [ "Destruction" ]
   - type: GuideHelp
     guides:
     - Cargo

--- a/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
@@ -27,9 +27,9 @@
     layers:
     - sprite: Structures/catwalk.rsi
       state: catwalk_preview
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: Metallic
+  #- type: Damageable
+  #  damageContainer: StructuralInorganic
+  #  damageModifierSet: Metallic
   #- type: Destructible
   #  thresholds:
   #    - trigger:

--- a/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Cargo/cargo_pallet.yml
@@ -1,8 +1,9 @@
 - type: entity
-  id: CargoPallet
+  id: BaseCargoPallet
+  parent: BaseStructure
   name: cargo pallet
   description: Common fixture of logistics and cargo. Subtle reminder where crates go during transport to avoid bruised shins.
-  parent: BaseStructure
+  abstract: true
   components:
   - type: InteractionOutline
   - type: Anchorable
@@ -19,7 +20,7 @@
           bounds: "-0.45,-0.45,0.45,0.45"
         density: 15
         mask:
-          - MachineMask
+        - MachineMask
   - type: StaticPrice
     price: 100
   - type: Sprite
@@ -32,15 +33,41 @@
     - Cargo
 
 - type: entity
+  id: CargoPallet
+  parent: BaseCargoPallet
+  components:
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 500
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          PartRodMetal: # takes two to construct, so drop less than that
+            min: 0
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+
+- type: entity
   id: CargoPalletSell
   name: cargo selling pallet
   description: Designates valid items to sell. Made of plastitanium to discourage pesky vandals.
-  parent: CargoPallet
+  parent: BaseCargoPallet
   components:
   - type: CargoPallet
     palletType: sell
   - type: Sprite
-    drawdepth: FloorTiles
     sprite: Structures/cargo_pallets.rsi
   - type: Icon
     sprite: Structures/cargo_pallets.rsi
@@ -53,12 +80,11 @@
   id: CargoPalletBuy
   name: cargo buying pallet
   description: Designates where orders will appear when purchased. Made of plastitanium to discourage pesky vandals.
-  parent: CargoPallet
+  parent: BaseCargoPallet
   components:
   - type: CargoPallet
     palletType: buy
   - type: Sprite
-    drawdepth: FloorTiles
     sprite: Structures/cargo_pallets.rsi
   - type: Icon
     sprite: Structures/cargo_pallets.rsi


### PR DESCRIPTION
## About the PR

- Made cargo buy and sell pallets indestructible by removing the destructible component.
- I added a note to the pallet descriptions to bring attention to the change in material to plastitanium.

## Why / Balance

- Cargo will no longer be useless when somebody destroys these pallets unable to buy or sell.
- There is currently no way to repair these pallets, so this is a fix until then.
- ATS can still be sabotaged through other less permanent means.

## Technical details

- I just removed the destructible component.

## Media

- Nothing to show sorry.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

- No breaking changes.

**Changelog**
:cl:

- tweak: Cargo buy and sell pallets aboard the ATS can no longer be destroyed, so cargo workers will no longer be unable to perform their job entirely for the rest of the round.