### PR TITLE
Allow to run `mappingclientsidesetup` and `showsubfloor` with +MAPPING permissions

### DIFF
--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -77,6 +77,9 @@
 - Flags: MAPPING
   Commands:
     - mapping
+    - mappingclientsidesetup
+    - showsubfloor
+    - showsubfloorforever
     - toggleautosave
     - toggledecals
 


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
You can do this with the `loadacts` command, so it's just a matter of convenience to allow them with +MAPPING.

## Technical details
Added them to the `clientCommandPerms.yml`.

## Media

![image](https://github.com/user-attachments/assets/1ccb83e7-73e1-43c9-8f4d-7875b2f71e4d)

![image](https://github.com/user-attachments/assets/5534f612-16d0-486a-8398-c78e84f986bb)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
No CL, no fun.
