### PR TITLE
Decouple water from evaporation code 

### DIFF
--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Evaporation.cs
@@ -20,7 +20,7 @@ public sealed partial class PuddleSystem
             return;
         }
 
-        if (solution.GetTotalPrototypeQuantity(EvaporationReagents) > FixedPoint2.Zero)
+        if (SolutionHasEvaporation(solution))
         {
             var evaporation = AddComp<EvaporationComponent>(uid);
             evaporation.NextTick = _timing.CurTime + EvaporationCooldown;
@@ -46,7 +46,7 @@ public sealed partial class PuddleSystem
                 continue;
 
             var reagentTick = evaporation.EvaporationAmount * EvaporationCooldown.TotalSeconds;
-            puddleSolution.SplitSolutionWithOnly(reagentTick, EvaporationReagents);
+            puddleSolution.SplitSolutionWithOnly(reagentTick, EvaporatableProtosInSolution(puddleSolution));
 
             // Despawn if we're done
             if (puddleSolution.Volume == FixedPoint2.Zero)

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -106,7 +106,7 @@ namespace Content.Shared.Chemistry.Reagent
         public bool Slippery;
 
         /// <summary>
-        /// If this reagent is part fo a puddle does it evaporate
+        /// If this reagent is part of a puddle does it evaporate
         /// </summary>
         [DataField]
         public bool Evaporates;

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -106,6 +106,12 @@ namespace Content.Shared.Chemistry.Reagent
         public bool Slippery;
 
         /// <summary>
+        /// If this reagent is part fo a puddle does it evaporate
+        /// </summary>
+        [DataField]
+        public bool Evaporates;
+
+        /// <summary>
         /// How easily this reagent becomes fizzy when aggitated.
         /// 0 - completely flat, 1 - fizzes up when nudged.
         /// </summary>

--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
 
 namespace Content.Shared.Fluids;
 
@@ -10,8 +11,31 @@ public abstract partial class SharedPuddleSystem
 
     public static readonly string[] EvaporationReagents = [Water];
 
+    public string[] EvaporatableProtosInSolution(Solution solution)
+    {
+        List<string> evaporationReagents = [];
+
+        foreach (var (reagent, _) in solution.Contents)
+        {
+            var reagentProto = _prototypeManager.Index<ReagentPrototype>(reagent.Prototype);
+            if (reagentProto.Evaporates)
+                evaporationReagents.Add(reagentProto.ID);
+        }
+        return evaporationReagents.ToArray();
+    }
+    public bool SolutionHasEvaporation(Solution solution)
+    {
+        foreach (var (reagent, quantity)  in solution.Contents)
+        {
+            var reagentProto = _prototypeManager.Index<ReagentPrototype>(reagent.Prototype);
+            if(reagentProto.Evaporates && quantity > FixedPoint2.Zero)
+                return true;
+        }
+        return false;
+    }
+
     public bool CanFullyEvaporate(Solution solution)
     {
-        return solution.GetTotalPrototypeQuantity(EvaporationReagents) == solution.Volume;
+        return solution.GetTotalPrototypeQuantity(EvaporatableProtosInSolution(solution)) == solution.Volume;
     }
 }

--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -23,12 +23,13 @@ public abstract partial class SharedPuddleSystem
         }
         return evaporationReagents.ToArray();
     }
+    
     public bool SolutionHasEvaporation(Solution solution)
     {
         foreach (var (reagent, quantity)  in solution.Contents)
         {
             var reagentProto = _prototypeManager.Index<ReagentPrototype>(reagent.Prototype);
-            if(reagentProto.Evaporates && quantity > FixedPoint2.Zero)
+            if (reagentProto.Evaporates && quantity > FixedPoint2.Zero)
                 return true;
         }
         return false;

--- a/Content.Shared/Fluids/SharedPuddleSystem.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.cs
@@ -100,7 +100,7 @@ public abstract partial class SharedPuddleSystem : EntitySystem
             {
                 if (CanFullyEvaporate(solution))
                     args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating"));
-                else if (solution.GetTotalPrototypeQuantity(EvaporationReagents) > FixedPoint2.Zero)
+                else if (SolutionHasEvaporation(solution))
                     args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating-partial"));
                 else
                     args.PushMarkup(Loc.GetString("puddle-component-examine-evaporating-no"));

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -442,6 +442,7 @@
   recognizable: true
   boilingPoint: 100.0
   meltingPoint: 0.0
+  evaporates: true
   metabolisms:
     Drink:
       effects:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed the hardcoding limiting evaporation to only Water. Left out applying this to anything (like space lube) to allow other PR's to handle adding it to reagents.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Evaporation is hardcoded to the water Prototype ID via a magic variable. By adding helper functions and a Prototype field, evaporation is able to be applied to any reagent.

## Technical details
<!-- Summary of code changes for easier review. -->
added 2 helper functions to cover all cases where Evaporation either utilizes The magic variable or otherwise would need to check if a reagent is evaporatable

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/565ef564-06fa-470f-a194-0057d22d20e4


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No CL No Fun 