### PR TITLE
Fix mv cable crate typo

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
@@ -58,7 +58,7 @@
   id: CrateEngineeringCableMV
   parent: CrateElectrical
   name: MV cable crate
-  description: 3 coils of LV cables.
+  description: 3 coils of MV cables.
   components:
   - type: StorageFill
     contents:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made MV cable crate description refer to MV cables instead of LV cables.

## Why / Balance
Typo.

## Technical details
Changed an item description.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

No cl.
