### PR TITLE
Fixed Thief starting gear failing on specific bag inventories.

### DIFF
--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -10,6 +10,6 @@
   id: ThiefGear
   storage:
     back:
+    - ThiefBeacon
     - ToolboxThief
     - ClothingHandsChameleonThief
-    - ThiefBeacon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed starting gear priority so that the larger 2x2 thieving beacon spawns before the 1x2 gloves and toolbox. Ideally there should be a warning for this if it fails to spawn, but I don't know code so this is the best you get.
The bug may still occur on even fuller inventories, but I doubt that those exist round-start.

## Why / Balance
fixes #34429 

## Technical details
Moved ThievingBeacon to the top of the list.

## Media
Fixed inventory:
![image](https://github.com/user-attachments/assets/e608756f-8ccc-473e-8f75-7e8da676f85d)
Related images can be found in the linked issue.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
None required.
