### PR TITLE
Fix nonsensical RegEx for name restriction

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -25,7 +25,7 @@ namespace Content.Shared.Preferences
     [Serializable, NetSerializable]
     public sealed partial class HumanoidCharacterProfile : ICharacterProfile
     {
-        private static readonly Regex RestrictedNameRegex = new("[^A-Za-z0-9 '-]");
+        private static readonly Regex RestrictedNameRegex = new(@"[^A-Za-z0-9 '\-]");
         private static readonly Regex ICNameCaseRegex = new(@"^(?<word>\w)|\b(?<word>\w)(?=\w*$)");
 
         public const int MaxNameLength = 32;

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -25,7 +25,7 @@ namespace Content.Shared.Preferences
     [Serializable, NetSerializable]
     public sealed partial class HumanoidCharacterProfile : ICharacterProfile
     {
-        private static readonly Regex RestrictedNameRegex = new("[^A-Z,a-z,0-9, ,\\-,']");
+        private static readonly Regex RestrictedNameRegex = new("[^A-Za-z0-9 '-]");
         private static readonly Regex ICNameCaseRegex = new(@"^(?<word>\w)|\b(?<word>\w)(?=\w*$)");
 
         public const int MaxNameLength = 32;


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Basically I cleaned up the RestrictedNameRegex, mainly by removing unnecessary delimiters (commas) and a backslash, then moved hyphen to the end of the expression for it to not be interpreted as a range of characters.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Correct regular expression is better than an incorrect one.

## Technical details
<!-- Summary of code changes for easier review. -->
Unfortunately, for C# and .NET I cannot shorten [A-Za-z0-9] to just \w, as it will include characters from most alphabets and writing systems in unicode.

**Clarification for the edited characters:**
- `-` is a range character, has to be taken literally or be at the end, otherwise causes an erroneous expression interpretation.
- No need for `,` to repeat so much, it's not a separator and names should not have commas in them.
- `\\` is just why? It was added alongside the apostrophe symbol in #28652 for no particular reason. Backslash repeated twice would escape itself and does not seem to affect anything. Replaced by a single backslash `\`.
- Added a `@` delimiter for proper interpretation of meta escape characters and for consistency to avoid further problems.

Tested and works as intended (no warnings as well).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
You can see how the new RegEx filters improper characters in this example.
![unknown_2025 01 13-06 28](https://github.com/user-attachments/assets/f9467b0f-60c1-46c9-bca0-e0c95449f2ae)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Uh, IDK, your characters with a name containing a backslash or a comma will no longer contain them.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->No CL, no fun.
