### PR TITLE
Fix vulture spawning additional salvage debris

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/vulture.toml
+++ b/Resources/ConfigPresets/WizardsDen/vulture.toml
@@ -5,6 +5,3 @@ hostname = "[EN] Wizard's Den Vulture [US East 2]"
 
 [hub]
 tags = "lang:en,region:am_n_e,rp:low"
-
-[worldgen]
-enabled = true


### PR DESCRIPTION
## About the PR
The setting was enabled on Vulture in the past, then enabled on all servers and later disabled on all servers for the salvage rework https://github.com/space-wizards/space-station-14/pull/31113, but the custom value for the vulture toml file was overlooked.

The cvar causes additional salvage wrecks to spawn around the station.

## Why / Balance
The servers should be the same for game content.

## Technical details
remove custom cvar setting for vulture
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
only affects one server, so no changelog
