### PR TITLE
Security Jetpack Rework

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -222,6 +222,7 @@
   id: JetpackSecurity
   parent: [BaseJetpack, BaseRestrictedContraband]
   name: security jetpack
+  description: It's a jetpack. It can hold 2.5 L of gas.
   suffix: Empty
   components:
   - type: Item
@@ -232,6 +233,11 @@
     sprite: Objects/Tanks/Jetpacks/security.rsi
     slots:
       - Back
+      - suitStorage
+  - type: GasTank
+    outputPressure: 42.6
+    air:
+      volume: 2.5
 
 #Filled security
 - type: entity
@@ -243,12 +249,12 @@
   - type: GasTank
     outputPressure: 42.6
     air:
-      # 13 minutes thrust
-      volume: 5
+      # 4 minutes of thrust
+      volume: 2.5
       temperature: 293.15
       moles:
-        - 1.025689525 # oxygen
-        - 1.025689525 # nitrogen
+        - 0.512844762 # oxygen
+        - 0.512844762 # nitrogen
 
 #Empty void
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -249,7 +249,7 @@
   - type: GasTank
     outputPressure: 42.6
     air:
-      # 4 minutes of thrust
+      # 6.5 minutes of thrust
       volume: 2.5
       temperature: 293.15
       moles:


### PR DESCRIPTION
- Halved Sec Jetpack Capacity
- Fits on Suit Slot
- Updated Description

## About the PR
Security Jetpack now fits on the suit slot, but has half the capacity it did before, making it more geared towards close to station space combat.

## Why / Balance
The Security Jetpack was just a regular jetpack with a red coat of paint which makes it a bit strange that it's contraband. It also is very clunky to use in the events where as a security officer you're having to deal with threats in space such as space dragons and carp as before it would take up either a hand slot or a backpack slot which made space combat very clunky and restrictive in ways that weren't fun. 

By letting it fit on your suit slot, it now has a niche for combat the regular jetpack doesn't have, and it's reduced capacity of 2.5L means you're still mostly station bound while giving enough capacity to hopefully last through whatever space fight you're engaging in. It also gives it a nice place inbetween mini-jetpacks and void/captain jetpacks in terms of use and reliability. 

## Technical details
- Modified Empty Security Jetpack Entity to fit on suitStorage slot
- Reduced Security Jetpack capacity to 2.5 L and modified default oxygen and nitrogen mol count to 2.5 L
- Modified item description to state its capacity is 2.5 L

## Media
![image](https://github.com/user-attachments/assets/5752e5f0-f4a5-445c-a523-c9b11cd08f42)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
I don't think there are any Breaking Changes, this is my first PR so hopefully I didn't break anything with 10 changed lines of code.

**Changelog**
:cl:
- tweak: Security Jetpack now fits on your suit slot, but has half the capacity making it geared towards close to station space combat.
