### PR TITLE
[HOTFIX] Fix Meta station power

### DIFF
--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -13781,7 +13781,7 @@ entities:
       pos: -29.5,15.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -208561.16
+      secondsUntilStateChange: -208680.4
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14039,7 +14039,7 @@ entities:
       pos: -4.5,53.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -63214.934
+      secondsUntilStateChange: -63334.184
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -43232,45 +43232,35 @@ entities:
     - type: Transform
       pos: 56.5,8.5
       parent: 5350
-  - uid: 12481
-    components:
-    - type: Transform
-      pos: 55.5,8.5
-      parent: 5350
   - uid: 12482
-    components:
-    - type: Transform
-      pos: 55.5,9.5
-      parent: 5350
-  - uid: 12483
     components:
     - type: Transform
       pos: 54.5,9.5
       parent: 5350
-  - uid: 12484
+  - uid: 12483
     components:
     - type: Transform
-      pos: 54.5,10.5
+      pos: 55.5,9.5
       parent: 5350
   - uid: 12485
     components:
     - type: Transform
-      pos: 54.5,11.5
+      pos: 56.5,9.5
       parent: 5350
   - uid: 12486
     components:
     - type: Transform
-      pos: 54.5,12.5
+      pos: 56.5,10.5
       parent: 5350
   - uid: 12487
     components:
     - type: Transform
-      pos: 54.5,13.5
+      pos: 52.5,20.5
       parent: 5350
   - uid: 12488
     components:
     - type: Transform
-      pos: 54.5,14.5
+      pos: 52.5,19.5
       parent: 5350
   - uid: 12489
     components:
@@ -47761,6 +47751,11 @@ entities:
     components:
     - type: Transform
       pos: 77.5,-30.5
+      parent: 5350
+  - uid: 28193
+    components:
+    - type: Transform
+      pos: 52.5,18.5
       parent: 5350
 - proto: CableHVStack
   entities:
@@ -56208,6 +56203,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,44.5
+      parent: 5350
+  - uid: 12484
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 55.5,9.5
       parent: 5350
   - uid: 13979
     components:
@@ -81427,7 +81428,7 @@ entities:
       pos: -10.5,51.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -61939.6
+      secondsUntilStateChange: -62058.85
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -144686,6 +144687,11 @@ entities:
       name: NW Solars SMES
     - type: Transform
       pos: -33.5,44.5
+      parent: 5350
+  - uid: 12481
+    components:
+    - type: Transform
+      pos: 54.5,9.5
       parent: 5350
   - uid: 13977
     components:

--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -13781,7 +13781,7 @@ entities:
       pos: -29.5,15.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -208680.4
+      secondsUntilStateChange: -208703.7
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14039,7 +14039,7 @@ entities:
       pos: -4.5,53.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -63334.184
+      secondsUntilStateChange: -63357.484
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -15595,7 +15595,12 @@ entities:
   - uid: 23812
     components:
     - type: Transform
-      pos: 73.53678,8.623411
+      pos: 73.68355,8.538181
+      parent: 5350
+  - uid: 28194
+    components:
+    - type: Transform
+      pos: 73.29292,8.538181
       parent: 5350
 - proto: AnomalyScanner
   entities:
@@ -81428,7 +81433,7 @@ entities:
       pos: -10.5,51.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -62058.85
+      secondsUntilStateChange: -62082.152
       state: Closing
     - type: DeviceNetwork
       deviceLists:

--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -13781,7 +13781,7 @@ entities:
       pos: -29.5,15.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -208703.7
+      secondsUntilStateChange: -208773.03
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14039,7 +14039,7 @@ entities:
       pos: -4.5,53.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -63357.484
+      secondsUntilStateChange: -63426.812
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -63427,6 +63427,12 @@ entities:
     - type: Transform
       pos: 71.5,-30.5
       parent: 5350
+  - uid: 28196
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -33.5,17.5
+      parent: 5350
 - proto: ChairOfficeLight
   entities:
   - uid: 1269
@@ -67315,11 +67321,11 @@ entities:
       parent: 5350
 - proto: ComputerCargoShuttle
   entities:
-  - uid: 3520
+  - uid: 28195
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -42.5,17.5
+      rot: -1.5707963267948966 rad
+      pos: -32.5,17.5
       parent: 5350
 - proto: ComputerComms
   entities:
@@ -67619,6 +67625,14 @@ entities:
     components:
     - type: Transform
       pos: -40.5,33.5
+      parent: 5350
+- proto: ComputerShuttleCargo
+  entities:
+  - uid: 3520
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -42.5,17.5
       parent: 5350
 - proto: ComputerSolarControl
   entities:
@@ -81433,7 +81447,7 @@ entities:
       pos: -10.5,51.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -62082.152
+      secondsUntilStateChange: -62151.48
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -152428,6 +152442,12 @@ entities:
     components:
     - type: Transform
       pos: 47.5,-24.5
+      parent: 5350
+  - uid: 28197
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -32.5,16.5
       parent: 5350
 - proto: TableCarpet
   entities:


### PR DESCRIPTION
## About the PR
Fixes Meta station power. Gives South Engineering Substation an SMES backup, and reroutes some HV wiring.

## Why / Balance
Unfortunately I slipped up when mirroring my changes for Nox's Meta Rework.

Engineering solars and half of engine power generation wasn't actually connected to the engineering HV subgrid.

This meant that almost all of Engineering would run out of power about 2 minutes, 30 seconds in.

This should be hotfixed to stable.

## Media
![Meta-0](https://github.com/user-attachments/assets/2d3bdcef-9fcf-4979-9866-c7de4a48248f)

### Highlighted Changes Media
![Content Client_hdJpem6HA3](https://github.com/user-attachments/assets/56bdf9c9-19b9-47d1-8bd9-6132ca308221)
![Content Client_QPdG6LEDDX](https://github.com/user-attachments/assets/459b0fc3-077a-48c0-a1f9-890f1a01faff)
![Content Client_fj3RFYNldg](https://github.com/user-attachments/assets/6d4260ac-24a9-4432-9329-123001d723a6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->