### PR TITLE
Cherry-pick to stable: Fix `emergency_elkridge` being saved as a map (#34496)

### DIFF
--- a/Resources/Maps/Shuttles/emergency_elkridge.yml
+++ b/Resources/Maps/Shuttles/emergency_elkridge.yml
@@ -18,7 +18,7 @@ entities:
       name: NT Evac Log
     - type: Transform
       pos: -0.42093527,-0.86894274
-      parent: 637
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -804,18 +804,6 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
-  - uid: 637
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: PhysicsMap
-    - type: GridTree
-    - type: MovedGrids
-    - type: Broadphase
-    - type: OccluderTree
 - proto: AirAlarm
   entities:
   - uid: 577


### PR DESCRIPTION
Save `emergency_elkridge` as a grid

(cherry picked from commit ef50219455f19f3139bebfe3ba233658b83cc096)

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Cherry picks #34496 from master to stable.

## Why / Balance
The emergency shuttle being saved as a grid means that evac won't actually arrive.

## Media
![image](https://github.com/user-attachments/assets/2150dc95-6d66-4c0b-be12-a25fbb3f3023)
![image](https://github.com/user-attachments/assets/b5ab3922-7f56-4e28-98df-a5ded0af624e)
![image](https://github.com/user-attachments/assets/caad01ba-68a0-4364-b64f-7736935fe70b)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
No CL no fun