### PR TITLE
[HOTFIX] Fix MRP whitelist auto denying people with any medium severity notes in 14 days

### DIFF
--- a/Resources/Prototypes/wizardsDenWhitelists.yml
+++ b/Resources/Prototypes/wizardsDenWhitelists.yml
@@ -15,7 +15,7 @@
   - !type:ConditionNotesPlaytimeRange # Deny for >=2 medium severity notes in the last 14 days
     includeExpired: false
     minimumSeverity: 2 # Medium
-    minimumNotes: 1
+    minimumNotes: 2
     range: 14 # 14 Days
     action: Deny
     includeSecret: false

--- a/Resources/Prototypes/wizardsDenWhitelists.yml
+++ b/Resources/Prototypes/wizardsDenWhitelists.yml
@@ -15,17 +15,17 @@
   - !type:ConditionNotesPlaytimeRange # Deny for >=2 medium severity notes in the last 14 days
     includeExpired: false
     minimumSeverity: 2 # Medium
-    minimumNotes: 2
-    range: 14 # 14 Days
-    action: Deny
-    includeSecret: false
-  - !type:ConditionNotesPlaytimeRange # Deny for >=3 low severity notes in the last 14 days
-    includeExpired: false
-    minimumSeverity: 1 # Low
     minimumNotes: 3
-    range: 14 # 14 Days
+    range: 90 # 90 Days
     action: Deny
     includeSecret: false
+#  - !type:ConditionNotesPlaytimeRange # Deny for >=3 low severity notes in the last 14 days
+#    includeExpired: false
+#    minimumSeverity: 1 # Low
+#    minimumNotes: 3
+#    range: 14 # 14 Days
+#    action: Deny
+#    includeSecret: false
   - !type:ConditionManualWhitelistMembership # Allow whitelisted players
     action: Allow
   - !type:ConditionPlayerCount # Allow when <= 15 players are online

--- a/Resources/Prototypes/wizardsDenWhitelists.yml
+++ b/Resources/Prototypes/wizardsDenWhitelists.yml
@@ -12,7 +12,7 @@
     range: 30 # 30 days
     action: Deny
     includeSecret: false
-  - !type:ConditionNotesPlaytimeRange # Deny for >=2 medium severity notes in the last 14 days
+  - !type:ConditionNotesPlaytimeRange # Deny for >=3 medium severity notes in the last 90 days
     includeExpired: false
     minimumSeverity: 2 # Medium
     minimumNotes: 3


### PR DESCRIPTION
## About the PR
Fixes a bug causing player connection to be denied to the salamander server if the user has medium severity notes in the past 14 days.

Previously this was supposed to be more than or equal to two, however a typo caused it to be one. This issue hasn't arisen until today.

## Why / Balance
Bug. Issue was discovered and relayed to me privately.

## Technical details
Changes `minimumNotes` from 1 to 2. It was supposed to be 2 as the comment describes it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
No CL no fun