### PR TITLE
Various Locale Typo Fixes (and spaces)

### DIFF
--- a/Content.Server/PowerSink/PowerSinkSystem.cs
+++ b/Content.Server/PowerSink/PowerSinkSystem.cs
@@ -128,7 +128,7 @@ namespace Content.Server.PowerSink
 
             _chat.DispatchStationAnnouncement(
                 station.Value,
-                Loc.GetString("powersink-immiment-explosion-announcement"),
+                Loc.GetString("powersink-imminent-explosion-announcement"),
                 playDefaultSound: true,
                 colorOverride: Color.Yellow
             );

--- a/Resources/Locale/en-US/advertisements/vending/theater.ftl
+++ b/Resources/Locale/en-US/advertisements/vending/theater.ftl
@@ -2,5 +2,5 @@
 advertisement-theater-2 = Suited and booted!
 advertisement-theater-3 = It's show time!
 advertisement-theater-4 = Why leave style up to fate? Use AutoDrobe!
-advertisement-theater-5 = All wacky outfits and clothes, from gladitor robes to who knows what!
+advertisement-theater-5 = All wacky outfits and clothes, from gladiator robes to who knows what!
 advertisement-theater-6 = The clown will appreciate your outfit!

--- a/Resources/Locale/en-US/devices/device-network.ftl
+++ b/Resources/Locale/en-US/devices/device-network.ftl
@@ -33,7 +33,7 @@ device-address-prefix-freezer = FZR-
 device-address-prefix-volume-pump = VPP-
 device-address-prefix-smes = SMS-
 
-#PDAs and terminals
+# PDAs and terminals
 device-address-prefix-console = CLS-
 device-address-prefix-fire-alarm = FIR-
 device-address-prefix-air-alarm = AIR-
@@ -42,7 +42,7 @@ device-address-prefix-sensor-monitor = MON-
 
 device-address-examine-message = The device's address is {$address}.
 
-#Device net ID names
+# Device net ID names
 device-net-id-private = Private
 device-net-id-wired = Wired
 device-net-id-wireless = Wireless

--- a/Resources/Locale/en-US/game-ticking/game-rules/gamerule-admin.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-rules/gamerule-admin.ftl
@@ -1,4 +1,4 @@
-#When an admin adds a game rule
+# When an admin adds a game rule
 add-gamerule-admin = Game rule({$rule}) added - {$admin}
 list-gamerule-admin-header = | Time       | Rule added
 list-gamerule-admin-no-rules = No game rules have been added.

--- a/Resources/Locale/en-US/powersink/powersink.ftl
+++ b/Resources/Locale/en-US/powersink/powersink.ftl
@@ -1,2 +1,2 @@
 powersink-examine-drain-amount = The power sink is draining [color={$markupDrainColor}]{$amount} kW[/color].
-powersink-immiment-explosion-announcement = System scans have detected a rogue power consuming device is becoming unstable.  Staff are advised to locate and disconnect this device immediately before the station is damaged.
+powersink-imminent-explosion-announcement = System scans have detected a rogue power consuming device is becoming unstable.  Staff are advised to locate and disconnect this device immediately before the station is damaged.

--- a/Resources/Locale/en-US/revenant/revenant.ftl
+++ b/Resources/Locale/en-US/revenant/revenant.ftl
@@ -16,7 +16,7 @@ revenant-soul-yield-low = {CAPITALIZE(THE($target))} has a below average soul.
 revenant-soul-begin-harvest = {CAPITALIZE(THE($target))} suddenly rises slightly into the air, {POSS-ADJ($target)} skin turning an ashy gray.
 revenant-soul-finish-harvest = {CAPITALIZE(THE($target))} slumps onto the ground!
 
-#UI
+# UI
 revenant-user-interface-title = Ability Shop
 revenant-user-interface-essence-amount = [color=plum]{$amount}[/color] Stolen Essence
 

--- a/Resources/Locale/en-US/weapons/melee/melee.ftl
+++ b/Resources/Locale/en-US/weapons/melee/melee.ftl
@@ -3,5 +3,5 @@ melee-inject-failed-hardsuit = Your {$weapon} cannot inject through hardsuits!
 melee-balloon-pop = {CAPITALIZE(THE($balloon))} popped!
 
 
-#BatteryComponent
+# BatteryComponent
 melee-battery-examine = It has enough charge for [color={$color}]{$count}[/color] hits.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Noticed a few spelling errors while looking at some things, and also I have the Fluent extension installed for VSCode and it shits itself at multiple FTL comments not having a space before the comment tag.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's a slight skill issue while I'm editing VScode for all these random locale files to show up red, and also the spelling errors are another thing that are nice to have fixed for code searching.
## Technical details
<!-- Summary of code changes for easier review. -->
Fixes a total of two spelling errors:
"powersink-immiment-explosion-announcement" is now Imminent, not Immiment. This also touches the C# for PowerSinkSystem, because it directly references that locale.
"All wacky outfits and clothes, from gladitor robes to who knows what!" has an extra A added to spell Gladiator properly.
Multiple files (device network, gamerule admin, melee, revenant) are touched to add spaces before the # in the comment, for the sake of the Fluent extension.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or **it does not require an ingame showcase.**
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
N/A, only one change in this PR is player facing.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
