### PR TITLE
HOTFIX Tweaked air alarm default settings for nitrogen breathing crew

### DIFF
--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -35,6 +35,17 @@
   id: stationOxygen
   lowerBound: !type:AlarmThresholdSetting
     threshold: 0.10
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 0.3
+  lowerWarnAround: !type:AlarmThresholdSetting
+    threshold: 1.5
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.8
+
+- type: alarmThreshold
+  id: stationNitrogen
+  lowerBound: !type:AlarmThresholdSetting
+    threshold: 0.10
   lowerWarnAround: !type:AlarmThresholdSetting
     threshold: 1.5
 

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -17,7 +17,7 @@
       pressureThresholdId: stationPressure
       gasThresholdPrototypes:
         Oxygen: stationOxygen
-        Nitrogen: ignore
+        Nitrogen: stationNitrogen
         CarbonDioxide: stationCO2
         Plasma: stationPlasma
         Tritium: stationTritium


### PR DESCRIPTION
## About the PR
Air Sensor Caution if N2 is under 15% and Warning if under 10% (same numbers as O2 low warnings)
Air Sensor Caution if O2 is over 24% and Warning if over 30%

## Why / Balance
There are two issues with the current air alarm:
-Rooms can be devoid of N2, and suffocate any Slimeperson crewmember that walks in. So long as there is O2 in the room, though, the air alarms currently still report Green in such an environment. 

-Higher-than-expected O2 in a room can crit a vox quickly or even instantly when they take off their mask. And we are now "conditioning" vox players to consider it normal to take their mask off for short exposures. There have been multiple incidents of _atmos_ vox getting crit by a room overpressurised with O2. While some amount of crew attrition to "atmos skill issues" is perhaps unavoidable, the Air Alarms should at least point out such situations. 
23.5% is also the maximum (sea level) O2 allowed by OSHA, because oxygen toxicity is a thing in the real world and if we ever code it, that should be considered the end of the safe range

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Errant
- tweak: Air sensors now report low N2 levels and too high O2 levels, to better accomodate crew that does not breathe oxygen.