### PR TITLE
Make station anchor hitbox less insufferable

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
@@ -39,7 +39,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.7,-0.8,0.7,0.8"
+          bounds: "-0.7,-0.7,0.7,0.7"
         density: 190
         mask:
         - LargeMobMask


### PR DESCRIPTION
## About the PR
Adjusts the hitbox on the station anchor so that it can be properly walked around when surrounded by walls making a 3x3 space.

This also makes the hitbox actually have a square hitbox instead of whatever weird rectangular thing it was previously.

## Why / Balance
People would get stuck because they wouldn't have enough room to walk around the anchor on the north and south sides, causing eternal and painful suffering until someone brought you a chair to sit on or you had a wrench.

Fixes #32013.

## Technical details
Adjusts the hitbox size in the YAML.

## Media
### Before
![Content Client_7RcBS5f2bV](https://github.com/user-attachments/assets/c1cb2fda-58c0-4111-861e-c18e2aa5e5c2)

### After
![Content Client_TvmsADb00x](https://github.com/user-attachments/assets/9f07a338-3c82-4a8c-97fd-d52ac0519c79)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: You can no longer get stuck when trying to walk between a station anchor and a wall.
