### PR TITLE
Slight instrument tweaks

### DIFF
--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -297,7 +297,7 @@
   description: bounty-description-percussion
   entries:
   - name: bounty-item-percussion
-    amount: 4
+    amount: 7
     whitelist:
       tags:
       - PercussionInstrument

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -14,7 +14,7 @@
     sprite: Objects/Fun/Instruments/structureinstruments.rsi
     state: tuba
   product: CrateFunInstrumentsBrass
-  cost: 2500
+  cost: 2000
   category: cargoproduct-category-name-fun
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Objects/Fun/Instruments/harmonica.rsi
     state: icon
   product: CrateFunInstrumentsWoodwind
-  cost: 2500
+  cost: 3000
   category: cargoproduct-category-name-fun
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -100,8 +100,6 @@
         amount: 2
       - id: FrenchHornInstrument
         amount: 2
-      - id: SaxophoneInstrument
-        amount: 2
       - id: EuphoniumInstrument
       - id: TubaInstrument
 
@@ -132,6 +130,8 @@
   - type: StorageFill
     contents:
       - id: RecorderInstrument
+        amount: 2
+      - id: SaxophoneInstrument
         amount: 2
       - id: BagpipeInstrument
       - id: ClarinetInstrument

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: BaseHandheldInstrument
   id: GlockenspielInstrument
   name: glockenspiel
@@ -98,7 +98,7 @@
     state: icon
   - type: Tag
     tags:
-    - KeyedInstrument
+    - PercussionInstrument
   - type: Item
     size: Small
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Put two saxophones in the woodwind crate, removed two saxophones from the brass crate, made the kalimba percussion, changed the price of woodwind instrument crate from 2500 --> 3000, and changed the price of the brass instrument crate from 2500 --> 2000 

Also increased the percussion instrument crate from needing 4 instruments to 7.

## Why / Balance
DESPITE BEING MADE OF BRASS, the saxophone is a woodwind instrument. This is because it uses a reed, and has a system like a flute. The kalimba is a percussion instrument, despite having keys. If the kalimba is a keyed instrument, by that logic so should a glockenspiel and xylophone. 
Because the woodwind instrument crate now has three more instruments than the brass instrument crate, and because the brass instrument crate lost it's two saxophones, the prices changed.

The increased percussion instrument bounty is so that you can't just buy one crate and immediately resell it for a profit. Now you have to buy two crates, like how it was before.e

## Technical details
Changed the number "2000" to "3000" and "2500." May cause the world to explode.

## Media
No media for you. Use your imagination, or listen to saxophone solos with rain in the background.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

🆑 fix: A Nanotrasen jazz enthusiast found out the ATS was packing saxophones into Brass Ensemble Crates. After an angry call, the saxophones are now put into the Woodwind Ensemble crates instead.
🆑 fix: The Kalimba is now a percussion instrument.
🆑 tweak: Increased the cost of the Woodwind Ensemble Crate from 2500 to 3000
🆑 tweak: Decreased the cost of the Brass Ensemble Crate from 2500 to 2000
🆑 tweak: Increased the amount of instruments needed for the "Percussion instrument bounty" from 4 to 7

