### PR TITLE
Special reagents now appear in the guidebook

### DIFF
--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -26,7 +26,6 @@ guide-entry-chef = Chef
 guide-entry-medical = Medical
 guide-entry-medicaldoctor = Medical Doctor
 guide-entry-chemist = Chemist
-guide-entry-medicine = Medicine
 guide-entry-brute = Advanced Brute Medication
 guide-entry-botanicals = Botanicals
 guide-entry-cloning = Cloning
@@ -57,16 +56,19 @@ guide-entry-controls = Controls
 guide-entry-radio = Radio and Speech
 
 guide-entry-references = Tables & References
+guide-entry-chemicals = Chemicals
 guide-entry-drinks = Drinks
 guide-entry-foodrecipes = Food Recipes
-guide-entry-chemicals = Chemicals
+
 guide-entry-elements = Elements
+guide-entry-medicine = Medicine
 guide-entry-narcotics = Narcotics
 guide-entry-pyrotechnics = Pyrotechnic
 guide-entry-toxins = Toxins
 guide-entry-foods = Foods
 guide-entry-biological = Biological
-guide-entry-botanical = Botanicals
+guide-entry-botanical = Botanical
+guide-entry-special = Special
 guide-entry-others = Others
 
 guide-entry-antagonists = Antagonists

--- a/Resources/Prototypes/Guidebook/chemicals.yml
+++ b/Resources/Prototypes/Guidebook/chemicals.yml
@@ -11,6 +11,7 @@
   - Foods
   - Botanical
   - Biological
+  - Special
   - Others
   filterEnabled: True
 
@@ -54,6 +55,12 @@
   id: Biological
   name: guide-entry-biological
   text: "/ServerInfo/Guidebook/ChemicalTabs/Biological.xml"
+  filterEnabled: True
+
+- type: guideEntry
+  id: Special
+  name: guide-entry-special
+  text: "/ServerInfo/Guidebook/ChemicalTabs/Special.xml"
   filterEnabled: True
 
 - type: guideEntry

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Special.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Special.xml
@@ -1,0 +1,9 @@
+<Document>
+
+# Special
+
+These reagents have strange or unusual sources or properties.
+
+<GuideReagentGroupEmbed Group="Special"/>
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/Chemicals.xml
+++ b/Resources/ServerInfo/Guidebook/Chemicals.xml
@@ -29,6 +29,9 @@ Knowing different types of chemicals and their effects is important for being ab
 ## Biological
 <GuideReagentGroupEmbed Group="Biological"/>
 
+## Special
+<GuideReagentGroupEmbed Group="Special"/>
+
 ## Other
 <GuideReagentGroupEmbed Group="Unknown"/>
 </Document>


### PR DESCRIPTION
## About the PR
Reagents with `group: Special` now appear in the guidebook.

## Why / Balance
They were missing.
(Partly?) resolves #34234

## Technical details

- Adds `Special.xml` to ServerInfo files.
- Entries added to `chemicals.yml`, `Chemicals.xml`
- Entries added to `guides.ftl` and reorganises relevant section of file.

## Media
![2025-1-07_07 32 32](https://github.com/user-attachments/assets/6b613110-49bf-4371-b9b0-f4a25069a974)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Shouldn't do; adds a new file and missing references, but doesn't significantly change any existing entries.

**Changelog**

:cl:
- add: Special reagents are now listed in the relevant section of the guidebook.
