### PR TITLE
Fix lathe arbitrage test

### DIFF
--- a/Content.Shared/Lathe/LatheComponent.cs
+++ b/Content.Shared/Lathe/LatheComponent.cs
@@ -16,10 +16,14 @@ namespace Content.Shared.Lathe
         public List<ProtoId<LatheRecipePrototype>> StaticRecipes = new();
 
         /// <summary>
-        /// All of the recipes that the lathe is capable of researching
+        /// All of the recipes that the lathe is capable of researching.
         /// </summary>
         [DataField]
         public List<ProtoId<LatheRecipePrototype>> DynamicRecipes = new();
+        // Note that this shouldn't be modified dynamically.
+        // I.e., this + the static recipies should represent all recipies that the lathe can ever make
+        // Otherwise the material arbitrage test and/or LatheSystem.GetAllBaseRecipes needs to be updated
+
 
         /// <summary>
         /// The lathe's construction queue
@@ -79,16 +83,16 @@ namespace Content.Shared.Lathe
 
     public sealed class LatheGetRecipesEvent : EntityEventArgs
     {
-        public readonly EntityUid Lathe;
+        public readonly Entity<LatheComponent> Lathe;
 
-        public bool getUnavailable;
+        public bool IncludeUnavailable;
 
         public HashSet<ProtoId<LatheRecipePrototype>> Recipes = new();
 
-        public LatheGetRecipesEvent(EntityUid lathe, bool forced)
+        public LatheGetRecipesEvent(Entity<LatheComponent> lathe, bool forced)
         {
             Lathe = lathe;
-            getUnavailable = forced;
+            IncludeUnavailable = forced;
         }
     }
 


### PR DESCRIPTION

## About the PR
This PR fixes the lathe arbitrage test, which has been broken for some time.

## Why / Balance
Getting more glass by destroying a beaker and putting it back into the lathe is bad.

## Technical details
The lathe part of the material arbitrage test has been broken since lathe upgrading was changed (I think around #23752), and completely failed to report arbitrage added by #23202. Also, it never actually accounted for "welder refinable" items (i.e., glass shards -> glass). E.g., see #34441

The test fails at the moment, and needs someone to fix a bunch of recipes, either by making it more expensive or disabling the multiplier via `LatheRecipePrototype.ApplyMaterialDiscount`. Alternatively, the  `BaseHyperlathe` multiplier of 0.5 needs to be reverted to the old minimum (which I guess was `0.85^3`?

## TODO / current errors
This is a collection of the current test failures. I CBF fixing them myself or dealing with the balance issues, so help would be appreciated.

- [ ] destroying a DrinkShotGlass spawns more Glass than required to produce. 50 < 100
- [ ] destroying a Beaker spawns more Glass than required to produce. 50 < 100
- [ ] destroying a SodiumLightTube spawns more Glass than required to produce. 25 < 100
- [ ] destroying a DrinkGlassCoupeShaped spawns more Glass than required to produce. 50 < 100
- [ ] destroying a LedLightBulb spawns more Glass than required to produce. 25 < 100
- [ ] destroying a ExteriorLightTube spawns more Glass than required to produce. 25 < 100
- [ ] destroying a LightTube spawns more Glass than required to produce. 25 < 100
- [ ] destroying a DrinkGlass spawns more Glass than required to produce. 50 < 100
- [ ] destroying a DimLightBulb spawns more Glass than required to produce. 25 < 100
- [ ] destroying a LightBulb spawns more Glass than required to produce. 25 < 100
- [ ] destroying a LedLightTube spawns more Glass than required to produce. 25 < 100
- [ ] destroying a SheetRGlass1 spawns more Glass than required to produce. 50 < 100
- [ ] destroying a ChemistryEmptyBottle01 spawns more Glass than required to produce. 25 < 100
- [ ] destroying a WarmLightBulb spawns more Glass than required to produce. 25 < 100
- [ ] The physical composition of FoodPlateSmall has more Glass than required to produce. 25 < 30
- [ ] The physical composition of AirTank has more Steel than required to produce. 150 < 185
- [ ] The physical composition of FoodPlateTin has more Steel than required to produce. 50 < 60
- [ ] The physical composition of FoodPlateMuffinTin has more Steel than required to produce. 25 < 30
- [ ] The physical composition of WeaponCapacitorRechargerCircuitboard has more Steel than required to produce. 25 < 30
- [ ] The physical composition of WeaponCapacitorRechargerCircuitboard has more Plastic than required to produce. 25 < 30
- [ ] The physical composition of BorgChargerCircuitboard has more Steel than required to produce. 25 < 30
- [ ] The physical composition of BorgChargerCircuitboard has more Plastic than required to produce. 25 < 30
- [ ] The physical composition of FoodPlate has more Glass than required to produce. 50 < 60
- [ ] The physical composition of CellRechargerCircuitboard has more Steel than required to produce. 25 < 30
- [ ] The physical composition of CellRechargerCircuitboard has more Plastic than required to produce. 25 < 30
