### PR TITLE
More Resilient grenades

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -24,6 +24,11 @@
         !type:DamageTrigger
         damage: 10
       behaviors:
+      - !type:TimerStartBehavior
+    - trigger:
+        !type:DamageTrigger
+        damage: 45
+      behaviors:
       - !type:TriggerBehavior
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -111,20 +116,6 @@
     sprite: Objects/Weapons/Grenades/syndgrenade.rsi
   - type: ExplosionResistance
     damageCoefficient: 0.1
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 10
-      behaviors:
-      - !type:TimerStartBehavior
-    - trigger:
-        !type:DamageTrigger
-        damage: 45
-      behaviors:
-      - !type:TriggerBehavior
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
   - type: OnUseTimerTrigger
     delay: 5
   - type: ExplodeOnTrigger

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -13,7 +13,13 @@
         !type:DamageTrigger
         damage: 10
       behaviors:
-      - !type:TriggerBehavior
+      - !type:TimerStartBehavior
+    - trigger:
+        !type:DamageTrigger
+        damage: 45
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
All grenade's damage fusing has been changed: all explosive grenades now act like the minibomb did, arming on 10 damage and instantly detonating at 45 damage. Fragmenting grenades also arm on 10 damage, but will be destroyed without detonating if they take 45 damage.

## Why / Balance
Prior to these changes, fragmenting grenades were incredibly dangerous to carry on you, as they would instantly detonate from  even a dragon fireball. Now you have a few seconds to get it out of your bag before it goes off. This also will make explosive grenades safer to use with minor explosions, while still keeping their ability to instantly detonate in a large explosion and chain react.

## Technical details
Changed the base grenade's destructable trigger from 10 seconds to the same as the minibomb. Changed the base projectile grenade's destructable trigger from 10 seconds to the same as the minibomb, but without the instant trigger on 45 damage.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Explosive grenades now use the minibomb's fusing logic: their fuse starts when hit for 10 damage, and explode when hit for 45.
- tweak: Fragmenting grenades now use different fusing logic: their fuse starts when hit with 10 damage, and are destroyed without detonation at 45 damage.
-->
