### PR TITLE
Replace DoorVisuals.Powered with PowerDeviceVisuals.Powered

### DIFF
--- a/Content.Client/Doors/AirlockSystem.cs
+++ b/Content.Client/Doors/AirlockSystem.cs
@@ -1,6 +1,7 @@
 using Content.Client.Wires.Visualizers;
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
+using Content.Shared.Power;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
 
@@ -84,7 +85,8 @@ public sealed class AirlockSystem : SharedAirlockSystem
         if (!_appearanceSystem.TryGetData<DoorState>(uid, DoorVisuals.State, out var state, args.Component))
             state = DoorState.Closed;
 
-        if (_appearanceSystem.TryGetData<bool>(uid, DoorVisuals.Powered, out var powered, args.Component) && powered)
+        if (_appearanceSystem.TryGetData<bool>(uid, PowerDeviceVisuals.Powered, out var powered, args.Component)
+            && powered)
         {
             boltedVisible = _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.BoltLights, out var lights, args.Component)
                             && lights && (state == DoorState.Closed || state == DoorState.Welded);

--- a/Content.Server/Doors/Systems/AirlockSystem.cs
+++ b/Content.Server/Doors/Systems/AirlockSystem.cs
@@ -18,19 +18,10 @@ public sealed class AirlockSystem : SharedAirlockSystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<AirlockComponent, ComponentInit>(OnAirlockInit);
         SubscribeLocalEvent<AirlockComponent, SignalReceivedEvent>(OnSignalReceived);
 
         SubscribeLocalEvent<AirlockComponent, PowerChangedEvent>(OnPowerChanged);
         SubscribeLocalEvent<AirlockComponent, ActivateInWorldEvent>(OnActivate, before: new[] { typeof(DoorSystem) });
-    }
-
-    private void OnAirlockInit(EntityUid uid, AirlockComponent component, ComponentInit args)
-    {
-        if (TryComp<ApcPowerReceiverComponent>(uid, out var receiverComponent))
-        {
-            Appearance.SetData(uid, DoorVisuals.Powered, receiverComponent.Powered);
-        }
     }
 
     private void OnSignalReceived(EntityUid uid, AirlockComponent component, ref SignalReceivedEvent args)
@@ -46,11 +37,6 @@ public sealed class AirlockSystem : SharedAirlockSystem
     {
         component.Powered = args.Powered;
         Dirty(uid, component);
-
-        if (TryComp<AppearanceComponent>(uid, out var appearanceComponent))
-        {
-            Appearance.SetData(uid, DoorVisuals.Powered, args.Powered, appearanceComponent);
-        }
 
         if (!TryComp(uid, out DoorComponent? door))
             return;

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -37,8 +37,6 @@ namespace Content.Server.Doors.Systems
 
         private void PowerChanged(EntityUid uid, FirelockComponent component, ref PowerChangedEvent args)
         {
-            // TODO this should REALLLLY not be door specific appearance thing.
-            _appearance.SetData(uid, DoorVisuals.Powered, args.Powered);
             component.Powered = args.Powered;
             Dirty(uid, component);
         }

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -314,7 +314,6 @@ public enum DoorState : byte
 public enum DoorVisuals : byte
 {
     State,
-    Powered,
     BoltLights,
     EmergencyLights,
     ClosedLights,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Cleanup change split from firelock light changes in #28339 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Removes old powered enum value that was implemented before PowerDeviceVisuals.Powered existed.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

DoorVisuals.Powered has been removed and replaced with PowerDeviceVisuals.Powered.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
