### PR TITLE
Rename shields

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -84,10 +84,10 @@
           Slash: 1
 
 - type: entity
-  name: riot laser shield
+  name: ablative shield
   parent: [ BaseShield, BaseRestrictedContraband ]
   id: RiotLaserShield
-  description: A riot shield built for withstanding lasers, but not much else.
+  description: A ablative shield built for absorbing lasers.
   components:
     - type: Sprite
       state: riot_laser-icon

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -104,10 +104,10 @@
           Heat: 1
 
 - type: entity
-  name: riot bullet shield
+  name: ballistic shield
   parent: [ BaseShield, BaseRestrictedContraband ]
   id: RiotBulletShield
-  description: A ballistic riot shield built for withstanding bullets, but not much else.
+  description: A ballistic shield built for protecting against firearms.
   components:
     - type: Sprite
       state: riot_bullet-icon

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -87,7 +87,7 @@
   name: ablative shield
   parent: [ BaseShield, BaseRestrictedContraband ]
   id: RiotLaserShield
-  description: A ablative shield built for withstanding lasers, but not much else.
+  description: An ablative shield built for withstanding lasers, but not much else.
   components:
     - type: Sprite
       state: riot_laser-icon

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -87,7 +87,7 @@
   name: ablative shield
   parent: [ BaseShield, BaseRestrictedContraband ]
   id: RiotLaserShield
-  description: A ablative shield built for absorbing lasers.
+  description: A ablative shield built for withstanding lasers, but not much else.
   components:
     - type: Sprite
       state: riot_laser-icon
@@ -107,7 +107,7 @@
   name: ballistic shield
   parent: [ BaseShield, BaseRestrictedContraband ]
   id: RiotBulletShield
-  description: A ballistic shield built for protecting against firearms.
+  description: A ballistic shield built for protecting against firearms, but not much else.
   components:
     - type: Sprite
       state: riot_bullet-icon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Renamed riot bullet shield to ballistic shield, renamed riot laser shield to ablative shield, changed descriptions.

## Why / Balance
The old names were clunky and not very descriptive.

## Technical details
Changed name and description in shields.yml

## Media
![image](https://github.com/user-attachments/assets/cbf6c37f-d3fb-4533-adb4-ab1974fa7eed)
![image](https://github.com/user-attachments/assets/0cb9fc51-f053-434c-9437-4492f4b63084)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Nox38
- tweak: Renamed riot bullet shield to ballistic shield
- tweak: Renamed riot laser shield to ablative shield
