### PR TITLE
New Gamemode: Oops, All Thieves!

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-oopsallthieves.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-oopsallthieves.ftl
@@ -1,0 +1,4 @@
+﻿# OopsAllThieves
+
+oops-all-thieves-title = Oops, all thieves!
+oops-all-thieves-description = The station is crawling with kleptomaniacs. Try to hold on to your stuff!

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -269,6 +269,29 @@
       mindRoles:
       - MindRoleInitialInfected
 
+- type: entity
+  parent: Thief
+  id: OopsAllThieves
+  components:
+  - type: GameRule
+    minPlayers: 30
+  - type: AntagSelection
+    agentName: thief-round-end-agent-name
+    definitions:
+    - prefRoles: [ Thief ]
+      max: 15
+      playerRatio: 7
+      lateJoinAdditional: true
+      allowNonHumans: true
+      multiAntagSetting: NotExclusive
+      startingGear: ThiefGear
+      components:
+      - type: Pacified
+      mindRoles:
+      - MindRoleThief
+      briefing:
+        sound: "/Audio/Misc/thief_greeting.ogg"
+
 # event schedulers
 
 - type: entityTable

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -279,8 +279,8 @@
     agentName: thief-round-end-agent-name
     definitions:
     - prefRoles: [ Thief ]
-      max: 15
-      playerRatio: 7
+      max: 10
+      playerRatio: 10
       lateJoinAdditional: true
       allowNonHumans: true
       multiAntagSetting: NotExclusive

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -234,3 +234,19 @@
   - KesslerSyndromeScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
+
+- type: gamePreset
+  id: OopsAllThieves
+  alias:
+  - oopsallthieves
+  - allthieves
+  - thieves
+  name: oops-all-thieves-title
+  description: oops-all-thieves-description
+  showInVote: false
+  rules:
+    - OopsAllThieves
+    - BasicStationEventScheduler
+    - MeteorSwarmScheduler
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,7 +2,8 @@
   id: Secret
   weights:
     Nukeops: 0.20
-    Traitor: 0.60
+    Traitor: 0.55
     Zombie: 0.05
     Survival: 0.10
     Revolutionary: 0.05
+    OopsAllThieves: 0.05


### PR DESCRIPTION
## About the PR
Adds a new gamemode: Oops, All Thieves!

This draws from the Traitor pool, making it 55%. Oops, All Thieves has a 5% chance to roll, and requires a minimum of 30 players, so there will at least be 3 thieves in a "lowpop" OopsAllThieves round. These numbers will be adjusted in the future after observer feedback.

Inspired from maintainer talks as to what would fill the gap in gamemodes after Kessler and Zombeteors were removed. (see #34051)

If this PR is merged, I plan to add AllAtOnce to the pool at a 1% chance.

## Why / Balance
Personally, I find SS14 really fun when I quite literally do not expect what happens next. It's a really nice turn of events and really highlights the chaos of SS14 when I expect one thing, but in reality another thing happens.

This boils down to having a lot more gamemodes, as having multiple gamemodes to choose from:
- Helps against metagaming and introduces variety. Players will be so caught up in thinking it's (x) or (y) that they won't think that it's actually (z), and will be shocked.
- Makes the game more fun. Players might want relief from endless or monotonous (x), (y), or (z) rounds.

I think that having thieves running around, competing over objectives, and making a mess ransacking stuff from the station introduces some excellent RP, while also making a unique case to security (as they're all pacifists!).

## Technical details
Changes related to the new game preset:

* [`Resources/Locale/en-US/game-ticking/game-presets/preset-oopsallthieves.ftl`](diffhunk://#diff-733f5a6646de129eb9276fbdec4d83103df07f0e9dfb546ddbe6727e3f2a8defR1-R4): Added localization strings for the new "OopsAllThieves" preset.
* [`Resources/Prototypes/GameRules/roundstart.yml`](diffhunk://#diff-dbe42fa5998ed2b7d4d9f585592dd73dec36800719907c122e826438d7b32c0eR272-R294): Defined the "OopsAllThieves" game rule, changed params like minimum players and amount of thieves compared to players. Parented from the base Thief rule.
* [`Resources/Prototypes/game_presets.yml`](diffhunk://#diff-0b2783a8b6f2617fdebc3dcf1a266fb09be2ddd7f9bfc4e587f89c9e62fe1b58R237-R252): Added the new "OopsAllThieves" game preset, including its alias, name, description, and associated base rules.

Changes related to game balance:

* [`Resources/Prototypes/secret_weights.yml`](diffhunk://#diff-d7134857b5f463ac7dcfbe5d2cca628d3a01a851a6fec27c0dd74a9c07b37407L5-R9): Adjusted the secret game mode weights to include the new "OopsAllThieves" preset with a weight of 0.05 and reduced the Traitor mode weight from 0.60 to 0.55.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: New gamemode: Oops, All Thieves!
- add: The Oops, All Thieves gamemode has been added to the secret gamemode pool. It can be rolled at a 5% chance, requires a minimum of 30 players to start.
- tweak: The Traitors gamemode's chance in the Secret gamemode pool has been reduced from 60% to 55%.