### PR TITLE
Fixed Intercom Encryption Key Deletion

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -310,9 +310,9 @@ namespace Content.Server.Construction
             if (GetCurrentNode(uid, construction)?.DoNotReplaceInheritingEntities == true &&
                 metaData.EntityPrototype?.ID != null)
             {
-                var parents = PrototypeManager.EnumerateParents<EntityPrototype>(metaData.EntityPrototype.ID)?.ToList();
+                var parents = PrototypeManager.EnumerateAllParents<EntityPrototype>(metaData.EntityPrototype.ID)?.ToList();
 
-                if (parents != null && parents.Any(x => x.ID == newEntity))
+                if (parents != null && parents.Any(x => x.id == newEntity))
                     return null;
             }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed an issue wherein using a welding tool on any intercom which inherited from BaseIntercomSecure, which should remove the security plate and allow access to the encryption keys, would delete all the encryption keys within it.

## Why / Balance
Fixes #32590
Fixes #34054
(Duplicate Issues)

## Technical details
Change: 
Changes the construction system to check abstract parents when checking if an entity inherits from a construction node's desired prototype. 

Explanation:
The problem is in how the "doNotReplaceInheritingEntities" code works. When an entity changes nodes on a construction graph, it is supposed to change to match the new node's prototype unless it is already that type. If "doNotReplaceInheritingEntities" is set to true, however, than it only needs to change if it doesn't inherit from the node's prototype rather than needing to match the type exactly. The function currently used to find the entity's parents doesn't check abstract parents or their grandparents, however, resulting in the error. 

For example, the CommandIntercom inherits from BaseIntercomSecure (an abstract prototype) which itself inherits from IntercomConstructed. The BaseIntercomSecure prototype sets the construction node to "intercomReinforced." When a player uses the welding tool on the command intercom, it changes from the "intercomReinforced" node to the "intercom" node. The "intercom" node has its prototype set as "IntercomConstructed", and the doNotReplaceInheritingEntities field set to true; as a result, the intercom shouldn't change prototypes because the construction system should recognize that it inherits from IntercomConstructed through BaseIntercomSecure. Because BaseIntercomSecure is abstract, however, the system won't realize that the intercom inherits from IntercomConstructed and will change the CommandIntercom into an IntercomConstructed, deleting the keys in the process.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/4b883a67-a8a6-4feb-bb2a-9ff0f4b69ab1

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None that I'm aware of.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Removing the security plate from an intercom will no longer delete its encryption keys.

