### PR TITLE
fix: Allow Station AI to hear speech during regular calls

### DIFF
--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -705,8 +705,7 @@ public sealed class HolopadSystem : SharedHolopadSystem
 
         var callOptions = new TelephoneCallOptions()
         {
-            ForceConnect = true,
-            MuteReceiver = true
+            ForceConnect = true
         };
 
         _telephoneSystem.CallTelephone(source, receiver, user, callOptions);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The AI can now hear speech during regular holopad calls, but not broadcasts.

## Why / Balance
It seemed unintentional for the AI not to be able to hear people who call it, or when using the regular projection feature.

**Edit**: It works here, for some reason. It shouldn't. See comments.

## Technical details
I removed the attribute deafening the AI. Copy-paste mistake?

## Media
None

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!-- - fix: The AI can now hear you during holopad calls. -->
No CL. Internal change. It shouldn't work here, but it does. Downstream, the setting correctly mutes the receiving end when built in Release configuration, and only in Release configuration. Here, it doesn't mute the receiver irrespective of Configuration.