### PR TITLE
HOTFIX: Fix lineedit focus

### DIFF
--- a/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
+++ b/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
@@ -33,15 +33,14 @@ namespace Content.Client.Labels.UI
                 _focused = false;
                 LabelLineEdit.Text = _label;
             };
-
-            // Give the editor keybard focus, since that's the only
-            // thing the user will want to be doing with this UI
-            // LabelLineEdit.GrabKeyboardFocus();
         }
 
         protected override void Opened()
         {
             base.Opened();
+            
+            // Give the editor keyboard focus, since that's the only
+            // thing the user will want to be doing with this UI
             LabelLineEdit.GrabKeyboardFocus();
         }
 

--- a/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
+++ b/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
@@ -39,13 +39,10 @@ namespace Content.Client.Labels.UI
             // LabelLineEdit.GrabKeyboardFocus();
         }
 
-        protected override void EnteredTree()
+        protected override void Opened()
         {
-            base.EnteredTree();
-            
-            // Give the editor keybard focus, since that's the only
-            // thing the user will want to be doing with this UI
-            Root?.Window?.TextInputStart();
+            base.Opened();
+            LabelLineEdit.GrabKeyboardFocus();
         }
 
         public void SetCurrentLabel(string label)

--- a/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
+++ b/Content.Client/Labels/UI/HandLabelerWindow.xaml.cs
@@ -36,7 +36,16 @@ namespace Content.Client.Labels.UI
 
             // Give the editor keybard focus, since that's the only
             // thing the user will want to be doing with this UI
-            LabelLineEdit.GrabKeyboardFocus();
+            // LabelLineEdit.GrabKeyboardFocus();
+        }
+
+        protected override void EnteredTree()
+        {
+            base.EnteredTree();
+            
+            // Give the editor keybard focus, since that's the only
+            // thing the user will want to be doing with this UI
+            Root?.Window?.TextInputStart();
         }
 
         public void SetCurrentLabel(string label)

--- a/Content.Client/UserInterface/Controls/DialogWindow.xaml.cs
+++ b/Content.Client/UserInterface/Controls/DialogWindow.xaml.cs
@@ -87,9 +87,6 @@ public sealed partial class DialogWindow : FancyWindow
             Prompts.AddChild(box);
         }
 
-        // Grab keyboard focus for the first dialog entry
-        _promptLines[0].Item2.GrabKeyboardFocus();
-
         OkButton.OnPressed += _ => Confirm();
 
         CancelButton.OnPressed += _ =>
@@ -108,6 +105,14 @@ public sealed partial class DialogWindow : FancyWindow
         MinWidth *= 2; // Just double it.
 
         OpenCentered();
+    }
+
+    protected override void Opened()
+    {
+        base.Opened();
+        
+        // Grab keyboard focus for the first dialog entry
+        _promptLines[0].Item2.GrabKeyboardFocus();
     }
 
     private void Confirm()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes keyboard focus on window open for Hand Labeler, Phone, Pray, Rename, and multiple other admin verbs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #34916
Fixes #34592

## Technical details
<!-- Summary of code changes for easier review. -->

Broke back in https://github.com/space-wizards/RobustToolbox/commit/87a574551957e5a37459120060c332050dd587bd, due to                 `TextInputStart` calls changing from `_clyde` to `Root?.Window?`. Root does not get set until after the LineEdit or TextEdit are added to the tree. Calling GrabKeyboardFocus in the constructor runs TextInputStart before the LineEdit is added to the tree.

This moves GrabKeyboardFocus to Opened, which runs after adding to the tree.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed keyboard focus on UI open for Hand Labeler, Phone, and Pray UIs.
ADMIN:
- fix: Fixed keyboard focus on UI open for Rename and other admin verbs.
