### PR TITLE
adds a clown horn to the toybox crate

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -337,6 +337,7 @@
       - id: BeachBall
       - id: ClothingShoesSkates
       - id: RubberChicken
+      - id: BikeHorn
 
 - type: entity
   id: CrateFunBikeHornImplants


### PR DESCRIPTION
## About the PR

- I added the clown horn to the buyable toy box in cargo.

## Why / Balance

- Clowns can now get new horns if they lose what little horns they have.
- More fun for the crew!

## Technical details

- I just added the horn ID to the box.

## Media

- Nothing to show sorry.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

- No breaking changes.

**Changelog**
:cl:

- tweak: One clown horn now comes with each toy box crate from cargo.