### PR TITLE
Add a CCVar to allow from hiding admins in the reported player count.

### DIFF
--- a/Content.Server/GameTicking/GameTicker.StatusShell.cs
+++ b/Content.Server/GameTicking/GameTicker.StatusShell.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.Json.Nodes;
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
@@ -43,7 +44,9 @@ namespace Content.Server.GameTicking
                 jObject["name"] = _baseServer.ServerName;
                 jObject["map"] = _gameMapManager.GetSelectedMap()?.MapName;
                 jObject["round_id"] = _gameTicker.RoundId;
-                jObject["players"] = _playerManager.PlayerCount;
+                jObject["players"] = _cfg.GetCVar(CCVars.AdminsCountInReportedPlayerCount)
+                    ? _playerManager.PlayerCount
+                    : _playerManager.PlayerCount - _adminManager.ActiveAdmins.Count();
                 jObject["soft_max_players"] = _cfg.GetCVar(CCVars.SoftMaxPlayers);
                 jObject["panic_bunker"] = _cfg.GetCVar(CCVars.PanicBunkerEnabled);
 

--- a/Content.Shared/CCVar/CCVars.Admin.cs
+++ b/Content.Shared/CCVar/CCVars.Admin.cs
@@ -159,6 +159,13 @@ public sealed partial class CCVars
         CVarDef.Create("admin.admins_count_for_max_players", false, CVar.SERVERONLY);
 
     /// <summary>
+    /// Should admins be hidden from the player count reported to the launcher/via api?
+    /// This is hub advert safe, in case that's a worry.
+    /// </summary>
+    public static readonly CVarDef<bool> AdminsCountInReportedPlayerCount =
+        CVarDef.Create("admin.admins_count_in_playercount", false, CVar.SERVERONLY);
+
+    /// <summary>
     ///     Determine if custom rank names are used.
     ///     If it is false, it'd use the actual rank name regardless of the individual's title.
     /// </summary>


### PR DESCRIPTION
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

- Keeping admins hidden
- Not confuse players seeing 84/80 players
- Nicely pairs up with the ``admin.admins_count_for_max_players`` ccvar

"Why is this not part of admin.admins_count_for_max_players"
I did not think that ccvars naming matched the function for this ccvar. So its seperate.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
-->

:cl: Myra
ADMIN:
- add: Admins are by default now hidden from the reported player count on the launcher.