### PR TITLE
Blueprint double emergency tank

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -222,6 +222,7 @@
   id: SalvageEquipmentRare
   table: !type:GroupSelector
     children:
+    - id: BlueprintDoubleEmergencyTank
     - id: FultonBeacon
     - id: Fulton
       amount: !type:RangeNumberSelector

--- a/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
@@ -47,3 +47,4 @@
   - type: Blueprint
     providedRecipes:
     - DoubleEmergencyOxygenTank
+    - DoubleEmergencyNitrogenTank

--- a/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
@@ -37,3 +37,13 @@
   - type: Blueprint
     providedRecipes:
     - SeismicCharge
+
+- type: entity
+  parent: BaseBlueprint
+  id: BlueprintDoubleEmergencyTank
+  name: double emergency tank blueprint
+  description: A blueprint with a double emergency tank. It can be inserted into an autolathe.
+  components:
+  - type: Blueprint
+    providedRecipes:
+    - DoubleEmergencyOxygenTank

--- a/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
@@ -42,7 +42,7 @@
   parent: BaseBlueprint
   id: BlueprintDoubleEmergencyTank
   name: double emergency tank blueprint
-  description: A blueprint with a double emergency tank. It can be inserted into an autolathe.
+  description: A blueprint with a schematic of a double emergency tank. It can be inserted into an autolathe.
   components:
   - type: Blueprint
     providedRecipes:

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -122,6 +122,13 @@
     Steel: 250
 
 - type: latheRecipe
+  id: DoubleEmergencyNitrogenTank
+  result: DoubleEmergencyNitrogenTank
+  completetime: 4
+  materials:
+    Steel: 250
+
+- type: latheRecipe
   id: ClothingShoesBootsMagSci
   result: ClothingShoesBootsMagSci
   completetime: 10

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -115,6 +115,13 @@
     Steel: 300
 
 - type: latheRecipe
+  id: DoubleEmergencyOxygenTank
+  result: DoubleEmergencyOxygenTank
+  completetime: 4
+  materials:
+    Steel: 250
+
+- type: latheRecipe
   id: ClothingShoesBootsMagSci
   result: ClothingShoesBootsMagSci
   completetime: 10


### PR DESCRIPTION
## About the PR

Adds Blueprint double emergency oxygen and nitrogen tanks as a rare find for salvagers.

## Why / Balance

Slightly more of interest to cargos, as a useful find to expand their abilities. Could be useful as a substitute for conventional tanks.

## Media

![изображение](https://github.com/user-attachments/assets/fad57270-6ffc-435e-b93d-1d2f6827a209)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

:cl:

- add: Adds Blueprint double emergency tank.
