### PR TITLE
Replace some sound PlayEntity with PlayPvs

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -356,6 +356,11 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         // + if the bomb is big enough, people outside of it too
         // this is capped to 30 because otherwise really huge bombs
         // will attempt to play regular audio for people who can't hear it anyway because the epicenter is so far away
+        //
+        // TODO EXPLOSION redo this.
+        // Use the Filter.Pvs range-multiplier option instead of AddInRange.
+        // Also the default PVS range is 25*2 = 50. So capping it at 30 makes no sense here.
+        // So actually maybe don't use Filter.Pvs at all and only use AddInRange?
         var audioRange = Math.Min(iterationIntensity.Count * 2, MaxExplosionAudioRange);
         var filter = Filter.Pvs(pos).AddInRange(pos, audioRange);
         var sound = iterationIntensity.Count < queued.Proto.SmallSoundIterationThreshold

--- a/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
@@ -165,7 +165,7 @@ namespace Content.Server.Kitchen.EntitySystems
                 QueueDel(gib);
             }
 
-            _audio.PlayEntity(component.SpikeSound, Filter.Pvs(uid), uid, true);
+            _audio.PlayPvs(component.SpikeSound, uid);
         }
 
         private bool TryGetPiece(EntityUid uid, EntityUid user, EntityUid used,

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -275,7 +275,7 @@ namespace Content.Server.Light.EntitySystems
                         if (time > light.LastThunk + ThunkDelay)
                         {
                             light.LastThunk = time;
-                            _audio.PlayEntity(light.TurnOnSound, Filter.Pvs(uid), uid, true, AudioParams.Default.WithVolume(-10f));
+                            _audio.PlayPvs(light.TurnOnSound, uid, light.TurnOnSound.Params.AddVolume(-10f));
                         }
                     }
                     else

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -235,7 +235,7 @@ public sealed class NukeSystem : EntitySystem
 
     private void OnClearButtonPressed(EntityUid uid, NukeComponent component, NukeKeypadClearMessage args)
     {
-        _audio.PlayEntity(component.KeypadPressSound, Filter.Pvs(uid), uid, true);
+        _audio.PlayPvs(component.KeypadPressSound, uid);
 
         if (component.Status != NukeStatus.AWAIT_CODE)
             return;
@@ -351,12 +351,12 @@ public sealed class NukeSystem : EntitySystem
                 {
                     component.Status = NukeStatus.AWAIT_ARM;
                     component.RemainingTime = component.Timer;
-                    _audio.PlayEntity(component.AccessGrantedSound, Filter.Pvs(uid), uid, true);
+                    _audio.PlayPvs(component.AccessGrantedSound, uid);
                 }
                 else
                 {
                     component.EnteredCode = "";
-                    _audio.PlayEntity(component.AccessDeniedSound, Filter.Pvs(uid), uid, true);
+                    _audio.PlayPvs(component.AccessDeniedSound, uid);
                 }
 
                 break;
@@ -425,7 +425,9 @@ public sealed class NukeSystem : EntitySystem
         // Don't double-dip on the octave shifting
         component.LastPlayedKeypadSemitones = number == 0 ? component.LastPlayedKeypadSemitones : semitoneShift;
 
-        _audio.PlayEntity(component.KeypadPressSound, Filter.Pvs(uid), uid, true, AudioHelpers.ShiftSemitone(semitoneShift).WithVolume(-5f));
+        var opts = component.KeypadPressSound.Params;
+        opts = AudioHelpers.ShiftSemitone(opts, semitoneShift).AddVolume(-5f);
+        _audio.PlayPvs(component.KeypadPressSound, uid, opts);
     }
 
     public string GenerateRandomNumberString(int length)

--- a/Content.Server/Power/Generator/PortableGeneratorSystem.cs
+++ b/Content.Server/Power/Generator/PortableGeneratorSystem.cs
@@ -117,7 +117,7 @@ public sealed class PortableGeneratorSystem : SharedPortableGeneratorSystem
         var clogged = _generator.GetIsClogged(uid);
 
         var sound = empty ? component.StartSoundEmpty : component.StartSound;
-        _audio.PlayEntity(sound, Filter.Pvs(uid), uid, true);
+        _audio.PlayPvs(sound, uid);
 
         if (!clogged && !empty && _random.Prob(component.StartChance))
         {

--- a/Content.Shared/Audio/AudioHelpers.cs
+++ b/Content.Shared/Audio/AudioHelpers.cs
@@ -4,11 +4,12 @@ using Robust.Shared.Random;
 
 namespace Content.Shared.Audio
 {
-    public static class AudioHelpers{
+    public static class AudioHelpers
+    {
         /// <summary>
         ///     Returns a random pitch.
         /// </summary>
-        [Obsolete("Use variation datafield.")]
+        [Obsolete("Use AudioParams.Variation data-field")]
         public static AudioParams WithVariation(float amplitude)
         {
             return WithVariation(amplitude, null);
@@ -17,6 +18,7 @@ namespace Content.Shared.Audio
         /// <summary>
         ///     Returns a random pitch.
         /// </summary>
+        [Obsolete("Use AudioParams.Variation data-field")]
         public static AudioParams WithVariation(float amplitude, IRobustRandom? rand)
         {
             IoCManager.Resolve(ref rand);
@@ -42,22 +44,22 @@ namespace Content.Shared.Audio
         /// </summary>
         /// <param name="shift">Number of semitones to shift, positive or negative. Clamped between -12 and 12
         /// which correspond to a pitch multiplier of 0.5 and 2.0 respectively.</param>
-        public static AudioParams ShiftSemitone(int shift)
+        public static AudioParams ShiftSemitone(AudioParams @params, int shift)
         {
             shift = MathHelper.Clamp(shift, -12, 12);
             float pitchMult = SemitoneMultipliers[shift + 12];
-            return AudioParams.Default.WithPitchScale(pitchMult);
+            return @params.WithPitchScale(pitchMult);
         }
 
         /// <summary>
         /// Returns a pitch multiplier shifted by a random number of semitones within variation.
         /// </summary>
         /// <param name="variation">Max number of semitones to shift in either direction. Values above 12 have no effect.</param>
-        public static AudioParams WithSemitoneVariation(int variation, IRobustRandom? rand)
+        public static AudioParams WithSemitoneVariation(AudioParams @params, int variation, IRobustRandom rand)
         {
             IoCManager.Resolve(ref rand);
             variation = Math.Clamp(variation, 0, 12);
-            return ShiftSemitone(rand.Next(-variation, variation));
+            return ShiftSemitone(@params, rand.Next(-variation, variation));
         }
     }
 }


### PR DESCRIPTION

## About the PR
Replaces some `AudioSystem.PlayEntity()` calls with `PlayPvs`.

## Why / Balance
Should be functionally equivalent, but faster for PVS because it avoids adding unnecessary PVS overrides.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- The semitone helper methods in `AudioHelpers` now need to be given `AudioParams` to modify.

