### PR TITLE
CentComm Map Updates

### DIFF
--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -1,13 +1,13 @@
 using Content.Server.Administration.Logs;
-using Content.Shared.Interaction;
-using Content.Shared.Doors.Components;
-using Content.Shared.Access.Components;
 using Content.Server.Doors.Systems;
 using Content.Server.Power.EntitySystems;
+using Content.Shared.Access.Components;
 using Content.Shared.Database;
+using Content.Shared.Doors.Components;
 using Content.Shared.Examine;
-using Content.Shared.Remotes.EntitySystems;
+using Content.Shared.Interaction;
 using Content.Shared.Remotes.Components;
+using Content.Shared.Remotes.EntitySystems;
 
 namespace Content.Shared.Remotes
 {
@@ -17,6 +17,7 @@ namespace Content.Shared.Remotes
         [Dependency] private readonly AirlockSystem _airlock = default!;
         [Dependency] private readonly DoorSystem _doorSystem = default!;
         [Dependency] private readonly ExamineSystemShared _examine = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -31,9 +32,12 @@ namespace Content.Shared.Remotes
             if (args.Handled
                 || args.Target == null
                 || !TryComp<DoorComponent>(args.Target, out var doorComp) // If it isn't a door we don't use it
-                                                                          // Only able to control doors if they are within your vision and within your max range.
-                                                                          // Not affected by mobs or machines anymore.
-                || !_examine.InRangeUnOccluded(args.User, args.Target.Value, SharedInteractionSystem.MaxRaycastRange, null))
+                // Only able to control doors if they are within your vision and within your max range.
+                // Not affected by mobs or machines anymore.
+                || !_examine.InRangeUnOccluded(args.User,
+                    args.Target.Value,
+                    SharedInteractionSystem.MaxRaycastRange,
+                    null))
 
             {
                 return;
@@ -50,7 +54,8 @@ namespace Content.Shared.Remotes
             if (TryComp<AccessReaderComponent>(args.Target, out var accessComponent)
                 && !_doorSystem.HasAccess(args.Target.Value, args.Used, doorComp, accessComponent))
             {
-                _doorSystem.Deny(args.Target.Value, doorComp, args.User);
+                if (isAirlock)
+                    _doorSystem.Deny(args.Target.Value, doorComp, args.User);
                 Popup.PopupEntity(Loc.GetString("door-remote-denied"), args.User, args.User);
                 return;
             }
@@ -59,7 +64,9 @@ namespace Content.Shared.Remotes
             {
                 case OperatingMode.OpenClose:
                     if (_doorSystem.TryToggleDoor(args.Target.Value, doorComp, args.Used))
-                        _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)}: {doorComp.State}");
+                        _adminLogger.Add(LogType.Action,
+                            LogImpact.Medium,
+                            $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)}: {doorComp.State}");
                     break;
                 case OperatingMode.ToggleBolts:
                     if (TryComp<DoorBoltComponent>(args.Target, out var boltsComp))
@@ -67,17 +74,22 @@ namespace Content.Shared.Remotes
                         if (!boltsComp.BoltWireCut)
                         {
                             _doorSystem.SetBoltsDown((args.Target.Value, boltsComp), !boltsComp.BoltsDown, args.Used);
-                            _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(boltsComp.BoltsDown ? "" : "un")}bolt it");
+                            _adminLogger.Add(LogType.Action,
+                                LogImpact.Medium,
+                                $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(boltsComp.BoltsDown ? "" : "un")}bolt it");
                         }
                     }
+
                     break;
                 case OperatingMode.ToggleEmergencyAccess:
                     if (airlockComp != null)
                     {
                         _airlock.SetEmergencyAccess((args.Target.Value, airlockComp), !airlockComp.EmergencyAccess);
-                        _adminLogger.Add(LogType.Action, LogImpact.Medium,
+                        _adminLogger.Add(LogType.Action,
+                            LogImpact.Medium,
                             $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to set emergency access {(airlockComp.EmergencyAccess ? "on" : "off")}");
                     }
+
                     break;
                 default:
                     throw new InvalidOperationException(

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -21423,7 +21423,6 @@ entities:
       inletTwoConcentration: 0.22000003
       inletOneConcentration: 0.78
       targetPressure: 4500
-      enabled: True
 - proto: GasPassiveVent
   entities:
   - uid: 3430
@@ -24862,7 +24861,6 @@ entities:
       parent: 1668
     - type: GasPressurePump
       targetPressure: 385
-      enabled: True
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5400
@@ -24873,7 +24871,6 @@ entities:
       parent: 1668
     - type: GasPressurePump
       targetPressure: 4500
-      enabled: True
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasThermoMachineFreezer
@@ -27420,13 +27417,6 @@ entities:
     components:
     - type: Transform
       pos: -11.5,-9.5
-      parent: 1668
-- proto: LockerParamedicFilled
-  entities:
-  - uid: 3989
-    components:
-    - type: Transform
-      pos: 11.5,-11.5
       parent: 1668
 - proto: LockerQuarterMasterFilled
   entities:

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -27404,9 +27404,9 @@ entities:
           showEnts: False
           occludes: True
           ent: null
-- proto: LockerHeadOfPersonnel
+- proto: LockerHeadOfPersonnelFilled
   entities:
-  - uid: 5133
+  - uid: 327
     components:
     - type: Transform
       pos: -10.5,-5.5

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -23,12 +23,24 @@ tilemap:
 entities:
 - proto: ""
   entities:
+  - uid: 327
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
   - uid: 1668
     components:
     - type: MetaData
       name: Central Command
     - type: Transform
-      parent: invalid
+      parent: 327
     - type: MapGrid
       chunks:
         -1,-1:
@@ -2330,7 +2342,8 @@ entities:
           0,-2:
             0: 65535
           1,-4:
-            0: 65535
+            0: 65023
+            1: 512
           1,-3:
             0: 65535
           1,-2:
@@ -2781,17 +2794,17 @@ entities:
             0: 65535
           4,-8:
             0: 30719
-            1: 34816
+            2: 34816
           4,-7:
             0: 65535
           5,-8:
             0: 61183
-            1: 4352
+            2: 4352
           5,-7:
             0: 65535
           6,-8:
             0: 52479
-            2: 13056
+            3: 13056
           6,-7:
             0: 65535
           7,-8:
@@ -2873,6 +2886,21 @@ entities:
           - 0
           - 0
         - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
           temperature: 293.15
           moles:
           - 6666.982
@@ -2930,8 +2958,6 @@ entities:
     - type: Transform
       pos: -16.5,4.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
 - proto: Airlock
   entities:
   - uid: 5314
@@ -2974,6 +3000,30 @@ entities:
       parent: 1668
 - proto: AirlockBrigGlassLocked
   entities:
+  - uid: 736
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,20.5
+      parent: 1668
+  - uid: 816
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,20.5
+      parent: 1668
+  - uid: 856
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,16.5
+      parent: 1668
+  - uid: 898
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,16.5
+      parent: 1668
   - uid: 2299
     components:
     - type: Transform
@@ -2996,25 +3046,10 @@ entities:
       parent: 1668
 - proto: AirlockBrigLocked
   entities:
-  - uid: 2300
-    components:
-    - type: Transform
-      pos: 21.5,22.5
-      parent: 1668
-  - uid: 2317
-    components:
-    - type: Transform
-      pos: 19.5,17.5
-      parent: 1668
   - uid: 2343
     components:
     - type: Transform
       pos: 33.5,20.5
-      parent: 1668
-  - uid: 2344
-    components:
-    - type: Transform
-      pos: 21.5,18.5
       parent: 1668
 - proto: AirlockCargoGlassLocked
   entities:
@@ -3291,6 +3326,28 @@ entities:
     - type: Transform
       pos: -19.5,7.5
       parent: 1668
+- proto: AirlockChemistryGlassLocked
+  entities:
+  - uid: 731
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 1668
+- proto: AirlockChemistryLocked
+  entities:
+  - uid: 732
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 1668
+  - uid: 734
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-11.5
+      parent: 1668
 - proto: AirlockEngineeringGlassLocked
   entities:
   - uid: 5175
@@ -3372,16 +3429,6 @@ entities:
     - type: Transform
       pos: 33.5,-5.5
       parent: 1668
-  - uid: 1615
-    components:
-    - type: Transform
-      pos: -14.5,25.5
-      parent: 1668
-  - uid: 1616
-    components:
-    - type: Transform
-      pos: -14.5,27.5
-      parent: 1668
   - uid: 3970
     components:
     - type: Transform
@@ -3402,18 +3449,42 @@ entities:
     - type: Transform
       pos: 0.5,-44.5
       parent: 1668
-- proto: AirlockExternalGlassLocked
+- proto: AirlockExternalGlassCargoLocked
   entities:
-  - uid: 1673
+  - uid: 620
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,27.5
+      parent: 1668
+  - uid: 688
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,25.5
+      parent: 1668
+  - uid: 729
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -9.5,32.5
       parent: 1668
-  - uid: 2010
+- proto: AirlockExternalGlassEngineeringLocked
+  entities:
+  - uid: 730
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -0.5,22.5
       parent: 1668
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        2011:
+        - DoorStatus: DoorBolt
+- proto: AirlockExternalGlassLocked
+  entities:
   - uid: 4243
     components:
     - type: Transform
@@ -3521,6 +3592,12 @@ entities:
     - type: Transform
       pos: -2.5,25.5
       parent: 1668
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        730:
+        - DoorStatus: DoorBolt
   - uid: 4242
     components:
     - type: Transform
@@ -3576,27 +3653,12 @@ entities:
     - type: Transform
       pos: 14.5,-3.5
       parent: 1668
-  - uid: 730
-    components:
-    - type: Transform
-      pos: 4.5,-8.5
-      parent: 1668
 - proto: AirlockMedicalLocked
   entities:
   - uid: 574
     components:
     - type: Transform
       pos: 16.5,-6.5
-      parent: 1668
-  - uid: 729
-    components:
-    - type: Transform
-      pos: 4.5,-6.5
-      parent: 1668
-  - uid: 731
-    components:
-    - type: Transform
-      pos: 8.5,-11.5
       parent: 1668
   - uid: 852
     components:
@@ -3625,25 +3687,22 @@ entities:
     - type: Transform
       pos: 23.5,-11.5
       parent: 1668
-  - uid: 2497
+- proto: AirlockSecurityLawyerLocked
+  entities:
+  - uid: 349
     components:
     - type: Transform
-      pos: 12.5,16.5
+      pos: 19.5,17.5
       parent: 1668
-  - uid: 2498
+  - uid: 354
     components:
     - type: Transform
-      pos: 11.5,16.5
+      pos: 21.5,22.5
       parent: 1668
-  - uid: 2499
+  - uid: 356
     components:
     - type: Transform
-      pos: 12.5,19.5
-      parent: 1668
-  - uid: 2500
-    components:
-    - type: Transform
-      pos: 11.5,19.5
+      pos: 21.5,18.5
       parent: 1668
 - proto: AirlockSecurityLocked
   entities:
@@ -3682,39 +3741,29 @@ entities:
     - type: Transform
       pos: 5.5,23.5
       parent: 1668
-- proto: APCBasic
+- proto: APCHyperCapacity
   entities:
-  - uid: 688
+  - uid: 905
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1668
-  - uid: 856
+  - uid: 963
     components:
     - type: Transform
       pos: 20.5,6.5
       parent: 1668
-  - uid: 905
+  - uid: 977
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,-7.5
       parent: 1668
-  - uid: 963
+  - uid: 978
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 23.5,-10.5
-      parent: 1668
-  - uid: 977
-    components:
-    - type: Transform
-      pos: 10.5,-3.5
-      parent: 1668
-  - uid: 978
-    components:
-    - type: Transform
-      pos: 12.5,7.5
       parent: 1668
   - uid: 979
     components:
@@ -3722,6 +3771,16 @@ entities:
       pos: 9.5,2.5
       parent: 1668
   - uid: 1088
+    components:
+    - type: Transform
+      pos: 12.5,7.5
+      parent: 1668
+  - uid: 1185
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 1668
+  - uid: 1188
     components:
     - type: Transform
       pos: -2.5,2.5
@@ -3742,238 +3801,238 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,-9.5
       parent: 1668
-  - uid: 1674
+  - uid: 1615
     components:
     - type: Transform
       pos: -14.5,18.5
       parent: 1668
-  - uid: 1675
+  - uid: 1616
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,17.5
       parent: 1668
-  - uid: 1676
+  - uid: 1673
     components:
     - type: Transform
       pos: -8.5,13.5
       parent: 1668
-  - uid: 1677
+  - uid: 1674
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,19.5
       parent: 1668
-  - uid: 1955
+  - uid: 1675
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 1668
-  - uid: 2013
+  - uid: 1676
     components:
     - type: Transform
       pos: -1.5,22.5
       parent: 1668
-  - uid: 2562
-    components:
-    - type: Transform
-      pos: 7.5,16.5
-      parent: 1668
-  - uid: 2563
-    components:
-    - type: Transform
-      pos: 17.5,17.5
-      parent: 1668
-  - uid: 2564
-    components:
-    - type: Transform
-      pos: 24.5,14.5
-      parent: 1668
-  - uid: 2565
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 35.5,19.5
-      parent: 1668
-  - uid: 2566
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.5,21.5
-      parent: 1668
-  - uid: 2944
-    components:
-    - type: Transform
-      pos: 9.5,26.5
-      parent: 1668
-  - uid: 2945
+  - uid: 1677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,18.5
       parent: 1668
-  - uid: 2946
+  - uid: 1955
+    components:
+    - type: Transform
+      pos: 17.5,17.5
+      parent: 1668
+  - uid: 2010
+    components:
+    - type: Transform
+      pos: 24.5,14.5
+      parent: 1668
+  - uid: 2235
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,21.5
+      parent: 1668
+  - uid: 2300
+    components:
+    - type: Transform
+      pos: 9.5,26.5
+      parent: 1668
+  - uid: 2317
+    components:
+    - type: Transform
+      pos: 7.5,16.5
+      parent: 1668
+  - uid: 2344
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,30.5
       parent: 1668
-  - uid: 3463
+  - uid: 2497
     components:
     - type: Transform
       pos: -22.5,7.5
       parent: 1668
-  - uid: 3464
+  - uid: 2498
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 1668
-  - uid: 3465
+  - uid: 2499
     components:
     - type: Transform
       pos: -22.5,13.5
       parent: 1668
-  - uid: 3466
+  - uid: 2500
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,6.5
       parent: 1668
-  - uid: 3986
+  - uid: 2556
     components:
     - type: Transform
       pos: -31.5,2.5
       parent: 1668
-  - uid: 3987
+  - uid: 2558
     components:
     - type: Transform
       pos: -31.5,7.5
       parent: 1668
-  - uid: 3988
+  - uid: 2562
     components:
     - type: Transform
       pos: -21.5,-2.5
       parent: 1668
-  - uid: 3989
+  - uid: 2563
     components:
     - type: Transform
       pos: -13.5,-2.5
       parent: 1668
-  - uid: 3990
+  - uid: 2564
     components:
     - type: Transform
       pos: -17.5,1.5
       parent: 1668
-  - uid: 4361
+  - uid: 2565
     components:
     - type: Transform
       pos: 34.5,-9.5
       parent: 1668
-  - uid: 4475
+  - uid: 2566
     components:
     - type: Transform
       pos: -2.5,-24.5
       parent: 1668
-  - uid: 4476
+  - uid: 2755
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-24.5
       parent: 1668
-  - uid: 4477
+  - uid: 2771
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-24.5
       parent: 1668
-  - uid: 4478
+  - uid: 2776
     components:
     - type: Transform
       pos: -9.5,-17.5
       parent: 1668
-  - uid: 4479
+  - uid: 2790
     components:
     - type: Transform
       pos: 8.5,-17.5
       parent: 1668
-  - uid: 4480
+  - uid: 2823
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-20.5
       parent: 1668
-  - uid: 4977
+  - uid: 2832
     components:
     - type: Transform
       pos: 20.5,-12.5
       parent: 1668
-  - uid: 4992
+  - uid: 2858
     components:
     - type: Transform
       pos: 18.5,-19.5
       parent: 1668
-  - uid: 5133
+  - uid: 2859
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,-23.5
       parent: 1668
-  - uid: 5146
+  - uid: 2862
     components:
     - type: Transform
       pos: 29.5,-19.5
       parent: 1668
-  - uid: 5257
+  - uid: 2863
     components:
     - type: Transform
       pos: 30.5,-14.5
       parent: 1668
-  - uid: 5321
+  - uid: 2876
     components:
     - type: Transform
       pos: 32.5,-27.5
       parent: 1668
-  - uid: 5423
+  - uid: 2886
     components:
     - type: Transform
       pos: 16.5,-28.5
       parent: 1668
-  - uid: 5934
+  - uid: 2920
     components:
     - type: Transform
       pos: -16.5,-30.5
       parent: 1668
-  - uid: 6004
+  - uid: 2925
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-22.5
       parent: 1668
-  - uid: 6103
+  - uid: 2926
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-28.5
       parent: 1668
-  - uid: 6180
+  - uid: 2927
     components:
     - type: Transform
       pos: 7.5,-30.5
       parent: 1668
-  - uid: 6181
+  - uid: 2928
     components:
     - type: Transform
       pos: -8.5,-30.5
       parent: 1668
-  - uid: 6277
+  - uid: 2944
     components:
     - type: Transform
       pos: -2.5,-34.5
       parent: 1668
-  - uid: 6397
+  - uid: 2945
     components:
     - type: Transform
       pos: -2.5,-40.5
+      parent: 1668
+  - uid: 6977
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 35.5,19.5
       parent: 1668
 - proto: Ash
   entities:
@@ -4180,8 +4239,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 19.5,-32.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
 - proto: Bed
   entities:
   - uid: 2718
@@ -4296,101 +4353,67 @@ entities:
     - type: Transform
       pos: -4.5,21.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1804
   - uid: 1607
     components:
     - type: Transform
       pos: -16.5,24.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1611
   - uid: 1608
     components:
     - type: Transform
       pos: -16.5,28.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1612
   - uid: 1609
     components:
     - type: Transform
       pos: -14.5,28.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1612
   - uid: 1610
     components:
     - type: Transform
       pos: -14.5,24.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1611
-  - uid: 2790
-    components:
-    - type: Transform
-      pos: 11.5,31.5
-      parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2928
-  - uid: 2886
-    components:
-    - type: Transform
-      pos: 14.5,31.5
-      parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2928
-  - uid: 2925
-    components:
-    - type: Transform
-      pos: 7.5,31.5
-      parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2927
-  - uid: 2926
-    components:
-    - type: Transform
-      pos: 4.5,31.5
-      parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2927
   - uid: 3787
     components:
     - type: Transform
       pos: -16.5,-7.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2920
   - uid: 3788
     components:
     - type: Transform
       pos: -16.5,-6.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2920
   - uid: 3789
     components:
     - type: Transform
       pos: -16.5,-5.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2920
   - uid: 4762
     components:
     - type: Transform
       pos: 18.5,-17.5
+      parent: 1668
+- proto: BlastDoorCentralCommand
+  entities:
+  - uid: 2946
+    components:
+    - type: Transform
+      pos: 4.5,31.5
+      parent: 1668
+  - uid: 3420
+    components:
+    - type: Transform
+      pos: 7.5,31.5
+      parent: 1668
+  - uid: 3431
+    components:
+    - type: Transform
+      pos: 11.5,31.5
+      parent: 1668
+  - uid: 4476
+    components:
+    - type: Transform
+      pos: 14.5,31.5
       parent: 1668
 - proto: BlastDoorExterior1Open
   entities:
@@ -4453,25 +4476,16 @@ entities:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 789
   - uid: 787
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 789
   - uid: 788
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 789
   - uid: 1430
     components:
     - type: Transform
@@ -4517,41 +4531,26 @@ entities:
     - type: Transform
       pos: 4.5,10.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2712
   - uid: 2147
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2712
   - uid: 2148
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2712
   - uid: 2149
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2712
   - uid: 2150
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 2712
   - uid: 3865
     components:
     - type: Transform
@@ -4567,65 +4566,41 @@ entities:
     - type: Transform
       pos: 28.5,-25.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5242
   - uid: 5235
     components:
     - type: Transform
       pos: 28.5,-24.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5242
   - uid: 5236
     components:
     - type: Transform
       pos: 28.5,-23.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5242
   - uid: 5237
     components:
     - type: Transform
       pos: 28.5,-22.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5242
   - uid: 5238
     components:
     - type: Transform
       pos: 28.5,-21.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5242
   - uid: 5239
     components:
     - type: Transform
       pos: 31.5,-19.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5242
   - uid: 5240
     components:
     - type: Transform
       pos: 33.5,-19.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5242
   - uid: 5241
     components:
     - type: Transform
       pos: 32.5,-19.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5242
   - uid: 5951
     components:
     - type: Transform
@@ -4661,41 +4636,26 @@ entities:
     - type: Transform
       pos: -2.5,-39.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 6442
   - uid: 6522
     components:
     - type: Transform
       pos: -1.5,-39.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 6442
   - uid: 6523
     components:
     - type: Transform
       pos: -0.5,-39.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 6442
   - uid: 6524
     components:
     - type: Transform
       pos: 0.5,-39.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 6442
   - uid: 6525
     components:
     - type: Transform
       pos: 1.5,-39.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 6442
 - proto: Bookshelf
   entities:
   - uid: 2370
@@ -4913,6 +4873,13 @@ entities:
     - type: Transform
       pos: -20.46677,5.55778
       parent: 1668
+- proto: BoxFolderNuclearCodes
+  entities:
+  - uid: 6994
+    components:
+    - type: Transform
+      pos: -10.309893,6.5837517
+      parent: 1668
 - proto: BoxFolderRed
   entities:
   - uid: 1398
@@ -5048,56 +5015,38 @@ entities:
     - type: Transform
       pos: 4.5,26.5
       parent: 1668
-    - type: DeviceLinkSource
-      linkedPorts:
-        2832:
-        - Start: Close
-        - Timer: AutoClose
-        - Timer: Open
   - uid: 3870
     components:
     - type: Transform
       pos: 14.5,29.5
       parent: 1668
-    - type: DeviceLinkSource
-      linkedPorts:
-        2863:
-        - Start: Close
-        - Timer: AutoClose
-        - Timer: Open
   - uid: 3906
     components:
     - type: Transform
       pos: 14.5,26.5
       parent: 1668
-    - type: DeviceLinkSource
-      linkedPorts:
-        2776:
-        - Start: Close
-        - Timer: AutoClose
-        - Timer: Open
   - uid: 6602
     components:
     - type: Transform
       pos: 4.5,29.5
       parent: 1668
-    - type: DeviceLinkSource
-      linkedPorts:
-        2862:
-        - Start: Close
-        - Timer: AutoClose
-        - Timer: Open
   - uid: 6649
     components:
     - type: Transform
       pos: 14.5,23.5
       parent: 1668
-    - type: DeviceLinkSource
-      linkedPorts:
-        2558:
-        - Start: Close
-        - Timer: AutoClose
-        - Timer: Open
+- proto: ButtonFrameCautionSecurity
+  entities:
+  - uid: 6578
+    components:
+    - type: Transform
+      pos: 4.5,32.5
+      parent: 1668
+  - uid: 6592
+    components:
+    - type: Transform
+      pos: 14.5,32.5
+      parent: 1668
 - proto: CableApcExtension
   entities:
   - uid: 857
@@ -16404,6 +16353,81 @@ entities:
     - type: Transform
       pos: -2.5,-40.5
       parent: 1668
+  - uid: 6515
+    components:
+    - type: Transform
+      pos: 5.5,30.5
+      parent: 1668
+  - uid: 6516
+    components:
+    - type: Transform
+      pos: 6.5,30.5
+      parent: 1668
+  - uid: 6517
+    components:
+    - type: Transform
+      pos: 7.5,29.5
+      parent: 1668
+  - uid: 6518
+    components:
+    - type: Transform
+      pos: 7.5,28.5
+      parent: 1668
+  - uid: 6519
+    components:
+    - type: Transform
+      pos: 7.5,27.5
+      parent: 1668
+  - uid: 6520
+    components:
+    - type: Transform
+      pos: 7.5,26.5
+      parent: 1668
+  - uid: 6547
+    components:
+    - type: Transform
+      pos: 8.5,26.5
+      parent: 1668
+  - uid: 6548
+    components:
+    - type: Transform
+      pos: 10.5,26.5
+      parent: 1668
+  - uid: 6549
+    components:
+    - type: Transform
+      pos: 11.5,26.5
+      parent: 1668
+  - uid: 6550
+    components:
+    - type: Transform
+      pos: 11.5,27.5
+      parent: 1668
+  - uid: 6551
+    components:
+    - type: Transform
+      pos: 11.5,28.5
+      parent: 1668
+  - uid: 6552
+    components:
+    - type: Transform
+      pos: 11.5,29.5
+      parent: 1668
+  - uid: 6553
+    components:
+    - type: Transform
+      pos: 11.5,30.5
+      parent: 1668
+  - uid: 6554
+    components:
+    - type: Transform
+      pos: 12.5,30.5
+      parent: 1668
+  - uid: 6577
+    components:
+    - type: Transform
+      pos: 13.5,30.5
+      parent: 1668
   - uid: 6849
     components:
     - type: Transform
@@ -17729,23 +17753,11 @@ entities:
     - type: Transform
       pos: -19.5,-4.5
       parent: 1668
-  - uid: 3883
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,-5.5
-      parent: 1668
   - uid: 3884
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-6.5
-      parent: 1668
-  - uid: 3885
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,-7.5
       parent: 1668
   - uid: 3886
     components:
@@ -17806,18 +17818,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,-29.5
       parent: 1668
-- proto: chem_master
-  entities:
-  - uid: 825
-    components:
-    - type: Transform
-      pos: 4.5,-13.5
-      parent: 1668
-  - uid: 4425
-    components:
-    - type: Transform
-      pos: 10.5,-23.5
-      parent: 1668
 - proto: ChemDispenser
   entities:
   - uid: 824
@@ -17831,6 +17831,18 @@ entities:
     components:
     - type: Transform
       pos: 3.5,-10.5
+      parent: 1668
+- proto: ChemMaster
+  entities:
+  - uid: 825
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 1668
+  - uid: 4425
+    components:
+    - type: Transform
+      pos: 10.5,-23.5
       parent: 1668
 - proto: ChessBoard
   entities:
@@ -17878,9 +17890,6 @@ entities:
     - type: Transform
       pos: 11.5,-13.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 575
     - type: Construction
       containers:
       - machine_parts
@@ -18196,13 +18205,6 @@ entities:
     components:
     - type: Transform
       pos: -16.552616,8.708888
-      parent: 1668
-- proto: ClothingHeadHatHairflower
-  entities:
-  - uid: 6605
-    components:
-    - type: Transform
-      pos: -11.182456,6.7149878
       parent: 1668
 - proto: ClothingHeadHatWelding
   entities:
@@ -19062,132 +19064,87 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -16.5,24.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1588
   - uid: 1577
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,24.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1588
   - uid: 1578
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,24.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1588
   - uid: 1579
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,24.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1588
   - uid: 1580
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,24.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1588
   - uid: 1581
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,24.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1588
   - uid: 1582
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,28.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1589
   - uid: 1583
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,28.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1589
   - uid: 1584
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,28.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1589
   - uid: 1585
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,28.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1589
   - uid: 1586
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,28.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1589
   - uid: 1587
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,28.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 1589
   - uid: 5902
     components:
     - type: Transform
       pos: -19.5,-33.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5906
   - uid: 5903
     components:
     - type: Transform
       pos: -19.5,-32.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5906
   - uid: 5904
     components:
     - type: Transform
       pos: -19.5,-31.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5906
 - proto: CrateArmoryLaser
   entities:
   - uid: 6533
@@ -19286,6 +19243,13 @@ entities:
     - type: Transform
       pos: -7.5,26.5
       parent: 1668
+- proto: CrateParticleDecelerators
+  entities:
+  - uid: 6995
+    components:
+    - type: Transform
+      pos: -7.5,28.5
+      parent: 1668
 - proto: CrowbarRed
   entities:
   - uid: 515
@@ -19342,8 +19306,6 @@ entities:
     - type: Transform
       pos: 11.5,-4.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
 - proto: DeathsquadPDA
   entities:
   - uid: 298
@@ -20869,11 +20831,6 @@ entities:
     - type: Transform
       pos: 1.5,1.5
       parent: 1668
-  - uid: 816
-    components:
-    - type: Transform
-      pos: -6.5,-9.5
-      parent: 1668
   - uid: 3840
     components:
     - type: Transform
@@ -21402,6 +21359,13 @@ entities:
     - type: Transform
       pos: 0.5503339,-25.316061
       parent: 1668
+- proto: FoodPoppy
+  entities:
+  - uid: 6605
+    components:
+    - type: Transform
+      pos: -11.182456,6.7149878
+      parent: 1668
 - proto: FoodSaladColeslaw
   entities:
   - uid: 6937
@@ -21441,30 +21405,24 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 12.5,-5.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#990000FF'
-- proto: GasMinerNitrogenStation
+- proto: GasMinerNitrogenStationLarge
   entities:
-  - uid: 4715
+  - uid: 3466
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,-29.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
-- proto: GasMinerOxygenStation
+- proto: GasMinerOxygenStationLarge
   entities:
-  - uid: 4703
+  - uid: 3797
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-29.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
 - proto: GasMixer
   entities:
   - uid: 5070
@@ -21473,8 +21431,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 21.5,-30.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
+    - type: GasMixer
+      inletTwoConcentration: 0.22000003
+      inletOneConcentration: 0.78
+      targetPressure: 4500
+      enabled: True
 - proto: GasPassiveVent
   entities:
   - uid: 3430
@@ -21483,32 +21444,24 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 25.5,-32.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 5399
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,-28.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 6141
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,-32.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 6312
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.5,-28.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
 - proto: GasPipeBend
   entities:
   - uid: 3660
@@ -21882,6 +21835,26 @@ entities:
       parent: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
+- proto: GasPipeSensorDistribution
+  entities:
+  - uid: 3883
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-30.5
+      parent: 1668
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeSensorWaste
+  entities:
+  - uid: 3860
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-31.5
+      parent: 1668
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeStraight
   entities:
   - uid: 3664
@@ -22024,27 +21997,11 @@ entities:
       parent: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5391
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-31.5
-      parent: 1668
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 5394
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-30.5
-      parent: 1668
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 5401
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-30.5
       parent: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -24864,46 +24821,34 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 20.5,-32.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 3577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,4.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 3659
     components:
     - type: Transform
       pos: -14.5,6.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 3662
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,4.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 6655
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-7.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 6705
     components:
     - type: Transform
       pos: 16.5,-31.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 6706
@@ -24911,8 +24856,6 @@ entities:
     - type: Transform
       pos: 17.5,-31.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPressurePump
@@ -24923,16 +24866,15 @@ entities:
       rot: 3.141592653589793 rad
       pos: -14.5,5.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 5395
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,-30.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
+    - type: GasPressurePump
+      targetPressure: 385
+      enabled: True
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5400
@@ -24941,8 +24883,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 20.5,-31.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
+    - type: GasPressurePump
+      targetPressure: 4500
+      enabled: True
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasThermoMachineFreezer
@@ -24952,8 +24895,6 @@ entities:
     - type: Transform
       pos: 13.5,-4.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
 - proto: GasVentPump
   entities:
   - uid: 3687
@@ -24962,39 +24903,29 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -14.5,9.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 3688
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,8.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 3689
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,6.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 3694
     components:
     - type: Transform
       pos: -21.5,14.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 5474
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-26.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5475
@@ -25002,8 +24933,6 @@ entities:
     - type: Transform
       pos: 20.5,-24.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5476
@@ -25012,8 +24941,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 26.5,-25.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5505
@@ -25022,8 +24949,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 20.5,-20.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5506
@@ -25031,8 +24956,6 @@ entities:
     - type: Transform
       pos: 25.5,-17.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5507
@@ -25041,8 +24964,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 32.5,-18.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5521
@@ -25050,8 +24971,6 @@ entities:
     - type: Transform
       pos: 7.5,-17.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5538
@@ -25059,8 +24978,6 @@ entities:
     - type: Transform
       pos: -8.5,-17.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5551
@@ -25069,8 +24986,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -0.5,-26.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5554
@@ -25079,8 +24994,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 10.5,-22.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5565
@@ -25089,8 +25002,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -11.5,-22.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5566
@@ -25099,8 +25010,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 0.5,-16.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5573
@@ -25109,8 +25018,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,-12.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5581
@@ -25119,8 +25026,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,-11.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5583
@@ -25129,8 +25034,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,-11.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5658
@@ -25138,8 +25041,6 @@ entities:
     - type: Transform
       pos: -30.5,4.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5659
@@ -25148,8 +25049,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -30.5,-2.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5663
@@ -25158,8 +25057,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -22.5,-1.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5664
@@ -25168,8 +25065,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -20.5,-3.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5666
@@ -25177,8 +25072,6 @@ entities:
     - type: Transform
       pos: -6.5,0.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5667
@@ -25186,8 +25079,6 @@ entities:
     - type: Transform
       pos: 5.5,0.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5669
@@ -25196,8 +25087,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5670
@@ -25206,8 +25095,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,-5.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5671
@@ -25215,8 +25102,6 @@ entities:
     - type: Transform
       pos: -1.5,4.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5696
@@ -25225,8 +25110,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,12.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5697
@@ -25235,8 +25118,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -6.5,9.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5712
@@ -25245,8 +25126,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -9.5,27.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5713
@@ -25255,8 +25134,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -9.5,23.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5714
@@ -25265,8 +25142,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -9.5,16.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5742
@@ -25274,8 +25149,6 @@ entities:
     - type: Transform
       pos: 10.5,13.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5743
@@ -25284,8 +25157,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 28.5,11.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5744
@@ -25293,8 +25164,6 @@ entities:
     - type: Transform
       pos: 18.5,13.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5756
@@ -25302,8 +25171,6 @@ entities:
     - type: Transform
       pos: 11.5,24.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5763
@@ -25311,8 +25178,6 @@ entities:
     - type: Transform
       pos: 28.5,19.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5779
@@ -25321,8 +25186,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 12.5,-1.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5780
@@ -25331,8 +25194,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 19.5,-0.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5806
@@ -25341,8 +25202,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -4.5,-32.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5814
@@ -25351,8 +25210,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 3.5,-32.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5824
@@ -25361,8 +25218,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -12.5,-31.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5825
@@ -25371,8 +25226,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 12.5,-31.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5887
@@ -25381,8 +25234,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -14.5,-23.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 6003
@@ -25391,8 +25242,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -19.5,-25.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 6227
@@ -25401,8 +25250,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -16.5,-32.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 6334
@@ -25410,8 +25257,6 @@ entities:
     - type: Transform
       pos: -0.5,-36.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 6335
@@ -25420,8 +25265,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -0.5,-41.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentScrubber
@@ -25432,8 +25275,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -17.5,-32.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
 - proto: GeneratorBasic15kW
   entities:
   - uid: 5176
@@ -26895,6 +26736,11 @@ entities:
     - type: Transform
       pos: 21.5,-23.5
       parent: 1668
+  - uid: 5079
+    components:
+    - type: Transform
+      pos: 20.5,6.5
+      parent: 1668
   - uid: 5114
     components:
     - type: Transform
@@ -27154,6 +27000,21 @@ entities:
     - type: Transform
       pos: 5.5,6.5
       parent: 1668
+  - uid: 6986
+    components:
+    - type: Transform
+      pos: 22.5,6.5
+      parent: 1668
+  - uid: 6992
+    components:
+    - type: Transform
+      pos: 30.5,6.5
+      parent: 1668
+  - uid: 6993
+    components:
+    - type: Transform
+      pos: 32.5,6.5
+      parent: 1668
 - proto: GroundTobacco
   entities:
   - uid: 3755
@@ -27238,16 +27099,6 @@ entities:
     - type: Transform
       pos: 3.5,0.5
       parent: 1668
-  - uid: 3797
-    components:
-    - type: Transform
-      pos: -20.5,-2.5
-      parent: 1668
-  - uid: 3860
-    components:
-    - type: Transform
-      pos: -22.5,-2.5
-      parent: 1668
   - uid: 3863
     components:
     - type: Transform
@@ -27264,6 +27115,16 @@ entities:
     components:
     - type: Transform
       pos: 32.5,-14.5
+      parent: 1668
+  - uid: 3885
+    components:
+    - type: Transform
+      pos: -22.5,-2.5
+      parent: 1668
+  - uid: 3902
+    components:
+    - type: Transform
+      pos: -20.5,-2.5
       parent: 1668
 - proto: HighSecDoor
   entities:
@@ -27400,6 +27261,53 @@ entities:
     - type: Transform
       pos: -18.379215,8.381029
       parent: 1668
+- proto: LockableButtonCentcomm
+  entities:
+  - uid: 3149
+    components:
+    - type: Transform
+      pos: 14.5,32.5
+      parent: 1668
+    - type: DeviceLinkSource
+      linkedPorts:
+        4476:
+        - Pressed: Toggle
+        6492:
+        - Pressed: Toggle
+        6397:
+        - Pressed: Toggle
+        3431:
+        - Pressed: Toggle
+  - uid: 4477
+    components:
+    - type: Transform
+      pos: 4.5,32.5
+      parent: 1668
+    - type: DeviceLinkSource
+      linkedPorts:
+        2946:
+        - Pressed: Toggle
+        5058:
+        - Pressed: Toggle
+        6314:
+        - Pressed: Toggle
+        3420:
+        - Pressed: Toggle
+- proto: LockableButtonCommand
+  entities:
+  - uid: 4475
+    components:
+    - type: Transform
+      pos: -16.5,-4.5
+      parent: 1668
+    - type: DeviceLinkSource
+      linkedPorts:
+        3789:
+        - Pressed: Toggle
+        3788:
+        - Pressed: Toggle
+        3787:
+        - Pressed: Toggle
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
   - uid: 3790
@@ -27416,7 +27324,7 @@ entities:
       parent: 1668
 - proto: LockerChemistryFilled
   entities:
-  - uid: 2876
+  - uid: 3986
     components:
     - type: Transform
       pos: 5.5,-13.5
@@ -27511,6 +27419,13 @@ entities:
           showEnts: False
           occludes: True
           ent: null
+- proto: LockerHeadOfPersonnel
+  entities:
+  - uid: 5133
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 1668
 - proto: LockerHeadOfSecurityFilled
   entities:
   - uid: 3153
@@ -27518,12 +27433,19 @@ entities:
     - type: Transform
       pos: -11.5,-9.5
       parent: 1668
-- proto: LockerQuarterMasterFilled
+- proto: LockerParamedicFilled
   entities:
-  - uid: 2235
+  - uid: 3989
     components:
     - type: Transform
-      pos: -8.5,19.5
+      pos: 11.5,-11.5
+      parent: 1668
+- proto: LockerQuarterMasterFilled
+  entities:
+  - uid: 5080
+    components:
+    - type: Transform
+      pos: -10.5,-7.5
       parent: 1668
 - proto: LockerResearchDirectorFilled
   entities:
@@ -27531,6 +27453,13 @@ entities:
     components:
     - type: Transform
       pos: -11.5,-3.5
+      parent: 1668
+- proto: LockerSalvageSpecialistFilledHardsuit
+  entities:
+  - uid: 3987
+    components:
+    - type: Transform
+      pos: -8.5,19.5
       parent: 1668
 - proto: LockerSecurityFilled
   entities:
@@ -27548,6 +27477,22 @@ entities:
     components:
     - type: Transform
       pos: -6.5,-10.5
+      parent: 1668
+- proto: LockerWallMedicalDoctorFilled
+  entities:
+  - uid: 6775
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-15.5
+      parent: 1668
+- proto: LockerWallMedicalFilled
+  entities:
+  - uid: 2013
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-7.5
       parent: 1668
 - proto: LockerWardenFilled
   entities:
@@ -27639,6 +27584,13 @@ entities:
     - type: Transform
       pos: 9.5,-7.5
       parent: 1668
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 6610
+    components:
+    - type: Transform
+      pos: 14.536912,-7.5898757
+      parent: 1668
 - proto: MedkitBruteFilled
   entities:
   - uid: 622
@@ -27655,11 +27607,6 @@ entities:
       parent: 1668
 - proto: MedkitFilled
   entities:
-  - uid: 620
-    components:
-    - type: Transform
-      pos: 14.516341,-7.5759134
-      parent: 1668
   - uid: 1454
     components:
     - type: Transform
@@ -27724,8 +27671,6 @@ entities:
     - type: Transform
       pos: 25.5,-28.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
 - proto: NTFlag
   entities:
   - uid: 1190
@@ -27764,6 +27709,13 @@ entities:
     - type: Transform
       pos: 9.5,-5.5
       parent: 1668
+- proto: OreProcessorIndustrial
+  entities:
+  - uid: 6978
+    components:
+    - type: Transform
+      pos: -5.5,29.5
+      parent: 1668
 - proto: OxygenCanister
   entities:
   - uid: 5415
@@ -27771,15 +27723,18 @@ entities:
     - type: Transform
       pos: 19.5,-28.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
   - uid: 6719
     components:
     - type: Transform
       pos: 12.5,-7.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
+- proto: OxygenTankFilled
+  entities:
+  - uid: 3901
+    components:
+    - type: Transform
+      pos: -12.625682,-7.0710163
+      parent: 1668
 - proto: PaintingAmogusTriptych
   entities:
   - uid: 3766
@@ -27925,6 +27880,84 @@ entities:
     components:
     - type: Transform
       pos: 17.5,-28.5
+      parent: 1668
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 5934
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-28.5
+      parent: 1668
+  - uid: 6004
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-29.5
+      parent: 1668
+  - uid: 6103
+    components:
+    - type: Transform
+      pos: 24.5,-29.5
+      parent: 1668
+  - uid: 6180
+    components:
+    - type: Transform
+      pos: 25.5,-29.5
+      parent: 1668
+  - uid: 6181
+    components:
+    - type: Transform
+      pos: 19.5,-29.5
+      parent: 1668
+  - uid: 6231
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-29.5
+      parent: 1668
+  - uid: 6232
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-28.5
+      parent: 1668
+  - uid: 6277
+    components:
+    - type: Transform
+      pos: 20.5,-29.5
+      parent: 1668
+- proto: PlasmaWindoorSecureSecurityLocked
+  entities:
+  - uid: 5410
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,22.5
+      parent: 1668
+  - uid: 5411
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,25.5
+      parent: 1668
+  - uid: 5416
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,28.5
+      parent: 1668
+  - uid: 5417
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,25.5
+      parent: 1668
+  - uid: 5423
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,28.5
       parent: 1668
 - proto: PlasticFlapsAirtightClear
   entities:
@@ -30431,13 +30464,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -22.5,-28.5
       parent: 1668
-- proto: Protolathe
-  entities:
-  - uid: 5311
-    components:
-    - type: Transform
-      pos: 24.5,-26.5
-      parent: 1668
 - proto: Rack
   entities:
   - uid: 1662
@@ -30840,9 +30866,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -19.5,-31.5
       parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 5907
 - proto: ReinforcedPlasmaWindow
   entities:
   - uid: 2791
@@ -30864,6 +30887,36 @@ entities:
     components:
     - type: Transform
       pos: 13.5,30.5
+      parent: 1668
+  - uid: 3990
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,21.5
+      parent: 1668
+  - uid: 4179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,24.5
+      parent: 1668
+  - uid: 4180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,24.5
+      parent: 1668
+  - uid: 4251
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,27.5
+      parent: 1668
+  - uid: 4361
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,27.5
       parent: 1668
   - uid: 5108
     components:
@@ -31885,21 +31938,6 @@ entities:
     - type: Transform
       pos: 8.5,16.5
       parent: 1668
-  - uid: 2556
-    components:
-    - type: Transform
-      pos: 14.5,21.5
-      parent: 1668
-  - uid: 2755
-    components:
-    - type: Transform
-      pos: 4.5,24.5
-      parent: 1668
-  - uid: 2771
-    components:
-    - type: Transform
-      pos: 14.5,24.5
-      parent: 1668
   - uid: 2777
     components:
     - type: Transform
@@ -31939,16 +31977,6 @@ entities:
     components:
     - type: Transform
       pos: 11.5,29.5
-      parent: 1668
-  - uid: 2858
-    components:
-    - type: Transform
-      pos: 14.5,27.5
-      parent: 1668
-  - uid: 2859
-    components:
-    - type: Transform
-      pos: 4.5,27.5
       parent: 1668
   - uid: 2906
     components:
@@ -32273,6 +32301,11 @@ entities:
     - type: Transform
       pos: 15.5,-22.5
       parent: 1668
+  - uid: 5321
+    components:
+    - type: Transform
+      pos: 30.5,6.5
+      parent: 1668
   - uid: 5333
     components:
     - type: Transform
@@ -32287,6 +32320,21 @@ entities:
     components:
     - type: Transform
       pos: 19.5,-23.5
+      parent: 1668
+  - uid: 5386
+    components:
+    - type: Transform
+      pos: 22.5,6.5
+      parent: 1668
+  - uid: 5391
+    components:
+    - type: Transform
+      pos: 20.5,6.5
+      parent: 1668
+  - uid: 5397
+    components:
+    - type: Transform
+      pos: 32.5,6.5
       parent: 1668
   - uid: 5880
     components:
@@ -32521,6 +32569,24 @@ entities:
       parent: 1668
 - proto: Screen
   entities:
+  - uid: 4479
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -32.5,-0.5
+      parent: 1668
+  - uid: 4480
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-25.5
+      parent: 1668
+  - uid: 5311
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-30.5
+      parent: 1668
   - uid: 6988
     components:
     - type: Transform
@@ -32530,6 +32596,47 @@ entities:
     components:
     - type: Transform
       pos: 33.5,-4.5
+      parent: 1668
+  - uid: 6996
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,26.5
+      parent: 1668
+  - uid: 6997
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-15.5
+      parent: 1668
+  - uid: 6998
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-15.5
+      parent: 1668
+  - uid: 6999
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-44.5
+      parent: 1668
+  - uid: 7000
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-30.5
+      parent: 1668
+  - uid: 7001
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-9.5
+      parent: 1668
+  - uid: 7002
+    components:
+    - type: Transform
+      pos: -11.5,13.5
       parent: 1668
 - proto: SecurityTechFab
   entities:
@@ -32573,6 +32680,28 @@ entities:
     components:
     - type: Transform
       pos: 19.5,-23.5
+      parent: 1668
+- proto: ShuttersWindowCentralCommand
+  entities:
+  - uid: 5058
+    components:
+    - type: Transform
+      pos: 5.5,30.5
+      parent: 1668
+  - uid: 6314
+    components:
+    - type: Transform
+      pos: 6.5,30.5
+      parent: 1668
+  - uid: 6397
+    components:
+    - type: Transform
+      pos: 12.5,30.5
+      parent: 1668
+  - uid: 6492
+    components:
+    - type: Transform
+      pos: 13.5,30.5
       parent: 1668
 - proto: SignalButton
   entities:
@@ -32637,45 +32766,6 @@ entities:
         - Pressed: Toggle
         2146:
         - Pressed: Toggle
-  - uid: 2920
-    components:
-    - type: Transform
-      pos: -16.5,-4.5
-      parent: 1668
-    - type: DeviceLinkSource
-      linkedPorts:
-        3789:
-        - Pressed: Toggle
-        3788:
-        - Pressed: Toggle
-        3787:
-        - Pressed: Toggle
-  - uid: 2927
-    components:
-    - type: MetaData
-      name: le funny admin button
-    - type: Transform
-      pos: 4.5,32.5
-      parent: 1668
-    - type: DeviceLinkSource
-      linkedPorts:
-        2926:
-        - Pressed: Toggle
-        2925:
-        - Pressed: Toggle
-  - uid: 2928
-    components:
-    - type: MetaData
-      name: le funny admin button
-    - type: Transform
-      pos: 14.5,32.5
-      parent: 1668
-    - type: DeviceLinkSource
-      linkedPorts:
-        2886:
-        - Pressed: Toggle
-        2790:
-        - Pressed: Toggle
   - uid: 5242
     components:
     - type: Transform
@@ -32734,7 +32824,7 @@ entities:
     - type: Transform
       pos: 8.5,4.5
       parent: 1668
-- proto: SignAtmosMinsky
+- proto: SignAtmos
   entities:
   - uid: 6888
     components:
@@ -32748,8 +32838,14 @@ entities:
     - type: Transform
       pos: -4.5,13.5
       parent: 1668
-- proto: SignChemistry1
+- proto: SignChem
   entities:
+  - uid: 4478
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 1668
   - uid: 6764
     components:
     - type: Transform
@@ -32910,11 +33006,6 @@ entities:
       parent: 1668
 - proto: SignMedical
   entities:
-  - uid: 736
-    components:
-    - type: Transform
-      pos: 5.5,-6.5
-      parent: 1668
   - uid: 6762
     components:
     - type: Transform
@@ -33016,6 +33107,18 @@ entities:
     - type: Transform
       pos: -2.5,-38.5
       parent: 1668
+- proto: SignSecureMedRed
+  entities:
+  - uid: 3988
+    components:
+    - type: Transform
+      pos: 7.5,32.5
+      parent: 1668
+  - uid: 6615
+    components:
+    - type: Transform
+      pos: 11.5,32.5
+      parent: 1668
 - proto: SignSecureSmall
   entities:
   - uid: 3868
@@ -33055,16 +33158,6 @@ entities:
     - type: Transform
       pos: -17.5,-25.5
       parent: 1668
-  - uid: 6231
-    components:
-    - type: Transform
-      pos: -32.5,-0.5
-      parent: 1668
-  - uid: 6232
-    components:
-    - type: Transform
-      pos: -21.5,-25.5
-      parent: 1668
 - proto: Sink
   entities:
   - uid: 3425
@@ -33099,24 +33192,24 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 19.5,-24.5
       parent: 1668
-- proto: SMESBasic
+- proto: SMESAdvanced
   entities:
-  - uid: 327
+  - uid: 4703
     components:
     - type: Transform
       pos: 27.5,-30.5
       parent: 1668
-  - uid: 5078
+  - uid: 4715
     components:
     - type: Transform
       pos: 22.5,-17.5
       parent: 1668
-  - uid: 5079
+  - uid: 4977
     components:
     - type: Transform
       pos: 22.5,-15.5
       parent: 1668
-  - uid: 5080
+  - uid: 4992
     components:
     - type: Transform
       pos: 22.5,-16.5
@@ -33135,7 +33228,7 @@ entities:
     - type: Transform
       pos: -20.47715,15.560694
       parent: 1668
-- proto: soda_dispenser
+- proto: SodaDispenser
   entities:
   - uid: 4427
     components:
@@ -33147,13 +33240,6 @@ entities:
     components:
     - type: Transform
       pos: 7.5,-21.5
-      parent: 1668
-- proto: SpawnVehicleSecway
-  entities:
-  - uid: 2823
-    components:
-    - type: Transform
-      pos: 11.5,25.5
       parent: 1668
 - proto: SS13Memorial
   entities:
@@ -33171,17 +33257,17 @@ entities:
       parent: 1668
 - proto: StatueVenusBlue
   entities:
-  - uid: 4180
+  - uid: 3463
     components:
     - type: Transform
-      pos: -20.5,-6.5
+      pos: 31.5,7.5
       parent: 1668
 - proto: StatueVenusRed
   entities:
-  - uid: 4179
+  - uid: 5078
     components:
     - type: Transform
-      pos: -21.5,-6.5
+      pos: 21.5,7.5
       parent: 1668
 - proto: Stool
   entities:
@@ -33218,8 +33304,6 @@ entities:
     - type: Transform
       pos: -14.5,6.5
       parent: 1668
-    - type: AtmosDevice
-      joinedGrid: 1668
 - proto: Stunbaton
   entities:
   - uid: 2746
@@ -33279,29 +33363,17 @@ entities:
     - type: Transform
       pos: -16.5,-29.5
       parent: 1668
-- proto: SuitStorageBasic
-  entities:
-  - uid: 1185
-    components:
-    - type: Transform
-      pos: -10.5,-7.5
-      parent: 1668
-  - uid: 1188
-    components:
-    - type: Transform
-      pos: -10.5,-5.5
-      parent: 1668
-  - uid: 3431
-    components:
-    - type: Transform
-      pos: -10.5,-6.5
-      parent: 1668
 - proto: SuitStorageCaptain
   entities:
   - uid: 3768
     components:
     - type: Transform
       pos: -11.5,4.5
+      parent: 1668
+  - uid: 5146
+    components:
+    - type: Transform
+      pos: -10.5,-6.5
       parent: 1668
 - proto: SuitStorageCE
   entities:
@@ -33330,6 +33402,13 @@ entities:
     components:
     - type: Transform
       pos: -10.5,-3.5
+      parent: 1668
+- proto: SuitStorageSec
+  entities:
+  - uid: 3465
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
       parent: 1668
 - proto: SurveillanceCameraCommand
   entities:
@@ -35390,9 +35469,9 @@ entities:
     - type: Transform
       pos: 7.5,21.5
       parent: 1668
-- proto: ToiletEmpty
+- proto: ToiletGoldenEmpty
   entities:
-  - uid: 3420
+  - uid: 5257
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -35433,6 +35512,11 @@ entities:
     - type: Transform
       pos: -12.035681,6.6117244
       parent: 1668
+  - uid: 6985
+    components:
+    - type: Transform
+      pos: -19.5,-6.5
+      parent: 1668
 - proto: ToyFigurineCargoTech
   entities:
   - uid: 6897
@@ -35468,12 +35552,22 @@ entities:
     - type: Transform
       pos: 27.221512,-23.216656
       parent: 1668
+  - uid: 6982
+    components:
+    - type: Transform
+      pos: -21.5,-7.5
+      parent: 1668
 - proto: ToyFigurineChiefMedicalOfficer
   entities:
   - uid: 6900
     components:
     - type: Transform
       pos: 13.343676,-12.106804
+      parent: 1668
+  - uid: 6980
+    components:
+    - type: Transform
+      pos: -20.5,-7.5
       parent: 1668
 - proto: ToyFigurineClown
   entities:
@@ -35489,6 +35583,11 @@ entities:
     - type: Transform
       pos: 8.249651,23.679073
       parent: 1668
+  - uid: 6508
+    components:
+    - type: Transform
+      pos: 4.5357866,22.481915
+      parent: 1668
 - proto: ToyFigurineEngineer
   entities:
   - uid: 6891
@@ -35496,12 +35595,24 @@ entities:
     - type: Transform
       pos: 26.955887,-23.01353
       parent: 1668
+- proto: ToyFigurineFootsoldier
+  entities:
+  - uid: 6510
+    components:
+    - type: Transform
+      pos: 3.5129395,25.168112
+      parent: 1668
 - proto: ToyFigurineGreytider
   entities:
   - uid: 2142
     components:
     - type: Transform
       pos: -1.5147417,19.684673
+      parent: 1668
+  - uid: 6509
+    components:
+    - type: Transform
+      pos: 16.351696,22.083393
       parent: 1668
 - proto: ToyFigurineHamlet
   entities:
@@ -35517,12 +35628,22 @@ entities:
     - type: Transform
       pos: 2.714695,-2.0789247
       parent: 1668
+  - uid: 6981
+    components:
+    - type: Transform
+      pos: -19.5,-5.5
+      parent: 1668
 - proto: ToyFigurineHeadOfSecurity
   entities:
   - uid: 592
     components:
     - type: Transform
       pos: 8.675076,17.818161
+      parent: 1668
+  - uid: 6983
+    components:
+    - type: Transform
+      pos: -19.5,-7.5
       parent: 1668
 - proto: ToyFigurineJanitor
   entities:
@@ -35566,6 +35687,27 @@ entities:
     - type: Transform
       pos: 0.78786826,-28.113647
       parent: 1668
+- proto: ToyFigurineNukie
+  entities:
+  - uid: 6512
+    components:
+    - type: Transform
+      pos: 3.1101613,28.112556
+      parent: 1668
+- proto: ToyFigurineNukieCommander
+  entities:
+  - uid: 6511
+    components:
+    - type: Transform
+      pos: 2.8740501,28.668112
+      parent: 1668
+- proto: ToyFigurineNukieElite
+  entities:
+  - uid: 6507
+    components:
+    - type: Transform
+      pos: 2.3733406,28.503387
+      parent: 1668
 - proto: ToyFigurineParamedic
   entities:
   - uid: 3427
@@ -35587,6 +35729,11 @@ entities:
     - type: Transform
       pos: -15.016072,14.885906
       parent: 1668
+  - uid: 6979
+    components:
+    - type: Transform
+      pos: -20.5,-5.5
+      parent: 1668
 - proto: ToyFigurineRatKing
   entities:
   - uid: 6906
@@ -35600,6 +35747,11 @@ entities:
     components:
     - type: Transform
       pos: -32.494865,6.5819006
+      parent: 1668
+  - uid: 6984
+    components:
+    - type: Transform
+      pos: -21.5,-5.5
       parent: 1668
 - proto: ToyFigurineSalvage
   entities:
@@ -35620,12 +35772,33 @@ entities:
     - type: Transform
       pos: 27.445951,-11.38564
       parent: 1668
+- proto: ToyFigurineThief
+  entities:
+  - uid: 6513
+    components:
+    - type: Transform
+      pos: 15.358348,28.515333
+      parent: 1668
 - proto: ToyFigurineWarden
   entities:
   - uid: 6894
     components:
     - type: Transform
       pos: 4.3459373,19.764877
+      parent: 1668
+- proto: ToyFigurineWizard
+  entities:
+  - uid: 6514
+    components:
+    - type: Transform
+      pos: 16.312458,25.32646
+      parent: 1668
+- proto: ToyOwlman
+  entities:
+  - uid: 3464
+    components:
+    - type: Transform
+      pos: -24.5,-6.5
       parent: 1668
 - proto: ToyRubberDuck
   entities:
@@ -35732,13 +35905,6 @@ entities:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-- proto: VehicleKeySecway
-  entities:
-  - uid: 3149
-    components:
-    - type: Transform
-      pos: 10.387553,25.600338
-      parent: 1668
 - proto: VendingMachineAmmo
   entities:
   - uid: 2821
@@ -36661,11 +36827,6 @@ entities:
     - type: Transform
       pos: 19.5,6.5
       parent: 1668
-  - uid: 349
-    components:
-    - type: Transform
-      pos: 22.5,6.5
-      parent: 1668
   - uid: 350
     components:
     - type: Transform
@@ -36685,16 +36846,6 @@ entities:
     components:
     - type: Transform
       pos: 29.5,6.5
-      parent: 1668
-  - uid: 354
-    components:
-    - type: Transform
-      pos: 30.5,6.5
-      parent: 1668
-  - uid: 356
-    components:
-    - type: Transform
-      pos: 32.5,6.5
       parent: 1668
   - uid: 357
     components:
@@ -37373,11 +37524,6 @@ entities:
     components:
     - type: Transform
       pos: -13.5,10.5
-      parent: 1668
-  - uid: 898
-    components:
-    - type: Transform
-      pos: 20.5,6.5
       parent: 1668
   - uid: 1080
     components:
@@ -41651,6 +41797,20 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -4.5,10.5
       parent: 1668
+- proto: WindoorSecureChemistryLocked
+  entities:
+  - uid: 5398
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-12.5
+      parent: 1668
+  - uid: 5401
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-11.5
+      parent: 1668
 - proto: WindoorSecureCommandLocked
   entities:
   - uid: 4230
@@ -41685,18 +41845,6 @@ entities:
       parent: 1668
 - proto: WindoorSecureMedicalLocked
   entities:
-  - uid: 732
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-11.5
-      parent: 1668
-  - uid: 734
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-12.5
-      parent: 1668
   - uid: 1198
     components:
     - type: Transform
@@ -41735,51 +41883,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,-12.5
       parent: 1668
-  - uid: 2558
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,22.5
-      parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 6649
-  - uid: 2776
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,25.5
-      parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 3906
-  - uid: 2832
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,25.5
-      parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 3723
-  - uid: 2862
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,28.5
-      parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 6602
-  - uid: 2863
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,28.5
-      parent: 1668
-    - type: DeviceLinkSink
-      links:
-      - 3870
 - proto: WindowReinforcedDirectional
   entities:
   - uid: 485
@@ -41972,44 +42075,6 @@ entities:
     - type: Transform
       pos: 4.5,-17.5
       parent: 1668
-  - uid: 5386
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.5,-28.5
-      parent: 1668
-  - uid: 5397
-    components:
-    - type: Transform
-      pos: 19.5,-29.5
-      parent: 1668
-  - uid: 5398
-    components:
-    - type: Transform
-      pos: 20.5,-29.5
-      parent: 1668
-  - uid: 5410
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.5,-29.5
-      parent: 1668
-  - uid: 5411
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 24.5,-28.5
-      parent: 1668
-  - uid: 5416
-    components:
-    - type: Transform
-      pos: 24.5,-29.5
-      parent: 1668
-  - uid: 5417
-    components:
-    - type: Transform
-      pos: 25.5,-29.5
-      parent: 1668
   - uid: 5453
     components:
     - type: Transform
@@ -42034,12 +42099,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -18.5,-32.5
       parent: 1668
-  - uid: 6314
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 24.5,-29.5
-      parent: 1668
   - uid: 6787
     components:
     - type: Transform
@@ -42052,12 +42111,5 @@ entities:
     components:
     - type: Transform
       pos: 9.506623,-4.4162817
-      parent: 1668
-- proto: YellowOxygenTankFilled
-  entities:
-  - uid: 3901
-    components:
-    - type: Transform
-      pos: -12.625682,-7.0710163
       parent: 1668
 ...

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -23,24 +23,12 @@ tilemap:
 entities:
 - proto: ""
   entities:
-  - uid: 327
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: PhysicsMap
-    - type: GridTree
-    - type: MovedGrids
-    - type: Broadphase
-    - type: OccluderTree
   - uid: 1668
     components:
     - type: MetaData
       name: Central Command
     - type: Transform
-      parent: 327
+      parent: invalid
     - type: MapGrid
       chunks:
         -1,-1:

--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -35566,11 +35566,6 @@ entities:
       parent: 1668
 - proto: ToyFigurineDetective
   entities:
-  - uid: 2145
-    components:
-    - type: Transform
-      pos: 8.249651,23.679073
-      parent: 1668
   - uid: 6508
     components:
     - type: Transform

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/access.yml
@@ -8,3 +8,16 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsCentralCommand ]
+
+#Window shutters
+
+- type: entity
+  parent: ShuttersWindow
+  id: ShuttersWindowCentralCommand
+  suffix: Central Command, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCentralCommand ]
+  - type: AccessReader
+    containerAccessProvider: board

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/access.yml
@@ -1,0 +1,10 @@
+#Blast door
+
+- type: entity
+  parent: BlastDoor
+  id: BlastDoorCentralCommand
+  suffix: Central Command, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCentralCommand ]

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -5,6 +5,7 @@
   description: This one says 'BLAST DONGER'.
   components:
   - type: AccessReader
+    containerAccessProvider: board
   - type: Sprite
     sprite: Structures/Doors/Shutters/blastdoor.rsi
     layers:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -494,6 +494,14 @@
   - type: AccessReader
     access: [["Atmospherics"]]
 
+- type: entity
+  id: LockableButtonCentcomm
+  suffix: CentComm
+  parent: LockableButton
+  components:
+  - type: AccessReader
+    access: [["CentralCommand"]]
+
 # button frames
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

* Added shutters to the armory to increase the effort needed for using death squad equipment to EORG. The armory blast doors and shutters are resistant to door remotes.
* The button to control the death squad armory doors is now CentComm locked.
* Added more figurines to populate security and the command debriefing room.
* Moved QM's locker from cargo to command debriefing gear room.
* Salvage specialist locker was added in place of where the QM locker was.
* Added HOP's locker to command debriefing room to finish the set.
* Brig doors are now brig doors.
* Chemistry doors are now chemistry doors.
* Cargo external airlocks are now cargo external airlocks.
* Lawyer doors are now lawyer (and security) doors.
* More screens were added to make it easier to tell how much time is left until the round restarts.
* Protolathe was removed from engineering (#33945).
* Gas pipe sensors were added.
* Gas pump and mixer values were preset.
* APCs were changed from the basic to the hyper model to resist EORG bombings for a bit longer.
* SMES were changed from the basic to the advanced model.
* Migrations changed some stuff
* An unhandled exception that occurred on the client when access to a non-airlock door was denied no longer happens.
* A security hardsuit was added next to the security external airlock.
* Air miners were switched to the higher pressure variant to recover from EORG bombing faster.
* Air miners are now surrounded in reinforced plasma glass to reduce risk of a leak.
* Paramedic and medical doctor lockers were added to the cloning room (the main room is too full)
* A medicine wall locker was added to medical to provide extra supplies.
* The first aid kit in medical was replaced with an advanced first aid kit.
* Supply was given an ore processor and a particle decelerator crate.
* The maiden statues were moved to allow for command debriefing roleplay.
* The command debriefing room was changed to command access to allow command debriefing roleplay.
* The central commander's toilet is now gold.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* EORG messes with roleplay.
* CentComm should logically have top of the line equipment and resources, it's Central Command.
* The debriefing room rarely gets to see use in its current state.

## Technical details
<!-- Summary of code changes for easier review. -->
1 line of C# was changed to fix a bug needed to protect the armory. A few CentComm locked variants of prototypes were added. The CentComm map was updated.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![CentComm-0](https://github.com/user-attachments/assets/73618d21-5138-4076-919d-2ab85a5d2291)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: WarPigeon
- tweak: The debriefing room in CentComm is now open to heads of staff for end of round roleplay.
