### PR TITLE
Fix muzzle accent

### DIFF
--- a/Content.Server/Speech/Components/MumbleAccentComponent.cs
+++ b/Content.Server/Speech/Components/MumbleAccentComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Audio;
+
+namespace Content.Server.Speech.Components;
+
+[RegisterComponent]
+public sealed partial class MumbleAccentComponent : Component
+{
+
+}

--- a/Content.Server/Speech/Components/MumbleAccentComponent.cs
+++ b/Content.Server/Speech/Components/MumbleAccentComponent.cs
@@ -1,5 +1,3 @@
-using Robust.Shared.Audio;
-
 namespace Content.Server.Speech.Components;
 
 [RegisterComponent]

--- a/Content.Server/Speech/EntitySystems/MumbleAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MumbleAccentSystem.cs
@@ -15,11 +15,7 @@ public sealed class MumbleAccentSystem : EntitySystem
 
     public string Accentuate(string message, MumbleAccentComponent component)
     {
-        var msg = message;
-
-        msg = _replacement.ApplyReplacements(msg, "mumble");
-
-        return msg;
+        return _replacement.ApplyReplacements(message, "mumble");
     }
 
     private void OnAccentGet(EntityUid uid, MumbleAccentComponent component, AccentGetEvent args)

--- a/Content.Server/Speech/EntitySystems/MumbleAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MumbleAccentSystem.cs
@@ -1,0 +1,29 @@
+using Content.Server.Speech.Components;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class MumbleAccentSystem : EntitySystem
+{
+    [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MumbleAccentComponent, AccentGetEvent>(OnAccentGet);
+    }
+
+    public string Accentuate(string message, MumbleAccentComponent component)
+    {
+        var msg = message;
+
+        msg = _replacement.ApplyReplacements(msg, "mumble");
+
+        return msg;
+    }
+
+    private void OnAccentGet(EntityUid uid, MumbleAccentComponent component, AccentGetEvent args)
+    {
+        args.Message = Accentuate(args.Message, component);
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -319,8 +319,7 @@
     unequipDelay: 3
   - type: IngestionBlocker
   - type: AddAccentClothing
-    accent: ReplacementAccent
-    replacement: mumble
+    accent: MumbleAccent
   - type: Construction
     graph: Muzzle
     node: muzzle


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR fixes a bug where characters with replacement accents could not be muzzled.
Discord thread: https://discord.com/channels/310555209753690112/1178210287439057027

## Technical details
<!-- Summary of code changes for easier review. -->

Characters can only have one ReplacementAccentComponent, so we are unable to add the 'mumble' replacement accent when putting on a muzzle if they already have one (e.g. dwarves, wearing a cowboy hat, etc.)

Since we want to be able to muzzle someone regardless of existing accent, we can simply split it into its own custom accent. (This does mean it can interact with other accents, like '¡Mmmf!' with Spanish accent. However, this seems OK and funny to me.)

I plan on expanding this new custom accent to have the muzzle reduce the volume of emotes, but since this is a bugfix I will split that into a separate PR.

I don't think there should be any breaking change, as 'mumble' can still be used in the preexisting manner elsewhere.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

A combination of accents with the updated muzzle:

https://github.com/user-attachments/assets/0d593325-a2da-461d-a81a-d3eb98802580

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed muzzles not working on some characters (e.g. dwarves)