### PR TITLE
Nuke Timer MinimumTime

### DIFF
--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -26,6 +26,14 @@ namespace Content.Server.Nuke
         public int Timer = 300;
 
         /// <summary>
+        ///     If the nuke is disarmed, this sets the minimum amount of time the timer can have.
+        ///     The remaining time will reset to this value if it is below it.
+        /// </summary>
+        [DataField("minimumTime")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public int MinimumTime = 180;
+
+        /// <summary>
         ///     How long until the bomb can arm again after deactivation.
         ///     Used to prevent announcements spam.
         /// </summary>

--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -29,8 +29,7 @@ namespace Content.Server.Nuke
         ///     If the nuke is disarmed, this sets the minimum amount of time the timer can have.
         ///     The remaining time will reset to this value if it is below it.
         /// </summary>
-        [DataField("minimumTime")]
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public int MinimumTime = 180;
 
         /// <summary>

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -522,6 +522,12 @@ public sealed class NukeSystem : EntitySystem
         _sound.PlayGlobalOnStation(uid, _audio.GetSound(component.DisarmSound));
         _sound.StopStationEventMusic(uid, StationEventMusicType.Nuke);
 
+        // reset nuke remaining time to the minimum time if it is shorter than the minimum time.
+        if (component.RemainingTime < component.MinimumTime)
+        {
+            component.RemainingTime = component.MinimumTime;
+        }
+
         // disable sound and reset it
         component.PlayedAlertSound = false;
         component.AlertAudioStream = _audio.Stop(component.AlertAudioStream);

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -522,11 +522,8 @@ public sealed class NukeSystem : EntitySystem
         _sound.PlayGlobalOnStation(uid, _audio.GetSound(component.DisarmSound));
         _sound.StopStationEventMusic(uid, StationEventMusicType.Nuke);
 
-        // reset nuke remaining time to the minimum time if it is shorter than the minimum time.
-        if (component.RemainingTime < component.MinimumTime)
-        {
-            component.RemainingTime = component.MinimumTime;
-        }
+        // reset nuke remaining time to either itself or the minimum time, whichever is higher
+        component.RemainingTime = Math.Max(component.RemainingTime, component.MinimumTime);
 
         // disable sound and reset it
         component.PlayedAlertSound = false;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Nuke timer now resets to a minimum value if it is disabled with a time remaining lower than that minimum value.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Disincentivize people "cooking" the timer on the nuke.

## Technical details
<!-- Summary of code changes for easier review. -->

Added a new attribute to the NukeComponent named `MinimumTime` which is utilized in `NukeSystem.cs::DisarmBomb`.
In `DisarmBomb` it checks if the RemainingTime is less than the `MinimumTime` and if so, sets the `RemainingTime` to the `MinimumTime`.

The current `MinimumTime` value is 180 seconds (three minutes) which I set since I felt like that gives crew plenty of time to respond, assuming they are already aware of the threat and have already geared up.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

[A video showcasing the nuke behaving as described](https://youtu.be/rQ36Alp8Scg)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

This could interfere with anything that utilizes or relies on a linear change in the RemainingTime value since the RemainingTime could jump up in value.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Southbridge
- tweak: The Nuke will now reset to a minimum countdown value when disarmed if the countdown is below the minimum value.

