### PR TITLE
Fixed bola effect stacking

### DIFF
--- a/Content.Shared/Ensnaring/Components/EnsnareableComponent.cs
+++ b/Content.Shared/Ensnaring/Components/EnsnareableComponent.cs
@@ -13,13 +13,13 @@ public sealed partial class EnsnareableComponent : Component
     /// <summary>
     /// How much should this slow down the entities walk?
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float WalkSpeed = 1.0f;
 
     /// <summary>
     /// How much should this slow down the entities sprint?
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float SprintSpeed = 1.0f;
 
     /// <summary>

--- a/Content.Shared/Ensnaring/Components/EnsnaringComponent.cs
+++ b/Content.Shared/Ensnaring/Components/EnsnaringComponent.cs
@@ -39,6 +39,12 @@ public sealed partial class EnsnaringComponent : Component
     public float StaminaDamage = 55f;
 
     /// <summary>
+    /// How many times can the ensnare be applied to the same target?
+    /// </summary>
+    [DataField]
+    public float MaxEnsnares = 1;
+
+    /// <summary>
     /// Should this ensnare someone when thrown?
     /// </summary>
     [DataField]

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -256,15 +256,15 @@ public abstract class SharedEnsnareableSystem : EntitySystem
         if (!TryComp<EnsnareableComponent>(target, out var ensnareable))
             return false;
 
-        // Need to insert before free legs check.
-        Container.Insert(ensnare, ensnareable.Container);
 
         var legs = _body.GetBodyChildrenOfType(target, BodyPartType.Leg).Count();
-        var ensnaredLegs = (2 * ensnareable.Container.ContainedEntities.Count);
-        var freeLegs = legs - ensnaredLegs;
+        var ensnaredLegs = (ensnareable.Container.ContainedEntities.Count);
 
-        if (freeLegs > 0)
+        //If both legs are ensnared, don't let it ensnare more
+        if (legs == ensnaredLegs)
             return false;
+
+        Container.Insert(ensnare, ensnareable.Container);
 
         // Apply stamina damage to target if they weren't ensnared before.
         if (ensnareable.IsEnsnared != true)

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -262,13 +262,10 @@ public abstract class SharedEnsnareableSystem : EntitySystem
 
         Container.Insert(ensnare, ensnareable.Container);
 
-        // Apply stamina damage to target if they weren't ensnared before.
-        if (ensnareable.IsEnsnared != true)
+        // Apply stamina damage to target
+        if (TryComp<StaminaComponent>(target, out var stamina))
         {
-            if (TryComp<StaminaComponent>(target, out var stamina))
-            {
-                _stamina.TakeStaminaDamage(target, component.StaminaDamage, with: ensnare, component: stamina);
-            }
+            _stamina.TakeStaminaDamage(target, component.StaminaDamage, with: ensnare, component: stamina);
         }
 
         component.Ensnared = target;

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -256,12 +256,8 @@ public abstract class SharedEnsnareableSystem : EntitySystem
         if (!TryComp<EnsnareableComponent>(target, out var ensnareable))
             return false;
 
-
-        var legs = _body.GetBodyChildrenOfType(target, BodyPartType.Leg).Count();
-        var ensnaredLegs = (ensnareable.Container.ContainedEntities.Count);
-
-        //If both legs are ensnared, don't let it ensnare more
-        if (legs == ensnaredLegs)
+        //Don't do anything if they are already ensnared
+        if (ensnareable.IsEnsnared)
             return false;
 
         Container.Insert(ensnare, ensnareable.Container);

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -256,8 +256,11 @@ public abstract class SharedEnsnareableSystem : EntitySystem
         if (!TryComp<EnsnareableComponent>(target, out var ensnareable))
             return false;
 
-        //Don't do anything if they are already ensnared
-        if (ensnareable.IsEnsnared)
+        var legs = _body.GetBodyChildrenOfType(target, BodyPartType.Leg).Count();
+        var ensnaredLegs = ensnareable.Container.ContainedEntities.Count;
+
+        //Don't do anything if all legs are ensnared
+        if (ensnaredLegs >= legs)
             return false;
 
         Container.Insert(ensnare, ensnareable.Container);

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -256,11 +256,10 @@ public abstract class SharedEnsnareableSystem : EntitySystem
         if (!TryComp<EnsnareableComponent>(target, out var ensnareable))
             return false;
 
-        var legs = _body.GetBodyChildrenOfType(target, BodyPartType.Leg).Count();
-        var ensnaredLegs = ensnareable.Container.ContainedEntities.Count;
+        var numEnsnares = ensnareable.Container.ContainedEntities.Count;
 
-        //Don't do anything if all legs are ensnared
-        if (ensnaredLegs >= legs)
+        //Don't do anything if the maximum number of ensnares is applied.
+        if (numEnsnares >= component.MaxEnsnares)
             return false;
 
         Container.Insert(ensnare, ensnareable.Container);

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -47,4 +47,5 @@
     staminaDamage: 0 # anything but this is gamebreaking
     canThrowTrigger: true
     canMoveBreakout: true
+    maxEnsnares: 1
   - type: LandAtCursor


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Bolas had a bug that allowed them to stack and apply to the same target ([#34694](https://github.com/space-wizards/space-station-14/issues/34694))
I changed the shared ensnareable system to only allow one bola to be applied as mentioned in ([#34694](https://github.com/space-wizards/space-station-14/issues/34694))

Fixes #34694

## Why / Balance
Removes the ability to movelock and makes it less annoying to remove many bolas.

## Technical details
Changed the checks in the SharedEnsnareableSystem's TryEnsnare method to only ensnare if they aren't already ensnared. (Try saying that 3 times fast lol)

## Media
![image](https://github.com/user-attachments/assets/aaedb9df-bfe0-469d-a701-34ac95d605f6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Bolas will now only be applied once.
