### PR TITLE
Rarer Highcaps

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -507,7 +507,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellHigh
+        startingItem: PowerCellMedium
   - type: StartingMindRole
     mindRole: "MindRoleSiliconBrain"
     silent: true

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -507,7 +507,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMedium
+        startingItem: PowerCellHigh
   - type: StartingMindRole
     mindRole: "MindRoleSiliconBrain"
     silent: true

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -90,6 +90,7 @@
         startingItem: PowerCellMedium
   - type: HandheldLight
     addPrefix: false
+    wattage: 0.53
   - type: ToggleableLightVisuals
     inhandVisuals:
       left:

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -90,7 +90,7 @@
         startingItem: PowerCellMedium
   - type: HandheldLight
     addPrefix: false
-    wattage: 0.53
+    wattage: 0.5
   - type: ToggleableLightVisuals
     inhandVisuals:
       left:

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -87,7 +87,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellHigh
+        startingItem: PowerCellMedium
   - type: HandheldLight
     addPrefix: false
   - type: ToggleableLightVisuals


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Seclites now start with medium-capacity cells, meaning you must unlock and build high-capacity cells rather than just getting them free from sec. Seclite power drain has been reduced so that they still last just as long.

## Why / Balance
Highcaps are tech-locked, it doesn't make sense for security to get a free supply of them at roundstart. This will nerf cyborgs a bit by removing their free highcap battery, but it isn't hard to change their power drain if this becomes a issue.

## Technical details
Changed starting battery of seclite, and its power draw (wattage) in Resources/Prototypes/Entities/Objects/Tools/flashlight.yml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Seclites now start with a medium-capacity power cell.
- tweak: Seclite power draw (wattage) has been reduced to 0.5.
