### PR TITLE
Allowed windows to be properly clicked on

### DIFF
--- a/Content.Client/Clickable/ClickMapManager.cs
+++ b/Content.Client/Clickable/ClickMapManager.cs
@@ -20,7 +20,7 @@ namespace Content.Client.Clickable
             "/Textures/Logo",
         };
 
-        private const float Threshold = 0.25f;
+        private const float Threshold = 0.1f;
         private const int ClickRadius = 2;
 
         [Dependency] private readonly IResourceCache _resourceCache = default!;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Previously, the center of some types of windows could not be clicked on properly due to updated textures being made more transparent. (See #33282 )
This allows you to melee attack through the center of windows and doesn't let you knock unless you are clicking the  edge.

## Why / Balance
This PR fixes #33832 and stops players from clicking on grilles underneath windows.

## Technical details
I just changed the clickMapManager's "threshold" variable to include more opaque parts of sprites. (From 0.25 to 0.1)
I don't think this will affect any other systems, but it might be worth checking.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
![Content Client_8WuBczWqwM](https://github.com/user-attachments/assets/4d6068e6-6603-4cb4-ac7f-0eef19195c6f)
![Content Client_wLz1ECyHTd](https://github.com/user-attachments/assets/79134d68-4960-4566-bad0-7ce1c8fb636c)

After:
![Content Client_J4fH1gjNz5](https://github.com/user-attachments/assets/bd65d136-827c-41ad-97f0-cc2c8c0b4df2)
![Content Client_dXzMVDERZM](https://github.com/user-attachments/assets/3067a67d-66a4-4861-a336-69cf52e9e642)



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: You can now knock on the center of windows.

