### PR TITLE
Fix airsensors not having a nitrogen threshold

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -17,7 +17,7 @@
     pressureThresholdId: stationPressure
     gasThresholdPrototypes:
       Oxygen: stationOxygen
-      Nitrogen: ignore
+      Nitrogen: stationNitrogen
       CarbonDioxide: stationCO2
       Plasma: stationPlasma
       Tritium: stationTritium


### PR DESCRIPTION
## About the PR
Reverts an accidental change I made in #33062 because I spite-webedited a merge conflict and I accidentally forgot a crucial change from master.

Don't webedit merge conflicts, kids.

## Why / Balance
Fixes a bug.

## Technical details
Reverts the change
`Nitrogen: stationNitrogen` yea yea yea

## Media
no

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no CL no fun, this should have existed for like... maybe 5 hours on master branch. not a big deal.
