### PR TITLE
Departmental shelves whitelist expansion

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/shelfs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/shelfs.yml
@@ -329,6 +329,9 @@
         - DrinkBottle
         - DrinkCan
         - Beer
+        - Wine
+      components:
+        - ReactionMixer
   - type: Construction
     graph: Shelf
     node: ShelfBar
@@ -395,6 +398,16 @@
         - Ingredient
         - Trash
         - Plastic
+        - SaltShaker
+        - PepperShaker
+        - Packet
+        - Ketchup
+        - Hotsauce
+        - Coldsauce
+        - BBQsauce
+      components:
+        - Utensil
+        - Bin
   - type: Construction
     graph: Shelf
     node: ShelfKitchen
@@ -454,6 +467,11 @@
         - ChemDispensable
         - GlassBeaker
         - Bottle
+        - Medkit
+        - CentrifugeCompatible
+        - PillCanister
+        - Syringe
+        - Spray
   - type: Construction
     graph: Shelf
     node: ShelfChemistry


### PR DESCRIPTION
## About the PR
Chemistry shelf can now store med kits (combat med kit is the only one that meets the other necessary criteria), vials, pill canisters, syringes and sprays (not hypo). Bar shelf can now store cans of wine, shakers and bar spoons. Kitchen shelf can now store salt/pepper shakers, Ketchup/Hotsauce/Coldsauce/BBQsauce bottles, metal utensils and candy bowls.
Unfortunately, cartons don't possess distinct tags so I decided not to touch that.
(First PR yay!)

## Why / Balance
I found the inability to store these particular items on those shelves rather confusing and nonsensical. Adding them to the whitelist brings more usability to such a functional structure as a shelf.

## Technical details
Expanded whitelist for:
- Chemistry shelf - Medkit, CentrifugeCompatible, PillCanister, Syringe, Spray (***tags***)
- Bar shelf - Wine (***tag***). ReactionMixer (***component***)
- Kitchen shelf - SaltShaker, PepperShaker, Packet, Ketchup, Hotsauce, Coldsauce, BBQsauce (***tags***). Utensil, Bin (***components***)

Tested and works as intended.

## Media
![unknown_2025 01 08-10 39](https://github.com/user-attachments/assets/002d4522-54de-4d82-b2b8-350c875a0e7b)
![unknown_2025 01 08-10 39_1](https://github.com/user-attachments/assets/ffb04bc3-d9bd-4cf3-ae8e-1f3d8efb895d)
![unknown_2025 01 08-10 41](https://github.com/user-attachments/assets/62d88994-f4cc-4a26-9bb1-5da1e9715d07)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No new tags added so none.

**Changelog**
:cl:
- tweak: Departmental shelves can now contain a wider variety of items.
