### PR TITLE
Make Mime PDA interactions silent

### DIFF
--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
@@ -75,10 +75,10 @@ namespace Content.Shared.Containers.ItemSlots
         public EntityWhitelist? Blacklist;
 
         [DataField]
-        public SoundSpecifier InsertSound = new SoundPathSpecifier("/Audio/Weapons/Guns/MagIn/revolver_magin.ogg");
+        public SoundSpecifier? InsertSound = new SoundPathSpecifier("/Audio/Weapons/Guns/MagIn/revolver_magin.ogg");
 
         [DataField]
-        public SoundSpecifier EjectSound = new SoundPathSpecifier("/Audio/Weapons/Guns/MagOut/revolver_magout.ogg");
+        public SoundSpecifier? EjectSound = new SoundPathSpecifier("/Audio/Weapons/Guns/MagOut/revolver_magout.ogg");
 
         /// <summary>
         ///     The name of this item slot. This will be shown to the user in the verb menu.

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -362,11 +362,22 @@
   components:
   - type: Pda
     id: MimeIDCard
+    paiSlot:
+      priority: -2
+      ejectSound: null
+      insertSound: null
+      whitelist:
+        components:
+        - PAI
     idSlot:
+      name: access-id-card-component-default
       ejectSound: null # mime is silent
       insertSound: null
+      whitelist:
+        components:
+        - IdCard
     penSlot:
-      startingItem: Pen # startingitem, priority, whitelist need to be kept or else they're overwritten
+      startingItem: Pen
       priority: -1
       whitelist:
         tags:
@@ -377,6 +388,9 @@
     cartridgeSlot:
       ejectSound: null
       insertSound: null
+      whitelist:
+        components:
+        - Cartridge
   - type: Appearance
     appearanceDataInit:
      enum.PdaVisuals.PdaType:

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -362,11 +362,21 @@
   components:
   - type: Pda
     id: MimeIDCard
-    idSlot: #  rewrite without sound because mime
-      name: ID Card
+    idSlot:
+      ejectSound: null # mime is silent
+      insertSound: null
+    penSlot:
+      startingItem: Pen # startingitem, priority, whitelist need to be kept or else they're overwritten
+      priority: -1
       whitelist:
-        components:
-        - IdCard
+        tags:
+        - Write
+      ejectSound: null
+      insertSound: null
+  - type: CartridgeLoader
+    cartridgeSlot:
+      ejectSound: null
+      insertSound: null
   - type: Appearance
     appearanceDataInit:
      enum.PdaVisuals.PdaType:


### PR DESCRIPTION
## About the PR
Makes the Mime PDA interactions completely silent. For example, inserting or removing cartridges, IDs, and pens are now silent.

This doesn't make the ringtone silent, because that's funny.

## Why / Balance
Mime should be silent.

## Technical details
Makes the SoundSpecifier InsertSound and EjectSound datafields nullable type.

Adds null insert/eject fields to relevant interaction slots in the Pda component for the mime PDA proto. Some components have to be kept to avoid them being overridden.

## Media
https://github.com/user-attachments/assets/27fa90fc-b8b5-45e9-81f6-7757a4d7f9e2

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Mime PDA item interactions (insertions/ejections of IDs, pens, etc.) are now silent.