### PR TITLE
The "Obvious Fake Disk" mapping item

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
@@ -2,6 +2,7 @@
   name: nuclear authentication disk
   parent: [BaseItem, BaseGrandTheftContraband]
   id: NukeDisk
+  suffix: DO NOT MAP
   description: A nuclear auth disk, capable of arming a nuke if used along with a code. Note from nanotrasen reads "THIS IS YOUR MOST IMPORTANT POSESSION, SECURE DAT FUKKEN DISK!"
   components:
   - type: NukeDisk
@@ -27,7 +28,7 @@
   name: nuclear authentication disk
   parent: [BaseItem, BaseGrandTheftContraband]
   id: NukeDiskFake
-  suffix: Fake
+  suffix: Fake, DO NOT MAP
   description: A nuclear auth disk, capable of arming a nuke if used along with a code. Note from nanotrasen reads "THIS IS YOUR MOST IMPORTANT POSESSION, SECURE DAT FUKKEN DISK!"
   components:
   - type: Sprite
@@ -38,3 +39,16 @@
   - type: Tag
     tags:
     - FakeNukeDisk
+
+ # The obvious fake is intended for map makers - to prevent incidents where a real-fake disk is used and it causes a mass panic.
+- type: entity
+  name: nuclear authentication disk
+  parent: BaseItem
+  id: NukeDiskFakeObvious
+  suffix: Obvious Fake
+  # It's encouraged to give your own custom description if your map includes a fake disk!
+  description: A cheap plastic replica of the nuclear authentication disk - with a small syndicate logo stamped onto it. Who could possibly fall for such an obvious fake?
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/nukedisk.rsi
+    state: icon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR adds an "obvious fake disk", which is a variant of the fake disk which is given a different description by default and lacks the contraband component.

## Why / Balance
When Amber was first released, it included a fake disk which did not have a custom description. This made it indistinguishable to players (and even some admins), which was problematic. Although this has been fixed, there should be some measure to ensure that a mistake like that doesn't happen again. The intention behind the "obvious fake disk" is to provide a fake nuclear authentication disk which is already obviously not a real disk upon inspection - ideal for mappers to include as an easter egg. This also means that fake disks can be given other interactions in the future without such interactions being transferred into a round start item.

## Technical details
Added an "obvious fake disk" which is a regular item that looks like the disk, but has a description mocking the reader and lacks a contraband component.
Added "DO NOT MAP" to the real nuke disk (even if this is included as part of the PR guidelines, best to be certain)
Added "DO NOT MAP" to the fake nuke disk to encourage use of the "obvious fake disk"

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/a3380378-b03a-493c-9947-51435257c8d7)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

Since this change is purely for mappers and won't show up in game until mapped in, I assume this doesn't need a PR.
