### PR TITLE
Fake Mindshield Implant cleans itself up on draw

### DIFF
--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
@@ -84,7 +84,6 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
         {
             _transformSystem.DropNextTo(entity, uid);
         }
-
     }
 
     /// <summary>

--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
@@ -73,6 +73,8 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
         if (component.ImplantAction != null)
             _actionsSystem.RemoveProvidedActions(component.ImplantedEntity.Value, uid);
 
+        var ev = new ImplantDrawnEvent(uid ,component.ImplantedEntity.Value);
+        RaiseLocalEvent(uid, ref ev);
         if (!_container.TryGetContainer(uid, BaseStorageId, out var storageImplant))
             return;
 
@@ -82,6 +84,7 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
         {
             _transformSystem.DropNextTo(entity, uid);
         }
+
     }
 
     /// <summary>
@@ -215,5 +218,18 @@ public readonly struct ImplantImplantedEvent
     {
         Implant = implant;
         Implanted = implanted;
+    }
+}
+
+[ByRefEvent]
+public readonly struct ImplantDrawnEvent
+{
+    public readonly EntityUid Implant;
+    public readonly EntityUid? ImplantDrawnFrom;
+
+    public ImplantDrawnEvent(EntityUid implant, EntityUid? implantDrawnFrom)
+    {
+        Implant = implant;
+        ImplantDrawnFrom = implantDrawnFrom;
     }
 }

--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
@@ -73,8 +73,6 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
         if (component.ImplantAction != null)
             _actionsSystem.RemoveProvidedActions(component.ImplantedEntity.Value, uid);
 
-        var ev = new ImplantDrawnEvent(uid ,component.ImplantedEntity.Value);
-        RaiseLocalEvent(uid, ref ev);
         if (!_container.TryGetContainer(uid, BaseStorageId, out var storageImplant))
             return;
 
@@ -217,18 +215,5 @@ public readonly struct ImplantImplantedEvent
     {
         Implant = implant;
         Implanted = implanted;
-    }
-}
-
-[ByRefEvent]
-public readonly struct ImplantDrawnEvent
-{
-    public readonly EntityUid Implant;
-    public readonly EntityUid? ImplantDrawnFrom;
-
-    public ImplantDrawnEvent(EntityUid implant, EntityUid? implantDrawnFrom)
-    {
-        Implant = implant;
-        ImplantDrawnFrom = implantDrawnFrom;
     }
 }

--- a/Content.Shared/Mindshield/FakeMindShield/SharedFakeMindShieldImplantSystem.cs
+++ b/Content.Shared/Mindshield/FakeMindShield/SharedFakeMindShieldImplantSystem.cs
@@ -13,7 +13,9 @@ public sealed class SharedFakeMindShieldImplantSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<SubdermalImplantComponent, FakeMindShieldToggleEvent>(OnFakeMindShieldToggle);
         SubscribeLocalEvent<FakeMindShieldImplantComponent, ImplantImplantedEvent>(ImplantCheck);
+        SubscribeLocalEvent<FakeMindShieldImplantComponent, ImplantDrawnEvent>(ImplantDraw);
     }
+
     /// <summary>
     /// Raise the Action of a Implanted user toggling their implant to the FakeMindshieldComponent on their entity
     /// </summary>
@@ -32,5 +34,11 @@ public sealed class SharedFakeMindShieldImplantSystem : EntitySystem
     {
         if (ev.Implanted != null)
             EnsureComp<FakeMindShieldComponent>(ev.Implanted.Value);
+    }
+
+    private void ImplantDraw(Entity<FakeMindShieldImplantComponent> ent, ref ImplantDrawnEvent ev)
+    {
+        if (ev.ImplantDrawnFrom != null)
+            RemComp<FakeMindShieldComponent>(ev.ImplantDrawnFrom.Value);
     }
 }

--- a/Content.Shared/Mindshield/FakeMindShield/SharedFakeMindShieldImplantSystem.cs
+++ b/Content.Shared/Mindshield/FakeMindShield/SharedFakeMindShieldImplantSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared.Implants;
 using Content.Shared.Implants.Components;
 using Content.Shared.Mindshield.Components;
+using Robust.Shared.Containers;
 
 namespace Content.Shared.Mindshield.FakeMindShield;
 
@@ -13,7 +14,7 @@ public sealed class SharedFakeMindShieldImplantSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<SubdermalImplantComponent, FakeMindShieldToggleEvent>(OnFakeMindShieldToggle);
         SubscribeLocalEvent<FakeMindShieldImplantComponent, ImplantImplantedEvent>(ImplantCheck);
-        SubscribeLocalEvent<FakeMindShieldImplantComponent, ImplantDrawnEvent>(ImplantDraw);
+        SubscribeLocalEvent<FakeMindShieldImplantComponent, EntGotRemovedFromContainerMessage>(ImplantDraw);
     }
 
     /// <summary>
@@ -36,9 +37,8 @@ public sealed class SharedFakeMindShieldImplantSystem : EntitySystem
             EnsureComp<FakeMindShieldComponent>(ev.Implanted.Value);
     }
 
-    private void ImplantDraw(Entity<FakeMindShieldImplantComponent> ent, ref ImplantDrawnEvent ev)
+    private void ImplantDraw(Entity<FakeMindShieldImplantComponent> ent, ref EntGotRemovedFromContainerMessage ev)
     {
-        if (ev.ImplantDrawnFrom != null)
-            RemComp<FakeMindShieldComponent>(ev.ImplantDrawnFrom.Value);
+        RemComp<FakeMindShieldComponent>(ev.Container.Owner);
     }
 }


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fake mindshield (#34079) has a minor bug on draw where the implant drawing doesn't clean up the components added to the implanted entity.

Adding an event that's relayed to the implant when it's drawn and having the implant clean itself up solves this problem (and further allows other Implants to have unique draw effects
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes a bug introduced with (#34079) where if you draw a Fake mindshield while it is toggled on, the Mindshield info icon will stay on.
## Technical details
<!-- Summary of code changes for easier review. -->
- Give Fake mindshield a cleanup method, to remove the component added fixing a problem where the icon persists after implant draw
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No CL No Fun