### PR TITLE
Vending machine inventories reorganised

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
@@ -1,14 +1,15 @@
 - type: vendingMachineInventory
-  id: RobustSoftdrinksInventory
+  id: SpaceColaInventory
   startingInventory:
     DrinkColaCan: 4
     DrinkGrapeCan: 2
-    DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
-    DrinkSolDryCan: 2
-    DrinkLemonLimeCan: 2
+    DrinkPwrGameCan: 2
+    DrinkRootBeerCan: 2
+    DrinkShamblersJuiceCan: 3
+    DrinkLemonLimeCan: 3
     DrinkLemonLimeCranberryCan: 2
-    DrinkFourteenLokoCan: 2
+    DrinkSolDryCan: 3
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/gib.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/gib.yml
@@ -2,13 +2,14 @@
   id: DrGibbInventory
   startingInventory:
     DrinkDrGibbCan: 4
+    DrinkFourteenLokoCan: 3
     DrinkGrapeCan: 2
-    DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
-    DrinkSolDryCan: 2
-    DrinkLemonLimeCan: 2
-    DrinkLemonLimeCranberryCan: 2
-    DrinkFourteenLokoCan: 2
+    DrinkEnergyDrinkCan: 2
+    DrinkRootBeerCan: 2
+    DrinkSpaceMountainWindCan: 2
+    DrinkSpaceUpCan: 3
+    DrinkStarkistCan: 3
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/pwrgame.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/pwrgame.yml
@@ -2,14 +2,14 @@
   id: PwrGameInventory
   startingInventory:
     DrinkPwrGameCan: 4
-    DrinkEnergyDrinkCan: 4
     DrinkGrapeCan: 2
-    DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
-    DrinkSolDryCan: 2
-    DrinkLemonLimeCan: 2
+    DrinkRootBeerCan: 2
+    DrinkShamblersJuiceCan: 3
+    DrinkLemonLimeCan: 3
     DrinkLemonLimeCranberryCan: 2
-    DrinkFourteenLokoCan: 2
+    DrinkSolDryCan: 3
+    DrinkColaCan: 3
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robustdrinks.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robustdrinks.yml
@@ -1,0 +1,13 @@
+- type: vendingMachineInventory
+  id: RobustSoftdrinksInventory
+  startingInventory:
+    DrinkIcedTeaCan: 3
+    DrinkEnergyDrinkCan: 3
+    DrinkLemonLimeCan: 3
+    DrinkLemonLimeCranberryCan: 3
+    DrinkSolDryCan: 3
+    DrinkSpaceMountainWindCan: 3
+    DrinkSpaceUpCan: 3
+  emaggedInventory:
+    DrinkNukieCan: 2
+    DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robustdrinksblack.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robustdrinksblack.yml
@@ -1,0 +1,14 @@
+- type: vendingMachineInventory
+  id: RobustSoftdrinksBlackInventory # Bit long, but makes sense with current IDs
+  startingInventory:
+    DrinkDrGibbCan: 3
+    DrinkFourteenLokoCan: 3
+    DrinkGrapeCan: 3
+    DrinkPwrGameCan: 3
+    DrinkShamblersJuiceCan: 3
+    DrinkColaCan: 3
+    DrinkRootBeerCan: 3
+    DrinkStarkistCan: 3
+  emaggedInventory:
+    DrinkNukieCan: 2
+    DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/shamblersjuice.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/shamblersjuice.yml
@@ -3,12 +3,13 @@
   startingInventory:
     DrinkShamblersJuiceCan: 4
     DrinkGrapeCan: 2
-    DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
+    DrinkPwrGameCan: 2
+    DrinkRootBeerCan: 2
     DrinkSolDryCan: 2
     DrinkLemonLimeCan: 2
     DrinkLemonLimeCranberryCan: 2
-    DrinkFourteenLokoCan: 2
+    DrinkColaCan: 3
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
@@ -7,6 +7,8 @@
     DrinkSpaceUpCan: 3
     DrinkSpaceMountainWindCan: 3
     DrinkStarkistCan: 3
+    DrinkLemonLimeCan: 3
+    DrinkLemonLimeCranberryCan: 3
     DrinkSolDryCan: 3
     DrinkFourteenLokoCan: 3
   emaggedInventory:

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
@@ -1,16 +1,16 @@
 ﻿- type: vendingMachineInventory
   id: SodaInventory
   startingInventory:
-    DrinkColaCan: 3
     DrinkDrGibbCan: 3
+    DrinkFourteenLokoCan: 3
     DrinkShamblersJuiceCan: 3
-    DrinkSpaceUpCan: 3
-    DrinkSpaceMountainWindCan: 3
-    DrinkStarkistCan: 3
     DrinkLemonLimeCan: 3
     DrinkLemonLimeCranberryCan: 3
     DrinkSolDryCan: 3
-    DrinkFourteenLokoCan: 3
+    DrinkColaCan: 3
+    DrinkSpaceUpCan: 3
+    DrinkSpaceMountainWindCan: 3
+    DrinkStarkistCan: 3
   emaggedInventory:
     DrinkNukieCan: 3
     DrinkChangelingStingCan: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
@@ -2,12 +2,12 @@
   id: SodaInventory
   startingInventory:
     DrinkColaCan: 3
-    DrinkGrapeCan: 3
-    DrinkRootBeerCan: 3
-    DrinkIcedTeaCan: 3
+    DrinkDrGibbCan: 3
+    DrinkShamblersJuiceCan: 3
+    DrinkSpaceUpCan: 3
+    DrinkSpaceMountainWindCan: 3
+    DrinkStarkistCan: 3
     DrinkSolDryCan: 3
-    DrinkLemonLimeCan: 3
-    DrinkLemonLimeCranberryCan: 3
     DrinkFourteenLokoCan: 3
   emaggedInventory:
     DrinkNukieCan: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sovietsoda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sovietsoda.yml
@@ -3,4 +3,5 @@
   startingInventory:
     DrinkSodaWaterCan: 10 #typically hacked product. Default product is "soda"
   contrabandInventory:
-    DrinkColaCan: 10
+    DrinkColaCan: 5
+    DrinkDrGibbCan: 5

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
@@ -1,15 +1,15 @@
 ﻿- type: vendingMachineInventory
   id: SpaceUpInventory
   startingInventory:
-    DrinkSpaceUpCan: 3
+    DrinkSpaceUpCan: 4
     DrinkSpaceMountainWindCan: 3
-    DrinkGrapeCan: 2
-    DrinkRootBeerCan: 2
-    DrinkIcedTeaCan: 2
-    DrinkSolDryCan: 2
-    DrinkLemonLimeCan: 2
-    DrinkLemonLimeCranberryCan: 2
+    DrinkDrGibbCan: 3
     DrinkFourteenLokoCan: 2
+    DrinkGrapeCan: 2
+    DrinkIcedTeaCan: 2
+    DrinkEnergyDrinkCan: 2
+    DrinkRootBeerCan: 2
+    DrinkStarkistCan: 3
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
@@ -2,13 +2,14 @@
   id: StarkistInventory
   startingInventory:
     DrinkStarkistCan: 4
-    DrinkGrapeCan: 2
-    DrinkRootBeerCan: 2
-    DrinkIcedTeaCan: 2
-    DrinkSolDryCan: 2
-    DrinkLemonLimeCan: 2
-    DrinkLemonLimeCranberryCan: 2
+    DrinkDrGibbCan: 3
     DrinkFourteenLokoCan: 2
+    DrinkGrapeCan: 2
+    DrinkIcedTeaCan: 2
+    DrinkEnergyDrinkCan: 2
+    DrinkRootBeerCan: 2
+    DrinkSpaceMountainWindCan: 2
+    DrinkSpaceUpCan: 3
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -328,14 +328,16 @@
   components:
   - type: VendingMachineRestock
     canRestock:
-    - RobustSoftdrinksInventory
     - BodaInventory
-    - PwrGameInventory
-    - ShamblersJuiceInventory
-    - StarkistInventory
-    - SpaceUpInventory
-    - SodaInventory
     - DrGibbInventory
+    - PwrGameInventory
+    - RobustSoftdrinksInventory
+    - RobustSoftdrinksBlackInventory
+    - ShamblersJuiceInventory
+    - SodaInventory
+    - SpaceColaInventory
+    - SpaceUpInventory
+    - StarkistInventory
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -475,6 +475,8 @@
   id: VendingMachineColaBlack
   suffix: Black
   components:
+  - type: VendingMachine
+    pack: RobustSoftdrinksBlackInventory
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/cola-black.rsi
     layers:
@@ -496,6 +498,8 @@
   name: Space Cola Vendor
   description: It vends cola, in space.
   components:
+  - type: VendingMachine
+    pack: SpaceColaInventory
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/cola-red.rsi
     layers:


### PR DESCRIPTION
## About the PR
Vending machines now have a more interesting distribution of drinks between them.

## Why / Balance
Some drinks were missing, or very unevendly distributed. Most branded drinks could only be purchased individually at each specific vendor.

This created a lot of head-canon for soft drink companies in the game, but in-short, the changes align along notional corporation rivalries between the currently established soft drink brands.

This PR addresses related inconsistencies noticed on #34178

## Technical details
* Adds two new `vendingMachineInventory` files.
* Adds those inventories to the generic RobustSoftdrinks vending machines.
* Edits the inventories of all the soft drink can vending machines.
* Adds new entries in `vending_machine_restock.yml`

## Media
Examples incomming

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
I don't think so; two new inventory IDs and related files added as references in vending_machines.yml.

**Changelog**
No. Nothing that dramatically alters gameplay.
