### PR TITLE
Fix `emergency_elkridge` being saved as a map

### DIFF
--- a/Resources/Maps/Shuttles/emergency_elkridge.yml
+++ b/Resources/Maps/Shuttles/emergency_elkridge.yml
@@ -18,7 +18,7 @@ entities:
       name: NT Evac Log
     - type: Transform
       pos: -0.42093527,-0.86894274
-      parent: 637
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -804,18 +804,6 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
-  - uid: 637
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: PhysicsMap
-    - type: GridTree
-    - type: MovedGrids
-    - type: Broadphase
-    - type: OccluderTree
 - proto: AirAlarm
   entities:
   - uid: 577


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Its a shuttle, it should be saved as a grid not a map.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

