### PR TITLE
Gives external access to paramedics

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -15,6 +15,7 @@
   access:
   - Medical
   - Maintenance
+  - External
   extendedAccess:
   - Chemistry
 


### PR DESCRIPTION
## About the PR
This simple PR will give Paramedic ID cards "External" access by default allowing them to open regular external airlocks.

## Why / Balance
Paramedics their main job is to retrieve dead/dying crew members wherever they may be and bring them to medical for further treatment if needed. They are also one of the few jobs on the station that has their own spacesuit and GPS which allows them to rescue crew members in space.

Some paramedic players will usually try and get external access from the HoP at the start of the round. And in a worst case scenario where nobody is available to help with opening the external airlock a paramedic player can simply break a window or unwrench a escape pod thruster to get to their patient in space quickly.

It seems counterproductive to give paramedics the job of rescuing people in space and then try to stop them from doing that job with a superficial barricade.

## Technical details
A simple change in the paramedic.yml file that adds a single line under access to give paramedics "External" access.

## Media
https://github.com/user-attachments/assets/b6594330-55cb-444b-bcc7-71c64d7a11f7

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- add: Paramedics can now open airlocks that require external access.