### PR TITLE
Radioxadone

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -147,3 +147,6 @@ reagent-desc-potassium-iodide = Will reduce the damaging effects of radiation by
 
 reagent-name-haloperidol = haloperidol
 reagent-desc-haloperidol = Removes most stimulating and hallucinogenic drugs. Reduces druggy effects and jitteriness. Causes drowsiness.
+
+reagent-name-radioxadone = radioxadone
+reagent-desc-radioxadone = Not stable cryogenics chemical, that can be used for treating the high radiation damage, even in dead corpses, but deal high brute damage.

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1706,12 +1706,6 @@
       collection: RubberChicken
       params:
         variation: 0.125
-  - type: Food
-    requiresSpecialDigestion: true
-    useSound:
-      collection: RubberChicken
-      params:
-        variation: 0.125
   - type: MeleeWeapon
     wideAnimationRotation: 110
     soundHit:

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1706,6 +1706,12 @@
       collection: RubberChicken
       params:
         variation: 0.125
+  - type: Food
+    requiresSpecialDigestion: true
+    useSound:
+      collection: RubberChicken
+      params:
+        variation: 0.125
   - type: MeleeWeapon
     wideAnimationRotation: 110
     soundHit:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1169,7 +1169,7 @@
         conditions:
         - !type:ReagentThreshold
           min: 12
-          
+
 - type: reagent
   id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
   name: reagent-name-opporozidone
@@ -1384,3 +1384,25 @@
       - !type:AdjustReagent
         reagent: MindbreakerToxin
         amount: -3.0
+
+- type: reagent
+  id: Radioxadone
+  name: reagent-name-radioxadone
+  group: Medicine
+  desc: reagent-desc-radioxadone
+  physicalDesc: reagent-physical-desc-glowing
+  flavor: medicine
+  color: "#1FE229"
+  worksOnTheDead: true
+  metabolisms:
+    Medicine:
+      effects:
+        - !type:HealthChange
+          conditions:
+          - !type:Temperature
+            max: 180.0
+          damage:
+            groups:
+              Brute: 10
+            types:
+            Radiation: -5

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -561,7 +561,7 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine: 
+    Cognizine:
       amount: 1
     Plasma:
       amount: 2
@@ -662,3 +662,16 @@
       amount: 1
   products:
     Haloperidol: 5
+
+- type: reaction
+  id: Radioxadone
+  minTemp: 550
+  reactants:
+    Doxarubixadone:
+      amount: 1
+    Tritium:
+      amount: 3
+    Plasma:
+      amount: 1
+  products:
+    Radioxadone: 3


### PR DESCRIPTION
## About the PR
So, I have added new reagent - radioxadone. That reagent can be used in cryogenics in a pretty low temperatures, and works even on dead.

## Why / Balance
Right now gas condenser actually useless. Frezon can be used just for one useless recipe. Tritium can be used for creating flamethrower, but nothing else. This is sad, because potential of interaction for atmos and chem is a pretty big. We also have radiation damage that can actually gibs players so much easy, because deals damage even on dead one. With that pull request I want add a new reagent that can be created used tritium and treats radiational damage. This will slightly increase the amount of interaction between med and engineering.
<!--## Media-->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added radioxadone, reagent that can be used for treating the radiation damage but should be created from tritium.
