### PR TITLE
Arachnid stomach organ yaml fix

### DIFF
--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -38,7 +38,7 @@
     size: Small
     heldPrefix: stomach
   - type: Stomach
-    updateInterval: 1.5
+    digestionDelay: 30
   - type: SolutionContainerManager
     solutions:
       stomach:


### PR DESCRIPTION
## About the PR
Arachnids had their stomach `updateInterval` set to 1.5, 50% slower than normal. But this doesn't actually slow down the speed that the stomach digests things, only the rate at which it updates to check if enough time has passed. (See [BodySystem.cs](https://github.com/space-wizards/space-station-14/blob/23f0b304f284d2600cb2c6b4c9d36fdca7f99ec4/Content.Server/Body/Systems/StomachSystem.cs#L57))

This PR changes arachnid stomachs to have a `digestionDelay` of 30 (20 is default) to achieve the desired effect.

Stasis beds are also bugged in a similar manner. They are intended to slow down the digestion speed, but similarly all they do is change the update rate. But fixing that requires actual code changes and is out of scope for this PR.

## Why / Balance
This just makes it work as intended.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- fix: Fix a bug that was causing arachnid stomachs to not digest at the intended, slower than normal speed.
