### PR TITLE
Raise syndicate kobold reinforcement HP crit threshold from 75 to 100 to match monkey.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1567,7 +1567,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      75: Critical
+      100: Critical
       200: Dead
   - type: NpcFactionMember
     factions:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Increases kobold genetic ancestor reinforcement crit threshold to be in line with monkey reinforcement.

## Why / Balance
Kobold mobs deal more unarmed damage than monkeys, but have substantially lower crit thresholds. This is true even for the Traitor/NukeOp reinforcement kobolds (75 health vs. 100 for monkey). Reinforcements overwhelmingly use weapons over unarmed attacks in almost every situation, and without wideswing player controlled kobolds can't even reliably use unarmed attacks. Doesn't actually change anything balance wise since you can always just pick monkeys for full effect, but some people like picking kobolds (and many don't even know they're different from monkeys).

## Technical details
One line change to \space-station-14\Resources\Prototypes\Entities\Mobs\NPCs\animals.yml, 75 --> 100 on MobBaseSyndicateKobold

## Media
![Screenshot 2025-01-12 135824](https://github.com/user-attachments/assets/1f164558-98de-4d7c-aa27-e3cfd4147c7b)
https://github.com/user-attachments/assets/30df70d0-a220-44bd-b7ac-0410e3b2a44e



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Syndicate kobold and monkey reinforcements now both take 100 damage to crit (was 75 for kobold).
-->
