### PR TITLE
Fix holopads phasing through walls.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -13,9 +13,18 @@
           !type:PhysShapeCircle
           radius: 0.25
         mask:
-        - TabletopMachineMask
+        - Impassable
+        - HighImpassable
+        - MidImpassable
+      fix2:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.25
+        mask:
+        - MachineLayer
         layer:
-        - Opaque
+        - LowImpassable
+        hard: False
   - type: ApcPowerReceiver
     powerLoad: 300
   - type: StationAiVision

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -13,10 +13,9 @@
           !type:PhysShapeCircle
           radius: 0.25
         mask:
-        - SubfloorMask
+        - TabletopMachineMask
         layer:
-        - LowImpassable
-        hard: false
+        - Opaque
   - type: ApcPowerReceiver
     powerLoad: 300
   - type: StationAiVision

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -24,7 +24,7 @@
         - MachineLayer
         layer:
         - LowImpassable
-        hard: False
+        hard: false
   - type: ApcPowerReceiver
     powerLoad: 300
   - type: StationAiVision


### PR DESCRIPTION
## About the PR
Fixes one of the issues of #33986

## Why / Balance
The issue is that holopads could be tossed under walls either intentionally or accidentally when being moved. Once under say a reinforced wall, you'd have to deconstruct the wall to get the holopad back.

## Technical details
Copies the masks of the artifact analyzer for the holopad as it has the desired behavior. I'm a touch confused on masks, levels, and fixtures at the moment so this is the best I could come up with.

## Media
https://github.com/user-attachments/assets/4c45bb76-a42e-4bad-8899-fbe3ef1d494b



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl:
- fix: Holopads now collide with walls instead of phasing through them.
