### PR TITLE
Make mini jetpack actually mini

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -187,6 +187,8 @@
   components:
     - type: Item
       sprite: Objects/Tanks/Jetpacks/mini.rsi
+      shape:
+        - 0,0,3,1
     - type: Sprite
       sprite: Objects/Tanks/Jetpacks/mini.rsi
     - type: Clothing
@@ -259,6 +261,8 @@
   components:
   - type: Item
     sprite: Objects/Tanks/Jetpacks/void.rsi
+    shape:
+      - 0,0,3,1
   - type: Sprite
     sprite: Objects/Tanks/Jetpacks/void.rsi
   - type: Clothing


### PR DESCRIPTION
## About the PR
Mini jetpack is now 2x4 (regular jetpacks are 4x4).
Void jetpack is also 2x4, because it goes into the same slots as a mini jetpack, and is exclusive to CE, so i think it makes sense.

## Why / Balance
Logic. Also resolves https://github.com/space-wizards/space-station-14/issues/34031.

## Technical details
YAML changes.

## Media
Not really.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Mini jetpacks and void jetpacks are now actually smaller than a normal jetpack
