### PR TITLE
Make syndicate assault cyborg 7% more menacing

### DIFF
--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -407,7 +407,7 @@
   params:
     variation: 0.05
   sounds:
-    Laugh:
+    SyndieborgLaugh:
       path: /Audio/Voice/Silicon/syndieborg_laugh.ogg
     Beep:
       path: /Audio/Machines/twobeep.ogg

--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -407,7 +407,7 @@
   params:
     variation: 0.05
   sounds:
-    SyndieborgLaugh:
+    Laugh:
       path: /Audio/Voice/Silicon/syndieborg_laugh.ogg
     Beep:
       path: /Audio/Machines/twobeep.ogg

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -437,3 +437,32 @@
     - pings
     - pinged
     - pinging
+
+- type: emote
+  id: SyndieborgLaugh
+  name: chat-emote-name-laugh
+  category: Vocal
+  icon: Interface/Emotes/laugh.png
+  whitelist:
+    requireAll: true
+    components:
+    - BorgChassis
+    - ShowSyndicateIcons
+    - Vocal
+  chatMessages: ["chat-emote-msg-laugh"]
+  chatTriggers:
+    - laugh
+    - laughs
+    - laughing
+    - laughed
+    - chuckle
+    - chuckles
+    - chuckled
+    - chuckling
+    - giggle
+    - giggles
+    - giggling
+    - giggled
+    - chortle
+    - chortles
+    - chortling

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -39,7 +39,8 @@
     - Vocal
   blacklist:
     components:
-    - BorgChassis
+    - BorgSwitchableType
+    - StartIonStormed
   chatMessages: ["chat-emote-msg-laugh"]
   chatTriggers:
     - laugh
@@ -437,32 +438,3 @@
     - pings
     - pinged
     - pinging
-
-- type: emote
-  id: SyndieborgLaugh
-  name: chat-emote-name-laugh
-  category: Vocal
-  icon: Interface/Emotes/laugh.png
-  whitelist:
-    requireAll: true
-    components:
-    - BorgChassis
-    - ShowSyndicateIcons
-    - Vocal
-  chatMessages: ["chat-emote-msg-laugh"]
-  chatTriggers:
-    - laugh
-    - laughs
-    - laughing
-    - laughed
-    - chuckle
-    - chuckles
-    - chuckled
-    - chuckling
-    - giggle
-    - giggles
-    - giggling
-    - giggled
-    - chortle
-    - chortles
-    - chortling


### PR DESCRIPTION
## About the PR
Syndicate assault borgs can laugh once again.

## Why / Balance
Bugfix. Was added in #27205, and then broken some time after that.

## Technical details
"Laugh" emote is now blacklisted by BorgSwitchableType (station cyborgs) and StartIonStormed (derelict cyborgs) instead of BorgChassis (all cyborgs).

## Media

https://github.com/user-attachments/assets/492327da-f6d5-4e63-81cb-331965ec1fce


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Syndicate cyborgs can laugh once again.
