### PR TITLE
Reorganised reagents listed in the guidebook

### DIFF
--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -68,6 +68,7 @@ guide-entry-toxins = Toxins
 guide-entry-foods = Foods
 guide-entry-biological = Biological
 guide-entry-botanical = Botanical
+guide-entry-domestic = Domestic
 guide-entry-special = Special
 guide-entry-others = Others
 

--- a/Resources/Prototypes/Guidebook/chemicals.yml
+++ b/Resources/Prototypes/Guidebook/chemicals.yml
@@ -8,9 +8,10 @@
   - Narcotics
   - Pyrotechnic
   - Toxins
-  - Foods
-  - Botanical
   - Biological
+  - Botanical
+  - Domestic
+  - Foods
   - Special
   - Others
   filterEnabled: True
@@ -40,9 +41,9 @@
   filterEnabled: True
 
 - type: guideEntry
-  id: Foods
-  name: guide-entry-foods
-  text: "/ServerInfo/Guidebook/ChemicalTabs/Foods.xml"
+  id: Biological
+  name: guide-entry-biological
+  text: "/ServerInfo/Guidebook/ChemicalTabs/Biological.xml"
   filterEnabled: True
 
 - type: guideEntry
@@ -52,9 +53,15 @@
   filterEnabled: True
 
 - type: guideEntry
-  id: Biological
-  name: guide-entry-biological
-  text: "/ServerInfo/Guidebook/ChemicalTabs/Biological.xml"
+  id: Domestic
+  name: guide-entry-domestic
+  text: "/ServerInfo/Guidebook/ChemicalTabs/Domestic.xml"
+  filterEnabled: True
+
+- type: guideEntry
+  id: Foods
+  name: guide-entry-foods
+  text: "/ServerInfo/Guidebook/ChemicalTabs/Foods.xml"
   filterEnabled: True
 
 - type: guideEntry

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -1,4 +1,16 @@
 - type: reagent
+  parent: Blood
+  id: AmmoniaBlood
+  name: reagent-name-ammonia-blood # Anaerobic blood
+  group: Biological
+  desc: reagent-desc-ammonia-blood
+  flavor: bitter
+  color: "#7a8bf2"
+  recognizable: true
+  physicalDesc: reagent-physical-desc-pungent
+  slippery: false
+
+- type: reagent
   id: Blood
   name: reagent-name-blood
   group: Biological
@@ -48,6 +60,91 @@
 
 - type: reagent
   parent: Blood
+  id: CopperBlood
+  name: reagent-name-hemocyanin-blood # Copper blood
+  group: Biological
+  desc: reagent-desc-hemocyanin-blood
+  flavor: metallic
+  color: "#162581"
+  recognizable: true
+  physicalDesc: reagent-physical-desc-metallic
+  slippery: false
+
+- type: reagent
+  id: Fat
+  name: reagent-name-fat
+  group: Biological
+  desc: reagent-desc-fat
+  flavor: terrible
+  color: "#d8d8b0"
+  physicalDesc: reagent-physical-desc-exotic-smelling
+  slippery: false
+  footstepSound:
+    collection: FootstepBlood
+    params:
+      volume: 6
+
+- type: reagent
+  id: GreyMatter
+  name: reagent-name-grey-matter
+  group: Biological # Also a Toxin
+  desc: reagent-desc-grey-matter
+  physicalDesc: reagent-physical-desc-neural
+  flavor: mindful
+  color: "#C584B8"
+  slippery: false
+  metabolisms:
+    Drink:
+      effects:
+        - !type:SatiateHunger
+          factor: 1.5
+    Poison:
+      effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Cellular: 2
+
+- type: reagent
+  id: Ichor
+  name: reagent-name-ichor
+  group: Biological # Also technically a Medicine
+  desc: reagent-desc-ichor
+  physicalDesc: reagent-physical-desc-roaring
+  flavor: metallic
+  color: "#f4692e"
+  recognizable: true
+  metabolisms:
+    Drink:
+      effects:
+        - !type:SatiateThirst
+          factor: 1.5
+    # Dragon doesn't require airloss healing, so omnizine is still best for humans.
+    Medicine:
+      effects:
+        - !type:ModifyBloodLevel
+          amount: 3
+        - !type:HealthChange
+          damage:
+            groups:
+              Burn: -5
+              Brute: -5
+              Toxin: -2
+            types:
+              Bloodloss: -5
+        - !type:ModifyBleedAmount
+          amount: -1.5
+  # Just in case you REALLY want to water your plants
+  plantMetabolism:
+    - !type:PlantAdjustWater
+      amount: 0.5
+  footstepSound:
+    collection: FootstepBlood
+    params:
+      volume: 6
+
+- type: reagent
+  parent: Blood
   id: InsectBlood
   name: reagent-name-insect-blood
   group: Biological
@@ -57,6 +154,32 @@
   recognizable: true
   physicalDesc: reagent-physical-desc-slimy
   slippery: false
+
+- type: reagent
+  id: Sap
+  name: reagent-name-sap
+  group: Biological
+  desc: reagent-desc-sap
+  flavor: sweet
+  color: "#cd7314"
+  recognizable: true
+  physicalDesc: reagent-physical-desc-sticky
+  slippery: false
+  viscosity: 0.10
+  tileReactions:
+    - !type:SpillTileReaction
+  metabolisms:
+    Food:
+      # Sweet!
+      effects:
+        - !type:SatiateHunger
+          factor: 1
+        - !type:SatiateThirst
+          factor: 1
+  footstepSound:
+    collection: FootstepBlood
+    params:
+      volume: 6
 
 - type: reagent
   id: Slime
@@ -77,132 +200,6 @@
       effects:
       - !type:SatiateHunger
         factor: 1
-  footstepSound:
-    collection: FootstepBlood
-    params:
-      volume: 6
-
-- type: reagent
-  id: Sap
-  name: reagent-name-sap
-  group: Biological
-  desc: reagent-desc-sap
-  flavor: sweet
-  color: "#cd7314"
-  recognizable: true
-  physicalDesc: reagent-physical-desc-sticky
-  slippery: false
-  viscosity: 0.10
-  tileReactions:
-    - !type:SpillTileReaction
-  metabolisms:
-    Food:
-      # Sweet!
-      effects:
-      - !type:SatiateHunger
-        factor: 1
-      - !type:SatiateThirst
-        factor: 1
-  footstepSound:
-    collection: FootstepBlood
-    params:
-      volume: 6
-
-- type: reagent
-  parent: Blood
-  id: CopperBlood
-  name: reagent-name-hemocyanin-blood
-  group: Biological
-  desc: reagent-desc-hemocyanin-blood
-  flavor: metallic
-  color: "#162581"
-  recognizable: true
-  physicalDesc: reagent-physical-desc-metallic
-  slippery: false
-
-- type: reagent
-  parent: Blood
-  id: AmmoniaBlood
-  name: reagent-name-ammonia-blood
-  group: Biological
-  desc: reagent-desc-ammonia-blood
-  flavor: bitter
-  color: "#7a8bf2"
-  recognizable: true
-  physicalDesc: reagent-physical-desc-pungent
-  slippery: false
-
-- type: reagent
-  id: ZombieBlood
-  name: reagent-name-zombie-blood
-  group: Biological
-  desc: reagent-desc-zombie-blood
-  physicalDesc: reagent-physical-desc-necrotic
-  flavor: bitter
-  color: "#2b0700"
-  slippery: false
-  metabolisms:
-    Drink:
-      # Disgusting!
-      effects:
-      - !type:SatiateThirst
-        factor: -0.5
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: 4
-      - !type:ChemVomit
-        probability: 0.25
-
-- type: reagent
-  id: Ichor
-  name: reagent-name-ichor
-  group: Biological
-  desc: reagent-desc-ichor
-  physicalDesc: reagent-physical-desc-roaring
-  flavor: metallic
-  color: "#f4692e"
-  recognizable: true
-  metabolisms:
-    Drink:
-      effects:
-      - !type:SatiateThirst
-        factor: 1.5
-    # Dragon doesn't require airloss healing, so omnizine is still best for humans.
-    Medicine:
-      effects:
-      - !type:ModifyBloodLevel
-        amount: 3
-      - !type:HealthChange
-        damage:
-          groups:
-            Burn: -5
-            Brute: -5
-            Toxin: -2
-          types:
-            Bloodloss: -5
-      - !type:ModifyBleedAmount
-        amount: -1.5
-  # Just in case you REALLY want to water your plants
-  plantMetabolism:
-  - !type:PlantAdjustWater
-    amount: 0.5
-  footstepSound:
-    collection: FootstepBlood
-    params:
-      volume: 6
-
-- type: reagent
-  id: Fat
-  name: reagent-name-fat
-  group: Biological
-  desc: reagent-desc-fat
-  flavor: terrible
-  color: "#d8d8b0"
-  physicalDesc: reagent-physical-desc-exotic-smelling
-  slippery: false
   footstepSound:
     collection: FootstepBlood
     params:
@@ -231,22 +228,25 @@
       volume: 6
 
 - type: reagent
-  id: GreyMatter
-  name: reagent-name-grey-matter
-  group: Biological
-  desc: reagent-desc-grey-matter
-  physicalDesc: reagent-physical-desc-neural
-  flavor: mindful
-  color: "#C584B8"
+  id: ZombieBlood
+  name: reagent-name-zombie-blood
+  group: Biological # Also a Toxin
+  desc: reagent-desc-zombie-blood
+  physicalDesc: reagent-physical-desc-necrotic
+  flavor: bitter
+  color: "#2b0700"
   slippery: false
   metabolisms:
     Drink:
+      # Disgusting!
       effects:
-      - !type:SatiateHunger
-        factor: 1.5
+        - !type:SatiateThirst
+          factor: -0.5
     Poison:
       effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Cellular: 2
+        - !type:HealthChange
+          damage:
+            types:
+              Poison: 4
+        - !type:ChemVomit
+          probability: 0.25

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -1,4 +1,112 @@
 - type: reagent
+  id: Ammonia
+  name: reagent-name-ammonia
+  group: Botanical # Also a Toxin
+  desc: reagent-desc-ammonia
+  physicalDesc: reagent-physical-desc-pungent
+  flavor: bitter
+  color: "#77b58e"
+  boilingPoint: -33.0
+  meltingPoint: -77.7
+  plantMetabolism:
+    - !type:PlantAdjustNutrition
+      amount: 1
+    - !type:PlantAdjustHealth
+      amount: 0.5
+  metabolisms:
+    Poison:
+      effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Caustic: 1
+    Gas:
+      effects:
+        - !type:HealthChange
+          conditions:
+            - !type:OrganType
+              type: Rat
+              shouldHave: false
+            - !type:ReagentThreshold
+              reagent: Ammonia
+              min: 1
+          ignoreResistances: true
+          damage:
+            types:
+              Poison: 0.25
+        - !type:ChemVomit
+          probability: 0.12
+          conditions:
+            - !type:OrganType
+              type: Rat
+              shouldHave: false
+            - !type:OrganType
+              type: Vox
+              shouldHave: false
+            - !type:ReagentThreshold
+              reagent: Ammonia
+              min: 0.8
+        - !type:PopupMessage
+          type: Local
+          visualType: Medium
+          messages: [ "ammonia-smell" ]
+          probability: 0.1
+          conditions:
+            - !type:ReagentThreshold
+              reagent: Ammonia
+              min: 0.25
+        - !type:HealthChange
+          conditions:
+            - !type:OrganType
+              type: Rat
+            - !type:ReagentThreshold
+              reagent: Ammonia
+              min: 1
+          scaleByQuantity: true
+          ignoreResistances: true
+          damage:
+            groups:
+              Brute: -5
+              Burn: -5
+            types:
+              Bloodloss: -5
+        - !type:Oxygenate # ammonia displaces nitrogen in vox blood
+          conditions:
+            - !type:OrganType
+              type: Vox
+          factor: -4
+
+- type: reagent
+  id: Diethylamine
+  name: reagent-name-diethylamine
+  group: Botanical # Also a Toxin
+  desc: reagent-desc-diethylamine
+  physicalDesc: reagent-physical-desc-strong-smelling
+  flavor: bitter
+  color: "#a1000b"
+  boilingPoint: 55.5
+  meltingPoint: -50.0
+  plantMetabolism:
+    - !type:PlantAdjustNutrition
+      amount: 0.1
+    - !type:PlantAdjustPests
+      probability: 0.1
+      amount: -1
+    - !type:PlantAdjustHealth
+      amount: 0.1
+    - !type:PlantAffectGrowth
+      probability: 0.2
+      amount: 1
+    - !type:PlantDiethylamine {}
+  metabolisms:
+    Poison:
+      effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Caustic: 1
+
+- type: reagent
   id: EZNutrient
   name: reagent-name-e-z-nutrient
   group: Botanical
@@ -51,7 +159,7 @@
 - type: reagent
   id: PestKiller
   name: reagent-name-pest-killer
-  group: Botanical
+  group: Botanical # For some reason this is only toxic to plants
   desc: reagent-desc-pest-killer
   flavor: bitter
   color: "#9e9886"
@@ -75,7 +183,7 @@
 - type: reagent
   id: PlantBGone
   name: reagent-name-plant-b-gone
-  group: Botanical
+  group: Botanical # For some reason this is only toxic to plants
   desc: reagent-desc-plant-b-gone
   flavor: bitter
   color: "#49002E"
@@ -106,7 +214,7 @@
 - type: reagent
   id: RobustHarvest
   name: reagent-name-robust-harvest
-  group: Botanical
+  group: Botanical # Also a Toxin
   desc: reagent-desc-robust-harvest
   flavor: bitter
   color: "#3e901c"
@@ -174,7 +282,7 @@
 - type: reagent
   id: WeedKiller
   name: reagent-name-weed-killer
-  group: Botanical
+  group: Botanical # For some reason this is only toxic to plants
   desc: reagent-desc-weed-killer
   flavor: bitter
   color: "#968395"
@@ -194,112 +302,3 @@
         conditions:
         - !type:OrganType
           type: Plant
-
-- type: reagent
-  id: Ammonia
-  name: reagent-name-ammonia
-  group: Botanical
-  desc: reagent-desc-ammonia
-  physicalDesc: reagent-physical-desc-pungent
-  flavor: bitter
-  color: "#77b58e"
-  boilingPoint: -33.0
-  meltingPoint: -77.7
-  plantMetabolism:
-  - !type:PlantAdjustNutrition
-    amount: 1
-  - !type:PlantAdjustHealth
-    amount: 0.5
-  metabolisms:
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Caustic: 1
-    Gas:
-      effects:
-      - !type:HealthChange
-        conditions:
-        - !type:OrganType
-          type: Rat
-          shouldHave: false
-        - !type:ReagentThreshold
-          reagent: Ammonia
-          min: 1
-        ignoreResistances: true
-        damage:
-          types:
-            Poison: 0.25
-      - !type:ChemVomit
-        probability: 0.12
-        conditions:
-        - !type:OrganType
-          type: Rat
-          shouldHave: false
-        - !type:OrganType
-          type: Vox
-          shouldHave: false
-        - !type:ReagentThreshold
-          reagent: Ammonia
-          min: 0.8
-      - !type:PopupMessage
-        type: Local
-        visualType: Medium
-        messages: [ "ammonia-smell" ]
-        probability: 0.1
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Ammonia
-          min: 0.25
-      - !type:HealthChange
-        conditions:
-        - !type:OrganType
-          type: Rat
-        - !type:ReagentThreshold
-          reagent: Ammonia
-          min: 1
-        scaleByQuantity: true
-        ignoreResistances: true
-        damage:
-          groups:
-            Brute: -5
-            Burn: -5
-          types:
-            Bloodloss: -5
-      - !type:Oxygenate # ammonia displaces nitrogen in vox blood
-        conditions:
-        - !type:OrganType
-          type: Vox
-        factor: -4
-
-
-- type: reagent
-  id: Diethylamine
-  name: reagent-name-diethylamine
-  group: Botanical
-  desc: reagent-desc-diethylamine
-  physicalDesc: reagent-physical-desc-strong-smelling
-  flavor: bitter
-  color: "#a1000b"
-  boilingPoint: 55.5
-  meltingPoint: -50.0
-  plantMetabolism:
-  - !type:PlantAdjustNutrition
-    amount: 0.1
-  - !type:PlantAdjustPests
-    probability: 0.1
-    amount: -1
-  - !type:PlantAdjustHealth
-    amount: 0.1
-  - !type:PlantAffectGrowth
-    probability: 0.2
-    amount: 1
-  - !type:PlantDiethylamine {}
-  metabolisms:
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Caustic: 1

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -1,6 +1,7 @@
 - type: reagent
   id: Acetone
   name: reagent-name-acetone
+  group: Unknown # An organic compound
   desc: reagent-desc-acetone
   physicalDesc: reagent-physical-desc-acidic
   flavor: bitter
@@ -9,8 +10,108 @@
   meltingPoint: -50.0
 
 - type: reagent
+  id: Artifexium
+  name: reagent-name-artifexium
+  group: Special # Also a toxin
+  desc: reagent-desc-artifexium
+  flavor: metallic
+  physicalDesc: reagent-physical-desc-crystalline
+  color: "#776291"
+  metabolisms:
+    Poison:
+      effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Caustic: 2
+  reactiveEffects:
+    Acidic:
+      methods: [ Touch ]
+      effects:
+        - !type:ActivateArtifact
+          conditions:
+            - !type:ReagentThreshold
+              min: 5
+
+- type: reagent
+  id: Ash
+  name: reagent-name-ash
+  group: Unknown # Could probably be classed as an organic compound
+  desc: reagent-desc-ash
+  physicalDesc: reagent-physical-desc-powdery
+  color: white
+
+- type: reagent
+  id: Benzene
+  name: reagent-name-benzene
+  group: Toxins
+  desc: reagent-desc-benzene
+  physicalDesc: reagent-physical-desc-acidic
+  color: "#E7EA91"
+  boilingPoint: 353.2
+  meltingPoint: 278.7
+  metabolisms:
+    Poison:
+      effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Cellular: 1 #it's a carcinogen, reckon this is fine
+
+- type: reagent
+  id: Cellulose
+  name: reagent-name-cellulose
+  group: Biological
+  desc: reagent-desc-cellulose
+  flavor: bitter
+  color: "#E6E6DA"
+  physicalDesc: reagent-physical-desc-crystalline
+  slippery: false
+
+- type: reagent
+  id: Charcoal
+  name: reagent-name-charcoal
+  group: Medicine # One of the oldest cures for poisoning
+  desc: reagent-desc-charcoal
+  physicalDesc: reagent-physical-desc-porous
+  color: "#22282b"
+  boilingPoint: 4200.0
+  meltingPoint: 3550.0
+  metabolisms:
+    Medicine:
+      effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Poison: -1
+        - !type:ChemCleanBloodstream
+          cleanseRate: 3
+
+- type: reagent
+  id: Fersilicite
+  name: reagent-name-fersilicite # The official name for this in RL is Naquite
+  group: Unknown # An iron silicate
+  desc: reagent-desc-fersilicite
+  physicalDesc: reagent-physical-desc-crystalline
+  flavor: metallic
+  color: "#434b4d"
+  boilingPoint: 2962.0
+  meltingPoint: 1638.0
+
+- type: reagent
+  id: Hydroxide
+  name: reagent-name-hydroxide
+  group: Unknown # Used to make lye in RL
+  desc: reagent-desc-hydroxide
+  physicalDesc: reagent-physical-desc-alkaline
+  color: "white"
+  boilingPoint: 1661.0
+  meltingPoint: 596.0
+
+- type: reagent
   id: Phenol
   name: reagent-name-phenol
+  group: Toxins
   desc: reagent-desc-phenol
   physicalDesc: reagent-physical-desc-acidic
   flavor: bitter
@@ -27,88 +128,37 @@
             Poison: 2 # Phenol is definitely not safe
 
 - type: reagent
-  id: Charcoal
-  name: reagent-name-charcoal
-  desc: reagent-desc-charcoal
-  physicalDesc: reagent-physical-desc-porous
-  color: "#22282b"
-  boilingPoint: 4200.0
-  meltingPoint: 3550.0
+  id: Rororium
+  name: reagent-name-rororium
+  group: Special # Also a medicine
+  desc: reagent-desc-rororium
+  flavor: tingly
+  physicalDesc: reagent-physical-desc-refreshing
+  color: "#bf1365"
   metabolisms:
     Medicine:
       effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: -1
-      - !type:ChemCleanBloodstream
-        cleanseRate: 3
-
-- type: reagent
-  id: Ash
-  name: reagent-name-ash
-  desc: reagent-desc-ash
-  physicalDesc: reagent-physical-desc-powdery
-  color: white
+        - !type:HealthChange
+          damage:
+            groups:
+              Brute: -4
+        - !type:GenericStatusEffect
+          key: Adrenaline
+          component: IgnoreSlowOnDamage
+          time: 120
 
 - type: reagent
   id: SodiumCarbonate
   name: reagent-name-sodium-carbonate
+  group: Domestic # AKA Washing soda. Commonly used as a food additive
   desc: reagent-desc-sodium-carbonate
   physicalDesc: reagent-physical-desc-powdery
   color: white
 
 - type: reagent
-  id: Artifexium
-  name: reagent-name-artifexium
-  desc: reagent-desc-artifexium
-  flavor: metallic
-  physicalDesc: reagent-physical-desc-crystalline
-  color: "#776291"
-  metabolisms:
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Caustic: 2
-  reactiveEffects:
-    Acidic:
-      methods: [ Touch ]
-      effects:
-      - !type:ActivateArtifact
-        conditions:
-        - !type:ReagentThreshold
-          min: 5
-
-- type: reagent
-  id: Benzene
-  name: reagent-name-benzene
-  desc: reagent-desc-benzene
-  physicalDesc: reagent-physical-desc-acidic
-  color: "#E7EA91"
-  boilingPoint: 353.2
-  meltingPoint: 278.7
-  metabolisms:
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Cellular: 1 #it's a carcinogen, reckon this is fine
-
-- type: reagent
-  id: Hydroxide
-  name: reagent-name-hydroxide
-  desc: reagent-desc-hydroxide
-  physicalDesc: reagent-physical-desc-alkaline
-  color: "white"
-  boilingPoint: 1661.0
-  meltingPoint: 596.0
-
-- type: reagent
   id: SodiumHydroxide
   name: reagent-name-sodium-hydroxide
+  group: Medicine # Well, technically a hermetic is a type of medicine
   desc: reagent-desc-sodium-hydroxide
   physicalDesc: reagent-physical-desc-alkaline
   color: "white"
@@ -130,18 +180,9 @@
         probability: 0.1
 
 - type: reagent
-  id: Fersilicite
-  name: reagent-name-fersilicite
-  desc: reagent-desc-fersilicite
-  physicalDesc: reagent-physical-desc-crystalline
-  flavor: metallic
-  color: "#434b4d"
-  boilingPoint: 2962.0
-  meltingPoint: 1638.0
-
-- type: reagent
   id: SodiumPolyacrylate
   name: reagent-name-sodium-polyacrylate
+  group: Unknown # Not really a toxin, it just makes you thirsty
   desc: reagent-desc-sodium-polyacrylate
   flavor: bitter
   physicalDesc: reagent-physical-desc-grainy
@@ -156,33 +197,3 @@
         type: Local
         messages: [ "generic-reagent-effect-parched" ]
         probability: 0.1
-
-- type: reagent
-  id: Cellulose
-  name: reagent-name-cellulose
-  group: Biological
-  desc: reagent-desc-cellulose
-  flavor: bitter
-  color: "#E6E6DA"
-  physicalDesc: reagent-physical-desc-crystalline
-  slippery: false
-
-- type: reagent
-  id: Rororium
-  name: reagent-name-rororium
-  desc: reagent-desc-rororium
-  group: Biological
-  flavor: tingly
-  physicalDesc: reagent-physical-desc-refreshing
-  color: "#bf1365"
-  metabolisms:
-    Medicine:
-      effects:
-      - !type:HealthChange
-        damage:
-          groups:
-            Brute: -4
-      - !type:GenericStatusEffect
-        key: Adrenaline
-        component: IgnoreSlowOnDamage
-        time: 120

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -1,6 +1,7 @@
 - type: reagent
   id: Bleach
   name: reagent-name-bleach
+  group: Domestic # Also a Toxin
   desc: reagent-desc-bleach
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: bitter
@@ -27,6 +28,7 @@
 - type: reagent
   id: SpaceCleaner
   name: reagent-name-space-cleaner
+  group: Domestic
   desc: reagent-desc-space-cleaner
   physicalDesc: reagent-physical-desc-lemony-fresh
   flavor: bitter
@@ -41,6 +43,7 @@
 - type: reagent
   id: SoapReagent
   name: reagent-name-soap
+  group: Domestic
   desc: reagent-desc-soap
   physicalDesc: reagent-physical-desc-soapy
   flavor: clean
@@ -67,6 +70,7 @@
 - type: reagent
   id: SpaceLube
   name: reagent-name-space-lube
+  group: Domestic
   desc: reagent-desc-space-lube
   slippery: true
   physicalDesc: reagent-physical-desc-shiny
@@ -83,6 +87,7 @@
 - type: reagent
   id: SpaceGlue
   name: reagent-name-space-glue
+  group: Domestic # Also a narcotic
   desc: reagent-desc-space-glue
   physicalDesc: reagent-physical-desc-sticky
   flavor: glue

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -20,10 +20,11 @@
   boilingPoint: 4200.0
   meltingPoint: 3550.0
 
+# This should probably be given gas properties at some point
 - type: reagent
   id: Chlorine
   name: reagent-name-chlorine
-  group: Elements
+  group: Elements # Also a toxin
   desc: reagent-desc-chlorine
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
@@ -50,7 +51,7 @@
 - type: reagent
   id: Copper
   name: reagent-name-copper
-  group: Elements
+  group: Elements # Also a very mild toxin, or medicine to arachnids
   desc: reagent-desc-copper
   physicalDesc: reagent-physical-desc-metallic
   flavor: metallic
@@ -78,10 +79,11 @@
           shouldHave: true
         amount: 0.4
 
+# This should probably be given gas properties at some point
 - type: reagent
   id: Fluorine
   name: reagent-name-fluorine
-  group: Elements
+  group: Elements # Also a toxin
   desc: reagent-desc-fluorine
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
@@ -105,6 +107,7 @@
           types:
             Caustic: 0.5
             Poison: 0.5
+            
 - type: reagent
   id: Gold
   name: reagent-name-gold
@@ -116,6 +119,7 @@
   boilingPoint: 2700.0
   meltingPoint: 1064.76
 
+# This should probably be given gas properties at some point
 - type: reagent
   id: Hydrogen
   name: reagent-name-hydrogen
@@ -130,7 +134,7 @@
 - type: reagent
   id: Iodine
   name: reagent-name-iodine
-  group: Elements
+  group: Elements # Probably ought to have some role in radiation treatment
   desc: reagent-desc-iodine
   physicalDesc: reagent-physical-desc-dark-brown
   flavor: bitter
@@ -195,7 +199,6 @@
         probability: 0.05
 
   # TODO: cause some brain damage when woundmed, and generally reduce the stutter/scrambledaccent unless high doses
-
 - type: reagent
   id: Mercury
   name: reagent-name-mercury

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -30,6 +30,7 @@
 - type: reagent
   id: Fiber
   name: reagent-name-fiber
+  group: Domestic
   desc: reagent-desc-fiber
   physicalDesc: reagent-physical-desc-fibrous
   flavor: fiber
@@ -139,14 +140,16 @@
 - type: reagent
   id: GroundBee
   name: reagent-name-ground-bee
+  group: Special
   desc: reagent-desc-ground-bee
   physicalDesc: reagent-physical-desc-bee-guts
-  flavor: bee
+  flavor: bee # Fibrous would make more technical sense as this is from a bee plushies
   color: "#86530E"
 
 - type: reagent
   id: Saxoite
   name: reagent-name-saxoite
+  group: Special
   desc: reagent-desc-saxoite
   physicalDesc: reagent-physical-desc-ground-brass
   flavor: sax
@@ -321,7 +324,7 @@
 - type: reagent
   id: JuiceThatMakesYouWeh
   name: reagent-name-weh
-  group: Toxins
+  group: Special # Metabolism type is poison, but not damage type.
   desc: reagent-desc-weh
   physicalDesc: reagent-physical-desc-vibrant
   flavor: weh
@@ -353,7 +356,7 @@
 - type: reagent
   id: JuiceThatMakesYouHew
   name: reagent-name-hew
-  group: Toxins
+  group: Special # Metabolism type is poison, but not damage type.
   desc: reagent-desc-hew
   physicalDesc: reagent-physical-desc-inversed
   flavor: hew

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -1,150 +1,7 @@
 - type: reagent
-  id: Oxygen
-  name: reagent-name-oxygen
-  desc: reagent-desc-oxygen
-  physicalDesc: reagent-physical-desc-gaseous
-  flavor: bitter
-  color: "#c4f5ff"
-  boilingPoint: -183.0
-  meltingPoint: -218.4
-  metabolisms:
-    Gas:
-      effects:
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Human
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Animal
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Rat
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Plant
-      # Convert Oxygen into CO2.
-      - !type:ModifyLungGas
-        conditions:
-        - !type:OrganType
-          type: Vox
-          shouldHave: false
-        ratios:
-          CarbonDioxide: 1.0
-          Oxygen: -1.0
-      - !type:HealthChange
-        conditions:
-        - !type:OrganType
-          type: Vox
-        scaleByQuantity: true
-        ignoreResistances: true
-        damage:
-          types:
-            Poison:
-              7
-      - !type:AdjustAlert
-        alertType: Toxins
-        conditions:
-          - !type:ReagentThreshold
-            min: 0.5
-          - !type:OrganType
-            type: Vox
-        clear: true
-        time: 5
-
-- type: reagent
-  id: Plasma
-  name: reagent-name-plasma
-  desc: reagent-desc-plasma
-  physicalDesc: reagent-physical-desc-gaseous
-  flavor: bitter
-  color: "#7e009e"
-  recognizable: true
-  boilingPoint: -127.3 # Random values picked between the actual values for CO2 and O2
-  meltingPoint: -186.4
-  tileReactions:
-  - !type:FlammableTileReaction
-    temperatureMultiplier: 1.5
-  metabolisms:
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: 3
-      - !type:AdjustReagent
-        reagent: Inaprovaline
-        amount: -2.0
-    Gas:
-      effects:
-      - !type:HealthChange
-        scaleByQuantity: true
-        ignoreResistances: true
-        damage:
-          types:
-            Poison:
-              1
-      # We need a metabolism effect on reagent removal
-      - !type:AdjustAlert
-        alertType: Toxins
-        conditions:
-          - !type:ReagentThreshold
-            min: 1.5
-        clear: True
-        time: 5
-  reactiveEffects:
-    Flammable:
-      methods: [ Touch ]
-      effects:
-      - !type:FlammableReaction
-
-- type: reagent
-  id: Tritium
-  name: reagent-name-tritium
-  desc: reagent-desc-tritium
-  physicalDesc: reagent-physical-desc-ionizing
-  flavor: bitter
-  color: "#66ff33"
-  tileReactions:
-  - !type:FlammableTileReaction
-    temperatureMultiplier: 2.0
-  reactiveEffects:
-    Flammable:
-      methods: [ Touch ]
-      effects:
-      - !type:FlammableReaction
-        multiplier: 0.8
-  metabolisms:
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Radiation: 3
-    Gas:
-      effects:
-      - !type:HealthChange
-        scaleByQuantity: true
-        ignoreResistances: true
-        damage:
-          types:
-            Radiation:
-              1
-      # We need a metabolism effect on reagent removal
-      - !type:AdjustAlert
-        alertType: Toxins
-        conditions:
-          - !type:ReagentThreshold
-            min: 1.5
-        clear: True
-        time: 5
-
-- type: reagent
   id: CarbonDioxide
   name: reagent-name-carbon-dioxide
+  group: Toxins
   desc: reagent-desc-carbon-dioxide
   physicalDesc: reagent-physical-desc-odorless
   flavor: bitter
@@ -152,41 +9,99 @@
   metabolisms:
     Gas:
       effects:
-      - !type:Oxygenate
-        conditions:
-        - !type:OrganType
-          type: Plant
-      - !type:HealthChange
-        conditions:
-        - !type:OrganType
-          type: Plant
-          shouldHave: false
-        - !type:OrganType
-          type: Vox
-          shouldHave: false
-        # Don't want people to get toxin damage from the gas they just
-        # exhaled, right?
-        - !type:ReagentThreshold
-          min: 0.5
-        scaleByQuantity: true
-        ignoreResistances: true
-        damage:
-          types:
-            Poison:
-              0.8
-      - !type:Oxygenate # carbon dioxide displaces oxygen from the bloodstream, causing asphyxiation
-        conditions:
-        - !type:OrganType
-          type: Plant
-          shouldHave: false
-        factor: -4
+        - !type:Oxygenate
+          conditions:
+            - !type:OrganType
+              type: Plant
+        - !type:HealthChange
+          conditions:
+            - !type:OrganType
+              type: Plant
+              shouldHave: false
+            - !type:OrganType
+              type: Vox
+              shouldHave: false
+            # Don't want people to get toxin damage from the gas they just
+            # exhaled, right?
+            - !type:ReagentThreshold
+              min: 0.5
+          scaleByQuantity: true
+          ignoreResistances: true
+          damage:
+            types:
+              Poison:
+                0.8
+        - !type:Oxygenate # carbon dioxide displaces oxygen from the bloodstream, causing asphyxiation
+          conditions:
+            - !type:OrganType
+              type: Plant
+              shouldHave: false
+          factor: -4
       # We need a metabolism effect on reagent removal
       #- !type:AdjustAlert
       #  alertType: CarbonDioxide
 
 - type: reagent
+  id: Frezon
+  name: reagent-name-frezon
+  group: Narcotics # Also a toxin
+  desc: reagent-desc-frezon
+  physicalDesc: reagent-physical-desc-gaseous
+  flavor: bitter
+  color: "#3a758c"
+  boilingPoint: -195.8
+  meltingPoint: -210.0
+  metabolisms:
+    Gas:
+      effects:
+        - !type:HealthChange
+          conditions:
+            - !type:ReagentThreshold
+              reagent: Frezon
+              min: 0.5
+          scaleByQuantity: true
+          ignoreResistances: true
+          damage:
+            types:
+              Cellular: 0.5
+        - !type:GenericStatusEffect
+          conditions:
+            - !type:ReagentThreshold
+              reagent: Frezon
+              min: 1
+          key: SeeingRainbows
+          component: SeeingRainbows
+          type: Add
+          time: 500
+          refresh: false
+        - !type:Drunk
+          boozePower: 500
+          conditions:
+            - !type:ReagentThreshold
+              reagent: Frezon
+              min: 1
+        - !type:PopupMessage
+          type: Local
+          messages: [ "frezon-lungs-cold" ]
+          probability: 0.1
+          conditions:
+            - !type:ReagentThreshold
+              reagent: Frezon
+              min: 0.5
+        - !type:PopupMessage
+          type: Local
+          visualType: Medium
+          messages: [ "frezon-euphoric" ]
+          probability: 0.1
+          conditions:
+            - !type:ReagentThreshold
+              reagent: Frezon
+              min: 1
+
+- type: reagent
   id: Nitrogen
   name: reagent-name-nitrogen
+  group: Elements # Shouldn't really need to be said, but liquid nitrogen is a Toxin
   desc: reagent-desc-nitrogen
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
@@ -229,6 +144,7 @@
 - type: reagent
   id: NitrousOxide
   name: reagent-name-nitrous-oxide
+  group: Narcotics # Also a mild toxin. Has no effects on Slime People
   desc: reagent-desc-nitrous-oxide
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
@@ -308,57 +224,148 @@
             Poison: 0.25
 
 - type: reagent
-  id: Frezon
-  name: reagent-name-frezon
-  desc: reagent-desc-frezon
+  id: Oxygen
+  name: reagent-name-oxygen
+  group: Elements # Also a very powerful Toxin to Vox
+  desc: reagent-desc-oxygen
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
-  color: "#3a758c"
-  boilingPoint: -195.8
-  meltingPoint: -210.0
+  color: "#c4f5ff"
+  boilingPoint: -183.0
+  meltingPoint: -218.4
   metabolisms:
     Gas:
       effects:
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Frezon
-          min: 0.5
-        scaleByQuantity: true
-        ignoreResistances: true
-        damage:
-          types:
-            Cellular: 0.5
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Frezon
-          min: 1
-        key: SeeingRainbows
-        component: SeeingRainbows
-        type: Add
-        time: 500
-        refresh: false
-      - !type:Drunk
-        boozePower: 500
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Frezon
-          min: 1
-      - !type:PopupMessage
-        type: Local
-        messages: [ "frezon-lungs-cold" ]
-        probability: 0.1
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Frezon
-          min: 0.5
-      - !type:PopupMessage
-        type: Local
-        visualType: Medium
-        messages: [ "frezon-euphoric" ]
-        probability: 0.1
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Frezon
-          min: 1
+        - !type:Oxygenate
+          conditions:
+            - !type:OrganType
+              type: Human
+        - !type:Oxygenate
+          conditions:
+            - !type:OrganType
+              type: Animal
+        - !type:Oxygenate
+          conditions:
+            - !type:OrganType
+              type: Rat
+        - !type:Oxygenate
+          conditions:
+            - !type:OrganType
+              type: Plant
+        # Convert Oxygen into CO2.
+        - !type:ModifyLungGas
+          conditions:
+            - !type:OrganType
+              type: Vox
+              shouldHave: false
+          ratios:
+            CarbonDioxide: 1.0
+            Oxygen: -1.0
+        - !type:HealthChange
+          conditions:
+            - !type:OrganType
+              type: Vox
+          scaleByQuantity: true
+          ignoreResistances: true
+          damage:
+            types:
+              Poison:
+                7
+        - !type:AdjustAlert
+          alertType: Toxins
+          conditions:
+            - !type:ReagentThreshold
+              min: 0.5
+            - !type:OrganType
+              type: Vox
+          clear: true
+          time: 5
+
+- type: reagent
+  id: Plasma
+  name: reagent-name-plasma
+  group: Pyrotechnic # Also a Toxin
+  desc: reagent-desc-plasma
+  physicalDesc: reagent-physical-desc-gaseous
+  flavor: bitter
+  color: "#7e009e"
+  recognizable: true
+  boilingPoint: -127.3 # Random values picked between the actual values for CO2 and O2
+  meltingPoint: -186.4
+  tileReactions:
+    - !type:FlammableTileReaction
+      temperatureMultiplier: 1.5
+  metabolisms:
+    Poison:
+      effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Poison: 3
+        - !type:AdjustReagent
+          reagent: Inaprovaline
+          amount: -2.0
+    Gas:
+      effects:
+        - !type:HealthChange
+          scaleByQuantity: true
+          ignoreResistances: true
+          damage:
+            types:
+              Poison:
+                1
+        # We need a metabolism effect on reagent removal
+        - !type:AdjustAlert
+          alertType: Toxins
+          conditions:
+            - !type:ReagentThreshold
+              min: 1.5
+          clear: True
+          time: 5
+  reactiveEffects:
+    Flammable:
+      methods: [ Touch ]
+      effects:
+        - !type:FlammableReaction
+
+- type: reagent
+  id: Tritium
+  name: reagent-name-tritium
+  group: Pyrotechnic # Also a Toxin
+  desc: reagent-desc-tritium
+  physicalDesc: reagent-physical-desc-ionizing
+  flavor: bitter
+  color: "#66ff33"
+  tileReactions:
+    - !type:FlammableTileReaction
+      temperatureMultiplier: 2.0
+  reactiveEffects:
+    Flammable:
+      methods: [ Touch ]
+      effects:
+        - !type:FlammableReaction
+          multiplier: 0.8
+  metabolisms:
+    Poison:
+      effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Radiation: 3
+    Gas:
+      effects:
+        - !type:HealthChange
+          scaleByQuantity: true
+          ignoreResistances: true
+          damage:
+            types:
+              Radiation:
+                1
+        # We need a metabolism effect on reagent removal
+        - !type:AdjustAlert
+          alertType: Toxins
+          conditions:
+            - !type:ReagentThreshold
+              min: 1.5
+          clear: True
+          time: 5

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -1,4 +1,22 @@
 - type: reagent
+  id: Bananadine
+  name: reagent-name-bananadine
+  group: Narcotics
+  desc: reagent-desc-bananadine
+  physicalDesc: reagent-physical-desc-powdery
+  flavor: bitter
+  color: "#ffff00"
+  metabolisms:
+    Narcotic:
+      effects:
+        - !type:GenericStatusEffect
+          key: SeeingRainbows
+          component: SeeingRainbows
+          type: Add
+          time: 5
+          refresh: false
+
+- type: reagent
   id: Desoxyephedrine
   name: reagent-name-desoxyephedrine
   group: Narcotics
@@ -109,8 +127,58 @@
           min: 30
 
 - type: reagent
+  id: Happiness
+  name: reagent-name-happiness
+  group: Narcotics
+  desc: reagent-desc-happiness
+  physicalDesc: reagent-physical-desc-soothing
+  flavor: paintthinner
+  color: "#EE35FF"
+  metabolisms:
+    Narcotic:
+      effects:
+        - !type:Emote
+          emote: Laugh
+          showInChat: true
+          probability: 0.1
+          conditions:
+            - !type:ReagentThreshold
+              max: 20
+        - !type:Emote
+          emote: Whistle
+          showInChat: true
+          probability: 0.1
+          conditions:
+            - !type:ReagentThreshold
+              max: 20
+        - !type:Emote
+          emote: Crying
+          showInChat: true
+          probability: 0.1
+          conditions:
+            - !type:ReagentThreshold
+              min: 20
+        - !type:PopupMessage # we dont have sanity/mood so this will have to do
+          type: Local
+          visualType: Medium
+          messages:
+            - "psicodine-effect-fearless"
+            - "psicodine-effect-anxieties-wash-away"
+            - "psicodine-effect-at-peace"
+          probability: 0.2
+          conditions:
+            - !type:ReagentThreshold
+              max: 20
+        - !type:GenericStatusEffect
+          key: SeeingRainbows
+          component: SeeingRainbows
+          type: Add
+          time: 5
+          refresh: false
+
+- type: reagent
   id: Stimulants
-  name: reagent-name-stimulants
+  name: reagent-name-stimulants # Hyperzine
   group: Narcotics
   desc: reagent-desc-stimulants
   physicalDesc: reagent-physical-desc-energizing
@@ -181,42 +249,6 @@
               Burn: -1
               Brute: -1
 
-- type: reagent
-  id: THC
-  name: reagent-name-thc
-  group: Narcotics
-  desc: reagent-desc-thc
-  flavor: bitter
-  flavorMinimum: 0.05
-  color: "#808080"
-  physicalDesc: reagent-physical-desc-crystalline
-  plantMetabolism:
-  - !type:PlantAdjustNutrition
-    amount: -5
-  - !type:PlantAdjustHealth
-    amount: -1
-  metabolisms:
-    Narcotic:
-      effects:
-      - !type:GenericStatusEffect
-        key: SeeingRainbows
-        component: SeeingRainbows
-        type: Add
-        time: 16
-        refresh: false
-
-- type: reagent
-  id: Nicotine
-  name: reagent-name-nicotine
-  group: Narcotics
-  desc: reagent-desc-nicotine
-  flavor: bitter
-  color: "#C0C0C0"
-  physicalDesc: reagent-physical-desc-strong-smelling
-  plantMetabolism:
-  - !type:PlantAdjustHealth
-    amount: -5
-
 # TODO: Replace these nonstandardized effects with generic brain damage
 - type: reagent
   id: Impedrezene
@@ -229,59 +261,54 @@
   metabolisms:
     Narcotic:
       effects:
-      - !type:MovespeedModifier
-        walkSpeedModifier: 0.65
-        sprintSpeedModifier: 0.65
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: 2
-      - !type:GenericStatusEffect
-        key: SeeingRainbows
-        component: SeeingRainbows
-        type: Add
-        time: 10
-        refresh: false
-      - !type:ChemVomit # Vomiting is a symptom of brain damage
-        probability: 0.05
-      - !type:Drunk # Headaches and slurring are major symptoms of brain damage, this is close enough
-        boozePower: 5
+        - !type:MovespeedModifier
+          walkSpeedModifier: 0.65
+          sprintSpeedModifier: 0.65
+        - !type:HealthChange
+          damage:
+            types:
+              Poison: 2
+        - !type:GenericStatusEffect
+          key: SeeingRainbows
+          component: SeeingRainbows
+          type: Add
+          time: 10
+          refresh: false
+        - !type:ChemVomit # Vomiting is a symptom of brain damage
+          probability: 0.05
+        - !type:Drunk # Headaches and slurring are major symptoms of brain damage, this is close enough
+          boozePower: 5
 
 - type: reagent
-  id: SpaceDrugs
-  name: reagent-name-space-drugs
+  id: MuteToxin
+  name: reagent-name-mute-toxin
   group: Narcotics
-  desc: reagent-desc-space-drugs
+  desc: reagent-desc-mute-toxin
   physicalDesc: reagent-physical-desc-syrupy
-  flavor: bitter
-  color: "#63806e"
+  color: "#000000"
+  boilingPoint: 255.0
+  meltingPoint: 36.0
   metabolisms:
     Narcotic:
       effects:
-      - !type:GenericStatusEffect
-        key: SeeingRainbows
-        component: SeeingRainbows
-        type: Add
-        time: 5
-        refresh: false
+        - !type:GenericStatusEffect
+          key: Muted
+          component: Muted
+          type: Add
+          time: 10
+          refresh: false
 
 - type: reagent
-  id: Bananadine
-  name: reagent-name-bananadine
+  id: Nicotine
+  name: reagent-name-nicotine
   group: Narcotics
-  desc: reagent-desc-bananadine
-  physicalDesc: reagent-physical-desc-powdery
+  desc: reagent-desc-nicotine
   flavor: bitter
-  color: "#ffff00"
-  metabolisms:
-    Narcotic:
-      effects:
-      - !type:GenericStatusEffect
-        key: SeeingRainbows
-        component: SeeingRainbows
-        type: Add
-        time: 5
-        refresh: false
+  color: "#C0C0C0"
+  physicalDesc: reagent-physical-desc-strong-smelling
+  plantMetabolism:
+  - !type:PlantAdjustHealth
+    amount: -5
 
 # Probably replace this one with sleeping chem when putting someone in a comatose state is easier
 - type: reagent
@@ -305,25 +332,6 @@
         component: ForcedSleeping
         refresh: false
         type: Add
-
-- type: reagent
-  id: MuteToxin
-  name: reagent-name-mute-toxin
-  group: Narcotics
-  desc: reagent-desc-mute-toxin
-  physicalDesc: reagent-physical-desc-syrupy
-  color: "#000000"
-  boilingPoint: 255.0
-  meltingPoint: 36.0
-  metabolisms:
-    Narcotic:
-      effects:
-      - !type:GenericStatusEffect
-        key: Muted
-        component: Muted
-        type: Add
-        time: 10
-        refresh: false
 
 - type: reagent
   id: NorepinephricAcid
@@ -368,6 +376,24 @@
         conditions:
         - !type:ReagentThreshold
           min: 20
+
+- type: reagent
+  id: SpaceDrugs
+  name: reagent-name-space-drugs
+  group: Narcotics
+  desc: reagent-desc-space-drugs
+  physicalDesc: reagent-physical-desc-syrupy
+  flavor: bitter
+  color: "#63806e"
+  metabolisms:
+    Narcotic:
+      effects:
+        - !type:GenericStatusEffect
+          key: SeeingRainbows
+          component: SeeingRainbows
+          type: Add
+          time: 5
+          refresh: false
 
 - type: reagent
   id: TearGas
@@ -416,51 +442,25 @@
           min: 20
 
 - type: reagent
-  id: Happiness
-  name: reagent-name-happiness
+  id: THC
+  name: reagent-name-thc
   group: Narcotics
-  desc: reagent-desc-happiness
-  physicalDesc: reagent-physical-desc-soothing
-  flavor: paintthinner
-  color: "#EE35FF"
+  desc: reagent-desc-thc
+  flavor: bitter
+  flavorMinimum: 0.05
+  color: "#808080"
+  physicalDesc: reagent-physical-desc-crystalline
+  plantMetabolism:
+    - !type:PlantAdjustNutrition
+      amount: -5
+    - !type:PlantAdjustHealth
+      amount: -1
   metabolisms:
     Narcotic:
       effects:
-      - !type:Emote
-        emote: Laugh
-        showInChat: true
-        probability: 0.1
-        conditions:
-        - !type:ReagentThreshold
-          max: 20
-      - !type:Emote
-        emote: Whistle
-        showInChat: true
-        probability: 0.1
-        conditions:
-        - !type:ReagentThreshold
-          max: 20
-      - !type:Emote
-        emote: Crying
-        showInChat: true
-        probability: 0.1
-        conditions:
-        - !type:ReagentThreshold
-          min: 20
-      - !type:PopupMessage # we dont have sanity/mood so this will have to do
-        type: Local
-        visualType: Medium
-        messages:
-        - "psicodine-effect-fearless"
-        - "psicodine-effect-anxieties-wash-away"
-        - "psicodine-effect-at-peace"
-        probability: 0.2
-        conditions:
-        - !type:ReagentThreshold
-          max: 20
-      - !type:GenericStatusEffect
-        key: SeeingRainbows
-        component: SeeingRainbows
-        type: Add
-        time: 5
-        refresh: false
+        - !type:GenericStatusEffect
+          key: SeeingRainbows
+          component: SeeingRainbows
+          type: Add
+          time: 16
+          refresh: false

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -14,26 +14,65 @@
       amount: -2
 
 - type: reagent
-  id: Thermite
-  name: reagent-name-thermite
+  id: ChlorineTrifluoride
+  name: reagent-name-chlorine-trifluoride
   parent: BasePyrotechnic
-  desc: reagent-desc-thermite
-  physicalDesc: reagent-physical-desc-grainy
+  desc: reagent-desc-chlorine-trifluoride
+  physicalDesc: reagent-physical-desc-blazing
   flavor: bitter
-  color: "#757245"
-  boilingPoint: 2977.0 # Aluminum oxide
-  meltingPoint: 2030.0
+  color: "#FFC8C8"
   tileReactions:
-  - !type:FlammableTileReaction
-    temperatureMultiplier: 2
+    - !type:PryTileReaction
   metabolisms:
     Poison:
       effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Heat: 2
-            Poison: 1
+        - !type:HealthChange
+          damage:
+            types:
+              Heat: 2
+              Poison: 1
+              Caustic: 0.5 # CLF3 is corrosive
+        - !type:FlammableReaction
+          multiplier: 0.2
+        - !type:AdjustTemperature
+          amount: 6000
+  reactiveEffects:
+    Flammable:
+      methods: [ Touch ]
+      effects:
+        - !type:FlammableReaction
+          multiplier: 0.3
+        - !type:Ignite
+        - !type:Emote
+          emote: Scream
+          probability: 0.2
+        - !type:PopupMessage
+          messages: [ "clf3-it-burns", "clf3-get-away" ]
+          visualType: MediumCaution
+          probability: 0.3
+          type: Local
+
+- type: reagent
+  id: Fluorosurfactant
+  name: reagent-name-fluorosurfactant
+  parent: BasePyrotechnic
+  desc: reagent-desc-fluorosurfactant
+  physicalDesc: reagent-physical-desc-opaque
+  flavor: bitter
+  color: "#9e6b38"
+  boilingPoint: 190.0 # Perfluorooctanoic Acid.
+  meltingPoint: 45.0
+
+- type: reagent
+  id: FoamingAgent
+  name: reagent-name-foaming-agent
+  parent: BasePyrotechnic
+  desc: reagent-desc-foaming-agent
+  physicalDesc: reagent-physical-desc-foamy
+  flavor: bitter
+  color: "#215263"
+  boilingPoint: 418.0 # I went with ammonium lauryl sulfate as the basis for this
+  meltingPoint: 7.4 # I made this up
 
 - type: reagent
   id: Napalm
@@ -94,54 +133,26 @@
       - !type:Ignite
 
 - type: reagent
-  id: ChlorineTrifluoride
-  name: reagent-name-chlorine-trifluoride
+  id: Thermite
+  name: reagent-name-thermite
   parent: BasePyrotechnic
-  desc: reagent-desc-chlorine-trifluoride
-  physicalDesc: reagent-physical-desc-blazing
+  desc: reagent-desc-thermite
+  physicalDesc: reagent-physical-desc-grainy
   flavor: bitter
-  color: "#FFC8C8"
+  color: "#757245"
+  boilingPoint: 2977.0 # Aluminum oxide
+  meltingPoint: 2030.0
   tileReactions:
-  - !type:PryTileReaction
+    - !type:FlammableTileReaction
+      temperatureMultiplier: 2
   metabolisms:
     Poison:
       effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Heat: 2
-            Poison: 1
-            Caustic: 0.5 # CLF3 is corrosive
-      - !type:FlammableReaction
-        multiplier: 0.2
-      - !type:AdjustTemperature
-        amount: 6000
-  reactiveEffects:
-    Flammable:
-      methods: [ Touch ]
-      effects:
-      - !type:FlammableReaction
-        multiplier: 0.3
-      - !type:Ignite
-      - !type:Emote
-        emote: Scream
-        probability: 0.2
-      - !type:PopupMessage
-        messages: [ "clf3-it-burns", "clf3-get-away" ]
-        visualType: MediumCaution
-        probability: 0.3
-        type: Local
-
-- type: reagent
-  id: FoamingAgent
-  name: reagent-name-foaming-agent
-  parent: BasePyrotechnic
-  desc: reagent-desc-foaming-agent
-  physicalDesc: reagent-physical-desc-foamy
-  flavor: bitter
-  color: "#215263"
-  boilingPoint: 418.0 # I went with ammonium lauryl sulfate as the basis for this
-  meltingPoint: 7.4 # I made this up
+        - !type:HealthChange
+          damage:
+            types:
+              Heat: 2
+              Poison: 1
 
 - type: reagent
   id: WeldingFuel
@@ -167,14 +178,3 @@
             Poison: 1
       - !type:FlammableReaction
         multiplier: 0.4
-
-- type: reagent
-  id: Fluorosurfactant
-  name: reagent-name-fluorosurfactant
-  parent: BasePyrotechnic
-  desc: reagent-desc-fluorosurfactant
-  physicalDesc: reagent-physical-desc-opaque
-  flavor: bitter
-  color: "#9e6b38"
-  boilingPoint: 190.0 # Perfluorooctanoic Acid.
-  meltingPoint: 45.0

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -465,7 +465,7 @@
 - type: reagent
   id: UncookedAnimalProteins
   name: reagent-name-uncooked-animal-proteins
-  group: Foods
+  group: Foods # Also a Toxin
   desc: reagent-desc-uncooked-animal-proteins
   physicalDesc: reagent-physical-desc-clumpy
   flavor: bitter
@@ -545,7 +545,7 @@
 - type: reagent
   id: Honk
   name: reagent-name-honk
-  group: Toxins
+  group: Special # Also a Toxin
   desc: reagent-desc-honk
   physicalDesc: reagent-physical-desc-pungent
   flavor: bitter
@@ -573,7 +573,7 @@
 - type: reagent
   id: Lead
   name: reagent-name-lead
-  group: Toxins
+  group: Elements # Also a Toxin
   desc: reagent-desc-lead
   physicalDesc: reagent-physical-desc-metallic
   color: "#5C6274"

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Biological.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Biological.xml
@@ -2,8 +2,7 @@
 
 # Biological
 
-These reagents include chemicals that you can get from certain materials and from living things. To get the other chemicals you have to use machines like the electrolyzer and the centrifuge.
+These reagents can be obtained from living creatures or plants.
 
 <GuideReagentGroupEmbed Group="Biological"/>
-
 </Document>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Domestic.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Domestic.xml
@@ -1,0 +1,7 @@
+<Document>
+# Domestic
+
+These reagents are common household chemicals and materials.
+
+<GuideReagentGroupEmbed Group="Domestic"/>
+</Document>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Elements.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Elements.xml
@@ -2,8 +2,7 @@
 
 # Elements
 
-This list contains all the basic reagents used to make other chemicals.
+These are reagents in their purest form. They can often be combined to form new chemicals.
 
 <GuideReagentGroupEmbed Group="Elements"/>
-
 </Document>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Foods.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Foods.xml
@@ -1,8 +1,8 @@
 <Document>
+
 # Foods
 
-These reagents are mostly used in the kitchen. Very helpful for Chefs and/or Service Workers.
+These reagents can be eaten, drunk, or used in cooking. They are of particular interest to chefs.
 
 <GuideReagentGroupEmbed Group="Foods"/>
-
 </Document>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Narcotics.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Narcotics.xml
@@ -1,5 +1,8 @@
 <Document>
+
 # Narcotics
-The reagents listed in this category includes stimulants, hallucinogens and other drug-like effects.
+
+The reagents listed in this category include stimulants, hallucinogens, intoxicants and other perception or mood altering drugs. These may also be harmful to your health.
+
 <GuideReagentGroupEmbed Group="Narcotics"/>
 </Document>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Other.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Other.xml
@@ -1,5 +1,8 @@
 <Document>
+
 # Other
-These are the other regeants listed in the Chemicals page.
+
+These reagents defy convenient classification.
+
 <GuideReagentGroupEmbed Group="Unknown"/>
 </Document>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Pyrotechnic.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Pyrotechnic.xml
@@ -1,5 +1,8 @@
 <Document>
+
 # Pyrotechnics
-These chemicals are flammable and causes hazardous effects when making them (Plasma gas and explosions). It is recommended to make these chemicals in a safe environment.
+
+These reagents are flammable, explosive or can undergo rapid expansion. It is recommended to only utilise these chemicals in a controlled environment.
+
 <GuideReagentGroupEmbed Group="Pyrotechnic"/>
 </Document>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Special.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Special.xml
@@ -5,5 +5,4 @@
 These reagents either have exotic sources, unique properties, or both.
 
 <GuideReagentGroupEmbed Group="Special"/>
-
 </Document>

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Toxins.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Toxins.xml
@@ -1,5 +1,44 @@
 <Document>
+
 # Toxins
-The chemicals in this list contain toxins that induce certain effects and can cause death. Use responsibly.
+
+These chemicals are toxic to most species. They are harmful to your health and may cause incapacitation or death.
+
+The following is a list of toxins that fall into other categories.
+
+<GuideReagentEmbed Reagent="Ammonia"/>
+<GuideReagentEmbed Reagent="Artifexium"/>
+<GuideReagentEmbed Reagent="Bleach"/>
+<GuideReagentEmbed Reagent="Chlorine"/>
+<GuideReagentEmbed Reagent="ChlorineTrifluoride"/>
+<GuideReagentEmbed Reagent="Copper"/>
+<GuideReagentEmbed Reagent="CapsaicinOil"/>
+<GuideReagentEmbed Reagent="Diethylamine"/>
+<GuideReagentEmbed Reagent="Frezon"/>
+<GuideReagentEmbed Reagent="GreyMatter"/>
+<GuideReagentEmbed Reagent="Lead"/>
+<GuideReagentEmbed Reagent="Mercury"/>
+<GuideReagentEmbed Reagent="NitrousOxide"/>
+<GuideReagentEmbed Reagent="Plasma"/>
+<GuideReagentEmbed Reagent="Radium"/>
+<GuideReagentEmbed Reagent="Silicon"/>
+<GuideReagentEmbed Reagent="Sulfur"/>
+<GuideReagentEmbed Reagent="Tritium"/>
+<GuideReagentEmbed Reagent="UncookedAnimalProteins"/>
+<GuideReagentEmbed Reagent="UnstableMutagen"/>
+<GuideReagentEmbed Reagent="Uranium"/>
+<GuideReagentEmbed Reagent="ZombieBlood"/>
+
+# Non-human Toxins
+
+These reagents are toxic to certain non-human species on the station.
+
+<GuideReagentEmbed Reagent="Iron"/>
+<GuideReagentEmbed Reagent="Oxygen"/>
+
+# All Toxins
+
+This is a list of -all- toxins available, including ones previously listed.
+
 <GuideReagentGroupEmbed Group="Toxins"/>
 </Document>

--- a/Resources/ServerInfo/Guidebook/Chemicals.xml
+++ b/Resources/ServerInfo/Guidebook/Chemicals.xml
@@ -23,11 +23,14 @@ Knowing different types of chemicals and their effects is important for being ab
 ## Foods
 <GuideReagentGroupEmbed Group="Foods"/>
 
+## Biological
+<GuideReagentGroupEmbed Group="Biological"/>
+
 ## Botanical
 <GuideReagentGroupEmbed Group="Botanical"/>
 
-## Biological
-<GuideReagentGroupEmbed Group="Biological"/>
+## Domestic
+<GuideReagentGroupEmbed Group="Domestic"/>
 
 ## Special
 <GuideReagentGroupEmbed Group="Special"/>

--- a/Resources/ServerInfo/Guidebook/Medical/Medicine.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Medicine.xml
@@ -27,6 +27,14 @@ These medications tend to have specific use cases.
 <GuideReagentEmbed Reagent="Ambuzol"/>
 <GuideReagentEmbed Reagent="Oculine"/>
 
+# Rare Medications
+
+These medications are particularly hard to create or source.
+
+<GuideReagentEmbed Reagent="Ichor"/>
+<GuideReagentEmbed Reagent="Omnizine"/>
+<GuideReagentEmbed Reagent="Rororium"/>
+
 # All Medications
 
 This is a list of -all- medications available, including ones previously listed.


### PR DESCRIPTION
## About the PR
Reagents that were listed in the guidebook have been reorganised. A new category has been made for domestic/houshold chemicals. Toxins have been updated to include any notable reagents that were otherwise better suited to another category.

## Why / Balance
The "Other" category was full of chemicals that could have been put into already existing categories. Some were inconsistently categorised, or missing from categories that could have been important for the player to be aware of, such as certain toxins.
The Medicine section of the guidebook was slightly updated.

Fixes #34266

## Technical details
Edited the majority of files that contained reagents listed in the guidebook, and the guidebook .xml files in question.
Most reagent files have had their entries alphabetised. Some comments were added where further information seemed helpful.

## Media
Should be pretty self explanatory. No xml formatting was changed.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
This shouldn't have changed any entity IDs, and in most cases simply added a missing `group:` line.

**Changelog**
:cl:
- tweak: A new category was added to the guidebook for household and cleaning reagents.
- tweak: Some toxins have been added to the relevant section of the guidebook, that were previously missing, or only appeared in other sections of the guidebook.
