### PR TITLE
Renamed water melon juice to watermelon juice

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/consumable/drink/juice.ftl
+++ b/Resources/Locale/en-US/reagents/meta/consumable/drink/juice.ftl
@@ -40,7 +40,7 @@ reagent-desc-juice-potato = Juice of the potato. Bleh.
 reagent-name-juice-tomato = tomato juice
 reagent-desc-juice-tomato = Tomatoes made into juice. What a waste of good tomatoes, huh?
 
-reagent-name-juice-watermelon = water melon juice
+reagent-name-juice-watermelon = watermelon juice
 reagent-desc-juice-watermelon = The delicious juice of a watermelon.
 
 reagent-name-juice-cherry = cherry juice


### PR DESCRIPTION
## About the PR
"water melon juice" is now called "watermelon juice"

## Why / Balance
It was wrong, and made the game unplayable.

## Technical details
Literally just deleted a space in juice.ftl

## Media
Come on.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
I mean, I really want to, but it does seem a bit frivolous.
