### PR TITLE
Make experimental welding tool less harmful to eyes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -171,6 +171,8 @@
       reagents:
       - ReagentId: WeldingFuel
         Quantity: 1
+  - type: RequiresEyeProtection
+    statusEffectTime: 5 # less harmful; sunglasses can block it
 
 - type: entity
   name: emergency welding tool


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR reduces the harshness of the eye-damage status of the experimental welding tool. This allows for things like sunglasses to provide protection.

Fixes #34738 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The description implies that you only need minimal eye protection, and that's the behavior from SS13.

It would help the experimental tool feel even more unique, and gives antags a potential option for welding without needing to wear a suspicious welding mask.

## Technical details
<!-- Summary of code changes for easier review. -->

We already had all the code in place to support this, including updated sunglasses YML, but the YML for the experimental tool was never updated.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2f9021f1-5ff1-4c3d-b00d-395848e1f098

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: The experimental welding tool now requires only minimal eye protection (e.g. sunglasses)
