### PR TITLE
Fix stunbaton component namespace

### DIFF
--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -1,7 +1,6 @@
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Power.Events;
-using Content.Shared.Stunnable.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage.Events;
 using Content.Shared.Examine;

--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -1,7 +1,7 @@
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Power.Events;
-using Content.Server.Stunnable.Components;
+using Content.Shared.Stunnable.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage.Events;
 using Content.Shared.Examine;

--- a/Content.Shared/Stunnable/StunbatonComponent.cs
+++ b/Content.Shared/Stunnable/StunbatonComponent.cs
@@ -2,7 +2,7 @@ using Content.Shared.Stunnable;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 
-namespace Content.Server.Stunnable.Components;
+namespace Content.Shared.Stunnable.Components;
 
 [RegisterComponent, NetworkedComponent]
 [AutoGenerateComponentState]

--- a/Content.Shared/Stunnable/StunbatonComponent.cs
+++ b/Content.Shared/Stunnable/StunbatonComponent.cs
@@ -2,7 +2,7 @@ using Content.Shared.Stunnable;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Stunnable.Components;
+namespace Content.Shared.Stunnable;
 
 [RegisterComponent, NetworkedComponent]
 [AutoGenerateComponentState]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed incorrect namespace in StunbatonComponent.cs

## Why / Balance
#34565 brought to attention the wrong namespace, so I changed this accordingly

## Technical details
I changed the namespace from `Content.Server.Stunnable.Components` to `Content.Shared.Stunnable`, `Content.Server.Stunnable.Components` was imported alongside `Content.Shared.Stunnable` in StunbatonSystem.cs, so I removed this import.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Namespace of StunbatonComponent.cs changed to `Content.Shared.Stunnable`

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
- tweak: Changed fun!
- fix: Fixed fun!
-->
