### PR TITLE
change locking to use ComplexInteraction

### DIFF
--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -1,10 +1,10 @@
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Construction.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Examine;
-using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
@@ -26,6 +26,7 @@ namespace Content.Shared.Lock;
 public sealed class LockSystem : EntitySystem
 {
     [Dependency] private readonly AccessReaderSystem _accessReader = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly ActivatableUISystem _activatableUI = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -246,7 +247,7 @@ public sealed class LockSystem : EntitySystem
     /// </summary>
     public bool CanToggleLock(EntityUid uid, EntityUid user, bool quiet = true)
     {
-        if (!HasComp<HandsComponent>(user))
+        if (!_actionBlocker.CanComplexInteract(user))
             return false;
 
         var ev = new LockToggleAttemptEvent(user, quiet);


### PR DESCRIPTION
## About the PR
title

## Why / Balance
this lets lockable buttons, which alreadyhad ai whitelist, get used by AIs
AI interaction whitelist still gets checked so you cant unlock lockers and stuff

## Technical details


## Media
![08:51:40](https://github.com/user-attachments/assets/cdbf7b2e-3f97-4f57-8bb4-17004316cab4)

![08:51:45](https://github.com/user-attachments/assets/d70a8871-6692-4349-9b5a-f99ba86fe93f)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed AIs not being able to use lockable buttons.