### PR TITLE
Box Armory Restock

### DIFF
--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -152,7 +152,7 @@ entities:
           version: 6
         -1,1:
           ind: -1,1
-          tiles: eQAAAAAAdgAAAAACdgAAAAAAdgAAAAACdgAAAAABdgAAAAACeQAAAAAAdgAAAAACdgAAAAADdgAAAAACdgAAAAABdgAAAAADdgAAAAACeQAAAAAAWQAAAAABWQAAAAADeQAAAAAAdgAAAAADdgAAAAAAdgAAAAAAdgAAAAACdgAAAAADeQAAAAAAdgAAAAADdgAAAAADdgAAAAADdgAAAAACdgAAAAAAdgAAAAAAeQAAAAAAWQAAAAACWQAAAAADeQAAAAAAeQAAAAAAWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAWQAAAAACWQAAAAAAWQAAAAACWQAAAAADWQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAABWQAAAAADWQAAAAAAWQAAAAACWQAAAAACWQAAAAACWQAAAAACWQAAAAAAWQAAAAACWQAAAAAAWQAAAAACWQAAAAACWQAAAAAAWQAAAAACWQAAAAAAWQAAAAADWQAAAAACWQAAAAABWQAAAAABWQAAAAAAWQAAAAADWQAAAAACWQAAAAAAWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAADWQAAAAACWQAAAAAAWQAAAAAAeQAAAAAAWQAAAAADWQAAAAABWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAADeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAWQAAAAABWQAAAAADWQAAAAAAeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAeQAAAAAAWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAADWQAAAAABWQAAAAADWQAAAAADWQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAACWQAAAAAAWQAAAAAAWQAAAAADWQAAAAAAWQAAAAABeQAAAAAAWQAAAAADWQAAAAADWQAAAAAAWQAAAAABWQAAAAAAWQAAAAACWQAAAAAAWQAAAAADWQAAAAABWQAAAAACWQAAAAADWQAAAAADWQAAAAADWQAAAAAAWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAWQAAAAACWQAAAAADeQAAAAAAWQAAAAACWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAAAHQAAAAACHQAAAAACHQAAAAAAHQAAAAABHQAAAAAAeQAAAAAAHQAAAAADUAAAAAAAUAAAAAAAWQAAAAACWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACHQAAAAADHQAAAAADHQAAAAACHQAAAAADHQAAAAABeQAAAAAAWQAAAAAAUAAAAAAAUAAAAAAAWQAAAAAAWQAAAAACWQAAAAADeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAHQAAAAAAHQAAAAACHQAAAAAAHQAAAAADHQAAAAABeQAAAAAAWQAAAAACUAAAAAAAUAAAAAAAWQAAAAACWQAAAAADWQAAAAACeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAA
+          tiles: eQAAAAAAdgAAAAACdgAAAAAAdgAAAAACdgAAAAABdgAAAAACeQAAAAAAdgAAAAACdgAAAAADdgAAAAACdgAAAAABdgAAAAADdgAAAAACeQAAAAAAWQAAAAABWQAAAAADeQAAAAAAdgAAAAADdgAAAAAAdgAAAAAAdgAAAAACdgAAAAADeQAAAAAAdgAAAAADdgAAAAADdgAAAAADdgAAAAACdgAAAAAAdgAAAAAAeQAAAAAAWQAAAAACWQAAAAADeQAAAAAAeQAAAAAAWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAWQAAAAACWQAAAAAAWQAAAAACWQAAAAADWQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAABWQAAAAADWQAAAAAAWQAAAAACWQAAAAACWQAAAAACWQAAAAACWQAAAAAAWQAAAAACWQAAAAAAWQAAAAACWQAAAAACWQAAAAAAWQAAAAACWQAAAAAAWQAAAAADWQAAAAACWQAAAAABWQAAAAABWQAAAAAAWQAAAAADWQAAAAACWQAAAAAAWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAADWQAAAAACWQAAAAAAWQAAAAAAeQAAAAAAWQAAAAADWQAAAAABWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAADeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAWQAAAAABWQAAAAADWQAAAAAAeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAADWQAAAAABWQAAAAADWQAAAAADWQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAACWQAAAAAAWQAAAAAAWQAAAAADWQAAAAAAWQAAAAABeQAAAAAAWQAAAAADWQAAAAADWQAAAAAAWQAAAAABWQAAAAAAWQAAAAACWQAAAAAAWQAAAAADWQAAAAABWQAAAAACWQAAAAADWQAAAAADWQAAAAADWQAAAAAAWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAWQAAAAACWQAAAAADeQAAAAAAWQAAAAACWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAAAHQAAAAACHQAAAAACHQAAAAAAHQAAAAABHQAAAAAAeQAAAAAAHQAAAAADUAAAAAAAUAAAAAAAWQAAAAACWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACHQAAAAADHQAAAAADHQAAAAACHQAAAAADHQAAAAABeQAAAAAAWQAAAAAAUAAAAAAAUAAAAAAAWQAAAAAAWQAAAAACWQAAAAADeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAHQAAAAAAHQAAAAACHQAAAAAAHQAAAAADHQAAAAABeQAAAAAAWQAAAAACUAAAAAAAUAAAAAAAWQAAAAACWQAAAAADWQAAAAACeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAA
           version: 6
         1,1:
           ind: 1,1
@@ -160,11 +160,11 @@ entities:
           version: 6
         -1,2:
           ind: -1,2
-          tiles: HQAAAAAAHQAAAAACHQAAAAABHQAAAAACHQAAAAABeQAAAAAAWQAAAAACLAAAAAAALAAAAAAAWQAAAAADWQAAAAAAWQAAAAABeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACLAAAAAAAeQAAAAAAWQAAAAAAWQAAAAADeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAHQAAAAACHQAAAAADHQAAAAADHQAAAAABHQAAAAACWQAAAAABWQAAAAABWQAAAAACWQAAAAACeQAAAAAAWQAAAAACWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADHQAAAAADHQAAAAADHQAAAAAAHQAAAAABWQAAAAACWQAAAAADWQAAAAADWQAAAAADWQAAAAAAWQAAAAACWQAAAAACeQAAAAAAHQAAAAABHQAAAAAAHQAAAAABHQAAAAACHQAAAAACHQAAAAADHQAAAAADHQAAAAAAWQAAAAADWQAAAAADWQAAAAADWQAAAAAAWQAAAAADWQAAAAAAWQAAAAADeQAAAAAAHQAAAAACWQAAAAABWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAAAWQAAAAAAeQAAAAAAHQAAAAAAWQAAAAACTQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAABHQAAAAADHQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABeQAAAAAAeQAAAAAAHQAAAAABWQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAHQAAAAADHQAAAAACHQAAAAABeQAAAAAAWQAAAAAAWQAAAAABWQAAAAAAeQAAAAAAHQAAAAAAHQAAAAABHQAAAAAAdgAAAAABdgAAAAACdgAAAAABeQAAAAAAHQAAAAABHQAAAAACHQAAAAAAHQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAAAdgAAAAABdgAAAAABeQAAAAAAHQAAAAABHQAAAAADHQAAAAACHQAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAACdgAAAAABdgAAAAABeQAAAAAAeQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAHQAAAAACHQAAAAADHQAAAAADHQAAAAADHQAAAAACHQAAAAAAHQAAAAACHQAAAAACHQAAAAABHQAAAAADHQAAAAADHQAAAAACeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAHQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAHQAAAAABHQAAAAAAHQAAAAACHQAAAAACHQAAAAACHQAAAAACHQAAAAAAHQAAAAABHQAAAAACHQAAAAADHQAAAAAAHQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAHQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAADdgAAAAAAdgAAAAAAdgAAAAAAdgAAAAACeQAAAAAAWQAAAAABWQAAAAADWQAAAAACWQAAAAAAWQAAAAADWQAAAAAAeQAAAAAACQAAAAAAHQAAAAADCQAAAAAB
+          tiles: HQAAAAAAHQAAAAACHQAAAAABHQAAAAACHQAAAAABeQAAAAAAWQAAAAACLAAAAAAALAAAAAAAWQAAAAADWQAAAAAAWQAAAAABeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACLAAAAAAAeQAAAAAAWQAAAAAAWQAAAAADeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAHQAAAAACHQAAAAADHQAAAAADHQAAAAABHQAAAAACWQAAAAABWQAAAAABWQAAAAACWQAAAAACeQAAAAAAWQAAAAACWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADHQAAAAADHQAAAAADHQAAAAAAHQAAAAABWQAAAAACWQAAAAADWQAAAAADWQAAAAADWQAAAAAAWQAAAAACWQAAAAACeQAAAAAAHQAAAAABHQAAAAAAHQAAAAABHQAAAAACHQAAAAACHQAAAAADHQAAAAADHQAAAAAAWQAAAAADWQAAAAADWQAAAAADWQAAAAAAWQAAAAADWQAAAAAAWQAAAAADeQAAAAAAHQAAAAACWQAAAAABWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAAAWQAAAAAAeQAAAAAAHQAAAAAAWQAAAAACTQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAHQAAAAABHQAAAAADHQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABeQAAAAAAeQAAAAAAHQAAAAABWQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAHQAAAAADHQAAAAACHQAAAAABeQAAAAAAWQAAAAAAWQAAAAABWQAAAAAAeQAAAAAAHQAAAAAAHQAAAAABHQAAAAAAdgAAAAABdgAAAAACdgAAAAABeQAAAAAAHQAAAAABHQAAAAACHQAAAAAAHQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAAAdgAAAAABdgAAAAABeQAAAAAAHQAAAAABHQAAAAADHQAAAAACHQAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAACdgAAAAABdgAAAAABeQAAAAAAeQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAHQAAAAACHQAAAAADHQAAAAADHQAAAAADHQAAAAACHQAAAAAAHQAAAAACHQAAAAACHQAAAAABHQAAAAADHQAAAAADHQAAAAACeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAHQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAHQAAAAABHQAAAAAAHQAAAAACHQAAAAACHQAAAAACHQAAAAACHQAAAAAAHQAAAAABHQAAAAACHQAAAAADHQAAAAAAHQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAHQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAADdgAAAAAAdgAAAAAAdgAAAAAAdgAAAAACeQAAAAAAWQAAAAABWQAAAAADWQAAAAACWQAAAAAAWQAAAAADWQAAAAAAeQAAAAAACQAAAAAAHQAAAAADCQAAAAAB
           version: 6
         0,2:
           ind: 0,2
-          tiles: UAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAWQAAAAAAWQAAAAACWQAAAAADWQAAAAADWQAAAAACWQAAAAAAWQAAAAADWQAAAAACWQAAAAAAWQAAAAABUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAAAWQAAAAAAWQAAAAACWQAAAAACWQAAAAAAWQAAAAADWQAAAAAAWQAAAAABeQAAAAAAWQAAAAADWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABeQAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAADWQAAAAAAWQAAAAAAHQAAAAAAWQAAAAACWQAAAAABWQAAAAACWQAAAAAAeQAAAAAAHQAAAAABHQAAAAACHQAAAAACHQAAAAADeQAAAAAAWQAAAAADWQAAAAACWQAAAAADWQAAAAAAWQAAAAADWQAAAAAAWQAAAAADWQAAAAABWQAAAAAAWQAAAAAAWQAAAAACHQAAAAAAHQAAAAABHQAAAAACHQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADeQAAAAAATQAAAAAATQAAAAAATQAAAAAAWQAAAAADWQAAAAACWQAAAAAAHQAAAAAAHQAAAAABHQAAAAAAHQAAAAAAHQAAAAABeQAAAAAAHQAAAAACHQAAAAADHQAAAAAAHQAAAAABWQAAAAABWQAAAAADWQAAAAACWQAAAAADWQAAAAAAeQAAAAAAHQAAAAAAHQAAAAAAHQAAAAADHQAAAAAAHQAAAAADeQAAAAAAdgAAAAADdgAAAAACdgAAAAACdgAAAAACHQAAAAADHQAAAAADHQAAAAACHQAAAAAAHQAAAAAAeQAAAAAAHQAAAAABHQAAAAAAHQAAAAABHQAAAAADHQAAAAAAeQAAAAAAdgAAAAACdgAAAAADdgAAAAADdgAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAACHQAAAAACHQAAAAABHQAAAAADHQAAAAADeQAAAAAAdgAAAAADdgAAAAACdgAAAAADdgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAHQAAAAABHQAAAAABHQAAAAABHQAAAAACeQAAAAAAdgAAAAAAdgAAAAADdgAAAAADdgAAAAACeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAHQAAAAACHQAAAAAACQAAAAADHQAAAAABCQAAAAACeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: UAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAWQAAAAAAWQAAAAACWQAAAAADWQAAAAADWQAAAAACWQAAAAAAWQAAAAADWQAAAAACWQAAAAAAWQAAAAABUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAAAWQAAAAAAWQAAAAACWQAAAAACWQAAAAAAWQAAAAADWQAAAAAAWQAAAAABeQAAAAAAWQAAAAADWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABeQAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAADWQAAAAAAWQAAAAAAHQAAAAAAWQAAAAACWQAAAAABHQAAAAAAHQAAAAAAeQAAAAAAHQAAAAABHQAAAAACHQAAAAACHQAAAAADeQAAAAAAWQAAAAADWQAAAAACWQAAAAADWQAAAAAAWQAAAAADWQAAAAAAWQAAAAADWQAAAAABWQAAAAAAWQAAAAAAaAAAAAAAHQAAAAAAHQAAAAABHQAAAAACHQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADeQAAAAAATQAAAAAATQAAAAAATQAAAAAAWQAAAAADWQAAAAACWQAAAAAAHQAAAAAAHQAAAAABHQAAAAAAHQAAAAAAHQAAAAABeQAAAAAAHQAAAAACHQAAAAADHQAAAAAAHQAAAAABWQAAAAABWQAAAAADWQAAAAACWQAAAAADWQAAAAAAeQAAAAAAHQAAAAAAHQAAAAAAHQAAAAADHQAAAAAAHQAAAAADeQAAAAAAdgAAAAADdgAAAAACdgAAAAACdgAAAAACHQAAAAADHQAAAAADHQAAAAACHQAAAAAAHQAAAAAAeQAAAAAAHQAAAAABHQAAAAAAHQAAAAABHQAAAAADHQAAAAAAeQAAAAAAdgAAAAACdgAAAAADdgAAAAADdgAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAACHQAAAAACHQAAAAABHQAAAAADHQAAAAADeQAAAAAAdgAAAAADdgAAAAACdgAAAAADdgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAHQAAAAAAHQAAAAABHQAAAAABHQAAAAABHQAAAAACeQAAAAAAdgAAAAAAdgAAAAADdgAAAAADdgAAAAACeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAHQAAAAACHQAAAAAACQAAAAADHQAAAAABCQAAAAACeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         1,2:
           ind: 1,2
@@ -1200,6 +1200,11 @@ entities:
           decals:
             2247: -15,-51
         - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteCornerSe
+          decals:
+            6283: -13,22
+        - node:
             color: '#EFB34196'
             id: BrickTileWhiteCornerSe
           decals:
@@ -1243,7 +1248,7 @@ entities:
             color: '#DE3A3A96'
             id: BrickTileWhiteCornerSw
           decals:
-            3529: -15,26
+            6284: -15,22
         - node:
             color: '#EFB34196'
             id: BrickTileWhiteCornerSw
@@ -1278,6 +1283,11 @@ entities:
             id: BrickTileWhiteInnerSe
           decals:
             1521: -10,8
+        - node:
+            color: '#DE3A3A96'
+            id: BrickTileWhiteInnerSe
+          decals:
+            6279: -13,26
         - node:
             color: '#334E6DC8'
             id: BrickTileWhiteInnerSw
@@ -1350,6 +1360,9 @@ entities:
             3533: -5,31
             3534: -5,32
             3535: -5,29
+            6280: -13,25
+            6281: -13,24
+            6282: -13,23
         - node:
             color: '#EFB34196'
             id: BrickTileWhiteLineE
@@ -1557,7 +1570,6 @@ entities:
             2081: 0,26
             2082: -8,26
             2083: -12,26
-            2084: -13,26
             2085: 1,26
             2086: 2,26
             2087: 3,26
@@ -1569,6 +1581,7 @@ entities:
             3563: -13,34
             3564: -14,34
             3565: -16,34
+            6286: -14,22
         - node:
             color: '#EFB34196'
             id: BrickTileWhiteLineS
@@ -1660,6 +1673,9 @@ entities:
             3543: -6,30
             3544: -6,31
             3545: -6,32
+            6276: -15,26
+            6277: -15,25
+            6278: -15,24
         - node:
             color: '#EFB34196'
             id: BrickTileWhiteLineW
@@ -4791,7 +4807,6 @@ entities:
             id: HalfTileOverlayGreyscale180
           decals:
             18: 9,23
-            25: -14,22
             55: 9,30
             56: 10,30
             57: 11,30
@@ -5050,9 +5065,6 @@ entities:
             id: HalfTileOverlayGreyscale90
           decals:
             15: 10,23
-            19: -13,24
-            20: -13,23
-            21: -13,22
             35: 19,35
             36: 19,36
             186: -20,-31
@@ -5347,7 +5359,6 @@ entities:
           decals:
             5: 1,28
             6: 6,28
-            22: -15,24
             28: 4,23
             39: 19,36
             40: 18,35
@@ -5658,7 +5669,6 @@ entities:
           decals:
             13: 10,24
             16: 8,23
-            24: -15,22
             29: 6,24
             33: 8,30
             184: -20,-30
@@ -5976,8 +5986,6 @@ entities:
           decals:
             12: 8,24
             17: 10,23
-            23: -15,22
-            26: -13,22
             27: 4,24
             47: 11,35
             51: 6,33
@@ -6858,6 +6866,7 @@ entities:
             1536: -13,6
             1663: 51,-17
             2317: -73,8
+            6275: 2,36
         - node:
             zIndex: 1
             color: '#FFFFFFFF'
@@ -6935,6 +6944,8 @@ entities:
             2477: 8,-48
             3510: -13,-62
             3514: 23,18
+            6271: 2,34
+            6272: 2,35
         - node:
             zIndex: 1
             color: '#FFFFFFFF'
@@ -7096,7 +7107,6 @@ entities:
             2093: 4,26
             3521: -9,34
             3522: -8,34
-            3530: -14,26
             3566: -15,34
         - node:
             color: '#EFB34196'
@@ -7137,6 +7147,11 @@ entities:
             6155: -7,-76
             6156: -6,-76
             6157: -5,-76
+        - node:
+            color: '#DE3A3A96'
+            id: WarnLineGreyscaleW
+          decals:
+            6285: -15,23
         - node:
             color: '#EFB34196'
             id: WarnLineGreyscaleW
@@ -7234,6 +7249,8 @@ entities:
             2602: -1,-79
             2603: -2,-79
             2604: -3,-79
+            6273: 4,36
+            6274: 3,36
         - node:
             zIndex: 1
             color: '#FFFFFFFF'
@@ -7718,7 +7735,8 @@ entities:
           -5,0:
             0: 39864
           -4,0:
-            0: 43744
+            0: 35552
+            2: 8192
           -4,1:
             0: 60942
           -5,1:
@@ -7799,7 +7817,7 @@ entities:
             0: 61423
           8,-1:
             0: 12320
-            2: 34944
+            3: 34944
           -8,-4:
             0: 30583
           -8,-5:
@@ -8007,7 +8025,7 @@ entities:
           -9,3:
             0: 15
             1: 9472
-            3: 4608
+            4: 4608
           -8,4:
             0: 13073
           -7,1:
@@ -8132,7 +8150,7 @@ entities:
             0: 45298
           3,-13:
             0: 61713
-            3: 204
+            4: 204
           4,-12:
             0: 65535
           4,-11:
@@ -8141,7 +8159,7 @@ entities:
             0: 53744
           4,-13:
             0: 64716
-            3: 17
+            4: 17
           5,-12:
             0: 30583
           5,-11:
@@ -8152,30 +8170,30 @@ entities:
             0: 30583
           6,-12:
             1: 4369
-            4: 204
-            3: 49152
+            5: 204
+            4: 49152
           6,-11:
             1: 61713
-            3: 204
+            4: 204
           6,-10:
             0: 29424
           6,-13:
             1: 4369
-            4: 49152
-            3: 204
+            5: 49152
+            4: 204
           7,-12:
-            4: 17
-            3: 4096
+            5: 17
+            4: 4096
             1: 17476
           7,-11:
-            3: 17
+            4: 17
             1: 29764
           7,-10:
             0: 61680
           7,-13:
-            4: 4096
+            5: 4096
             1: 17476
-            3: 17
+            4: 17
           8,-12:
             0: 7647
           8,-11:
@@ -8211,7 +8229,7 @@ entities:
             1: 8704
           8,0:
             0: 63523
-            2: 8
+            3: 8
           8,1:
             0: 61440
           8,2:
@@ -8232,8 +8250,8 @@ entities:
             0: 61071
           0,8:
             0: 26367
-            5: 4096
-            6: 32768
+            6: 4096
+            2: 32768
           1,4:
             0: 61680
           1,5:
@@ -8244,7 +8262,7 @@ entities:
             0: 64911
           1,8:
             0: 49373
-            6: 4096
+            2: 4096
           2,5:
             0: 28799
           2,6:
@@ -8288,21 +8306,21 @@ entities:
             0: 65358
           -3,7:
             0: 55769
-            5: 1024
+            6: 1024
           -3,8:
             0: 65421
           -2,5:
             0: 57599
           -2,6:
             0: 65356
-            5: 2
+            6: 2
           -2,7:
             0: 65533
           -2,8:
             0: 64991
           -1,8:
             0: 206
-            5: 57376
+            6: 57376
           4,8:
             0: 65535
           5,4:
@@ -8368,10 +8386,10 @@ entities:
             0: 65535
           -1,9:
             0: 61038
-            5: 128
+            6: 128
           -1,10:
             1: 60928
-            3: 192
+            4: 192
           -1,11:
             1: 14
             0: 57344
@@ -8379,11 +8397,12 @@ entities:
             0: 65518
           0,9:
             0: 32655
-            5: 48
+            6: 16
+            2: 32
             7: 64
             8: 32768
           0,10:
-            3: 240
+            4: 240
             1: 65280
           0,11:
             1: 15
@@ -8395,12 +8414,12 @@ entities:
             8: 4096
           1,10:
             1: 53504
-            3: 8192
+            4: 8192
             0: 204
           1,11:
             1: 19549
             0: 4096
-            3: 34
+            4: 34
           1,12:
             0: 4369
             1: 17476
@@ -8468,7 +8487,7 @@ entities:
             1: 34952
           10,7:
             1: 33249
-            3: 3598
+            4: 3598
           9,8:
             1: 34952
           10,3:
@@ -8480,10 +8499,10 @@ entities:
           11,6:
             1: 40844
           11,7:
-            3: 771
+            4: 771
             1: 35064
           10,8:
-            3: 3598
+            4: 3598
             1: 33249
           11,5:
             0: 34956
@@ -8499,29 +8518,29 @@ entities:
             1: 20293
           12,7:
             1: 33008
-            3: 3598
+            4: 3598
           11,8:
             1: 35064
-            3: 771
+            4: 771
           9,0:
-            2: 15
+            3: 15
             0: 65296
           9,1:
             0: 47232
           9,2:
             0: 48955
           9,-1:
-            2: 65520
+            3: 65520
             0: 1
           10,0:
-            2: 1
+            3: 1
             0: 65292
           10,1:
             0: 56789
           10,2:
             0: 64961
           10,-1:
-            2: 4368
+            3: 4368
             0: 57548
           11,0:
             0: 30543
@@ -8647,7 +8666,7 @@ entities:
             0: 65520
           -10,4:
             1: 3
-            3: 8
+            4: 8
             0: 60928
           -13,4:
             0: 61432
@@ -8658,24 +8677,24 @@ entities:
           -12,6:
             1: 44868
           -12,7:
-            3: 3855
+            4: 3855
             1: 16624
           -13,7:
             1: 17652
-            3: 257
+            4: 257
           -12,8:
-            3: 3855
+            4: 3855
             1: 16624
           -11,5:
             0: 4095
           -11,6:
             1: 18210
           -11,7:
-            3: 257
+            4: 257
             1: 18006
           -11,8:
             1: 18006
-            3: 257
+            4: 257
           -10,5:
             0: 61182
           -10,6:
@@ -8706,19 +8725,19 @@ entities:
           -14,6:
             1: 44953
           -14,7:
-            3: 3855
+            4: 3855
             1: 16624
           -14,3:
             0: 65535
           -14,8:
-            3: 3855
+            4: 3855
             1: 16624
           -13,6:
             1: 57600
             0: 1092
           -13,8:
             1: 17652
-            3: 257
+            4: 257
           -16,0:
             0: 55807
           -16,-1:
@@ -8954,10 +8973,10 @@ entities:
           13,6:
             1: 40866
           13,7:
-            3: 771
+            4: 771
             1: 36024
           12,8:
-            3: 3598
+            4: 3598
             1: 33008
           14,5:
             0: 3
@@ -8966,7 +8985,7 @@ entities:
             1: 310
           13,8:
             1: 36028
-            3: 771
+            4: 771
           15,5:
             1: 304
           16,4:
@@ -9005,17 +9024,17 @@ entities:
           18,3:
             0: 15
             1: 3840
-            3: 4096
+            4: 4096
           19,0:
             1: 61455
           19,1:
             1: 36608
           19,2:
             1: 742
-            3: 8192
+            4: 8192
           19,3:
             1: 226
-            3: 32768
+            4: 32768
           20,0:
             1: 61715
           20,1:
@@ -9222,7 +9241,7 @@ entities:
           3,-14:
             0: 4415
             1: 192
-            3: 49152
+            4: 49152
           3,-17:
             9: 30576
           4,-16:
@@ -9233,7 +9252,7 @@ entities:
           4,-14:
             0: 52463
             1: 16
-            3: 4096
+            4: 4096
           8,-13:
             0: 56605
           9,-12:
@@ -9649,7 +9668,7 @@ entities:
             0: 15
           16,-20:
             1: 16
-            3: 52454
+            4: 52454
           15,-20:
             1: 44719
           16,-19:
@@ -9664,60 +9683,60 @@ entities:
             0: 234
             1: 20480
           16,-21:
-            3: 16384
+            4: 16384
             1: 15
           17,-20:
             1: 144
-            3: 14178
+            4: 14178
           17,-19:
-            3: 1
+            4: 1
             1: 63744
           17,-18:
             1: 153
             0: 61440
           17,-21:
             1: 8207
-            3: 16384
+            4: 16384
           18,-20:
             1: 9910
-            3: 2056
+            4: 2056
           18,-19:
             1: 13990
-            3: 2056
+            4: 2056
           18,-18:
             0: 4096
             1: 17486
           18,-21:
             1: 9895
-            3: 2056
+            4: 2056
           19,-20:
-            3: 3855
+            4: 3855
             1: 8432
           19,-19:
-            3: 3855
+            4: 3855
             1: 20720
           19,-18:
             1: 17487
           19,-21:
             1: 8432
-            3: 3855
+            4: 3855
           20,-20:
             1: 8946
-            3: 2056
+            4: 2056
           20,-19:
             1: 8946
-            3: 2056
+            4: 2056
           20,-18:
             1: 1839
             0: 8192
           20,-21:
             1: 8946
-            3: 2056
+            4: 2056
           21,-20:
-            3: 3855
+            4: 3855
             1: 8432
           21,-19:
-            3: 3855
+            4: 3855
             1: 20720
           21,-18:
             1: 21855
@@ -9725,7 +9744,7 @@ entities:
             1: 5621
           21,-21:
             1: 8432
-            3: 3855
+            4: 3855
           22,-20:
             1: 8995
           22,-19:
@@ -9754,7 +9773,7 @@ entities:
           13,-18:
             1: 17476
           14,-20:
-            3: 16
+            4: 16
           14,-19:
             1: 241
           15,-21:
@@ -9791,7 +9810,7 @@ entities:
             0: 65535
           4,-21:
             0: 65348
-            3: 1
+            4: 1
           3,-20:
             0: 65535
           4,-19:
@@ -9817,7 +9836,7 @@ entities:
             0: 30576
           5,-21:
             0: 65280
-            3: 15
+            4: 15
           6,-20:
             0: 30583
           6,-19:
@@ -9849,15 +9868,15 @@ entities:
             0: 30583
           6,-15:
             1: 4592
-            3: 49152
+            4: 49152
           6,-14:
             1: 4369
-            3: 49356
+            4: 49356
           7,-15:
             1: 17520
-            3: 4096
+            4: 4096
           7,-14:
-            3: 4113
+            4: 4113
             1: 17476
           -4,-20:
             0: 61440
@@ -9873,28 +9892,28 @@ entities:
             0: 57297
           -3,-20:
             0: 28672
-            3: 76
+            4: 76
           -3,-19:
             0: 30711
           -3,-18:
             0: 65520
           -3,-21:
-            3: 52428
+            4: 52428
             1: 4353
           -2,-20:
-            3: 15
+            4: 15
             0: 3840
           -2,-19:
             0: 65535
           -2,-18:
             0: 65535
           -2,-21:
-            3: 61696
+            4: 61696
             1: 248
           -1,-18:
             0: 65534
           -1,-21:
-            3: 61440
+            4: 61440
             1: 2296
           -1,-20:
             0: 61152
@@ -9902,7 +9921,7 @@ entities:
             0: 36590
           0,-20:
             0: 15152
-            3: 8
+            4: 8
           0,-19:
             0: 35771
           0,-18:
@@ -9939,26 +9958,26 @@ entities:
             1: 34824
           -12,-16:
             1: 20292
-            3: 10
+            4: 10
           -13,-16:
             1: 20292
-            3: 10
+            4: 10
           -12,-15:
             1: 17732
-            3: 43690
+            4: 43690
           -13,-15:
-            3: 43690
+            4: 43690
             1: 17732
           -12,-14:
             1: 49060
-            3: 10
+            4: 10
           -13,-14:
             1: 65444
-            3: 10
+            4: 10
           -12,-13:
             1: 62
           -12,-17:
-            3: 43690
+            4: 43690
             1: 17732
           -11,-16:
             1: 8994
@@ -9983,7 +10002,7 @@ entities:
           -13,-18:
             1: 44800
           -13,-17:
-            3: 43690
+            4: 43690
             1: 17732
           -11,-18:
             1: 8960
@@ -9992,10 +10011,10 @@ entities:
           -9,-18:
             1: 1811
           0,-21:
-            3: 61440
+            4: 61440
             1: 248
           1,-20:
-            3: 7
+            4: 7
             0: 1792
           1,-19:
             0: 65535
@@ -10004,7 +10023,7 @@ entities:
           1,-17:
             0: 4095
           1,-21:
-            3: 64648
+            4: 64648
             1: 112
           2,-20:
             0: 43962
@@ -10013,17 +10032,17 @@ entities:
           2,-18:
             0: 46011
           2,-21:
-            3: 13107
+            4: 13107
             0: 34816
             1: 8
           3,-21:
             0: 65280
-            3: 14
+            4: 14
           0,-24:
-            3: 64512
+            4: 64512
             1: 136
           -1,-24:
-            3: 61696
+            4: 61696
             1: 136
           0,-23:
             1: 35064
@@ -10032,32 +10051,32 @@ entities:
           0,-22:
             1: 35064
           -1,-22:
-            3: 128
+            4: 128
             1: 34936
           0,-25:
             1: 36744
           1,-24:
-            3: 62208
+            4: 62208
             1: 136
           1,-23:
             1: 112
-            3: 34956
+            4: 34956
           1,-22:
             1: 112
-            3: 34952
+            4: 34952
           1,-25:
             1: 36736
           2,-23:
-            3: 13073
+            4: 13073
             1: 52224
           2,-22:
-            3: 4369
+            4: 4369
             1: 36044
           3,-23:
             1: 61440
           3,-22:
             1: 15
-            3: 60928
+            4: 60928
           3,-24:
             1: 35939
           3,-25:
@@ -10068,7 +10087,7 @@ entities:
             1: 64739
           4,-22:
             1: 15
-            3: 4352
+            4: 4352
             0: 58368
           -4,-24:
             1: 310
@@ -10085,25 +10104,25 @@ entities:
             0: 4
           -4,-21:
             1: 65295
-            3: 112
+            4: 112
           -4,-25:
             1: 51200
           -3,-23:
             1: 4352
-            3: 52462
+            4: 52462
           -3,-22:
             1: 4112
-            3: 61132
+            4: 61132
           -3,-24:
-            3: 32768
+            4: 32768
             1: 136
           -3,-25:
             1: 36342
           -2,-24:
-            3: 63232
+            4: 63232
             1: 136
           -2,-23:
-            3: 1
+            4: 1
             1: 35064
           -2,-22:
             1: 35064
@@ -10115,7 +10134,7 @@ entities:
             1: 61459
           5,-22:
             1: 15
-            3: 65280
+            4: 65280
           5,-24:
             1: 62432
           6,-24:
@@ -10152,24 +10171,24 @@ entities:
             0: 2184
           -15,-16:
             1: 23391
-            3: 1024
+            4: 1024
           -15,-15:
             1: 34959
           -15,-17:
             1: 34952
           -14,-16:
             1: 20292
-            3: 10
+            4: 10
           -14,-15:
             1: 21588
-            3: 43690
+            4: 43690
           -15,-14:
             1: 2184
           -14,-14:
             1: 36772
-            3: 10
+            4: 10
           -14,-17:
-            3: 43690
+            4: 43690
             1: 21588
           -15,-18:
             1: 34816
@@ -10180,23 +10199,23 @@ entities:
           -15,10:
             1: 12
           -14,9:
-            3: 3855
+            4: 3855
             1: 41200
           -14,10:
             1: 15
           -13,9:
-            3: 257
+            4: 257
             1: 17652
           -13,10:
             1: 62901
-            3: 64
+            4: 64
           -12,9:
             1: 41200
-            3: 3855
+            4: 3855
           -12,10:
             1: 4383
           -11,9:
-            3: 257
+            4: 257
             1: 18006
           -11,10:
             1: 7
@@ -10223,24 +10242,24 @@ entities:
             1: 34952
           10,9:
             1: 16865
-            3: 3598
+            4: 3598
           9,10:
             1: 8
           10,10:
             1: 15
           11,9:
-            3: 771
+            4: 771
             1: 39160
           11,10:
             1: 60011
-            3: 128
+            4: 128
           12,9:
             1: 16624
-            3: 3598
+            4: 3598
           12,10:
             1: 12862
           13,9:
-            3: 771
+            4: 771
             1: 40124
           13,10:
             1: 15
@@ -10258,7 +10277,7 @@ entities:
             1: 32768
           20,-22:
             1: 10970
-            3: 32
+            4: 32
           19,-22:
             1: 24456
           21,-22:
@@ -10303,6 +10322,21 @@ entities:
           moles:
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 21.824879
+          - 82.10312
           - 0
           - 0
           - 0
@@ -10374,25 +10408,10 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.14975
-          moles:
-          - 21.824879
-          - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
           temperature: 293.14923
           moles:
-          - 18.472576
-          - 69.49208
+          - 20.078888
+          - 75.53487
           - 0
           - 0
           - 0
@@ -10472,8 +10491,8 @@ entities:
           id: docking46345
           localAnchorB: -0.5,-1
           localAnchorA: -66.5,22
-          damping: 42.40074
-          stiffness: 380.58823
+          damping: 42.400753
+          stiffness: 380.5883
     - type: OccluderTree
     - type: Shuttle
     - type: RadiationGridResistance
@@ -10553,20 +10572,6 @@ entities:
       parent: 8364
 - proto: ActionToggleInternals
   entities:
-  - uid: 9516
-    components:
-    - type: Transform
-      parent: 9515
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 9515
-  - uid: 10056
-    components:
-    - type: Transform
-      parent: 9567
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 9567
   - uid: 25167
     components:
     - type: Transform
@@ -12786,6 +12791,15 @@ entities:
     - type: Transform
       pos: 38.5,-39.5
       parent: 8364
+- proto: AirlockCommandGlass
+  entities:
+  - uid: 4214
+    components:
+    - type: MetaData
+      name: EVA
+    - type: Transform
+      pos: -11.5,5.5
+      parent: 8364
 - proto: AirlockCommandGlassLocked
   entities:
   - uid: 5514
@@ -13818,7 +13832,7 @@ entities:
       pos: 24.5,16.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -83117.086
+      secondsUntilStateChange: -88221.33
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14208,15 +14222,6 @@ entities:
         DockStatus: True
     - type: Physics
       canCollide: False
-- proto: AirlockHeadOfPersonnelGlassLocked
-  entities:
-  - uid: 12024
-    components:
-    - type: MetaData
-      name: EVA Gear
-    - type: Transform
-      pos: -11.5,5.5
-      parent: 8364
 - proto: AirlockHeadOfPersonnelLocked
   entities:
   - uid: 5647
@@ -14945,11 +14950,6 @@ entities:
     - type: Transform
       pos: 42.5,-45.5
       parent: 8364
-  - uid: 12033
-    components:
-    - type: Transform
-      pos: -13.5,4.5
-      parent: 8364
   - uid: 15102
     components:
     - type: Transform
@@ -15141,11 +15141,6 @@ entities:
     - type: Transform
       pos: 56.5,-19.5
       parent: 8364
-  - uid: 11980
-    components:
-    - type: Transform
-      pos: -13.5,1.5
-      parent: 8364
   - uid: 20191
     components:
     - type: MetaData
@@ -15290,13 +15285,6 @@ entities:
     - type: Transform
       pos: 8.5,34.5
       parent: 8364
-  - uid: 8642
-    components:
-    - type: MetaData
-      name: Evidence Storage
-    - type: Transform
-      pos: -13.5,25.5
-      parent: 8364
   - uid: 8643
     components:
     - type: MetaData
@@ -15380,6 +15368,20 @@ entities:
     - type: Transform
       pos: -23.5,-30.5
       parent: 8364
+  - uid: 26257
+    components:
+    - type: MetaData
+      name: Holding Cell
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,25.5
+      parent: 8364
+    - type: Door
+      secondsUntilStateChange: -1477.8262
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
 - proto: AirlockSecurityLocked
   entities:
   - uid: 971
@@ -16067,6 +16069,9 @@ entities:
     - type: Transform
       pos: -8.5,20.5
       parent: 8364
+    - type: DeviceNetwork
+      deviceLists:
+      - 7797
   - uid: 23944
     components:
     - type: Transform
@@ -16644,6 +16649,8 @@ entities:
       parent: 8364
   - uid: 8620
     components:
+    - type: MetaData
+      name: Interrigation APC
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,30.5
@@ -18142,11 +18149,6 @@ entities:
     - type: Transform
       pos: 44.5,36.5
       parent: 8364
-  - uid: 4481
-    components:
-    - type: Transform
-      pos: -0.5,41.5
-      parent: 8364
   - uid: 4482
     components:
     - type: Transform
@@ -18292,20 +18294,10 @@ entities:
     - type: Transform
       pos: 41.5,36.5
       parent: 8364
-  - uid: 4645
-    components:
-    - type: Transform
-      pos: 1.5,41.5
-      parent: 8364
   - uid: 4648
     components:
     - type: Transform
       pos: -47.5,34.5
-      parent: 8364
-  - uid: 4650
-    components:
-    - type: Transform
-      pos: -1.5,41.5
       parent: 8364
   - uid: 4652
     components:
@@ -18441,11 +18433,6 @@ entities:
     components:
     - type: Transform
       pos: -43.5,34.5
-      parent: 8364
-  - uid: 6419
-    components:
-    - type: Transform
-      pos: 5.5,45.5
       parent: 8364
   - uid: 6596
     components:
@@ -18677,21 +18664,6 @@ entities:
     - type: Transform
       pos: -48.5,-55.5
       parent: 8364
-  - uid: 22451
-    components:
-    - type: Transform
-      pos: 3.5,41.5
-      parent: 8364
-  - uid: 22452
-    components:
-    - type: Transform
-      pos: 5.5,43.5
-      parent: 8364
-  - uid: 22453
-    components:
-    - type: Transform
-      pos: 5.5,44.5
-      parent: 8364
   - uid: 22454
     components:
     - type: Transform
@@ -18812,11 +18784,6 @@ entities:
     - type: Transform
       pos: -46.5,-56.5
       parent: 8364
-  - uid: 23135
-    components:
-    - type: Transform
-      pos: 0.5,41.5
-      parent: 8364
   - uid: 23139
     components:
     - type: Transform
@@ -18856,11 +18823,6 @@ entities:
     components:
     - type: Transform
       pos: 84.5,-75.5
-      parent: 8364
-  - uid: 23537
-    components:
-    - type: Transform
-      pos: 2.5,41.5
       parent: 8364
   - uid: 23538
     components:
@@ -20884,7 +20846,7 @@ entities:
     - type: Transform
       pos: 5.5,-76.5
       parent: 8364
-  - uid: 9182
+  - uid: 6419
     components:
     - type: Transform
       pos: 5.5,36.5
@@ -21403,7 +21365,7 @@ entities:
   - uid: 9388
     components:
     - type: Transform
-      pos: -2.3561149,38.959312
+      pos: -2.28955,39.38977
       parent: 8364
   - uid: 9589
     components:
@@ -21495,21 +21457,43 @@ entities:
     - type: Transform
       pos: -11.686346,32.74469
       parent: 8364
-  - uid: 9172
+  - uid: 9384
     components:
     - type: Transform
-      pos: -14.5,22.5
+      pos: -1.2688226,30.437838
       parent: 8364
-  - uid: 9173
-    components:
-    - type: Transform
-      pos: -14.5,22.5
-      parent: 8364
-  - uid: 9174
-    components:
-    - type: Transform
-      pos: -14.5,22.5
-      parent: 8364
+    - type: Storage
+      storedItems:
+        9390:
+          position: 0,0
+          _rotation: South
+        9453:
+          position: 1,0
+          _rotation: South
+        9454:
+          position: 2,0
+          _rotation: South
+        9507:
+          position: 3,0
+          _rotation: South
+        9515:
+          position: 4,0
+          _rotation: South
+        9516:
+          position: 0,1
+          _rotation: South
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 9390
+          - 9453
+          - 9454
+          - 9507
+          - 9515
+          - 9516
   - uid: 9404
     components:
     - type: Transform
@@ -21620,7 +21604,7 @@ entities:
   - uid: 9389
     components:
     - type: Transform
-      pos: -2.7208788,39.167786
+      pos: -2.648925,39.67102
       parent: 8364
 - proto: BoxingBell
   entities:
@@ -21644,20 +21628,26 @@ entities:
       parent: 8364
 - proto: BoxLethalshot
   entities:
-  - uid: 9361
+  - uid: 4645
     components:
     - type: Transform
-      parent: 9359
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 9367
+      pos: -1.2980705,35.389374
+      parent: 8364
+  - uid: 8641
     components:
     - type: Transform
-      parent: 9359
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      pos: -1.6730705,35.712288
+      parent: 8364
+  - uid: 9229
+    components:
+    - type: Transform
+      pos: -1.7147372,35.399788
+      parent: 8364
+  - uid: 9233
+    components:
+    - type: Transform
+      pos: -1.2668205,35.701874
+      parent: 8364
 - proto: BoxLightbulb
   entities:
   - uid: 1999
@@ -21814,6 +21804,7 @@ entities:
       linkedPorts:
         8624:
         - Start: Close
+        - Timer: AutoClose
         - Timer: Open
   - uid: 25829
     components:
@@ -21824,6 +21815,7 @@ entities:
       linkedPorts:
         8625:
         - Start: Close
+        - Timer: AutoClose
         - Timer: Open
   - uid: 26575
     components:
@@ -21834,6 +21826,7 @@ entities:
       linkedPorts:
         8626:
         - Start: Close
+        - Timer: AutoClose
         - Timer: Open
 - proto: Bucket
   entities:
@@ -21923,17 +21916,17 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 0.5,23.5
       parent: 8364
-  - uid: 8630
+  - uid: 7779
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.505839,38.730606
+      pos: 5.4761214,38.22741
       parent: 8364
-  - uid: 25233
+  - uid: 25742
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.4954224,38.251434
+      pos: 5.469177,38.803795
       parent: 8364
 - proto: ButtonFrameExit
   entities:
@@ -21949,10 +21942,16 @@ entities:
     - type: Transform
       pos: 8.5,42.5
       parent: 8364
-  - uid: 9390
+  - uid: 8989
     components:
     - type: Transform
-      pos: 16.5,42.5
+      rot: -1.5707963267948966 rad
+      pos: 17.5,40.5
+      parent: 8364
+  - uid: 22452
+    components:
+    - type: Transform
+      pos: 13.5,29.5
       parent: 8364
 - proto: CableApcExtension
   entities:
@@ -24636,6 +24635,11 @@ entities:
     - type: Transform
       pos: -2.5,37.5
       parent: 8364
+  - uid: 8630
+    components:
+    - type: Transform
+      pos: -15.5,52.5
+      parent: 8364
   - uid: 8636
     components:
     - type: Transform
@@ -26395,16 +26399,6 @@ entities:
     components:
     - type: Transform
       pos: 3.5,22.5
-      parent: 8364
-  - uid: 10086
-    components:
-    - type: Transform
-      pos: 8.5,25.5
-      parent: 8364
-  - uid: 10087
-    components:
-    - type: Transform
-      pos: 10.5,25.5
       parent: 8364
   - uid: 10088
     components:
@@ -43006,26 +43000,6 @@ entities:
     - type: Transform
       pos: -11.5,49.5
       parent: 8364
-  - uid: 25742
-    components:
-    - type: Transform
-      pos: -11.5,50.5
-      parent: 8364
-  - uid: 25743
-    components:
-    - type: Transform
-      pos: -11.5,51.5
-      parent: 8364
-  - uid: 25744
-    components:
-    - type: Transform
-      pos: -11.5,52.5
-      parent: 8364
-  - uid: 25747
-    components:
-    - type: Transform
-      pos: -11.5,53.5
-      parent: 8364
   - uid: 25995
     components:
     - type: Transform
@@ -43045,11 +43019,6 @@ entities:
     components:
     - type: Transform
       pos: 9.5,-75.5
-      parent: 8364
-  - uid: 26136
-    components:
-    - type: Transform
-      pos: -15.5,51.5
       parent: 8364
   - uid: 26137
     components:
@@ -52427,11 +52396,6 @@ entities:
     - type: Transform
       pos: 17.5,30.5
       parent: 8364
-  - uid: 7659
-    components:
-    - type: Transform
-      pos: 4.5,43.5
-      parent: 8364
   - uid: 7735
     components:
     - type: Transform
@@ -52481,6 +52445,11 @@ entities:
     components:
     - type: Transform
       pos: 11.5,27.5
+      parent: 8364
+  - uid: 8470
+    components:
+    - type: Transform
+      pos: -15.5,51.5
       parent: 8364
   - uid: 8485
     components:
@@ -52552,10 +52521,55 @@ entities:
     - type: Transform
       pos: 12.5,27.5
       parent: 8364
+  - uid: 8553
+    components:
+    - type: Transform
+      pos: -15.5,52.5
+      parent: 8364
+  - uid: 8554
+    components:
+    - type: Transform
+      pos: -15.5,53.5
+      parent: 8364
+  - uid: 8555
+    components:
+    - type: Transform
+      pos: -15.5,54.5
+      parent: 8364
+  - uid: 8569
+    components:
+    - type: Transform
+      pos: -11.5,50.5
+      parent: 8364
   - uid: 8592
     components:
     - type: Transform
       pos: 3.5,34.5
+      parent: 8364
+  - uid: 8597
+    components:
+    - type: Transform
+      pos: -14.5,54.5
+      parent: 8364
+  - uid: 8606
+    components:
+    - type: Transform
+      pos: -12.5,54.5
+      parent: 8364
+  - uid: 8607
+    components:
+    - type: Transform
+      pos: -11.5,53.5
+      parent: 8364
+  - uid: 8610
+    components:
+    - type: Transform
+      pos: -11.5,54.5
+      parent: 8364
+  - uid: 8615
+    components:
+    - type: Transform
+      pos: -11.5,51.5
       parent: 8364
   - uid: 8632
     components:
@@ -52927,6 +52941,11 @@ entities:
     - type: Transform
       pos: -0.5,34.5
       parent: 8364
+  - uid: 9046
+    components:
+    - type: Transform
+      pos: -16.5,39.5
+      parent: 8364
   - uid: 9143
     components:
     - type: Transform
@@ -52967,11 +52986,6 @@ entities:
     - type: Transform
       pos: -19.5,23.5
       parent: 8364
-  - uid: 9207
-    components:
-    - type: Transform
-      pos: 4.5,42.5
-      parent: 8364
   - uid: 9218
     components:
     - type: Transform
@@ -52981,11 +52995,6 @@ entities:
     components:
     - type: Transform
       pos: 1.5,37.5
-      parent: 8364
-  - uid: 9248
-    components:
-    - type: Transform
-      pos: 3.5,42.5
       parent: 8364
   - uid: 9249
     components:
@@ -53232,15 +53241,15 @@ entities:
     - type: Transform
       pos: 17.5,32.5
       parent: 8364
-  - uid: 10057
-    components:
-    - type: Transform
-      pos: 5.5,43.5
-      parent: 8364
   - uid: 10061
     components:
     - type: Transform
       pos: 1.5,34.5
+      parent: 8364
+  - uid: 10063
+    components:
+    - type: Transform
+      pos: -11.5,52.5
       parent: 8364
   - uid: 10064
     components:
@@ -58202,11 +58211,6 @@ entities:
     - type: Transform
       pos: -7.5,-54.5
       parent: 8364
-  - uid: 19886
-    components:
-    - type: Transform
-      pos: -1.5,42.5
-      parent: 8364
   - uid: 19887
     components:
     - type: Transform
@@ -58221,11 +58225,6 @@ entities:
     components:
     - type: Transform
       pos: 1.5,42.5
-      parent: 8364
-  - uid: 19890
-    components:
-    - type: Transform
-      pos: -2.5,42.5
       parent: 8364
   - uid: 19925
     components:
@@ -60087,60 +60086,10 @@ entities:
     - type: Transform
       pos: -11.5,49.5
       parent: 8364
-  - uid: 26251
-    components:
-    - type: Transform
-      pos: -11.5,50.5
-      parent: 8364
-  - uid: 26252
-    components:
-    - type: Transform
-      pos: -11.5,51.5
-      parent: 8364
-  - uid: 26253
-    components:
-    - type: Transform
-      pos: -11.5,52.5
-      parent: 8364
-  - uid: 26254
-    components:
-    - type: Transform
-      pos: -11.5,53.5
-      parent: 8364
-  - uid: 26255
-    components:
-    - type: Transform
-      pos: -11.5,54.5
-      parent: 8364
-  - uid: 26256
-    components:
-    - type: Transform
-      pos: -12.5,54.5
-      parent: 8364
-  - uid: 26257
-    components:
-    - type: Transform
-      pos: -12.5,53.5
-      parent: 8364
-  - uid: 26258
-    components:
-    - type: Transform
-      pos: -13.5,53.5
-      parent: 8364
   - uid: 26259
     components:
     - type: Transform
-      pos: -14.5,53.5
-      parent: 8364
-  - uid: 26260
-    components:
-    - type: Transform
-      pos: -14.5,54.5
-      parent: 8364
-  - uid: 26261
-    components:
-    - type: Transform
-      pos: -15.5,54.5
+      pos: -16.5,38.5
       parent: 8364
   - uid: 26262
     components:
@@ -60701,16 +60650,6 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-22.5
-      parent: 8364
-  - uid: 28253
-    components:
-    - type: Transform
-      pos: 5.5,44.5
-      parent: 8364
-  - uid: 28254
-    components:
-    - type: Transform
-      pos: 5.5,45.5
       parent: 8364
 - proto: CableMVStack
   entities:
@@ -61344,7 +61283,7 @@ entities:
     - type: Transform
       pos: 12.5,24.5
       parent: 8364
-  - uid: 8989
+  - uid: 8611
     components:
     - type: Transform
       pos: -15.5,51.5
@@ -66976,6 +66915,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -11.5,40.5
       parent: 8364
+  - uid: 7798
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,23.5
+      parent: 8364
   - uid: 7978
     components:
     - type: Transform
@@ -67041,6 +66986,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 12.5,22.5
       parent: 8364
+  - uid: 8436
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,23.5
+      parent: 8364
   - uid: 8617
     components:
     - type: Transform
@@ -67085,6 +67036,12 @@ entities:
     components:
     - type: Transform
       pos: 8.5,21.5
+      parent: 8364
+  - uid: 9248
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,23.5
       parent: 8364
   - uid: 9414
     components:
@@ -67529,6 +67486,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 4.5,-63.5
       parent: 8364
+  - uid: 25714
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,41.5
+      parent: 8364
   - uid: 26133
     components:
     - type: Transform
@@ -67574,12 +67537,6 @@ entities:
     components:
     - type: Transform
       pos: 1.5,50.5
-      parent: 8364
-  - uid: 26577
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,40.5
       parent: 8364
   - uid: 26868
     components:
@@ -68733,8 +68690,11 @@ entities:
   - uid: 27286
     components:
     - type: Transform
+      anchored: True
       pos: 10.5,40.5
       parent: 8364
+    - type: Physics
+      bodyType: Static
     - type: EntityStorage
       air:
         volume: 200
@@ -70379,8 +70339,11 @@ entities:
   - uid: 9261
     components:
     - type: Transform
+      anchored: True
       pos: 10.5,41.5
       parent: 8364
+    - type: Physics
+      bodyType: Static
     - type: EntityStorage
       air:
         volume: 200
@@ -72618,36 +72581,6 @@ entities:
     - type: Transform
       pos: 66.509186,-76.72045
       parent: 8364
-- proto: ClothingOuterHardsuitSecurity
-  entities:
-  - uid: 9230
-    components:
-    - type: Transform
-      parent: 9229
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 9238
-    components:
-    - type: Transform
-      parent: 9235
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 9517
-    components:
-    - type: Transform
-      parent: 9507
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 9566
-    components:
-    - type: Transform
-      parent: 9518
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: ClothingOuterHoodieGrey
   entities:
   - uid: 21633
@@ -73573,6 +73506,11 @@ entities:
     - type: Transform
       pos: 13.5,41.5
       parent: 8364
+  - uid: 9345
+    components:
+    - type: Transform
+      pos: 4.5,28.5
+      parent: 8364
   - uid: 9362
     components:
     - type: Transform
@@ -73875,21 +73813,6 @@ entities:
       parent: 8364
 - proto: ComputerTelevision
   entities:
-  - uid: 4213
-    components:
-    - type: Transform
-      pos: -4.5,24.5
-      parent: 8364
-  - uid: 4214
-    components:
-    - type: Transform
-      pos: -0.5,24.5
-      parent: 8364
-  - uid: 6253
-    components:
-    - type: Transform
-      pos: -8.5,24.5
-      parent: 8364
   - uid: 6594
     components:
     - type: Transform
@@ -73904,6 +73827,24 @@ entities:
     components:
     - type: Transform
       pos: -3.5,14.5
+      parent: 8364
+  - uid: 8780
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,24.5
+      parent: 8364
+  - uid: 26251
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,24.5
+      parent: 8364
+  - uid: 26252
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,24.5
       parent: 8364
   - uid: 27653
     components:
@@ -75225,6 +75166,14 @@ entities:
     - type: Transform
       pos: 29.484377,-32.156303
       parent: 8364
+- proto: CurtainsRed
+  entities:
+  - uid: 4650
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,41.5
+      parent: 8364
 - proto: d20Dice
   entities:
   - uid: 6522
@@ -75700,15 +75649,20 @@ entities:
       parent: 8364
 - proto: DeployableBarrier
   entities:
-  - uid: 8761
+  - uid: 7678
     components:
     - type: Transform
-      pos: 3.5,35.5
+      pos: -13.5,22.5
       parent: 8364
-  - uid: 9267
+  - uid: 7680
     components:
     - type: Transform
-      pos: 4.5,35.5
+      pos: -12.5,22.5
+      parent: 8364
+  - uid: 25712
+    components:
+    - type: Transform
+      pos: -14.5,22.5
       parent: 8364
 - proto: DeskBell
   entities:
@@ -84497,10 +84451,10 @@ entities:
       parent: 8364
 - proto: DresserHeadOfSecurityFilled
   entities:
-  - uid: 5606
+  - uid: 9377
     components:
     - type: Transform
-      pos: 16.5,40.5
+      pos: 15.5,41.5
       parent: 8364
 - proto: DresserQuarterMasterFilled
   entities:
@@ -85374,20 +85328,6 @@ entities:
     - type: Transform
       pos: 5.5,46.5
       parent: 8364
-  - uid: 18370
-    components:
-    - type: MetaData
-      desc: WARNING! Live minefield!
-    - type: Transform
-      pos: -24.5,52.5
-      parent: 8364
-  - uid: 28261
-    components:
-    - type: MetaData
-      desc: WARNING! Live minefield!
-    - type: Transform
-      pos: -7.5,54.5
-      parent: 8364
   - uid: 28263
     components:
     - type: MetaData
@@ -86032,6 +85972,20 @@ entities:
       - 14149
       - 22663
       - 19972
+  - uid: 7797
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,18.5
+      parent: 8364
+    - type: DeviceList
+      devices:
+      - 11605
+      - 11600
+      - 11377
+      - 11603
+      - 23940
+      - 9291
   - uid: 10714
     components:
     - type: Transform
@@ -86703,19 +86657,6 @@ entities:
       - 11605
       - 11600
       - 23935
-  - uid: 23942
-    components:
-    - type: Transform
-      pos: 0.5,22.5
-      parent: 8364
-    - type: DeviceList
-      devices:
-      - 11605
-      - 11600
-      - 11377
-      - 11603
-      - 23940
-      - 9291
   - uid: 25807
     components:
     - type: Transform
@@ -87651,11 +87592,9 @@ entities:
       pos: -1.5,18.5
       parent: 8364
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
-      - 23942
       - 23898
+      - 7797
   - uid: 9811
     components:
     - type: Transform
@@ -87743,6 +87682,9 @@ entities:
     - type: Transform
       pos: 1.5,22.5
       parent: 8364
+    - type: DeviceNetwork
+      deviceLists:
+      - 7797
   - uid: 11553
     components:
     - type: Transform
@@ -87758,11 +87700,17 @@ entities:
     - type: Transform
       pos: 0.5,18.5
       parent: 8364
+    - type: DeviceNetwork
+      deviceLists:
+      - 7797
   - uid: 11603
     components:
     - type: Transform
       pos: 2.5,22.5
       parent: 8364
+    - type: DeviceNetwork
+      deviceLists:
+      - 7797
   - uid: 11604
     components:
     - type: Transform
@@ -87773,6 +87721,9 @@ entities:
     - type: Transform
       pos: -0.5,18.5
       parent: 8364
+    - type: DeviceNetwork
+      deviceLists:
+      - 7797
   - uid: 11719
     components:
     - type: Transform
@@ -87963,6 +87914,7 @@ entities:
     - type: Transform
       pos: 20.5,24.5
       parent: 8364
+    - type: DeviceNetwork
   - uid: 13461
     components:
     - type: Transform
@@ -88095,7 +88047,7 @@ entities:
       pos: -34.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -77305.625
+      secondsUntilStateChange: -82409.87
       state: Closing
   - uid: 15010
     components:
@@ -108143,6 +108095,11 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 25233
+    components:
+    - type: Transform
+      pos: 8.5,24.5
+      parent: 8364
   - uid: 25247
     components:
     - type: Transform
@@ -109749,14 +109706,6 @@ entities:
       parent: 8364
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 25554
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,24.5
-      parent: 8364
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 25555
     components:
     - type: Transform
@@ -121522,11 +121471,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 20.5,-82.5
       parent: 8364
-  - uid: 4163
-    components:
-    - type: Transform
-      pos: 5.5,44.5
-      parent: 8364
   - uid: 4234
     components:
     - type: Transform
@@ -122421,12 +122365,12 @@ entities:
   - uid: 4945
     components:
     - type: Transform
-      pos: 4.5,42.5
+      pos: -1.5,41.5
       parent: 8364
   - uid: 4946
     components:
     - type: Transform
-      pos: 3.5,42.5
+      pos: 0.5,41.5
       parent: 8364
   - uid: 4947
     components:
@@ -122446,12 +122390,7 @@ entities:
   - uid: 4951
     components:
     - type: Transform
-      pos: -1.5,42.5
-      parent: 8364
-  - uid: 4952
-    components:
-    - type: Transform
-      pos: -2.5,42.5
+      pos: 3.5,41.5
       parent: 8364
   - uid: 4957
     components:
@@ -123025,6 +122964,11 @@ entities:
     - type: Transform
       pos: 29.5,-22.5
       parent: 8364
+  - uid: 5606
+    components:
+    - type: Transform
+      pos: 2.5,41.5
+      parent: 8364
   - uid: 5709
     components:
     - type: Transform
@@ -123045,6 +122989,11 @@ entities:
     - type: Transform
       pos: -0.5,-79.5
       parent: 8364
+  - uid: 5791
+    components:
+    - type: Transform
+      pos: -0.5,41.5
+      parent: 8364
   - uid: 5913
     components:
     - type: Transform
@@ -123059,6 +123008,11 @@ entities:
     components:
     - type: Transform
       pos: -6.5,-93.5
+      parent: 8364
+  - uid: 6253
+    components:
+    - type: Transform
+      pos: 1.5,41.5
       parent: 8364
   - uid: 6305
     components:
@@ -123541,11 +123495,6 @@ entities:
     - type: Transform
       pos: 8.5,25.5
       parent: 8364
-  - uid: 7779
-    components:
-    - type: Transform
-      pos: 10.5,25.5
-      parent: 8364
   - uid: 7788
     components:
     - type: Transform
@@ -123998,6 +123947,11 @@ entities:
     - type: Transform
       pos: -6.5,-78.5
       parent: 8364
+  - uid: 8614
+    components:
+    - type: Transform
+      pos: -11.5,54.5
+      parent: 8364
   - uid: 8755
     components:
     - type: Transform
@@ -124007,6 +123961,11 @@ entities:
     components:
     - type: Transform
       pos: -6.5,38.5
+      parent: 8364
+  - uid: 8776
+    components:
+    - type: Transform
+      pos: -15.5,54.5
       parent: 8364
   - uid: 8786
     components:
@@ -124027,11 +123986,6 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-79.5
-      parent: 8364
-  - uid: 8825
-    components:
-    - type: Transform
-      pos: 5.5,45.5
       parent: 8364
   - uid: 8976
     components:
@@ -124095,10 +124049,15 @@ entities:
     - type: Transform
       pos: -13.5,39.5
       parent: 8364
-  - uid: 9208
+  - uid: 9169
     components:
     - type: Transform
-      pos: 5.5,43.5
+      pos: 5.5,45.5
+      parent: 8364
+  - uid: 9230
+    components:
+    - type: Transform
+      pos: -12.5,54.5
       parent: 8364
   - uid: 9332
     components:
@@ -124135,6 +124094,11 @@ entities:
     - type: Transform
       pos: 25.5,42.5
       parent: 8364
+  - uid: 9567
+    components:
+    - type: Transform
+      pos: -14.5,54.5
+      parent: 8364
   - uid: 9569
     components:
     - type: Transform
@@ -124149,6 +124113,12 @@ entities:
     components:
     - type: Transform
       pos: -18.5,21.5
+      parent: 8364
+  - uid: 10057
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,25.5
       parent: 8364
   - uid: 10082
     components:
@@ -124230,16 +124200,6 @@ entities:
     components:
     - type: Transform
       pos: -9.5,2.5
-      parent: 8364
-  - uid: 11607
-    components:
-    - type: Transform
-      pos: -13.5,3.5
-      parent: 8364
-  - uid: 11608
-    components:
-    - type: Transform
-      pos: -13.5,2.5
       parent: 8364
   - uid: 11648
     components:
@@ -125499,30 +125459,10 @@ entities:
     - type: Transform
       pos: -6.5,46.5
       parent: 8364
-  - uid: 25712
-    components:
-    - type: Transform
-      pos: -14.5,54.5
-      parent: 8364
-  - uid: 25713
-    components:
-    - type: Transform
-      pos: -15.5,54.5
-      parent: 8364
-  - uid: 25714
-    components:
-    - type: Transform
-      pos: -12.5,54.5
-      parent: 8364
   - uid: 25721
     components:
     - type: Transform
       pos: -8.5,46.5
-      parent: 8364
-  - uid: 25726
-    components:
-    - type: Transform
-      pos: -11.5,54.5
       parent: 8364
   - uid: 25860
     components:
@@ -126237,6 +126177,17 @@ entities:
     - type: Transform
       pos: 88.5,-85.5
       parent: 8364
+  - uid: 5767
+    components:
+    - type: Transform
+      pos: 5.5,43.5
+      parent: 8364
+  - uid: 9361
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,44.5
+      parent: 8364
   - uid: 11161
     components:
     - type: Transform
@@ -126369,62 +126320,21 @@ entities:
       parent: 8364
 - proto: GunSafeDisabler
   entities:
-  - uid: 10063
+  - uid: 9207
     components:
     - type: Transform
       anchored: True
-      pos: -1.5,39.5
+      pos: 1.5,37.5
       parent: 8364
     - type: Physics
       bodyType: Static
-- proto: GunSafeLaserCarbine
+- proto: GunSafePistolMk58
   entities:
-  - uid: 9377
+  - uid: 7751
     components:
-    - type: MetaData
-      desc: A standard-issue Nanotrasen storage unit, containing 4 Laser Carbines.
     - type: Transform
       anchored: True
       pos: 2.5,37.5
-      parent: 8364
-    - type: Physics
-      bodyType: Static
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14597
-        moles:
-        - 1.606311
-        - 6.042789
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 9380
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-- proto: GunSafePistolMk58
-  entities:
-  - uid: 9345
-    components:
-    - type: Transform
-      anchored: True
-      pos: -0.5,39.5
       parent: 8364
     - type: Physics
       bodyType: Static
@@ -126464,53 +126374,9 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 9374
-          - 9375
           - 9376
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-- proto: GunSafeShotgunKammerer
-  entities:
-  - uid: 9359
-    components:
-    - type: MetaData
-      desc: A standard-issue Nanotrasen storage unit, containing 4 Kammerer shotguns.
-    - type: Transform
-      anchored: True
-      pos: 1.5,37.5
-      parent: 8364
-    - type: Physics
-      bodyType: Static
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 9368
-          - 9367
-          - 9366
-          - 9361
+          - 9375
+          - 9374
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -126568,21 +126434,6 @@ entities:
       parent: 8364
 - proto: Handcuffs
   entities:
-  - uid: 8571
-    components:
-    - type: Transform
-      pos: 10.5,24.5
-      parent: 8364
-  - uid: 8572
-    components:
-    - type: Transform
-      pos: 10.5,24.5
-      parent: 8364
-  - uid: 8573
-    components:
-    - type: Transform
-      pos: 10.5,24.5
-      parent: 8364
   - uid: 8591
     components:
     - type: Transform
@@ -126609,11 +126460,6 @@ entities:
     components:
     - type: Transform
       pos: 38.4924,-28.821447
-      parent: 8364
-  - uid: 9175
-    components:
-    - type: Transform
-      pos: -14.5,22.5
       parent: 8364
   - uid: 9705
     components:
@@ -127507,6 +127353,12 @@ entities:
       parent: 8364
 - proto: IntercomAll
   entities:
+  - uid: 4481
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-15.5
+      parent: 8364
   - uid: 5526
     components:
     - type: Transform
@@ -127518,6 +127370,22 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-19.5
+      parent: 8364
+  - uid: 7752
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 8364
+  - uid: 9366
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-15.5
+      parent: 8364
+  - uid: 9367
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
       parent: 8364
   - uid: 27818
     components:
@@ -127664,11 +127532,6 @@ entities:
       parent: 8364
 - proto: IntercomSecurity
   entities:
-  - uid: 9576
-    components:
-    - type: Transform
-      pos: 4.5,29.5
-      parent: 8364
   - uid: 21091
     components:
     - type: Transform
@@ -127678,6 +127541,11 @@ entities:
     components:
     - type: Transform
       pos: -10.5,28.5
+      parent: 8364
+  - uid: 26256
+    components:
+    - type: Transform
+      pos: 0.5,22.5
       parent: 8364
 - proto: IntercomSupply
   entities:
@@ -127733,6 +127601,18 @@ entities:
     components:
     - type: Transform
       pos: -12.493954,3.065948
+      parent: 8364
+- proto: JetpackSecurityFilled
+  entities:
+  - uid: 8572
+    components:
+    - type: Transform
+      pos: -0.68612957,39.73207
+      parent: 8364
+  - uid: 9182
+    components:
+    - type: Transform
+      pos: -0.38925457,39.51332
       parent: 8364
 - proto: Jukebox
   entities:
@@ -128120,6 +128000,12 @@ entities:
       parent: 8364
 - proto: LandMineExplosive
   entities:
+  - uid: 9359
+    components:
+    - type: Transform
+      anchored: True
+      pos: 4.5,44.5
+      parent: 8364
   - uid: 27309
     components:
     - type: Transform
@@ -128131,48 +128017,6 @@ entities:
     - type: Transform
       anchored: True
       pos: 2.5,43.5
-      parent: 8364
-  - uid: 28248
-    components:
-    - type: Transform
-      anchored: True
-      pos: 6.5,44.5
-      parent: 8364
-  - uid: 28255
-    components:
-    - type: Transform
-      anchored: True
-      pos: -20.5,55.5
-      parent: 8364
-  - uid: 28256
-    components:
-    - type: Transform
-      anchored: True
-      pos: -13.5,56.5
-      parent: 8364
-  - uid: 28257
-    components:
-    - type: Transform
-      anchored: True
-      pos: 1.5,54.5
-      parent: 8364
-  - uid: 28258
-    components:
-    - type: Transform
-      anchored: True
-      pos: 13.5,44.5
-      parent: 8364
-  - uid: 28259
-    components:
-    - type: Transform
-      anchored: True
-      pos: 7.5,52.5
-      parent: 8364
-  - uid: 28260
-    components:
-    - type: Transform
-      anchored: True
-      pos: 22.5,44.5
       parent: 8364
 - proto: LandMineModular
   entities:
@@ -128256,29 +128100,29 @@ entities:
       parent: 8364
 - proto: LockableButtonArmory
   entities:
-  - uid: 8631
+  - uid: 23135
     components:
     - type: MetaData
       name: Open Armory
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.4954224,38.730606
+      pos: 5.477743,38.812943
       parent: 8364
     - type: DeviceLinkSource
       linkedPorts:
-        9182:
+        6419:
         - Pressed: Open
-  - uid: 25235
+  - uid: 25554
     components:
     - type: MetaData
       name: Close Armory
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.4954224,38.24102
+      pos: 5.4868402,38.244164
       parent: 8364
     - type: DeviceLinkSource
       linkedPorts:
-        9182:
+        6419:
         - Pressed: Close
 - proto: LockableButtonChiefMedicalOfficer
   entities:
@@ -128626,75 +128470,6 @@ entities:
     - type: Transform
       pos: -14.5,36.5
       parent: 8364
-  - uid: 8553
-    components:
-    - type: Transform
-      pos: -12.5,24.5
-      parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 5.001885
-        - 18.816614
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-  - uid: 8554
-    components:
-    - type: Transform
-      pos: -12.5,23.5
-      parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 5.001885
-        - 18.816614
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-  - uid: 8555
-    components:
-    - type: Transform
-      pos: -12.5,22.5
-      parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 5.001885
-        - 18.816614
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
   - uid: 8961
     components:
     - type: Transform
@@ -129007,8 +128782,11 @@ entities:
   - uid: 9250
     components:
     - type: Transform
+      anchored: True
       pos: 16.5,38.5
       parent: 8364
+    - type: Physics
+      bodyType: Static
     - type: EntityStorage
       air:
         volume: 200
@@ -129353,18 +129131,27 @@ entities:
   - uid: 8791
     components:
     - type: Transform
+      anchored: True
       pos: 8.5,37.5
       parent: 8364
+    - type: Physics
+      bodyType: Static
   - uid: 8811
     components:
     - type: Transform
+      anchored: True
       pos: 8.5,38.5
       parent: 8364
+    - type: Physics
+      bodyType: Static
   - uid: 9256
     components:
     - type: Transform
+      anchored: True
       pos: 10.5,37.5
       parent: 8364
+    - type: Physics
+      bodyType: Static
     - type: EntityStorage
       air:
         volume: 200
@@ -129400,8 +129187,11 @@ entities:
   - uid: 9258
     components:
     - type: Transform
+      anchored: True
       pos: 10.5,38.5
       parent: 8364
+    - type: Physics
+      bodyType: Static
     - type: EntityStorage
       air:
         volume: 200
@@ -129437,8 +129227,11 @@ entities:
   - uid: 9259
     components:
     - type: Transform
+      anchored: True
       pos: 10.5,39.5
       parent: 8364
+    - type: Physics
+      bodyType: Static
     - type: EntityStorage
       air:
         volume: 200
@@ -129511,8 +129304,11 @@ entities:
   - uid: 27287
     components:
     - type: Transform
+      anchored: True
       pos: 8.5,40.5
       parent: 8364
+    - type: Physics
+      bodyType: Static
     - type: EntityStorage
       air:
         volume: 200
@@ -129534,8 +129330,11 @@ entities:
   - uid: 27288
     components:
     - type: Transform
+      anchored: True
       pos: 8.5,39.5
       parent: 8364
+    - type: Physics
+      bodyType: Static
     - type: EntityStorage
       air:
         volume: 200
@@ -131240,50 +131039,6 @@ entities:
       parent: 8364
 - proto: NitrogenTankFilled
   entities:
-  - uid: 9231
-    components:
-    - type: Transform
-      parent: 9229
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 9236
-    components:
-    - type: Transform
-      parent: 9235
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 9515
-    components:
-    - type: Transform
-      parent: 9507
-    - type: GasTank
-      toggleActionEntity: 9516
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 9516
-    - type: InsideEntityStorage
-  - uid: 9567
-    components:
-    - type: Transform
-      parent: 9518
-    - type: GasTank
-      toggleActionEntity: 10056
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 10056
-    - type: InsideEntityStorage
   - uid: 27177
     components:
     - type: Transform
@@ -131723,11 +131478,6 @@ entities:
     - type: Transform
       pos: -11.519596,32.598755
       parent: 8364
-  - uid: 9233
-    components:
-    - type: Transform
-      pos: -0.5,29.5
-      parent: 8364
   - uid: 9406
     components:
     - type: Transform
@@ -132033,6 +131783,44 @@ entities:
     - type: Transform
       pos: 6.5,-56.5
       parent: 8364
+- proto: PaperOffice
+  entities:
+  - uid: 9390
+    components:
+    - type: Transform
+      parent: 9384
+    - type: Physics
+      canCollide: False
+  - uid: 9453
+    components:
+    - type: Transform
+      parent: 9384
+    - type: Physics
+      canCollide: False
+  - uid: 9454
+    components:
+    - type: Transform
+      parent: 9384
+    - type: Physics
+      canCollide: False
+  - uid: 9507
+    components:
+    - type: Transform
+      parent: 9384
+    - type: Physics
+      canCollide: False
+  - uid: 9515
+    components:
+    - type: Transform
+      parent: 9384
+    - type: Physics
+      canCollide: False
+  - uid: 9516
+    components:
+    - type: Transform
+      parent: 9384
+    - type: Physics
+      canCollide: False
 - proto: ParchisBoard
   entities:
   - uid: 11673
@@ -132227,7 +132015,7 @@ entities:
   - uid: 9232
     components:
     - type: Transform
-      pos: -0.5,29.5
+      pos: -1.6906976,30.406588
       parent: 8364
   - uid: 9727
     components:
@@ -132537,19 +132325,19 @@ entities:
     - type: Transform
       pos: 7.5224895,-74.49767
       parent: 8364
-- proto: PlasmaWindoorSecureSecurityLocked
+- proto: PlasmaWindoorSecureArmoryLocked
   entities:
-  - uid: 28243
+  - uid: 9517
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
       pos: 5.5,37.5
       parent: 8364
     - type: DeviceLinkSink
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        28246:
+        26255:
         - DoorStatus: Close
 - proto: PlasticFlapsAirtightClear
   entities:
@@ -132639,16 +132427,56 @@ entities:
       parent: 8364
 - proto: PortableFlasher
   entities:
-  - uid: 9169
+  - uid: 9267
     components:
     - type: Transform
+      anchored: False
+      pos: -12.5,25.5
+      parent: 8364
+    - type: TriggerOnProximity
+      enabled: False
+    - type: Physics
+      bodyType: Dynamic
+  - uid: 9380
+    components:
+    - type: Transform
+      anchored: False
+      pos: -12.5,23.5
+      parent: 8364
+    - type: TriggerOnProximity
+      enabled: False
+    - type: Physics
+      bodyType: Dynamic
+  - uid: 9518
+    components:
+    - type: Transform
+      anchored: False
       pos: -2.5,36.5
       parent: 8364
-  - uid: 9453
+    - type: TriggerOnProximity
+      enabled: False
+    - type: Physics
+      bodyType: Dynamic
+  - uid: 9566
     components:
     - type: Transform
+      anchored: False
       pos: -2.5,35.5
       parent: 8364
+    - type: TriggerOnProximity
+      enabled: False
+    - type: Physics
+      bodyType: Dynamic
+  - uid: 25713
+    components:
+    - type: Transform
+      anchored: False
+      pos: -12.5,24.5
+      parent: 8364
+    - type: TriggerOnProximity
+      enabled: False
+    - type: Physics
+      bodyType: Dynamic
 - proto: PortableGeneratorJrPacman
   entities:
   - uid: 6258
@@ -136339,6 +136167,12 @@ entities:
       parent: 8364
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 9576
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,47.5
+      parent: 8364
   - uid: 10007
     components:
     - type: Transform
@@ -136425,6 +136259,18 @@ entities:
       powerLoad: 0
 - proto: PoweredlightLED
   entities:
+  - uid: 4952
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,41.5
+      parent: 8364
+  - uid: 9175
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,41.5
+      parent: 8364
   - uid: 14468
     components:
     - type: Transform
@@ -136469,22 +136315,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-24.5
-      parent: 8364
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 27281
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,41.5
-      parent: 8364
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 27282
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,41.5
       parent: 8364
     - type: ApcPowerReceiver
       powerLoad: 0
@@ -138077,10 +137907,10 @@ entities:
     - type: Transform
       pos: 66.5,-64.5
       parent: 8364
-  - uid: 8570
+  - uid: 8779
     components:
     - type: Transform
-      pos: 10.5,24.5
+      pos: 3.5,39.5
       parent: 8364
   - uid: 9002
     components:
@@ -138101,6 +137931,11 @@ entities:
     components:
     - type: Transform
       pos: 2.5,39.5
+      parent: 8364
+  - uid: 9231
+    components:
+    - type: Transform
+      pos: -0.5,39.5
       parent: 8364
   - uid: 9364
     components:
@@ -138127,6 +137962,11 @@ entities:
     - type: Transform
       pos: 25.5,25.5
       parent: 8364
+  - uid: 10086
+    components:
+    - type: Transform
+      pos: 4.5,39.5
+      parent: 8364
   - uid: 10274
     components:
     - type: Transform
@@ -138141,6 +137981,11 @@ entities:
     components:
     - type: Transform
       pos: 66.5,6.5
+      parent: 8364
+  - uid: 11608
+    components:
+    - type: Transform
+      pos: -1.5,35.5
       parent: 8364
   - uid: 11680
     components:
@@ -138624,11 +138469,6 @@ entities:
     components:
     - type: Transform
       pos: 9.443931,-54.34355
-      parent: 8364
-  - uid: 8597
-    components:
-    - type: Transform
-      pos: 3.5,23.5
       parent: 8364
   - uid: 15394
     components:
@@ -140269,6 +140109,11 @@ entities:
     - type: Transform
       pos: 44.5,-54.5
       parent: 8364
+  - uid: 5765
+    components:
+    - type: Transform
+      pos: 1.5,42.5
+      parent: 8364
   - uid: 5799
     components:
     - type: Transform
@@ -140294,6 +140139,16 @@ entities:
     - type: Transform
       pos: -0.5,40.5
       parent: 8364
+  - uid: 8761
+    components:
+    - type: Transform
+      pos: 0.5,42.5
+      parent: 8364
+  - uid: 8775
+    components:
+    - type: Transform
+      pos: -0.5,42.5
+      parent: 8364
   - uid: 10059
     components:
     - type: Transform
@@ -140305,6 +140160,11 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,34.5
+      parent: 8364
+  - uid: 11607
+    components:
+    - type: Transform
+      pos: 2.5,42.5
       parent: 8364
   - uid: 15138
     components:
@@ -143354,16 +143214,6 @@ entities:
     - type: Transform
       pos: 5.5,25.5
       parent: 8364
-  - uid: 7751
-    components:
-    - type: Transform
-      pos: 8.5,25.5
-      parent: 8364
-  - uid: 7752
-    components:
-    - type: Transform
-      pos: 10.5,25.5
-      parent: 8364
   - uid: 7753
     components:
     - type: Transform
@@ -143826,6 +143676,11 @@ entities:
     - type: Transform
       pos: -13.5,39.5
       parent: 8364
+  - uid: 8631
+    components:
+    - type: Transform
+      pos: -15.5,54.5
+      parent: 8364
   - uid: 8656
     components:
     - type: Transform
@@ -143881,11 +143736,6 @@ entities:
     - type: Transform
       pos: -18.5,39.5
       parent: 8364
-  - uid: 9046
-    components:
-    - type: Transform
-      pos: -15.5,54.5
-      parent: 8364
   - uid: 9047
     components:
     - type: Transform
@@ -143925,6 +143775,18 @@ entities:
     components:
     - type: Transform
       pos: -14.5,39.5
+      parent: 8364
+  - uid: 9236
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,25.5
+      parent: 8364
+  - uid: 9238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,25.5
       parent: 8364
   - uid: 9399
     components:
@@ -144031,20 +143893,10 @@ entities:
     - type: Transform
       pos: 67.5,3.5
       parent: 8364
-  - uid: 11379
-    components:
-    - type: Transform
-      pos: -13.5,3.5
-      parent: 8364
   - uid: 11590
     components:
     - type: Transform
       pos: -9.5,2.5
-      parent: 8364
-  - uid: 11592
-    components:
-    - type: Transform
-      pos: -13.5,2.5
       parent: 8364
   - uid: 11646
     components:
@@ -144870,21 +144722,6 @@ entities:
     - type: Transform
       pos: 60.5,-69.5
       parent: 8364
-  - uid: 28265
-    components:
-    - type: Transform
-      pos: 5.5,45.5
-      parent: 8364
-  - uid: 28266
-    components:
-    - type: Transform
-      pos: 5.5,44.5
-      parent: 8364
-  - uid: 28267
-    components:
-    - type: Transform
-      pos: 5.5,43.5
-      parent: 8364
 - proto: RemoteSignaller
   entities:
   - uid: 5286
@@ -145222,10 +145059,10 @@ entities:
       parent: 8364
 - proto: SecurityTechFab
   entities:
-  - uid: 9454
+  - uid: 9235
     components:
     - type: Transform
-      pos: -1.5,35.5
+      pos: -1.5,39.5
       parent: 8364
 - proto: SeedExtractor
   entities:
@@ -145466,7 +145303,7 @@ entities:
   - uid: 9316
     components:
     - type: Transform
-      pos: -2.4700446,39.637985
+      pos: -2.430175,38.67102
       parent: 8364
   - uid: 11753
     components:
@@ -145735,26 +145572,6 @@ entities:
     - type: Transform
       pos: 6.5,-23.5
       parent: 8364
-  - uid: 8606
-    components:
-    - type: Transform
-      pos: 3.5,23.5
-      parent: 8364
-  - uid: 8607
-    components:
-    - type: Transform
-      pos: 3.5,24.5
-      parent: 8364
-  - uid: 8614
-    components:
-    - type: Transform
-      pos: 2.5,22.5
-      parent: 8364
-  - uid: 8615
-    components:
-    - type: Transform
-      pos: 1.5,22.5
-      parent: 8364
   - uid: 9639
     components:
     - type: Transform
@@ -145779,6 +145596,27 @@ entities:
     components:
     - type: Transform
       pos: 10.5,-32.5
+      parent: 8364
+  - uid: 11980
+    components:
+    - type: Transform
+      pos: -9.5,22.5
+      parent: 8364
+  - uid: 12024
+    components:
+    - type: Transform
+      pos: -10.5,22.5
+      parent: 8364
+  - uid: 12030
+    components:
+    - type: Transform
+      pos: 3.5,24.5
+      parent: 8364
+  - uid: 12033
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,23.5
       parent: 8364
   - uid: 14148
     components:
@@ -145819,6 +145657,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -29.5,-25.5
       parent: 8364
+  - uid: 17151
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,22.5
+      parent: 8364
   - uid: 17669
     components:
     - type: Transform
@@ -145834,6 +145678,12 @@ entities:
     components:
     - type: Transform
       pos: -0.5,-65.5
+      parent: 8364
+  - uid: 18370
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,22.5
       parent: 8364
   - uid: 18406
     components:
@@ -145855,11 +145705,46 @@ entities:
     - type: Transform
       pos: 23.5,-19.5
       parent: 8364
+  - uid: 19886
+    components:
+    - type: Transform
+      pos: -0.5,22.5
+      parent: 8364
+  - uid: 19890
+    components:
+    - type: Transform
+      pos: -1.5,22.5
+      parent: 8364
+  - uid: 19931
+    components:
+    - type: Transform
+      pos: -2.5,22.5
+      parent: 8364
+  - uid: 19959
+    components:
+    - type: Transform
+      pos: -4.5,22.5
+      parent: 8364
+  - uid: 19968
+    components:
+    - type: Transform
+      pos: -5.5,22.5
+      parent: 8364
+  - uid: 20152
+    components:
+    - type: Transform
+      pos: -6.5,22.5
+      parent: 8364
   - uid: 22014
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-15.5
+      parent: 8364
+  - uid: 22451
+    components:
+    - type: Transform
+      pos: -8.5,22.5
       parent: 8364
   - uid: 22990
     components:
@@ -145979,51 +145864,6 @@ entities:
     components:
     - type: Transform
       pos: 12.5,23.5
-      parent: 8364
-  - uid: 8775
-    components:
-    - type: Transform
-      pos: -10.5,22.5
-      parent: 8364
-  - uid: 8776
-    components:
-    - type: Transform
-      pos: -9.5,22.5
-      parent: 8364
-  - uid: 8777
-    components:
-    - type: Transform
-      pos: -8.5,22.5
-      parent: 8364
-  - uid: 8778
-    components:
-    - type: Transform
-      pos: -6.5,22.5
-      parent: 8364
-  - uid: 8779
-    components:
-    - type: Transform
-      pos: -5.5,22.5
-      parent: 8364
-  - uid: 8780
-    components:
-    - type: Transform
-      pos: -4.5,22.5
-      parent: 8364
-  - uid: 8781
-    components:
-    - type: Transform
-      pos: -2.5,22.5
-      parent: 8364
-  - uid: 8782
-    components:
-    - type: Transform
-      pos: -1.5,22.5
-      parent: 8364
-  - uid: 8783
-    components:
-    - type: Transform
-      pos: -0.5,22.5
       parent: 8364
   - uid: 10454
     components:
@@ -146364,27 +146204,6 @@ entities:
         10456:
         - Pressed: Toggle
         10457:
-        - Pressed: Toggle
-  - uid: 9936
-    components:
-    - type: Transform
-      pos: 14.5,29.5
-      parent: 8364
-    - type: DeviceLinkSource
-      linkedPorts:
-        8650:
-        - Pressed: Toggle
-        8649:
-        - Pressed: Toggle
-        8648:
-        - Pressed: Toggle
-        8647:
-        - Pressed: Toggle
-        8646:
-        - Pressed: Toggle
-        8645:
-        - Pressed: Toggle
-        8644:
         - Pressed: Toggle
   - uid: 11625
     components:
@@ -146737,6 +146556,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,30.5
       parent: 8364
+    - type: SignalSwitch
+      state: True
     - type: DeviceLinkSource
       linkedPorts:
         19930:
@@ -146754,68 +146575,46 @@ entities:
       parent: 8364
 - proto: SignalSwitchDirectional
   entities:
-  - uid: 11568
+  - uid: 9142
     components:
     - type: MetaData
-      name: Brig Shutters
+      name: Shutters
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,23.5
+      pos: 13.5,29.5
       parent: 8364
     - type: DeviceLinkSource
       linkedPorts:
-        8783:
+        8650:
         - On: Open
         - Off: Close
-        8782:
+        8649:
         - On: Open
         - Off: Close
-        8781:
+        8648:
         - On: Open
         - Off: Close
-        8780:
+        8647:
         - On: Open
         - Off: Close
-        8778:
+        8646:
         - On: Open
         - Off: Close
-        8777:
+        8645:
         - On: Open
         - Off: Close
-        8776:
+        8644:
         - On: Open
         - Off: Close
-        8775:
-        - On: Open
-        - Off: Close
-        8615:
-        - On: Open
-        - Off: Close
-        8614:
-        - On: Open
-        - Off: Close
-  - uid: 15129
+  - uid: 9368
     components:
     - type: MetaData
       name: Window Blast Doors
     - type: Transform
-      pos: 8.5,42.5
+      rot: -1.5707963267948966 rad
+      pos: 17.5,40.5
       parent: 8364
-    - type: DeviceLinkSource
-      linkedPorts:
-        4495:
-        - On: Open
-        - Off: Close
-        4494:
-        - On: Open
-        - Off: Close
-  - uid: 28264
-    components:
-    - type: MetaData
-      name: Window Blast Doors
-    - type: Transform
-      pos: 16.5,42.5
-      parent: 8364
+    - type: SignalSwitch
+      state: True
     - type: DeviceLinkSource
       linkedPorts:
         6970:
@@ -146825,6 +146624,74 @@ entities:
         - On: Open
         - Off: Close
         3134:
+        - On: Open
+        - Off: Close
+  - uid: 11568
+    components:
+    - type: MetaData
+      name: Brig Shutters
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,23.5
+      parent: 8364
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        12030:
+        - On: Open
+        - Off: Close
+        12033:
+        - On: Open
+        - Off: Close
+        17151:
+        - Off: Close
+        - On: Open
+        18370:
+        - On: Open
+        - Off: Close
+        19886:
+        - On: Open
+        - Off: Close
+        19890:
+        - On: Open
+        - Off: Close
+        19931:
+        - On: Open
+        - Off: Close
+        19959:
+        - On: Open
+        - Off: Close
+        19968:
+        - Off: Close
+        - On: Open
+        20152:
+        - On: Open
+        - Off: Close
+        22451:
+        - On: Open
+        - Off: Close
+        11980:
+        - On: Open
+        - Off: Close
+        12024:
+        - On: Open
+        - Off: Close
+  - uid: 15129
+    components:
+    - type: MetaData
+      name: Window Blast Doors
+    - type: Transform
+      pos: 8.5,42.5
+      parent: 8364
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        4495:
+        - On: Open
+        - Off: Close
+        4494:
         - On: Open
         - Off: Close
 - proto: SignAnomaly
@@ -147707,11 +147574,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 13.5,-53.5
       parent: 8364
-  - uid: 8470
-    components:
-    - type: Transform
-      pos: 11.5,28.5
-      parent: 8364
 - proto: SignSecureMed
   entities:
   - uid: 3806
@@ -147745,11 +147607,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,22.5
-      parent: 8364
-  - uid: 19931
-    components:
-    - type: Transform
-      pos: -3.5,43.5
       parent: 8364
   - uid: 20149
     components:
@@ -150697,24 +150554,6 @@ entities:
       parent: 8364
 - proto: SteelBench
   entities:
-  - uid: 5765
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,23.5
-      parent: 8364
-  - uid: 5767
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,23.5
-      parent: 8364
-  - uid: 5791
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,24.5
-      parent: 8364
   - uid: 7912
     components:
     - type: Transform
@@ -150732,6 +150571,30 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,32.5
+      parent: 8364
+  - uid: 9174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,24.5
+      parent: 8364
+  - uid: 9936
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,23.5
+      parent: 8364
+  - uid: 10056
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,23.5
+      parent: 8364
+  - uid: 23942
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,24.5
       parent: 8364
 - proto: Stool
   entities:
@@ -151389,18 +151252,6 @@ entities:
     - type: Transform
       pos: 72.5,-34.5
       parent: 8364
-- proto: SuitStorageEVAAlternate
-  entities:
-  - uid: 19959
-    components:
-    - type: Transform
-      pos: -14.5,2.5
-      parent: 8364
-  - uid: 19968
-    components:
-    - type: Transform
-      pos: -14.5,3.5
-      parent: 8364
 - proto: SuitStorageHOS
   entities:
   - uid: 25002
@@ -151417,138 +151268,26 @@ entities:
       parent: 8364
 - proto: SuitStorageSec
   entities:
-  - uid: 9229
+  - uid: 4163
     components:
-    - type: MetaData
-      desc: Contains two security hardsuits.
-    - type: Transform
-      pos: 4.5,39.5
-      parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.734816
-        - 6.5262127
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 9230
-          - 9231
-  - uid: 9235
-    components:
-    - type: MetaData
-      desc: Contains two security hardsuits.
-    - type: Transform
-      pos: 3.5,39.5
-      parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.734816
-        - 6.5262127
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 9238
-          - 9236
-  - uid: 9507
-    components:
-    - type: MetaData
-      desc: Contains two security hardsuits.
     - type: Transform
       pos: 0.5,35.5
       parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 9515
-          - 9517
-  - uid: 9518
+  - uid: 4213
     components:
-    - type: MetaData
-      desc: Contains two security hardsuits.
     - type: Transform
       pos: -0.5,35.5
       parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 9567
-          - 9566
+  - uid: 8783
+    components:
+    - type: Transform
+      pos: 3.5,35.5
+      parent: 8364
+  - uid: 8825
+    components:
+    - type: Transform
+      pos: 4.5,35.5
+      parent: 8364
   - uid: 16531
     components:
     - type: Transform
@@ -153507,6 +153246,17 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Security
+  - uid: 7659
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,24.5
+      parent: 8364
+    - type: SurveillanceCamera
+      setupAvailableNetworks:
+      - SurveillanceCameraSecurity
+      nameSet: True
+      id: Storage
   - uid: 17694
     components:
     - type: Transform
@@ -153540,17 +153290,6 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Security External West
-  - uid: 20152
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,24.5
-      parent: 8364
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraSecurity
-      nameSet: True
-      id: Evidence Room
   - uid: 20860
     components:
     - type: Transform
@@ -154138,11 +153877,6 @@ entities:
     components:
     - type: Transform
       pos: 12.5,19.5
-      parent: 8364
-  - uid: 8641
-    components:
-    - type: Transform
-      pos: -14.5,22.5
       parent: 8364
   - uid: 8785
     components:
@@ -155338,6 +155072,12 @@ entities:
     components:
     - type: Transform
       pos: -33.5,-18.5
+      parent: 8364
+  - uid: 25743
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,41.5
       parent: 8364
   - uid: 25826
     components:
@@ -158334,15 +158074,15 @@ entities:
       parent: 8364
 - proto: VendingMachineSec
   entities:
+  - uid: 8777
+    components:
+    - type: Transform
+      pos: 6.5,40.5
+      parent: 8364
   - uid: 9074
     components:
     - type: Transform
       pos: 6.5,38.5
-      parent: 8364
-  - uid: 9384
-    components:
-    - type: Transform
-      pos: 6.5,41.5
       parent: 8364
 - proto: VendingMachineSecDrobe
   entities:
@@ -158351,15 +158091,15 @@ entities:
     - type: Transform
       pos: -60.5,5.5
       parent: 8364
-  - uid: 9142
-    components:
-    - type: Transform
-      pos: 6.5,39.5
-      parent: 8364
   - uid: 17677
     components:
     - type: Transform
       pos: -21.5,-31.5
+      parent: 8364
+  - uid: 25726
+    components:
+    - type: Transform
+      pos: 6.5,39.5
       parent: 8364
 - proto: VendingMachineSeeds
   entities:
@@ -165021,20 +164761,10 @@ entities:
     - type: Transform
       pos: 4.5,40.5
       parent: 8364
-  - uid: 7678
-    components:
-    - type: Transform
-      pos: 5.5,39.5
-      parent: 8364
   - uid: 7679
     components:
     - type: Transform
       pos: 5.5,40.5
-      parent: 8364
-  - uid: 7680
-    components:
-    - type: Transform
-      pos: 5.5,41.5
       parent: 8364
   - uid: 7682
     components:
@@ -166018,6 +165748,11 @@ entities:
     - type: Transform
       pos: -12.5,-6.5
       parent: 8364
+  - uid: 8573
+    components:
+    - type: Transform
+      pos: 4.5,42.5
+      parent: 8364
   - uid: 8574
     components:
     - type: Transform
@@ -166320,6 +166055,11 @@ entities:
     - type: Transform
       pos: 17.5,38.5
       parent: 8364
+  - uid: 9173
+    components:
+    - type: Transform
+      pos: 3.5,42.5
+      parent: 8364
   - uid: 9206
     components:
     - type: Transform
@@ -166523,10 +166263,20 @@ entities:
     - type: Transform
       pos: 21.5,-70.5
       parent: 8364
+  - uid: 11379
+    components:
+    - type: Transform
+      pos: -2.5,42.5
+      parent: 8364
   - uid: 11571
     components:
     - type: Transform
       pos: 24.5,-70.5
+      parent: 8364
+  - uid: 11592
+    components:
+    - type: Transform
+      pos: -1.5,42.5
       parent: 8364
   - uid: 11593
     components:
@@ -167598,6 +167348,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,-93.5
+      parent: 8364
+  - uid: 25235
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,39.5
       parent: 8364
   - uid: 25248
     components:
@@ -174152,16 +173908,6 @@ entities:
     - type: Transform
       pos: -14.5,28.5
       parent: 8364
-  - uid: 7797
-    components:
-    - type: Transform
-      pos: -12.5,25.5
-      parent: 8364
-  - uid: 7798
-    components:
-    - type: Transform
-      pos: -14.5,25.5
-      parent: 8364
   - uid: 7803
     components:
     - type: Transform
@@ -176781,15 +176527,25 @@ entities:
     - type: Transform
       pos: -12.5,36.5
       parent: 8364
+  - uid: 8781
+    components:
+    - type: Transform
+      pos: -4.5,24.5
+      parent: 8364
+  - uid: 8782
+    components:
+    - type: Transform
+      pos: -8.5,24.5
+      parent: 8364
   - uid: 9168
     components:
     - type: Transform
       pos: -11.5,36.5
       parent: 8364
-  - uid: 17151
+  - uid: 26136
     components:
     - type: Transform
-      pos: -2.5,24.5
+      pos: -0.5,24.5
       parent: 8364
   - uid: 26345
     components:
@@ -176883,34 +176639,6 @@ entities:
         - 0
         - 0
         - 0
-  - uid: 28250
-    components:
-    - type: Transform
-      pos: -6.5,24.5
-      parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-  - uid: 28251
-    components:
-    - type: Transform
-      pos: -10.5,24.5
-      parent: 8364
 - proto: WardrobeSalvageFilled
   entities:
   - uid: 14570
@@ -177459,13 +177187,26 @@ entities:
       parent: 8364
 - proto: WeaponLaserCarbine
   entities:
-  - uid: 9380
+  - uid: 8570
     components:
     - type: Transform
-      parent: 9377
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      pos: 4.4934177,39.504333
+      parent: 8364
+  - uid: 8571
+    components:
+    - type: Transform
+      pos: 4.4934177,39.39322
+      parent: 8364
+  - uid: 9172
+    components:
+    - type: Transform
+      pos: 4.4934177,39.629333
+      parent: 8364
+  - uid: 23537
+    components:
+    - type: Transform
+      pos: 4.4934177,39.747383
+      parent: 8364
 - proto: WeaponLaserCarbinePractice
   entities:
   - uid: 8772
@@ -177484,20 +177225,26 @@ entities:
     - type: InsideEntityStorage
 - proto: WeaponShotgunKammerer
   entities:
-  - uid: 9366
+  - uid: 8642
     components:
     - type: Transform
-      parent: 9359
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 9368
+      pos: 3.5233402,39.390335
+      parent: 8364
+  - uid: 9208
     components:
     - type: Transform
-      parent: 9359
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      pos: 3.5233402,39.53617
+      parent: 8364
+  - uid: 10087
+    components:
+    - type: Transform
+      pos: 3.5233402,39.668114
+      parent: 8364
+  - uid: 26258
+    components:
+    - type: Transform
+      pos: 3.5474372,39.816833
+      parent: 8364
 - proto: WeaponSubMachineGunDrozd
   entities:
   - uid: 9370
@@ -177759,20 +177506,6 @@ entities:
         - DoorStatus: Close
         8605:
         - DoorStatus: Close
-  - uid: 8610
-    components:
-    - type: MetaData
-      name: Brig Desk
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,23.5
-      parent: 8364
-  - uid: 8611
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,24.5
-      parent: 8364
   - uid: 9242
     components:
     - type: MetaData
@@ -178001,6 +177734,16 @@ entities:
       linkedPorts:
         9242:
         - DoorStatus: Close
+  - uid: 25744
+    components:
+    - type: Transform
+      pos: 4.5,39.5
+      parent: 8364
+  - uid: 25747
+    components:
+    - type: Transform
+      pos: 3.5,39.5
+      parent: 8364
 - proto: WindoorSecureBrigLocked
   entities:
   - uid: 8619
@@ -178125,17 +177868,17 @@ entities:
       parent: 8364
 - proto: WindoorSecurePlasma
   entities:
-  - uid: 28246
+  - uid: 26255
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
+      rot: 1.5707963267948966 rad
       pos: 5.5,37.5
       parent: 8364
     - type: DeviceLinkSink
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        28243:
+        9517:
         - DoorStatus: Close
 - proto: WindoorSecureScienceLocked
   entities:
@@ -178208,12 +177951,6 @@ entities:
     - type: Transform
       pos: 16.5,23.5
       parent: 8364
-  - uid: 8436
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,26.5
-      parent: 8364
   - uid: 8483
     components:
     - type: MetaData
@@ -178229,13 +177966,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,23.5
-      parent: 8364
-  - uid: 8569
-    components:
-    - type: MetaData
-      name: Holding Cell
-    - type: Transform
-      pos: 9.5,25.5
       parent: 8364
   - uid: 8604
     components:
@@ -178309,6 +178039,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -6.5,40.5
       parent: 8364
+  - uid: 22453
+    components:
+    - type: Transform
+      pos: 18.5,27.5
+      parent: 8364
   - uid: 25738
     components:
     - type: Transform
@@ -178319,6 +178054,18 @@ entities:
     components:
     - type: Transform
       pos: 79.5,-4.5
+      parent: 8364
+  - uid: 26253
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,24.5
+      parent: 8364
+  - uid: 26254
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,23.5
       parent: 8364
 - proto: Window
   entities:
@@ -179297,6 +179044,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -5.5,32.5
       parent: 8364
+  - uid: 8778
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,39.5
+      parent: 8364
   - uid: 9824
     components:
     - type: Transform
@@ -179311,11 +179064,6 @@ entities:
     components:
     - type: Transform
       pos: 50.5,17.5
-      parent: 8364
-  - uid: 12030
-    components:
-    - type: Transform
-      pos: -14.5,3.5
       parent: 8364
   - uid: 12223
     components:

--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -168,7 +168,7 @@ entities:
           version: 6
         1,2:
           ind: 1,2
-          tiles: WQAAAAAAWQAAAAADWQAAAAACWQAAAAADeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAWQAAAAAAWQAAAAABWQAAAAAAWQAAAAADUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAABWQAAAAACWQAAAAACWQAAAAADeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAABWQAAAAAAWQAAAAAAWQAAAAADeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAHQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAADeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdgAAAAADeQAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAABWQAAAAACWQAAAAACeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdgAAAAAAeQAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAADWQAAAAAAWQAAAAABeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdgAAAAAAeQAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAWQAAAAADWQAAAAADWQAAAAACeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdgAAAAABeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAABeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAABWQAAAAABWQAAAAABeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: WQAAAAAAWQAAAAADWQAAAAACWQAAAAADeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAWQAAAAAAWQAAAAABWQAAAAAAWQAAAAADUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAABWQAAAAACWQAAAAACWQAAAAADeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAABWQAAAAAAWQAAAAAAWQAAAAADeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABeQAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAHQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAADeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAdgAAAAADeQAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAABWQAAAAACWQAAAAACeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAdgAAAAAAeQAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAADWQAAAAAAWQAAAAABeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAdgAAAAAAeQAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAWQAAAAADWQAAAAADWQAAAAACeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAdgAAAAABeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAABeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAABWQAAAAABWQAAAAABeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         2,1:
           ind: 2,1
@@ -428,7 +428,7 @@ entities:
           version: 6
         -1,3:
           ind: -1,3
-          tiles: dgAAAAACdgAAAAACdgAAAAAAdgAAAAABdgAAAAACWQAAAAABWQAAAAACWQAAAAAAWQAAAAABWQAAAAADWQAAAAACWQAAAAAAeQAAAAAACQAAAAABHQAAAAACCQAAAAACdgAAAAADdgAAAAAAdgAAAAADdgAAAAABdgAAAAADeQAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAAAWQAAAAABWQAAAAABeQAAAAAAWQAAAAADWQAAAAADWQAAAAAAdgAAAAACdgAAAAABdgAAAAABdgAAAAACdgAAAAADeQAAAAAAWQAAAAABWQAAAAACWQAAAAACWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAAAWQAAAAADWQAAAAABdgAAAAACdgAAAAABdgAAAAACdgAAAAAAdgAAAAABeQAAAAAAPQAAAAAAPQAAAAAAWQAAAAABWQAAAAADWQAAAAADWQAAAAACeQAAAAAAWQAAAAADWQAAAAABWQAAAAADdgAAAAAAdgAAAAAAdgAAAAACdgAAAAAAdgAAAAADeQAAAAAAPQAAAAAAPQAAAAAAWQAAAAAAWQAAAAABWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADHQAAAAABHQAAAAACHQAAAAAAHQAAAAACeQAAAAAAPQAAAAAAPQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: dgAAAAACdgAAAAACdgAAAAAAdgAAAAABdgAAAAACWQAAAAABWQAAAAACWQAAAAAAWQAAAAABWQAAAAADWQAAAAACWQAAAAAAeQAAAAAACQAAAAABHQAAAAACCQAAAAACdgAAAAADdgAAAAAAdgAAAAADdgAAAAABdgAAAAADeQAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAAAWQAAAAABWQAAAAABeQAAAAAAWQAAAAADWQAAAAADWQAAAAAAdgAAAAACdgAAAAABdgAAAAABdgAAAAACdgAAAAADeQAAAAAAWQAAAAABWQAAAAACWQAAAAACWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAAAWQAAAAADWQAAAAABdgAAAAACdgAAAAABdgAAAAACdgAAAAAAdgAAAAABeQAAAAAAPQAAAAAAPQAAAAAAWQAAAAABWQAAAAADWQAAAAADWQAAAAACeQAAAAAAWQAAAAADWQAAAAABWQAAAAADdgAAAAAAdgAAAAAAdgAAAAACdgAAAAAAdgAAAAADeQAAAAAAPQAAAAAAPQAAAAAAWQAAAAAAWQAAAAABWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADHQAAAAABHQAAAAACHQAAAAAAHQAAAAACeQAAAAAAPQAAAAAAPQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         1,3:
           ind: 1,3
@@ -563,7 +563,6 @@ entities:
             280: 10,39
             281: 10,40
             282: 10,41
-            283: 6,41
             284: 8,37
             285: 8,38
             286: 8,39
@@ -681,12 +680,12 @@ entities:
             3448: 1,-60
             3449: 9,-64
             3450: 9,-63
-            3519: -10,31
             3520: -7,31
             3547: -10,29
             3639: 60,-51
             3640: 59,-51
             3642: 57,-51
+            6270: -7,32
         - node:
             zIndex: 1
             color: '#FFFFFFFF'
@@ -764,11 +763,6 @@ entities:
             6019: -2,-22
             6226: -26,-75
             6227: -24,-77
-        - node:
-            color: '#FFFFFFFF'
-            id: Box
-          decals:
-            3546: -7,32
         - node:
             color: '#FFFFFFFF'
             id: BoxGreyscale
@@ -3911,7 +3905,6 @@ entities:
             4653: -1,32
             4654: -5,30
             4655: -6,32
-            4656: -9,32
             4657: -5,27
             4658: -8,27
             4659: -12,26
@@ -8238,7 +8231,9 @@ entities:
           -1,7:
             0: 61071
           0,8:
-            0: 63231
+            0: 26367
+            5: 4096
+            6: 32768
           1,4:
             0: 61680
           1,5:
@@ -8248,7 +8243,8 @@ entities:
           1,7:
             0: 64911
           1,8:
-            0: 53469
+            0: 49373
+            6: 4096
           2,5:
             0: 28799
           2,6:
@@ -8291,19 +8287,22 @@ entities:
           -3,6:
             0: 65358
           -3,7:
-            0: 56793
+            0: 55769
+            5: 1024
           -3,8:
             0: 65421
           -2,5:
             0: 57599
           -2,6:
-            0: 65358
+            0: 65356
+            5: 2
           -2,7:
             0: 65533
           -2,8:
             0: 64991
           -1,8:
-            0: 57582
+            0: 206
+            5: 57376
           4,8:
             0: 65535
           5,4:
@@ -8368,7 +8367,8 @@ entities:
           -2,12:
             0: 65535
           -1,9:
-            0: 61166
+            0: 61038
+            5: 128
           -1,10:
             1: 60928
             3: 192
@@ -8378,7 +8378,10 @@ entities:
           -1,12:
             0: 65518
           0,9:
-            0: 65535
+            0: 32655
+            5: 48
+            7: 64
+            8: 32768
           0,10:
             3: 240
             1: 65280
@@ -8388,7 +8391,8 @@ entities:
           0,12:
             0: 65535
           1,9:
-            0: 56829
+            0: 52733
+            8: 4096
           1,10:
             1: 53504
             3: 8192
@@ -9220,7 +9224,7 @@ entities:
             1: 192
             3: 49152
           3,-17:
-            5: 30576
+            9: 30576
           4,-16:
             1: 240
             0: 61440
@@ -9801,7 +9805,7 @@ entities:
             0: 255
             1: 49152
           4,-17:
-            6: 30576
+            10: 30576
           5,-20:
             0: 65535
           5,-19:
@@ -10210,7 +10214,8 @@ entities:
           -3,14:
             1: 3855
           -2,13:
-            0: 15
+            11: 1
+            0: 14
             1: 11776
           -2,14:
             1: 1831
@@ -10354,6 +10359,66 @@ entities:
           - 0
           - 0
         - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14923
+          moles:
+          - 18.472576
+          - 69.49208
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 19.950384
+          - 75.051445
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
           temperature: 293.15
           moles:
           - 0
@@ -10373,6 +10438,21 @@ entities:
           moles:
           - 6666.982
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 24.680622
+          - 92.84615
           - 0
           - 0
           - 0
@@ -10473,6 +10553,20 @@ entities:
       parent: 8364
 - proto: ActionToggleInternals
   entities:
+  - uid: 9516
+    components:
+    - type: Transform
+      parent: 9515
+    - type: InstantAction
+      originalIconColor: '#FFFFFFFF'
+      container: 9515
+  - uid: 10056
+    components:
+    - type: Transform
+      parent: 9567
+    - type: InstantAction
+      originalIconColor: '#FFFFFFFF'
+      container: 9567
   - uid: 25167
     components:
     - type: Transform
@@ -11702,7 +11796,6 @@ entities:
       - 7393
       - 7390
       - 7146
-      - 9262
       - 11605
       - 11600
       - 23935
@@ -11712,6 +11805,7 @@ entities:
       - 25420
       - 25422
       - 25421
+      - 9291
   - uid: 23899
     components:
     - type: MetaData
@@ -11731,7 +11825,6 @@ entities:
       parent: 8364
     - type: DeviceList
       devices:
-      - 9262
       - 11605
       - 11600
       - 11377
@@ -12411,6 +12504,18 @@ entities:
     - type: Transform
       pos: 5.5,31.5
       parent: 8364
+  - uid: 28244
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,34.5
+      parent: 8364
+  - uid: 28245
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,34.5
+      parent: 8364
 - proto: AirlockAtmosphericsGlassLocked
   entities:
   - uid: 18739
@@ -12484,6 +12589,16 @@ entities:
       parent: 8364
 - proto: AirlockBrigGlassLocked
   entities:
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -8.5,28.5
+      parent: 8364
+  - uid: 3813
+    components:
+    - type: Transform
+      pos: -7.5,28.5
+      parent: 8364
   - uid: 8544
     components:
     - type: Transform
@@ -13703,7 +13818,7 @@ entities:
       pos: 24.5,16.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -78641.14
+      secondsUntilStateChange: -83117.086
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -15175,11 +15290,6 @@ entities:
     - type: Transform
       pos: 8.5,34.5
       parent: 8364
-  - uid: 8589
-    components:
-    - type: Transform
-      pos: -8.5,28.5
-      parent: 8364
   - uid: 8642
     components:
     - type: MetaData
@@ -15214,11 +15324,6 @@ entities:
       name: Permanent Detention
     - type: Transform
       pos: -4.5,34.5
-      parent: 8364
-  - uid: 9380
-    components:
-    - type: Transform
-      pos: -7.5,28.5
       parent: 8364
   - uid: 9382
     components:
@@ -16551,15 +16656,11 @@ entities:
       parent: 8364
   - uid: 8622
     components:
+    - type: MetaData
+      name: HOS Office APC
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,39.5
-      parent: 8364
-  - uid: 8623
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,38.5
       parent: 8364
   - uid: 8634
     components:
@@ -16581,15 +16682,6 @@ entities:
       currentReceiving: 120.00047
       currentSupply: 120
       supplyRampPosition: -0.00047302246
-  - uid: 8822
-    components:
-    - type: MetaData
-      name: Brig Control APC
-    - type: Transform
-      pos: -1.5,34.5
-      parent: 8364
-    - type: Battery
-      startingCharge: 12000
   - uid: 8944
     components:
     - type: Transform
@@ -16684,6 +16776,13 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-18.5
+      parent: 8364
+  - uid: 11965
+    components:
+    - type: MetaData
+      name: Warden's Office APC
+    - type: Transform
+      pos: 3.5,34.5
       parent: 8364
   - uid: 12020
     components:
@@ -16815,6 +16914,14 @@ entities:
     - type: PowerNetworkBattery
       loadingNetworkDemand: 25
       supplyRampPosition: 9.488577
+  - uid: 15128
+    components:
+    - type: MetaData
+      name: Security Lockers APC
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,36.5
+      parent: 8364
   - uid: 15812
     components:
     - type: MetaData
@@ -20384,26 +20491,6 @@ entities:
     - type: Transform
       pos: 44.5,-58.5
       parent: 8364
-  - uid: 8630
-    components:
-    - type: Transform
-      pos: -10.5,23.5
-      parent: 8364
-  - uid: 8631
-    components:
-    - type: Transform
-      pos: -6.5,23.5
-      parent: 8364
-  - uid: 8632
-    components:
-    - type: Transform
-      pos: -2.5,23.5
-      parent: 8364
-  - uid: 9361
-    components:
-    - type: Transform
-      pos: -6.5,31.5
-      parent: 8364
   - uid: 10570
     components:
     - type: Transform
@@ -20439,15 +20526,15 @@ entities:
     - type: Transform
       pos: 71.5,-35.5
       parent: 8364
-  - uid: 21244
-    components:
-    - type: Transform
-      pos: 15.5,41.5
-      parent: 8364
   - uid: 21743
     components:
     - type: Transform
       pos: -30.5,-74.5
+      parent: 8364
+  - uid: 21784
+    components:
+    - type: Transform
+      pos: 16.5,41.5
       parent: 8364
   - uid: 26349
     components:
@@ -20468,6 +20555,21 @@ entities:
     components:
     - type: Transform
       pos: -20.5,48.5
+      parent: 8364
+  - uid: 26546
+    components:
+    - type: Transform
+      pos: -0.5,23.5
+      parent: 8364
+  - uid: 26603
+    components:
+    - type: Transform
+      pos: -4.5,23.5
+      parent: 8364
+  - uid: 27489
+    components:
+    - type: Transform
+      pos: -8.5,23.5
       parent: 8364
 - proto: BedsheetCaptain
   entities:
@@ -20517,10 +20619,10 @@ entities:
       parent: 8364
 - proto: BedsheetHOS
   entities:
-  - uid: 21245
+  - uid: 9287
     components:
     - type: Transform
-      pos: 15.5,41.5
+      pos: 16.5,41.5
       parent: 8364
 - proto: BedsheetMedical
   entities:
@@ -20533,6 +20635,11 @@ entities:
     components:
     - type: Transform
       pos: 30.5,-27.5
+      parent: 8364
+  - uid: 9245
+    components:
+    - type: Transform
+      pos: -6.5,32.5
       parent: 8364
   - uid: 9485
     components:
@@ -20569,6 +20676,12 @@ entities:
       parent: 8364
 - proto: BedsheetOrange
   entities:
+  - uid: 7716
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,23.5
+      parent: 8364
   - uid: 26353
     components:
     - type: Transform
@@ -20583,6 +20696,18 @@ entities:
     components:
     - type: Transform
       pos: -21.5,40.5
+      parent: 8364
+  - uid: 28249
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,23.5
+      parent: 8364
+  - uid: 28252
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,23.5
       parent: 8364
 - proto: BedsheetQM
   entities:
@@ -20651,23 +20776,6 @@ entities:
     components:
     - type: Transform
       pos: -17.5,48.5
-      parent: 8364
-- proto: BedsheetWhite
-  entities:
-  - uid: 8627
-    components:
-    - type: Transform
-      pos: -10.5,23.5
-      parent: 8364
-  - uid: 8628
-    components:
-    - type: Transform
-      pos: -6.5,23.5
-      parent: 8364
-  - uid: 8629
-    components:
-    - type: Transform
-      pos: -2.5,23.5
       parent: 8364
 - proto: BigBox
   entities:
@@ -21250,20 +21358,6 @@ entities:
       parent: 8364
     - type: BallisticAmmoProvider
       unspawnedCount: 12
-  - uid: 9381
-    components:
-    - type: Transform
-      pos: -0.63110375,35.29573
-      parent: 8364
-    - type: BallisticAmmoProvider
-      unspawnedCount: 12
-  - uid: 9384
-    components:
-    - type: Transform
-      pos: -0.28735375,35.29573
-      parent: 8364
-    - type: BallisticAmmoProvider
-      unspawnedCount: 12
 - proto: BoxBodyBag
   entities:
   - uid: 2276
@@ -21306,11 +21400,6 @@ entities:
       parent: 8364
 - proto: BoxFlashbang
   entities:
-  - uid: 9345
-    components:
-    - type: Transform
-      pos: 0.32543182,35.35921
-      parent: 8364
   - uid: 9388
     components:
     - type: Transform
@@ -21421,11 +21510,6 @@ entities:
     - type: Transform
       pos: -14.5,22.5
       parent: 8364
-  - uid: 9230
-    components:
-    - type: Transform
-      pos: -1.4970741,30.587648
-      parent: 8364
   - uid: 9404
     components:
     - type: Transform
@@ -21533,11 +21617,6 @@ entities:
     - type: Transform
       pos: 15.418736,30.571737
       parent: 8364
-  - uid: 9346
-    components:
-    - type: Transform
-      pos: 0.7629318,35.499836
-      parent: 8364
   - uid: 9389
     components:
     - type: Transform
@@ -21565,13 +21644,20 @@ entities:
       parent: 8364
 - proto: BoxLethalshot
   entities:
-  - uid: 8929
+  - uid: 9361
     components:
     - type: Transform
-      pos: -0.3215518,35.63938
-      parent: 8364
-    - type: BallisticAmmoProvider
-      unspawnedCount: 12
+      parent: 9359
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 9367
+    components:
+    - type: Transform
+      parent: 9359
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: BoxLightbulb
   entities:
   - uid: 1999
@@ -21636,15 +21722,6 @@ entities:
     - type: Transform
       pos: -11.614725,-21.270159
       parent: 8364
-- proto: BoxShotgunIncendiary
-  entities:
-  - uid: 9178
-    components:
-    - type: Transform
-      pos: -0.6496768,35.60813
-      parent: 8364
-    - type: BallisticAmmoProvider
-      unspawnedCount: 12
 - proto: BoxSterileMask
   entities:
   - uid: 5467
@@ -21662,7 +21739,7 @@ entities:
   - uid: 7928
     components:
     - type: Transform
-      pos: -6.5023327,30.526033
+      pos: -6.6457787,30.567604
       parent: 8364
   - uid: 19263
     components:
@@ -21838,12 +21915,44 @@ entities:
       rot: 3.141592653589793 rad
       pos: 12.5,-82.5
       parent: 8364
+- proto: ButtonFrameCautionSecurity
+  entities:
+  - uid: 7677
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,23.5
+      parent: 8364
+  - uid: 8630
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.505839,38.730606
+      parent: 8364
+  - uid: 25233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.4954224,38.251434
+      parent: 8364
 - proto: ButtonFrameExit
   entities:
   - uid: 3810
     components:
     - type: Transform
       pos: 24.5,-21.5
+      parent: 8364
+- proto: ButtonFrameGrey
+  entities:
+  - uid: 7721
+    components:
+    - type: Transform
+      pos: 8.5,42.5
+      parent: 8364
+  - uid: 9390
+    components:
+    - type: Transform
+      pos: 16.5,42.5
       parent: 8364
 - proto: CableApcExtension
   entities:
@@ -24347,6 +24456,16 @@ entities:
     - type: Transform
       pos: 18.5,13.5
       parent: 8364
+  - uid: 7661
+    components:
+    - type: Transform
+      pos: 10.5,36.5
+      parent: 8364
+  - uid: 7733
+    components:
+    - type: Transform
+      pos: 2.5,37.5
+      parent: 8364
   - uid: 7743
     components:
     - type: Transform
@@ -24432,6 +24551,16 @@ entities:
     - type: Transform
       pos: 15.5,28.5
       parent: 8364
+  - uid: 8546
+    components:
+    - type: Transform
+      pos: 4.5,37.5
+      parent: 8364
+  - uid: 8547
+    components:
+    - type: Transform
+      pos: 3.5,33.5
+      parent: 8364
   - uid: 8557
     components:
     - type: Transform
@@ -24491,6 +24620,21 @@ entities:
     components:
     - type: Transform
       pos: 17.5,20.5
+      parent: 8364
+  - uid: 8589
+    components:
+    - type: Transform
+      pos: 3.5,32.5
+      parent: 8364
+  - uid: 8590
+    components:
+    - type: Transform
+      pos: -0.5,37.5
+      parent: 8364
+  - uid: 8623
+    components:
+    - type: Transform
+      pos: -2.5,37.5
       parent: 8364
   - uid: 8636
     components:
@@ -24842,6 +24986,11 @@ entities:
     - type: Transform
       pos: -8.5,22.5
       parent: 8364
+  - uid: 8751
+    components:
+    - type: Transform
+      pos: 1.5,37.5
+      parent: 8364
   - uid: 8762
     components:
     - type: Transform
@@ -25167,50 +25316,15 @@ entities:
     - type: Transform
       pos: -20.5,23.5
       parent: 8364
-  - uid: 9283
+  - uid: 9268
     components:
     - type: Transform
-      pos: 4.5,38.5
-      parent: 8364
-  - uid: 9284
-    components:
-    - type: Transform
-      pos: 5.5,38.5
-      parent: 8364
-  - uid: 9285
-    components:
-    - type: Transform
-      pos: 6.5,38.5
-      parent: 8364
-  - uid: 9286
-    components:
-    - type: Transform
-      pos: 3.5,38.5
-      parent: 8364
-  - uid: 9287
-    components:
-    - type: Transform
-      pos: 2.5,38.5
+      pos: 3.5,34.5
       parent: 8364
   - uid: 9288
     components:
     - type: Transform
-      pos: 1.5,38.5
-      parent: 8364
-  - uid: 9289
-    components:
-    - type: Transform
-      pos: 0.5,38.5
-      parent: 8364
-  - uid: 9290
-    components:
-    - type: Transform
-      pos: -0.5,38.5
-      parent: 8364
-  - uid: 9291
-    components:
-    - type: Transform
-      pos: -1.5,38.5
+      pos: -3.5,33.5
       parent: 8364
   - uid: 9292
     components:
@@ -25226,11 +25340,6 @@ entities:
     components:
     - type: Transform
       pos: 0.5,37.5
-      parent: 8364
-  - uid: 9295
-    components:
-    - type: Transform
-      pos: 7.5,38.5
       parent: 8364
   - uid: 9296
     components:
@@ -25381,16 +25490,6 @@ entities:
     components:
     - type: Transform
       pos: 19.5,35.5
-      parent: 8364
-  - uid: 9334
-    components:
-    - type: Transform
-      pos: -1.5,34.5
-      parent: 8364
-  - uid: 9335
-    components:
-    - type: Transform
-      pos: -1.5,33.5
       parent: 8364
   - uid: 9336
     components:
@@ -26196,51 +26295,6 @@ entities:
     components:
     - type: Transform
       pos: 8.5,41.5
-      parent: 8364
-  - uid: 10056
-    components:
-    - type: Transform
-      pos: 7.5,41.5
-      parent: 8364
-  - uid: 10057
-    components:
-    - type: Transform
-      pos: 7.5,42.5
-      parent: 8364
-  - uid: 10058
-    components:
-    - type: Transform
-      pos: 9.5,41.5
-      parent: 8364
-  - uid: 10059
-    components:
-    - type: Transform
-      pos: 9.5,42.5
-      parent: 8364
-  - uid: 10060
-    components:
-    - type: Transform
-      pos: 3.5,36.5
-      parent: 8364
-  - uid: 10061
-    components:
-    - type: Transform
-      pos: 3.5,35.5
-      parent: 8364
-  - uid: 10062
-    components:
-    - type: Transform
-      pos: 3.5,34.5
-      parent: 8364
-  - uid: 10063
-    components:
-    - type: Transform
-      pos: 0.5,36.5
-      parent: 8364
-  - uid: 10064
-    components:
-    - type: Transform
-      pos: 0.5,35.5
       parent: 8364
   - uid: 10065
     components:
@@ -51218,6 +51272,11 @@ entities:
     - type: Transform
       pos: -7.5,-61.5
       parent: 8364
+  - uid: 3898
+    components:
+    - type: Transform
+      pos: 0.5,40.5
+      parent: 8364
   - uid: 4030
     components:
     - type: Transform
@@ -51297,6 +51356,11 @@ entities:
     components:
     - type: Transform
       pos: -22.5,-72.5
+      parent: 8364
+  - uid: 5288
+    components:
+    - type: Transform
+      pos: 1.5,41.5
       parent: 8364
   - uid: 5313
     components:
@@ -52333,6 +52397,11 @@ entities:
     - type: Transform
       pos: 26.5,1.5
       parent: 8364
+  - uid: 7340
+    components:
+    - type: Transform
+      pos: 10.5,36.5
+      parent: 8364
   - uid: 7380
     components:
     - type: Transform
@@ -52357,6 +52426,16 @@ entities:
     components:
     - type: Transform
       pos: 17.5,30.5
+      parent: 8364
+  - uid: 7659
+    components:
+    - type: Transform
+      pos: 4.5,43.5
+      parent: 8364
+  - uid: 7735
+    components:
+    - type: Transform
+      pos: 1.5,35.5
       parent: 8364
   - uid: 7786
     components:
@@ -52473,6 +52552,16 @@ entities:
     - type: Transform
       pos: 12.5,27.5
       parent: 8364
+  - uid: 8592
+    components:
+    - type: Transform
+      pos: 3.5,34.5
+      parent: 8364
+  - uid: 8632
+    components:
+    - type: Transform
+      pos: 9.5,42.5
+      parent: 8364
   - uid: 8640
     components:
     - type: Transform
@@ -52553,20 +52642,25 @@ entities:
     - type: Transform
       pos: -4.5,28.5
       parent: 8364
+  - uid: 8750
+    components:
+    - type: Transform
+      pos: 9.5,41.5
+      parent: 8364
+  - uid: 8822
+    components:
+    - type: Transform
+      pos: 1.5,36.5
+      parent: 8364
   - uid: 8823
     components:
     - type: Transform
-      pos: 7.5,38.5
+      pos: 1.5,38.5
       parent: 8364
   - uid: 8824
     components:
     - type: Transform
-      pos: 6.5,38.5
-      parent: 8364
-  - uid: 8825
-    components:
-    - type: Transform
-      pos: 5.5,38.5
+      pos: 1.5,39.5
       parent: 8364
   - uid: 8826
     components:
@@ -52723,11 +52817,6 @@ entities:
     - type: Transform
       pos: -4.5,34.5
       parent: 8364
-  - uid: 8858
-    components:
-    - type: Transform
-      pos: -5.5,34.5
-      parent: 8364
   - uid: 8859
     components:
     - type: Transform
@@ -52828,6 +52917,16 @@ entities:
     - type: Transform
       pos: -19.5,22.5
       parent: 8364
+  - uid: 8929
+    components:
+    - type: Transform
+      pos: 0.5,34.5
+      parent: 8364
+  - uid: 9004
+    components:
+    - type: Transform
+      pos: -0.5,34.5
+      parent: 8364
   - uid: 9143
     components:
     - type: Transform
@@ -52873,20 +52972,15 @@ entities:
     - type: Transform
       pos: 4.5,42.5
       parent: 8364
-  - uid: 9208
-    components:
-    - type: Transform
-      pos: 5.5,42.5
-      parent: 8364
-  - uid: 9209
-    components:
-    - type: Transform
-      pos: 6.5,42.5
-      parent: 8364
   - uid: 9218
     components:
     - type: Transform
       pos: 7.5,42.5
+      parent: 8364
+  - uid: 9224
+    components:
+    - type: Transform
+      pos: 1.5,37.5
       parent: 8364
   - uid: 9248
     components:
@@ -52913,25 +53007,20 @@ entities:
     - type: Transform
       pos: 1.5,33.5
       parent: 8364
-  - uid: 9267
+  - uid: 9289
     components:
     - type: Transform
-      pos: 0.5,33.5
+      pos: 3.5,33.5
       parent: 8364
-  - uid: 9268
+  - uid: 9346
     components:
     - type: Transform
-      pos: -0.5,33.5
+      pos: 2.5,40.5
       parent: 8364
-  - uid: 9269
+  - uid: 9381
     components:
     - type: Transform
-      pos: -1.5,33.5
-      parent: 8364
-  - uid: 9270
-    components:
-    - type: Transform
-      pos: -1.5,34.5
+      pos: -0.5,40.5
       parent: 8364
   - uid: 9615
     components:
@@ -53142,6 +53231,21 @@ entities:
     components:
     - type: Transform
       pos: 17.5,32.5
+      parent: 8364
+  - uid: 10057
+    components:
+    - type: Transform
+      pos: 5.5,43.5
+      parent: 8364
+  - uid: 10061
+    components:
+    - type: Transform
+      pos: 1.5,34.5
+      parent: 8364
+  - uid: 10064
+    components:
+    - type: Transform
+      pos: 9.5,36.5
       parent: 8364
   - uid: 10193
     components:
@@ -58138,11 +58242,6 @@ entities:
     - type: Transform
       pos: 8.5,41.5
       parent: 8364
-  - uid: 19928
-    components:
-    - type: Transform
-      pos: 8.5,42.5
-      parent: 8364
   - uid: 20164
     components:
     - type: Transform
@@ -59428,6 +59527,11 @@ entities:
     - type: Transform
       pos: -0.5,-19.5
       parent: 8364
+  - uid: 25005
+    components:
+    - type: Transform
+      pos: 1.5,40.5
+      parent: 8364
   - uid: 25089
     components:
     - type: Transform
@@ -60223,6 +60327,11 @@ entities:
     - type: Transform
       pos: -9.5,37.5
       parent: 8364
+  - uid: 26456
+    components:
+    - type: Transform
+      pos: 7.5,41.5
+      parent: 8364
   - uid: 26572
     components:
     - type: Transform
@@ -60592,6 +60701,16 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-22.5
+      parent: 8364
+  - uid: 28253
+    components:
+    - type: Transform
+      pos: 5.5,44.5
+      parent: 8364
+  - uid: 28254
+    components:
+    - type: Transform
+      pos: 5.5,45.5
       parent: 8364
 - proto: CableMVStack
   entities:
@@ -68897,11 +69016,6 @@ entities:
           showEnts: False
           occludes: True
           ent: null
-  - uid: 9197
-    components:
-    - type: Transform
-      pos: -17.5,24.5
-      parent: 8364
   - uid: 9255
     components:
     - type: Transform
@@ -69785,29 +69899,6 @@ entities:
     - type: Transform
       pos: 63.5,-72.5
       parent: 8364
-  - uid: 26546
-    components:
-    - type: Transform
-      pos: -22.5,51.5
-      parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 5.001885
-        - 18.816614
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
   - uid: 27598
     components:
     - type: Transform
@@ -69829,6 +69920,11 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-57.5
+      parent: 8364
+  - uid: 9119
+    components:
+    - type: Transform
+      pos: -17.5,24.5
       parent: 8364
   - uid: 20638
     components:
@@ -72126,20 +72222,25 @@ entities:
       parent: 8364
 - proto: ClothingHeadHelmetRiot
   entities:
-  - uid: 9366
+  - uid: 9190
     components:
     - type: Transform
-      pos: 2.689872,39.342834
+      pos: 2.7655263,39.62697
       parent: 8364
-  - uid: 9367
+  - uid: 9193
     components:
     - type: Transform
-      pos: 2.689872,39.624084
+      pos: 2.7655263,39.512383
       parent: 8364
-  - uid: 9368
+  - uid: 9197
     components:
     - type: Transform
-      pos: 2.689872,39.51471
+      pos: 2.7655263,39.366547
+      parent: 8364
+  - uid: 10062
+    components:
+    - type: Transform
+      pos: 2.7551093,39.762383
       parent: 8364
 - proto: ClothingHeadsetEngineering
   entities:
@@ -72278,23 +72379,6 @@ entities:
     - type: Transform
       pos: -44.458595,14.399037
       parent: 8364
-- proto: ClothingMaskGasSecurity
-  entities:
-  - uid: 9223
-    components:
-    - type: Transform
-      pos: 4.830586,32.536835
-      parent: 8364
-  - uid: 9224
-    components:
-    - type: Transform
-      pos: 4.547027,32.818085
-      parent: 8364
-  - uid: 9228
-    components:
-    - type: Transform
-      pos: 4.656402,32.724335
-      parent: 8364
 - proto: ClothingMaskSterile
   entities:
   - uid: 17899
@@ -72423,54 +72507,59 @@ entities:
       parent: 8364
 - proto: ClothingOuterArmorBulletproof
   entities:
-  - uid: 9375
+  - uid: 9170
     components:
     - type: Transform
-      pos: 0.54769325,39.79596
+      pos: 1.2759427,39.481133
       parent: 8364
-  - uid: 9376
+  - uid: 9178
     components:
     - type: Transform
-      pos: 0.71956825,39.592834
+      pos: 1.2759427,39.59572
       parent: 8364
-  - uid: 9377
+  - uid: 21244
     components:
     - type: Transform
-      pos: 0.81331825,39.405334
+      pos: 1.2759427,39.699883
+      parent: 8364
+  - uid: 28242
+    components:
+    - type: Transform
+      pos: 1.2759427,39.37697
       parent: 8364
 - proto: ClothingOuterArmorReflective
   entities:
-  - uid: 9372
+  - uid: 9483
     components:
     - type: Transform
-      pos: 0.3043524,39.56628
+      pos: 1.6821928,39.418633
       parent: 8364
-  - uid: 9373
+  - uid: 28240
     components:
     - type: Transform
-      pos: 0.4762274,39.44128
-      parent: 8364
-  - uid: 9374
-    components:
-    - type: Transform
-      pos: 0.6793524,39.28503
+      pos: 1.6926093,39.574883
       parent: 8364
 - proto: ClothingOuterArmorRiot
   entities:
-  - uid: 9369
+  - uid: 9166
     components:
     - type: Transform
-      pos: 2.330497,39.530334
+      pos: 2.3384428,39.68947
       parent: 8364
-  - uid: 9370
+  - uid: 9167
     components:
     - type: Transform
-      pos: 2.346122,39.38971
+      pos: 2.3384428,39.554047
       parent: 8364
-  - uid: 9371
+  - uid: 9216
     components:
     - type: Transform
-      pos: 2.314872,39.67096
+      pos: 2.3488593,39.481133
+      parent: 8364
+  - uid: 9223
+    components:
+    - type: Transform
+      pos: 2.3384428,39.366547
       parent: 8364
 - proto: ClothingOuterCardborg
   entities:
@@ -72531,27 +72620,31 @@ entities:
       parent: 8364
 - proto: ClothingOuterHardsuitSecurity
   entities:
-  - uid: 4163
+  - uid: 9230
     components:
     - type: Transform
-      pos: 0.37893665,35.52849
-      parent: 8364
-  - uid: 15129
-    components:
-    - type: Transform
-      pos: 0.37893665,35.52849
-      parent: 8364
-  - uid: 20856
-    components:
-    - type: Transform
-      parent: 11965
+      parent: 9229
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 20857
+  - uid: 9238
     components:
     - type: Transform
-      parent: 17151
+      parent: 9235
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 9517
+    components:
+    - type: Transform
+      parent: 9507
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 9566
+    components:
+    - type: Transform
+      parent: 9518
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -73365,11 +73458,6 @@ entities:
     - type: Transform
       pos: 39.5,-16.5
       parent: 8364
-  - uid: 8751
-    components:
-    - type: Transform
-      pos: -9.5,32.5
-      parent: 8364
   - uid: 20882
     components:
     - type: Transform
@@ -73480,11 +73568,6 @@ entities:
       parent: 8364
 - proto: ComputerCriminalRecords
   entities:
-  - uid: 9075
-    components:
-    - type: Transform
-      pos: -1.5,33.5
-      parent: 8364
   - uid: 9181
     components:
     - type: Transform
@@ -73516,6 +73599,11 @@ entities:
     components:
     - type: Transform
       pos: -8.5,-6.5
+      parent: 8364
+  - uid: 21245
+    components:
+    - type: Transform
+      pos: 0.5,33.5
       parent: 8364
 - proto: ComputerFrame
   entities:
@@ -73787,6 +73875,21 @@ entities:
       parent: 8364
 - proto: ComputerTelevision
   entities:
+  - uid: 4213
+    components:
+    - type: Transform
+      pos: -4.5,24.5
+      parent: 8364
+  - uid: 4214
+    components:
+    - type: Transform
+      pos: -0.5,24.5
+      parent: 8364
+  - uid: 6253
+    components:
+    - type: Transform
+      pos: -8.5,24.5
+      parent: 8364
   - uid: 6594
     components:
     - type: Transform
@@ -73806,6 +73909,11 @@ entities:
     components:
     - type: Transform
       pos: 10.5,-27.5
+      parent: 8364
+  - uid: 28241
+    components:
+    - type: Transform
+      pos: 16.5,34.5
       parent: 8364
 - proto: ContainmentFieldGenerator
   entities:
@@ -74204,10 +74312,10 @@ entities:
       parent: 8364
 - proto: CrateContrabandStorageSecure
   entities:
-  - uid: 27489
+  - uid: 8629
     components:
     - type: Transform
-      pos: -2.5,32.5
+      pos: 3.5,33.5
       parent: 8364
 - proto: CrateEmergencyRadiation
   entities:
@@ -74765,6 +74873,24 @@ entities:
     - type: Transform
       pos: -9.5,30.5
       parent: 8364
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
   - uid: 19237
     components:
     - type: Transform
@@ -75574,12 +75700,12 @@ entities:
       parent: 8364
 - proto: DeployableBarrier
   entities:
-  - uid: 9566
+  - uid: 8761
     components:
     - type: Transform
       pos: 3.5,35.5
       parent: 8364
-  - uid: 9567
+  - uid: 9267
     components:
     - type: Transform
       pos: 4.5,35.5
@@ -75788,23 +75914,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,32.5
-      parent: 8364
-  - uid: 9515
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,31.5
-      parent: 8364
-  - uid: 9517
-    components:
-    - type: Transform
-      pos: 6.5,31.5
-      parent: 8364
-  - uid: 9518
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,30.5
       parent: 8364
   - uid: 9534
     components:
@@ -76735,6 +76844,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,5.5
+      parent: 8364
+  - uid: 9284
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,30.5
       parent: 8364
   - uid: 9499
     components:
@@ -77904,10 +78019,42 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -5.5,26.5
       parent: 8364
+  - uid: 8819
+    components:
+    - type: Transform
+      pos: 9.5,33.5
+      parent: 8364
+  - uid: 8820
+    components:
+    - type: Transform
+      pos: 9.5,34.5
+      parent: 8364
   - uid: 9105
     components:
     - type: Transform
       pos: -26.5,-17.5
+      parent: 8364
+  - uid: 9270
+    components:
+    - type: Transform
+      pos: 9.5,32.5
+      parent: 8364
+  - uid: 9283
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,30.5
+      parent: 8364
+  - uid: 9285
+    components:
+    - type: Transform
+      pos: 9.5,31.5
+      parent: 8364
+  - uid: 9286
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,30.5
       parent: 8364
   - uid: 9401
     components:
@@ -78040,12 +78187,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 10.5,30.5
       parent: 8364
-  - uid: 9507
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,30.5
-      parent: 8364
   - uid: 9508
     components:
     - type: Transform
@@ -78062,12 +78203,6 @@ entities:
     components:
     - type: Transform
       pos: 18.5,33.5
-      parent: 8364
-  - uid: 9516
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,31.5
       parent: 8364
   - uid: 9520
     components:
@@ -83703,21 +83838,26 @@ entities:
       rot: 3.141592653589793 rad
       pos: -24.5,-13.5
       parent: 8364
+  - uid: 9075
+    components:
+    - type: Transform
+      pos: 9.5,35.5
+      parent: 8364
   - uid: 9246
     components:
     - type: Transform
       pos: -22.5,-15.5
       parent: 8364
+  - uid: 9269
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,30.5
+      parent: 8364
   - uid: 9481
     components:
     - type: Transform
       pos: 19.5,36.5
-      parent: 8364
-  - uid: 9483
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,30.5
       parent: 8364
   - uid: 9559
     components:
@@ -84045,6 +84185,11 @@ entities:
     - type: Transform
       pos: 4.5,30.5
       parent: 8364
+  - uid: 9262
+    components:
+    - type: Transform
+      pos: 9.5,35.5
+      parent: 8364
   - uid: 9400
     components:
     - type: Transform
@@ -84352,7 +84497,7 @@ entities:
       parent: 8364
 - proto: DresserHeadOfSecurityFilled
   entities:
-  - uid: 9238
+  - uid: 5606
     components:
     - type: Transform
       pos: 16.5,40.5
@@ -84370,6 +84515,13 @@ entities:
     components:
     - type: Transform
       pos: 71.5,-33.5
+      parent: 8364
+- proto: DresserWardenFilled
+  entities:
+  - uid: 9257
+    components:
+    - type: Transform
+      pos: -1.5,33.5
       parent: 8364
 - proto: DrinkBeerBottleFull
   entities:
@@ -84479,6 +84631,11 @@ entities:
       parent: 8364
 - proto: EmergencyLight
   entities:
+  - uid: 9135
+    components:
+    - type: Transform
+      pos: 4.5,33.5
+      parent: 8364
   - uid: 20300
     components:
     - type: Transform
@@ -84544,15 +84701,6 @@ entities:
     components:
     - type: Transform
       pos: -7.5,21.5
-      parent: 8364
-    - type: PointLight
-      enabled: True
-    - type: ActiveEmergencyLight
-  - uid: 21326
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,32.5
       parent: 8364
     - type: PointLight
       enabled: True
@@ -85217,6 +85365,36 @@ entities:
     - type: Transform
       pos: 59.5,-19.5
       parent: 8364
+- proto: ExplosivesSignMed
+  entities:
+  - uid: 18369
+    components:
+    - type: MetaData
+      desc: WARNING! Live minefield!
+    - type: Transform
+      pos: 5.5,46.5
+      parent: 8364
+  - uid: 18370
+    components:
+    - type: MetaData
+      desc: WARNING! Live minefield!
+    - type: Transform
+      pos: -24.5,52.5
+      parent: 8364
+  - uid: 28261
+    components:
+    - type: MetaData
+      desc: WARNING! Live minefield!
+    - type: Transform
+      pos: -7.5,54.5
+      parent: 8364
+  - uid: 28263
+    components:
+    - type: MetaData
+      desc: WARNING! Live minefield!
+    - type: Transform
+      pos: 25.5,43.5
+      parent: 8364
 - proto: ExtendedEmergencyOxygenTankFilled
   entities:
   - uid: 17647
@@ -85613,7 +85791,7 @@ entities:
       pos: 12.5,41.5
       parent: 8364
     - type: FaxMachine
-      name: HoS
+      name: HoS Office
   - uid: 21237
     components:
     - type: Transform
@@ -85635,6 +85813,13 @@ entities:
       parent: 8364
     - type: FaxMachine
       name: Medical
+  - uid: 28093
+    components:
+    - type: Transform
+      pos: 4.5,32.5
+      parent: 8364
+    - type: FaxMachine
+      name: Warden's Office
 - proto: FaxMachineCaptain
   entities:
   - uid: 21189
@@ -86498,7 +86683,6 @@ entities:
       - 7393
       - 7390
       - 7146
-      - 9262
       - 11605
       - 11600
       - 23935
@@ -86516,7 +86700,6 @@ entities:
       - 7393
       - 7390
       - 7146
-      - 9262
       - 11605
       - 11600
       - 23935
@@ -86527,35 +86710,12 @@ entities:
       parent: 8364
     - type: DeviceList
       devices:
-      - 9262
       - 11605
       - 11600
       - 11377
       - 11603
       - 23940
-  - uid: 25233
-    components:
-    - type: Transform
-      pos: -2.5,34.5
-      parent: 8364
-    - type: DeviceList
-      devices:
-      - 25040
-      - 9219
-      - 8930
-      - 8934
-  - uid: 25235
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,39.5
-      parent: 8364
-    - type: DeviceList
-      devices:
-      - 8930
-      - 8934
-      - 25236
-      - 19934
+      - 9291
   - uid: 25807
     components:
     - type: Transform
@@ -87485,11 +87645,17 @@ entities:
     - type: Transform
       pos: -0.5,29.5
       parent: 8364
-  - uid: 9262
+  - uid: 9291
     components:
     - type: Transform
       pos: -1.5,18.5
       parent: 8364
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 23942
+      - 23898
   - uid: 9811
     components:
     - type: Transform
@@ -87929,7 +88095,7 @@ entities:
       pos: -34.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -72829.68
+      secondsUntilStateChange: -77305.625
       state: Closing
   - uid: 15010
     components:
@@ -89343,11 +89509,6 @@ entities:
     components:
     - type: Transform
       pos: 15.5,27.5
-      parent: 8364
-  - uid: 9411
-    components:
-    - type: Transform
-      pos: 14.5,39.5
       parent: 8364
 - proto: FoodBreadBaguette
   entities:
@@ -121361,6 +121522,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 20.5,-82.5
       parent: 8364
+  - uid: 4163
+    components:
+    - type: Transform
+      pos: 5.5,44.5
+      parent: 8364
   - uid: 4234
     components:
     - type: Transform
@@ -123265,11 +123431,6 @@ entities:
     - type: Transform
       pos: 6.5,34.5
       parent: 8364
-  - uid: 7716
-    components:
-    - type: Transform
-      pos: 3.5,34.5
-      parent: 8364
   - uid: 7717
     components:
     - type: Transform
@@ -123289,11 +123450,6 @@ entities:
     components:
     - type: Transform
       pos: -0.5,34.5
-      parent: 8364
-  - uid: 7721
-    components:
-    - type: Transform
-      pos: 3.5,34.5
       parent: 8364
   - uid: 7722
     components:
@@ -123872,6 +124028,11 @@ entities:
     - type: Transform
       pos: -1.5,-79.5
       parent: 8364
+  - uid: 8825
+    components:
+    - type: Transform
+      pos: 5.5,45.5
+      parent: 8364
   - uid: 8976
     components:
     - type: Transform
@@ -123933,6 +124094,11 @@ entities:
     components:
     - type: Transform
       pos: -13.5,39.5
+      parent: 8364
+  - uid: 9208
+    components:
+    - type: Transform
+      pos: 5.5,43.5
       parent: 8364
   - uid: 9332
     components:
@@ -125305,6 +125471,11 @@ entities:
     - type: Transform
       pos: 0.5,42.5
       parent: 8364
+  - uid: 25004
+    components:
+    - type: Transform
+      pos: -3.5,33.5
+      parent: 8364
   - uid: 25230
     components:
     - type: Transform
@@ -125919,6 +126090,51 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 3.5,-24.5
       parent: 8364
+  - uid: 28262
+    components:
+    - type: Transform
+      pos: 30.5,43.5
+      parent: 8364
+  - uid: 28268
+    components:
+    - type: Transform
+      pos: 30.5,42.5
+      parent: 8364
+  - uid: 28269
+    components:
+    - type: Transform
+      pos: 30.5,41.5
+      parent: 8364
+  - uid: 28270
+    components:
+    - type: Transform
+      pos: 30.5,40.5
+      parent: 8364
+  - uid: 28271
+    components:
+    - type: Transform
+      pos: 30.5,44.5
+      parent: 8364
+  - uid: 28272
+    components:
+    - type: Transform
+      pos: 30.5,45.5
+      parent: 8364
+  - uid: 28273
+    components:
+    - type: Transform
+      pos: 30.5,39.5
+      parent: 8364
+  - uid: 28274
+    components:
+    - type: Transform
+      pos: 27.5,45.5
+      parent: 8364
+  - uid: 28275
+    components:
+    - type: Transform
+      pos: 28.5,45.5
+      parent: 8364
 - proto: GrilleBroken
   entities:
   - uid: 453
@@ -126153,44 +126369,195 @@ entities:
       parent: 8364
 - proto: GunSafeDisabler
   entities:
-  - uid: 6253
+  - uid: 10063
     components:
     - type: Transform
-      pos: -0.5,39.5
+      anchored: True
+      pos: -1.5,39.5
       parent: 8364
-  - uid: 15128
-    components:
-    - type: Transform
-      pos: 3.5,33.5
-      parent: 8364
+    - type: Physics
+      bodyType: Static
 - proto: GunSafeLaserCarbine
   entities:
-  - uid: 9236
+  - uid: 9377
     components:
+    - type: MetaData
+      desc: A standard-issue Nanotrasen storage unit, containing 4 Laser Carbines.
     - type: Transform
-      pos: 1.5,37.5
-      parent: 8364
-- proto: GunSafeRifleLecter
-  entities:
-  - uid: 9177
-    components:
-    - type: Transform
-      pos: 0.5,37.5
-      parent: 8364
-- proto: GunSafeShotgunKammerer
-  entities:
-  - uid: 9170
-    components:
-    - type: Transform
-      pos: -0.5,37.5
-      parent: 8364
-- proto: GunSafeSubMachineGunDrozd
-  entities:
-  - uid: 9235
-    components:
-    - type: Transform
+      anchored: True
       pos: 2.5,37.5
       parent: 8364
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14597
+        moles:
+        - 1.606311
+        - 6.042789
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 9380
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: GunSafePistolMk58
+  entities:
+  - uid: 9345
+    components:
+    - type: Transform
+      anchored: True
+      pos: -0.5,39.5
+      parent: 8364
+    - type: Physics
+      bodyType: Static
+- proto: GunSafeRifleLecter
+  entities:
+  - uid: 9373
+    components:
+    - type: MetaData
+      desc: A standard-issue Nanotrasen storage unit, containing 3 Lecter combat rifles.
+    - type: Transform
+      anchored: True
+      pos: -0.5,37.5
+      parent: 8364
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 9374
+          - 9375
+          - 9376
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: GunSafeShotgunKammerer
+  entities:
+  - uid: 9359
+    components:
+    - type: MetaData
+      desc: A standard-issue Nanotrasen storage unit, containing 4 Kammerer shotguns.
+    - type: Transform
+      anchored: True
+      pos: 1.5,37.5
+      parent: 8364
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 9368
+          - 9367
+          - 9366
+          - 9361
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: GunSafeSubMachineGunDrozd
+  entities:
+  - uid: 9369
+    components:
+    - type: MetaData
+      desc: A standard-issue Nanotrasen storage unit, containing 3 Drozd submachine guns.
+    - type: Transform
+      anchored: True
+      pos: 0.5,37.5
+      parent: 8364
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 9370
+          - 9371
+          - 9372
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: GyroscopeUnanchored
   entities:
   - uid: 25012
@@ -126247,11 +126614,6 @@ entities:
     components:
     - type: Transform
       pos: -14.5,22.5
-      parent: 8364
-  - uid: 9229
-    components:
-    - type: Transform
-      pos: 1.530674,30.52632
       parent: 8364
   - uid: 9705
     components:
@@ -126689,10 +127051,10 @@ entities:
       parent: 8364
 - proto: HolopadSecurityArmory
   entities:
-  - uid: 28138
+  - uid: 7709
     components:
     - type: Transform
-      pos: 1.5,38.5
+      pos: 3.5,37.5
       parent: 8364
 - proto: HolopadSecurityArrivalsCheckpoint
   entities:
@@ -126745,10 +127107,10 @@ entities:
       parent: 8364
 - proto: HolopadSecurityFront
   entities:
-  - uid: 28093
+  - uid: 28247
     components:
     - type: Transform
-      pos: 1.5,23.5
+      pos: 5.5,20.5
       parent: 8364
 - proto: HolopadSecurityInterrogation
   entities:
@@ -127761,12 +128123,56 @@ entities:
   - uid: 27309
     components:
     - type: Transform
+      anchored: True
       pos: -0.5,43.5
       parent: 8364
   - uid: 27313
     components:
     - type: Transform
+      anchored: True
       pos: 2.5,43.5
+      parent: 8364
+  - uid: 28248
+    components:
+    - type: Transform
+      anchored: True
+      pos: 6.5,44.5
+      parent: 8364
+  - uid: 28255
+    components:
+    - type: Transform
+      anchored: True
+      pos: -20.5,55.5
+      parent: 8364
+  - uid: 28256
+    components:
+    - type: Transform
+      anchored: True
+      pos: -13.5,56.5
+      parent: 8364
+  - uid: 28257
+    components:
+    - type: Transform
+      anchored: True
+      pos: 1.5,54.5
+      parent: 8364
+  - uid: 28258
+    components:
+    - type: Transform
+      anchored: True
+      pos: 13.5,44.5
+      parent: 8364
+  - uid: 28259
+    components:
+    - type: Transform
+      anchored: True
+      pos: 7.5,52.5
+      parent: 8364
+  - uid: 28260
+    components:
+    - type: Transform
+      anchored: True
+      pos: 22.5,44.5
       parent: 8364
 - proto: LandMineModular
   entities:
@@ -127848,6 +128254,32 @@ entities:
     - type: Transform
       pos: -28.5095,-5.350807
       parent: 8364
+- proto: LockableButtonArmory
+  entities:
+  - uid: 8631
+    components:
+    - type: MetaData
+      name: Open Armory
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.4954224,38.730606
+      parent: 8364
+    - type: DeviceLinkSource
+      linkedPorts:
+        9182:
+        - Pressed: Open
+  - uid: 25235
+    components:
+    - type: MetaData
+      name: Close Armory
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.4954224,38.24102
+      parent: 8364
+    - type: DeviceLinkSource
+      linkedPorts:
+        9182:
+        - Pressed: Close
 - proto: LockableButtonChiefMedicalOfficer
   entities:
   - uid: 3809
@@ -128309,29 +128741,6 @@ entities:
         - 0
         - 0
         - 0
-  - uid: 9118
-    components:
-    - type: Transform
-      pos: 6.5,41.5
-      parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 5.001885
-        - 18.816614
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
   - uid: 9356
     components:
     - type: Transform
@@ -128524,8 +128933,8 @@ entities:
         immutable: False
         temperature: 293.1496
         moles:
-        - 5.001885
-        - 18.816614
+        - 2.146141
+        - 8.073578
         - 0
         - 0
         - 0
@@ -128741,6 +129150,13 @@ entities:
         - 0
         - 0
         - 0
+  - uid: 25003
+    components:
+    - type: Transform
+      pos: -9.5,31.5
+      parent: 8364
+    - type: Lock
+      locked: False
 - proto: LockerParamedicFilled
   entities:
   - uid: 27687
@@ -129496,22 +129912,54 @@ entities:
     - type: Transform
       pos: -43.5,-12.5
       parent: 8364
+- proto: MagazinePistolSubMachineGun
+  entities:
+  - uid: 9371
+    components:
+    - type: Transform
+      parent: 9369
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 9372
+    components:
+    - type: Transform
+      parent: 9369
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: MagazinePistolSubMachineGunTopMounted
   entities:
   - uid: 534
     components:
     - type: Transform
-      pos: 16.383898,41.80004
+      pos: 14.262794,39.806297
       parent: 8364
     - type: BallisticAmmoProvider
       unspawnedCount: 30
   - uid: 535
     components:
     - type: Transform
-      pos: 16.383898,41.80004
+      pos: 14.247169,39.821922
       parent: 8364
     - type: BallisticAmmoProvider
       unspawnedCount: 30
+- proto: MagazineRifle
+  entities:
+  - uid: 9374
+    components:
+    - type: Transform
+      parent: 9373
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 9376
+    components:
+    - type: Transform
+      parent: 9373
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: MailingUnit
   entities:
   - uid: 8179
@@ -129942,10 +130390,20 @@ entities:
     - type: Transform
       pos: 32.5,-36.5
       parent: 8364
+  - uid: 5594
+    components:
+    - type: Transform
+      pos: -6.5,31.5
+      parent: 8364
   - uid: 18648
     components:
     - type: Transform
       pos: 30.5,-27.5
+      parent: 8364
+  - uid: 19933
+    components:
+    - type: Transform
+      pos: -6.5,32.5
       parent: 8364
 - proto: MedicalTechFab
   entities:
@@ -129963,6 +130421,11 @@ entities:
       parent: 8364
 - proto: MedkitBruteFilled
   entities:
+  - uid: 9118
+    components:
+    - type: Transform
+      pos: -6.4267135,29.876205
+      parent: 8364
   - uid: 21717
     components:
     - type: Transform
@@ -129997,11 +130460,6 @@ entities:
       parent: 8364
 - proto: MedkitFilled
   entities:
-  - uid: 5606
-    components:
-    - type: Transform
-      pos: 4.550616,-5.4263577
-      parent: 8364
   - uid: 6523
     components:
     - type: Transform
@@ -130016,11 +130474,6 @@ entities:
     components:
     - type: Transform
       pos: -6.5648327,29.651033
-      parent: 8364
-  - uid: 9086
-    components:
-    - type: Transform
-      pos: -2.4584026,39.71956
       parent: 8364
   - uid: 12264
     components:
@@ -130047,7 +130500,7 @@ entities:
   - uid: 7927
     components:
     - type: Transform
-      pos: -6.3929577,29.432283
+      pos: -6.3642135,29.51683
       parent: 8364
 - proto: MedkitRadiationFilled
   entities:
@@ -130787,6 +131240,50 @@ entities:
       parent: 8364
 - proto: NitrogenTankFilled
   entities:
+  - uid: 9231
+    components:
+    - type: Transform
+      parent: 9229
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 9236
+    components:
+    - type: Transform
+      parent: 9235
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 9515
+    components:
+    - type: Transform
+      parent: 9507
+    - type: GasTank
+      toggleActionEntity: 9516
+    - type: Physics
+      canCollide: False
+    - type: ActionsContainer
+    - type: ContainerContainer
+      containers:
+        actions: !type:Container
+          ents:
+          - 9516
+    - type: InsideEntityStorage
+  - uid: 9567
+    components:
+    - type: Transform
+      parent: 9518
+    - type: GasTank
+      toggleActionEntity: 10056
+    - type: Physics
+      canCollide: False
+    - type: ActionsContainer
+    - type: ContainerContainer
+      containers:
+        actions: !type:Container
+          ents:
+          - 10056
+    - type: InsideEntityStorage
   - uid: 27177
     components:
     - type: Transform
@@ -130840,11 +131337,6 @@ entities:
     components:
     - type: Transform
       pos: 19.5,-32.5
-      parent: 8364
-  - uid: 8750
-    components:
-    - type: Transform
-      pos: -9.5,31.5
       parent: 8364
   - uid: 19015
     components:
@@ -131732,11 +132224,6 @@ entities:
     - type: Transform
       pos: -11.650579,32.527164
       parent: 8364
-  - uid: 9231
-    components:
-    - type: Transform
-      pos: -1.2001991,30.822023
-      parent: 8364
   - uid: 9232
     components:
     - type: Transform
@@ -132050,6 +132537,20 @@ entities:
     - type: Transform
       pos: 7.5224895,-74.49767
       parent: 8364
+- proto: PlasmaWindoorSecureSecurityLocked
+  entities:
+  - uid: 28243
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,37.5
+      parent: 8364
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        28246:
+        - DoorStatus: Close
 - proto: PlasticFlapsAirtightClear
   entities:
   - uid: 3067
@@ -132138,20 +132639,15 @@ entities:
       parent: 8364
 - proto: PortableFlasher
   entities:
-  - uid: 9166
-    components:
-    - type: Transform
-      pos: -1.5,35.5
-      parent: 8364
-  - uid: 9167
-    components:
-    - type: Transform
-      pos: -2.5,35.5
-      parent: 8364
   - uid: 9169
     components:
     - type: Transform
       pos: -2.5,36.5
+      parent: 8364
+  - uid: 9453
+    components:
+    - type: Transform
+      pos: -2.5,35.5
       parent: 8364
 - proto: PortableGeneratorJrPacman
   entities:
@@ -132809,11 +133305,6 @@ entities:
     components:
     - type: Transform
       pos: 34.5,-51.5
-      parent: 8364
-  - uid: 5599
-    components:
-    - type: Transform
-      pos: 12.5,37.5
       parent: 8364
   - uid: 14510
     components:
@@ -137601,11 +138092,6 @@ entities:
     - type: Transform
       pos: -8.5,53.5
       parent: 8364
-  - uid: 9190
-    components:
-    - type: Transform
-      pos: 0.5,39.5
-      parent: 8364
   - uid: 9191
     components:
     - type: Transform
@@ -137615,16 +138101,6 @@ entities:
     components:
     - type: Transform
       pos: 2.5,39.5
-      parent: 8364
-  - uid: 9193
-    components:
-    - type: Transform
-      pos: 0.5,35.5
-      parent: 8364
-  - uid: 9194
-    components:
-    - type: Transform
-      pos: -0.5,35.5
       parent: 8364
   - uid: 9364
     components:
@@ -137960,6 +138436,11 @@ entities:
     components:
     - type: Transform
       pos: 72.5,-35.5
+      parent: 8364
+  - uid: 21326
+    components:
+    - type: Transform
+      pos: 0.5,39.5
       parent: 8364
   - uid: 21389
     components:
@@ -139152,11 +139633,6 @@ entities:
     - type: Transform
       pos: -12.5,26.5
       parent: 8364
-  - uid: 9463
-    components:
-    - type: Transform
-      pos: -1.5,23.5
-      parent: 8364
   - uid: 9474
     components:
     - type: Transform
@@ -139817,6 +140293,18 @@ entities:
     components:
     - type: Transform
       pos: -0.5,40.5
+      parent: 8364
+  - uid: 10059
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,34.5
+      parent: 8364
+  - uid: 10060
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,34.5
       parent: 8364
   - uid: 15138
     components:
@@ -142750,6 +143238,12 @@ entities:
     - type: Transform
       pos: 11.5,40.5
       parent: 8364
+  - uid: 7706
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,33.5
+      parent: 8364
   - uid: 7724
     components:
     - type: Transform
@@ -142789,21 +143283,6 @@ entities:
     components:
     - type: Transform
       pos: 5.5,32.5
-      parent: 8364
-  - uid: 7733
-    components:
-    - type: Transform
-      pos: 3.5,34.5
-      parent: 8364
-  - uid: 7734
-    components:
-    - type: Transform
-      pos: -0.5,34.5
-      parent: 8364
-  - uid: 7735
-    components:
-    - type: Transform
-      pos: 0.5,34.5
       parent: 8364
   - uid: 7736
     components:
@@ -144391,6 +144870,21 @@ entities:
     - type: Transform
       pos: 60.5,-69.5
       parent: 8364
+  - uid: 28265
+    components:
+    - type: Transform
+      pos: 5.5,45.5
+      parent: 8364
+  - uid: 28266
+    components:
+    - type: Transform
+      pos: 5.5,44.5
+      parent: 8364
+  - uid: 28267
+    components:
+    - type: Transform
+      pos: 5.5,43.5
+      parent: 8364
 - proto: RemoteSignaller
   entities:
   - uid: 5286
@@ -144429,17 +144923,71 @@ entities:
     - type: Transform
       pos: 51.721848,-23.02736
       parent: 8364
+- proto: RiotBulletShield
+  entities:
+  - uid: 7681
+    components:
+    - type: Transform
+      pos: 0.21283889,39.394394
+      parent: 8364
+  - uid: 9194
+    components:
+    - type: Transform
+      pos: 0.22672784,39.679115
+      parent: 8364
+  - uid: 9209
+    components:
+    - type: Transform
+      pos: 0.2197833,39.57495
+      parent: 8364
+  - uid: 9383
+    components:
+    - type: Transform
+      pos: 0.2197833,39.47773
+      parent: 8364
+- proto: RiotLaserShield
+  entities:
+  - uid: 8627
+    components:
+    - type: Transform
+      pos: 0.7406167,39.408287
+      parent: 8364
+  - uid: 9290
+    components:
+    - type: Transform
+      pos: 0.73367226,39.581894
+      parent: 8364
+  - uid: 9335
+    components:
+    - type: Transform
+      pos: 0.73367226,39.69301
+      parent: 8364
+  - uid: 21786
+    components:
+    - type: Transform
+      pos: 0.73367226,39.498558
+      parent: 8364
 - proto: RiotShield
   entities:
-  - uid: 9119
+  - uid: 9226
     components:
     - type: Transform
-      pos: 0.2666831,39.43831
+      pos: 0.4975611,39.720787
       parent: 8364
-  - uid: 9135
+  - uid: 9228
     components:
     - type: Transform
-      pos: 0.2510581,39.68831
+      pos: 0.4975611,39.616615
+      parent: 8364
+  - uid: 9334
+    components:
+    - type: Transform
+      pos: 0.4975611,39.519394
+      parent: 8364
+  - uid: 10058
+    components:
+    - type: Transform
+      pos: 0.4975611,39.394394
       parent: 8364
 - proto: RobocopCircuitBoard
   entities:
@@ -144674,10 +145222,10 @@ entities:
       parent: 8364
 - proto: SecurityTechFab
   entities:
-  - uid: 9359
+  - uid: 9454
     components:
     - type: Transform
-      pos: -1.5,39.5
+      pos: -1.5,35.5
       parent: 8364
 - proto: SeedExtractor
   entities:
@@ -144875,11 +145423,6 @@ entities:
     components:
     - type: Transform
       pos: 69.50902,-26.620325
-      parent: 8364
-  - uid: 8761
-    components:
-    - type: Transform
-      pos: -2.4544196,39.606735
       parent: 8364
   - uid: 19207
     components:
@@ -145950,50 +146493,6 @@ entities:
         - Pressed: Toggle
         20180:
         - Pressed: Toggle
-  - uid: 19931
-    components:
-    - type: Transform
-      pos: 0.5,25.5
-      parent: 8364
-    - type: DeviceLinkSource
-      linkedPorts:
-        8783:
-        - Pressed: Toggle
-        8782:
-        - Pressed: Toggle
-        8781:
-        - Pressed: Toggle
-        8780:
-        - Pressed: Toggle
-        8779:
-        - Pressed: Toggle
-        8778:
-        - Pressed: Toggle
-        8777:
-        - Pressed: Toggle
-        8776:
-        - Pressed: Toggle
-        8775:
-        - Pressed: Toggle
-        8615:
-        - Pressed: Toggle
-        8614:
-        - Pressed: Toggle
-        8606:
-        - Pressed: Toggle
-        8607:
-        - Pressed: Toggle
-  - uid: 19933
-    components:
-    - type: Transform
-      pos: -3.5,33.5
-      parent: 8364
-    - type: DeviceLinkSource
-      linkedPorts:
-        19930:
-        - Pressed: Toggle
-        19932:
-        - Pressed: Toggle
   - uid: 20896
     components:
     - type: Transform
@@ -146144,32 +146643,6 @@ entities:
         - Pressed: Toggle
 - proto: SignalButtonDirectional
   entities:
-  - uid: 4213
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,36.5
-      parent: 8364
-    - type: DeviceLinkSource
-      linkedPorts:
-        4494:
-        - Pressed: Toggle
-        4495:
-        - Pressed: Toggle
-  - uid: 4214
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,36.5
-      parent: 8364
-    - type: DeviceLinkSource
-      linkedPorts:
-        3134:
-        - Pressed: Toggle
-        4212:
-        - Pressed: Toggle
-        6970:
-        - Pressed: Toggle
   - uid: 10732
     components:
     - type: MetaData
@@ -146256,13 +146729,22 @@ entities:
         - Pressed: DoorBolt
 - proto: SignalSwitch
   entities:
-  - uid: 8784
+  - uid: 9411
     components:
     - type: MetaData
-      name: brig shutters switch
+      name: Perma Blast Doors
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -1.5,30.5
       parent: 8364
+    - type: DeviceLinkSource
+      linkedPorts:
+        19930:
+        - On: Open
+        - Off: Close
+        19932:
+        - On: Open
+        - Off: Close
   - uid: 13247
     components:
     - type: MetaData
@@ -146270,6 +146752,81 @@ entities:
     - type: Transform
       pos: 10.8,3.5
       parent: 8364
+- proto: SignalSwitchDirectional
+  entities:
+  - uid: 11568
+    components:
+    - type: MetaData
+      name: Brig Shutters
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,23.5
+      parent: 8364
+    - type: DeviceLinkSource
+      linkedPorts:
+        8783:
+        - On: Open
+        - Off: Close
+        8782:
+        - On: Open
+        - Off: Close
+        8781:
+        - On: Open
+        - Off: Close
+        8780:
+        - On: Open
+        - Off: Close
+        8778:
+        - On: Open
+        - Off: Close
+        8777:
+        - On: Open
+        - Off: Close
+        8776:
+        - On: Open
+        - Off: Close
+        8775:
+        - On: Open
+        - Off: Close
+        8615:
+        - On: Open
+        - Off: Close
+        8614:
+        - On: Open
+        - Off: Close
+  - uid: 15129
+    components:
+    - type: MetaData
+      name: Window Blast Doors
+    - type: Transform
+      pos: 8.5,42.5
+      parent: 8364
+    - type: DeviceLinkSource
+      linkedPorts:
+        4495:
+        - On: Open
+        - Off: Close
+        4494:
+        - On: Open
+        - Off: Close
+  - uid: 28264
+    components:
+    - type: MetaData
+      name: Window Blast Doors
+    - type: Transform
+      pos: 16.5,42.5
+      parent: 8364
+    - type: DeviceLinkSource
+      linkedPorts:
+        6970:
+        - On: Open
+        - Off: Close
+        4212:
+        - On: Open
+        - Off: Close
+        3134:
+        - On: Open
+        - Off: Close
 - proto: SignAnomaly
   entities:
   - uid: 25994
@@ -146757,20 +147314,10 @@ entities:
     - type: Transform
       pos: -2.5,-60.5
       parent: 8364
-  - uid: 26456
-    components:
-    - type: Transform
-      pos: 5.5,46.5
-      parent: 8364
   - uid: 26457
     components:
     - type: Transform
       pos: -3.5,46.5
-      parent: 8364
-  - uid: 26458
-    components:
-    - type: Transform
-      pos: -25.5,46.5
       parent: 8364
   - uid: 26459
     components:
@@ -147165,16 +147712,6 @@ entities:
     - type: Transform
       pos: 11.5,28.5
       parent: 8364
-  - uid: 8592
-    components:
-    - type: Transform
-      pos: 7.5,22.5
-      parent: 8364
-  - uid: 9004
-    components:
-    - type: Transform
-      pos: -3.5,43.5
-      parent: 8364
 - proto: SignSecureMed
   entities:
   - uid: 3806
@@ -147202,6 +147739,17 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-64.5
+      parent: 8364
+  - uid: 19928
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,22.5
+      parent: 8364
+  - uid: 19931
+    components:
+    - type: Transform
+      pos: -3.5,43.5
       parent: 8364
   - uid: 20149
     components:
@@ -147502,11 +148050,6 @@ entities:
     components:
     - type: Transform
       pos: 31.5,1.5
-      parent: 8364
-  - uid: 7340
-    components:
-    - type: Transform
-      pos: -6.5,32.5
       parent: 8364
   - uid: 13245
     components:
@@ -149848,33 +150391,28 @@ entities:
       parent: 8364
 - proto: SpawnPointSecurityCadet
   entities:
-  - uid: 9453
+  - uid: 5599
     components:
     - type: Transform
-      pos: 7.5,39.5
+      pos: 8.5,36.5
       parent: 8364
-  - uid: 9454
+  - uid: 9177
     components:
     - type: Transform
-      pos: 7.5,38.5
+      pos: 7.5,36.5
       parent: 8364
-  - uid: 11568
+  - uid: 9295
     components:
     - type: Transform
-      pos: 7.5,37.5
+      pos: 9.5,36.5
       parent: 8364
-  - uid: 26603
-    components:
-    - type: Transform
-      pos: 7.5,40.5
-      parent: 8364
-- proto: SpawnPointSecurityOfficer
-  entities:
-  - uid: 8590
+  - uid: 20856
     components:
     - type: Transform
       pos: 9.5,40.5
       parent: 8364
+- proto: SpawnPointSecurityOfficer
+  entities:
   - uid: 8633
     components:
     - type: Transform
@@ -149889,6 +150427,26 @@ entities:
     components:
     - type: Transform
       pos: 9.5,37.5
+      parent: 8364
+  - uid: 19935
+    components:
+    - type: Transform
+      pos: 7.5,37.5
+      parent: 8364
+  - uid: 20159
+    components:
+    - type: Transform
+      pos: 7.5,38.5
+      parent: 8364
+  - uid: 20174
+    components:
+    - type: Transform
+      pos: 7.5,39.5
+      parent: 8364
+  - uid: 20857
+    components:
+    - type: Transform
+      pos: 7.5,40.5
       parent: 8364
 - proto: SpawnPointServiceWorker
   entities:
@@ -150845,10 +151403,10 @@ entities:
       parent: 8364
 - proto: SuitStorageHOS
   entities:
-  - uid: 5288
+  - uid: 25002
     components:
     - type: Transform
-      pos: 13.5,37.5
+      pos: 16.5,39.5
       parent: 8364
 - proto: SuitStorageSalv
   entities:
@@ -150859,48 +151417,10 @@ entities:
       parent: 8364
 - proto: SuitStorageSec
   entities:
-  - uid: 3813
+  - uid: 9229
     components:
-    - type: Transform
-      pos: 0.5,33.5
-      parent: 8364
-  - uid: 11965
-    components:
-    - type: Transform
-      pos: 3.5,39.5
-      parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 20856
-  - uid: 16531
-    components:
-    - type: Transform
-      pos: -8.5,3.5
-      parent: 8364
-  - uid: 17151
-    components:
+    - type: MetaData
+      desc: Contains two security hardsuits.
     - type: Transform
       pos: 4.5,39.5
       parent: 8364
@@ -150910,6 +151430,72 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
+        - 1.734816
+        - 6.5262127
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 9230
+          - 9231
+  - uid: 9235
+    components:
+    - type: MetaData
+      desc: Contains two security hardsuits.
+    - type: Transform
+      pos: 3.5,39.5
+      parent: 8364
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.734816
+        - 6.5262127
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 9238
+          - 9236
+  - uid: 9507
+    components:
+    - type: MetaData
+      desc: Contains two security hardsuits.
+    - type: Transform
+      pos: 0.5,35.5
+      parent: 8364
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
         - 1.7459903
         - 6.568249
         - 0
@@ -150928,7 +151514,46 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 20857
+          - 9515
+          - 9517
+  - uid: 9518
+    components:
+    - type: MetaData
+      desc: Contains two security hardsuits.
+    - type: Transform
+      pos: -0.5,35.5
+      parent: 8364
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 9567
+          - 9566
+  - uid: 16531
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 8364
 - proto: SuitStorageWarden
   entities:
   - uid: 11999
@@ -150936,6 +151561,24 @@ entities:
     - type: Transform
       pos: -2.5,33.5
       parent: 8364
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
 - proto: SurveillanceCameraCommand
   entities:
   - uid: 296
@@ -152765,17 +153408,6 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Locker Room
-  - uid: 389
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,39.5
-      parent: 8364
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraSecurity
-      nameSet: True
-      id: Armory
   - uid: 394
     components:
     - type: Transform
@@ -153026,6 +153658,17 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Perma Entryway
+  - uid: 28138
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,39.5
+      parent: 8364
+    - type: SurveillanceCamera
+      setupAvailableNetworks:
+      - SurveillanceCameraSecurity
+      nameSet: True
+      id: Armory
 - proto: SurveillanceCameraService
   entities:
   - uid: 20939
@@ -155912,11 +156555,6 @@ entities:
     - type: Transform
       pos: 14.5,39.5
       parent: 8364
-  - uid: 9216
-    components:
-    - type: Transform
-      pos: 16.5,41.5
-      parent: 8364
   - uid: 9624
     components:
     - type: Transform
@@ -157232,17 +157870,6 @@ entities:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-  - uid: 19935
-    components:
-    - type: Transform
-      pos: 4.5,36.5
-      parent: 8364
-    - type: DeviceLinkSource
-      linkedPorts:
-        9182:
-        - Left: Open
-        - Right: Open
-        - Middle: Close
   - uid: 20027
     components:
     - type: Transform
@@ -157437,15 +158064,15 @@ entities:
     - type: Transform
       pos: 68.5,-47.5
       parent: 8364
-  - uid: 5594
-    components:
-    - type: Transform
-      pos: 16.5,39.5
-      parent: 8364
   - uid: 5690
     components:
     - type: Transform
       pos: 5.5,-12.5
+      parent: 8364
+  - uid: 9463
+    components:
+    - type: Transform
+      pos: 12.5,37.5
       parent: 8364
   - uid: 12244
     components:
@@ -157643,6 +158270,11 @@ entities:
     - type: Transform
       pos: 41.5,-31.5
       parent: 8364
+  - uid: 9391
+    components:
+    - type: Transform
+      pos: -9.5,32.5
+      parent: 8364
   - uid: 16753
     components:
     - type: Transform
@@ -157706,6 +158338,11 @@ entities:
     components:
     - type: Transform
       pos: 6.5,38.5
+      parent: 8364
+  - uid: 9384
+    components:
+    - type: Transform
+      pos: 6.5,41.5
       parent: 8364
 - proto: VendingMachineSecDrobe
   entities:
@@ -164324,20 +164961,10 @@ entities:
     - type: Transform
       pos: -3.5,31.5
       parent: 8364
-  - uid: 7659
-    components:
-    - type: Transform
-      pos: -1.5,34.5
-      parent: 8364
   - uid: 7660
     components:
     - type: Transform
       pos: -2.5,34.5
-      parent: 8364
-  - uid: 7661
-    components:
-    - type: Transform
-      pos: -3.5,33.5
       parent: 8364
   - uid: 7662
     components:
@@ -164394,11 +165021,6 @@ entities:
     - type: Transform
       pos: 4.5,40.5
       parent: 8364
-  - uid: 7677
-    components:
-    - type: Transform
-      pos: 5.5,38.5
-      parent: 8364
   - uid: 7678
     components:
     - type: Transform
@@ -164413,11 +165035,6 @@ entities:
     components:
     - type: Transform
       pos: 5.5,41.5
-      parent: 8364
-  - uid: 7681
-    components:
-    - type: Transform
-      pos: 5.5,42.5
       parent: 8364
   - uid: 7682
     components:
@@ -164484,25 +165101,21 @@ entities:
     - type: Transform
       pos: 11.5,39.5
       parent: 8364
-  - uid: 7706
-    components:
-    - type: Transform
-      pos: 6.5,42.5
-      parent: 8364
   - uid: 7707
     components:
     - type: Transform
       pos: 11.5,42.5
       parent: 8364
-  - uid: 7709
-    components:
-    - type: Transform
-      pos: 8.5,42.5
-      parent: 8364
   - uid: 7726
     components:
     - type: Transform
       pos: 10.5,42.5
+      parent: 8364
+  - uid: 7734
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,38.5
       parent: 8364
   - uid: 7755
     components:
@@ -165423,6 +166036,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,12.5
       parent: 8364
+  - uid: 8628
+    components:
+    - type: Transform
+      pos: -1.5,34.5
+      parent: 8364
   - uid: 8747
     components:
     - type: Transform
@@ -165433,10 +166051,28 @@ entities:
     - type: Transform
       pos: -20.5,52.5
       parent: 8364
+  - uid: 8784
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,34.5
+      parent: 8364
   - uid: 8817
     components:
     - type: Transform
       pos: -18.5,25.5
+      parent: 8364
+  - uid: 8853
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,42.5
+      parent: 8364
+  - uid: 8858
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,42.5
       parent: 8364
   - uid: 8860
     components:
@@ -165637,6 +166273,12 @@ entities:
     components:
     - type: Transform
       pos: -2.5,52.5
+      parent: 8364
+  - uid: 9086
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,42.5
       parent: 8364
   - uid: 9114
     components:
@@ -167107,6 +167749,11 @@ entities:
     components:
     - type: Transform
       pos: 38.5,-85.5
+      parent: 8364
+  - uid: 26458
+    components:
+    - type: Transform
+      pos: -3.5,29.5
       parent: 8364
   - uid: 26583
     components:
@@ -174175,11 +174822,6 @@ entities:
     - type: Transform
       pos: 16.5,29.5
       parent: 8364
-  - uid: 8853
-    components:
-    - type: Transform
-      pos: -3.5,29.5
-      parent: 8364
   - uid: 8904
     components:
     - type: Transform
@@ -176134,52 +176776,6 @@ entities:
         - 0
 - proto: WardrobePrisonFilled
   entities:
-  - uid: 8546
-    components:
-    - type: Transform
-      pos: -0.5,23.5
-      parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 5.001885
-        - 18.816614
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-  - uid: 8547
-    components:
-    - type: Transform
-      pos: -4.5,23.5
-      parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 5.001885
-        - 18.816614
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
   - uid: 8760
     components:
     - type: Transform
@@ -176190,29 +176786,11 @@ entities:
     - type: Transform
       pos: -11.5,36.5
       parent: 8364
-  - uid: 9257
+  - uid: 17151
     components:
     - type: Transform
-      pos: -8.5,23.5
+      pos: -2.5,24.5
       parent: 8364
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.1496
-        moles:
-        - 5.001885
-        - 18.816614
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
   - uid: 26345
     components:
     - type: Transform
@@ -176305,6 +176883,34 @@ entities:
         - 0
         - 0
         - 0
+  - uid: 28250
+    components:
+    - type: Transform
+      pos: -6.5,24.5
+      parent: 8364
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - uid: 28251
+    components:
+    - type: Transform
+      pos: -10.5,24.5
+      parent: 8364
 - proto: WardrobeSalvageFilled
   entities:
   - uid: 14570
@@ -176790,11 +177396,6 @@ entities:
     - type: Transform
       pos: 4.5,33.5
       parent: 8364
-  - uid: 9226
-    components:
-    - type: Transform
-      pos: 4.5,32.5
-      parent: 8364
   - uid: 9343
     components:
     - type: Transform
@@ -176844,28 +177445,6 @@ entities:
     - type: Transform
       pos: -2.5,38.5
       parent: 8364
-- proto: WeaponDisabler
-  entities:
-  - uid: 8819
-    components:
-    - type: Transform
-      pos: 1.4993298,39.638985
-      parent: 8364
-  - uid: 8820
-    components:
-    - type: Transform
-      pos: 1.4993298,39.52961
-      parent: 8364
-  - uid: 21784
-    components:
-    - type: Transform
-      pos: 16.460697,34.505676
-      parent: 8364
-  - uid: 21786
-    components:
-    - type: Transform
-      pos: 4.4614744,33.066376
-      parent: 8364
 - proto: WeaponDisablerPractice
   entities:
   - uid: 6611
@@ -176878,6 +177457,15 @@ entities:
     - type: Transform
       pos: 25.540077,32.58242
       parent: 8364
+- proto: WeaponLaserCarbine
+  entities:
+  - uid: 9380
+    components:
+    - type: Transform
+      parent: 9377
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: WeaponLaserCarbinePractice
   entities:
   - uid: 8772
@@ -176885,12 +177473,46 @@ entities:
     - type: Transform
       pos: 21.462696,34.988297
       parent: 8364
+- proto: WeaponRifleLecter
+  entities:
+  - uid: 9375
+    components:
+    - type: Transform
+      parent: 9373
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: WeaponShotgunKammerer
+  entities:
+  - uid: 9366
+    components:
+    - type: Transform
+      parent: 9359
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 9368
+    components:
+    - type: Transform
+      parent: 9359
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: WeaponSubMachineGunDrozd
+  entities:
+  - uid: 9370
+    components:
+    - type: Transform
+      parent: 9369
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: WeaponSubMachineGunWt550
   entities:
   - uid: 536
     components:
     - type: Transform
-      pos: 16.540148,41.51879
+      pos: 14.512794,39.540672
       parent: 8364
 - proto: WeedSpray
   entities:
@@ -177114,6 +177736,14 @@ entities:
     - type: Transform
       pos: 2.5,22.5
       parent: 8364
+    - type: DeviceLinkSink
+      invokeCounter: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        8605:
+        - DoorStatus: Close
+        8604:
+        - DoorStatus: Close
   - uid: 8609
     components:
     - type: MetaData
@@ -177121,6 +177751,14 @@ entities:
     - type: Transform
       pos: 1.5,22.5
       parent: 8364
+    - type: DeviceLinkSink
+      invokeCounter: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        8604:
+        - DoorStatus: Close
+        8605:
+        - DoorStatus: Close
   - uid: 8610
     components:
     - type: MetaData
@@ -177142,6 +177780,12 @@ entities:
     - type: Transform
       pos: -0.5,29.5
       parent: 8364
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        12663:
+        - DoorStatus: Close
   - uid: 9805
     components:
     - type: MetaData
@@ -177345,28 +177989,18 @@ entities:
       parent: 8364
 - proto: WindoorSecureArmoryLocked
   entities:
-  - uid: 3898
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,37.5
-      parent: 8364
   - uid: 12663
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,29.5
       parent: 8364
-  - uid: 20159
-    components:
-    - type: Transform
-      pos: 2.5,34.5
-      parent: 8364
-  - uid: 20174
-    components:
-    - type: Transform
-      pos: 1.5,34.5
-      parent: 8364
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        9242:
+        - DoorStatus: Close
 - proto: WindoorSecureBrigLocked
   entities:
   - uid: 8619
@@ -177489,6 +178123,20 @@ entities:
       rot: 3.141592653589793 rad
       pos: 32.5,-19.5
       parent: 8364
+- proto: WindoorSecurePlasma
+  entities:
+  - uid: 28246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,37.5
+      parent: 8364
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        28243:
+        - DoorStatus: Close
 - proto: WindoorSecureScienceLocked
   entities:
   - uid: 2317
@@ -177597,6 +178245,14 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,22.5
       parent: 8364
+    - type: DeviceLinkSink
+      invokeCounter: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        8609:
+        - DoorStatus: Close
+        8608:
+        - DoorStatus: Close
   - uid: 8605
     components:
     - type: MetaData
@@ -177605,6 +178261,14 @@ entities:
       rot: 3.141592653589793 rad
       pos: 2.5,22.5
       parent: 8364
+    - type: DeviceLinkSink
+      invokeCounter: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        8608:
+        - DoorStatus: Close
+        8609:
+        - DoorStatus: Close
   - uid: 8624
     components:
     - type: MetaData
@@ -177630,19 +178294,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,40.5
-      parent: 8364
-  - uid: 9245
-    components:
-    - type: MetaData
-      name: Armory Desk
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,37.5
-      parent: 8364
-  - uid: 9391
-    components:
-    - type: Transform
-      pos: 23.5,37.5
       parent: 8364
   - uid: 12330
     components:
@@ -178645,16 +179296,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,32.5
-      parent: 8364
-  - uid: 9383
-    components:
-    - type: Transform
-      pos: 22.5,37.5
-      parent: 8364
-  - uid: 9390
-    components:
-    - type: Transform
-      pos: 24.5,37.5
       parent: 8364
   - uid: 9824
     components:

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -16,7 +16,7 @@
           emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
         - type: StationJobs
           availableJobs:
-            #service (16)
+            #service
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 2, 2 ]
@@ -25,41 +25,40 @@
             Janitor: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
             Librarian: [ 1, 1 ]
-            Reporter: [ 1, 2 ]
+            Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            #engineering (9)
+            #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 5, 5 ]
             TechnicalAssistant: [ 4, 4 ]
-            #medical (9)
+            #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
             MedicalDoctor: [ 4, 4 ]
             Paramedic: [ 1, 1 ]
             MedicalIntern: [ 4, 4 ]
             Psychologist: [ 1, 1 ]
-            #science (6)
+            #science
             ResearchDirector: [ 1, 1 ]
             Scientist: [ 5, 5 ]
             ResearchAssistant: [ 4, 4 ]
-            #security (12)
+            #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 7, 7 ]
+            SecurityOfficer: [ 5, 7 ]
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 2, 4 ]
             Lawyer: [ 2, 2 ]
-            #supply (7)
+            #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
-            #civilian (3+)
+            #civilian
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            #silicon (3)
+            #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
-

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -59,7 +59,7 @@
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            #silicon (4)
+            #silicon (3)
             StationAi: [ 1, 1 ]
-            Borg: [ 3, 3 ]
+            Borg: [ 2, 2 ]
 

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -16,7 +16,7 @@
           emergencyShuttlePath: /Maps/Shuttles/emergency_box.yml
         - type: StationJobs
           availableJobs:
-            #service
+            #service (16)
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 2, 2 ]
@@ -25,41 +25,41 @@
             Janitor: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
             Librarian: [ 1, 1 ]
-            Reporter: [ 1, 1 ]
+            Reporter: [ 1, 2 ]
             ServiceWorker: [ 2, 2 ]
-            #engineering
+            #engineering (9)
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 5, 5 ]
             TechnicalAssistant: [ 4, 4 ]
-            #medical
+            #medical (9)
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
             MedicalDoctor: [ 4, 4 ]
             Paramedic: [ 1, 1 ]
             MedicalIntern: [ 4, 4 ]
             Psychologist: [ 1, 1 ]
-            #science
+            #science (6)
             ResearchDirector: [ 1, 1 ]
             Scientist: [ 5, 5 ]
             ResearchAssistant: [ 4, 4 ]
-            #security
+            #security (12)
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 5, 5 ]
+            SecurityOfficer: [ 7, 7 ]
             Detective: [ 1, 1 ]
             SecurityCadet: [ 4, 4 ]
             Lawyer: [ 2, 2 ]
-            #supply
+            #supply (7)
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
-            #civilian
+            #civilian (3+)
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            #silicon
+            #silicon (4)
             StationAi: [ 1, 1 ]
-            Borg: [ 2, 2 ]
+            Borg: [ 3, 3 ]
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Redid the content of box's armory, changed the max number of secoffs for box (7 now), and made the armory a bit more secure. Did a few other touchups, such as adding TVs to the cells (it is a basic right to watch the reporter's slop) and fixing some broken buttons.

New armory content:
3 Lecter, 3 Drozd, 4 Kammerer, 4 Laser
4 Hardsuit, 4 Bulletproof, 4 Riot, 2 Reflective, 2 Jetpack

## Why / Balance
Box's armory was way too easy to break into from outside, and was also a bit understocked. This should bring the armory content in line with the standard and give the warden just a bit more of a chance to arm sec before they get MetaOps blitzed.

## Media
![Box-0](https://github.com/user-attachments/assets/5eea0786-12c9-4ea0-8d5c-2194fb9920e6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Nox38
- tweak: Rebalanced Box's armory and increased its max security officers to 7.
