### PR TITLE
safe embeddable checks

### DIFF
--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -104,9 +104,9 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         Embed(uid, args.Target, args.Shooter, component);
 
         // Raise a specific event for projectiles.
-        if (TryComp(uid, out ProjectileComponent? projectile))
+        if (TryComp(uid, out ProjectileComponent? projectile) && projectile.Shooter is not null && projectile.Weapon is not null)
         {
-            var ev = new ProjectileEmbedEvent(projectile.Shooter!.Value, projectile.Weapon!.Value, args.Target);
+            var ev = new ProjectileEmbedEvent(projectile.Shooter.Value, projectile.Weapon.Value, args.Target);
             RaiseLocalEvent(uid, ref ev);
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Just making code more crash-safe

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
![image](https://github.com/user-attachments/assets/4d5c74dc-7fa7-4833-8f24-77ad1afd97b8)
i catch random integration tests thats fails in this point, and i see unsafe .! calls. I dont like unsafe !!!
