### PR TITLE
Fixed Attachbodypart Console Command

### DIFF
--- a/Content.Server/Body/Commands/AttachBodyPartCommand.cs
+++ b/Content.Server/Body/Commands/AttachBodyPartCommand.cs
@@ -102,7 +102,7 @@ namespace Content.Server.Body.Commands
 
             if (body.RootContainer.ContainedEntity is null && !bodySystem.AttachPartToRoot(bodyId, partUid.Value, body, part))
             {
-                shell.WriteError("Whoopsie!");
+                shell.WriteError("Body container does not have a root entity to attach to the body part!");
                 return;
             }
 
@@ -117,8 +117,6 @@ namespace Content.Server.Body.Commands
                 shell.WriteError($"Could not create slot {slotId} on entity {_entManager.ToPrettyString(bodyId)}");
                 return;
             }
-
-
             shell.WriteLine($"Attached part {_entManager.ToPrettyString(partUid.Value)} to {_entManager.ToPrettyString(bodyId)}");
         }
     }


### PR DESCRIPTION
## About the PR
Fixed a console command that would state it was functioning as intended but never actually attached a selected limb to an entity.

_Massive thanks for Milon for helping out with this code!_

## Why / Balance
Want to mess with attaching body parts and would be good to have a command working.

## Technical details
First portion of the implementation to connect a limb checked if the root container wasn't null, which in the right circumstance should be the case. This meant that the code to simply check was always running, and never the code to **actually** connect the limp.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Attachbodypart command now functions as intended.
