### PR TITLE
[HOTFIX] fix holopads with multiple ai cores dying

### DIFF
--- a/Content.Server/Silicons/StationAi/StationAiSystem.cs
+++ b/Content.Server/Silicons/StationAi/StationAiSystem.cs
@@ -43,10 +43,10 @@ public sealed class StationAiSystem : SharedStationAiSystem
             var stationAiCore = new Entity<StationAiCoreComponent>(ent, entStationAiCore);
 
             if (!TryGetInsertedAI(stationAiCore, out var insertedAi) || !TryComp(insertedAi, out ActorComponent? actor))
-                return;
+                continue;
 
             if (stationAiCore.Comp.RemoteEntity == null || stationAiCore.Comp.Remote)
-                return;
+                continue;
 
             var xform = Transform(stationAiCore.Comp.RemoteEntity.Value);
 


### PR DESCRIPTION
## About the PR
github trolled last pr, remade this from stable

changed return to continue

Edit: Original PR (#34271) description

"chromiumboy suggested this

reason why it worked sometimes was arbitrary entity order, it might pick the station's ai core vs a different one (in this case on centcomm) so it might never have to return

imagine if return inside a loop had a warning the amount of bugs its created is insane..."