### PR TITLE
Remove instant cryobed insertion

### DIFF
--- a/Content.Shared/Containers/DragInsertContainerComponent.cs
+++ b/Content.Shared/Containers/DragInsertContainerComponent.cs
@@ -22,7 +22,7 @@ public sealed partial class DragInsertContainerComponent : Component
     /// The delay in seconds before a drag will be completed.
     /// </summary>
     [DataField]
-    public float EntryDelay;
+    public TimeSpan EntryDelay = TimeSpan.Zero;
 
     /// <summary>
     /// If entry delay isn't zero, this sets whether an entity dragging itself into the container should be delayed.

--- a/Content.Shared/Containers/DragInsertContainerComponent.cs
+++ b/Content.Shared/Containers/DragInsertContainerComponent.cs
@@ -17,4 +17,16 @@ public sealed partial class DragInsertContainerComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool UseVerbs = true;
+
+    /// <summary>
+    /// The delay in seconds before a drag will be completed.
+    /// </summary>
+    [DataField]
+    public float EntryDelay;
+
+    /// <summary>
+    /// If entry delay isn't zero, this sets whether an entity dragging itself into the container should be delayed.
+    /// </summary>
+    [DataField]
+    public bool DelaySelfEntry = false;
 }

--- a/Content.Shared/Containers/DragInsertContainerSystem.cs
+++ b/Content.Shared/Containers/DragInsertContainerSystem.cs
@@ -37,9 +37,8 @@ public sealed partial class DragInsertContainerSystem : EntitySystem
         if (!_container.TryGetContainer(ent, comp.ContainerId, out var container))
             return;
 
-        if (comp.EntryDelay <= 0 ||
-            !comp.DelaySelfEntry && args.User == args.Dragged
-            )
+        if (comp.EntryDelay <= TimeSpan.Zero ||
+            !comp.DelaySelfEntry && args.User == args.Dragged)
         {
             //instant insertion
             args.Handled = Insert(args.Dragged, args.User, ent, container);

--- a/Content.Shared/Containers/DragInsertContainerSystem.cs
+++ b/Content.Shared/Containers/DragInsertContainerSystem.cs
@@ -2,24 +2,28 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Climbing.Systems;
 using Content.Shared.Database;
+using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Containers;
 
-public sealed class DragInsertContainerSystem : EntitySystem
+public sealed partial class DragInsertContainerSystem : EntitySystem
 {
     [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly ClimbSystem _climb = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<DragInsertContainerComponent, DragDropTargetEvent>(OnDragDropOn, before: new []{ typeof(ClimbSystem)});
+        SubscribeLocalEvent<DragInsertContainerComponent, DragInsertContainerInsertFinished>(OnDragFinished);
         SubscribeLocalEvent<DragInsertContainerComponent, CanDropTargetEvent>(OnCanDragDropOn);
         SubscribeLocalEvent<DragInsertContainerComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAlternativeVerb);
     }
@@ -33,7 +37,34 @@ public sealed class DragInsertContainerSystem : EntitySystem
         if (!_container.TryGetContainer(ent, comp.ContainerId, out var container))
             return;
 
-        args.Handled = Insert(args.Dragged, args.User, ent, container);
+        if (comp.EntryDelay <= 0 ||
+            !comp.DelaySelfEntry && args.User == args.Dragged
+            )
+        {
+            args.Handled = Insert(args.Dragged, args.User, ent, container);
+            return;
+        }
+
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, comp.EntryDelay, new DragInsertContainerInsertFinished(), ent, args.Dragged, ent)
+        {
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            NeedHand = false,
+        };
+        _doAfter.TryStartDoAfter(doAfterArgs);
+        args.Handled = true;
+    }
+
+    private void OnDragFinished(Entity<DragInsertContainerComponent> ent, ref DragInsertContainerInsertFinished args)
+    {
+        if (args.Handled || args.Cancelled || args.Args.Target == null)
+            return;
+
+        if (!_container.TryGetContainer(ent, ent.Comp.ContainerId, out var container))
+            return;
+
+        Insert(args.Args.Target.Value, args.User, ent, container);
     }
 
     private void OnCanDragDropOn(Entity<DragInsertContainerComponent> ent, ref CanDropTargetEvent args)
@@ -116,5 +147,10 @@ public sealed class DragInsertContainerSystem : EntitySystem
 
         _adminLog.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(user):player} inserted {ToPrettyString(target):player} into container {ToPrettyString(containerEntity)}");
         return true;
+    }
+
+    [Serializable, NetSerializable]
+    public sealed partial class DragInsertContainerInsertFinished : SimpleDoAfterEvent
+    {
     }
 }

--- a/Content.Shared/Containers/DragInsertContainerSystem.cs
+++ b/Content.Shared/Containers/DragInsertContainerSystem.cs
@@ -41,11 +41,12 @@ public sealed partial class DragInsertContainerSystem : EntitySystem
             !comp.DelaySelfEntry && args.User == args.Dragged
             )
         {
+            //instant insertion
             args.Handled = Insert(args.Dragged, args.User, ent, container);
             return;
         }
 
-
+        //delayed insertion
         var doAfterArgs = new DoAfterArgs(EntityManager, args.User, comp.EntryDelay, new DragInsertContainerInsertFinished(), ent, args.Dragged, ent)
         {
             BreakOnDamage = true,

--- a/Content.Shared/Containers/DragInsertContainerSystem.cs
+++ b/Content.Shared/Containers/DragInsertContainerSystem.cs
@@ -23,7 +23,7 @@ public sealed partial class DragInsertContainerSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<DragInsertContainerComponent, DragDropTargetEvent>(OnDragDropOn, before: new []{ typeof(ClimbSystem)});
-        SubscribeLocalEvent<DragInsertContainerComponent, DragInsertContainerInsertFinished>(OnDragFinished);
+        SubscribeLocalEvent<DragInsertContainerComponent, DragInsertContainerDoAfterEvent>(OnDragFinished);
         SubscribeLocalEvent<DragInsertContainerComponent, CanDropTargetEvent>(OnCanDragDropOn);
         SubscribeLocalEvent<DragInsertContainerComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAlternativeVerb);
     }
@@ -46,7 +46,7 @@ public sealed partial class DragInsertContainerSystem : EntitySystem
         }
 
         //delayed insertion
-        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, comp.EntryDelay, new DragInsertContainerInsertFinished(), ent, args.Dragged, ent)
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, comp.EntryDelay, new DragInsertContainerDoAfterEvent(), ent, args.Dragged, ent)
         {
             BreakOnDamage = true,
             BreakOnMove = true,
@@ -56,7 +56,7 @@ public sealed partial class DragInsertContainerSystem : EntitySystem
         args.Handled = true;
     }
 
-    private void OnDragFinished(Entity<DragInsertContainerComponent> ent, ref DragInsertContainerInsertFinished args)
+    private void OnDragFinished(Entity<DragInsertContainerComponent> ent, ref DragInsertContainerDoAfterEvent args)
     {
         if (args.Handled || args.Cancelled || args.Args.Target == null)
             return;
@@ -150,7 +150,7 @@ public sealed partial class DragInsertContainerSystem : EntitySystem
     }
 
     [Serializable, NetSerializable]
-    public sealed partial class DragInsertContainerInsertFinished : SimpleDoAfterEvent
+    public sealed partial class DragInsertContainerDoAfterEvent : SimpleDoAfterEvent
     {
     }
 }

--- a/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
+++ b/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
@@ -25,6 +25,7 @@
     canCollide: false
   - type: DragInsertContainer
     containerId: storage
+    entryDelay: 2
   - type: ExitContainerOnMove
     containerId: storage
   - type: PointLight


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a delay when putting someone else into a cryobed.

## Why / Balance
It's currently possible to trap someone in a cryobed by repeatedly dragging them into it. When they get out, they don't have time to do anything before being dragged back in.
Resolves #33983

## Technical details
Adds an EntryDelay field to the DragInsertContainer component. When it has a value other than zero, insertions will be handled after a doAfter. Also adds another field, DelaySelfEntry, that determines whether someone dragging themself into the container should have the delay.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/28119c78-cbcc-4198-8c70-c28a1e81669e


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Adds two fields to DragInsertContainerComponent.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Inserting another person into a cryogenic sleeping unit is no longer instant.
