### PR TITLE
Reduced speed penalty for engineering/atmos hardsuit

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -58,8 +58,8 @@
         Heat: 0.8
         Radiation: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitAtmos
@@ -90,8 +90,8 @@
         Caustic: 0.5
         Radiation: 0.2
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineering

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -83,7 +83,7 @@
     sprite: Clothing/OuterClothing/Suits/atmos_firesuit.rsi
   - type: PressureProtection
     highPressureMultiplier: 0.02
-    lowPressureMultiplier: 1000
+    lowPressureMultiplier: 1 # Protects from fires, not space
   - type: TemperatureProtection
     heatingCoefficient: 0.001
     coolingCoefficient: 0.05
@@ -96,8 +96,8 @@
         Heat: 0.8
         Cold: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: GroupExamine
   - type: ProtectedFromStepTriggers


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR reduces the speed penalty of the atmospherics and engi hardsuits, and reduces the speed penalty of the firesuit while removing it's barotrauma resistance.

## Why / Balance
Engineers are the most common users of hardsuits (aside salvage) and are likely to be wearing them nearly constantly, particularly during eventful rounds where spacing is constant. Although both hardsuits provide relevant protection against specific hazards, they will only be used for such specific protections in specific scenarios. Given the hardsuits are used primarily for their space protection, the 30% speed penalty is harsh. 

This penalty would make sense if the hardsuit was used explicitly for engine maintenance, and another alternative was available for station repairs, but this alternative does not exist - meaning that going to work sites requires engineers endure the 30% speed penalty always.

This PR reduces the speed penalty to 20%, which is still very noticable, but makes slogging between engineering and breach sites more bearable. This brings it in line with other non-combat hardsuits.

For atmos techs specifically, they had access to the firesuit, which was better than the hardsuit for almost all situations because it had less speed penalty. In line with the speed penalty reduction for the hardsuits, the atmos tech's firesuit has had it's speed penalty reduced from 20% to 10%, but removes it's spacing resistance. It will still protect the wearer from high pressures, which makes it perfect for quickly responding to station fires - but not outright better than the hardsuit.

## Technical details
Changed engineering hardsuit speed modifier from 0.7 to 0.8
Changed atmospheric hardsuit speed modifier from 0.7 to 0.8
Changed atmospheric firesuit speed modifier from 0.8 to 0.9
Changed atmospheric firesuit low pressure multiplier from 1000 to 1

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Reduced the engineering and atmospheric hardsuit speed penalty to 20%
- tweak: Reduced the atmospheric firesuit speed penalty to 10%
- tweak: The atmospheric firesuit no longer provides space protection
