### PR TITLE
[HOTFIX] Admin Menu player jobs

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using Content.Server.Administration.Managers;
+using Content.Server.Administration.Systems;
 using Content.Server.GameTicking.Events;
 using Content.Server.Spawners.Components;
 using Content.Server.Speech.Components;
@@ -27,6 +28,7 @@ namespace Content.Server.GameTicking
     {
         [Dependency] private readonly IAdminManager _adminManager = default!;
         [Dependency] private readonly SharedJobSystem _jobs = default!;
+        [Dependency] private readonly AdminSystem _admin = default!;
 
         [ValidatePrototypeId<EntityPrototype>]
         public const string ObserverPrototypeName = "MobObserver";
@@ -233,6 +235,7 @@ namespace Content.Server.GameTicking
 
             _roles.MindAddJobRole(newMind, silent: silent, jobPrototype:jobId);
             var jobName = _jobs.MindTryGetJobName(newMind);
+            _admin.UpdatePlayerList(player);
 
             if (lateJoin && !silent)
             {


### PR DESCRIPTION
## About the PR
Jobs are once again shown for all players in the Admin Menu

## Technical details
Role Types requried a slight reorganisation of the GameTicker spawn sequence, which accidentally resulted in the PlayerInfo data being refreshed before the players had their job mind roles added. The order should not be changed back because it would cause SharedRoleSystem to log some errors every time a player spawns. Instead, there is now an additional playerinfo refresh after the jobs are added.

## Media
before
![image](https://github.com/user-attachments/assets/6f57a794-cedf-499f-a979-696ce1153e3c)

after
![image](https://github.com/user-attachments/assets/6ee5dd4c-f60c-48f0-ad6e-92333900785a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Errant
ADMIN:
- fix: The admin playerlist once again shows all player jobs on roundstart.