### PR TITLE
Adding the ability and implementing using job pools for trainee and regular jobs

### DIFF
--- a/Content.Server/Station/Components/StationJobsComponent.cs
+++ b/Content.Server/Station/Components/StationJobsComponent.cs
@@ -79,4 +79,29 @@ public sealed partial class StationJobsComponent : Component
     /// </summary>
     [DataField("availableJobs", required: true)]
     public Dictionary<ProtoId<JobPrototype>, int[]> SetupAvailableJobs = default!;
+
+    /// <summary>
+    /// Dictionary contatining jobs that are in a shared job pools, containing the usual roundstart, midround or negative value.
+    /// JobGroup class described separately
+    /// </summary>
+    [DataField("jobGroups")]
+    public Dictionary<string, JobGroup> JobGroups = new();
+
+}
+
+/// <summary>
+/// Containing list of jobs that are part of shared job pool
+/// Also containing numbers for the usual roundstart/midround amount logic
+/// </summary>
+[DataDefinition]
+public sealed partial class JobGroup
+{
+    [DataField("roundStart")]
+    public int RoundStart;
+
+    [DataField("midRound")]
+    public int MidRound;
+
+    [DataField("members")]
+    public List<ProtoId<JobPrototype>> Members = new();
 }

--- a/Content.Server/Station/Systems/StationJobsSystem.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.cs
@@ -75,6 +75,18 @@ public sealed partial class StationJobsSystem : EntitySystem
             x => x.Key,
             x=> (int?)(x.Value[1] < 0 ? null : x.Value[1]));
 
+        /// JobGroup logic
+        foreach (var (_, group) in stationJobs.JobGroups)
+        {
+            foreach (var member in group.Members)
+            {
+                if (stationJobs.JobList.TryGetValue(member, out _))
+                {
+                    stationJobs.JobList[member] = group.MidRound;
+                }
+            }
+        }
+
         stationJobs.TotalJobs = stationJobs.JobList.Values.Select(x => x ?? 0).Sum();
 
         UpdateJobsAvailable();
@@ -160,6 +172,29 @@ public sealed partial class StationJobsSystem : EntitySystem
 
         if (amount == 0)
             return true;
+
+        //Adjustment logic for jobs that are in JobGroups
+        foreach (var (_, group) in stationJobs.JobGroups)
+        {
+            if (group.Members.Contains(jobPrototypeId))
+                {
+                    var newMidRound = group.MidRound + amount;
+                
+                    if (newMidRound < 0 && !clamp)
+                        return false;
+
+                    group.MidRound = Math.Max(newMidRound, 0);
+                
+                    // Update all group members
+                    foreach (var member in group.Members)
+                    {
+                        stationJobs.JobList[member] = group.MidRound;
+                    }
+                
+                    UpdateJobsAvailable();
+                    return true;
+                }
+        }
 
         switch (jobList.TryGetValue(jobPrototypeId, out var available))
         {
@@ -343,6 +378,16 @@ public sealed partial class StationJobsSystem : EntitySystem
     {
         if (!Resolve(station, ref stationJobs))
             throw new ArgumentException("Tried to use a non-station entity as a station!", nameof(station));
+
+        /// Logic to update slots for jobs in JobGroups
+        foreach (var (_, group) in stationJobs.JobGroups)
+        {
+            if (group.Members.Contains(jobPrototypeId))
+            {
+                slots = group.MidRound;
+                return true;
+            }
+        }
 
         return stationJobs.JobList.TryGetValue(jobPrototypeId, out slots);
     }

--- a/Content.Server/Station/Systems/StationJobsSystem.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.cs
@@ -82,7 +82,7 @@ public sealed partial class StationJobsSystem : EntitySystem
             {
                 if (stationJobs.JobList.TryGetValue(member, out _))
                 {
-                    stationJobs.JobList[member] = group.MidRound;
+                    stationJobs.JobList[member] = group.RoundStart;
                 }
             }
         }

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -31,25 +31,25 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 2, 4 ]
-            TechnicalAssistant: [ 1, 1 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 2, 4 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 1, 2 ]
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 1, 2 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 1, 1 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 1, 1 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -63,3 +63,28 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 3
+              midRound: 5
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 3
+              midRound: 6
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 5
+              midRound: 6
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 5
+              midRound: 5
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -31,24 +31,24 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 4, 4 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -63,3 +63,29 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 7
+              midRound: 7
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 9
+              midRound: 9
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - SecurityOfficer
+                - SecurityCadet
+

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -30,25 +30,25 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 4, 4 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 5, 5 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -62,4 +62,28 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
-
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 9
+              midRound: 9
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 9
+              midRound: 9
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 9
+              midRound: 9
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -32,8 +32,8 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
+            StationEngineer: [ 0, 0 ]
+            TechnicalAssistant: [ 0, 0 ]
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 3, 3 ]
@@ -65,3 +65,10 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 3, 3 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 7
+              midRound: 7
+              members:
+                - StationEngineer
+                - TechnicalAssistant

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -37,20 +37,20 @@
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 3, 3 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 3 ]
+            MedicalDoctor: [ 0, 0 ]
+            MedicalIntern: [ 0, 0 ]
             Psychologist: [ 1, 1 ]
             Paramedic: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 3, 3 ]
+            Scientist: [ 0, 0 ]
+            ResearchAssistant: [ 0, 0 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
+            SecurityOfficer: [ 0, 0 ]
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 0, 0 ]
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -72,3 +72,23 @@
               members:
                 - StationEngineer
                 - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 7
+              midRound: 7
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - SecurityOfficer
+                - SecurityCadet
+            
+            

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -31,25 +31,25 @@
             ServiceWorker: [ 3, 3 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
-            StationEngineer: [ 4, 4 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
             AtmosphericTechnician: [ 2, 2 ]
-            TechnicalAssistant: [ 2, 2 ]
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
-            MedicalDoctor: [ 3, 4 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
             Chemist: [ 2, 2 ]
-            MedicalIntern: [ 2, 2 ]
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 1, 2 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 3, 3 ]
-            ResearchAssistant: [ 1, 1 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Warden: [ 1, 1 ]
             Lawyer: [ 1, 1 ]
-            SecurityCadet: [ 1, 1 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
             #supply
             CargoTechnician: [ 3, 3 ]
@@ -65,3 +65,28 @@
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 6
+              midRound: 6
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 5
+              midRound: 6
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 4
+              midRound: 4
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 5
+              midRound: 5
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -33,25 +33,25 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 3, 4 ]
-            TechnicalAssistant: [ 2, 2 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            MedicalIntern: [ 2, 2 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 1, 1 ]
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 3, 4 ]
-            ResearchAssistant: [ 2, 2 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 3, 4 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 1, 1 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -65,3 +65,28 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 5
+              midRound: 6
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 5
+              midRound: 5
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 5
+              midRound: 6
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 5
+              midRound: 6
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -32,24 +32,24 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 3, 3 ]
-            MedicalDoctor: [ 6, 6 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 6, 6 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 8, 8 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -63,3 +63,28 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 9
+              midRound: 9
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 10
+              midRound: 10
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 11
+              midRound: 11
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 12
+              midRound: 12
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/gate.yml
+++ b/Resources/Prototypes/Maps/gate.yml
@@ -31,25 +31,25 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 4, 4 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 6, 6 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -63,3 +63,28 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 7
+              midRound: 7
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 10
+              midRound: 10
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/loop.yml
+++ b/Resources/Prototypes/Maps/loop.yml
@@ -31,24 +31,24 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 5, 5 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 3, 3 ]
-            MedicalDoctor: [ 4, 5 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 4, 4 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 5, 5 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -63,3 +63,28 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 10
+              midRound: 10
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 8
+              midRound: 9
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 9
+              midRound: 9
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 9
+              midRound: 9
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -30,25 +30,25 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 3 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Psychologist: [ 1, 1 ]
             Paramedic: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 3, 3 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -62,3 +62,28 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 7
+              midRound: 7
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 7
+              midRound: 7
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 7
+              midRound: 7
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -30,24 +30,24 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 6, 8 ]
-            TechnicalAssistant: [ 6, 8 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 3 ]
-            MedicalDoctor: [ 4, 6 ]
-            MedicalIntern: [ 4, 6 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 1, 2 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 7 ]
-            ResearchAssistant: [ 3, 6 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 6, 6 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -61,3 +61,28 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 4, 4 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 12
+              midRound: 16
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 8
+              midRound: 12
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 8
+              midRound: 13
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 10
+              midRound: 10
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -31,27 +31,27 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 6, 6 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 6, 6 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 8, 8 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 3, 3 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -62,3 +62,28 @@
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 9
+              midRound: 9
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 10
+              midRound: 10
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 11
+              midRound: 11
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 12
+              midRound: 12
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -30,24 +30,24 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 3, 3 ]
-            TechnicalAssistant: [ 2, 2 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 2, 2 ]
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 2, 2 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 1, 1 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -61,3 +61,28 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 5
+              midRound: 5
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 5
+              midRound: 5
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 6
+              midRound: 6
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 6
+              midRound: 6
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -30,24 +30,24 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            MedicalIntern: [ 2, 2 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 2, 2 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 1, 1 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -61,3 +61,28 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 7
+              midRound: 7
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 5
+              midRound: 5
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 6
+              midRound: 6
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 6
+              midRound: 6
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -40,27 +40,52 @@
             Musician: [ 1, 1 ]
             #engineering - 8-12
             AtmosphericTechnician: [ 4, 4 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical - 9-13
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Psychologist: [ 1, 1 ]
             #science - 7-13
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 4, 4 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             StationAi: [ 1, 1 ]
             Borg: [ 2, 4 ]
             #security - 9-17
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 6, 8 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
             Detective: [ 1, 2 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 1, 2 ]
             #supply - 8-10
             SalvageSpecialist: [ 4, 4 ]
             CargoTechnician: [ 4, 6 ]
             #civilian - the tiders yearn for the mines
             Passenger: [ -1, -1 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 10
+              midRound: 12
+              members:
+                - SecurityOfficer
+                - SecurityCadet

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -29,25 +29,25 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 3, 3 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 2, 2 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             Borg: [ 2, 2 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
             Detective: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 1, 3 ]
@@ -57,4 +57,30 @@
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 7
+              midRound: 7
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 6
+              midRound: 6
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 8
+              midRound: 8
+              members:
+                - SecurityOfficer
+                - SecurityCadet
+
 

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -33,23 +33,23 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 2, 2 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
+            StationEngineer: [ 0, 0 ] # Handled in its own jobgroup
+            TechnicalAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 2, 2 ]
-            MedicalIntern: [ 2, 2 ]
+            MedicalDoctor: [ 0, 0 ] # Handled in its own jobgroup
+            MedicalIntern: [ 0, 0 ] # Handled in its own jobgroup
             Paramedic: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 2, 2 ]
+            Scientist: [ 0, 0 ] # Handled in its own jobgroup
+            ResearchAssistant: [ 0, 0 ] # Handled in its own jobgroup
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 6, 6 ]
-            SecurityCadet: [ 3, 3 ]
+            SecurityOfficer: [ 0, 0 ] # Handled in its own jobgroup
+            SecurityCadet: [ 0, 0 ] # Handled in its own jobgroup
             Lawyer: [ 1, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -62,3 +62,29 @@
             Musician: [ 1, 1 ]
             Borg: [ 2, 2 ]
             Reporter: [ 1, 1 ]
+          jobGroups:
+            EngineeringTeam:
+              roundStart: 7
+              midRound: 7
+              members:
+                - StationEngineer
+                - TechnicalAssistant
+            MedicalTeam:
+              roundStart: 4
+              midRound: 4
+              members:
+                - MedicalIntern
+                - MedicalDoctor
+            ResearchTeam:
+              roundStart: 6
+              midRound: 6
+              members:
+                - Scientist
+                - ResearchAssistant
+            SecurityTeam:
+              roundStart: 9
+              midRound: 9
+              members:
+                - SecurityOfficer
+                - SecurityCadet
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Non destructively changed the station YAMLs and added shared job pools logic, so the trainee and regular jobs share the same job pool
Backwards compatible with the old styling.


## Why / Balance
There were a bit of a balancing issue between starter and advanced servers in terms of map design. Example: Grasshopper could enjoy massive security crews, while Salamander almost never had any. 
This was due us having a starter jobs separate from regular (they are exclusive based on the time played), so when server population has some time played, almost never there are any starter job slots taken.
This addresses the issue and uses a common job pool for all starter/regular jobs that are exclusive
Now mappers can just figure out amount of regular workers for a map and forget about it. 

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new field in Station Jobs named jobGroups:
YAML example
```
- type: StationJobs
   availableJobs:
...
      #engineering
      ChiefEngineer: [ 1, 1 ]
      AtmosphericTechnician: [ 3, 3 ]
      StationEngineer: [ 0, 0 ]
      TechnicalAssistant: [ 0, 0 ]
    jobGroups:
      EngineeringTeam:
        roundStart: 7
        midRound: 7
        members:
          - StationEngineer
          - TechnicalAssistant
```
Made new passes in job system to adjust for jobgroups them being
In OnStationInitialized to handle new datafield and add job slots in jobgroups
In TryAdjustJobSlot to handle jobs being taken from a group correctly
In TryGetJobSlot to handle jobs being displayed properly

Tested by loading new map, checking that job slots are correctly showing start/midround values
Respawning a bunch of times until the slots are exhausted
Observed 0 slots

Also tested loading the old-style prototype, all been handled correctly (like it did before)

## Media
![image](https://github.com/user-attachments/assets/876870e4-13c0-4225-a998-067f046c7d29)
![image](https://github.com/user-attachments/assets/73549c90-fdc4-4532-aadc-f9aaf19265e3)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Should not break anything
One edge case would be using the new YAML JobGroups implementation and the old one with values different from [0, 0] for the grouped jobs.
One should check if its present before adding new jobslots
I have added comments in YAMLs to minimize the chance of this happening

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- Add: New logic to handle trainee and regular jobs so their slots are shared
- Tweak: Modification to map prototypes to use the new job shared pools
-->
