### PR TITLE
added a test for the MagazineVisualsComponent and fixed found issues

### DIFF
--- a/Content.IntegrationTests/Tests/MagazineVisualsSpriteTest.cs
+++ b/Content.IntegrationTests/Tests/MagazineVisualsSpriteTest.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using Content.Client.Weapons.Ranged.Components;
+using Content.Shared.Prototypes;
+using Robust.Client.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests;
+
+/// <summary>
+/// Tests all entity prototypes with the MagazineVisualsComponent.
+/// </summary>
+[TestFixture]
+public sealed class MagazineVisualsSpriteTest
+{
+    [Test]
+    public async Task MagazineVisualsSpritesExist()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var client = pair.Client;
+        var protoMan = client.ResolveDependency<IPrototypeManager>();
+        var componentFactory = client.ResolveDependency<IComponentFactory>();
+
+        await client.WaitAssertion(() =>
+        {
+            var protos = protoMan.EnumeratePrototypes<EntityPrototype>()
+                .Where(p => !p.Abstract)
+                .Where(p => !pair.IsTestPrototype(p))
+                .Where(p => p.TryGetComponent<MagazineVisualsComponent>(out _, componentFactory))
+                .OrderBy(p => p.ID)
+                .ToList();
+
+            foreach (var proto in protos)
+            {
+                Assert.That(proto.TryGetComponent<MagazineVisualsComponent>(out var visuals, componentFactory));
+                Assert.That(proto.TryGetComponent<SpriteComponent>(out var sprite, componentFactory));
+                if (!proto.HasComponent<AppearanceComponent>(componentFactory))
+                {
+                    Assert.Fail(@$"{proto.ID} has MagazineVisualsComponent but no AppearanceComponent.");
+                }
+
+                var hasMag = sprite.LayerMapTryGet(GunVisualLayers.Mag, out var magLayerId);
+                var hasUnshadedMag = sprite.LayerMapTryGet(GunVisualLayers.MagUnshaded, out var magUnshadedLayerId);
+
+                if (!hasMag && !hasUnshadedMag)
+                {
+                    Assert.Fail(@$"{proto.ID} has MagazineVisualsComponent but no Mag or MagUnshaded layer map.");
+                }
+
+                var start = visuals.ZeroVisible ? 0 : 1;
+                for (var i = start; i < visuals.MagSteps; i++)
+                {
+                    if (hasMag)
+                    {
+                        Assert.That(sprite.TryGetLayer(magLayerId, out var layer));
+                        var rsi = layer.ActualRsi;
+                        var state = $"{visuals.MagState}-{i}";
+
+                        Assert.That(rsi.TryGetState(state, out _), @$"{proto.ID} has MagazineVisualsComponent with
+                                    MagSteps = {visuals.MagSteps}, but {rsi.Path} doesn't have state {state}!");
+
+                        // MagSteps includes the 0th step, so sometimes people are off by one.
+                        var extraState = $"{visuals.MagState}-{visuals.MagSteps}";
+                        Assert.That(!rsi.TryGetState(extraState, out _), @$"{proto.ID} has MagazineVisualsComponent with
+                                        MagSteps = {visuals.MagSteps}, but more states exist!");
+                    }
+                    if (hasUnshadedMag)
+                    {
+                        Assert.That(sprite.TryGetLayer(magUnshadedLayerId, out var layer));
+                        var rsi = layer.ActualRsi;
+                        var state = $"{visuals.MagState}-unshaded-{i}";
+
+                        Assert.That(rsi.TryGetState(state, out _), @$"{proto.ID} has MagazineVisualsComponent with
+                                    MagSteps = {visuals.MagSteps}, but {rsi.Path} doesn't have state {state}!");
+
+                        // MagSteps includes the 0th step, so sometimes people are off by one.
+                        var extraState = $"{visuals.MagState}-unshaded-{visuals.MagSteps}";
+                        Assert.That(!rsi.TryGetState(extraState, out _), @$"{proto.ID} has MagazineVisualsComponent with
+                                        MagSteps = {visuals.MagSteps}, but more states exist!");
+                    }
+                }
+            }
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/MagazineVisualsSpriteTest.cs
+++ b/Content.IntegrationTests/Tests/MagazineVisualsSpriteTest.cs
@@ -81,5 +81,7 @@ public sealed class MagazineVisualsSpriteTest
                 }
             }
         });
+
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/MagazineVisualsSpriteTest.cs
+++ b/Content.IntegrationTests/Tests/MagazineVisualsSpriteTest.cs
@@ -26,9 +26,7 @@ public sealed class MagazineVisualsSpriteTest
             var protos = protoMan.EnumeratePrototypes<EntityPrototype>()
                 .Where(p => !p.Abstract)
                 .Where(p => !pair.IsTestPrototype(p))
-                .Where(p => p.TryGetComponent<MagazineVisualsComponent>(out _, componentFactory))
-                .OrderBy(p => p.ID)
-                .ToList();
+                .Where(p => p.HasComponent<MagazineVisualsComponent>(componentFactory));
 
             foreach (var proto in protos)
             {

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
@@ -91,6 +91,10 @@
     capacity: 99
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Magazine/CaselessRifle/10x24.rsi
+  - type: MagazineVisuals
+    magState: mag
+    steps: 8
+    zeroVisible: false
 
 - type: entity
   id: MagazinePistolCaselessRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
@@ -80,6 +80,8 @@
     layers:
     - state: base
       map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
 
 - type: entity
   id: MagazineLightRiflePractice
@@ -146,6 +148,6 @@
     sprite: Objects/Weapons/Guns/Ammunition/Magazine/LightRifle/pk_box.rsi
   - type: MagazineVisuals
     magState: mag
-    steps: 7
+    steps: 8
     zeroVisible: false
   - type: Appearance

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
@@ -59,6 +59,8 @@
     layers:
     - state: base
       map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
 
 - type: entity
   id: MagazineMagnum
@@ -128,6 +130,8 @@
     layers:
     - state: base
       map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
 
 - type: entity
   id: MagazineMagnumSubMachineGun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -27,7 +27,7 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: MagazineVisuals
     magState: mag
-    steps: 5
+    steps: 6
     zeroVisible: false
   - type: Appearance
 
@@ -162,6 +162,8 @@
     layers:
     - state: base
       map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
 
 
 - type: entity
@@ -212,6 +214,8 @@
     layers:
     - state: base
       map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
 
 - type: entity
   id: MagazinePistolHighCapacity
@@ -287,6 +291,8 @@
     layers:
     - state: base
       map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
 
 - type: entity
   id: MagazinePistolSubMachineGunPractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
@@ -59,6 +59,8 @@
     layers:
     - state: base
       map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
 
 - type: entity
   id: MagazineRifleIncendiary

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
@@ -51,6 +51,11 @@
     layers:
       - state: base
         map: [ "enum.GunVisualLayers.Base" ]
+      # TODO: This is actually a issue with all the speed loaders:
+      #       You can mix different ammo types, but it will always
+      #       use the one it was printed for.
+      - state: base-6
+        map: [ "enum.GunVisualLayers.Mag" ]
 
 - type: entity
   id: SpeedLoaderMagnumIncendiary

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -23,11 +23,6 @@
   - type: Battery
     maxCharge: 1000
     startingCharge: 1000
-  - type: MagazineVisuals
-    magState: mag
-    steps: 5
-    zeroVisible: false
-  - type: Appearance
   - type: StaticPrice
     price: 500
 
@@ -160,6 +155,11 @@
     - state: mag-unshaded-4
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
+  - type: MagazineVisuals
+    magState: mag
+    steps: 5
+    zeroVisible: false
+  - type: Appearance
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/makeshift.rsi
   - type: HitscanBatteryAmmoProvider
@@ -212,6 +212,11 @@
     - state: mag-unshaded-4
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
+  - type: MagazineVisuals
+    magState: mag
+    steps: 5
+    zeroVisible: false
+  - type: Appearance
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
   - type: Gun
@@ -250,6 +255,11 @@
     - state: mag-unshaded-4
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
+  - type: MagazineVisuals
+    magState: mag
+    steps: 5
+    zeroVisible: false
+  - type: Appearance
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/pulse_pistol.rsi
   - type: Gun
@@ -279,6 +289,11 @@
     - state: mag-unshaded-4
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
+  - type: MagazineVisuals
+    magState: mag
+    steps: 5
+    zeroVisible: false
+  - type: Appearance
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/pulse_carbine.rsi
   - type: Gun
@@ -310,6 +325,11 @@
     - state: mag-unshaded-4
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
+  - type: MagazineVisuals
+    magState: mag
+    steps: 5
+    zeroVisible: false
+  - type: Appearance
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/pulse_rifle.rsi
   - type: Gun
@@ -337,6 +357,11 @@
     - state: mag-unshaded-4
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
+  - type: MagazineVisuals
+    magState: mag
+    steps: 5
+    zeroVisible: false
+  - type: Appearance
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/laser_cannon.rsi
   - type: Gun
@@ -506,6 +531,7 @@
     magState: mag
     steps: 5
     zeroVisible: true
+  - type: Appearance
   - type: StaticPrice
     price: 260
 
@@ -710,11 +736,6 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 40
-  - type: MagazineVisuals
-    magState: mag
-    steps: 5
-    zeroVisible: true
-  - type: Appearance
   - type: StaticPrice
     price: 750
 
@@ -732,6 +753,11 @@
       - state: mag-unshaded-4
         map: ["enum.GunVisualLayers.MagUnshaded"]
         shader: unshaded
+  - type: MagazineVisuals
+    magState: mag
+    steps: 5
+    zeroVisible: false
+  - type: Appearance
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/energy_shotgun.rsi
   - type: Gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -31,7 +31,6 @@
     sprite: Objects/Weapons/Guns/HMGs/minigun.rsi
     layers:
     - state: icon
-      map: ["enum.GunVisualLayers.Base"]
   - type: Item
     sprite: Objects/Weapons/Guns/HMGs/minigun.rsi
   - type: Gun
@@ -41,11 +40,6 @@
   - type: BallisticAmmoProvider
     proto: CartridgeMinigun
     capacity: 1000
-  - type: MagazineVisuals
-    magState: mag
-    steps: 4
-    zeroVisible: true
-  - type: Appearance
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -117,7 +117,7 @@
       path: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
   - type: MagazineVisuals
     magState: mag
-    steps: 1
+    steps: 2
     zeroVisible: true
   - type: Appearance
 


### PR DESCRIPTION
## About the PR

Started out as only a fix for #34477 but ended up creating a test for that issue and making it pass.

## Why / Balance

- Fixes #34477
- More tests.

## Technical details

- Added tests for the `MagazineVisualsComponent`.
- Added missing `enum.GunVisualLayers.Mag` mapping to multiple entities.
- Fixed off by one errors for `MagazineVisuals.MagSteps`.
- Removed the `MagazineVisualsComponent` (and `AppearanceComponent`) from components that did not use them.

## Media

![image](https://github.com/user-attachments/assets/cf32c72c-e118-4178-9b51-18a1665b220d)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

None

**Changelog**

:cl:
- fix: Magazines that started out empty now visually fill.
