### PR TITLE
Fix Long Produce Time After De-aging A Plant with cryoxadone.

### DIFF
--- a/Content.Server/EntityEffects/Effects/PlantMetabolism/PlantCryoxadone.cs
+++ b/Content.Server/EntityEffects/Effects/PlantMetabolism/PlantCryoxadone.cs
@@ -24,6 +24,7 @@ public sealed partial class PlantCryoxadone : EntityEffect
         else
             deviation = (int) (seed.Maturation / seed.GrowthStages);
         plantHolderComp.Age -= deviation;
+        plantHolderComp.LastProduce = plantHolderComp.Age;
         plantHolderComp.SkipAging++;
         plantHolderComp.ForceUpdate = true;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When cryoxadone de-ages a plant, it now updates it's the `LastProduce` field as well.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
When using 1u of cryoxadone on a plant to de-age it, the plant will not be harvestable again until a much longer delay than usual.
After this update/fix: When da-aging with cryoxadone, the plant will only need to wait one standard "Produce" time.

## Technical details
<!-- Summary of code changes for easier review. -->
A plant being harvestable is determined by comparing the Plant's `Age - LastProduce` to the Seeds `Produce` time

The "LastProduce" field was not getting updated and as a result the plant was never being  marked as harvestable until it fully aged again (or unless more cryoxadone is used to revert the plant to seeds and start over with a new plant).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
After using cryox, the plant's age drops to 7, but the plant is not harvestable again until it reaches age 33.

https://github.com/user-attachments/assets/98ca2057-8fa4-4620-a44b-b49a3fd6fe24


After:
After using cryox, the plant's age drops to 9, but the plant is harvestable again at age 16

https://github.com/user-attachments/assets/e1685532-6f5b-4d38-9c27-f8c47277c08e



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Quantus
fix: Fixed the unusual delay in production after de-aging a plant with cryoxadone.
