### PR TITLE
Ghost orbit jitter fix

### DIFF
--- a/Content.Client/Orbit/OrbitVisualsSystem.cs
+++ b/Content.Client/Orbit/OrbitVisualsSystem.cs
@@ -77,7 +77,8 @@ public sealed class OrbitVisualsSystem : EntitySystem
 
         foreach (var (orbit, sprite) in EntityManager.EntityQuery<OrbitVisualsComponent, SpriteComponent>())
         {
-            var angle = new Angle(Math.PI * 2 * orbit.Orbit);
+            var progress = (float)(_timing.CurTime.TotalSeconds / orbit.OrbitLength) % 1;
+            var angle = new Angle(Math.PI * 2 * progress);
             var vec = angle.RotateVec(new Vector2(orbit.OrbitDistance, 0));
 
             sprite.Rotation = angle;

--- a/Content.Client/Orbit/OrbitVisualsSystem.cs
+++ b/Content.Client/Orbit/OrbitVisualsSystem.cs
@@ -41,7 +41,7 @@ public sealed class OrbitVisualsSystem : EntitySystem
         var animationPlayer = EnsureComp<AnimationPlayerComponent>(uid);
         if (_animations.HasRunningAnimation(uid, animationPlayer, _orbitStopKey))
         {
-            _animations.Stop(uid, animationPlayer, _orbitStopKey);
+            _animations.Stop((uid, animationPlayer), _orbitStopKey);
         }
     }
 
@@ -55,7 +55,7 @@ public sealed class OrbitVisualsSystem : EntitySystem
         var animationPlayer = EnsureComp<AnimationPlayerComponent>(uid);
         if (!_animations.HasRunningAnimation(uid, animationPlayer, _orbitStopKey))
         {
-            _animations.Play(uid, animationPlayer, GetStopAnimation(component, sprite), _orbitStopKey);
+            _animations.Play((uid, animationPlayer), GetStopAnimation(component, sprite), _orbitStopKey);
         }
     }
 

--- a/Content.Client/Orbit/OrbitVisualsSystem.cs
+++ b/Content.Client/Orbit/OrbitVisualsSystem.cs
@@ -4,6 +4,7 @@ using Robust.Client.Animations;
 using Robust.Client.GameObjects;
 using Robust.Shared.Animations;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Client.Orbit;
 
@@ -11,6 +12,7 @@ public sealed class OrbitVisualsSystem : EntitySystem
 {
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly AnimationPlayerSystem _animations = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     private readonly string _orbitAnimationKey = "orbiting";
     private readonly string _orbitStopKey = "orbiting_stop";
@@ -26,10 +28,13 @@ public sealed class OrbitVisualsSystem : EntitySystem
 
     private void OnComponentInit(EntityUid uid, OrbitVisualsComponent component, ComponentInit args)
     {
-        component.OrbitDistance =
-            _robustRandom.NextFloat(0.75f * component.OrbitDistance, 1.25f * component.OrbitDistance);
+        if (_timing.IsFirstTimePredicted)
+        {
+            component.OrbitDistance =
+                _robustRandom.NextFloat(0.75f * component.OrbitDistance, 1.25f * component.OrbitDistance);
 
-        component.OrbitLength = _robustRandom.NextFloat(0.5f * component.OrbitLength, 1.5f * component.OrbitLength);
+            component.OrbitLength = _robustRandom.NextFloat(0.5f * component.OrbitLength, 1.5f * component.OrbitLength);
+        }
 
         if (TryComp<SpriteComponent>(uid, out var sprite))
         {

--- a/Content.Client/Orbit/OrbitVisualsSystem.cs
+++ b/Content.Client/Orbit/OrbitVisualsSystem.cs
@@ -4,6 +4,7 @@ using Robust.Client.Animations;
 using Robust.Client.GameObjects;
 using Robust.Shared.Animations;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Client.Orbit;
 
@@ -11,6 +12,7 @@ public sealed class OrbitVisualsSystem : EntitySystem
 {
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly AnimationPlayerSystem _animations = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     private readonly string _orbitAnimationKey = "orbiting";
     private readonly string _orbitStopKey = "orbiting_stop";
@@ -26,6 +28,7 @@ public sealed class OrbitVisualsSystem : EntitySystem
 
     private void OnComponentInit(EntityUid uid, OrbitVisualsComponent component, ComponentInit args)
     {
+        _robustRandom.SetSeed((int)_timing.CurTime.TotalMilliseconds);
         component.OrbitDistance =
             _robustRandom.NextFloat(0.75f * component.OrbitDistance, 1.25f * component.OrbitDistance);
 

--- a/Content.Client/Orbit/OrbitVisualsSystem.cs
+++ b/Content.Client/Orbit/OrbitVisualsSystem.cs
@@ -4,7 +4,6 @@ using Robust.Client.Animations;
 using Robust.Client.GameObjects;
 using Robust.Shared.Animations;
 using Robust.Shared.Random;
-using Robust.Shared.Timing;
 
 namespace Content.Client.Orbit;
 
@@ -12,7 +11,6 @@ public sealed class OrbitVisualsSystem : EntitySystem
 {
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly AnimationPlayerSystem _animations = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
 
     private readonly string _orbitAnimationKey = "orbiting";
     private readonly string _orbitStopKey = "orbiting_stop";
@@ -28,13 +26,10 @@ public sealed class OrbitVisualsSystem : EntitySystem
 
     private void OnComponentInit(EntityUid uid, OrbitVisualsComponent component, ComponentInit args)
     {
-        if (_timing.IsFirstTimePredicted)
-        {
-            component.OrbitDistance =
-                _robustRandom.NextFloat(0.75f * component.OrbitDistance, 1.25f * component.OrbitDistance);
+        component.OrbitDistance =
+            _robustRandom.NextFloat(0.75f * component.OrbitDistance, 1.25f * component.OrbitDistance);
 
-            component.OrbitLength = _robustRandom.NextFloat(0.5f * component.OrbitLength, 1.5f * component.OrbitLength);
-        }
+        component.OrbitLength = _robustRandom.NextFloat(0.5f * component.OrbitLength, 1.5f * component.OrbitLength);
 
         if (TryComp<SpriteComponent>(uid, out var sprite))
         {

--- a/Content.Shared/Follower/Components/OrbitVisualsComponent.cs
+++ b/Content.Shared/Follower/Components/OrbitVisualsComponent.cs
@@ -21,10 +21,4 @@ public sealed partial class OrbitVisualsComponent : Component
     ///     How long should the orbit stop animation last in seconds?
     /// </summary>
     public float OrbitStopLength = 1.0f;
-
-    /// <summary>
-    ///     How far along in the orbit, from 0 to 1, is this entity?
-    /// </summary>
-    [Animatable]
-    public float Orbit { get; set; } = 0.0f;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed the "jittering" visual glitch seen when starting to follow an entity as a ghost. Also made the orbit begin at a "random" point in the circle instead of always starting from the right.

These changes also apply to the orbiting effect of anomaly cores (since they use the same code).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The jitter was ugly.

## Technical details
<!-- Summary of code changes for easier review. -->
The random number generator is now seeded with the current time before generating the orbit speed and distance values, which means it will produce consistent values throughout prediction (previously it would generate completely new values each predicted frame, which caused the visual jittering).

After fixing this, another issue became much more apparent: there is a significant pause at the start of the orbit before the ghost begins circling. This is due to prediction again: the orbit animation is stopping and restarting on each predicted frame, causing the ghost to repeatedly get sent back to the start of the animation. The orbit "animation" just linearly interpolates a single float value (`OrbitVisualsComponent.Orbit`) from 0 to 1 over `OrbitVisualsComponent.OrbitLength` seconds. To fix this issue, I removed the orbit animation, and instead the system now derives the ghost's position in the orbit based on the current time. (`(float)(_timing.CurTime.TotalSeconds / orbit.OrbitLength) % 1`, which still produces a linear interpolation between 0 and 1, lasting `OrbitVisualsComponent.OrbitLength` seconds). This has the side effect of causing the orbit to start at a (seemingly) random point in the circle (actually based on the current time). This can be returned to the old behavior of always starting at the right (0 degrees) if desired, but I think it's kind of nice.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/077653a0-7cac-4292-bf7e-8bcbad2b6c0a

https://github.com/user-attachments/assets/46397ea7-ab9d-44de-aaa2-f8549a798191

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Ghosts and anomaly cores no longer jitter when starting to follow a target.