### PR TITLE
pluralize the job name in the contra description

### DIFF
--- a/Content.Shared/Contraband/ContrabandSystem.cs
+++ b/Content.Shared/Contraband/ContrabandSystem.cs
@@ -56,8 +56,8 @@ public sealed class ContrabandSystem : EntitySystem
         using (args.PushGroup(nameof(ContrabandComponent)))
         {
             // TODO shouldn't department prototypes have a localized name instead of just using the ID for this?
-            var localizedDepartments = ent.Comp.AllowedDepartments.Select(p => Loc.GetString($"department-{p.Id}"));
-            var localizedJobs = ent.Comp.AllowedJobs.Select(p => Loc.GetString("generic-plural", ("thing", _proto.Index(p).LocalizedName)));
+            var localizedDepartments = ent.Comp.AllowedDepartments.Select(p => Loc.GetString("contraband-department-plural", ("department", Loc.GetString($"department-{p.Id}"))));
+            var localizedJobs = ent.Comp.AllowedJobs.Select(p => Loc.GetString("contraband-job-plural", ("job", _proto.Index(p).LocalizedName)));
 
             var severity = _proto.Index(ent.Comp.Severity);
             if (severity.ShowDepartmentsAndJobs)

--- a/Content.Shared/Contraband/ContrabandSystem.cs
+++ b/Content.Shared/Contraband/ContrabandSystem.cs
@@ -57,7 +57,7 @@ public sealed class ContrabandSystem : EntitySystem
         {
             // TODO shouldn't department prototypes have a localized name instead of just using the ID for this?
             var localizedDepartments = ent.Comp.AllowedDepartments.Select(p => Loc.GetString($"department-{p.Id}"));
-            var localizedJobs = ent.Comp.AllowedJobs.Select(p => _proto.Index(p).LocalizedName);
+            var localizedJobs = ent.Comp.AllowedJobs.Select(p => Loc.GetString("generic-plural", ("thing", _proto.Index(p).LocalizedName)));
 
             var severity = _proto.Index(ent.Comp.Severity);
             if (severity.ShowDepartmentsAndJobs)

--- a/Resources/Locale/en-US/contraband/contraband-severity.ftl
+++ b/Resources/Locale/en-US/contraband/contraband-severity.ftl
@@ -7,3 +7,6 @@ contraband-examine-text-Syndicate = [color=crimson]This item is highly illegal S
 
 contraband-examine-text-avoid-carrying-around = [color=red][italic]You probably want to avoid visibly carrying this around without a good reason.[/italic][/color]
 contraband-examine-text-in-the-clear = [color=green][italic]You should be in the clear to visibly carry this around.[/italic][/color]
+
+contraband-department-plural = {$department}
+contraband-job-plural = {MAKEPLURAL($job)}

--- a/Resources/Locale/en-US/generic.ftl
+++ b/Resources/Locale/en-US/generic.ftl
@@ -15,5 +15,3 @@ generic-minutes = minutes
 generic-playtime-title = Playtime
 
 generic-confirm = Confirm
-
-generic-plural = {MAKEPLURAL($thing)}

--- a/Resources/Locale/en-US/generic.ftl
+++ b/Resources/Locale/en-US/generic.ftl
@@ -15,3 +15,5 @@ generic-minutes = minutes
 generic-playtime-title = Playtime
 
 generic-confirm = Confirm
+
+generic-plural = {MAKEPLURAL($thing)}


### PR DESCRIPTION
## About the PR

Change the jobname in the contraband description to its plural form.

## Why / Balance

Correct grammar.

## Technical details

Please tell me if you know a way to use the `MAKEPLURAL` ftl function directly.

- Added a `generic-plural` localization string and used it on every job in the list.

## Media

|before|after|
|-|-|
|![387075525-e9f89b29-d873-41e9-af9d-e755fec08301](https://github.com/user-attachments/assets/39124685-db9e-42d3-a2c1-e9c402d033fc)|![Screenshot From 2025-01-21 19-34-13](https://github.com/user-attachments/assets/a6fe0b0e-4b71-48e2-af9d-2f15dbd2a20b)|

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Job specific contraband descriptions are now grammatically sound.
