### PR TITLE
map rotation fix take 2

### DIFF
--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -221,7 +221,6 @@ public sealed class GameMapManager : IGameMapManager
         var eligible = CurrentlyEligibleMaps()
             .Select(x => (proto: x, weight: GetMapRotationQueueWeight(x.ID)))
             .OrderByDescending(x => x.weight)//unsure if this should be kept in the weighted random version? frankly not sure what it was doing in the original version either, that didn't need to be ordered afaik
-            //.Where(x => x.weight > 0)//force at least one round between the same map rolling for variety. causes a test to fail for some reason?
             .ToDictionary();
 
         _log.Info($"eligible queue: {string.Join(", ", eligible.Select(x => (x.Key.ID, x.Value)))}");

--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.GameTicking;
 using Content.Shared.CCVar;
+using Content.Shared.Random.Helpers;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
@@ -201,7 +202,7 @@ public sealed class GameMapManager : IGameMapManager
         return _prototypeManager.TryIndex(gameMap, out map);
     }
 
-    private int GetMapRotationQueuePriority(string gameMapProtoName)
+    private int GetMapRotationQueueWeight(string gameMapProtoName)
     {
         var i = 0;
         foreach (var map in _previousMaps.Reverse())
@@ -218,19 +219,16 @@ public sealed class GameMapManager : IGameMapManager
         _log.Info($"map queue: {string.Join(", ", _previousMaps)}");
 
         var eligible = CurrentlyEligibleMaps()
-            .Select(x => (proto: x, weight: GetMapRotationQueuePriority(x.ID)))
-            .OrderByDescending(x => x.weight)
-            .ToArray();
+            .Select(x => (proto: x, weight: GetMapRotationQueueWeight(x.ID)))
+            .OrderByDescending(x => x.weight) //unsure if this should be kept in the weigted random version? frankly not sure what it was doing in the original version either, that didn't need to be ordered afaik
+            .ToDictionary();
 
-        _log.Info($"eligible queue: {string.Join(", ", eligible.Select(x => (x.proto.ID, x.weight)))}");
+        _log.Info($"eligible queue: {string.Join(", ", eligible.Select(x => (x.Key.ID, x.Value)))}");
 
         // YML "should" be configured with at least one fallback map
-        Debug.Assert(eligible.Length != 0, $"couldn't select a map with {nameof(GetFirstInRotationQueue)}()! No eligible maps and no fallback maps!");
+        Debug.Assert(eligible.Keys.Count != 0, $"couldn't select a map with {nameof(GetFirstInRotationQueue)}()! No eligible maps and no fallback maps!");
 
-        var weight = eligible[0].weight;
-        return eligible.Where(x => x.Item2 == weight)
-            .MinBy(x => x.proto.ID)
-            .proto;
+        return SharedRandomExtensions.Pick(eligible, new Random());
     }
 
     private void EnqueueMap(string mapProtoName)

--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -221,7 +221,7 @@ public sealed class GameMapManager : IGameMapManager
         var eligible = CurrentlyEligibleMaps()
             .Select(x => (proto: x, weight: GetMapRotationQueueWeight(x.ID)))
             .OrderByDescending(x => x.weight)//unsure if this should be kept in the weighted random version? frankly not sure what it was doing in the original version either, that didn't need to be ordered afaik
-            .Where(x => x.weight > 0)//force at least one round between the same map rolling for variety
+            //.Where(x => x.weight > 0)//force at least one round between the same map rolling for variety. causes a test to fail for some reason?
             .ToDictionary();
 
         _log.Info($"eligible queue: {string.Join(", ", eligible.Select(x => (x.Key.ID, x.Value)))}");

--- a/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
+++ b/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
@@ -129,6 +129,27 @@ namespace Content.Shared.Random.Helpers
             throw new InvalidOperationException("Invalid weighted pick");
         }
 
+        public static T Pick<T>(Dictionary<T, int> weights, System.Random random)
+            where T : notnull
+        {
+            var sum = weights.Values.Sum();
+            var accumulated = 0;
+
+            var rand = (int) Math.Round(random.NextFloat() * sum);
+
+            foreach (var (key, weight) in weights)
+            {
+                accumulated += weight;
+
+                if (accumulated >= rand)
+                {
+                    return key;
+                }
+            }
+
+            throw new InvalidOperationException("Invalid weighted pick");
+        }
+
         public static (string reagent, FixedPoint2 quantity) Pick(this WeightedRandomFillSolutionPrototype prototype, IRobustRandom? random = null)
         {
             var randomFill = prototype.PickRandomFill(random);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Replaces the alphabetical tiebreak with a weighted random pick, should add some more variety to what maps get played.
More or less a re-do of #34340.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The players on the fork I play on were annoyed by a few maps rolling constantly, so we looked into it & changed it, figured it could be another useful fix / change for upstream.

## Technical details
<!-- Summary of code changes for easier review. -->
Renames Content.Server.Maps.GameMapManager.GetFirstInRotationQueue() to PickFromWeightedRotationQueue() for clarity.

Makes some changes to above method to make it use a weighted random picker instead of resolving ties alphabetically.

Renames Content.Server.Maps.GameMapManager.GetMapRotationQueuePriority() to GetMapRotationQueueWeight() for clarity.

Adds an overload for Content.Shared.Random.Helpers.SharedRandomExtensions.Pick() that takes a <T, int> dict instead of a <T, float> dict.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**

n/a (should this have a cl entry? seems small and technical but does affect players)