### PR TITLE
Remove the ability to print the station anchor circuit board

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -451,7 +451,6 @@
     - SodaDispenserMachineCircuitboard
     - SpaceHeaterMachineCircuitBoard
     - CutterMachineCircuitboard
-    - StationAnchorCircuitboard
     - SalvageMagnetMachineCircuitboard
     dynamicRecipes:
       - ThermomachineFreezerMachineCircuitBoard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -586,12 +586,6 @@
 
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
-  id: StationAnchorCircuitboard
-  result: StationAnchorCircuitboard
-  completetime: 8
-
-- type: latheRecipe
-  parent: BaseGoldCircuitboardRecipe
   id: ReagentGrinderIndustrialMachineCircuitboard
   result: ReagentGrinderIndustrialMachineCircuitboard
 


### PR DESCRIPTION
## About the PR
Removes the ability to print the station anchor machine board.

Note that this board can still be obtained by admemery.

## Why / Balance
Right now, the Station Anchor can be printed and flatpacked by Science.

Unfortunately, this can be abused. People can easily multitool a station anchor in the halls, a tight space, etc. You're not supposed to be able to make and easily deploy machines of this size. This is exactly why you can't make the station Gravity Generator for example.

Recently I've seen people making a station anchor flatpack and then unpacking it on Evac. Evac will still launch, but it doesn't move while in FTL space.

While I do agree that this violates some core design principles (removing player agency, and working against the dynamic environment SS14 should be), the station anchor isn't a necessary part of the station, and if destroyed, isn't really an issue. Except for maybe salvage. But not really.

The station gravity generator acts similarly in this regard, however it is much more important and usually leads to a shuttle-call if destroyed. Science can research shuttlecraft and make a mini gravity generator, which works, however I haven't actually seen this occur in a round before evac arrives.

![image](https://github.com/user-attachments/assets/e8cc15c0-0b68-4172-a7b4-0d1bc2143c37)

## Technical details
Removes the recipe from the lathe.

## Media
![image](https://github.com/user-attachments/assets/e3c3f0f8-dd89-4345-99bc-2568f1af95d8)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- remove: The station anchor machine board can no longer be printed at the circuit imprinter.