### PR TITLE
Reduce base electrocution stun time from 8 to 5 seconds

### DIFF
--- a/Content.Shared/Electrocution/Components/ElectrifiedComponent.cs
+++ b/Content.Shared/Electrocution/Components/ElectrifiedComponent.cs
@@ -103,7 +103,7 @@ public sealed partial class ElectrifiedComponent : Component
     /// Shock time, in seconds.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float ShockTime = 8f;
+    public float ShockTime = 3f;
 
     [DataField, AutoNetworkedField]
     public float SiemensCoefficient = 1f;

--- a/Content.Shared/Electrocution/Components/ElectrifiedComponent.cs
+++ b/Content.Shared/Electrocution/Components/ElectrifiedComponent.cs
@@ -82,7 +82,7 @@ public sealed partial class ElectrifiedComponent : Component
     /// Shock time multiplier for HV electrocution
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float HighVoltageTimeMultiplier = 1.5f;
+    public float HighVoltageTimeMultiplier = 2f;
 
     /// <summary>
     /// Damage multiplier for MV electrocution
@@ -94,7 +94,7 @@ public sealed partial class ElectrifiedComponent : Component
     /// Shock time multiplier for MV electrocution
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float MediumVoltageTimeMultiplier = 1.25f;
+    public float MediumVoltageTimeMultiplier = 1.5f;
 
     [DataField, AutoNetworkedField]
     public float ShockDamage = 7.5f;
@@ -103,7 +103,7 @@ public sealed partial class ElectrifiedComponent : Component
     /// Shock time, in seconds.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float ShockTime = 3f;
+    public float ShockTime = 5f;
 
     [DataField, AutoNetworkedField]
     public float SiemensCoefficient = 1f;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Electrocution stun duration decreased overall; LV or hacking from 8 seconds to 5, MV from 10 seconds to 7.5, HV from 12 seconds to 10.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Being stunned for 8 seconds because you stood too close to a grille is arguably too long given the faster combat and pacing of SS14. 

Doesn't resolve the issue of getting stunlocked and dragged into grilles repeatedly.

## Technical details
<!-- Summary of code changes for easier review. -->
cs change only
- `Content.Shared/Electrocution/Components/ElectrifiedComponent.cs` (reduced ShockTime from 8 to 5 seconds)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Electrocution stun duration decreased overall; LV or hacking from 8 seconds to 5, MV from 10 seconds to 7.5, HV from 12 seconds to 10.
