### PR TITLE
Fixed Loop Station's southern solar array unlinked airlocks 

### DIFF
--- a/Resources/Maps/loop.yml
+++ b/Resources/Maps/loop.yml
@@ -7299,7 +7299,7 @@ entities:
       pos: -30.5,13.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -44351.34
+      secondsUntilStateChange: -44385.21
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -7691,11 +7691,23 @@ entities:
     - type: Transform
       pos: -28.5,-12.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        13404:
+        - DoorStatus: DoorBolt
   - uid: 13404
     components:
     - type: Transform
       pos: -28.5,-9.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        13402:
+        - DoorStatus: DoorBolt
   - uid: 14633
     components:
     - type: Transform
@@ -43388,7 +43400,7 @@ entities:
       pos: -9.5,51.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -292106.88
+      secondsUntilStateChange: -292140.75
       state: Opening
   - uid: 6747
     components:
@@ -43396,7 +43408,7 @@ entities:
       pos: -8.5,51.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -292107.6
+      secondsUntilStateChange: -292141.47
       state: Opening
   - uid: 6749
     components:
@@ -43404,7 +43416,7 @@ entities:
       pos: -6.5,51.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -292106.16
+      secondsUntilStateChange: -292140.03
       state: Opening
   - uid: 6750
     components:
@@ -43412,7 +43424,7 @@ entities:
       pos: -5.5,51.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -292105.53
+      secondsUntilStateChange: -292139.4
       state: Opening
 - proto: CyberPen
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Linked the unlinked airlocks at the southern solar array on Loop Station. Fixes #34211

## Why / Balance
The airlocks at the other three solar arrays are linked correctly. Prevents spacing the room inside the station

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![airlock-fix](https://github.com/user-attachments/assets/5981219b-3aca-42db-989a-b65abec791e7)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
