### PR TITLE
Fix Mixed puddles not updating slips when evap

### DIFF
--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
@@ -1,6 +1,4 @@
-using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Shared.Chemistry.Components;
-using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;
 

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
@@ -1,3 +1,4 @@
+using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.FixedPoint;
@@ -57,9 +58,7 @@ public sealed partial class PuddleSystem
                 QueueDel(uid);
             }
 
-            var ev = new SolutionContainerChangedEvent(puddleSolution, puddle.SolutionName);
-            RaiseLocalEvent(uid, ref ev);
-            Dirty(puddle.Solution.Value.Owner, puddle.Solution.Value.Comp);
+            _solutionContainerSystem.UpdateChemicals(puddle.Solution.Value);
         }
     }
 }

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;
 
@@ -55,6 +56,10 @@ public sealed partial class PuddleSystem
                 Spawn("PuddleSparkle", xformQuery.GetComponent(uid).Coordinates);
                 QueueDel(uid);
             }
+
+            var ev = new SolutionContainerChangedEvent(puddleSolution, puddle.SolutionName);
+            RaiseLocalEvent(uid, ref ev);
+            Dirty(puddle.Solution.Value.Owner, puddle.Solution.Value.Comp); // Fix the misprediction
         }
     }
 }

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
@@ -59,7 +59,7 @@ public sealed partial class PuddleSystem
 
             var ev = new SolutionContainerChangedEvent(puddleSolution, puddle.SolutionName);
             RaiseLocalEvent(uid, ref ev);
-            Dirty(puddle.Solution.Value.Owner, puddle.Solution.Value.Comp); // Fix the misprediction
+            Dirty(puddle.Solution.Value.Owner, puddle.Solution.Value.Comp);
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When a puddle evaporates it does so in steps.
These steps will never be displayed to players cause the solution container is never told to update.
Further, If a solution is a "mixed solution" (i.e has 2 reagents in it) it will not update it's state when an evaporatable reagent evaporates out of the solution, causing it to be displayed in the larger puddle state, With an incorrect description and will act as though it is still slippery for at least 1 slip/external forces firing an SolutionContainerUpdateEvent
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mixed solution puddles are and have always been broken

## Technical details
<!-- Summary of code changes for easier review. -->
Update the solution every evaporation tick

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


https://github.com/user-attachments/assets/f3404643-bed7-4c8a-8f02-b29a2ff9c5bf

https://github.com/user-attachments/assets/0ac15342-4493-4939-b1c2-38d709cd28f8

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Kickguy223
- fix: Puddles will now correctly evaporate
