### PR TITLE
Removes radioactive suppermatter from Plasma Station

### DIFF
--- a/Resources/Maps/plasma.yml
+++ b/Resources/Maps/plasma.yml
@@ -82955,23 +82955,9 @@ entities:
   entities:
   - uid: 20467
     components:
-    - type: MetaData
-      desc: A single portion of pow- why do i feel sick?
-      name: supermatter shard
     - type: Transform
       pos: -112.51823,36.525185
       parent: 2
-    - type: Item
-      size: Huge
-    - type: RadiationSource
-    missingComponents:
-    - SolutionContainerManager
-    - Food
-    - FoodSequenceElement
-    - FlavorProfile
-    - InjectableSolution
-    - RefillableSolution
-    - SpaceGarbage
 - proto: FoodCartCold
   entities:
   - uid: 3449


### PR DESCRIPTION
Literally 1984 can't have shit on SS14 e.t.c. e.t.c.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes the radiation component from Plasma Station. The item is still there, just not a cool gimmick item and now just a regular boring item.

## Why / Balance
https://github.com/space-wizards/space-station-14/issues/34710

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

No CL needed as it's just a tweak