### PR TITLE
Remove Signal Trigger, adds signal to Timer Trigger 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/triggers.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/triggers.yml
@@ -20,6 +20,9 @@
     size: Small
   - type: StaticPrice
     price: 40
+  - type: Tag
+    tags:
+    - TimerSignalTrigger
   - type: PayloadTrigger
     components:
     - type: OnUseTimerTrigger
@@ -39,30 +42,6 @@
     - type: DeviceLinkSink
       ports:
       - Timer
-
-#- type: entity
-#  parent: TimerTrigger
-#  id: SignalTrigger
-#  name: signal trigger
-#  description: Adds a machine link that is triggered by signals.
-#  components:
-#  - type: Sprite
-#    sprite: Objects/Devices/signaltrigger.rsi
-#    state: signaltrigger
-#  - type: StaticPrice
-#    price: 40
-#  - type: Tag
-#    tags:
-#    - SignalTrigger
-#  - type: PayloadTrigger
-#    components:
-#    - type: TriggerOnSignal
-#    - type: DeviceNetwork
-#      deviceNetId: Wireless
-#      receiveFrequencyId: BasicDevice
-#    - type: WirelessNetworkConnection
-#      range: 200
-#    - type: DeviceLinkSink
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -316,7 +316,6 @@
       - FlashPayload
       - Signaller
       - SignallerAdvanced
-      - SignalTrigger
       - VoiceTrigger
       - Igniter
       - HandHeldMassScanner
@@ -771,7 +770,6 @@
       - ShuttleGunPerforatorCircuitboard
       - ShuttleGunSvalinnMachineGunCircuitboard
       - Signaller
-      - SignalTrigger
       - SpeedLoaderMagnumIncendiary
       - SpeedLoaderMagnumUranium
       - TelescopicShield

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/glassbox.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/glassbox.yml
@@ -41,11 +41,11 @@
           conditions:
             - !type:EntityAnchored
           steps:
-            - tag: SignalTrigger
-              name: a signal trigger
+            - tag: TimerSignalTrigger
+              name: a timer-signal trigger
               icon:
-                sprite: Objects/Devices/signaltrigger.rsi
-                state: signaltrigger
+                sprite: Objects/Devices/timer.rsi
+                state: timer
               doAfter: 0.5
 
         - to: boxMissingWires
@@ -76,7 +76,7 @@
               doAfter: 0.5
           completed:
             - !type:SpawnPrototype
-              prototype: SignalTrigger
+              prototype: TimerTrigger
               amount: 1
 
     - node: boxMissingRGlass
@@ -153,7 +153,7 @@
               prototype: CableApcStack1
               amount: 2
             - !type:SpawnPrototype
-              prototype: SignalTrigger
+              prototype: TimerTrigger
               amount: 1
             - !type:SpawnPrototype
               prototype: SheetRGlass1

--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -5,11 +5,6 @@
 
 - type: latheRecipe
   parent: BasePartRecipe
-  id: SignalTrigger
-  result: SignalTrigger
-
-- type: latheRecipe
-  parent: BasePartRecipe
   id: VoiceTrigger
   result: VoiceTrigger
 

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -108,7 +108,6 @@
   cost: 10000
   recipeUnlocks:
   - SignallerAdvanced
-  - SignalTrigger
   - VoiceTrigger
   - TimerTrigger
   - FlashPayload

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1127,9 +1127,6 @@
   id: Sidearm
 
 - type: Tag
-  id: SignalTrigger
-
-- type: Tag
   id: SkeletonMotorcycleKeys
 
 - type: Tag
@@ -1248,6 +1245,9 @@
 
 - type: Tag
   id: TimerSignalElectronics
+
+- type:
+  id: TimerSignalTrigger
 
 - type: Tag
   id: Toolbox

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -540,3 +540,6 @@ LightTree06: LightTree
 
 #2024-12-28
 DrinkIrishCarBomb: DrinkIrishSlammer
+
+#2025-01-05
+SignalTrigger: TimerTrigger


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Removes Signal Trigger for modular grenades
- Adds signal to Timer Trigger, renames Timer Trigger to Timer-Signal Trigger

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Directly nerfs remote toolbox bombs by giving crew/antags time to escape the toolbox or throw it back before it detonates. Remote bombs are still possible as the Timer Trigger can accept signals, which activates a countdown to trigger payloads.

Nerf applies similar principle to C-4 being given a delay rather than instant detonation (#32423).

Does not affect voice triggers, which can still instantly detonate upon stating a designated codeword. Unfortunately I am unable to add a timer delay on voice triggers with my current skillset.

## Technical details
<!-- Summary of code changes for easier review. -->
yml changes only
- `Resources/Prototypes/Entities/Objects/Devices/Electronics/triggers.yml` (removes Signal Trigger and adds timer device link to Timer Trigger)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Removed Signal Triggers for modular grenades.
- tweak: Timer Triggers are renamed to Timer-Signal Triggers as they can now accept signals, which activates a countdown.