### PR TITLE
Fix embeddable projectiles dissapearing

### DIFF
--- a/Content.Shared/Projectiles/EmbeddableProjectileComponent.cs
+++ b/Content.Shared/Projectiles/EmbeddableProjectileComponent.cs
@@ -27,7 +27,7 @@ public sealed partial class EmbeddableProjectileComponent : Component
     /// How long it takes to remove the embedded object.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float? RemovalTime = 3f;
+    public float RemovalTime = 3f;
 
     /// <summary>
     ///     Whether this entity will embed when thrown, or only when shot as a projectile.

--- a/Content.Shared/Projectiles/EmbeddedContainerComponent.cs
+++ b/Content.Shared/Projectiles/EmbeddedContainerComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared.Projectiles;
+
+/// <summary>
+/// Stores a list of all stuck entities to release when this entity is deleted.
+/// </summary>
+[RegisterComponent]
+public sealed partial class EmbeddedContainerComponent : Component
+{
+    [DataField]
+    public HashSet<EntityUid?> EmbeddedObjects = new();
+}


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Now embedded projectiles are not removed if the main entity has been removed, destroyed, or disappeared for any other reason. 

Fixed a bug where the time to pull embedded projectiles could be 0 or less and the doAfter event would not work correctly. In this case now detachment will be instantaneous.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/76aecbfc-29e6-44ca-95f2-ed18886d97ae


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
