### PR TITLE
Thrown weapons hit crit/dead people

### DIFF
--- a/Content.Shared/Ensnaring/Components/EnsnaringComponent.cs
+++ b/Content.Shared/Ensnaring/Components/EnsnaringComponent.cs
@@ -58,6 +58,12 @@ public sealed partial class EnsnaringComponent : Component
 
     [DataField]
     public SoundSpecifier? EnsnareSound = new SoundPathSpecifier("/Audio/Effects/snap.ogg");
+
+    /// <summary>
+    /// Whether this entity will ignore Corpses/Crit People when thrown
+    /// </summary>
+    [DataField]
+    public bool IgnoreDowned = true;
 }
 
 /// <summary>

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -256,15 +256,15 @@ public abstract class SharedEnsnareableSystem : EntitySystem
         if (!TryComp<EnsnareableComponent>(target, out var ensnareable))
             return false;
 
-        // Need to insert before free legs check.
-        Container.Insert(ensnare, ensnareable.Container);
 
         var legs = _body.GetBodyChildrenOfType(target, BodyPartType.Leg).Count();
-        var ensnaredLegs = (2 * ensnareable.Container.ContainedEntities.Count);
-        var freeLegs = legs - ensnaredLegs;
+        var ensnaredLegs = (ensnareable.Container.ContainedEntities.Count);
 
-        if (freeLegs > 0)
+        //If both legs are ensnared, don't let it ensnare more
+        if (legs == ensnaredLegs)
             return false;
+
+        Container.Insert(ensnare, ensnareable.Container);
 
         // Apply stamina damage to target if they weren't ensnared before.
         if (ensnareable.IsEnsnared != true)

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -262,13 +262,10 @@ public abstract class SharedEnsnareableSystem : EntitySystem
 
         Container.Insert(ensnare, ensnareable.Container);
 
-        // Apply stamina damage to target if they weren't ensnared before.
-        if (ensnareable.IsEnsnared != true)
+        // Apply stamina damage to target
+        if (TryComp<StaminaComponent>(target, out var stamina))
         {
-            if (TryComp<StaminaComponent>(target, out var stamina))
-            {
-                _stamina.TakeStaminaDamage(target, component.StaminaDamage, with: ensnare, component: stamina);
-            }
+            _stamina.TakeStaminaDamage(target, component.StaminaDamage, with: ensnare, component: stamina);
         }
 
         component.Ensnared = target;

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -9,6 +9,8 @@ using Content.Shared.DoAfter;
 using Content.Shared.Ensnaring.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.StepTrigger.Systems;
@@ -255,6 +257,15 @@ public abstract class SharedEnsnareableSystem : EntitySystem
         //Don't do anything if they don't have the ensnareable component.
         if (!TryComp<EnsnareableComponent>(target, out var ensnareable))
             return false;
+
+        //Don't do anything if the ensnaring weapon encounters someone who is dead/crit and the weapon is set to ignore dead/crit people
+        if (TryComp<EnsnaringComponent>(ensnare, out var ensnaringComponent) && ensnaringComponent.IgnoreDowned)
+        {
+            if (TryComp<MobStateComponent>(target, out var mob) && !(mob.CurrentState == MobState.Alive))
+            {
+                return false;
+            }
+        }
 
         //Don't do anything if they are already ensnared
         if (ensnareable.IsEnsnared)

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -256,12 +256,8 @@ public abstract class SharedEnsnareableSystem : EntitySystem
         if (!TryComp<EnsnareableComponent>(target, out var ensnareable))
             return false;
 
-
-        var legs = _body.GetBodyChildrenOfType(target, BodyPartType.Leg).Count();
-        var ensnaredLegs = (ensnareable.Container.ContainedEntities.Count);
-
-        //If both legs are ensnared, don't let it ensnare more
-        if (legs == ensnaredLegs)
+        //Don't do anything if they are already ensnared
+        if (ensnareable.IsEnsnared)
             return false;
 
         Container.Insert(ensnare, ensnareable.Container);

--- a/Content.Shared/Projectiles/EmbeddableProjectileComponent.cs
+++ b/Content.Shared/Projectiles/EmbeddableProjectileComponent.cs
@@ -52,4 +52,10 @@ public sealed partial class EmbeddableProjectileComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public EntityUid? EmbeddedIntoUid;
+
+    /// <summary>
+    /// Whether this entity will ignore Corpses/Crit People when thrown
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool IgnoreDowned = true;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ensnaring (bolas) and throwing weapons no longer hit crit/dead people.

## Why / Balance
This fixes #34509 and brings throwing weapon's consistency in line with other ranged weapons like guns.

## Technical details
Added IgnoreDowned variable to both Ensnaring and EmbeddableProjectile Components.
Added logic to check if the thing being hit is crit or dead, and if so ignore collisions (assuming the projectile has IgnoreDowned = true)

## Media
![Content Client_Dvnrew99af](https://github.com/user-attachments/assets/cba31153-8a09-4dd2-9d9a-8c4549597bb4)
![Content Client_a1anRzBUGc](https://github.com/user-attachments/assets/3e45e6b2-aa11-4db0-8662-12f411d4469c)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Throwing weapons do not hit corpses or critical people/animals.

