### PR TITLE
Increase the price of bulletproof armor.

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -4,7 +4,7 @@
     sprite: Clothing/OuterClothing/Armor/bulletproof.rsi
     state: icon
   product: CrateSecurityArmor
-  cost: 725
+  cost: 1250
   category: cargoproduct-category-name-security
   group: market
 


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
I have changed the price of the bulletproof vests from 725 spesos to 1250 spesos.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I believe that armor normally restricted to security should be slighty more expensive than 725. So I increased it to 1.25K instead.
While, for a solo antag this makes not too much difference, in situations like revs or nukies, it means that crew/revs take slightly more time to fully arm up if cargo has been slacking. Future changes, such as the increase of helmets aswell could lead to Cargo becoming more productive in the future.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the value of armor crate inside cargo_security.yml from 725 to 1250, thats it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Increased the armor crates price from 725 spesos to 1250 spesos.
