### PR TITLE
Fix SuperSlippery And StepTriggers persisting when UpdateSlip is called

### DIFF
--- a/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/SpillTileReaction.cs
@@ -17,14 +17,14 @@ namespace Content.Server.Chemistry.TileReactions
     [DataDefinition]
     public sealed partial class SpillTileReaction : ITileReaction
     {
-        [DataField("launchForwardsMultiplier")] private float _launchForwardsMultiplier = 1;
-        [DataField("requiredSlipSpeed")] private float _requiredSlipSpeed = 6;
-        [DataField("paralyzeTime")] private float _paralyzeTime = 1;
+        [DataField("launchForwardsMultiplier")] public float LaunchForwardsMultiplier = 1;
+        [DataField("requiredSlipSpeed")] public float RequiredSlipSpeed = 6;
+        [DataField("paralyzeTime")] public float ParalyzeTime = 1;
 
         /// <summary>
         /// <see cref="SlipperyComponent.SuperSlippery"/>
         /// </summary>
-        [DataField("superSlippery")] private bool _superSlippery;
+        [DataField("superSlippery")] public bool SuperSlippery;
 
         public FixedPoint2 TileReact(TileRef tile,
             ReagentPrototype reagent,
@@ -39,13 +39,13 @@ namespace Content.Server.Chemistry.TileReactions
                 .TrySpillAt(tile, new Solution(reagent.ID, reactVolume, data), out var puddleUid, false, false))
             {
                 var slippery = entityManager.EnsureComponent<SlipperyComponent>(puddleUid);
-                slippery.LaunchForwardsMultiplier = _launchForwardsMultiplier;
-                slippery.ParalyzeTime = _paralyzeTime;
-                slippery.SuperSlippery = _superSlippery;
+                slippery.LaunchForwardsMultiplier = LaunchForwardsMultiplier;
+                slippery.ParalyzeTime = ParalyzeTime;
+                slippery.SuperSlippery = SuperSlippery;
                 entityManager.Dirty(puddleUid, slippery);
 
                 var step = entityManager.EnsureComponent<StepTriggerComponent>(puddleUid);
-                entityManager.EntitySysManager.GetEntitySystem<StepTriggerSystem>().SetRequiredTriggerSpeed(puddleUid, _requiredSlipSpeed, step);
+                entityManager.EntitySysManager.GetEntitySystem<StepTriggerSystem>().SetRequiredTriggerSpeed(puddleUid, RequiredSlipSpeed, step);
 
                 var slow = entityManager.EnsureComponent<SpeedModifierContactsComponent>(puddleUid);
                 var speedModifier = 1 - reagent.Viscosity;

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using Content.Server.Administration.Logs;
+using Content.Server.Chemistry.TileReactions;
 using Content.Server.DoAfter;
 using Content.Server.Fluids.Components;
 using Content.Server.Spreader;
@@ -387,23 +389,36 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
     private void UpdateSlip(EntityUid entityUid, PuddleComponent component, Solution solution)
     {
         var isSlippery = false;
+        var isSuperSlippery = false;
         // The base sprite is currently at 0.3 so we require at least 2nd tier to be slippery or else it's too hard to see.
         var amountRequired = FixedPoint2.New(component.OverflowVolume.Float() * LowThreshold);
         var slipperyAmount = FixedPoint2.Zero;
+
+        //Utilize the defaults from their relevant systems... this sucks, and is a bandaid
+        var launchForwardsMultiplier = SlipperyComponent.DefaultLaunchForwardsMultiplier;
+        var paralyzeTime = SlipperyComponent.DefaultParalyzeTime;
+        var requiredSlipSpeed = StepTriggerComponent.DefaultRequiredTriggeredSpeed;
 
         foreach (var (reagent, quantity) in solution.Contents)
         {
             var reagentProto = _prototypeManager.Index<ReagentPrototype>(reagent.Prototype);
 
-            if (reagentProto.Slippery)
-            {
-                slipperyAmount += quantity;
+            if (!reagentProto.Slippery)
+                continue;
+            slipperyAmount += quantity;
 
-                if (slipperyAmount > amountRequired)
-                {
-                    isSlippery = true;
-                    break;
-                }
+            if (slipperyAmount <= amountRequired)
+                continue;
+            isSlippery = true;
+
+            foreach (var tileReaction in reagentProto.TileReactions)
+            {
+                if (tileReaction is not SpillTileReaction spillTileReaction)
+                    continue;
+                isSuperSlippery = spillTileReaction.SuperSlippery;
+                launchForwardsMultiplier = launchForwardsMultiplier < spillTileReaction.LaunchForwardsMultiplier ? spillTileReaction.LaunchForwardsMultiplier : launchForwardsMultiplier;
+                requiredSlipSpeed = requiredSlipSpeed > spillTileReaction.RequiredSlipSpeed ? spillTileReaction.RequiredSlipSpeed : requiredSlipSpeed;
+                paralyzeTime = paralyzeTime < spillTileReaction.ParalyzeTime ? spillTileReaction.ParalyzeTime : paralyzeTime;
             }
         }
 
@@ -413,6 +428,14 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
             _stepTrigger.SetActive(entityUid, true, comp);
             var friction = EnsureComp<TileFrictionModifierComponent>(entityUid);
             _tile.SetModifier(entityUid, TileFrictionController.DefaultFriction * 0.5f, friction);
+
+            if (!TryComp<SlipperyComponent>(entityUid, out var slipperyComponent))
+                return;
+            slipperyComponent.SuperSlippery = isSuperSlippery;
+            _stepTrigger.SetRequiredTriggerSpeed(entityUid, requiredSlipSpeed);
+            slipperyComponent.LaunchForwardsMultiplier = launchForwardsMultiplier;
+            slipperyComponent.ParalyzeTime = paralyzeTime;
+
         }
         else if (TryComp<StepTriggerComponent>(entityUid, out var comp))
         {

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -394,7 +394,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         var amountRequired = FixedPoint2.New(component.OverflowVolume.Float() * LowThreshold);
         var slipperyAmount = FixedPoint2.Zero;
 
-        //Utilize the defaults from their relevant systems... this sucks, and is a bandaid
+        // Utilize the defaults from their relevant systems... this sucks, and is a bandaid
         var launchForwardsMultiplier = SlipperyComponent.DefaultLaunchForwardsMultiplier;
         var paralyzeTime = SlipperyComponent.DefaultParalyzeTime;
         var requiredSlipSpeed = StepTriggerComponent.DefaultRequiredTriggeredSpeed;

--- a/Content.Shared/Slippery/SlipperyComponent.cs
+++ b/Content.Shared/Slippery/SlipperyComponent.cs
@@ -13,6 +13,8 @@ namespace Content.Shared.Slippery
     [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
     public sealed partial class SlipperyComponent : Component
     {
+        public const float DefaultParalyzeTime = 1.5f;
+        public const float DefaultLaunchForwardsMultiplier = 1.5f;
         /// <summary>
         /// Path to the sound to be played when a mob slips.
         /// </summary>
@@ -25,14 +27,14 @@ namespace Content.Shared.Slippery
         /// </summary>
         [DataField, AutoNetworkedField]
         [Access(Other = AccessPermissions.ReadWrite)]
-        public float ParalyzeTime = 1.5f;
+        public float ParalyzeTime = DefaultParalyzeTime;
 
         /// <summary>
         /// The entity's speed will be multiplied by this to slip it forwards.
         /// </summary>
         [DataField, AutoNetworkedField]
         [Access(Other = AccessPermissions.ReadWrite)]
-        public float LaunchForwardsMultiplier = 1.5f;
+        public float LaunchForwardsMultiplier = DefaultLaunchForwardsMultiplier;
 
         /// <summary>
         /// If this is true, any slipping entity loses its friction until

--- a/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerComponent.cs
@@ -8,6 +8,7 @@ namespace Content.Shared.StepTrigger.Components;
 [Access(typeof(StepTriggerSystem))]
 public sealed partial class StepTriggerComponent : Component
 {
+    public const float DefaultRequiredTriggeredSpeed = 3.5f;
     /// <summary>
     ///     List of entities that are currently colliding with the entity.
     /// </summary>
@@ -37,7 +38,7 @@ public sealed partial class StepTriggerComponent : Component
     ///     Entities will only be triggered if their speed exceeds this limit.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float RequiredTriggeredSpeed = 3.5f;
+    public float RequiredTriggeredSpeed = DefaultRequiredTriggeredSpeed;
 
     /// <summary>
     ///     If any entities occupy the blacklist on the same tile then steptrigger won't work.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Updated `PuddleSystem::UpdateSlip` to change a puddles steptrigger and slippery component to reflect the contents of a puddle as the reagents within it change, such as when using a mop or Space cleaner on space lube, in response to #34303 not fully solving the issue (fixes #29229)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was broken and never updated the properties of the puddle entity
## Technical details
<!-- Summary of code changes for easier review. -->
Made values in SpillTileReaction's public so we can query the
reagents prototype for those values

Made the default values for slippery component and
StepTriggerComponent based on default constants
for easier resetting

Added a calculation and check in UpdateSlips to check
if a super slip is present as well as Update
relevant steptrigger and slip values based on the contents of the
solution
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


https://github.com/user-attachments/assets/3833fe3b-3099-4060-ac23-e3ed1bc63cde


https://github.com/user-attachments/assets/323d35c3-5e47-43a8-bda9-5a2089734cf1


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Kickguy223
- fix: Cleaning up a puddle properly changes its slippery properties.
