### PR TITLE
Fix glass duplication with beakers

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/Recipes/Lathes/chemistry.yml
@@ -3,14 +3,14 @@
   result: Beaker
   completetime: 2
   materials:
-    Glass: 100
+    Glass: 200
 
 - type: latheRecipe
   id: LargeBeaker
   result: LargeBeaker
   completetime: 2
   materials:
-    Glass: 200
+    Glass: 400
 
 - type: latheRecipe
   id: CryostasisBeaker


### PR DESCRIPTION
Fixing glass dupe.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I have changed the amount of glass sheets required to create beakers to the 2 glass sheets by default instead of one. Large beakers still require twice as much as small beakers.

## Why / Balance
This minor change is made with the single purpose of preventing so-called glass dupe. Since hyperconvectional autolathes need only half of the resources of the original receipt, it made glassware cost only 0.5 glass sheets. At the same time, glass shards that could be obtained through breaking glassware still can be turned into glass sheets by using a welding tool. It made it so that you spent 1 sheet of glass and got back 2. This abuse can basically create an infinite amount of building resources and money completely for free. I do believe that it is a glitch and wasn't originally meant, so I decided to fix it.

## Technical details
Simple change of numbers.

## Media
No needed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Only minor changes.

**Changelog**
:cl:
- tweak: Changed the amount of glass sheets needed to create beakers to 2 on normal autolathe and 1 on hyperconvectional autolathe.
- tweak: Changed the amount of glass sheets needed to create large beakers to 4 on normal autolathe and 2 on hyperconvectional autolathe.