### PR TITLE
Add a popup message when ghost Boo action does nothing

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -24,6 +24,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
@@ -61,6 +62,7 @@ namespace Content.Server.Ghost
         [Dependency] private readonly SharedMindSystem _mind = default!;
         [Dependency] private readonly GameTicker _gameTicker = default!;
         [Dependency] private readonly DamageableSystem _damageable = default!;
+        [Dependency] private readonly SharedPopupSystem _popup = default!;
 
         private EntityQuery<GhostComponent> _ghostQuery;
         private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -138,6 +140,9 @@ namespace Content.Server.Ghost
                 if (booCounter >= component.BooMaxTargets)
                     break;
             }
+
+            if (booCounter == 0)
+                _popup.PopupEntity(Loc.GetString("ghost-component-boo-action-failed"), uid, uid);
 
             args.Handled = true;
         }

--- a/Resources/Locale/en-US/ghost/components/ghost-component.ftl
+++ b/Resources/Locale/en-US/ghost/components/ghost-component.ftl
@@ -1,3 +1,5 @@
 ghost-component-on-examine-death-time-info-minutes = {$minutes} minutes ago
 ghost-component-on-examine-death-time-info-seconds = {$seconds} seconds ago
 ghost-component-on-examine-message = Died [color=yellow]{$timeOfDeath}[/color].
+
+ghost-component-boo-action-failed = Despite your best efforts, nothing spooky happens


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a simple notification to the player when they use the "Boo!" action as a ghost but it doesn't affect anything.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Activating the Boo ability and seeing no result feels bad and has led people to think that the ability is broken. Giving the player feedback when the ability fails makes it clear that at least the game is working correctly.

## Technical details
<!-- Summary of code changes for easier review. -->
The code for the Boo action already tracks the number of entities that reacted. So this just checks if the number is zero and displays a popup on the specific client if it is.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="325" alt="Screenshot 2025-01-10 at 3 03 38 PM" src="https://github.com/user-attachments/assets/b69ae183-3ddc-41bb-a7fe-a98d3871ee68" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.