### PR TITLE
Reduce NukeOps Reinforcement price from 35TC to 30TC

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1142,7 +1142,7 @@
   productEntity: ReinforcementRadioSyndicateNukeops
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-nukeop }
   cost:
-    Telecrystal: 35
+    Telecrystal: 25
   categories:
   - UplinkAllies
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1142,7 +1142,7 @@
   productEntity: ReinforcementRadioSyndicateNukeops
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-nukeop }
   cost:
-    Telecrystal: 30
+    Telecrystal: 25
   categories:
   - UplinkAllies
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1142,7 +1142,7 @@
   productEntity: ReinforcementRadioSyndicateNukeops
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-nukeop }
   cost:
-    Telecrystal: 25
+    Telecrystal: 30
   categories:
   - UplinkAllies
   conditions:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
"Nuclear Operative Teleporter" in NukeOp/LoneOp uplink price reduced from 35TeleCrystals to 30 TeleCrystals.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
When compared to the syndicate assault borg and its unique and powerful equipment, the NukeOp reinforcement is picked considerably less often. After the usual nukie trimmings (noslips, EMP implant, agent ID) the price for an extra operative is 42TC, which is pretty hard to stomach when you still have to think about weapons for the team. A two-step price reduction from 35 to 30 and then from 30 to 25 could be tried to see if a 5TC reduction would be enough for people to consider buying more often (or buying when war hasn't been declared.)

## Technical details
<!-- Summary of code changes for easier review. -->
One line change to uplink_catalog.yml, 35 changed to 30.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/419ab4d8-698b-498c-bd22-fe669d16170b)
![image](https://github.com/user-attachments/assets/942dda6f-db4e-48d6-b26f-789da82ce954)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None that I'm aware of.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: The Nuclear Operative Reinforcement Teleporter now costs 30TC (was 35).