### PR TITLE
Fixed: Ore now correctly drops the right amount of ore

### DIFF
--- a/Content.Server/Mining/MiningSystem.cs
+++ b/Content.Server/Mining/MiningSystem.cs
@@ -35,7 +35,7 @@ public sealed class MiningSystem : EntitySystem
             return;
 
         var coords = Transform(uid).Coordinates;
-        var toSpawn = _random.Next(proto.MinOreYield, proto.MaxOreYield);
+        var toSpawn = _random.Next(proto.MinOreYield, proto.MaxOreYield+1);
         for (var i = 0; i < toSpawn; i++)
         {
             Spawn(proto.OreEntity, coords.Offset(_random.NextVector2(0.2f)));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Ore was broken! The new drop rates are:
```
Steel, Quartz, Coal:                 1-4 -> 1-5  (+20% increase)
Gold, Silver, Salt:                  1-2 -> 1-3  (+33% increase)
Plasma, Uranium, Bananium, Diamond:  1-1 -> 1-2  (+66% increase)
```
## Technical details
<!-- Summary of code changes for easier review. -->
`random.Next` has an exclusive max so max was never chosen! Added 1 so the max actually happens. 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Ore rocks now drop the correct amount of ore when mined.

