### PR TITLE
Changes acids to work on dead, 400 caustic damage gibs with acidifier VFX but does not destroy items.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -69,6 +69,18 @@
       - !type:GibBehavior { }
     - trigger:
         !type:DamageTypeTrigger
+        damageType: Caustic
+        damage: 400
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawnInContainer: false
+        spawn:
+          Acidifier:
+            min: 1
+            max: 1
+      - !type:GibBehavior { }
+    - trigger:
+        !type:DamageTypeTrigger
         damageType: Heat
         damage: 1500
       behaviors:

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -124,6 +124,7 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: acid
   color: "#a1000b"
+  worksOnTheDead: true
   boilingPoint: 78.2 # This isn't a real chemical...
   meltingPoint: -19.4
   plantMetabolism:
@@ -170,6 +171,7 @@
   desc: reagent-desc-ferrochromic-acid
   flavor: sour
   color: "#48b3b8"
+  worksOnTheDead: true
   physicalDesc: reagent-physical-desc-ferrous
   slippery: false
   metabolisms:
@@ -193,6 +195,7 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: acid
   color: "#5050ff"
+  worksOnTheDead: true
   boilingPoint: 165
   meltingPoint: -87
   reactiveEffects:
@@ -233,6 +236,7 @@
   physicalDesc: reagent-physical-desc-oily
   flavor: acid
   color: "#BF8C00"
+  worksOnTheDead: true
   recognizable: true
   boilingPoint: 337.0
   meltingPoint: 10.31


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Polytrinic acid, fluorosulfuric acid, sulfuric acid and ferrochromic acid were changed to work on the dead. Bodies now gib at 400 caustic damage and spawn the death acidifier VFX, but do not delete items.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I thought it would be cool if acids could acidify! I did not want it to delete items because that already has weird interactions with the meat spike and the death acidifier AFAIK. It takes 110 units of polytrinic acid, 150 units of fluorosulfuric acid, 200 units of ferrochromic acid, or 240 units of sulfuric acid to melt someone. After factoring in the contact damage, it takes about the same amount of each in an acid foam to dissolve people who stay inside for the full duration. 
## Technical details
<!-- Summary of code changes for easier review. -->
New trigger added to the base mob .yml for 400 caustic gibbing, also spawns acidifier VFX entity in the same way ash spawns at 1500 heat. spawnInContainer set to false so that the VFX spawns outside of any containers the mob dissolved in.
worksOnTheDead: true added to Polytrinic, Fluorosulfuric, Sulfuric, and Ferrochromic acids.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Begone Urist](https://github.com/user-attachments/assets/92d835db-232c-4fe7-8409-af40786e8a31)
![RIP Urist](https://github.com/user-attachments/assets/82faab06-a9de-4444-9ebf-f075442a0eab)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None that I'm aware of.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: Polytrinic, Fluorosulfuric, Ferrochromic, and Sulfuric Acids now work on the dead.
- add: Bodies now gib at 400 caustic damage with acidifier visual (does not destroy items).