### PR TITLE
Make MindShielded players immune to becoming Sleeper Agents.

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -503,6 +503,7 @@
       blacklist:
         components:
         - AntagImmune
+        - MindShield
       mindRoles:
       - MindRoleTraitorSleeper
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made MindShielded players ineligible to be Sleeper Agent.

## Why / Balance
Command members are antag immune due to the damage that can be caused by an antag command member. People promoted into command and mindshielded should be immune for the same reasons. This also allows for Captains to point acting heads more comfortably, knowing that they will not become a sleeper agent.

## Technical details
Single line yaml change

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/987d4a52-e01e-4ca3-82a6-8b364718be9b



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Mind Shielded players will now be immune from becoming Sleeper Agents.
