### PR TITLE
Rebalancing base alcohol and drink effects.

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -1,6 +1,4 @@
-
 # Base Alcohol
-
 - type: reagent
   id: Absinthe
   name: reagent-name-absinthe
@@ -18,8 +16,6 @@
   metabolisms:
     Drink:
       effects:
-      - !type:SatiateThirst
-        factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.3
@@ -27,7 +23,7 @@
 - type: reagent
   id: Ale
   name: reagent-name-ale
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-ale
   physicalDesc: reagent-physical-desc-bubbly
   flavor: ale
@@ -44,7 +40,7 @@
 - type: reagent
   id: Beer
   name: reagent-name-beer
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-beer
   physicalDesc: reagent-physical-desc-bubbly
   flavor: beer
@@ -75,11 +71,9 @@
   metabolisms:
     Drink:
       effects:
-      - !type:SatiateThirst
-        factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.1
+        amount: 0.15
 
 - type: reagent
   id: BlueHawaiian
@@ -95,11 +89,9 @@
   metabolisms:
     Drink:
       effects:
-      - !type:SatiateThirst
-        factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.15
 
 - type: reagent
   id: Cognac
@@ -116,14 +108,6 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
-  metabolisms:
-    Drink:
-      effects:
-      - !type:SatiateThirst
-        factor: 2
-      - !type:AdjustReagent
-        reagent: Ethanol
-        amount: 0.2
 
 - type: reagent
   id: DeadRum
@@ -139,14 +123,6 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
-  metabolisms:
-    Drink:
-      effects:
-      - !type:SatiateThirst
-        factor: 2
-      - !type:AdjustReagent
-        reagent: Ethanol
-        amount: 0.2
 
 - type: reagent
   id: Ethanol
@@ -219,19 +195,11 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
-  metabolisms:
-    Drink:
-      effects:
-      - !type:SatiateThirst
-        factor: 2
-      - !type:AdjustReagent
-        reagent: Ethanol
-        amount: 0.2
 
 - type: reagent
   id: CoffeeLiqueur
   name: reagent-name-coffeeliqueur
-  parent: BaseAlcohol
+  parent: BaseBooze # Stong alcohol, but shouldn't be flammable
   desc: reagent-desc-coffeeliqueur
   physicalDesc: reagent-physical-desc-cloudy
   flavor: coffeeliquor
@@ -242,6 +210,12 @@
   metamorphicMaxFillLevels: 3
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.12
 
 - type: reagent
   id: MelonLiquor
@@ -257,11 +231,17 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.15
 
 - type: reagent
   id: NTCahors
   name: reagent-name-n-t-cahors
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-n-t-cahors
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: bitter
@@ -272,11 +252,17 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1
 
 - type: reagent
   id: PoisonWine
   name: reagent-name-poison-wine
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-poison-wine
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: bitter
@@ -317,23 +303,21 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
-  metabolisms:
-    Drink:
-      effects:
-      - !type:SatiateThirst
-        factor: 2
-      - !type:AdjustReagent
-        reagent: Ethanol
-        amount: 0.2
 
 - type: reagent
   id: Sake
   name: reagent-name-sake
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-sake
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: sake
   color: "#DDDDDD"
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.12
 
 - type: reagent
   id: Tequila
@@ -349,19 +333,11 @@
   metamorphicMaxFillLevels: 3
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
-  metabolisms:
-    Drink:
-      effects:
-      - !type:SatiateThirst
-        factor: 2
-      - !type:AdjustReagent
-        reagent: Ethanol
-        amount: 0.2
 
 - type: reagent
   id: Vermouth
   name: reagent-name-vermouth
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-vermouth
   physicalDesc: reagent-physical-desc-aromatic
   flavor: vermouth
@@ -372,6 +348,12 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.12
 
 - type: reagent
   id: Vodka
@@ -388,14 +370,6 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
-  metabolisms:
-    Drink:
-      effects:
-      - !type:SatiateThirst
-        factor: 2
-      - !type:AdjustReagent
-        reagent: Ethanol
-        amount: 0.2
 
 - type: reagent
   id: Whiskey
@@ -415,8 +389,6 @@
   metabolisms:
     Drink:
       effects:
-      - !type:SatiateThirst
-        factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.2
@@ -424,7 +396,7 @@
 - type: reagent
   id: Wine
   name: reagent-name-wine
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-wine
   physicalDesc: reagent-physical-desc-translucent
   flavor: shittywine
@@ -436,11 +408,17 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.1
 
 - type: reagent
   id: Champagne
   name: reagent-name-champagne
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-champagne
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: champagne
@@ -455,19 +433,16 @@
   metabolisms:
     Drink:
       effects:
-      - !type:SatiateThirst
-        factor: 3
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.3
+        amount: 0.11
   fizziness: 0.8
 
 # Mixed Alcohol
-
 - type: reagent
   id: AcidSpit
   name: reagent-name-acid-spit
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-acid-spit
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: acidspit
@@ -478,6 +453,12 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  metabolisms:
+    Drink:
+      effects: # Has sulfuric acid in it. Maybe this should do something else too
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.8
 
 - type: reagent
   id: AlliesCocktail
@@ -493,11 +474,17 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.18
 
 - type: reagent
   id: Aloe
   name: reagent-name-aloe
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-aloe
   physicalDesc: reagent-physical-desc-aromatic
   flavor: aloe
@@ -508,6 +495,12 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.02 # It can't be that alcoholic surely
 
 - type: reagent
   id: Amasec
@@ -523,6 +516,15 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.14
+      - !type:AdjustReagent
+        reagent: Iron # The emperor protects
+        amount: 0.05
 
 - type: reagent
   id: Andalusia
@@ -538,6 +540,15 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.18
+      - !type:AdjustReagent
+        reagent: Vitamin
+        amount: 0.05
 
 - type: reagent
   id: Antifreeze
@@ -556,11 +567,12 @@
   metabolisms:
     Drink:
       effects:
-      - !type:SatiateThirst
-        factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.15
+        amount: 0.14
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.05
 
 - type: reagent
   id: AtomicBomb
@@ -579,8 +591,6 @@
   metabolisms:
     Drink:
       effects:
-      - !type:SatiateThirst
-        factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.15
@@ -605,8 +615,6 @@
   metabolisms:
     Drink:
       effects:
-      - !type:SatiateThirst
-        factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.15
@@ -614,7 +622,7 @@
 - type: reagent
   id: BahamaMama
   name: reagent-name-bahama-mama
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-bahama-mama
   physicalDesc: reagent-physical-desc-tropical
   flavor: bahamamama
@@ -625,11 +633,20 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.12
+      - !type:AdjustReagent
+        reagent: Vitamin
+        amount: 0.2 # Half of this is juice
 
 - type: reagent
   id: BananaHonk
   name: reagent-name-banana-honk
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-banana-honk
   physicalDesc: reagent-physical-desc-creamy
   flavor: bananahonk
@@ -640,11 +657,26 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  metabolisms:
+    Drink:
+      effects: # This Sugar, juice and cream, and no alcohol
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.05
+      - !type:AdjustReagent
+        reagent: Sugar
+        amount: 0.1
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.05
+      - !type:AdjustReagent
+        reagent: Vitamin
+        amount: 0.05
 
 - type: reagent
   id: Barefoot
   name: reagent-name-barefoot
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-barefoot
   physicalDesc: reagent-physical-desc-creamy
   flavor: barefoot
@@ -655,11 +687,23 @@
   metamorphicMaxFillLevels: 3
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.06
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.05
+      - !type:AdjustReagent
+        reagent: Vitamin
+        amount: 0.05
 
 - type: reagent
   id: BeepskySmash
   name: reagent-name-beepsky-smash
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-beepsky-smash
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: beepsky
@@ -673,11 +717,15 @@
   metabolisms:
     Drink:
       effects:
-      - !type:SatiateThirst
-        factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.15
+      - !type:AdjustReagent
+        reagent: Iron
+        amount: 0.05
+      - !type:AdjustReagent
+        reagent: Vitamin
+        amount: 0.05
   fizziness: 0.3
 
 - type: reagent
@@ -697,16 +745,14 @@
   metabolisms:
     Drink:
       effects:
-      - !type:SatiateThirst
-        factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.2
+        amount: 0.18
 
 - type: reagent
   id: BloodyMary
   name: reagent-name-bloody-mary
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-bloody-mary
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: bloodymary
@@ -717,11 +763,23 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  metabolisms:
+    Drink:
+      effects: # Over half of this is tomato and lime juice
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.08
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.1
+      - !type:AdjustReagent
+        reagent: Vitamin
+        amount: 0.1
 
 - type: reagent
   id:  Booger
   name: reagent-name-booger
-  parent: BaseAlcohol
+  parent: BaseBooze
   desc: reagent-desc-booger
   physicalDesc: reagent-physical-desc-slimy
   flavor: booger
@@ -732,6 +790,18 @@
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.07
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.15
+      - !type:AdjustReagent
+        reagent: Vitamin
+        amount: 0.05
 
 - type: reagent
   id: BraveBull

--- a/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
@@ -43,7 +43,28 @@
   fizziness: 0.5
 
 - type: reagent
-  id: BaseAlcohol
+  id: BaseAlcohol # Distilled alcohol, flammable and highly intoxicating
+  group: Drinks
+  abstract: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 1 # This should probably actually dehydrate you
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.08
+  reactiveEffects:
+    Flammable:
+      methods: [ Touch ]
+      effects:
+      - !type:FlammableReaction
+  tileReactions:
+  - !type:FlammableTileReaction
+    temperatureMultiplier: 1.35
+
+- type: reagent
+  id: BaseBooze # Brewed alcohol, not flammable, less intoxicating
   group: Drinks
   abstract: true
   metabolisms:
@@ -53,20 +74,20 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.06
+        amount: 0.02
   reactiveEffects:
-    Flammable:
+    Extinguish: # Beer puts out fires
       methods: [ Touch ]
       effects:
-      - !type:FlammableReaction
-  tileReactions:
-  - !type:FlammableTileReaction
-    temperatureMultiplier: 1.35
+      - !type:ExtinguishReaction
   plantMetabolism:
   - !type:PlantAdjustNutrition
     amount: 0.25
   - !type:PlantAdjustWater
     amount: 0.7
+  tileReactions:
+  - !type:ExtinguishTileReaction { }
+  - !type:SpillIfPuddlePresentTileReaction { }
 
 - type: reagent
   id: BaseJuice

--- a/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
@@ -53,7 +53,7 @@
         factor: 1 # This should probably actually dehydrate you
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.08
+        amount: 0.2
   reactiveEffects:
     Flammable:
       methods: [ Touch ]
@@ -74,7 +74,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Ethanol
-        amount: 0.02
+        amount: 0.05
   reactiveEffects:
     Extinguish: # Beer puts out fires
       methods: [ Touch ]


### PR DESCRIPTION
## About the PR
All alcoholic drinks inherited from BaseAlcohol, which meant beer was flammable, and would accelerate a fire if poured on it. Some drinks also had improbabe effects or levels of ethanol in them.

## Why / Balance
Beer should put out fires. Whiskey should not help plants grow. An alcohol free drink should not be as alcoholic as vodka. Beer should satiate your thirst more than rum.

## Technical details
This edits base_drink.yml and alcohol.yml; primarily the effects of the protoypes within.
Broadly speaking, brewed and distilled drinks are no longer flammable and will put out fires. Distilled drinks will satiate thirst about half as much.

## Media
Not much too see other than some numbers changing if you look at drinks in the guidebook.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Nothing deleted and no IDs changed. Should be fine.

**Changelog**
:cl:
- fix: Beer and other low alcohol drinks are no longer flammable and will put out fires.
- tweak: Strong alcohol is about 1/3 as thirst quenching as water.
- tweak: Strong alcohol is no longer beneficial to plants.
- tweak: Some drinks now get you more, or less drunk, based on their ingredients.
