### PR TITLE
remove tropico from devmap

### DIFF
--- a/Resources/Maps/Test/dev_map.yml
+++ b/Resources/Maps/Test/dev_map.yml
@@ -6701,13 +6701,6 @@ entities:
     - type: Transform
       pos: 3.5,8.5
       parent: 179
-- proto: SpawnMobCrabAtmos
-  entities:
-  - uid: 729
-    components:
-    - type: Transform
-      pos: 15.5,-10.5
-      parent: 179
 - proto: SpawnMobHuman
   entities:
   - uid: 138


### PR DESCRIPTION
## About the PR
Sends devmap's tropico to the farm

## Why / Balance
Fixes #34576
The presence of any mobs can sometime interfere with testing by tripping breakpoints, particularly when they can walk into zones full of various gases. When one has to delete the mobs for every test, having to go and hunt down tropico in another room each time gets annoying

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
