### PR TITLE
Mapping rotation fix

### DIFF
--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -228,9 +228,7 @@ public sealed class GameMapManager : IGameMapManager
         Debug.Assert(eligible.Length != 0, $"couldn't select a map with {nameof(GetFirstInRotationQueue)}()! No eligible maps and no fallback maps!");
 
         // Choose a random map from all eligible maps
-        var selected = eligible[_random.Next(eligible.Length)];
-
-        return selected.proto;
+        return eligible[_random.Next(eligible.Length)].proto;
     }
 
     private void EnqueueMap(string mapProtoName)

--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -219,7 +219,7 @@ public sealed class GameMapManager : IGameMapManager
 
         var eligible = CurrentlyEligibleMaps()
             .Select(x => (proto: x, weight: GetMapRotationQueuePriority(x.ID)))
-            .OrderByDescending(x => x.weight)
+            .Where(x => x.weight > 0)
             .ToArray();
 
         _log.Info($"eligible queue: {string.Join(", ", eligible.Select(x => (x.proto.ID, x.weight)))}");
@@ -227,10 +227,10 @@ public sealed class GameMapManager : IGameMapManager
         // YML "should" be configured with at least one fallback map
         Debug.Assert(eligible.Length != 0, $"couldn't select a map with {nameof(GetFirstInRotationQueue)}()! No eligible maps and no fallback maps!");
 
-        var weight = eligible[0].weight;
-        return eligible.Where(x => x.Item2 == weight)
-            .MinBy(x => x.proto.ID)
-            .proto;
+        // Choose a random map from all eligible maps
+        var selected = eligible[_random.Next(eligible.Length)];
+
+        return selected.proto;
     }
 
     private void EnqueueMap(string mapProtoName)


### PR DESCRIPTION
## About the PR
Fixes a blatant issue where ties between maps with the same priority are broken with alphabetical order, this is really egregious with maps like Amber, which can roll constantly.

## Why / Balance
It is a horrible bug, really bad especially for downstream servers with more maps

## Technical details
Previously, the GetFirstInRotationQueue function in GameMapManager.cs sorted alphabetically last, this has been changed to no longer sort alphabetically, and instead choose a map randomly (with a fail safe if maps have the same weird)

## Media
No media required 
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
No known breaking changes 

**Changelog**
:cl:
- fix: Fixed map rotations not being truely random
