### PR TITLE
added missing allowed department to the restricted severity

### DIFF
--- a/Content.IntegrationTests/Tests/ContrabandTest.cs
+++ b/Content.IntegrationTests/Tests/ContrabandTest.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Shared.Contraband;
+using Content.Shared.Prototypes;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
@@ -21,9 +22,7 @@ public sealed class ContrabandTest
             var protos = protoMan.EnumeratePrototypes<EntityPrototype>()
                 .Where(p => !p.Abstract)
                 .Where(p => !pair.IsTestPrototype(p))
-                .Where(p => p.TryGetComponent<ContrabandComponent>(out _, componentFactory))
-                .OrderBy(p => p.ID)
-                .ToList();
+                .Where(p => p.HasComponent<ContrabandComponent>(componentFactory));
 
             foreach (var proto in protos)
             {

--- a/Content.IntegrationTests/Tests/ContrabandTest.cs
+++ b/Content.IntegrationTests/Tests/ContrabandTest.cs
@@ -25,16 +25,14 @@ public sealed class ContrabandTest
                 if (!proto.TryGetComponent<ContrabandComponent>(out var contraband, componentFactory))
                     continue;
 
-                if (!protoMan.TryIndex(contraband.Severity, out var severity))
-                    Assert.Fail(@$"{proto.ID} has a ContrabandComponent with a unknown severity.");
+                Assert.That(protoMan.TryIndex(contraband.Severity, out var severity, false),
+                    @$"{proto.ID} has a ContrabandComponent with a unknown severity.");
 
-                if (severity.ShowDepartmentsAndJobs)
-                {
-                    if (contraband.AllowedDepartments.Count + contraband.AllowedJobs.Count == 0)
-                    {
-                        Assert.Fail(@$"{proto.ID} has a ContrabandComponent with ShowDepartmentsAndJobs but no allowed departments or jobs.");
-                    }
-                }
+                if (!severity.ShowDepartmentsAndJobs)
+                    continue;
+
+                Assert.That(contraband.AllowedDepartments.Count + contraband.AllowedJobs.Count, Is.Not.EqualTo(0),
+                    @$"{proto.ID} has a ContrabandComponent with ShowDepartmentsAndJobs but no allowed departments or jobs.");
             }
         });
 

--- a/Content.IntegrationTests/Tests/ContrabandTest.cs
+++ b/Content.IntegrationTests/Tests/ContrabandTest.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using Content.Shared.Contraband;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests;
+
+[TestFixture]
+public sealed class ContrabandTest
+{
+    [Test]
+    public async Task EntityShowDepartmentsAndJobs()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var client = pair.Client;
+        var protoMan = client.ResolveDependency<IPrototypeManager>();
+        var componentFactory = client.ResolveDependency<IComponentFactory>();
+
+        await client.WaitAssertion(() =>
+        {
+            var protos = protoMan.EnumeratePrototypes<EntityPrototype>()
+                .Where(p => !p.Abstract)
+                .Where(p => !pair.IsTestPrototype(p))
+                .Where(p => p.TryGetComponent<ContrabandComponent>(out _, componentFactory))
+                .OrderBy(p => p.ID)
+                .ToList();
+
+            foreach (var proto in protos)
+            {
+                Assert.That(proto.TryGetComponent<ContrabandComponent>(out var contraband, componentFactory));
+                Assert.That(protoMan.TryIndex(contraband.Severity, out var severity));
+
+                var list = contraband.AllowedDepartments.Select(p => p.Id).Concat(contraband.AllowedJobs.Select(p => p.Id)).ToList();
+                if (severity.ShowDepartmentsAndJobs)
+                    Assert.That(list, Is.Not.Empty, @$"{proto.ID} has a ContrabandComponent with ShowDepartmentsAndJobs but no allowed departments or jobs.");
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -29,6 +29,7 @@
   components:
   - type: Contraband
     severity: Restricted
+    allowedDepartments: [ Security ]
 
 # one department restricted contraband
 - type: entity


### PR DESCRIPTION
## About the PR

The #33385 PR removed the default allowedDepartments member from the ContrabandComponent class causing all entities with it to have a broken description and status.

## Why / Balance

Bugfix; Reverting it to how it was before it PR. Fixes #34581

## Technical details

- Added `allowedDepartments: [ Security ]` to `BaseRestrictedContraband`
- Added a test to check if any entity is affected by this.

## Media
![code-change](https://github.com/user-attachments/assets/8b79cc94-b8c7-4cd6-8433-a7777e0cf56b)

![before](https://github.com/user-attachments/assets/5548337b-f8fb-481a-aef9-52c44e3a2286)

![after](https://github.com/user-attachments/assets/e7dd9cb7-a50f-4e60-9ec5-acf58220593f)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Restricted contraband now gets displayed correctly.
