### PR TITLE
Added Unused HoS's Flask to HoS locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -329,6 +329,7 @@
     - id: SecurityTechFabCircuitboard
     - id: WeaponDisabler
     - id: WantedListCartridge
+    - id: DrinkHosFlask
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable


### PR DESCRIPTION
## About the PR
Added an unused item called the 'hos's flask' to the spawn of the hos locker. I am unsure why this wasn't already but wanted to see if this is unintended.

## Why / Balance
Flask is nice, detective has one so I wanted to use this cool unused item and give it some life for all heads of security out there!

## Technical details
Added one line to heads.yml

## Media
![image](https://github.com/user-attachments/assets/592792e4-a160-44f2-bef0-b97b47cdaa2c)
_(Kai HoS real...?)_

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- add: Added the HoS's flask to their respective lockers.
