### PR TITLE
Sec can open firelocks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -106,7 +106,7 @@
     - type: StaticPrice
       price: 150
     - type: AccessReader
-      access: [ [ "Engineering" ] ]
+      access: [ ["Engineering"], ["Security"] ]
     - type: PryUnpowered
       pryModifier: 0.5
     - type: PointLight


### PR DESCRIPTION
## About the PR
Make triggered firelocks openable with Security access

## Why / Balance
Currently, only Engineers can instantly open a triggered firelock without any tools. This is because they are meant to work in depressurised areas. However, Sec is meant to keep crew safe. Thus, they should be able to open firelocks to get people out of depressurised areas. Additionally, not being able to open firelocks is apparently specifically a problem for them when facing China Lake users.

Sec access is regulated enough that they can probably be trusted with this ability.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Errant
- tweak: Firelocks can now be opened with Security access.
