### PR TITLE
Small OnRefillableDragged bugfix

### DIFF
--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Transfers.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Transfers.cs
@@ -2,11 +2,14 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.DragDrop;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids;
+using Content.Shared.Nutrition.EntitySystems;
 
 namespace Content.Server.Fluids.EntitySystems;
 
 public sealed partial class PuddleSystem
 {
+    [Dependency] private readonly OpenableSystem _openable = default!;
+
     private void InitializeTransfers()
     {
         SubscribeLocalEvent<RefillableSolutionComponent, DragDropDraggedEvent>(OnRefillableDragged);
@@ -24,6 +27,12 @@ public sealed partial class PuddleSystem
         if (TryComp<DumpableSolutionComponent>(args.Target, out var dump))
         {
             if (!_solutionContainerSystem.TryGetDumpableSolution((args.Target, dump, null), out var dumpableSoln, out var dumpableSolution))
+                return;
+
+            if (!_solutionContainerSystem.TryGetDrainableSolution(entity.Owner, out _, out _))
+                return;
+
+            if (_openable.IsClosed(entity))
                 return;
 
             bool success = true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
OnRefillableDragged - drag and drop system for solution containers
now checks if container being droped is open and Drainable
Drainable component is defined as:
"Denotes the solution that can be easily removed through any reagent container.
Think pouring this or draining from a water tank."
It makes check for that when drag and dropping container.

You could make closed but empty soda cans using drains which is also goofy.

## Why / Balance
- small bugfix of #33115

## Technical details
OnRefillableDragged checks for DrainableComponent and checks if it is open if openable

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://studio.youtube.com/video/waQ_NSvvgt4

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
Merging #29413 may now make a lot of people angry

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: being able to drag certain food items onto drain and chemmasters
-->
