### PR TITLE
Tweak pill eat delays

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -531,7 +531,8 @@
     sprite: Objects/Specific/Chemistry/pills.rsi
   - type: Pill
   - type: Food
-    forceFeedDelay: 1
+    delay: 0.6
+    forceFeedDelay: 2
     transferAmount: null
     eatMessage: food-swallow
     useSound: /Audio/Items/pill.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Forcefeeding someone a pill now takes 2 seconds (used to be 1 second).
Eating a pill now takes 0.6 seconds (used to be 1 second).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

1 second is a weird amount of time where a player is only able to react if they either anticipate it or they are not currently doing anything. It makes meta-activities the determining factor; some amount of high ping or currently typing makes it very difficult to react in time. Moving it to 2 seconds gives enough time for someone to react in a reasonable manner, but still allows for sneaking in a pill if someone is busy doing something else like flying a shuttle, being treated in medbay or is stunned.

0.6 seconds means you eat the pills faster, which is fine because pills are kinda underutilized anyhow. Cronchcronchcronch.

## Technical details
<!-- Summary of code changes for easier review. -->

yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Forcefeeding pills now takes 2 seconds (was 1 second), while eating them takes 0.6 seconds (was 1 second).
