### PR TITLE
fix ghost_component.ftl locale grammar

### DIFF
--- a/Resources/Locale/en-US/ghost/components/ghost-component.ftl
+++ b/Resources/Locale/en-US/ghost/components/ghost-component.ftl
@@ -2,4 +2,4 @@ ghost-component-on-examine-death-time-info-minutes = {$minutes} minutes ago
 ghost-component-on-examine-death-time-info-seconds = {$seconds} seconds ago
 ghost-component-on-examine-message = Died [color=yellow]{$timeOfDeath}[/color].
 
-ghost-component-boo-action-failed = Despite your best efforts, nothing spooky happens
+ghost-component-boo-action-failed = Despite your best efforts, nothing spooky happens.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed a missing period in `Resources/Locale/en-US/ghost/components/ghost-component.ftl`

## Why / Balance
slart is eepy

![image](https://github.com/user-attachments/assets/b44b70d9-ea17-4103-82e0-6b74503e06ef)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no cl no fun
