### PR TITLE
Replace starter borg brain with Positronic

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -502,7 +502,7 @@
   - type: ContainerFill
     containers:
       borg_brain:
-        - MMIFilled
+      - PositronicBrain
   - type: ItemSlots
     slots:
       cell_slot:


### PR DESCRIPTION
## About the PR
Changes the brains of roundstart/spawnable borgs from MMI to Positronic

## Why / Balance
#32586 made the roundstart/spawnable borgs all have MMI brains, apparently somewhat arbitrarily (it's not even mentioned anywhere). I think it's more fitting for them to be fully synthetic, and MMI only be used for brains actually saved during the round.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Errant
- tweak: Cyborgs now start with positronic brains.
