### PR TITLE
Copy Thresholds Added to Air Alarms

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -161,7 +161,7 @@ public sealed partial class AirAlarmWindow : FancyWindow
                 {
                     var control = new SensorInfo(sensor, addr);
                     control.OnThresholdUpdate += AtmosAlarmThresholdChanged;
-                    control.SensorDataCopied += AtmosDeviceDataCopied!.Invoke;
+                    control.SensorDataCopied += AtmosDeviceDataCopied.Invoke;
                     _sensors.Add(addr, control);
                     CSensorContainer.AddChild(control);
                 }

--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -130,8 +130,8 @@ public sealed partial class AirAlarmWindow : FancyWindow
                 if (!_pumps.TryGetValue(addr, out var pumpControl))
                 {
                     var control= new PumpControl(pump, addr);
-                    control.PumpDataChanged += AtmosDeviceDataChanged!.Invoke;
-					control.PumpDataCopied += AtmosDeviceDataCopied!.Invoke;
+                    control.PumpDataChanged += AtmosDeviceDataChanged;
+                    control.PumpDataCopied += AtmosDeviceDataCopied;
                     _pumps.Add(addr, control);
                     CVentContainer.AddChild(control);
                 }
@@ -145,8 +145,8 @@ public sealed partial class AirAlarmWindow : FancyWindow
                 if (!_scrubbers.TryGetValue(addr, out var scrubberControl))
                 {
                     var control = new ScrubberControl(scrubber, addr);
-                    control.ScrubberDataChanged += AtmosDeviceDataChanged!.Invoke;
-					control.ScrubberDataCopied += AtmosDeviceDataCopied!.Invoke;
+                    control.ScrubberDataChanged += AtmosDeviceDataChanged;
+					control.ScrubberDataCopied += AtmosDeviceDataCopied;
                     _scrubbers.Add(addr, control);
                     CScrubberContainer.AddChild(control);
                 }
@@ -161,7 +161,7 @@ public sealed partial class AirAlarmWindow : FancyWindow
                 {
                     var control = new SensorInfo(sensor, addr);
                     control.OnThresholdUpdate += AtmosAlarmThresholdChanged;
-                    control.SensorDataCopied += AtmosDeviceDataCopied.Invoke;
+                    control.SensorDataCopied += AtmosDeviceDataCopied;
                     _sensors.Add(addr, control);
                     CSensorContainer.AddChild(control);
                 }

--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -161,6 +161,7 @@ public sealed partial class AirAlarmWindow : FancyWindow
                 {
                     var control = new SensorInfo(sensor, addr);
                     control.OnThresholdUpdate += AtmosAlarmThresholdChanged;
+                    control.SensorDataCopied += AtmosDeviceDataCopied!.Invoke;
                     _sensors.Add(addr, control);
                     CSensorContainer.AddChild(control);
                 }

--- a/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml.cs
@@ -83,10 +83,10 @@ public sealed partial class PumpControl : BoxContainer
             PumpDataChanged?.Invoke(_address, _data);
         };
 
-		_copySettings.OnPressed += _ =>
-		{
-			PumpDataCopied?.Invoke(_data);
-		};
+        _copySettings.OnPressed += _ =>
+        {
+            PumpDataCopied?.Invoke(_data);
+        };
     }
 
     public void ChangeData(GasVentPumpData data)

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
@@ -72,10 +72,10 @@ public sealed partial class ScrubberControl : BoxContainer
             ScrubberDataChanged?.Invoke(_address, _data);
         };
 
-		_copySettings.OnPressed += _ =>
-		{
-			ScrubberDataCopied?.Invoke(_data);
-		};
+        _copySettings.OnPressed += _ =>
+        {
+            ScrubberDataCopied?.Invoke(_data);
+        };
 
         foreach (var value in Enum.GetValues<Gas>())
         {

--- a/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml
@@ -3,6 +3,9 @@
         <CollapsibleHeading Name="SensorAddress" />
         <CollapsibleBody Margin="20 2 2 2">
             <BoxContainer Orientation="Vertical" HorizontalExpand="True">
+                <BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
+                    <Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-thresholds-copy'}" ToolTip="{Loc 'air-alarm-ui-thresholds-copy-tooltip'}" />
+                </BoxContainer>
                 <BoxContainer Orientation="Vertical" Margin="0 0 2 0" HorizontalExpand="True">
                     <RichTextLabel Name="AlarmStateLabel" />
                     <RichTextLabel Name="PressureLabel" />

--- a/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
@@ -82,11 +82,10 @@ public sealed partial class SensorInfo : BoxContainer
             OnThresholdUpdate!(_address, type, threshold, arg3);
         };
 
-		_copySettings.OnPressed += _ =>
-		{
-			SensorDataCopied?.Invoke(data);
-		};
-
+        _copySettings.OnPressed += _ =>
+        {
+            SensorDataCopied?.Invoke(data);
+        };
     }
 
     public void ChangeData(AtmosSensorData data)

--- a/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
@@ -58,7 +58,7 @@ public sealed partial class SensorInfo : BoxContainer
             gasThresholdControl.Margin = new Thickness(20, 2, 2, 2);
             gasThresholdControl.ThresholdDataChanged += (type, alarmThreshold, arg3) =>
             {
-                OnThresholdUpdate!(_address, type, alarmThreshold, arg3);
+                OnThresholdUpdate?.Invoke(_address, type, alarmThreshold, arg3);
             };
 
             _gasThresholds.Add(gas, gasThresholdControl);
@@ -74,12 +74,12 @@ public sealed partial class SensorInfo : BoxContainer
 
         _pressureThreshold.ThresholdDataChanged += (type, threshold, arg3) =>
         {
-            OnThresholdUpdate!(_address, type, threshold, arg3);
+            OnThresholdUpdate?.Invoke(_address, type, threshold, arg3);
         };
 
         _temperatureThreshold.ThresholdDataChanged += (type, threshold, arg3) =>
         {
-            OnThresholdUpdate!(_address, type, threshold, arg3);
+            OnThresholdUpdate?.Invoke(_address, type, threshold, arg3);
         };
 
         _copySettings.OnPressed += _ =>

--- a/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
@@ -12,12 +12,14 @@ namespace Content.Client.Atmos.Monitor.UI.Widgets;
 public sealed partial class SensorInfo : BoxContainer
 {
     public Action<string, AtmosMonitorThresholdType, AtmosAlarmThreshold, Gas?>? OnThresholdUpdate;
+    public event Action<AtmosSensorData>? SensorDataCopied;
     private string _address;
 
     private ThresholdControl _pressureThreshold;
     private ThresholdControl _temperatureThreshold;
     private Dictionary<Gas, ThresholdControl> _gasThresholds = new();
     private Dictionary<Gas, RichTextLabel> _gasLabels = new();
+    private Button _copySettings => CCopySettings;
 
     public SensorInfo(AtmosSensorData data, string address)
     {
@@ -79,6 +81,12 @@ public sealed partial class SensorInfo : BoxContainer
         {
             OnThresholdUpdate!(_address, type, threshold, arg3);
         };
+
+		_copySettings.OnPressed += _ =>
+		{
+			SensorDataCopied?.Invoke(data);
+		};
+
     }
 
     public void ChangeData(AtmosSensorData data)

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -131,6 +131,19 @@ public sealed class AirAlarmSystem : EntitySystem
         SyncDevice(uid, address);
     }
 
+    private void SetAllThresholds(EntityUid uid, string address, AtmosSensorData data)
+    {
+        var payload = new NetworkPayload
+        {
+            [DeviceNetworkConstants.Command] = AtmosMonitorSystem.AtmosMonitorSetAllThresholdsCmd,
+            [AtmosMonitorSystem.AtmosMonitorAllThresholdData] = data
+        };
+
+        _deviceNet.QueuePacket(uid, address, payload);
+
+        SyncDevice(uid, address);
+    }
+
     /// <summary>
     ///     Sync this air alarm's mode with the rest of the network.
     /// </summary>
@@ -339,6 +352,13 @@ public sealed class AirAlarmSystem : EntitySystem
                 foreach (string addr in component.ScrubberData.Keys)
                 {
                     SetData(uid, addr, args.Data);
+                }
+                break;
+
+            case AtmosSensorData sensorData:
+                foreach (string addr in component.SensorData.Keys)
+                {
+                    SetAllThresholds(uid, addr, sensorData);
                 }
                 break;
         }

--- a/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
@@ -33,10 +33,11 @@ public sealed class AtmosMonitorSystem : EntitySystem
 
     // Commands
     public const string AtmosMonitorSetThresholdCmd = "atmos_monitor_set_threshold";
+    public const string AtmosMonitorSetAllThresholdsCmd = "atmos_monitor_set_all_thresholds";
 
     // Packet data
     public const string AtmosMonitorThresholdData = "atmos_monitor_threshold_data";
-
+    public const string AtmosMonitorAllThresholdData = "atmos_monitor_all_threshold_data";
     public const string AtmosMonitorThresholdDataType = "atmos_monitor_threshold_type";
 
     public const string AtmosMonitorThresholdGasType = "atmos_monitor_threshold_gas";
@@ -138,7 +139,12 @@ public sealed class AtmosMonitorSystem : EntitySystem
                     args.Data.TryGetValue(AtmosMonitorThresholdGasType, out Gas? gas);
                     SetThreshold(uid, thresholdType.Value, thresholdData, gas);
                 }
-
+                break;
+            case AtmosMonitorSetAllThresholdsCmd:
+                if (args.Data.TryGetValue(AtmosMonitorAllThresholdData, out AtmosSensorData? allThresholdData))
+                {
+                    SetAllThresholds(uid, allThresholdData);
+                }
                 break;
             case AtmosDeviceNetworkSystem.SyncData:
                 var payload = new NetworkPayload();
@@ -402,5 +408,15 @@ public sealed class AtmosMonitorSystem : EntitySystem
                 break;
         }
 
+    }
+
+    public void SetAllThresholds(EntityUid uid, AtmosSensorData allThresholdData)
+    {
+        SetThreshold(uid, AtmosMonitorThresholdType.Temperature, allThresholdData.TemperatureThreshold);
+        SetThreshold(uid, AtmosMonitorThresholdType.Pressure, allThresholdData.PressureThreshold);
+        foreach (var gas in Enum.GetValues<Gas>())
+        {
+            SetThreshold(uid, AtmosMonitorThresholdType.Gas, allThresholdData.GasThresholds[gas], gas);
+        }
     }
 }

--- a/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
@@ -410,6 +410,12 @@ public sealed class AtmosMonitorSystem : EntitySystem
 
     }
 
+    /// <summary>
+    ///     Sets all of a monitor's thresholds at once according to the incoming
+    ///     AtmosSensorData object's thresholds.
+    /// </summary>
+    /// <param name="uid">The entity's uid</param>
+    /// <param name="allThresholdData">An AtmosSensorData object from which the thresholds will be loaded.</param>
     public void SetAllThresholds(EntityUid uid, AtmosSensorData allThresholdData)
     {
         SetThreshold(uid, AtmosMonitorThresholdType.Temperature, allThresholdData.TemperatureThreshold);

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -69,3 +69,5 @@ air-alarm-ui-thresholds-upper-bound = Danger above
 air-alarm-ui-thresholds-lower-bound = Danger below
 air-alarm-ui-thresholds-upper-warning-bound = Warning above
 air-alarm-ui-thresholds-lower-warning-bound = Warning below
+air-alarm-ui-thresholds-copy = Copy thresholds to all devices
+air-alarm-ui-thresholds-copy-tooltip = Copies the sensor thresholds of this device to all devices in this air alarm tab.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Air alarms can now have the sensor threshold settings copied from one sensor on their network to all other sensors.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

People with hand and wrist problems, (like myself) would love this QoL change which allows for a far better experience when adjusting the sensors on an air alarm.

## Technical details
<!-- Summary of code changes for easier review. -->

- Added a new button to `SensorInfo.xaml`, added loc strings for it and the tooltip.
- Added the functionality for the button to the init method for `SensorInfo` which invokes the `SensorDataCopied` Action, passing on the `AtmosSensorData` data.
- The `SensorDataCopied` Action calls the preexisting `AtmosDeviceDataCopied` Action, similar to copying scrubber and vent information. 
- `AirAlarmSystem` is already configured to listen for the `AtmosDeviceDataCopied` Action, so I added an additional case in it's switch statement list which checks for if the provided data is of the type `AtmosSensorData` (since it inherits from the same interface as `GasVentPumpData` and `GasVentScrubberData`, this worked just fine).
- Within the switch statement, if it finds the `AtmosSensorData` type, it will then iterate over all sensors in the air alarm, calling a new method for each one called `SetAllThresholds`.
- `SetAllThresholds` is a new helper method I wrote which sends a network payload to a sensor with the new `AtmosMonitorSetAllThresholdsCmd` command and `AtmosMonitorAllThresholdData` data. This data is simply the `AtmosSensorData` from the client. It also calls `SyncDevice` since the regular `SetThreshold` does so as well.
- Then in `AtmosMonitoringsystem` `OnPacketRecv` it checks for the new `AtmosMonitorSetAllThresholdsCmd` command, and if found calls the new `SetAllThresholds` method. 
- `SetAllThresholds` then calls the pre-existing method `SetThreshold` with the TemperatureThreshold, the PressureThreshold and - iterating over all the gases - it calls it for each gas as well. This data originates from the AtmosSensorData supplied by the client.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

A video of this working
https://github.com/user-attachments/assets/b9683274-5569-480d-a9f9-d7c376106f2c

UI example, for now the button is just placed on top of the fold-out section
![image](https://github.com/user-attachments/assets/fa2bb76f-26cf-4791-aebb-ba91e7167b34)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Southbridge
- add: Air Alarms can now copy sensor thresholds to all attached sensors.

