### PR TITLE
fix: AI should not have alt-menu option and alt-menu-related verb in drop-down menu as it have no options in it

### DIFF
--- a/Content.Client/Silicons/StationAi/StationAiMenu.xaml.cs
+++ b/Content.Client/Silicons/StationAi/StationAiMenu.xaml.cs
@@ -44,6 +44,11 @@ public sealed partial class StationAiMenu : RadialMenu
     {
         var ev = new GetStationAiRadialEvent();
         _entManager.EventBus.RaiseLocalEvent(_tracked, ref ev);
+        if (ev.Actions.Count == 0)
+        {
+            Close(); // todo: move accumulation of buttons to BUI and put popup with feedback there
+            return;
+        }
 
         var main = FindControl<RadialContainer>("Main");
         main.DisposeAllChildren();

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -378,7 +378,6 @@
     unlistedNumber: true
     requiresPower: false
   - type: Holopad
-  - type: StationAiWhitelist
   - type: UserInterface
     interfaces:
         enum.HolopadUiKey.AiRequestWindow:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Now AI core doesn't have radial menu related verb on it. It had no options ready for radial menu (so if it could work, it would display just empty radial), and radial menu display couldn't work because it requires core to be powered using APC (which it is not).
Also if any AI radial menu would become empty (menu option collecting event returns empty) menu will close itself, instead of opening empty menu (this is tmp fix until simplified radial menu rework is done and all radial menu could be refactored).

## Why / Balance
Useless option raised questions - look at https://discord.com/channels/310555209753690112/770682801607278632/1329502538591895676

## Technical details
Removed ability of AI to see radial menu on itself (by removing StationAiWhitelist from PlayerStationAiEmpty) and added call to Close() on GetStationAiRadialEvent returning empty Actions.

## Media

before 

![image](https://github.com/user-attachments/assets/57d74a1e-0a4c-4b48-88e4-7e03a40206ce)

after 

![image](https://github.com/user-attachments/assets/81efa9aa-fbfb-4fbf-a55e-ed98ae54f9ce)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Fildrance
- fix: removed unused 'Open actions' verb on AI Core
