### PR TITLE
Fix ghost visibility

### DIFF
--- a/Content.Client/Ghost/GhostSystem.cs
+++ b/Content.Client/Ghost/GhostSystem.cs
@@ -17,7 +17,7 @@ namespace Content.Client.Ghost
 
         public int AvailableGhostRoleCount { get; private set; }
 
-        private bool _ghostVisibility = true;
+        private bool _ghostVisibility;
 
         private bool GhostVisibility
         {
@@ -32,9 +32,9 @@ namespace Content.Client.Ghost
                 _ghostVisibility = value;
 
                 var query = AllEntityQuery<GhostComponent, SpriteComponent>();
-                while (query.MoveNext(out var uid, out _, out var sprite))
+                while (query.MoveNext(out var uid, out var ghost, out var sprite))
                 {
-                    sprite.Visible = value || uid == _playerManager.LocalEntity;
+                    UpdateVisibility((uid, ghost, sprite));
                 }
             }
         }
@@ -70,8 +70,15 @@ namespace Content.Client.Ghost
 
         private void OnStartup(EntityUid uid, GhostComponent component, ComponentStartup args)
         {
-            if (TryComp(uid, out SpriteComponent? sprite))
-                sprite.Visible = GhostVisibility || uid == _playerManager.LocalEntity;
+            UpdateVisibility((uid, component));
+        }
+
+        private void UpdateVisibility(Entity<GhostComponent?, SpriteComponent?> ghost)
+        {
+            if (!Resolve(ghost.Owner, ref ghost.Comp1, ref ghost.Comp2))
+                return;
+
+            ghost.Comp2.Visible = GhostVisibility || ghost.Comp1.Visible || ghost.Owner == _playerManager.LocalEntity;
         }
 
         private void OnToggleLighting(EntityUid uid, EyeComponent component, ToggleLightingActionEvent args)
@@ -130,7 +137,9 @@ namespace Content.Client.Ghost
         private void OnGhostState(EntityUid uid, GhostComponent component, ref AfterAutoHandleStateEvent args)
         {
             if (TryComp<SpriteComponent>(uid, out var sprite))
-                sprite.LayerSetColor(0, component.color);
+                sprite.LayerSetColor(0, component.Color);
+
+            UpdateVisibility((uid, component, null));
 
             if (uid != _playerManager.LocalEntity)
                 return;

--- a/Content.Server/Administration/Commands/ShowGhostsCommand.cs
+++ b/Content.Server/Administration/Commands/ShowGhostsCommand.cs
@@ -28,11 +28,7 @@ namespace Content.Server.Administration.Commands
                 return;
             }
 
-            var ghostSys = _entities.EntitySysManager.GetEntitySystem<GhostSystem>();
-            var revSys = _entities.EntitySysManager.GetEntitySystem<RevenantSystem>();
-
-            ghostSys.MakeVisible(visible);
-            revSys.MakeVisible(visible);
+            _entities.System<GhostSystem>().MakeVisible(visible);
         }
     }
 }

--- a/Content.Server/Revenant/EntitySystems/CorporealSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/CorporealSystem.cs
@@ -1,37 +1,8 @@
-using Content.Server.GameTicking;
-using Content.Shared.Eye;
-using Content.Shared.Revenant.Components;
 using Content.Shared.Revenant.EntitySystems;
-using Robust.Server.GameObjects;
 
 namespace Content.Server.Revenant.EntitySystems;
 
 public sealed class CorporealSystem : SharedCorporealSystem
 {
-    [Dependency] private readonly VisibilitySystem _visibilitySystem = default!;
-    [Dependency] private readonly GameTicker _ticker = default!;
 
-    public override void OnStartup(EntityUid uid, CorporealComponent component, ComponentStartup args)
-    {
-        base.OnStartup(uid, component, args);
-
-        if (TryComp<VisibilityComponent>(uid, out var visibility))
-        {
-            _visibilitySystem.RemoveLayer((uid, visibility), (int) VisibilityFlags.Ghost, false);
-            _visibilitySystem.AddLayer((uid, visibility), (int) VisibilityFlags.Normal, false);
-            _visibilitySystem.RefreshVisibility(uid, visibility);
-        }
-    }
-
-    public override void OnShutdown(EntityUid uid, CorporealComponent component, ComponentShutdown args)
-    {
-        base.OnShutdown(uid, component, args);
-
-        if (TryComp<VisibilityComponent>(uid, out var visibility) && _ticker.RunLevel != GameRunLevel.PostRound)
-        {
-            _visibilitySystem.AddLayer((uid, visibility), (int) VisibilityFlags.Ghost, false);
-            _visibilitySystem.RemoveLayer((uid, visibility), (int) VisibilityFlags.Normal, false);
-            _visibilitySystem.RefreshVisibility(uid, visibility);
-        }
-    }
 }

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -83,11 +83,18 @@ public sealed partial class GhostComponent : Component
     }
 
     /// <summary>
+    /// Whether or not the ghost should be visible by default.
+    /// The ghost will still always be visible if global ghost visibility is enabled in the ghost system.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Visible;
+
+    /// <summary>
     /// Ghost color
     /// </summary>
     /// <remarks>Used to allow admins to change ghost colors. Should be removed if the capability to edit existing sprite colors is ever added back.</remarks>
-    [DataField("color"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public Color color = Color.White;
+    [DataField, AutoNetworkedField]
+    public Color Color = Color.White;
 
     [DataField("canReturnToBody"), AutoNetworkedField]
     private bool _canReturnToBody;

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -57,6 +57,15 @@ namespace Content.Shared.Ghost
         {
             component.CanReturnToBody = value;
         }
+
+        public virtual void SetVisible(Entity<GhostComponent?> ghost, bool visible)
+        {
+            if (!Resolve(ghost.Owner, ref ghost.Comp))
+                return;
+
+            ghost.Comp.Visible = visible;
+            Dirty(ghost);
+        }
     }
 
     /// <summary>

--- a/Content.Shared/Revenant/Components/CorporealComponent.cs
+++ b/Content.Shared/Revenant/Components/CorporealComponent.cs
@@ -1,5 +1,9 @@
+using Content.Shared.Eye;
+
 namespace Content.Shared.Revenant.Components;
 
+// TODO separate component
+// Visibility, collision, and slowdown should be separate components
 /// <summary>
 /// Makes the target solid, visible, and applies a slowdown.
 /// Meant to be used in conjunction with statusEffectSystem
@@ -12,4 +16,7 @@ public sealed partial class CorporealComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     public float MovementSpeedDebuff = 0.66f;
+
+    [DataField]
+    public bool MadeVisible;
 }


### PR DESCRIPTION
## About the PR
Updates ghost system so that ghosts are invisible by default.

## Technical details
Revenants made ghosts default to being visible instead of invisible, while relying on PVS visibility masks to prevent clients from seeing them, but that obviously doesn't work when PVS is disabled and can introduce bugs (e.g., see space-wizards/RobustToolbox/pull/5598).

Ghost sprite visibility and PVS visibility masks are now configurable via `GhostSystem.SetVisible`, and revenants now use that.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
- fix: Fixed ghosts sometimes being visible when they shouldn't be.
