### PR TITLE
Emancizine

### DIFF
--- a/Content.Server/EntityEffects/Effects/MakeSentientFreeAgent.cs
+++ b/Content.Server/EntityEffects/Effects/MakeSentientFreeAgent.cs
@@ -1,0 +1,59 @@
+using Content.Server.Ghost.Roles.Components;
+using Content.Server.Speech.Components;
+using Content.Shared.EntityEffects;
+using Content.Shared.Mind.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.EntityEffects.Effects;
+
+public sealed partial class MakeSentientFreeAgent : EntityEffect
+{
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => Loc.GetString("reagent-effect-guidebook-make-sentient-freeagent", ("chance", Probability));
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        var entityManager = args.EntityManager;
+        var uid = args.TargetEntity;
+
+        // Let affected entities speak normally to make this effect different from, say, the "random sentience" event
+        // This also works on entities that already have a mind
+        // We call this before the mind check to allow things like player-controlled mice to be able to benefit from the effect
+        entityManager.RemoveComponent<ReplacementAccentComponent>(uid);
+        entityManager.RemoveComponent<MonkeyAccentComponent>(uid);
+
+        // Stops from adding a ghost role to things like people who already have a mind
+        if (entityManager.TryGetComponent<MindContainerComponent>(uid, out var mindContainer) && mindContainer.HasMind)
+        {
+            return;
+        }
+
+        // Convert pre-existing ghost roles (if present) into Free Agents
+        if (entityManager.TryGetComponent(uid, out GhostRoleComponent? ghostRole))
+        {
+            foreach (string MindRole in ghostRole.MindRoles)
+            {
+                // Let's not turn them into a free agent if they're already one.. is there a cleaner way to do this?
+                if (MindRole == "MindRoleGhostRoleFreeAgent")
+                {
+                    return;
+                }
+            }
+
+            ghostRole.RoleDescription += " " + Loc.GetString("ghost-role-information-emancizine-converted-description");
+            ghostRole.RoleRules = Loc.GetString("ghost-role-information-freeagent-rules");
+            ghostRole.MindRoles = new() {"MindRoleGhostRoleFreeAgent"};
+
+            return;
+        }
+
+        ghostRole = entityManager.AddComponent<GhostRoleComponent>(uid);
+        entityManager.EnsureComponent<GhostTakeoverAvailableComponent>(uid);
+
+        var entityData = entityManager.GetComponent<MetaDataComponent>(uid);
+        ghostRole.RoleName = entityData.EntityName;
+        ghostRole.RoleDescription = Loc.GetString("ghost-role-information-emancizine-description");
+        ghostRole.RoleRules = Loc.GetString("ghost-role-information-freeagent-rules");
+        ghostRole.MindRoles = new() {"MindRoleGhostRoleFreeAgent"};
+    }
+}

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -49,6 +49,8 @@ ghost-role-information-giant-spider-description = This station's inhabitants loo
 ghost-role-information-giant-spider-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all other giant spiders.
 
 ghost-role-information-cognizine-description = Made conscious with the magic of cognizine.
+ghost-role-information-emancizine-description = Made conscious with the magic of emancizine; you have free will!
+ghost-role-information-emancizine-converted-description = Given free will with the magic of emancizine.
 
 ghost-role-information-hamster-name = Hamster
 ghost-role-information-hamster-description = A grumpy little ball of fluff.

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -273,6 +273,12 @@ reagent-effect-guidebook-make-sentient =
         *[other] make
     } the metabolizer sentient
 
+reagent-effect-guidebook-make-sentient-freeagent =
+    { $chance ->
+        [1] Makes
+        *[other] make
+    } the metabolizer sentient as a Free Agent
+
 reagent-effect-guidebook-make-polymorph =
     { $chance ->
         [1] Polymorphs

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -95,10 +95,10 @@ reagent-name-ethylredoxrazine = ethylredoxrazine
 reagent-desc-ethylredoxrazine = Neutralises the effects of alcohol in the blood stream. Though it is commonly needed, it is rarely requested.
 
 reagent-name-cognizine = cognizine
-reagent-desc-cognizine = A mysterious chemical which is able to make any non-sentient creature sentient. Can not be used in cooking, unlike cognizine. Use with great caution.
+reagent-desc-cognizine = A mysterious chemical which is able to make any non-sentient creature sentient.
 
 reagent-name-emancizine = emancizine
-reagent-desc-emancizine = A derivative of cognizine, and is able to make any non-sentient creature sentient, with absolute free will.
+reagent-desc-emancizine = A derivative of cognizine, and is able to make any non-sentient creature sentient, with absolute free will. Can not be used in cooking, unlike cognizine. Use with great caution.
 
 reagent-name-ethyloxyephedrine = ethyloxyephedrine
 reagent-desc-ethyloxyephedrine = A mildly unstable medicine derived from desoxyephedrine, primarily used to combat narcolepsy.

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -95,7 +95,10 @@ reagent-name-ethylredoxrazine = ethylredoxrazine
 reagent-desc-ethylredoxrazine = Neutralises the effects of alcohol in the blood stream. Though it is commonly needed, it is rarely requested.
 
 reagent-name-cognizine = cognizine
-reagent-desc-cognizine = A mysterious chemical which is able to make any non-sentient creature sentient.
+reagent-desc-cognizine = A mysterious chemical which is able to make any non-sentient creature sentient. Can not be used in cooking, unlike cognizine. Use with great caution.
+
+reagent-name-emancizine = emancizine
+reagent-desc-emancizine = A derivative of cognizine, and is able to make any non-sentient creature sentient, with absolute free will.
 
 reagent-name-ethyloxyephedrine = ethyloxyephedrine
 reagent-desc-ethyloxyephedrine = A mildly unstable medicine derived from desoxyephedrine, primarily used to combat narcolepsy.

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -358,6 +358,21 @@
           Quantity: 30
 
 - type: entity
+  parent: BaseChemistryBottleFilled
+  id: EmancizineChemistryBottle
+  suffix: emancizine
+  components:
+  - type: Label
+    currentLabel: reagent-name-emancizine
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: Emancizine
+          Quantity: 30
+
+- type: entity
   id: PaxChemistryBottle
   suffix: pax
   parent: BaseChemistryBottleFilled

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -798,6 +798,7 @@
     - Pax
     - Ipecac
     - Cognizine
+    - Emancizine
     - Beer
     - SpaceGlue
     - SpaceLube

--- a/Resources/Prototypes/Hydroponics/randomChemicals.yml
+++ b/Resources/Prototypes/Hydroponics/randomChemicals.yml
@@ -10,6 +10,7 @@
     - Honk
     - BuzzochloricBees
     - Stimulants
+    - Emancizine
   - quantity: 5
     weight: 1
     reagents:

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -105,6 +105,8 @@
         - proto: WeaponTeslaGun
           prob: 0.1
           cost: 2
+        - proto: EmancizineChemistryBottle
+          prob: 0.1
 
 # Mob loot table
 

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -881,6 +881,22 @@
           min: 5
 
 - type: reagent
+  id: Emancizine
+  name: reagent-name-emancizine
+  desc: reagent-desc-emancizine
+  group: Medicine
+  physicalDesc: reagent-physical-desc-enigmatic
+  flavor: magical
+  color: "#d6094a"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:MakeSentientFreeAgent
+        conditions:
+        - !type:ReagentThreshold
+          min: 5
+
+- type: reagent
   id: Ethyloxyephedrine
   name: reagent-name-ethyloxyephedrine
   desc: reagent-desc-ethyloxyephedrine
@@ -1169,7 +1185,7 @@
         conditions:
         - !type:ReagentThreshold
           min: 12
-          
+
 - type: reagent
   id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
   name: reagent-name-opporozidone

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -387,7 +387,7 @@
     Cognizine:
       amount: 1
     Vestine:
-      amount: 1
+      amount: 2
     NorepinephricAcid:
       amount: 1
     MindbreakerToxin:

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -381,6 +381,21 @@
     Cognizine: 1
 
 - type: reaction
+  id: Emancizine
+  impact: High
+  reactants:
+    Cognizine:
+      amount: 1
+    Vestine:
+      amount: 1
+    NorepinephricAcid:
+      amount: 1
+    MindbreakerToxin:
+      amount: 1
+  products:
+    Emancizine: 1
+
+- type: reaction
   id: Sigynate
   impact: Medium
   minTemp: 370
@@ -561,7 +576,7 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine: 
+    Cognizine:
       amount: 1
     Plasma:
       amount: 2


### PR DESCRIPTION
## About the PR
_(edit: this is being PR'd to goobstation in https://github.com/Goob-Station/Goob-Station/pull/1551)_
Adds a new chemical: Emancizine. 
Works almost exactly like cognizine, but:
1. Instead of making non-antag ghost roles out of non-sentient mobs, instead makes free agent ghost roles.
2. If used on a mob that already has a ghost role, converts that ghost role into a free agent if it isn't already one.

1 unit of emancizine can be produced with:
1u cognizine, 2u vestine, 1u mindbreaker toxin, 1u norepinephric acid.

..which means 60u of vestine (4TC worth of vestine) and appropriate amounts of the other precursors
will yield 30u of emancizine, equivalent to 6 uses of it.

Has the same examine text ('enigmatic') as cognizine, but is tinted red.

## Why / Balance
Traitors usually have no way to convert mobs/people/players onto their side. Emancizine allows traitors to
make free agents, who can choose to either team up with the traitor(s) that made them sentient, or to betray them.

Emancizine can be found in bottles of 30 units (6 uses) each as salvage loot, but is as rare as a tesla cannon. (aka, exceptionally rare.)
Emancizine can also very rarely be found as a random botanical chem, with the same rarity as omnizine, lexorin and nocturine,
and as a random chem from anomalies.

## Technical details
Adds a new reagent effect, MakeSentientFreeAgent, that does all of the effects listed at the start of the PR. Also accidentally fucked with some whitespace in recipes/reactions/medicine.yml and prototypes/reagents/medicine.yml but i'm sure its fine.

## Media
demo: https://www.youtube.com/watch?v=evR977pjaGA
recipe (slightly outdated; shows 1u of vestine per 1u of emancizine instead of 2u): https://www.youtube.com/watch?v=MM1Riw8d2uc

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Added Emancizine, a reagent alike to cognizine, that can make soon-to-be sentient free agents out of non-sentient creatures, and convert existing non-sentient creatures into free agents. 1 unit of it is made with 1u of cognizine, mindbreaker toxin, & norepinephric acid each and 2u vestine.