### PR TITLE
Pulled item interaction fix

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
@@ -188,11 +188,13 @@ public abstract partial class SharedHandsSystem : EntitySystem
         if (args.Handled)
             return;
 
-        // TODO: this pattern is super uncommon, but it might be worth changing GetUsedEntityEvent to be recursive.
-        if (TryComp<VirtualItemComponent>(component.ActiveHandEntity, out var virtualItem))
-            args.Used = virtualItem.BlockingEntity;
-        else
-            args.Used = component.ActiveHandEntity;
+        if (component.ActiveHandEntity.HasValue)
+        {
+            // allow for the item to return a different entity, e.g. virtual items
+            RaiseLocalEvent(component.ActiveHandEntity.Value, ref args);
+        }
+
+        args.Used ??= component.ActiveHandEntity;
     }
 
     //TODO: Actually shows all items/clothing/etc.

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -1409,7 +1409,7 @@ namespace Content.Shared.Interaction
         /// <returns>If there is an entity being used.</returns>
         public bool TryGetUsedEntity(EntityUid user, [NotNullWhen(true)] out EntityUid? used, bool checkCanUse = true)
         {
-            var ev = new GetUsedEntityEvent();
+            var ev = new GetUsedEntityEvent(user);
             RaiseLocalEvent(user, ref ev);
 
             used = ev.Used;
@@ -1460,8 +1460,9 @@ namespace Content.Shared.Interaction
     ///     Raised directed by-ref on an entity to determine what item will be used in interactions.
     /// </summary>
     [ByRefEvent]
-    public record struct GetUsedEntityEvent()
+    public record struct GetUsedEntityEvent(EntityUid User)
     {
+        public EntityUid User = User;
         public EntityUid? Used = null;
 
         public bool Handled => Used != null;

--- a/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
+++ b/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
@@ -46,6 +46,8 @@ public abstract class SharedVirtualItemSystem : EntitySystem
 
         SubscribeLocalEvent<VirtualItemComponent, BeforeRangedInteractEvent>(OnBeforeRangedInteract);
         SubscribeLocalEvent<VirtualItemComponent, GettingInteractedWithAttemptEvent>(OnGettingInteractedWithAttemptEvent);
+
+        SubscribeLocalEvent<VirtualItemComponent, GetUsedEntityEvent>(OnGetUsedEntity);
     }
 
     /// <summary>
@@ -79,6 +81,23 @@ public abstract class SharedVirtualItemSystem : EntitySystem
     {
         // No interactions with a virtual item, please.
         args.Cancelled = true;
+    }
+
+    private void OnGetUsedEntity(Entity<VirtualItemComponent> ent, ref GetUsedEntityEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        // if the user is holding the real item the virtual item points to,
+        // we allow them to use it in the interaction
+        foreach (var hand in _handsSystem.EnumerateHands(args.User))
+        {
+            if (hand.HeldEntity == ent.Comp.BlockingEntity)
+            {
+                args.Used = ent.Comp.BlockingEntity;
+                return;
+            }
+        }
     }
 
     #region Hands


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR fixes an issue where pulled items, represented by a virtual item in hand, could be used in interactions as if they were being held. This PR still allows a virtual item to be used in hand interactions if its blocking (real) item is held in another hand.

Fixes #30157 
Fixes #30166 
Fixes #30161 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

We want to allow virtual items to be used if the real item they point to is also in your hands. For example, if we are holding a multi-handed item like a defibrillator, or an item wielded in both hands (currently switching hands causes it to un-wield, but maybe there is some future case), we want to be able to use it even if our active hand is the off-hand (holding the virtual item.)

However, if we are merely pulling the item, we don't want to be able to use it in hand interactions, as this allows us to use a dead zombie's strength to pry doors, or use a pulled defib with only one hand, etc.

## Technical details
<!-- Summary of code changes for easier review. -->

We raise the GetUsedEntityEvent on the active-hand item. The SharedVirtualItemSystem subscribes and checks if the user is holding the blocking (real) item in some other hand. If so, we allow the blocking item to be used in the interaction. Otherwise, we default to using the active-hand item itself.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

I'm pretty sure right-click wielding from the off-hand isn't intentional, but I just wanted to show it here as POC.

https://github.com/user-attachments/assets/48181ad3-5254-4f21-9013-f0943c468496

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: You can no longer use pulled objects as tools.