### PR TITLE
craftable pet carrier

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
@@ -68,4 +68,4 @@
     graph: Petcarrier
     node: petcarrier
     containers:
-      - entity_storage
+    - entity_storage

--- a/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
@@ -66,6 +66,6 @@
     sprite: Objects/Storage/petcarrier.rsi
   - type: Construction
     graph: PetCarrier
-    node: petcarrier
+    node: petCarrier
     containers:
     - entity_storage

--- a/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
@@ -65,7 +65,7 @@
     size: Ginormous
     sprite: Objects/Storage/petcarrier.rsi
   - type: Construction
-    graph: Petcarrier
+    graph: PetCarrier
     node: petcarrier
     containers:
     - entity_storage

--- a/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
@@ -64,3 +64,6 @@
   - type: Item
     size: Ginormous
     sprite: Objects/Storage/petcarrier.rsi
+  - type: Construction
+    graph: Petcarrier
+    node: petcarrier

--- a/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
@@ -67,3 +67,5 @@
   - type: Construction
     graph: Petcarrier
     node: petcarrier
+    containers:
+      - entity_storage

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/pet_carrier.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/pet_carrier.yml
@@ -1,0 +1,16 @@
+- type: constructionGraph
+  id: Petcarrier
+  start: start
+  graph:
+    - node: start
+      edges:
+      - to: petcarrier
+        steps:
+        - material: Plastic
+          amount: 5
+          doAfter: 7
+        - material: MetalRod
+          amount: 4
+          doAfter: 3
+    - node: petcarrier
+      entity: PetCarrier

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/pet_carrier.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/pet_carrier.yml
@@ -1,5 +1,5 @@
 - type: constructionGraph
-  id: Petcarrier
+  id: PetCarrier
   start: start
   graph:
     - node: start

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/pet_carrier.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/pet_carrier.yml
@@ -13,4 +13,4 @@
         amount: 4
         doAfter: 3
   - node: petCarrier
-      entity: PetCarrier
+    entity: PetCarrier

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/pet_carrier.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/pet_carrier.yml
@@ -2,15 +2,15 @@
   id: PetCarrier
   start: start
   graph:
-    - node: start
-      edges:
-      - to: petcarrier
-        steps:
-        - material: Plastic
-          amount: 5
-          doAfter: 7
-        - material: MetalRod
-          amount: 4
-          doAfter: 3
-    - node: petcarrier
+  - node: start
+    edges:
+    - to: petCarrier
+      steps:
+      - material: Plastic
+        amount: 5
+        doAfter: 7
+      - material: MetalRod
+        amount: 4
+        doAfter: 3
+  - node: petCarrier
       entity: PetCarrier

--- a/Resources/Prototypes/Recipes/Crafting/improvised.yml
+++ b/Resources/Prototypes/Recipes/Crafting/improvised.yml
@@ -230,10 +230,10 @@
 
 - type: construction
   name: pet carrier
-  id: Petcarrier
-  graph: Petcarrier
+  id: PetCarrier
+  graph: PetCarrier
   startNode: start
-  targetNode: petcarrier
+  targetNode: petCarrier
   category: construction-category-misc
   objectType: Item
   description: Allows large animals to be carried comfortably.

--- a/Resources/Prototypes/Recipes/Crafting/improvised.yml
+++ b/Resources/Prototypes/Recipes/Crafting/improvised.yml
@@ -227,3 +227,16 @@
   icon:
     sprite: Objects/Tools/rolling_pin.rsi
     state: icon
+
+- type: construction
+  name: pet carrier
+  id: Petcarrier
+  graph: Petcarrier
+  startNode: start
+  targetNode: petcarrier
+  category: construction-category-misc
+  objectType: Item
+  description: Allows large animals to be carried comfortably.
+  icon:
+    sprite: Objects/Storage/petcarrier.rsi
+    state: icon


### PR DESCRIPTION
## About the PR
pet carriers can now be crafted

## Why / Balance
these are mostly needed for thieves, which means there is a good chance your order gets rejected for (probably) metagaming reasons. with this, you can craft them, which at least allows you to have access to it without getting screwed over by cargo.
besides, it's just a plastic box with a grating door, it's not that hard to make yourself

## Technical details

## Media
![image](https://github.com/user-attachments/assets/0a5e4873-097b-46b5-a7fd-290a49a95851)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Pet carriers can now be crafted.
