### PR TITLE
Fix dumpable containers stacking disposals sound on dump

### DIFF
--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -803,13 +803,11 @@ public abstract class SharedDisposalUnitSystem : EntitySystem
         args.Handled = true;
         args.PlaySound = true;
 
-        while (args.DumpQueue.Count > 0)
+        var playDumpSound = true;
+        foreach (var entity in args.DumpQueue)
         {
-            var entity = args.DumpQueue.Dequeue();
-
-            var playSound = args.DumpQueue.Count == 0;
-
-            DoInsertDisposalUnit(ent, entity, args.User, playDumpSound: playSound);
+            DoInsertDisposalUnit(ent, entity, args.User, playDumpSound: playDumpSound);
+            playDumpSound = false;
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed an issue where dumping something like a trash bag (or anything dumpable) into a disposals unit would stack the sound depending on the number of items that were dumped.

I couldn't find any issues relating to this, though I thought they existed.

This may also fix a duplicate admin log in some cases.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I personally thought it was annoying. Save janitor ears. Since this relates to a PlayPvs call I guess everyone else heard it as well.

## Technical details
<!-- Summary of code changes for easier review. -->

Added one argument to `DoInsertDisposalUnit` and `AfterInsert` on `SharedDisposalUnit` that toggles whether or not AfterInsert plays a sound. This is true by default, but is set to false after the first thing is dumped from something like a trash bag.

Make the userId optional on DoInsertDisposalUnit. The tests don't send a user ID.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

### Loud:

https://github.com/user-attachments/assets/a1b18b30-3272-4500-a8f5-e8be30e99d90

### like smooth jazz on delicate janitor ears:

https://github.com/user-attachments/assets/26c07a26-620a-4551-a0a6-69fadce28120



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Crude Oil
- fix: Dumping a container into a disposal unit will no longer play a sound for each of the dumped items