### PR TITLE
Fix hitscan reflection ignoring reflects param

### DIFF
--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -62,7 +62,7 @@ public sealed class ReflectSystem : EntitySystem
 
         foreach (var ent in _inventorySystem.GetHandOrInventoryEntities(uid, SlotFlags.All & ~SlotFlags.POCKET))
         {
-            if (!TryReflectHitscan(uid, ent, args.Shooter, args.SourceItem, args.Direction, out var dir))
+            if (!TryReflectHitscan(uid, ent, args.Shooter, args.SourceItem, args.Reflective, args.Direction, out var dir))
                 continue;
 
             args.Direction = dir.Value;
@@ -142,13 +142,10 @@ public sealed class ReflectSystem : EntitySystem
 
     private void OnReflectHitscan(EntityUid uid, ReflectComponent component, ref HitScanReflectAttemptEvent args)
     {
-        if (args.Reflected ||
-            (component.Reflects & args.Reflective) == 0x0)
-        {
+        if (args.Reflected)
             return;
-        }
 
-        if (TryReflectHitscan(uid, uid, args.Shooter, args.SourceItem, args.Direction, out var dir))
+        if (TryReflectHitscan(uid, uid, args.Shooter, args.SourceItem, args.Reflective, args.Direction, out var dir))
         {
             args.Direction = dir.Value;
             args.Reflected = true;
@@ -160,11 +157,13 @@ public sealed class ReflectSystem : EntitySystem
         EntityUid reflector,
         EntityUid? shooter,
         EntityUid shotSource,
+        ReflectType reflective,
         Vector2 direction,
         [NotNullWhen(true)] out Vector2? newDirection)
     {
         if (!TryComp<ReflectComponent>(reflector, out var reflect) ||
             !_toggle.IsActivated(reflector) ||
+            (reflect.Reflects & reflective) == 0x0 ||
             !_random.Prob(reflect.ReflectProb))
         {
             newDirection = null;


### PR DESCRIPTION
## About the PR
Reflection code ignores `reflective` and `reflects` params in the reflector and hitscan when handling user reflection (when character reflects using sword or armor). It's not true for general reflection (when character has component `ReflectionComponent`), so I think it's a bug.

## Why / Balance
It's a bug.

## Technical details
Moved reflection check from event handlers to `TryReflectHitscan`. `TryReflectProjectile` has the similar check.

## Media

https://github.com/user-attachments/assets/8c12e40d-c3c0-4e7f-8780-1dcd6e66fb76

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None, it's a bug

**Changelog**
There's no items that were affected by this, so no CL.