### PR TITLE
Bagel Armory Restock

### DIFF
--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -113635,7 +113635,7 @@ entities:
   - uid: 18573
     components:
     - type: Transform
-      pos: -0.465486,3.4514241
+      pos: -0.5153366,3.463149
       parent: 60
   - uid: 19153
     components:

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -125,11 +125,11 @@ entities:
           version: 6
         -2,-1:
           ind: -2,-1
-          tiles: XQAAAAAAXQAAAAABHwAAAAAALgAAAAAALgAAAAAATgAAAAABLgAAAAAALgAAAAAAHwAAAAAAXQAAAAADXQAAAAACXQAAAAAAXQAAAAABXQAAAAACfgAAAAAAXQAAAAADXQAAAAACXQAAAAADfgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAAfgAAAAAAXQAAAAADXQAAAAABXQAAAAADXQAAAAAAXQAAAAABfgAAAAAAXQAAAAADXQAAAAADXQAAAAABfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACXQAAAAACHwAAAAADHwAAAAADHwAAAAACfgAAAAAAXQAAAAAATQAAAAACTQAAAAABfgAAAAAAHwAAAAAAHwAAAAADHwAAAAADHwAAAAABHwAAAAACfgAAAAAATQAAAAABTQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAfgAAAAAAHwAAAAABHwAAAAACHwAAAAADHwAAAAAAHwAAAAABfgAAAAAAXQAAAAACXQAAAAAAHwAAAAADHwAAAAADHwAAAAADfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAHwAAAAABHwAAAAADHwAAAAABHwAAAAABHwAAAAACHwAAAAADHwAAAAADXQAAAAABXQAAAAAAfgAAAAAAHwAAAAADHwAAAAACfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAfgAAAAAAfgAAAAAAHwAAAAADHwAAAAADHwAAAAADfgAAAAAAfgAAAAAAXQAAAAACXQAAAAABXQAAAAABHwAAAAABHwAAAAADfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAXQAAAAABfgAAAAAAHwAAAAABHwAAAAACHwAAAAACfgAAAAAAXQAAAAABXQAAAAABXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAAAXQAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAHwAAAAABHwAAAAACHwAAAAADfgAAAAAAXQAAAAADXQAAAAACXQAAAAABXQAAAAADXQAAAAACXQAAAAADXQAAAAADXQAAAAABXQAAAAABXQAAAAABXQAAAAAAXQAAAAACfgAAAAAAHwAAAAABHwAAAAACfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAXQAAAAADXQAAAAABXQAAAAACXQAAAAADXQAAAAACXQAAAAAAXQAAAAAAXQAAAAACXQAAAAAAXQAAAAABHwAAAAADHwAAAAACfgAAAAAAXQAAAAADXQAAAAAAXQAAAAACXQAAAAADXQAAAAADXQAAAAAAXQAAAAAAXQAAAAABXQAAAAADXQAAAAABXQAAAAACXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAADXQAAAAACXQAAAAADXQAAAAACXQAAAAABXQAAAAABXQAAAAACXQAAAAABXQAAAAABXQAAAAADfgAAAAAAHwAAAAADHwAAAAAAfgAAAAAAXQAAAAACbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAfgAAAAAATQAAAAACHwAAAAABHwAAAAAAfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAHwAAAAABHwAAAAAAHwAAAAACHwAAAAADfgAAAAAAXQAAAAADXQAAAAABHwAAAAAAHwAAAAACfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAegAAAAADegAAAAABegAAAAADegAAAAACfgAAAAAAXQAAAAADXQAAAAAC
+          tiles: XQAAAAAAXQAAAAABHwAAAAAALgAAAAAALgAAAAAATgAAAAABLgAAAAAALgAAAAAAHwAAAAAAXQAAAAADXQAAAAACXQAAAAAAXQAAAAABXQAAAAACfgAAAAAAXQAAAAADXQAAAAACXQAAAAADfgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAAfgAAAAAAXQAAAAADXQAAAAABXQAAAAADXQAAAAAAXQAAAAABfgAAAAAAXQAAAAADXQAAAAADXQAAAAABfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACXQAAAAACHwAAAAADHwAAAAADHwAAAAACfgAAAAAAXQAAAAAATQAAAAACTQAAAAABfgAAAAAAHwAAAAAAHwAAAAADHwAAAAADHwAAAAABHwAAAAACfgAAAAAATQAAAAABTQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAfgAAAAAAHwAAAAABHwAAAAACHwAAAAADHwAAAAAAHwAAAAABfgAAAAAAXQAAAAACXQAAAAAAHwAAAAADHwAAAAADHwAAAAADfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAHwAAAAABHwAAAAADHwAAAAABHwAAAAABHwAAAAACHwAAAAADHwAAAAADXQAAAAABXQAAAAAAfgAAAAAAHwAAAAADHwAAAAACfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAfgAAAAAAfgAAAAAAHwAAAAADHwAAAAADHwAAAAADfgAAAAAAfgAAAAAAXQAAAAACXQAAAAABXQAAAAABHwAAAAABHwAAAAADfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAXQAAAAABfgAAAAAAHwAAAAABHwAAAAACHwAAAAACfgAAAAAAXQAAAAABXQAAAAABXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAAAXQAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAHwAAAAABHwAAAAACHwAAAAADfgAAAAAAXQAAAAADXQAAAAACXQAAAAABXQAAAAADXQAAAAACXQAAAAADXQAAAAADXQAAAAABXQAAAAABXQAAAAABXQAAAAAAXQAAAAACfgAAAAAAHwAAAAABHwAAAAACfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAXQAAAAADXQAAAAABXQAAAAACXQAAAAADXQAAAAACXQAAAAAAXQAAAAAAXQAAAAACXQAAAAAAXQAAAAABHwAAAAADHwAAAAACfgAAAAAAXQAAAAADXQAAAAAAXQAAAAACXQAAAAADXQAAAAADXQAAAAAAXQAAAAAAXQAAAAABXQAAAAADXQAAAAABXQAAAAACXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAADXQAAAAACXQAAAAADXQAAAAACXQAAAAABXQAAAAABXQAAAAACXQAAAAABXQAAAAABXQAAAAADfgAAAAAAHwAAAAADHwAAAAAAfgAAAAAAXQAAAAACHwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAfgAAAAAATQAAAAACHwAAAAABHwAAAAAAfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAHwAAAAABHwAAAAAAHwAAAAACHwAAAAADfgAAAAAAXQAAAAADXQAAAAABHwAAAAAAHwAAAAACfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAegAAAAADegAAAAABegAAAAADegAAAAACfgAAAAAAXQAAAAADXQAAAAAC
           version: 6
         -2,0:
           ind: -2,0
-          tiles: HwAAAAADHwAAAAABfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAegAAAAADegAAAAABegAAAAADegAAAAACfgAAAAAAXQAAAAACXQAAAAAAfgAAAAAAbQAAAAAAfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAHwAAAAABHwAAAAABHwAAAAADfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABbAAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAADfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAATQAAAAABXQAAAAAAXQAAAAADXQAAAAAAXQAAAAABXQAAAAAAXQAAAAACXQAAAAABXQAAAAAAXQAAAAAAXQAAAAADXQAAAAAAXQAAAAABXQAAAAABXQAAAAACTQAAAAAAXQAAAAADXQAAAAABXQAAAAABXQAAAAADXQAAAAABXQAAAAABXQAAAAACXQAAAAABXQAAAAACXQAAAAADXQAAAAACXQAAAAAAXQAAAAAAXQAAAAABXQAAAAAATQAAAAAAXQAAAAAAXQAAAAACXQAAAAABXQAAAAACXQAAAAAAXQAAAAABXQAAAAADXQAAAAABXQAAAAACXQAAAAAAXQAAAAACXQAAAAACXQAAAAABXQAAAAAAXQAAAAADTQAAAAACXQAAAAACHwAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAXQAAAAAAXQAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAATQAAAAAAXQAAAAADHwAAAAAAfgAAAAAAHwAAAAAAegAAAAADegAAAAABegAAAAAAegAAAAACegAAAAAAHwAAAAADfgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfgAAAAAAXQAAAAACEQAAAAAAHwAAAAABfgAAAAAAHwAAAAADegAAAAADegAAAAADegAAAAAAegAAAAABegAAAAADHwAAAAABfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAXQAAAAADEQAAAAAAXQAAAAACfgAAAAAAHwAAAAAAegAAAAABegAAAAABegAAAAACegAAAAACegAAAAABHwAAAAADfgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfgAAAAAAXQAAAAACEQAAAAAAHwAAAAACfgAAAAAAHwAAAAAAegAAAAADegAAAAAAegAAAAACegAAAAACegAAAAACHwAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACXQAAAAABHwAAAAABfgAAAAAAHwAAAAAAegAAAAADegAAAAADegAAAAABegAAAAAAegAAAAADHwAAAAACfgAAAAAAHwAAAAABHwAAAAAAHwAAAAADfgAAAAAAXQAAAAAB
+          tiles: HwAAAAADHwAAAAABfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAegAAAAADegAAAAABegAAAAADegAAAAACfgAAAAAAXQAAAAACXQAAAAAAfgAAAAAAHwAAAAAAfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAHwAAAAABHwAAAAABHwAAAAADfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABbAAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAADfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAATQAAAAABXQAAAAAAXQAAAAADXQAAAAAAXQAAAAABXQAAAAAAXQAAAAACXQAAAAABXQAAAAAAXQAAAAAAXQAAAAADXQAAAAAAXQAAAAABXQAAAAABXQAAAAACTQAAAAAAXQAAAAADXQAAAAABXQAAAAABXQAAAAADXQAAAAABXQAAAAABXQAAAAACXQAAAAABXQAAAAACXQAAAAADXQAAAAACXQAAAAAAXQAAAAAAXQAAAAABXQAAAAAATQAAAAAAXQAAAAAAXQAAAAACXQAAAAABXQAAAAACXQAAAAAAXQAAAAABXQAAAAADXQAAAAABXQAAAAACXQAAAAAAXQAAAAACXQAAAAACXQAAAAABXQAAAAAAXQAAAAADTQAAAAACXQAAAAACHwAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAXQAAAAAAXQAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAATQAAAAAAXQAAAAADHwAAAAAAfgAAAAAAHwAAAAAAegAAAAADegAAAAABegAAAAAAegAAAAACegAAAAAAHwAAAAADfgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfgAAAAAAXQAAAAACEQAAAAAAHwAAAAABfgAAAAAAHwAAAAADegAAAAADegAAAAADegAAAAAAegAAAAABegAAAAADHwAAAAABfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAXQAAAAADEQAAAAAAXQAAAAACfgAAAAAAHwAAAAAAegAAAAABegAAAAABegAAAAACegAAAAACegAAAAABHwAAAAADfgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfgAAAAAAXQAAAAACEQAAAAAAHwAAAAACfgAAAAAAHwAAAAAAegAAAAADegAAAAAAegAAAAACegAAAAACegAAAAACHwAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACXQAAAAABHwAAAAABfgAAAAAAHwAAAAAAegAAAAADegAAAAADegAAAAABegAAAAAAegAAAAADHwAAAAACfgAAAAAAHwAAAAABHwAAAAAAHwAAAAADfgAAAAAAXQAAAAAB
           version: 6
         1,-3:
           ind: 1,-3
@@ -9609,6 +9609,8 @@ entities:
       - 777
   - uid: 178
     components:
+    - type: MetaData
+      name: Brig Air Alarm
     - type: Transform
       pos: -29.5,-2.5
       parent: 60
@@ -9658,6 +9660,8 @@ entities:
       - 792
   - uid: 3204
     components:
+    - type: MetaData
+      name: Ready Room Air Alarm
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-21.5
@@ -9721,6 +9725,8 @@ entities:
       - 7463
   - uid: 5933
     components:
+    - type: MetaData
+      name: Warden's Office Air Alarm
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,-13.5
@@ -14549,6 +14555,8 @@ entities:
       parent: 60
   - uid: 9465
     components:
+    - type: MetaData
+      name: HoS Office APC
     - type: Transform
       pos: -19.5,1.5
       parent: 60
@@ -16387,10 +16395,35 @@ entities:
     - type: Transform
       pos: -4.5,1.5
       parent: 60
+  - uid: 1568
+    components:
+    - type: Transform
+      pos: -17.5,-10.5
+      parent: 60
+  - uid: 1569
+    components:
+    - type: Transform
+      pos: -17.5,-11.5
+      parent: 60
   - uid: 1681
     components:
     - type: Transform
       pos: -18.5,-1.5
+      parent: 60
+  - uid: 1720
+    components:
+    - type: Transform
+      pos: -17.5,-9.5
+      parent: 60
+  - uid: 1947
+    components:
+    - type: Transform
+      pos: -17.5,-7.5
+      parent: 60
+  - uid: 1981
+    components:
+    - type: Transform
+      pos: -17.5,-5.5
       parent: 60
   - uid: 4457
     components:
@@ -16426,6 +16459,11 @@ entities:
     components:
     - type: Transform
       pos: -3.5,4.5
+      parent: 60
+  - uid: 5201
+    components:
+    - type: Transform
+      pos: -17.5,-6.5
       parent: 60
   - uid: 5344
     components:
@@ -16473,6 +16511,36 @@ entities:
     components:
     - type: Transform
       pos: -18.5,0.5
+      parent: 60
+  - uid: 6365
+    components:
+    - type: Transform
+      pos: -35.5,-7.5
+      parent: 60
+  - uid: 7166
+    components:
+    - type: Transform
+      pos: -35.5,-11.5
+      parent: 60
+  - uid: 8278
+    components:
+    - type: Transform
+      pos: -35.5,-10.5
+      parent: 60
+  - uid: 8282
+    components:
+    - type: Transform
+      pos: -35.5,-9.5
+      parent: 60
+  - uid: 8296
+    components:
+    - type: Transform
+      pos: -35.5,-6.5
+      parent: 60
+  - uid: 8335
+    components:
+    - type: Transform
+      pos: -35.5,-5.5
       parent: 60
   - uid: 8721
     components:
@@ -17342,12 +17410,6 @@ entities:
       parent: 60
 - proto: ButtonFrameCautionSecurity
   entities:
-  - uid: 10
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -27.58968,-9.505666
-      parent: 60
   - uid: 4299
     components:
     - type: Transform
@@ -17428,11 +17490,6 @@ entities:
     - type: Transform
       pos: -65.5,7.5
       parent: 60
-  - uid: 69
-    components:
-    - type: Transform
-      pos: -35.5,-6.5
-      parent: 60
   - uid: 70
     components:
     - type: Transform
@@ -17443,11 +17500,6 @@ entities:
     - type: Transform
       pos: -31.5,-6.5
       parent: 60
-  - uid: 96
-    components:
-    - type: Transform
-      pos: -23.5,-5.5
-      parent: 60
   - uid: 112
     components:
     - type: Transform
@@ -17457,26 +17509,6 @@ entities:
     components:
     - type: Transform
       pos: -25.5,0.5
-      parent: 60
-  - uid: 119
-    components:
-    - type: Transform
-      pos: -29.5,-5.5
-      parent: 60
-  - uid: 151
-    components:
-    - type: Transform
-      pos: -17.5,-10.5
-      parent: 60
-  - uid: 152
-    components:
-    - type: Transform
-      pos: -35.5,-5.5
-      parent: 60
-  - uid: 155
-    components:
-    - type: Transform
-      pos: -17.5,-7.5
       parent: 60
   - uid: 167
     components:
@@ -17593,6 +17625,11 @@ entities:
     - type: Transform
       pos: -11.5,5.5
       parent: 60
+  - uid: 721
+    components:
+    - type: Transform
+      pos: -31.5,-4.5
+      parent: 60
   - uid: 815
     components:
     - type: Transform
@@ -17607,6 +17644,11 @@ entities:
     components:
     - type: Transform
       pos: -65.5,12.5
+      parent: 60
+  - uid: 963
+    components:
+    - type: Transform
+      pos: -22.5,-4.5
       parent: 60
   - uid: 1167
     components:
@@ -17738,11 +17780,6 @@ entities:
     - type: Transform
       pos: 1.5,-6.5
       parent: 60
-  - uid: 1720
-    components:
-    - type: Transform
-      pos: -17.5,-5.5
-      parent: 60
   - uid: 1722
     components:
     - type: Transform
@@ -17862,11 +17899,6 @@ entities:
     components:
     - type: Transform
       pos: -27.5,-15.5
-      parent: 60
-  - uid: 1947
-    components:
-    - type: Transform
-      pos: -17.5,-9.5
       parent: 60
   - uid: 1951
     components:
@@ -18848,11 +18880,6 @@ entities:
     - type: Transform
       pos: -16.5,-54.5
       parent: 60
-  - uid: 6365
-    components:
-    - type: Transform
-      pos: -17.5,-6.5
-      parent: 60
   - uid: 6428
     components:
     - type: Transform
@@ -19378,11 +19405,6 @@ entities:
     - type: Transform
       pos: 12.5,-2.5
       parent: 7536
-  - uid: 8282
-    components:
-    - type: Transform
-      pos: -17.5,-11.5
-      parent: 60
   - uid: 8315
     components:
     - type: Transform
@@ -19412,16 +19434,6 @@ entities:
     components:
     - type: Transform
       pos: -59.5,-13.5
-      parent: 60
-  - uid: 8335
-    components:
-    - type: Transform
-      pos: -35.5,-11.5
-      parent: 60
-  - uid: 8340
-    components:
-    - type: Transform
-      pos: -35.5,-7.5
       parent: 60
   - uid: 8347
     components:
@@ -19463,11 +19475,6 @@ entities:
     - type: Transform
       pos: 5.5,-3.5
       parent: 7536
-  - uid: 8429
-    components:
-    - type: Transform
-      pos: -35.5,-10.5
-      parent: 60
   - uid: 8465
     components:
     - type: Transform
@@ -19486,7 +19493,7 @@ entities:
   - uid: 8482
     components:
     - type: Transform
-      pos: -35.5,-9.5
+      pos: -30.5,-4.5
       parent: 60
   - uid: 8512
     components:
@@ -19678,6 +19685,16 @@ entities:
     - type: Transform
       pos: -9.5,-3.5
       parent: 7536
+  - uid: 9089
+    components:
+    - type: Transform
+      pos: -17.5,-6.5
+      parent: 60
+  - uid: 9159
+    components:
+    - type: Transform
+      pos: -17.5,-5.5
+      parent: 60
   - uid: 9172
     components:
     - type: Transform
@@ -19687,6 +19704,11 @@ entities:
     components:
     - type: Transform
       pos: 33.5,-11.5
+      parent: 60
+  - uid: 9176
+    components:
+    - type: Transform
+      pos: -17.5,-7.5
       parent: 60
   - uid: 9198
     components:
@@ -19737,6 +19759,11 @@ entities:
     components:
     - type: Transform
       pos: -46.5,16.5
+      parent: 60
+  - uid: 9546
+    components:
+    - type: Transform
+      pos: -17.5,-10.5
       parent: 60
   - uid: 9630
     components:
@@ -22463,6 +22490,16 @@ entities:
     - type: Transform
       pos: 8.5,-24.5
       parent: 60
+  - uid: 10657
+    components:
+    - type: Transform
+      pos: -17.5,-9.5
+      parent: 60
+  - uid: 10658
+    components:
+    - type: Transform
+      pos: -17.5,-11.5
+      parent: 60
   - uid: 10673
     components:
     - type: Transform
@@ -22473,10 +22510,25 @@ entities:
     - type: Transform
       pos: -19.5,-21.5
       parent: 60
+  - uid: 10680
+    components:
+    - type: Transform
+      pos: -35.5,-6.5
+      parent: 60
+  - uid: 10682
+    components:
+    - type: Transform
+      pos: -35.5,-5.5
+      parent: 60
   - uid: 10683
     components:
     - type: Transform
       pos: 51.5,-37.5
+      parent: 60
+  - uid: 10685
+    components:
+    - type: Transform
+      pos: -35.5,-7.5
       parent: 60
   - uid: 10703
     components:
@@ -23593,6 +23645,11 @@ entities:
     - type: Transform
       pos: 24.5,-37.5
       parent: 60
+  - uid: 11338
+    components:
+    - type: Transform
+      pos: -35.5,-10.5
+      parent: 60
   - uid: 11373
     components:
     - type: Transform
@@ -23668,6 +23725,11 @@ entities:
     - type: Transform
       pos: -15.5,-4.5
       parent: 7536
+  - uid: 11510
+    components:
+    - type: Transform
+      pos: -35.5,-9.5
+      parent: 60
   - uid: 11512
     components:
     - type: Transform
@@ -25342,6 +25404,11 @@ entities:
     components:
     - type: Transform
       pos: -32.5,0.5
+      parent: 60
+  - uid: 13158
+    components:
+    - type: Transform
+      pos: -35.5,-11.5
       parent: 60
   - uid: 13203
     components:
@@ -27087,6 +27154,11 @@ entities:
     components:
     - type: Transform
       pos: -34.5,-2.5
+      parent: 60
+  - uid: 14730
+    components:
+    - type: Transform
+      pos: -21.5,-4.5
       parent: 60
   - uid: 14904
     components:
@@ -33329,6 +33401,31 @@ entities:
     - type: Transform
       pos: -65.5,-17.5
       parent: 60
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -35.5,-5.5
+      parent: 60
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -17.5,-7.5
+      parent: 60
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -17.5,-5.5
+      parent: 60
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -17.5,-9.5
+      parent: 60
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -17.5,-6.5
+      parent: 60
   - uid: 255
     components:
     - type: Transform
@@ -33338,6 +33435,11 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-34.5
+      parent: 60
+  - uid: 284
+    components:
+    - type: Transform
+      pos: -35.5,-10.5
       parent: 60
   - uid: 289
     components:
@@ -33374,6 +33476,11 @@ entities:
     - type: Transform
       pos: 31.5,-60.5
       parent: 60
+  - uid: 667
+    components:
+    - type: Transform
+      pos: -16.5,-7.5
+      parent: 60
   - uid: 807
     components:
     - type: Transform
@@ -33398,6 +33505,11 @@ entities:
     components:
     - type: Transform
       pos: 30.5,-55.5
+      parent: 60
+  - uid: 1293
+    components:
+    - type: Transform
+      pos: -17.5,-10.5
       parent: 60
   - uid: 1371
     components:
@@ -33433,6 +33545,31 @@ entities:
     components:
     - type: Transform
       pos: 31.5,-58.5
+      parent: 60
+  - uid: 1529
+    components:
+    - type: Transform
+      pos: -35.5,-11.5
+      parent: 60
+  - uid: 1532
+    components:
+    - type: Transform
+      pos: -35.5,-9.5
+      parent: 60
+  - uid: 1541
+    components:
+    - type: Transform
+      pos: -35.5,-7.5
+      parent: 60
+  - uid: 1542
+    components:
+    - type: Transform
+      pos: -35.5,-6.5
+      parent: 60
+  - uid: 1561
+    components:
+    - type: Transform
+      pos: -17.5,-11.5
       parent: 60
   - uid: 1582
     components:
@@ -40729,11 +40866,6 @@ entities:
     - type: Transform
       pos: -16.5,-3.5
       parent: 60
-  - uid: 18604
-    components:
-    - type: Transform
-      pos: -16.5,-7.5
-      parent: 60
   - uid: 18605
     components:
     - type: Transform
@@ -44158,11 +44290,6 @@ entities:
     - type: Transform
       pos: -18.5,-0.5
       parent: 60
-  - uid: 8418
-    components:
-    - type: Transform
-      pos: -21.5,-2.5
-      parent: 60
   - uid: 8425
     components:
     - type: Transform
@@ -47178,6 +47305,11 @@ entities:
     - type: Transform
       pos: -44.5,14.5
       parent: 60
+  - uid: 17959
+    components:
+    - type: Transform
+      pos: -21.5,-2.5
+      parent: 60
   - uid: 17972
     components:
     - type: Transform
@@ -47347,16 +47479,6 @@ entities:
     components:
     - type: Transform
       pos: -5.5,-16.5
-      parent: 60
-  - uid: 18773
-    components:
-    - type: Transform
-      pos: -12.5,-5.5
-      parent: 60
-  - uid: 18774
-    components:
-    - type: Transform
-      pos: -12.5,-4.5
       parent: 60
   - uid: 18842
     components:
@@ -56351,6 +56473,18 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 56.5,-5.5
       parent: 60
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-7.5
+      parent: 60
+  - uid: 119
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-11.5
+      parent: 60
   - uid: 662
     components:
     - type: Transform
@@ -56809,6 +56943,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 2.5,21.5
       parent: 60
+  - uid: 15898
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -33.5,-7.5
+      parent: 60
   - uid: 17262
     components:
     - type: Transform
@@ -56903,6 +57043,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-51.5
+      parent: 60
+  - uid: 17955
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -33.5,-11.5
       parent: 60
   - uid: 18210
     components:
@@ -63709,8 +63855,15 @@ entities:
   - uid: 8722
     components:
     - type: Transform
+      anchored: True
       pos: -33.5,-13.5
       parent: 60
+    - type: Physics
+      bodyType: Static
+    - type: Lock
+      locked: True
+    - type: PointLight
+      enabled: True
   - uid: 21733
     components:
     - type: Transform
@@ -69853,6 +70006,8 @@ entities:
       - 671
   - uid: 177
     components:
+    - type: MetaData
+      name: Brig Fire Alarm
     - type: Transform
       pos: -23.5,-2.5
       parent: 60
@@ -73669,7 +73824,7 @@ entities:
       pos: 47.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
 - proto: GasFilterFlipped
   entities:
   - uid: 23468
@@ -73876,7 +74031,7 @@ entities:
       pos: 23.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
 - proto: GasPassiveVent
   entities:
   - uid: 2979
@@ -74100,7 +74255,7 @@ entities:
       pos: 44.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 125
     components:
     - type: Transform
@@ -74116,7 +74271,7 @@ entities:
       pos: 27.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 222
     components:
     - type: Transform
@@ -74124,7 +74279,7 @@ entities:
       pos: 20.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 248
     components:
     - type: Transform
@@ -74132,14 +74287,14 @@ entities:
       pos: -24.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 311
     components:
     - type: Transform
       pos: 27.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 766
     components:
     - type: Transform
@@ -74147,14 +74302,14 @@ entities:
       pos: -25.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 784
     components:
     - type: Transform
       pos: -27.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 793
     components:
     - type: Transform
@@ -74162,14 +74317,14 @@ entities:
       pos: -34.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 947
     components:
     - type: Transform
       pos: 16.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 995
     components:
     - type: Transform
@@ -74177,14 +74332,14 @@ entities:
       pos: 9.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1388
     components:
     - type: Transform
       pos: 4.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1408
     components:
     - type: Transform
@@ -74192,7 +74347,7 @@ entities:
       pos: 5.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1409
     components:
     - type: Transform
@@ -74200,7 +74355,7 @@ entities:
       pos: 7.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1700
     components:
     - type: Transform
@@ -74208,7 +74363,7 @@ entities:
       pos: -31.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1776
     components:
     - type: Transform
@@ -74216,7 +74371,7 @@ entities:
       pos: -9.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2025
     components:
     - type: Transform
@@ -74224,7 +74379,7 @@ entities:
       pos: -23.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2113
     components:
     - type: Transform
@@ -74232,14 +74387,14 @@ entities:
       pos: -32.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2120
     components:
     - type: Transform
       pos: -20.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2203
     components:
     - type: Transform
@@ -74247,7 +74402,7 @@ entities:
       pos: 15.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2207
     components:
     - type: Transform
@@ -74255,14 +74410,14 @@ entities:
       pos: 32.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2274
     components:
     - type: Transform
       pos: 34.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2278
     components:
     - type: Transform
@@ -74270,7 +74425,7 @@ entities:
       pos: -30.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2366
     components:
     - type: Transform
@@ -74278,7 +74433,7 @@ entities:
       pos: 30.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2443
     components:
     - type: Transform
@@ -74286,7 +74441,7 @@ entities:
       pos: 16.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2513
     components:
     - type: Transform
@@ -74294,7 +74449,7 @@ entities:
       pos: -32.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2569
     components:
     - type: Transform
@@ -74302,7 +74457,7 @@ entities:
       pos: -22.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2999
     components:
     - type: Transform
@@ -74348,7 +74503,7 @@ entities:
       pos: 40.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3188
     components:
     - type: Transform
@@ -74363,7 +74518,7 @@ entities:
       pos: 49.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3960
     components:
     - type: Transform
@@ -74371,7 +74526,7 @@ entities:
       pos: -13.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3961
     components:
     - type: Transform
@@ -74379,7 +74534,7 @@ entities:
       pos: -13.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4739
     components:
     - type: Transform
@@ -74387,7 +74542,7 @@ entities:
       pos: 43.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4911
     components:
     - type: Transform
@@ -74395,14 +74550,14 @@ entities:
       pos: -2.5,-70.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4912
     components:
     - type: Transform
       pos: -0.5,-70.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4913
     components:
     - type: Transform
@@ -74410,7 +74565,7 @@ entities:
       pos: 3.5,-70.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4914
     components:
     - type: Transform
@@ -74418,7 +74573,7 @@ entities:
       pos: -2.5,-63.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4935
     components:
     - type: Transform
@@ -74426,14 +74581,14 @@ entities:
       pos: 1.5,-63.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4936
     components:
     - type: Transform
       pos: 3.5,-63.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4961
     components:
     - type: Transform
@@ -74441,7 +74596,7 @@ entities:
       pos: 43.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4985
     components:
     - type: Transform
@@ -74449,7 +74604,7 @@ entities:
       pos: 1.5,-70.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4987
     components:
     - type: Transform
@@ -74457,7 +74612,7 @@ entities:
       pos: -0.5,-63.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5474
     components:
     - type: Transform
@@ -74465,7 +74620,7 @@ entities:
       pos: -38.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5550
     components:
     - type: Transform
@@ -74488,14 +74643,14 @@ entities:
       pos: 8.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5695
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5699
     components:
     - type: Transform
@@ -74503,7 +74658,7 @@ entities:
       pos: 5.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5700
     components:
     - type: Transform
@@ -74511,21 +74666,21 @@ entities:
       pos: 6.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5701
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5702
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5703
     components:
     - type: Transform
@@ -74533,7 +74688,7 @@ entities:
       pos: -7.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5706
     components:
     - type: Transform
@@ -74541,7 +74696,7 @@ entities:
       pos: -7.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5709
     components:
     - type: Transform
@@ -74549,7 +74704,7 @@ entities:
       pos: -4.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5710
     components:
     - type: Transform
@@ -74557,7 +74712,7 @@ entities:
       pos: -4.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5711
     components:
     - type: Transform
@@ -74565,7 +74720,7 @@ entities:
       pos: -5.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5712
     components:
     - type: Transform
@@ -74573,14 +74728,14 @@ entities:
       pos: -5.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5819
     components:
     - type: Transform
       pos: 19.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5902
     components:
     - type: Transform
@@ -74588,7 +74743,7 @@ entities:
       pos: 15.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5950
     components:
     - type: Transform
@@ -74596,7 +74751,7 @@ entities:
       pos: -54.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5967
     components:
     - type: Transform
@@ -74604,14 +74759,14 @@ entities:
       pos: -55.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6046
     components:
     - type: Transform
       pos: -44.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6047
     components:
     - type: Transform
@@ -74619,14 +74774,14 @@ entities:
       pos: -49.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6062
     components:
     - type: Transform
       pos: -43.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6112
     components:
     - type: Transform
@@ -74634,7 +74789,7 @@ entities:
       pos: -43.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6135
     components:
     - type: Transform
@@ -74642,7 +74797,7 @@ entities:
       pos: -44.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6309
     components:
     - type: Transform
@@ -74650,7 +74805,7 @@ entities:
       pos: -21.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6401
     components:
     - type: Transform
@@ -74658,7 +74813,7 @@ entities:
       pos: -47.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6796
     components:
     - type: Transform
@@ -74666,14 +74821,14 @@ entities:
       pos: -27.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6823
     components:
     - type: Transform
       pos: 17.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7357
     components:
     - type: Transform
@@ -74693,7 +74848,7 @@ entities:
       pos: 23.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7907
     components:
     - type: Transform
@@ -74701,28 +74856,28 @@ entities:
       pos: -25.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8212
     components:
     - type: Transform
       pos: -18.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8343
     components:
     - type: Transform
       pos: -31.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8386
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8417
     components:
     - type: Transform
@@ -74730,21 +74885,21 @@ entities:
       pos: -45.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8472
     components:
     - type: Transform
       pos: -46.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8475
     components:
     - type: Transform
       pos: -43.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8511
     components:
     - type: Transform
@@ -74752,7 +74907,7 @@ entities:
       pos: -43.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8580
     components:
     - type: Transform
@@ -74760,7 +74915,7 @@ entities:
       pos: -46.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8919
     components:
     - type: Transform
@@ -74768,14 +74923,14 @@ entities:
       pos: -7.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8943
     components:
     - type: Transform
       pos: -7.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8944
     components:
     - type: Transform
@@ -74783,14 +74938,14 @@ entities:
       pos: -12.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8970
     components:
     - type: Transform
       pos: 21.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9019
     components:
     - type: Transform
@@ -74806,7 +74961,7 @@ entities:
       pos: -54.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 11105
     components:
     - type: Transform
@@ -74821,7 +74976,7 @@ entities:
       pos: -6.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11281
     components:
     - type: Transform
@@ -74835,7 +74990,7 @@ entities:
       pos: 37.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11488
     components:
     - type: Transform
@@ -74843,7 +74998,7 @@ entities:
       pos: 12.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11723
     components:
     - type: Transform
@@ -74851,7 +75006,7 @@ entities:
       pos: 40.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11841
     components:
     - type: Transform
@@ -74859,7 +75014,7 @@ entities:
       pos: 48.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12192
     components:
     - type: Transform
@@ -74867,7 +75022,7 @@ entities:
       pos: 41.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12629
     components:
     - type: Transform
@@ -74875,7 +75030,7 @@ entities:
       pos: 39.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12635
     components:
     - type: Transform
@@ -74883,7 +75038,7 @@ entities:
       pos: 40.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12823
     components:
     - type: Transform
@@ -74891,7 +75046,7 @@ entities:
       pos: -36.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12829
     components:
     - type: Transform
@@ -74899,7 +75054,7 @@ entities:
       pos: -43.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12835
     components:
     - type: Transform
@@ -74907,7 +75062,7 @@ entities:
       pos: -43.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13230
     components:
     - type: Transform
@@ -74930,7 +75085,7 @@ entities:
       pos: 49.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13515
     components:
     - type: Transform
@@ -74938,7 +75093,7 @@ entities:
       pos: 41.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13516
     components:
     - type: Transform
@@ -74946,7 +75101,7 @@ entities:
       pos: 37.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13517
     components:
     - type: Transform
@@ -74954,7 +75109,7 @@ entities:
       pos: 37.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13537
     components:
     - type: Transform
@@ -74962,7 +75117,7 @@ entities:
       pos: 20.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13538
     components:
     - type: Transform
@@ -74970,7 +75125,7 @@ entities:
       pos: 20.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13631
     components:
     - type: Transform
@@ -74978,7 +75133,7 @@ entities:
       pos: -8.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14217
     components:
     - type: Transform
@@ -74986,7 +75141,7 @@ entities:
       pos: -7.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14219
     components:
     - type: Transform
@@ -74994,14 +75149,14 @@ entities:
       pos: -11.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14260
     components:
     - type: Transform
       pos: -14.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14297
     components:
     - type: Transform
@@ -75009,14 +75164,14 @@ entities:
       pos: -7.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14311
     components:
     - type: Transform
       pos: -8.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14666
     components:
     - type: Transform
@@ -75031,7 +75186,7 @@ entities:
       pos: -12.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14668
     components:
     - type: Transform
@@ -75039,7 +75194,7 @@ entities:
       pos: -20.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14674
     components:
     - type: Transform
@@ -75047,7 +75202,7 @@ entities:
       pos: -20.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14698
     components:
     - type: Transform
@@ -75055,7 +75210,7 @@ entities:
       pos: -12.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14702
     components:
     - type: Transform
@@ -75069,6 +75224,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -17.5,29.5
       parent: 60
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 14749
     components:
     - type: Transform
@@ -75076,7 +75233,7 @@ entities:
       pos: -20.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14842
     components:
     - type: Transform
@@ -75173,7 +75330,7 @@ entities:
       pos: -33.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15181
     components:
     - type: Transform
@@ -75273,14 +75430,14 @@ entities:
       pos: -22.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15594
     components:
     - type: Transform
       pos: -10.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15612
     components:
     - type: Transform
@@ -75288,14 +75445,14 @@ entities:
       pos: -20.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15613
     components:
     - type: Transform
       pos: -12.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16611
     components:
     - type: Transform
@@ -75303,7 +75460,7 @@ entities:
       pos: 1.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16641
     components:
     - type: Transform
@@ -75311,7 +75468,7 @@ entities:
       pos: -3.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16741
     components:
     - type: Transform
@@ -75341,7 +75498,7 @@ entities:
       pos: -47.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17290
     components:
     - type: Transform
@@ -75349,7 +75506,7 @@ entities:
       pos: -52.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17586
     components:
     - type: Transform
@@ -75357,7 +75514,7 @@ entities:
       pos: -41.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17587
     components:
     - type: Transform
@@ -75365,7 +75522,7 @@ entities:
       pos: -43.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18020
     components:
     - type: Transform
@@ -75379,7 +75536,7 @@ entities:
       pos: -2.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18250
     components:
     - type: Transform
@@ -75387,14 +75544,14 @@ entities:
       pos: -3.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18276
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18277
     components:
     - type: Transform
@@ -75402,7 +75559,7 @@ entities:
       pos: -4.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18366
     components:
     - type: Transform
@@ -75415,7 +75572,7 @@ entities:
       pos: 4.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18435
     components:
     - type: Transform
@@ -75423,7 +75580,7 @@ entities:
       pos: -3.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18511
     components:
     - type: Transform
@@ -75431,21 +75588,21 @@ entities:
       pos: -2.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18532
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18534
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18712
     components:
     - type: Transform
@@ -75453,7 +75610,7 @@ entities:
       pos: 39.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18713
     components:
     - type: Transform
@@ -75461,7 +75618,7 @@ entities:
       pos: 37.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18914
     components:
     - type: Transform
@@ -75469,7 +75626,7 @@ entities:
       pos: 47.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21325
     components:
     - type: Transform
@@ -75477,14 +75634,14 @@ entities:
       pos: -58.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21326
     components:
     - type: Transform
       pos: -58.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21393
     components:
     - type: Transform
@@ -75492,14 +75649,14 @@ entities:
       pos: -15.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21440
     components:
     - type: Transform
       pos: -7.5,-38.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21441
     components:
     - type: Transform
@@ -75507,7 +75664,7 @@ entities:
       pos: -8.5,-38.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21534
     components:
     - type: Transform
@@ -75515,14 +75672,14 @@ entities:
       pos: 53.5,45.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21666
     components:
     - type: Transform
       pos: -29.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22829
     components:
     - type: Transform
@@ -75530,7 +75687,7 @@ entities:
       pos: -119.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22846
     components:
     - type: Transform
@@ -75538,7 +75695,7 @@ entities:
       pos: -111.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22872
     components:
     - type: Transform
@@ -75546,14 +75703,14 @@ entities:
       pos: -110.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22873
     components:
     - type: Transform
       pos: -102.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22874
     components:
     - type: Transform
@@ -75561,35 +75718,35 @@ entities:
       pos: -102.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22875
     components:
     - type: Transform
       pos: -99.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22877
     components:
     - type: Transform
       pos: -110.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22880
     components:
     - type: Transform
       pos: -98.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22895
     components:
     - type: Transform
       pos: -111.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22896
     components:
     - type: Transform
@@ -75597,7 +75754,7 @@ entities:
       pos: -113.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22897
     components:
     - type: Transform
@@ -75605,7 +75762,7 @@ entities:
       pos: -113.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22898
     components:
     - type: Transform
@@ -75613,7 +75770,7 @@ entities:
       pos: -111.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22899
     components:
     - type: Transform
@@ -75621,7 +75778,7 @@ entities:
       pos: -111.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22909
     components:
     - type: Transform
@@ -75857,7 +76014,7 @@ entities:
       pos: 55.5,47.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24902
     components:
     - type: Transform
@@ -75865,14 +76022,14 @@ entities:
       pos: 33.5,45.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 25167
     components:
     - type: Transform
       pos: 35.5,47.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
 - proto: GasPipeFourway
   entities:
   - uid: 467
@@ -75881,77 +76038,77 @@ entities:
       pos: 1.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 483
     components:
     - type: Transform
       pos: -0.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 872
     components:
     - type: Transform
       pos: 44.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 942
     components:
     - type: Transform
       pos: 45.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1040
     components:
     - type: Transform
       pos: 15.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1177
     components:
     - type: Transform
       pos: -16.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1664
     components:
     - type: Transform
       pos: -22.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1744
     components:
     - type: Transform
       pos: -30.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2361
     components:
     - type: Transform
       pos: 23.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2470
     components:
     - type: Transform
       pos: 21.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2491
     components:
     - type: Transform
       pos: 39.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2903
     components:
     - type: Transform
@@ -75970,133 +76127,133 @@ entities:
       pos: 45.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3194
     components:
     - type: Transform
       pos: 44.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3195
     components:
     - type: Transform
       pos: 44.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4002
     components:
     - type: Transform
       pos: -7.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4116
     components:
     - type: Transform
       pos: 33.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4656
     components:
     - type: Transform
       pos: -0.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5247
     components:
     - type: Transform
       pos: -38.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5473
     components:
     - type: Transform
       pos: -9.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5837
     components:
     - type: Transform
       pos: -20.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5991
     components:
     - type: Transform
       pos: -52.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6213
     components:
     - type: Transform
       pos: 1.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6264
     components:
     - type: Transform
       pos: 17.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6268
     components:
     - type: Transform
       pos: -38.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6275
     components:
     - type: Transform
       pos: -47.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6834
     components:
     - type: Transform
       pos: -47.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7904
     components:
     - type: Transform
       pos: -14.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9232
     components:
     - type: Transform
       pos: 17.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14241
     components:
     - type: Transform
       pos: -14.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15113
     components:
     - type: Transform
       pos: -33.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15531
     components:
     - type: Transform
@@ -76110,35 +76267,35 @@ entities:
       pos: 39.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17887
     components:
     - type: Transform
       pos: 45.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18231
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18239
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22822
     components:
     - type: Transform
       pos: -111.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22997
     components:
     - type: Transform
@@ -76180,7 +76337,7 @@ entities:
       pos: -30.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
 - proto: GasPipeSensorTEGCold
   entities:
   - uid: 15074
@@ -76208,7 +76365,7 @@ entities:
       pos: -30.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
 - proto: GasPipeStraight
   entities:
   - uid: 47
@@ -76217,7 +76374,7 @@ entities:
       pos: -36.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 133
     components:
     - type: Transform
@@ -76225,14 +76382,14 @@ entities:
       pos: 23.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 171
     components:
     - type: Transform
       pos: 44.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 195
     components:
     - type: Transform
@@ -76240,7 +76397,7 @@ entities:
       pos: 39.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 196
     components:
     - type: Transform
@@ -76248,7 +76405,7 @@ entities:
       pos: 40.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 198
     components:
     - type: Transform
@@ -76256,7 +76413,7 @@ entities:
       pos: 41.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 199
     components:
     - type: Transform
@@ -76264,7 +76421,7 @@ entities:
       pos: 42.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 202
     components:
     - type: Transform
@@ -76272,7 +76429,7 @@ entities:
       pos: 23.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 212
     components:
     - type: Transform
@@ -76280,7 +76437,7 @@ entities:
       pos: 21.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 221
     components:
     - type: Transform
@@ -76288,7 +76445,7 @@ entities:
       pos: 20.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 224
     components:
     - type: Transform
@@ -76296,7 +76453,7 @@ entities:
       pos: 21.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 272
     components:
     - type: Transform
@@ -76304,7 +76461,7 @@ entities:
       pos: 21.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 293
     components:
     - type: Transform
@@ -76312,7 +76469,7 @@ entities:
       pos: 20.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 294
     components:
     - type: Transform
@@ -76320,7 +76477,7 @@ entities:
       pos: 27.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 299
     components:
     - type: Transform
@@ -76328,7 +76485,7 @@ entities:
       pos: 21.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 301
     components:
     - type: Transform
@@ -76336,7 +76493,7 @@ entities:
       pos: 27.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 302
     components:
     - type: Transform
@@ -76344,7 +76501,7 @@ entities:
       pos: 23.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 305
     components:
     - type: Transform
@@ -76352,7 +76509,7 @@ entities:
       pos: 24.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 310
     components:
     - type: Transform
@@ -76360,7 +76517,7 @@ entities:
       pos: 26.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 312
     components:
     - type: Transform
@@ -76368,7 +76525,7 @@ entities:
       pos: 23.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 318
     components:
     - type: Transform
@@ -76376,7 +76533,7 @@ entities:
       pos: 27.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 336
     components:
     - type: Transform
@@ -76384,7 +76541,7 @@ entities:
       pos: -31.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 360
     components:
     - type: Transform
@@ -76392,7 +76549,7 @@ entities:
       pos: 21.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 361
     components:
     - type: Transform
@@ -76400,105 +76557,105 @@ entities:
       pos: 25.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 412
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 413
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 414
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 415
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 416
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 418
     components:
     - type: Transform
       pos: 1.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 420
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 421
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 422
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 423
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 424
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 425
     components:
     - type: Transform
       pos: -0.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 427
     components:
     - type: Transform
       pos: -0.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 440
     components:
     - type: Transform
       pos: 44.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 462
     components:
     - type: Transform
@@ -76506,7 +76663,7 @@ entities:
       pos: 1.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 463
     components:
     - type: Transform
@@ -76514,14 +76671,14 @@ entities:
       pos: 0.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 465
     components:
     - type: Transform
       pos: 45.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 468
     components:
     - type: Transform
@@ -76529,7 +76686,7 @@ entities:
       pos: -0.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 469
     components:
     - type: Transform
@@ -76537,7 +76694,7 @@ entities:
       pos: -1.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 470
     components:
     - type: Transform
@@ -76545,7 +76702,7 @@ entities:
       pos: -2.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 471
     components:
     - type: Transform
@@ -76553,7 +76710,7 @@ entities:
       pos: 2.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 472
     components:
     - type: Transform
@@ -76561,35 +76718,35 @@ entities:
       pos: 3.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 475
     components:
     - type: Transform
       pos: 1.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 476
     components:
     - type: Transform
       pos: 1.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 477
     components:
     - type: Transform
       pos: 1.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 478
     components:
     - type: Transform
       pos: 1.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 480
     components:
     - type: Transform
@@ -76597,7 +76754,7 @@ entities:
       pos: -0.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 481
     components:
     - type: Transform
@@ -76605,7 +76762,7 @@ entities:
       pos: -0.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 484
     components:
     - type: Transform
@@ -76613,7 +76770,7 @@ entities:
       pos: -0.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 485
     components:
     - type: Transform
@@ -76621,7 +76778,7 @@ entities:
       pos: -0.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 486
     components:
     - type: Transform
@@ -76629,7 +76786,7 @@ entities:
       pos: -0.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 495
     components:
     - type: Transform
@@ -76637,7 +76794,7 @@ entities:
       pos: -2.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 496
     components:
     - type: Transform
@@ -76645,7 +76802,7 @@ entities:
       pos: -1.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 505
     components:
     - type: Transform
@@ -76653,7 +76810,7 @@ entities:
       pos: 0.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 506
     components:
     - type: Transform
@@ -76661,7 +76818,7 @@ entities:
       pos: 1.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 507
     components:
     - type: Transform
@@ -76669,7 +76826,7 @@ entities:
       pos: 2.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 509
     components:
     - type: Transform
@@ -76677,7 +76834,7 @@ entities:
       pos: 4.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 510
     components:
     - type: Transform
@@ -76685,7 +76842,7 @@ entities:
       pos: 4.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 512
     components:
     - type: Transform
@@ -76693,7 +76850,7 @@ entities:
       pos: -3.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 532
     components:
     - type: Transform
@@ -76701,7 +76858,7 @@ entities:
       pos: 43.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 618
     components:
     - type: Transform
@@ -76709,7 +76866,7 @@ entities:
       pos: -32.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 619
     components:
     - type: Transform
@@ -76717,14 +76874,14 @@ entities:
       pos: -31.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 632
     components:
     - type: Transform
       pos: -14.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 716
     components:
     - type: Transform
@@ -76732,14 +76889,14 @@ entities:
       pos: 13.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 735
     components:
     - type: Transform
       pos: 30.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 781
     components:
     - type: Transform
@@ -76747,7 +76904,7 @@ entities:
       pos: -21.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 782
     components:
     - type: Transform
@@ -76755,7 +76912,7 @@ entities:
       pos: -29.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 783
     components:
     - type: Transform
@@ -76763,7 +76920,7 @@ entities:
       pos: -28.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 794
     components:
     - type: Transform
@@ -76771,7 +76928,7 @@ entities:
       pos: -15.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 838
     components:
     - type: Transform
@@ -76779,7 +76936,7 @@ entities:
       pos: -23.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 839
     components:
     - type: Transform
@@ -76787,21 +76944,21 @@ entities:
       pos: -22.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 874
     components:
     - type: Transform
       pos: -3.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 875
     components:
     - type: Transform
       pos: -3.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 879
     components:
     - type: Transform
@@ -76809,7 +76966,7 @@ entities:
       pos: -7.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 880
     components:
     - type: Transform
@@ -76817,7 +76974,7 @@ entities:
       pos: -6.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 881
     components:
     - type: Transform
@@ -76825,7 +76982,7 @@ entities:
       pos: -5.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 882
     components:
     - type: Transform
@@ -76833,7 +76990,7 @@ entities:
       pos: -4.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 883
     components:
     - type: Transform
@@ -76841,7 +76998,7 @@ entities:
       pos: -4.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 884
     components:
     - type: Transform
@@ -76849,7 +77006,7 @@ entities:
       pos: -8.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 885
     components:
     - type: Transform
@@ -76857,7 +77014,7 @@ entities:
       pos: -8.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 886
     components:
     - type: Transform
@@ -76865,7 +77022,7 @@ entities:
       pos: -9.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 888
     components:
     - type: Transform
@@ -76873,7 +77030,7 @@ entities:
       pos: -11.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 889
     components:
     - type: Transform
@@ -76881,14 +77038,14 @@ entities:
       pos: -12.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 890
     components:
     - type: Transform
       pos: -9.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 891
     components:
     - type: Transform
@@ -76896,7 +77053,7 @@ entities:
       pos: -4.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 892
     components:
     - type: Transform
@@ -76904,7 +77061,7 @@ entities:
       pos: -5.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 893
     components:
     - type: Transform
@@ -76912,7 +77069,7 @@ entities:
       pos: -6.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 894
     components:
     - type: Transform
@@ -76920,7 +77077,7 @@ entities:
       pos: -7.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 897
     components:
     - type: Transform
@@ -76928,7 +77085,7 @@ entities:
       pos: -10.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 899
     components:
     - type: Transform
@@ -76936,7 +77093,7 @@ entities:
       pos: -11.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 900
     components:
     - type: Transform
@@ -76944,7 +77101,7 @@ entities:
       pos: -12.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 901
     components:
     - type: Transform
@@ -76952,7 +77109,7 @@ entities:
       pos: -13.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 903
     components:
     - type: Transform
@@ -76960,42 +77117,42 @@ entities:
       pos: -14.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 905
     components:
     - type: Transform
       pos: -9.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 906
     components:
     - type: Transform
       pos: -9.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 908
     components:
     - type: Transform
       pos: -3.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 909
     components:
     - type: Transform
       pos: -3.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 917
     components:
     - type: Transform
       pos: 30.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 950
     components:
     - type: Transform
@@ -77003,7 +77160,7 @@ entities:
       pos: 42.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 951
     components:
     - type: Transform
@@ -77011,7 +77168,7 @@ entities:
       pos: 44.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 961
     components:
     - type: Transform
@@ -77019,7 +77176,7 @@ entities:
       pos: -13.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 991
     components:
     - type: Transform
@@ -77027,7 +77184,7 @@ entities:
       pos: -16.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 996
     components:
     - type: Transform
@@ -77035,7 +77192,7 @@ entities:
       pos: 14.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1029
     components:
     - type: Transform
@@ -77043,7 +77200,7 @@ entities:
       pos: 5.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1030
     components:
     - type: Transform
@@ -77051,7 +77208,7 @@ entities:
       pos: 6.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1031
     components:
     - type: Transform
@@ -77059,7 +77216,7 @@ entities:
       pos: 7.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1032
     components:
     - type: Transform
@@ -77067,7 +77224,7 @@ entities:
       pos: 8.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1033
     components:
     - type: Transform
@@ -77075,7 +77232,7 @@ entities:
       pos: 9.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1034
     components:
     - type: Transform
@@ -77083,7 +77240,7 @@ entities:
       pos: 10.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1035
     components:
     - type: Transform
@@ -77091,7 +77248,7 @@ entities:
       pos: 11.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1037
     components:
     - type: Transform
@@ -77099,7 +77256,7 @@ entities:
       pos: 13.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1038
     components:
     - type: Transform
@@ -77107,7 +77264,7 @@ entities:
       pos: 14.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1039
     components:
     - type: Transform
@@ -77115,7 +77272,7 @@ entities:
       pos: 15.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1041
     components:
     - type: Transform
@@ -77123,7 +77280,7 @@ entities:
       pos: 5.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1042
     components:
     - type: Transform
@@ -77131,7 +77288,7 @@ entities:
       pos: 6.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1044
     components:
     - type: Transform
@@ -77139,7 +77296,7 @@ entities:
       pos: 8.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1046
     components:
     - type: Transform
@@ -77147,7 +77304,7 @@ entities:
       pos: 10.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1048
     components:
     - type: Transform
@@ -77155,7 +77312,7 @@ entities:
       pos: 12.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1049
     components:
     - type: Transform
@@ -77163,7 +77320,7 @@ entities:
       pos: 13.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1050
     components:
     - type: Transform
@@ -77171,7 +77328,7 @@ entities:
       pos: 14.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1053
     components:
     - type: Transform
@@ -77179,7 +77336,7 @@ entities:
       pos: 17.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1054
     components:
     - type: Transform
@@ -77187,7 +77344,7 @@ entities:
       pos: 17.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1055
     components:
     - type: Transform
@@ -77195,7 +77352,7 @@ entities:
       pos: 15.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1056
     components:
     - type: Transform
@@ -77203,7 +77360,7 @@ entities:
       pos: 17.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1057
     components:
     - type: Transform
@@ -77211,7 +77368,7 @@ entities:
       pos: 17.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1058
     components:
     - type: Transform
@@ -77219,7 +77376,7 @@ entities:
       pos: 15.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1060
     components:
     - type: Transform
@@ -77227,7 +77384,7 @@ entities:
       pos: 17.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1062
     components:
     - type: Transform
@@ -77235,7 +77392,7 @@ entities:
       pos: 15.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1063
     components:
     - type: Transform
@@ -77243,7 +77400,7 @@ entities:
       pos: 15.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1064
     components:
     - type: Transform
@@ -77251,7 +77408,7 @@ entities:
       pos: 17.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1065
     components:
     - type: Transform
@@ -77259,7 +77416,7 @@ entities:
       pos: 17.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1067
     components:
     - type: Transform
@@ -77267,7 +77424,7 @@ entities:
       pos: 15.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1068
     components:
     - type: Transform
@@ -77275,7 +77432,7 @@ entities:
       pos: 17.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1069
     components:
     - type: Transform
@@ -77283,7 +77440,7 @@ entities:
       pos: 17.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1070
     components:
     - type: Transform
@@ -77291,7 +77448,7 @@ entities:
       pos: 15.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1073
     components:
     - type: Transform
@@ -77299,7 +77456,7 @@ entities:
       pos: 17.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1076
     components:
     - type: Transform
@@ -77307,7 +77464,7 @@ entities:
       pos: 17.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1078
     components:
     - type: Transform
@@ -77315,7 +77472,7 @@ entities:
       pos: 15.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1080
     components:
     - type: Transform
@@ -77323,7 +77480,7 @@ entities:
       pos: 17.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1081
     components:
     - type: Transform
@@ -77331,7 +77488,7 @@ entities:
       pos: 17.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1082
     components:
     - type: Transform
@@ -77339,7 +77496,7 @@ entities:
       pos: 15.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1083
     components:
     - type: Transform
@@ -77347,7 +77504,7 @@ entities:
       pos: 15.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1084
     components:
     - type: Transform
@@ -77355,7 +77512,7 @@ entities:
       pos: 17.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1085
     components:
     - type: Transform
@@ -77363,7 +77520,7 @@ entities:
       pos: 17.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1086
     components:
     - type: Transform
@@ -77371,7 +77528,7 @@ entities:
       pos: 15.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1087
     components:
     - type: Transform
@@ -77379,7 +77536,7 @@ entities:
       pos: 15.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1088
     components:
     - type: Transform
@@ -77387,7 +77544,7 @@ entities:
       pos: 17.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1089
     components:
     - type: Transform
@@ -77395,7 +77552,7 @@ entities:
       pos: 17.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1090
     components:
     - type: Transform
@@ -77403,7 +77560,7 @@ entities:
       pos: 15.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1091
     components:
     - type: Transform
@@ -77411,14 +77568,14 @@ entities:
       pos: 15.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1092
     components:
     - type: Transform
       pos: 17.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1093
     components:
     - type: Transform
@@ -77426,7 +77583,7 @@ entities:
       pos: 15.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1094
     components:
     - type: Transform
@@ -77434,14 +77591,14 @@ entities:
       pos: 17.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1095
     components:
     - type: Transform
       pos: 15.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1097
     components:
     - type: Transform
@@ -77449,7 +77606,7 @@ entities:
       pos: 15.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1098
     components:
     - type: Transform
@@ -77457,7 +77614,7 @@ entities:
       pos: 17.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1100
     components:
     - type: Transform
@@ -77465,7 +77622,7 @@ entities:
       pos: 17.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1101
     components:
     - type: Transform
@@ -77473,7 +77630,7 @@ entities:
       pos: 15.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1102
     components:
     - type: Transform
@@ -77481,7 +77638,7 @@ entities:
       pos: 17.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1103
     components:
     - type: Transform
@@ -77489,7 +77646,7 @@ entities:
       pos: 15.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1104
     components:
     - type: Transform
@@ -77497,7 +77654,7 @@ entities:
       pos: 17.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1105
     components:
     - type: Transform
@@ -77505,7 +77662,7 @@ entities:
       pos: 15.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1106
     components:
     - type: Transform
@@ -77513,7 +77670,7 @@ entities:
       pos: 17.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1107
     components:
     - type: Transform
@@ -77521,7 +77678,7 @@ entities:
       pos: 15.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1108
     components:
     - type: Transform
@@ -77529,7 +77686,7 @@ entities:
       pos: 17.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1109
     components:
     - type: Transform
@@ -77537,7 +77694,7 @@ entities:
       pos: 15.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1110
     components:
     - type: Transform
@@ -77545,7 +77702,7 @@ entities:
       pos: 17.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1111
     components:
     - type: Transform
@@ -77553,7 +77710,7 @@ entities:
       pos: 15.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1112
     components:
     - type: Transform
@@ -77561,7 +77718,7 @@ entities:
       pos: 17.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1113
     components:
     - type: Transform
@@ -77569,7 +77726,7 @@ entities:
       pos: -15.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1119
     components:
     - type: Transform
@@ -77577,7 +77734,7 @@ entities:
       pos: -14.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1120
     components:
     - type: Transform
@@ -77585,7 +77742,7 @@ entities:
       pos: -14.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1123
     components:
     - type: Transform
@@ -77593,7 +77750,7 @@ entities:
       pos: -14.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1124
     components:
     - type: Transform
@@ -77601,7 +77758,7 @@ entities:
       pos: -14.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1125
     components:
     - type: Transform
@@ -77609,14 +77766,14 @@ entities:
       pos: -16.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1126
     components:
     - type: Transform
       pos: -16.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1127
     components:
     - type: Transform
@@ -77624,7 +77781,7 @@ entities:
       pos: -14.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1129
     components:
     - type: Transform
@@ -77632,7 +77789,7 @@ entities:
       pos: -16.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1130
     components:
     - type: Transform
@@ -77640,7 +77797,7 @@ entities:
       pos: -16.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1131
     components:
     - type: Transform
@@ -77648,7 +77805,7 @@ entities:
       pos: -14.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1132
     components:
     - type: Transform
@@ -77656,7 +77813,7 @@ entities:
       pos: -14.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1134
     components:
     - type: Transform
@@ -77664,7 +77821,7 @@ entities:
       pos: -16.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1135
     components:
     - type: Transform
@@ -77672,7 +77829,7 @@ entities:
       pos: -16.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1137
     components:
     - type: Transform
@@ -77680,7 +77837,7 @@ entities:
       pos: -14.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1138
     components:
     - type: Transform
@@ -77688,7 +77845,7 @@ entities:
       pos: -14.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1139
     components:
     - type: Transform
@@ -77696,7 +77853,7 @@ entities:
       pos: -16.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1140
     components:
     - type: Transform
@@ -77704,7 +77861,7 @@ entities:
       pos: -16.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1141
     components:
     - type: Transform
@@ -77712,7 +77869,7 @@ entities:
       pos: -14.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1142
     components:
     - type: Transform
@@ -77720,7 +77877,7 @@ entities:
       pos: -14.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1143
     components:
     - type: Transform
@@ -77728,7 +77885,7 @@ entities:
       pos: -16.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1144
     components:
     - type: Transform
@@ -77736,7 +77893,7 @@ entities:
       pos: -16.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1145
     components:
     - type: Transform
@@ -77744,7 +77901,7 @@ entities:
       pos: -14.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1146
     components:
     - type: Transform
@@ -77752,7 +77909,7 @@ entities:
       pos: -14.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1147
     components:
     - type: Transform
@@ -77760,7 +77917,7 @@ entities:
       pos: -16.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1149
     components:
     - type: Transform
@@ -77768,7 +77925,7 @@ entities:
       pos: -14.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1151
     components:
     - type: Transform
@@ -77776,7 +77933,7 @@ entities:
       pos: -16.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1152
     components:
     - type: Transform
@@ -77784,7 +77941,7 @@ entities:
       pos: -16.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1153
     components:
     - type: Transform
@@ -77792,7 +77949,7 @@ entities:
       pos: -14.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1154
     components:
     - type: Transform
@@ -77800,7 +77957,7 @@ entities:
       pos: -14.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1155
     components:
     - type: Transform
@@ -77808,7 +77965,7 @@ entities:
       pos: -16.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1156
     components:
     - type: Transform
@@ -77816,7 +77973,7 @@ entities:
       pos: -16.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1157
     components:
     - type: Transform
@@ -77824,7 +77981,7 @@ entities:
       pos: -14.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1158
     components:
     - type: Transform
@@ -77832,7 +77989,7 @@ entities:
       pos: -14.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1159
     components:
     - type: Transform
@@ -77840,7 +77997,7 @@ entities:
       pos: -16.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1160
     components:
     - type: Transform
@@ -77848,7 +78005,7 @@ entities:
       pos: -16.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1161
     components:
     - type: Transform
@@ -77856,7 +78013,7 @@ entities:
       pos: -14.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1163
     components:
     - type: Transform
@@ -77864,7 +78021,7 @@ entities:
       pos: -16.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1164
     components:
     - type: Transform
@@ -77872,7 +78029,7 @@ entities:
       pos: -16.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1165
     components:
     - type: Transform
@@ -77880,7 +78037,7 @@ entities:
       pos: -14.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1166
     components:
     - type: Transform
@@ -77888,7 +78045,7 @@ entities:
       pos: -14.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1169
     components:
     - type: Transform
@@ -77896,7 +78053,7 @@ entities:
       pos: -14.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1171
     components:
     - type: Transform
@@ -77904,7 +78061,7 @@ entities:
       pos: -16.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1172
     components:
     - type: Transform
@@ -77912,7 +78069,7 @@ entities:
       pos: -16.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1173
     components:
     - type: Transform
@@ -77920,7 +78077,7 @@ entities:
       pos: -14.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1176
     components:
     - type: Transform
@@ -77928,28 +78085,28 @@ entities:
       pos: -17.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1214
     components:
     - type: Transform
       pos: -14.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1215
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1216
     components:
     - type: Transform
       pos: -14.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1218
     components:
     - type: Transform
@@ -77957,14 +78114,14 @@ entities:
       pos: -13.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1219
     components:
     - type: Transform
       pos: -16.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1220
     components:
     - type: Transform
@@ -77972,7 +78129,7 @@ entities:
       pos: -12.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1221
     components:
     - type: Transform
@@ -77980,7 +78137,7 @@ entities:
       pos: -12.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1222
     components:
     - type: Transform
@@ -77988,7 +78145,7 @@ entities:
       pos: -11.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1223
     components:
     - type: Transform
@@ -77996,7 +78153,7 @@ entities:
       pos: -11.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1224
     components:
     - type: Transform
@@ -78004,7 +78161,7 @@ entities:
       pos: -10.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1227
     components:
     - type: Transform
@@ -78012,7 +78169,7 @@ entities:
       pos: -9.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1228
     components:
     - type: Transform
@@ -78020,7 +78177,7 @@ entities:
       pos: -8.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1231
     components:
     - type: Transform
@@ -78028,7 +78185,7 @@ entities:
       pos: -15.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1260
     components:
     - type: Transform
@@ -78036,7 +78193,7 @@ entities:
       pos: 9.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1261
     components:
     - type: Transform
@@ -78044,7 +78201,7 @@ entities:
       pos: 10.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1263
     components:
     - type: Transform
@@ -78052,7 +78209,7 @@ entities:
       pos: 11.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1264
     components:
     - type: Transform
@@ -78060,7 +78217,7 @@ entities:
       pos: 11.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1266
     components:
     - type: Transform
@@ -78068,7 +78225,7 @@ entities:
       pos: 12.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1267
     components:
     - type: Transform
@@ -78076,7 +78233,7 @@ entities:
       pos: 13.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1268
     components:
     - type: Transform
@@ -78084,7 +78241,7 @@ entities:
       pos: 14.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1270
     components:
     - type: Transform
@@ -78092,7 +78249,7 @@ entities:
       pos: 14.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1271
     components:
     - type: Transform
@@ -78100,7 +78257,7 @@ entities:
       pos: 15.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1272
     components:
     - type: Transform
@@ -78108,7 +78265,7 @@ entities:
       pos: 16.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1274
     components:
     - type: Transform
@@ -78116,7 +78273,7 @@ entities:
       pos: 17.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1279
     components:
     - type: Transform
@@ -78124,14 +78281,14 @@ entities:
       pos: -48.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1281
     components:
     - type: Transform
       pos: -16.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1306
     components:
     - type: Transform
@@ -78139,7 +78296,7 @@ entities:
       pos: -17.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1308
     components:
     - type: Transform
@@ -78147,7 +78304,7 @@ entities:
       pos: -1.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1359
     components:
     - type: Transform
@@ -78162,112 +78319,112 @@ entities:
       pos: 3.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1390
     components:
     - type: Transform
       pos: 3.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1391
     components:
     - type: Transform
       pos: 3.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1395
     components:
     - type: Transform
       pos: 4.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1396
     components:
     - type: Transform
       pos: 4.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1399
     components:
     - type: Transform
       pos: 7.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1400
     components:
     - type: Transform
       pos: 7.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1401
     components:
     - type: Transform
       pos: 7.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1402
     components:
     - type: Transform
       pos: 7.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1403
     components:
     - type: Transform
       pos: 7.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1404
     components:
     - type: Transform
       pos: 7.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1413
     components:
     - type: Transform
       pos: -0.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1414
     components:
     - type: Transform
       pos: -0.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1415
     components:
     - type: Transform
       pos: 1.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1416
     components:
     - type: Transform
       pos: 1.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1418
     components:
     - type: Transform
       pos: 1.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1420
     components:
     - type: Transform
@@ -78275,7 +78432,7 @@ entities:
       pos: -0.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1421
     components:
     - type: Transform
@@ -78283,7 +78440,7 @@ entities:
       pos: -0.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1422
     components:
     - type: Transform
@@ -78291,7 +78448,7 @@ entities:
       pos: -0.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1423
     components:
     - type: Transform
@@ -78299,7 +78456,7 @@ entities:
       pos: -0.5,-34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1424
     components:
     - type: Transform
@@ -78307,7 +78464,7 @@ entities:
       pos: -0.5,-35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1425
     components:
     - type: Transform
@@ -78315,7 +78472,7 @@ entities:
       pos: 1.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1426
     components:
     - type: Transform
@@ -78323,7 +78480,7 @@ entities:
       pos: 1.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1427
     components:
     - type: Transform
@@ -78331,7 +78488,7 @@ entities:
       pos: 1.5,-34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1428
     components:
     - type: Transform
@@ -78339,7 +78496,7 @@ entities:
       pos: 1.5,-35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1497
     components:
     - type: Transform
@@ -78347,14 +78504,14 @@ entities:
       pos: -20.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1500
     components:
     - type: Transform
       pos: -36.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1505
     components:
     - type: Transform
@@ -78362,7 +78519,7 @@ entities:
       pos: -21.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1506
     components:
     - type: Transform
@@ -78370,7 +78527,7 @@ entities:
       pos: -16.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1519
     components:
     - type: Transform
@@ -78378,7 +78535,7 @@ entities:
       pos: -22.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1526
     components:
     - type: Transform
@@ -78386,7 +78543,7 @@ entities:
       pos: -21.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1531
     components:
     - type: Transform
@@ -78394,7 +78551,7 @@ entities:
       pos: -24.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1588
     components:
     - type: Transform
@@ -78402,14 +78559,14 @@ entities:
       pos: -18.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1592
     components:
     - type: Transform
       pos: -28.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1602
     components:
     - type: Transform
@@ -78417,7 +78574,7 @@ entities:
       pos: -16.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1605
     components:
     - type: Transform
@@ -78425,7 +78582,7 @@ entities:
       pos: -25.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1606
     components:
     - type: Transform
@@ -78433,7 +78590,7 @@ entities:
       pos: -27.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1607
     components:
     - type: Transform
@@ -78441,7 +78598,7 @@ entities:
       pos: -26.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1609
     components:
     - type: Transform
@@ -78449,7 +78606,7 @@ entities:
       pos: -23.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1612
     components:
     - type: Transform
@@ -78457,7 +78614,7 @@ entities:
       pos: -26.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1613
     components:
     - type: Transform
@@ -78465,7 +78622,7 @@ entities:
       pos: -27.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1614
     components:
     - type: Transform
@@ -78473,7 +78630,7 @@ entities:
       pos: -28.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1629
     components:
     - type: Transform
@@ -78481,7 +78638,7 @@ entities:
       pos: -16.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1630
     components:
     - type: Transform
@@ -78489,7 +78646,7 @@ entities:
       pos: -16.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1641
     components:
     - type: Transform
@@ -78497,7 +78654,7 @@ entities:
       pos: 4.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1663
     components:
     - type: Transform
@@ -78505,7 +78662,7 @@ entities:
       pos: -32.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1666
     components:
     - type: Transform
@@ -78513,7 +78670,7 @@ entities:
       pos: -31.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1668
     components:
     - type: Transform
@@ -78521,7 +78678,7 @@ entities:
       pos: -32.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1669
     components:
     - type: Transform
@@ -78529,7 +78686,7 @@ entities:
       pos: -9.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1684
     components:
     - type: Transform
@@ -78537,14 +78694,14 @@ entities:
       pos: -18.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1692
     components:
     - type: Transform
       pos: -36.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1694
     components:
     - type: Transform
@@ -78552,7 +78709,7 @@ entities:
       pos: -17.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1702
     components:
     - type: Transform
@@ -78560,7 +78717,7 @@ entities:
       pos: -20.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1705
     components:
     - type: Transform
@@ -78568,7 +78725,7 @@ entities:
       pos: -25.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1712
     components:
     - type: Transform
@@ -78576,7 +78733,7 @@ entities:
       pos: -29.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1713
     components:
     - type: Transform
@@ -78584,7 +78741,7 @@ entities:
       pos: -30.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1718
     components:
     - type: Transform
@@ -78592,7 +78749,7 @@ entities:
       pos: -35.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1721
     components:
     - type: Transform
@@ -78600,21 +78757,21 @@ entities:
       pos: -32.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1724
     components:
     - type: Transform
       pos: -22.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1725
     components:
     - type: Transform
       pos: -22.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1729
     components:
     - type: Transform
@@ -78622,14 +78779,14 @@ entities:
       pos: -32.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1730
     components:
     - type: Transform
       pos: -38.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1732
     components:
     - type: Transform
@@ -78637,7 +78794,7 @@ entities:
       pos: -34.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1734
     components:
     - type: Transform
@@ -78645,7 +78802,7 @@ entities:
       pos: -23.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1747
     components:
     - type: Transform
@@ -78653,7 +78810,7 @@ entities:
       pos: -33.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1748
     components:
     - type: Transform
@@ -78661,7 +78818,7 @@ entities:
       pos: -32.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1752
     components:
     - type: Transform
@@ -78669,14 +78826,14 @@ entities:
       pos: -31.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1753
     components:
     - type: Transform
       pos: -38.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1754
     components:
     - type: Transform
@@ -78684,14 +78841,14 @@ entities:
       pos: -30.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1755
     components:
     - type: Transform
       pos: -38.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1757
     components:
     - type: Transform
@@ -78699,21 +78856,21 @@ entities:
       pos: -20.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1758
     components:
     - type: Transform
       pos: -22.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1765
     components:
     - type: Transform
       pos: -22.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1766
     components:
     - type: Transform
@@ -78721,35 +78878,35 @@ entities:
       pos: -20.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1767
     components:
     - type: Transform
       pos: -22.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1769
     components:
     - type: Transform
       pos: -36.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1770
     components:
     - type: Transform
       pos: -36.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1772
     components:
     - type: Transform
       pos: -36.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1774
     components:
     - type: Transform
@@ -78757,49 +78914,49 @@ entities:
       pos: -25.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1777
     components:
     - type: Transform
       pos: -36.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1778
     components:
     - type: Transform
       pos: -38.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1779
     components:
     - type: Transform
       pos: -36.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1782
     components:
     - type: Transform
       pos: -38.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1783
     components:
     - type: Transform
       pos: -36.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1784
     components:
     - type: Transform
       pos: -36.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1786
     components:
     - type: Transform
@@ -78807,14 +78964,14 @@ entities:
       pos: -18.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1788
     components:
     - type: Transform
       pos: -38.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1790
     components:
     - type: Transform
@@ -78822,7 +78979,7 @@ entities:
       pos: -36.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1791
     components:
     - type: Transform
@@ -78830,7 +78987,7 @@ entities:
       pos: -24.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1793
     components:
     - type: Transform
@@ -78838,7 +78995,7 @@ entities:
       pos: -37.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1794
     components:
     - type: Transform
@@ -78846,7 +79003,7 @@ entities:
       pos: -25.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1796
     components:
     - type: Transform
@@ -78854,7 +79011,7 @@ entities:
       pos: -26.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1797
     components:
     - type: Transform
@@ -78862,7 +79019,7 @@ entities:
       pos: -20.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1798
     components:
     - type: Transform
@@ -78870,7 +79027,7 @@ entities:
       pos: -35.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1799
     components:
     - type: Transform
@@ -78878,7 +79035,7 @@ entities:
       pos: -18.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1800
     components:
     - type: Transform
@@ -78886,7 +79043,7 @@ entities:
       pos: -20.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1804
     components:
     - type: Transform
@@ -78894,14 +79051,14 @@ entities:
       pos: -30.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1805
     components:
     - type: Transform
       pos: -30.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1811
     components:
     - type: Transform
@@ -78909,7 +79066,7 @@ entities:
       pos: -30.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1812
     components:
     - type: Transform
@@ -78917,7 +79074,7 @@ entities:
       pos: -34.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1813
     components:
     - type: Transform
@@ -78925,7 +79082,7 @@ entities:
       pos: -30.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1816
     components:
     - type: Transform
@@ -78933,7 +79090,7 @@ entities:
       pos: -30.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1819
     components:
     - type: Transform
@@ -78941,7 +79098,7 @@ entities:
       pos: -14.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1823
     components:
     - type: Transform
@@ -78949,14 +79106,14 @@ entities:
       pos: -29.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1825
     components:
     - type: Transform
       pos: -38.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1826
     components:
     - type: Transform
@@ -78964,42 +79121,42 @@ entities:
       pos: -30.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1827
     components:
     - type: Transform
       pos: -38.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1828
     components:
     - type: Transform
       pos: -38.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1829
     components:
     - type: Transform
       pos: -36.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1837
     components:
     - type: Transform
       pos: -36.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1838
     components:
     - type: Transform
       pos: -22.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1839
     components:
     - type: Transform
@@ -79007,7 +79164,7 @@ entities:
       pos: -24.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1841
     components:
     - type: Transform
@@ -79015,14 +79172,14 @@ entities:
       pos: -34.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1842
     components:
     - type: Transform
       pos: -38.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1843
     components:
     - type: Transform
@@ -79030,7 +79187,7 @@ entities:
       pos: -30.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1844
     components:
     - type: Transform
@@ -79038,7 +79195,7 @@ entities:
       pos: -19.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1851
     components:
     - type: Transform
@@ -79046,7 +79203,7 @@ entities:
       pos: -21.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1852
     components:
     - type: Transform
@@ -79054,7 +79211,7 @@ entities:
       pos: -22.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1871
     components:
     - type: Transform
@@ -79062,35 +79219,35 @@ entities:
       pos: -27.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1875
     components:
     - type: Transform
       pos: -38.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1876
     components:
     - type: Transform
       pos: -38.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1877
     components:
     - type: Transform
       pos: -38.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1878
     components:
     - type: Transform
       pos: -38.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1879
     components:
     - type: Transform
@@ -79098,14 +79255,14 @@ entities:
       pos: -35.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1880
     components:
     - type: Transform
       pos: -36.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1890
     components:
     - type: Transform
@@ -79113,28 +79270,28 @@ entities:
       pos: -36.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1894
     components:
     - type: Transform
       pos: -24.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1895
     components:
     - type: Transform
       pos: -38.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1896
     components:
     - type: Transform
       pos: -36.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1897
     components:
     - type: Transform
@@ -79142,7 +79299,7 @@ entities:
       pos: -32.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1898
     components:
     - type: Transform
@@ -79150,7 +79307,7 @@ entities:
       pos: -35.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1899
     components:
     - type: Transform
@@ -79158,7 +79315,7 @@ entities:
       pos: -31.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1900
     components:
     - type: Transform
@@ -79166,7 +79323,7 @@ entities:
       pos: -34.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1961
     components:
     - type: Transform
@@ -79174,7 +79331,7 @@ entities:
       pos: -21.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1973
     components:
     - type: Transform
@@ -79182,7 +79339,7 @@ entities:
       pos: -21.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1978
     components:
     - type: Transform
@@ -79190,7 +79347,7 @@ entities:
       pos: -31.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1991
     components:
     - type: Transform
@@ -79198,28 +79355,28 @@ entities:
       pos: -33.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1992
     components:
     - type: Transform
       pos: -38.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1995
     components:
     - type: Transform
       pos: -36.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1997
     components:
     - type: Transform
       pos: -38.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1998
     components:
     - type: Transform
@@ -79227,28 +79384,28 @@ entities:
       pos: -37.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1999
     components:
     - type: Transform
       pos: -36.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2000
     components:
     - type: Transform
       pos: -38.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2001
     components:
     - type: Transform
       pos: -38.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2006
     components:
     - type: Transform
@@ -79256,14 +79413,14 @@ entities:
       pos: -27.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2010
     components:
     - type: Transform
       pos: -24.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2013
     components:
     - type: Transform
@@ -79271,7 +79428,7 @@ entities:
       pos: -23.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2016
     components:
     - type: Transform
@@ -79279,21 +79436,21 @@ entities:
       pos: -36.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2020
     components:
     - type: Transform
       pos: -23.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2021
     components:
     - type: Transform
       pos: -23.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2023
     components:
     - type: Transform
@@ -79301,7 +79458,7 @@ entities:
       pos: -24.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2028
     components:
     - type: Transform
@@ -79309,7 +79466,7 @@ entities:
       pos: -24.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2029
     components:
     - type: Transform
@@ -79317,49 +79474,49 @@ entities:
       pos: -23.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2031
     components:
     - type: Transform
       pos: -23.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2032
     components:
     - type: Transform
       pos: -24.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2033
     components:
     - type: Transform
       pos: -24.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2107
     components:
     - type: Transform
       pos: -36.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2108
     components:
     - type: Transform
       pos: -36.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2109
     components:
     - type: Transform
       pos: -36.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2110
     components:
     - type: Transform
@@ -79367,28 +79524,28 @@ entities:
       pos: -39.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2111
     components:
     - type: Transform
       pos: -38.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2122
     components:
     - type: Transform
       pos: -36.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2123
     components:
     - type: Transform
       pos: -38.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2124
     components:
     - type: Transform
@@ -79396,7 +79553,7 @@ entities:
       pos: -18.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2125
     components:
     - type: Transform
@@ -79404,7 +79561,7 @@ entities:
       pos: -20.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2126
     components:
     - type: Transform
@@ -79412,7 +79569,7 @@ entities:
       pos: -23.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2128
     components:
     - type: Transform
@@ -79420,7 +79577,7 @@ entities:
       pos: -27.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2129
     components:
     - type: Transform
@@ -79428,7 +79585,7 @@ entities:
       pos: -28.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2131
     components:
     - type: Transform
@@ -79436,7 +79593,7 @@ entities:
       pos: -33.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2133
     components:
     - type: Transform
@@ -79444,7 +79601,7 @@ entities:
       pos: -28.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2159
     components:
     - type: Transform
@@ -79452,7 +79609,7 @@ entities:
       pos: 43.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2160
     components:
     - type: Transform
@@ -79460,7 +79617,7 @@ entities:
       pos: -18.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2161
     components:
     - type: Transform
@@ -79468,70 +79625,70 @@ entities:
       pos: -22.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2162
     components:
     - type: Transform
       pos: -18.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2183
     components:
     - type: Transform
       pos: -22.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2194
     components:
     - type: Transform
       pos: 15.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2195
     components:
     - type: Transform
       pos: 15.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2196
     components:
     - type: Transform
       pos: 15.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2197
     components:
     - type: Transform
       pos: 15.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2198
     components:
     - type: Transform
       pos: 15.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2201
     components:
     - type: Transform
       pos: 16.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2202
     components:
     - type: Transform
       pos: 16.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2204
     components:
     - type: Transform
@@ -79539,7 +79696,7 @@ entities:
       pos: 34.5,-35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2206
     components:
     - type: Transform
@@ -79547,7 +79704,7 @@ entities:
       pos: 33.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2209
     components:
     - type: Transform
@@ -79555,7 +79712,7 @@ entities:
       pos: 34.5,-34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2288
     components:
     - type: Transform
@@ -79563,21 +79720,21 @@ entities:
       pos: -4.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2356
     components:
     - type: Transform
       pos: 32.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2357
     components:
     - type: Transform
       pos: 32.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2362
     components:
     - type: Transform
@@ -79585,7 +79742,7 @@ entities:
       pos: 23.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2363
     components:
     - type: Transform
@@ -79593,7 +79750,7 @@ entities:
       pos: 23.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2364
     components:
     - type: Transform
@@ -79609,7 +79766,7 @@ entities:
       pos: 22.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2367
     components:
     - type: Transform
@@ -79617,7 +79774,7 @@ entities:
       pos: 23.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2372
     components:
     - type: Transform
@@ -79625,7 +79782,7 @@ entities:
       pos: 23.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2373
     components:
     - type: Transform
@@ -79633,7 +79790,7 @@ entities:
       pos: 25.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2460
     components:
     - type: Transform
@@ -79641,7 +79798,7 @@ entities:
       pos: 16.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2461
     components:
     - type: Transform
@@ -79649,7 +79806,7 @@ entities:
       pos: 17.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2462
     components:
     - type: Transform
@@ -79657,7 +79814,7 @@ entities:
       pos: 18.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2463
     components:
     - type: Transform
@@ -79665,7 +79822,7 @@ entities:
       pos: 19.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2464
     components:
     - type: Transform
@@ -79673,7 +79830,7 @@ entities:
       pos: 20.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2465
     components:
     - type: Transform
@@ -79681,7 +79838,7 @@ entities:
       pos: 18.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2466
     components:
     - type: Transform
@@ -79689,7 +79846,7 @@ entities:
       pos: 19.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2467
     components:
     - type: Transform
@@ -79697,7 +79854,7 @@ entities:
       pos: 20.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2468
     components:
     - type: Transform
@@ -79705,7 +79862,7 @@ entities:
       pos: 21.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2469
     components:
     - type: Transform
@@ -79713,7 +79870,7 @@ entities:
       pos: 22.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2471
     components:
     - type: Transform
@@ -79721,7 +79878,7 @@ entities:
       pos: 24.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2472
     components:
     - type: Transform
@@ -79729,7 +79886,7 @@ entities:
       pos: 25.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2474
     components:
     - type: Transform
@@ -79737,7 +79894,7 @@ entities:
       pos: 22.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2475
     components:
     - type: Transform
@@ -79745,7 +79902,7 @@ entities:
       pos: 23.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2476
     components:
     - type: Transform
@@ -79753,7 +79910,7 @@ entities:
       pos: 24.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2477
     components:
     - type: Transform
@@ -79761,7 +79918,7 @@ entities:
       pos: 25.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2478
     components:
     - type: Transform
@@ -79769,7 +79926,7 @@ entities:
       pos: 26.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2479
     components:
     - type: Transform
@@ -79777,7 +79934,7 @@ entities:
       pos: 27.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2480
     components:
     - type: Transform
@@ -79785,7 +79942,7 @@ entities:
       pos: 28.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2483
     components:
     - type: Transform
@@ -79793,7 +79950,7 @@ entities:
       pos: 31.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2484
     components:
     - type: Transform
@@ -79801,7 +79958,7 @@ entities:
       pos: 32.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2485
     components:
     - type: Transform
@@ -79809,7 +79966,7 @@ entities:
       pos: 33.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2487
     components:
     - type: Transform
@@ -79817,7 +79974,7 @@ entities:
       pos: 35.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2488
     components:
     - type: Transform
@@ -79825,7 +79982,7 @@ entities:
       pos: 36.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2489
     components:
     - type: Transform
@@ -79833,7 +79990,7 @@ entities:
       pos: 37.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2490
     components:
     - type: Transform
@@ -79841,7 +79998,7 @@ entities:
       pos: 38.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2492
     components:
     - type: Transform
@@ -79849,7 +80006,7 @@ entities:
       pos: 26.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2493
     components:
     - type: Transform
@@ -79857,7 +80014,7 @@ entities:
       pos: 27.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2494
     components:
     - type: Transform
@@ -79865,7 +80022,7 @@ entities:
       pos: 28.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2495
     components:
     - type: Transform
@@ -79873,7 +80030,7 @@ entities:
       pos: 29.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2496
     components:
     - type: Transform
@@ -79881,7 +80038,7 @@ entities:
       pos: 30.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2497
     components:
     - type: Transform
@@ -79889,7 +80046,7 @@ entities:
       pos: 31.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2500
     components:
     - type: Transform
@@ -79897,7 +80054,7 @@ entities:
       pos: 34.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2501
     components:
     - type: Transform
@@ -79905,7 +80062,7 @@ entities:
       pos: 35.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2502
     components:
     - type: Transform
@@ -79913,7 +80070,7 @@ entities:
       pos: 36.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2503
     components:
     - type: Transform
@@ -79921,7 +80078,7 @@ entities:
       pos: 37.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2504
     components:
     - type: Transform
@@ -79929,7 +80086,7 @@ entities:
       pos: 38.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2505
     components:
     - type: Transform
@@ -79937,7 +80094,7 @@ entities:
       pos: 39.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2545
     components:
     - type: Transform
@@ -79945,7 +80102,7 @@ entities:
       pos: 32.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2546
     components:
     - type: Transform
@@ -79953,7 +80110,7 @@ entities:
       pos: 30.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2547
     components:
     - type: Transform
@@ -79961,7 +80118,7 @@ entities:
       pos: 32.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2548
     components:
     - type: Transform
@@ -79969,7 +80126,7 @@ entities:
       pos: 30.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2549
     components:
     - type: Transform
@@ -79977,7 +80134,7 @@ entities:
       pos: 32.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2550
     components:
     - type: Transform
@@ -79985,7 +80142,7 @@ entities:
       pos: 30.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2554
     components:
     - type: Transform
@@ -79993,7 +80150,7 @@ entities:
       pos: 32.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2613
     components:
     - type: Transform
@@ -80001,7 +80158,7 @@ entities:
       pos: 29.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2638
     components:
     - type: Transform
@@ -80009,14 +80166,14 @@ entities:
       pos: 33.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2639
     components:
     - type: Transform
       pos: 30.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2669
     components:
     - type: Transform
@@ -80024,7 +80181,7 @@ entities:
       pos: 19.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2670
     components:
     - type: Transform
@@ -80032,7 +80189,7 @@ entities:
       pos: 20.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2692
     components:
     - type: Transform
@@ -80040,49 +80197,49 @@ entities:
       pos: 18.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2695
     components:
     - type: Transform
       pos: 40.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2696
     components:
     - type: Transform
       pos: 40.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2697
     components:
     - type: Transform
       pos: 40.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2698
     components:
     - type: Transform
       pos: 39.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2699
     components:
     - type: Transform
       pos: 39.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2700
     components:
     - type: Transform
       pos: 39.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2701
     components:
     - type: Transform
@@ -80090,7 +80247,7 @@ entities:
       pos: 40.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2702
     components:
     - type: Transform
@@ -80098,7 +80255,7 @@ entities:
       pos: 41.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2703
     components:
     - type: Transform
@@ -80106,14 +80263,14 @@ entities:
       pos: 41.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2707
     components:
     - type: Transform
       pos: 40.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2783
     components:
     - type: Transform
@@ -80121,7 +80278,7 @@ entities:
       pos: 19.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2786
     components:
     - type: Transform
@@ -80129,7 +80286,7 @@ entities:
       pos: 29.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2787
     components:
     - type: Transform
@@ -80137,14 +80294,14 @@ entities:
       pos: 19.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2788
     components:
     - type: Transform
       pos: 17.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2794
     components:
     - type: Transform
@@ -80152,7 +80309,7 @@ entities:
       pos: 25.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2796
     components:
     - type: Transform
@@ -80160,7 +80317,7 @@ entities:
       pos: 24.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2797
     components:
     - type: Transform
@@ -80168,7 +80325,7 @@ entities:
       pos: 26.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2798
     components:
     - type: Transform
@@ -80176,7 +80333,7 @@ entities:
       pos: 31.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2800
     components:
     - type: Transform
@@ -80184,7 +80341,7 @@ entities:
       pos: 28.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2801
     components:
     - type: Transform
@@ -80192,7 +80349,7 @@ entities:
       pos: 27.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2803
     components:
     - type: Transform
@@ -80200,7 +80357,7 @@ entities:
       pos: 25.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2804
     components:
     - type: Transform
@@ -80208,7 +80365,7 @@ entities:
       pos: 33.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2805
     components:
     - type: Transform
@@ -80216,14 +80373,14 @@ entities:
       pos: 19.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2808
     components:
     - type: Transform
       pos: -22.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2810
     components:
     - type: Transform
@@ -80231,7 +80388,7 @@ entities:
       pos: 21.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2811
     components:
     - type: Transform
@@ -80239,7 +80396,7 @@ entities:
       pos: 20.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2814
     components:
     - type: Transform
@@ -80247,7 +80404,7 @@ entities:
       pos: 21.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2815
     components:
     - type: Transform
@@ -80255,7 +80412,7 @@ entities:
       pos: 26.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2816
     components:
     - type: Transform
@@ -80263,14 +80420,14 @@ entities:
       pos: 19.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2820
     components:
     - type: Transform
       pos: 17.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2842
     components:
     - type: Transform
@@ -80278,7 +80435,7 @@ entities:
       pos: 28.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2843
     components:
     - type: Transform
@@ -80286,14 +80443,14 @@ entities:
       pos: 30.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2844
     components:
     - type: Transform
       pos: 17.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2849
     components:
     - type: Transform
@@ -80301,14 +80458,14 @@ entities:
       pos: 16.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2860
     components:
     - type: Transform
       pos: -22.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2862
     components:
     - type: Transform
@@ -80316,7 +80473,7 @@ entities:
       pos: 42.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2863
     components:
     - type: Transform
@@ -80324,7 +80481,7 @@ entities:
       pos: 43.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2864
     components:
     - type: Transform
@@ -80332,7 +80489,7 @@ entities:
       pos: 44.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2867
     components:
     - type: Transform
@@ -80340,7 +80497,7 @@ entities:
       pos: 42.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2868
     components:
     - type: Transform
@@ -80348,14 +80505,14 @@ entities:
       pos: 43.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2885
     components:
     - type: Transform
       pos: 45.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2899
     components:
     - type: Transform
@@ -80363,14 +80520,14 @@ entities:
       pos: 32.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2901
     components:
     - type: Transform
       pos: 44.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2940
     components:
     - type: Transform
@@ -80378,7 +80535,7 @@ entities:
       pos: -23.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2980
     components:
     - type: Transform
@@ -80402,7 +80559,7 @@ entities:
       pos: 46.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2987
     components:
     - type: Transform
@@ -80410,7 +80567,7 @@ entities:
       pos: 45.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2988
     components:
     - type: Transform
@@ -80418,14 +80575,14 @@ entities:
       pos: 45.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2990
     components:
     - type: Transform
       pos: 45.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2991
     components:
     - type: Transform
@@ -80433,7 +80590,7 @@ entities:
       pos: 45.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2992
     components:
     - type: Transform
@@ -80441,7 +80598,7 @@ entities:
       pos: 45.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2993
     components:
     - type: Transform
@@ -80449,7 +80606,7 @@ entities:
       pos: 45.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2994
     components:
     - type: Transform
@@ -80457,7 +80614,7 @@ entities:
       pos: 45.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2995
     components:
     - type: Transform
@@ -80465,7 +80622,7 @@ entities:
       pos: 45.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2997
     components:
     - type: Transform
@@ -80497,7 +80654,7 @@ entities:
       pos: 22.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3011
     components:
     - type: Transform
@@ -80545,7 +80702,7 @@ entities:
       pos: -21.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3072
     components:
     - type: Transform
@@ -80553,7 +80710,7 @@ entities:
       pos: -20.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3113
     components:
     - type: Transform
@@ -80561,7 +80718,7 @@ entities:
       pos: 46.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3148
     components:
     - type: Transform
@@ -80569,7 +80726,7 @@ entities:
       pos: 45.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3168
     components:
     - type: Transform
@@ -80577,7 +80734,7 @@ entities:
       pos: -28.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3186
     components:
     - type: Transform
@@ -80585,7 +80742,7 @@ entities:
       pos: -29.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3190
     components:
     - type: Transform
@@ -80593,7 +80750,7 @@ entities:
       pos: 43.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3191
     components:
     - type: Transform
@@ -80601,14 +80758,14 @@ entities:
       pos: 44.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3193
     components:
     - type: Transform
       pos: 45.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3197
     components:
     - type: Transform
@@ -80616,7 +80773,7 @@ entities:
       pos: -40.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3216
     components:
     - type: Transform
@@ -80624,7 +80781,7 @@ entities:
       pos: 45.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3219
     components:
     - type: Transform
@@ -80632,140 +80789,140 @@ entities:
       pos: 42.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3561
     components:
     - type: Transform
       pos: 45.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3562
     components:
     - type: Transform
       pos: 45.5,-34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3563
     components:
     - type: Transform
       pos: 45.5,-35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3564
     components:
     - type: Transform
       pos: 45.5,-37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3565
     components:
     - type: Transform
       pos: 45.5,-36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3566
     components:
     - type: Transform
       pos: 45.5,-38.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3568
     components:
     - type: Transform
       pos: 44.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3569
     components:
     - type: Transform
       pos: 44.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3570
     components:
     - type: Transform
       pos: 44.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3571
     components:
     - type: Transform
       pos: 44.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3572
     components:
     - type: Transform
       pos: 44.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3574
     components:
     - type: Transform
       pos: 44.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3575
     components:
     - type: Transform
       pos: 44.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3576
     components:
     - type: Transform
       pos: 44.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3577
     components:
     - type: Transform
       pos: 44.5,-34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3578
     components:
     - type: Transform
       pos: 44.5,-35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3579
     components:
     - type: Transform
       pos: 44.5,-36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3580
     components:
     - type: Transform
       pos: 44.5,-37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3581
     components:
     - type: Transform
       pos: 44.5,-38.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3618
     components:
     - type: Transform
@@ -80773,7 +80930,7 @@ entities:
       pos: -6.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3619
     components:
     - type: Transform
@@ -80781,7 +80938,7 @@ entities:
       pos: -3.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3620
     components:
     - type: Transform
@@ -80789,7 +80946,7 @@ entities:
       pos: -4.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3711
     components:
     - type: Transform
@@ -80797,105 +80954,105 @@ entities:
       pos: 44.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3914
     components:
     - type: Transform
       pos: 1.5,-36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3916
     components:
     - type: Transform
       pos: 1.5,-38.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3917
     components:
     - type: Transform
       pos: 1.5,-39.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3919
     components:
     - type: Transform
       pos: 1.5,-41.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3921
     components:
     - type: Transform
       pos: 1.5,-43.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3922
     components:
     - type: Transform
       pos: 1.5,-44.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3923
     components:
     - type: Transform
       pos: 1.5,-45.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3925
     components:
     - type: Transform
       pos: -0.5,-44.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3926
     components:
     - type: Transform
       pos: -0.5,-43.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3927
     components:
     - type: Transform
       pos: -0.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3928
     components:
     - type: Transform
       pos: -0.5,-41.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3931
     components:
     - type: Transform
       pos: -0.5,-38.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3932
     components:
     - type: Transform
       pos: -0.5,-37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3933
     components:
     - type: Transform
       pos: -0.5,-36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3934
     components:
     - type: Transform
@@ -80903,7 +81060,7 @@ entities:
       pos: 0.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3935
     components:
     - type: Transform
@@ -80911,7 +81068,7 @@ entities:
       pos: -0.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3936
     components:
     - type: Transform
@@ -80919,7 +81076,7 @@ entities:
       pos: -1.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3937
     components:
     - type: Transform
@@ -80927,7 +81084,7 @@ entities:
       pos: -2.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3938
     components:
     - type: Transform
@@ -80935,7 +81092,7 @@ entities:
       pos: -3.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3939
     components:
     - type: Transform
@@ -80943,7 +81100,7 @@ entities:
       pos: -2.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3940
     components:
     - type: Transform
@@ -80951,7 +81108,7 @@ entities:
       pos: -3.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3941
     components:
     - type: Transform
@@ -80959,7 +81116,7 @@ entities:
       pos: -1.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3942
     components:
     - type: Transform
@@ -80967,7 +81124,7 @@ entities:
       pos: -4.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3943
     components:
     - type: Transform
@@ -80975,7 +81132,7 @@ entities:
       pos: -4.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3944
     components:
     - type: Transform
@@ -80983,7 +81140,7 @@ entities:
       pos: -5.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3945
     components:
     - type: Transform
@@ -80991,7 +81148,7 @@ entities:
       pos: -5.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3946
     components:
     - type: Transform
@@ -80999,7 +81156,7 @@ entities:
       pos: -6.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3947
     components:
     - type: Transform
@@ -81007,7 +81164,7 @@ entities:
       pos: -6.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3948
     components:
     - type: Transform
@@ -81015,7 +81172,7 @@ entities:
       pos: -7.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3951
     components:
     - type: Transform
@@ -81023,7 +81180,7 @@ entities:
       pos: -8.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3952
     components:
     - type: Transform
@@ -81031,7 +81188,7 @@ entities:
       pos: -9.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3953
     components:
     - type: Transform
@@ -81039,7 +81196,7 @@ entities:
       pos: -9.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3954
     components:
     - type: Transform
@@ -81047,7 +81204,7 @@ entities:
       pos: -10.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3955
     components:
     - type: Transform
@@ -81055,7 +81212,7 @@ entities:
       pos: -10.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3956
     components:
     - type: Transform
@@ -81063,7 +81220,7 @@ entities:
       pos: -11.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3957
     components:
     - type: Transform
@@ -81071,7 +81228,7 @@ entities:
       pos: -11.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3958
     components:
     - type: Transform
@@ -81079,7 +81236,7 @@ entities:
       pos: -12.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3959
     components:
     - type: Transform
@@ -81087,28 +81244,28 @@ entities:
       pos: -12.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3983
     components:
     - type: Transform
       pos: -0.5,-46.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3997
     components:
     - type: Transform
       pos: -42.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4001
     components:
     - type: Transform
       pos: 48.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4006
     components:
     - type: Transform
@@ -81116,7 +81273,7 @@ entities:
       pos: 14.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4008
     components:
     - type: Transform
@@ -81124,7 +81281,7 @@ entities:
       pos: -5.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4014
     components:
     - type: Transform
@@ -81132,7 +81289,7 @@ entities:
       pos: -43.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4023
     components:
     - type: Transform
@@ -81140,7 +81297,7 @@ entities:
       pos: -34.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4024
     components:
     - type: Transform
@@ -81148,7 +81305,7 @@ entities:
       pos: -35.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4025
     components:
     - type: Transform
@@ -81156,7 +81313,7 @@ entities:
       pos: -31.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4026
     components:
     - type: Transform
@@ -81164,7 +81321,7 @@ entities:
       pos: -32.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4027
     components:
     - type: Transform
@@ -81172,7 +81329,7 @@ entities:
       pos: -33.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4028
     components:
     - type: Transform
@@ -81180,7 +81337,7 @@ entities:
       pos: -34.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4029
     components:
     - type: Transform
@@ -81188,7 +81345,7 @@ entities:
       pos: -35.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4030
     components:
     - type: Transform
@@ -81196,7 +81353,7 @@ entities:
       pos: -36.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4032
     components:
     - type: Transform
@@ -81204,7 +81361,7 @@ entities:
       pos: -37.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4077
     components:
     - type: Transform
@@ -81212,7 +81369,7 @@ entities:
       pos: -42.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4107
     components:
     - type: Transform
@@ -81220,14 +81377,14 @@ entities:
       pos: 35.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4112
     components:
     - type: Transform
       pos: 33.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4122
     components:
     - type: Transform
@@ -81235,7 +81392,7 @@ entities:
       pos: 30.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4126
     components:
     - type: Transform
@@ -81243,7 +81400,7 @@ entities:
       pos: 31.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4130
     components:
     - type: Transform
@@ -81251,7 +81408,7 @@ entities:
       pos: 34.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4132
     components:
     - type: Transform
@@ -81259,7 +81416,7 @@ entities:
       pos: 34.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4134
     components:
     - type: Transform
@@ -81267,7 +81424,7 @@ entities:
       pos: 34.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4137
     components:
     - type: Transform
@@ -81281,14 +81438,14 @@ entities:
       pos: 34.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4151
     components:
     - type: Transform
       pos: 33.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4155
     components:
     - type: Transform
@@ -81296,7 +81453,7 @@ entities:
       pos: 43.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4183
     components:
     - type: Transform
@@ -81304,7 +81461,7 @@ entities:
       pos: 33.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4184
     components:
     - type: Transform
@@ -81312,7 +81469,7 @@ entities:
       pos: 31.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4185
     components:
     - type: Transform
@@ -81320,7 +81477,7 @@ entities:
       pos: 30.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4186
     components:
     - type: Transform
@@ -81328,7 +81485,7 @@ entities:
       pos: 33.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4206
     components:
     - type: Transform
@@ -81336,7 +81493,7 @@ entities:
       pos: -44.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4207
     components:
     - type: Transform
@@ -81344,7 +81501,7 @@ entities:
       pos: -46.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4208
     components:
     - type: Transform
@@ -81352,7 +81509,7 @@ entities:
       pos: -41.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4325
     components:
     - type: Transform
@@ -81360,7 +81517,7 @@ entities:
       pos: 36.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4335
     components:
     - type: Transform
@@ -81368,7 +81525,7 @@ entities:
       pos: 34.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4356
     components:
     - type: Transform
@@ -81376,7 +81533,7 @@ entities:
       pos: 35.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4484
     components:
     - type: Transform
@@ -81384,7 +81541,7 @@ entities:
       pos: 40.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4485
     components:
     - type: Transform
@@ -81392,14 +81549,14 @@ entities:
       pos: 37.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4486
     components:
     - type: Transform
       pos: 44.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4488
     components:
     - type: Transform
@@ -81407,7 +81564,7 @@ entities:
       pos: 46.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4489
     components:
     - type: Transform
@@ -81415,7 +81572,7 @@ entities:
       pos: 47.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4490
     components:
     - type: Transform
@@ -81423,7 +81580,7 @@ entities:
       pos: 36.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4497
     components:
     - type: Transform
@@ -81431,7 +81588,7 @@ entities:
       pos: 48.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4507
     components:
     - type: Transform
@@ -81439,21 +81596,21 @@ entities:
       pos: 46.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4550
     components:
     - type: Transform
       pos: -36.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4629
     components:
     - type: Transform
       pos: -0.5,-60.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4645
     components:
     - type: Transform
@@ -81461,42 +81618,42 @@ entities:
       pos: 40.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4648
     components:
     - type: Transform
       pos: -0.5,-59.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4649
     components:
     - type: Transform
       pos: -0.5,-58.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4650
     components:
     - type: Transform
       pos: -0.5,-57.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4657
     components:
     - type: Transform
       pos: 1.5,-56.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4658
     components:
     - type: Transform
       pos: 1.5,-57.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4666
     components:
     - type: Transform
@@ -81504,21 +81661,21 @@ entities:
       pos: 38.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4725
     components:
     - type: Transform
       pos: 1.5,-54.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4726
     components:
     - type: Transform
       pos: 1.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4836
     components:
     - type: Transform
@@ -81526,7 +81683,7 @@ entities:
       pos: 1.5,-47.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4837
     components:
     - type: Transform
@@ -81534,7 +81691,7 @@ entities:
       pos: -0.5,-48.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4838
     components:
     - type: Transform
@@ -81542,7 +81699,7 @@ entities:
       pos: -0.5,-49.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4839
     components:
     - type: Transform
@@ -81550,7 +81707,7 @@ entities:
       pos: 1.5,-49.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4840
     components:
     - type: Transform
@@ -81558,7 +81715,7 @@ entities:
       pos: 1.5,-50.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4841
     components:
     - type: Transform
@@ -81566,7 +81723,7 @@ entities:
       pos: -0.5,-50.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4842
     components:
     - type: Transform
@@ -81574,7 +81731,7 @@ entities:
       pos: -0.5,-51.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4843
     components:
     - type: Transform
@@ -81582,7 +81739,7 @@ entities:
       pos: 1.5,-51.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4844
     components:
     - type: Transform
@@ -81590,7 +81747,7 @@ entities:
       pos: -0.5,-52.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4845
     components:
     - type: Transform
@@ -81598,14 +81755,14 @@ entities:
       pos: 1.5,-52.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4908
     components:
     - type: Transform
       pos: 1.5,-60.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4909
     components:
     - type: Transform
@@ -81613,7 +81770,7 @@ entities:
       pos: -2.5,-65.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4916
     components:
     - type: Transform
@@ -81621,7 +81778,7 @@ entities:
       pos: 2.5,-70.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4917
     components:
     - type: Transform
@@ -81629,7 +81786,7 @@ entities:
       pos: 3.5,-64.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4918
     components:
     - type: Transform
@@ -81637,7 +81794,7 @@ entities:
       pos: 2.5,-63.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4919
     components:
     - type: Transform
@@ -81645,7 +81802,7 @@ entities:
       pos: 3.5,-69.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4920
     components:
     - type: Transform
@@ -81653,7 +81810,7 @@ entities:
       pos: 3.5,-68.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4921
     components:
     - type: Transform
@@ -81661,7 +81818,7 @@ entities:
       pos: -2.5,-67.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4927
     components:
     - type: Transform
@@ -81669,14 +81826,14 @@ entities:
       pos: -3.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4928
     components:
     - type: Transform
       pos: -0.5,-62.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4930
     components:
     - type: Transform
@@ -81684,7 +81841,7 @@ entities:
       pos: -4.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4931
     components:
     - type: Transform
@@ -81692,7 +81849,7 @@ entities:
       pos: 1.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4932
     components:
     - type: Transform
@@ -81700,7 +81857,7 @@ entities:
       pos: -5.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4933
     components:
     - type: Transform
@@ -81708,14 +81865,14 @@ entities:
       pos: -2.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4934
     components:
     - type: Transform
       pos: 1.5,-62.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4967
     components:
     - type: Transform
@@ -81723,7 +81880,7 @@ entities:
       pos: -6.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4968
     components:
     - type: Transform
@@ -81731,7 +81888,7 @@ entities:
       pos: -7.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4969
     components:
     - type: Transform
@@ -81739,7 +81896,7 @@ entities:
       pos: -7.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4970
     components:
     - type: Transform
@@ -81747,7 +81904,7 @@ entities:
       pos: -8.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4972
     components:
     - type: Transform
@@ -81755,7 +81912,7 @@ entities:
       pos: -2.5,-68.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4974
     components:
     - type: Transform
@@ -81763,7 +81920,7 @@ entities:
       pos: 2.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4975
     components:
     - type: Transform
@@ -81771,14 +81928,14 @@ entities:
       pos: -8.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4981
     components:
     - type: Transform
       pos: 1.5,-58.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4982
     components:
     - type: Transform
@@ -81786,7 +81943,7 @@ entities:
       pos: -2.5,-66.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4983
     components:
     - type: Transform
@@ -81794,7 +81951,7 @@ entities:
       pos: -2.5,-69.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4984
     components:
     - type: Transform
@@ -81802,14 +81959,14 @@ entities:
       pos: -1.5,-70.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4986
     components:
     - type: Transform
       pos: 1.5,-59.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4988
     components:
     - type: Transform
@@ -81817,7 +81974,7 @@ entities:
       pos: -1.5,-63.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4989
     components:
     - type: Transform
@@ -81825,14 +81982,14 @@ entities:
       pos: -2.5,-64.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4991
     components:
     - type: Transform
       pos: 1.5,-71.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4994
     components:
     - type: Transform
@@ -81840,7 +81997,7 @@ entities:
       pos: 3.5,-67.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4995
     components:
     - type: Transform
@@ -81848,14 +82005,14 @@ entities:
       pos: 3.5,-66.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4998
     components:
     - type: Transform
       pos: -0.5,-71.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5000
     components:
     - type: Transform
@@ -81863,7 +82020,7 @@ entities:
       pos: 2.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5012
     components:
     - type: Transform
@@ -81871,7 +82028,7 @@ entities:
       pos: 3.5,-65.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5055
     components:
     - type: Transform
@@ -81879,7 +82036,7 @@ entities:
       pos: 37.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5098
     components:
     - type: Transform
@@ -81887,21 +82044,21 @@ entities:
       pos: 6.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5115
     components:
     - type: Transform
       pos: 1.5,-73.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5117
     components:
     - type: Transform
       pos: 1.5,-74.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5118
     components:
     - type: Transform
@@ -81909,7 +82066,7 @@ entities:
       pos: 4.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5142
     components:
     - type: Transform
@@ -81917,7 +82074,7 @@ entities:
       pos: 3.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5147
     components:
     - type: Transform
@@ -81925,7 +82082,7 @@ entities:
       pos: -9.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5148
     components:
     - type: Transform
@@ -81933,14 +82090,14 @@ entities:
       pos: 4.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5215
     components:
     - type: Transform
       pos: -0.5,-73.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5246
     components:
     - type: Transform
@@ -81948,7 +82105,7 @@ entities:
       pos: -21.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5299
     components:
     - type: Transform
@@ -81956,35 +82113,35 @@ entities:
       pos: -36.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5392
     components:
     - type: Transform
       pos: 13.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5393
     components:
     - type: Transform
       pos: 13.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5394
     components:
     - type: Transform
       pos: 13.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5396
     components:
     - type: Transform
       pos: 9.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5425
     components:
     - type: Transform
@@ -81992,7 +82149,7 @@ entities:
       pos: -20.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5426
     components:
     - type: Transform
@@ -82000,7 +82157,7 @@ entities:
       pos: -14.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5427
     components:
     - type: Transform
@@ -82008,7 +82165,7 @@ entities:
       pos: -15.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5441
     components:
     - type: Transform
@@ -82016,7 +82173,7 @@ entities:
       pos: 41.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5443
     components:
     - type: Transform
@@ -82024,7 +82181,7 @@ entities:
       pos: 42.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5444
     components:
     - type: Transform
@@ -82032,7 +82189,7 @@ entities:
       pos: 38.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5447
     components:
     - type: Transform
@@ -82040,7 +82197,7 @@ entities:
       pos: 31.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5448
     components:
     - type: Transform
@@ -82048,7 +82205,7 @@ entities:
       pos: 32.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5449
     components:
     - type: Transform
@@ -82056,14 +82213,14 @@ entities:
       pos: 31.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5450
     components:
     - type: Transform
       pos: 44.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5451
     components:
     - type: Transform
@@ -82071,7 +82228,7 @@ entities:
       pos: 30.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5452
     components:
     - type: Transform
@@ -82079,7 +82236,7 @@ entities:
       pos: 30.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5463
     components:
     - type: Transform
@@ -82087,7 +82244,7 @@ entities:
       pos: 38.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5464
     components:
     - type: Transform
@@ -82095,7 +82252,7 @@ entities:
       pos: 44.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5465
     components:
     - type: Transform
@@ -82103,7 +82260,7 @@ entities:
       pos: -22.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5467
     components:
     - type: Transform
@@ -82111,7 +82268,7 @@ entities:
       pos: 44.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5468
     components:
     - type: Transform
@@ -82119,21 +82276,21 @@ entities:
       pos: 41.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5469
     components:
     - type: Transform
       pos: -38.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5470
     components:
     - type: Transform
       pos: -38.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5471
     components:
     - type: Transform
@@ -82141,7 +82298,7 @@ entities:
       pos: -17.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5475
     components:
     - type: Transform
@@ -82149,7 +82306,7 @@ entities:
       pos: -16.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5487
     components:
     - type: Transform
@@ -82157,7 +82314,7 @@ entities:
       pos: 42.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5511
     components:
     - type: Transform
@@ -82165,7 +82322,7 @@ entities:
       pos: -13.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5517
     components:
     - type: Transform
@@ -82173,7 +82330,7 @@ entities:
       pos: 43.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5549
     components:
     - type: Transform
@@ -82189,7 +82346,7 @@ entities:
       pos: 45.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5558
     components:
     - type: Transform
@@ -82197,14 +82354,14 @@ entities:
       pos: 44.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5563
     components:
     - type: Transform
       pos: -16.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5565
     components:
     - type: Transform
@@ -82212,7 +82369,7 @@ entities:
       pos: -21.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5569
     components:
     - type: Transform
@@ -82220,7 +82377,7 @@ entities:
       pos: -44.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5570
     components:
     - type: Transform
@@ -82228,7 +82385,7 @@ entities:
       pos: -42.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5571
     components:
     - type: Transform
@@ -82236,7 +82393,7 @@ entities:
       pos: -42.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5572
     components:
     - type: Transform
@@ -82244,7 +82401,7 @@ entities:
       pos: -44.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5573
     components:
     - type: Transform
@@ -82252,7 +82409,7 @@ entities:
       pos: -44.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5574
     components:
     - type: Transform
@@ -82260,7 +82417,7 @@ entities:
       pos: -44.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5575
     components:
     - type: Transform
@@ -82268,7 +82425,7 @@ entities:
       pos: -42.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5576
     components:
     - type: Transform
@@ -82298,7 +82455,7 @@ entities:
       pos: 41.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5596
     components:
     - type: Transform
@@ -82306,7 +82463,7 @@ entities:
       pos: 45.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5648
     components:
     - type: Transform
@@ -82329,7 +82486,7 @@ entities:
       pos: -22.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5682
     components:
     - type: Transform
@@ -82337,7 +82494,7 @@ entities:
       pos: -31.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5685
     components:
     - type: Transform
@@ -82345,7 +82502,7 @@ entities:
       pos: 33.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5689
     components:
     - type: Transform
@@ -82353,7 +82510,7 @@ entities:
       pos: -27.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5694
     components:
     - type: Transform
@@ -82361,7 +82518,7 @@ entities:
       pos: 8.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5697
     components:
     - type: Transform
@@ -82369,7 +82526,7 @@ entities:
       pos: 6.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5698
     components:
     - type: Transform
@@ -82377,7 +82534,7 @@ entities:
       pos: 7.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5704
     components:
     - type: Transform
@@ -82385,7 +82542,7 @@ entities:
       pos: -7.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5705
     components:
     - type: Transform
@@ -82393,7 +82550,7 @@ entities:
       pos: -6.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5707
     components:
     - type: Transform
@@ -82401,7 +82558,7 @@ entities:
       pos: -6.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5708
     components:
     - type: Transform
@@ -82409,7 +82566,7 @@ entities:
       pos: -5.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5713
     components:
     - type: Transform
@@ -82417,7 +82574,7 @@ entities:
       pos: -3.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5714
     components:
     - type: Transform
@@ -82425,7 +82582,7 @@ entities:
       pos: -2.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5715
     components:
     - type: Transform
@@ -82433,7 +82590,7 @@ entities:
       pos: -1.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5716
     components:
     - type: Transform
@@ -82441,7 +82598,7 @@ entities:
       pos: 1.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5717
     components:
     - type: Transform
@@ -82449,7 +82606,7 @@ entities:
       pos: 3.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5718
     components:
     - type: Transform
@@ -82457,7 +82614,7 @@ entities:
       pos: 4.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5719
     components:
     - type: Transform
@@ -82465,7 +82622,7 @@ entities:
       pos: 2.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5720
     components:
     - type: Transform
@@ -82473,7 +82630,7 @@ entities:
       pos: -0.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5721
     components:
     - type: Transform
@@ -82481,7 +82638,7 @@ entities:
       pos: -4.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5722
     components:
     - type: Transform
@@ -82489,7 +82646,7 @@ entities:
       pos: -3.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5723
     components:
     - type: Transform
@@ -82497,7 +82654,7 @@ entities:
       pos: -2.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5724
     components:
     - type: Transform
@@ -82505,7 +82662,7 @@ entities:
       pos: -1.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5726
     components:
     - type: Transform
@@ -82513,7 +82670,7 @@ entities:
       pos: 5.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5727
     components:
     - type: Transform
@@ -82521,7 +82678,7 @@ entities:
       pos: 4.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5728
     components:
     - type: Transform
@@ -82529,7 +82686,7 @@ entities:
       pos: 3.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5729
     components:
     - type: Transform
@@ -82537,7 +82694,7 @@ entities:
       pos: 2.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5731
     components:
     - type: Transform
@@ -82545,7 +82702,7 @@ entities:
       pos: 0.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5732
     components:
     - type: Transform
@@ -82553,28 +82710,28 @@ entities:
       pos: 0.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5734
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5735
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5737
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5743
     components:
     - type: Transform
@@ -82582,7 +82739,7 @@ entities:
       pos: -30.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5753
     components:
     - type: Transform
@@ -82590,14 +82747,14 @@ entities:
       pos: -40.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5754
     components:
     - type: Transform
       pos: -25.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5756
     components:
     - type: Transform
@@ -82605,7 +82762,7 @@ entities:
       pos: -20.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5762
     components:
     - type: Transform
@@ -82613,7 +82770,7 @@ entities:
       pos: 15.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5763
     components:
     - type: Transform
@@ -82621,7 +82778,7 @@ entities:
       pos: 15.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5764
     components:
     - type: Transform
@@ -82629,7 +82786,7 @@ entities:
       pos: 17.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5818
     components:
     - type: Transform
@@ -82637,7 +82794,7 @@ entities:
       pos: 17.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5832
     components:
     - type: Transform
@@ -82645,28 +82802,28 @@ entities:
       pos: 34.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5834
     components:
     - type: Transform
       pos: -38.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5842
     components:
     - type: Transform
       pos: -21.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5846
     components:
     - type: Transform
       pos: 1.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5852
     components:
     - type: Transform
@@ -82674,7 +82831,7 @@ entities:
       pos: 43.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5875
     components:
     - type: Transform
@@ -82687,42 +82844,42 @@ entities:
       pos: 15.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5893
     components:
     - type: Transform
       pos: -28.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5894
     components:
     - type: Transform
       pos: -29.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5895
     components:
     - type: Transform
       pos: -29.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5896
     components:
     - type: Transform
       pos: -28.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5904
     components:
     - type: Transform
       pos: 48.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5913
     components:
     - type: Transform
@@ -82730,7 +82887,7 @@ entities:
       pos: 46.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5916
     components:
     - type: Transform
@@ -82738,7 +82895,7 @@ entities:
       pos: 6.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5920
     components:
     - type: Transform
@@ -82746,49 +82903,49 @@ entities:
       pos: 19.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5931
     components:
     - type: Transform
       pos: -38.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5939
     components:
     - type: Transform
       pos: -36.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5941
     components:
     - type: Transform
       pos: -52.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5944
     components:
     - type: Transform
       pos: -52.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5945
     components:
     - type: Transform
       pos: -36.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5946
     components:
     - type: Transform
       pos: -49.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5947
     components:
     - type: Transform
@@ -82796,21 +82953,21 @@ entities:
       pos: -21.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5948
     components:
     - type: Transform
       pos: -52.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5949
     components:
     - type: Transform
       pos: -36.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5957
     components:
     - type: Transform
@@ -82818,7 +82975,7 @@ entities:
       pos: -40.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5958
     components:
     - type: Transform
@@ -82826,7 +82983,7 @@ entities:
       pos: -50.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5959
     components:
     - type: Transform
@@ -82834,7 +82991,7 @@ entities:
       pos: -43.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5961
     components:
     - type: Transform
@@ -82842,7 +82999,7 @@ entities:
       pos: -23.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5965
     components:
     - type: Transform
@@ -82850,7 +83007,7 @@ entities:
       pos: -38.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5966
     components:
     - type: Transform
@@ -82858,14 +83015,14 @@ entities:
       pos: -43.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5968
     components:
     - type: Transform
       pos: 48.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5969
     components:
     - type: Transform
@@ -82873,7 +83030,7 @@ entities:
       pos: -42.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5970
     components:
     - type: Transform
@@ -82881,7 +83038,7 @@ entities:
       pos: -49.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5973
     components:
     - type: Transform
@@ -82889,7 +83046,7 @@ entities:
       pos: -38.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5974
     components:
     - type: Transform
@@ -82897,7 +83054,7 @@ entities:
       pos: -24.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5975
     components:
     - type: Transform
@@ -82905,14 +83062,14 @@ entities:
       pos: -55.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5976
     components:
     - type: Transform
       pos: -36.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5977
     components:
     - type: Transform
@@ -82920,7 +83077,7 @@ entities:
       pos: -53.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5978
     components:
     - type: Transform
@@ -82928,7 +83085,7 @@ entities:
       pos: -52.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5979
     components:
     - type: Transform
@@ -82936,7 +83093,7 @@ entities:
       pos: -48.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5981
     components:
     - type: Transform
@@ -82944,35 +83101,35 @@ entities:
       pos: -45.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5982
     components:
     - type: Transform
       pos: -42.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5984
     components:
     - type: Transform
       pos: -47.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5985
     components:
     - type: Transform
       pos: -47.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5986
     components:
     - type: Transform
       pos: -49.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5989
     components:
     - type: Transform
@@ -82980,7 +83137,7 @@ entities:
       pos: -37.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5992
     components:
     - type: Transform
@@ -82988,14 +83145,14 @@ entities:
       pos: -46.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5993
     components:
     - type: Transform
       pos: -55.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5994
     components:
     - type: Transform
@@ -83003,7 +83160,7 @@ entities:
       pos: -39.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5995
     components:
     - type: Transform
@@ -83011,7 +83168,7 @@ entities:
       pos: -40.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5996
     components:
     - type: Transform
@@ -83019,7 +83176,7 @@ entities:
       pos: -41.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5997
     components:
     - type: Transform
@@ -83027,7 +83184,7 @@ entities:
       pos: -45.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5998
     components:
     - type: Transform
@@ -83035,7 +83192,7 @@ entities:
       pos: -39.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5999
     components:
     - type: Transform
@@ -83043,7 +83200,7 @@ entities:
       pos: -46.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6000
     components:
     - type: Transform
@@ -83051,7 +83208,7 @@ entities:
       pos: -37.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6001
     components:
     - type: Transform
@@ -83059,7 +83216,7 @@ entities:
       pos: -55.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6003
     components:
     - type: Transform
@@ -83067,7 +83224,7 @@ entities:
       pos: -40.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6004
     components:
     - type: Transform
@@ -83075,7 +83232,7 @@ entities:
       pos: -44.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6006
     components:
     - type: Transform
@@ -83083,7 +83240,7 @@ entities:
       pos: -54.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6007
     components:
     - type: Transform
@@ -83091,7 +83248,7 @@ entities:
       pos: -51.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6009
     components:
     - type: Transform
@@ -83099,7 +83256,7 @@ entities:
       pos: 10.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6010
     components:
     - type: Transform
@@ -83107,7 +83264,7 @@ entities:
       pos: -55.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6011
     components:
     - type: Transform
@@ -83115,14 +83272,14 @@ entities:
       pos: -35.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6016
     components:
     - type: Transform
       pos: -38.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6017
     components:
     - type: Transform
@@ -83130,7 +83287,7 @@ entities:
       pos: -51.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6019
     components:
     - type: Transform
@@ -83138,7 +83295,7 @@ entities:
       pos: -53.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6021
     components:
     - type: Transform
@@ -83146,7 +83303,7 @@ entities:
       pos: -46.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6022
     components:
     - type: Transform
@@ -83154,7 +83311,7 @@ entities:
       pos: -47.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6023
     components:
     - type: Transform
@@ -83162,7 +83319,7 @@ entities:
       pos: -45.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6025
     components:
     - type: Transform
@@ -83170,7 +83327,7 @@ entities:
       pos: -44.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6027
     components:
     - type: Transform
@@ -83178,14 +83335,14 @@ entities:
       pos: -47.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6029
     components:
     - type: Transform
       pos: -47.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6030
     components:
     - type: Transform
@@ -83193,7 +83350,7 @@ entities:
       pos: -48.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6031
     components:
     - type: Transform
@@ -83201,7 +83358,7 @@ entities:
       pos: -50.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6033
     components:
     - type: Transform
@@ -83209,7 +83366,7 @@ entities:
       pos: -40.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6034
     components:
     - type: Transform
@@ -83217,7 +83374,7 @@ entities:
       pos: -24.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6035
     components:
     - type: Transform
@@ -83225,7 +83382,7 @@ entities:
       pos: -39.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6039
     components:
     - type: Transform
@@ -83233,7 +83390,7 @@ entities:
       pos: -22.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6040
     components:
     - type: Transform
@@ -83241,7 +83398,7 @@ entities:
       pos: -44.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6044
     components:
     - type: Transform
@@ -83249,7 +83406,7 @@ entities:
       pos: -21.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6045
     components:
     - type: Transform
@@ -83257,14 +83414,14 @@ entities:
       pos: -55.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6048
     components:
     - type: Transform
       pos: -47.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6057
     components:
     - type: Transform
@@ -83272,7 +83429,7 @@ entities:
       pos: -45.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6059
     components:
     - type: Transform
@@ -83280,14 +83437,14 @@ entities:
       pos: -46.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6060
     components:
     - type: Transform
       pos: -47.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6063
     components:
     - type: Transform
@@ -83295,7 +83452,7 @@ entities:
       pos: -45.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6064
     components:
     - type: Transform
@@ -83303,7 +83460,7 @@ entities:
       pos: -42.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6095
     components:
     - type: Transform
@@ -83311,7 +83468,7 @@ entities:
       pos: -43.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6096
     components:
     - type: Transform
@@ -83319,7 +83476,7 @@ entities:
       pos: -55.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6106
     components:
     - type: Transform
@@ -83327,7 +83484,7 @@ entities:
       pos: -44.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6107
     components:
     - type: Transform
@@ -83335,7 +83492,7 @@ entities:
       pos: -44.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6108
     components:
     - type: Transform
@@ -83343,14 +83500,14 @@ entities:
       pos: -44.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6110
     components:
     - type: Transform
       pos: -49.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6111
     components:
     - type: Transform
@@ -83358,14 +83515,14 @@ entities:
       pos: -47.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6113
     components:
     - type: Transform
       pos: -49.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6114
     components:
     - type: Transform
@@ -83373,7 +83530,7 @@ entities:
       pos: -46.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6115
     components:
     - type: Transform
@@ -83381,7 +83538,7 @@ entities:
       pos: -44.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6116
     components:
     - type: Transform
@@ -83389,7 +83546,7 @@ entities:
       pos: -44.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6122
     components:
     - type: Transform
@@ -83397,7 +83554,7 @@ entities:
       pos: -48.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6124
     components:
     - type: Transform
@@ -83405,7 +83562,7 @@ entities:
       pos: 11.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6134
     components:
     - type: Transform
@@ -83413,7 +83570,7 @@ entities:
       pos: -48.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6178
     components:
     - type: Transform
@@ -83421,7 +83578,7 @@ entities:
       pos: -19.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6180
     components:
     - type: Transform
@@ -83429,7 +83586,7 @@ entities:
       pos: -23.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6197
     components:
     - type: Transform
@@ -83437,7 +83594,7 @@ entities:
       pos: 7.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6198
     components:
     - type: Transform
@@ -83445,7 +83602,7 @@ entities:
       pos: 3.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6199
     components:
     - type: Transform
@@ -83453,7 +83610,7 @@ entities:
       pos: 5.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6208
     components:
     - type: Transform
@@ -83461,28 +83618,28 @@ entities:
       pos: -31.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6212
     components:
     - type: Transform
       pos: -0.5,-54.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6217
     components:
     - type: Transform
       pos: -0.5,-56.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6218
     components:
     - type: Transform
       pos: -0.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6267
     components:
     - type: Transform
@@ -83490,7 +83647,7 @@ entities:
       pos: -55.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6269
     components:
     - type: Transform
@@ -83498,7 +83655,7 @@ entities:
       pos: -38.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6279
     components:
     - type: Transform
@@ -83506,7 +83663,7 @@ entities:
       pos: 12.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6281
     components:
     - type: Transform
@@ -83514,7 +83671,7 @@ entities:
       pos: 17.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6283
     components:
     - type: Transform
@@ -83522,14 +83679,14 @@ entities:
       pos: 17.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6284
     components:
     - type: Transform
       pos: 15.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6285
     components:
     - type: Transform
@@ -83537,7 +83694,7 @@ entities:
       pos: 15.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6287
     components:
     - type: Transform
@@ -83545,7 +83702,7 @@ entities:
       pos: 15.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6289
     components:
     - type: Transform
@@ -83553,7 +83710,7 @@ entities:
       pos: 16.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6291
     components:
     - type: Transform
@@ -83561,7 +83718,7 @@ entities:
       pos: 14.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6292
     components:
     - type: Transform
@@ -83569,7 +83726,7 @@ entities:
       pos: 13.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6293
     components:
     - type: Transform
@@ -83577,7 +83734,7 @@ entities:
       pos: 12.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6294
     components:
     - type: Transform
@@ -83585,7 +83742,7 @@ entities:
       pos: 16.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6295
     components:
     - type: Transform
@@ -83593,7 +83750,7 @@ entities:
       pos: 15.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6296
     components:
     - type: Transform
@@ -83601,7 +83758,7 @@ entities:
       pos: 14.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6297
     components:
     - type: Transform
@@ -83609,7 +83766,7 @@ entities:
       pos: 13.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6298
     components:
     - type: Transform
@@ -83617,7 +83774,7 @@ entities:
       pos: 15.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6358
     components:
     - type: Transform
@@ -83625,7 +83782,7 @@ entities:
       pos: -35.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6371
     components:
     - type: Transform
@@ -83633,7 +83790,7 @@ entities:
       pos: 17.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6379
     components:
     - type: Transform
@@ -83641,7 +83798,7 @@ entities:
       pos: -1.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6391
     components:
     - type: Transform
@@ -83649,7 +83806,7 @@ entities:
       pos: 17.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6399
     components:
     - type: Transform
@@ -83657,7 +83814,7 @@ entities:
       pos: 17.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6410
     components:
     - type: Transform
@@ -83665,7 +83822,7 @@ entities:
       pos: -2.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6457
     components:
     - type: Transform
@@ -83673,7 +83830,7 @@ entities:
       pos: -0.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6542
     components:
     - type: Transform
@@ -83681,7 +83838,7 @@ entities:
       pos: -27.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6596
     components:
     - type: Transform
@@ -83697,7 +83854,7 @@ entities:
       pos: 7.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6651
     components:
     - type: Transform
@@ -83705,7 +83862,7 @@ entities:
       pos: -31.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6706
     components:
     - type: Transform
@@ -83713,7 +83870,7 @@ entities:
       pos: -27.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6710
     components:
     - type: Transform
@@ -83721,7 +83878,7 @@ entities:
       pos: -31.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6759
     components:
     - type: Transform
@@ -83729,7 +83886,7 @@ entities:
       pos: -45.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6760
     components:
     - type: Transform
@@ -83737,7 +83894,7 @@ entities:
       pos: -19.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6778
     components:
     - type: Transform
@@ -83753,21 +83910,21 @@ entities:
       pos: 2.5,-37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6798
     components:
     - type: Transform
       pos: -31.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6799
     components:
     - type: Transform
       pos: -38.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6800
     components:
     - type: Transform
@@ -83775,7 +83932,7 @@ entities:
       pos: -32.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6801
     components:
     - type: Transform
@@ -83783,7 +83940,7 @@ entities:
       pos: -31.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6802
     components:
     - type: Transform
@@ -83791,7 +83948,7 @@ entities:
       pos: -29.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6809
     components:
     - type: Transform
@@ -83799,7 +83956,7 @@ entities:
       pos: 17.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6833
     components:
     - type: Transform
@@ -83807,7 +83964,7 @@ entities:
       pos: 45.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6837
     components:
     - type: Transform
@@ -83815,7 +83972,7 @@ entities:
       pos: 41.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6838
     components:
     - type: Transform
@@ -83823,7 +83980,7 @@ entities:
       pos: 42.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6839
     components:
     - type: Transform
@@ -83831,7 +83988,7 @@ entities:
       pos: 44.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6840
     components:
     - type: Transform
@@ -83839,7 +83996,7 @@ entities:
       pos: 45.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6884
     components:
     - type: Transform
@@ -83847,7 +84004,7 @@ entities:
       pos: -34.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6887
     components:
     - type: Transform
@@ -83855,7 +84012,7 @@ entities:
       pos: -27.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6982
     components:
     - type: Transform
@@ -83863,7 +84020,7 @@ entities:
       pos: -41.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7012
     components:
     - type: Transform
@@ -83871,7 +84028,7 @@ entities:
       pos: 15.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7115
     components:
     - type: Transform
@@ -83884,7 +84041,7 @@ entities:
       pos: 15.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7123
     components:
     - type: Transform
@@ -83898,21 +84055,21 @@ entities:
       pos: 16.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7211
     components:
     - type: Transform
       pos: -49.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7214
     components:
     - type: Transform
       pos: -23.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7215
     components:
     - type: Transform
@@ -83920,7 +84077,7 @@ entities:
       pos: 23.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7220
     components:
     - type: Transform
@@ -83928,7 +84085,7 @@ entities:
       pos: -25.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7225
     components:
     - type: Transform
@@ -83936,7 +84093,7 @@ entities:
       pos: -14.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7335
     components:
     - type: Transform
@@ -83973,21 +84130,21 @@ entities:
       pos: 1.5,-75.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7382
     components:
     - type: Transform
       pos: -0.5,-74.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7383
     components:
     - type: Transform
       pos: -0.5,-75.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7458
     components:
     - type: Transform
@@ -83995,7 +84152,7 @@ entities:
       pos: -28.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7473
     components:
     - type: Transform
@@ -84003,7 +84160,7 @@ entities:
       pos: 5.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7478
     components:
     - type: Transform
@@ -84011,7 +84168,7 @@ entities:
       pos: 6.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7601
     components:
     - type: Transform
@@ -84019,7 +84176,7 @@ entities:
       pos: -14.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7604
     components:
     - type: Transform
@@ -84027,7 +84184,7 @@ entities:
       pos: -19.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7612
     components:
     - type: Transform
@@ -84035,7 +84192,7 @@ entities:
       pos: -31.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7647
     components:
     - type: Transform
@@ -84043,7 +84200,7 @@ entities:
       pos: -20.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7657
     components:
     - type: Transform
@@ -84051,7 +84208,7 @@ entities:
       pos: -39.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7670
     components:
     - type: Transform
@@ -84059,21 +84216,21 @@ entities:
       pos: 27.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7676
     components:
     - type: Transform
       pos: -49.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7680
     components:
     - type: Transform
       pos: -36.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7681
     components:
     - type: Transform
@@ -84081,14 +84238,14 @@ entities:
       pos: -29.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7715
     components:
     - type: Transform
       pos: 33.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7716
     components:
     - type: Transform
@@ -84096,7 +84253,7 @@ entities:
       pos: 32.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7717
     components:
     - type: Transform
@@ -84104,7 +84261,7 @@ entities:
       pos: 32.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7787
     components:
     - type: Transform
@@ -84112,14 +84269,14 @@ entities:
       pos: -21.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7835
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7856
     components:
     - type: Transform
@@ -84127,7 +84284,7 @@ entities:
       pos: 45.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7896
     components:
     - type: Transform
@@ -84141,14 +84298,14 @@ entities:
       pos: -14.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7905
     components:
     - type: Transform
       pos: -36.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7981
     components:
     - type: Transform
@@ -84306,7 +84463,7 @@ entities:
       pos: 25.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8130
     components:
     - type: Transform
@@ -84314,7 +84471,7 @@ entities:
       pos: -1.5,-45.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8131
     components:
     - type: Transform
@@ -84322,7 +84479,7 @@ entities:
       pos: -2.5,-45.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8132
     components:
     - type: Transform
@@ -84330,7 +84487,7 @@ entities:
       pos: 0.5,-46.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8133
     components:
     - type: Transform
@@ -84338,7 +84495,7 @@ entities:
       pos: -0.5,-46.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8134
     components:
     - type: Transform
@@ -84346,7 +84503,7 @@ entities:
       pos: -1.5,-46.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8135
     components:
     - type: Transform
@@ -84354,7 +84511,7 @@ entities:
       pos: -2.5,-46.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8151
     components:
     - type: Transform
@@ -84368,21 +84525,21 @@ entities:
       pos: -21.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8204
     components:
     - type: Transform
       pos: -38.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8206
     components:
     - type: Transform
       pos: -38.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8207
     components:
     - type: Transform
@@ -84390,7 +84547,7 @@ entities:
       pos: -26.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8230
     components:
     - type: Transform
@@ -84398,7 +84555,7 @@ entities:
       pos: -25.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8242
     components:
     - type: Transform
@@ -84406,14 +84563,14 @@ entities:
       pos: -38.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8244
     components:
     - type: Transform
       pos: -25.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8246
     components:
     - type: Transform
@@ -84421,7 +84578,7 @@ entities:
       pos: -21.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8253
     components:
     - type: Transform
@@ -84429,7 +84586,7 @@ entities:
       pos: -32.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8257
     components:
     - type: Transform
@@ -84437,7 +84594,7 @@ entities:
       pos: 45.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8258
     components:
     - type: Transform
@@ -84445,7 +84602,7 @@ entities:
       pos: -21.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8269
     components:
     - type: Transform
@@ -84453,7 +84610,7 @@ entities:
       pos: -18.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8270
     components:
     - type: Transform
@@ -84461,7 +84618,7 @@ entities:
       pos: -26.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8274
     components:
     - type: Transform
@@ -84469,7 +84626,7 @@ entities:
       pos: -31.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8277
     components:
     - type: Transform
@@ -84477,7 +84634,7 @@ entities:
       pos: -31.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8292
     components:
     - type: Transform
@@ -84485,7 +84642,7 @@ entities:
       pos: -8.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8336
     components:
     - type: Transform
@@ -84493,7 +84650,7 @@ entities:
       pos: -30.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8350
     components:
     - type: Transform
@@ -84501,7 +84658,7 @@ entities:
       pos: -13.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8387
     components:
     - type: Transform
@@ -84509,14 +84666,14 @@ entities:
       pos: 23.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8436
     components:
     - type: Transform
       pos: -43.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8508
     components:
     - type: Transform
@@ -84524,56 +84681,56 @@ entities:
       pos: -31.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8533
     components:
     - type: Transform
       pos: 17.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8534
     components:
     - type: Transform
       pos: 17.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8535
     components:
     - type: Transform
       pos: 17.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8538
     components:
     - type: Transform
       pos: 15.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8539
     components:
     - type: Transform
       pos: 15.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8540
     components:
     - type: Transform
       pos: 15.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8541
     components:
     - type: Transform
       pos: 15.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8569
     components:
     - type: Transform
@@ -84581,14 +84738,14 @@ entities:
       pos: -39.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8792
     components:
     - type: Transform
       pos: -16.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8891
     components:
     - type: Transform
@@ -84596,7 +84753,7 @@ entities:
       pos: -7.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8899
     components:
     - type: Transform
@@ -84616,7 +84773,7 @@ entities:
       pos: -55.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8922
     components:
     - type: Transform
@@ -84624,42 +84781,42 @@ entities:
       pos: -32.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8945
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8963
     components:
     - type: Transform
       pos: 44.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8964
     components:
     - type: Transform
       pos: 44.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9003
     components:
     - type: Transform
       pos: 19.5,-34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9022
     components:
     - type: Transform
       pos: 44.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9042
     components:
     - type: Transform
@@ -84667,7 +84824,7 @@ entities:
       pos: -44.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9045
     components:
     - type: Transform
@@ -84675,7 +84832,7 @@ entities:
       pos: 39.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9111
     components:
     - type: Transform
@@ -84683,7 +84840,7 @@ entities:
       pos: -18.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9149
     components:
     - type: Transform
@@ -84691,7 +84848,7 @@ entities:
       pos: -18.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9151
     components:
     - type: Transform
@@ -84699,7 +84856,7 @@ entities:
       pos: -7.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9153
     components:
     - type: Transform
@@ -84707,14 +84864,14 @@ entities:
       pos: -11.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9154
     components:
     - type: Transform
       pos: -45.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9358
     components:
     - type: Transform
@@ -84742,7 +84899,7 @@ entities:
       pos: -29.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9609
     components:
     - type: Transform
@@ -84750,7 +84907,7 @@ entities:
       pos: -46.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9610
     components:
     - type: Transform
@@ -84758,7 +84915,7 @@ entities:
       pos: -45.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9635
     components:
     - type: Transform
@@ -84766,7 +84923,7 @@ entities:
       pos: -53.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9636
     components:
     - type: Transform
@@ -84774,7 +84931,7 @@ entities:
       pos: -54.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9639
     components:
     - type: Transform
@@ -84782,7 +84939,7 @@ entities:
       pos: -39.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9640
     components:
     - type: Transform
@@ -84790,7 +84947,7 @@ entities:
       pos: -40.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9642
     components:
     - type: Transform
@@ -84798,7 +84955,7 @@ entities:
       pos: -43.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9649
     components:
     - type: Transform
@@ -84806,7 +84963,7 @@ entities:
       pos: -44.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9650
     components:
     - type: Transform
@@ -84814,7 +84971,7 @@ entities:
       pos: -45.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9653
     components:
     - type: Transform
@@ -84822,63 +84979,63 @@ entities:
       pos: -53.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9654
     components:
     - type: Transform
       pos: -54.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9655
     components:
     - type: Transform
       pos: -54.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9657
     components:
     - type: Transform
       pos: -54.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9658
     components:
     - type: Transform
       pos: -54.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9659
     components:
     - type: Transform
       pos: -54.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9660
     components:
     - type: Transform
       pos: -54.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9661
     components:
     - type: Transform
       pos: -54.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9662
     components:
     - type: Transform
       pos: -54.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9663
     components:
     - type: Transform
@@ -84915,14 +85072,14 @@ entities:
       pos: -21.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 10310
     components:
     - type: Transform
       pos: -58.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 10585
     components:
     - type: Transform
@@ -84930,7 +85087,7 @@ entities:
       pos: -21.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 10676
     components:
     - type: Transform
@@ -84938,7 +85095,7 @@ entities:
       pos: -21.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 10695
     components:
     - type: Transform
@@ -84946,7 +85103,7 @@ entities:
       pos: -51.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 10696
     components:
     - type: Transform
@@ -84954,7 +85111,7 @@ entities:
       pos: -49.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 11132
     components:
     - type: Transform
@@ -84962,7 +85119,7 @@ entities:
       pos: 46.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11158
     components:
     - type: Transform
@@ -84970,7 +85127,7 @@ entities:
       pos: 43.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11361
     components:
     - type: Transform
@@ -84978,7 +85135,7 @@ entities:
       pos: -47.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11371
     components:
     - type: Transform
@@ -84986,7 +85143,7 @@ entities:
       pos: -33.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 11379
     components:
     - type: Transform
@@ -84994,7 +85151,7 @@ entities:
       pos: 14.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11739
     components:
     - type: Transform
@@ -85002,7 +85159,7 @@ entities:
       pos: 44.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11757
     components:
     - type: Transform
@@ -85010,7 +85167,7 @@ entities:
       pos: 47.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11814
     components:
     - type: Transform
@@ -85018,7 +85175,7 @@ entities:
       pos: 45.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11830
     components:
     - type: Transform
@@ -85026,14 +85183,14 @@ entities:
       pos: 48.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12221
     components:
     - type: Transform
       pos: 9.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12284
     components:
     - type: Transform
@@ -85041,7 +85198,7 @@ entities:
       pos: 42.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12522
     components:
     - type: Transform
@@ -85062,28 +85219,28 @@ entities:
       pos: 41.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12620
     components:
     - type: Transform
       pos: 49.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12627
     components:
     - type: Transform
       pos: 38.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12628
     components:
     - type: Transform
       pos: 38.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12630
     components:
     - type: Transform
@@ -85091,7 +85248,7 @@ entities:
       pos: 40.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12824
     components:
     - type: Transform
@@ -85099,7 +85256,7 @@ entities:
       pos: -37.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12826
     components:
     - type: Transform
@@ -85107,7 +85264,7 @@ entities:
       pos: -40.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12827
     components:
     - type: Transform
@@ -85115,7 +85272,7 @@ entities:
       pos: -41.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12828
     components:
     - type: Transform
@@ -85123,42 +85280,42 @@ entities:
       pos: -42.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12830
     components:
     - type: Transform
       pos: -43.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12831
     components:
     - type: Transform
       pos: -43.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12832
     components:
     - type: Transform
       pos: -43.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12833
     components:
     - type: Transform
       pos: -43.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12834
     components:
     - type: Transform
       pos: -43.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12836
     components:
     - type: Transform
@@ -85166,7 +85323,7 @@ entities:
       pos: -44.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12838
     components:
     - type: Transform
@@ -85174,7 +85331,7 @@ entities:
       pos: -47.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12843
     components:
     - type: Transform
@@ -85182,7 +85339,7 @@ entities:
       pos: -39.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12844
     components:
     - type: Transform
@@ -85190,21 +85347,21 @@ entities:
       pos: -38.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12847
     components:
     - type: Transform
       pos: -43.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12848
     components:
     - type: Transform
       pos: -43.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12849
     components:
     - type: Transform
@@ -85212,7 +85369,7 @@ entities:
       pos: -46.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12850
     components:
     - type: Transform
@@ -85220,7 +85377,7 @@ entities:
       pos: -45.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13081
     components:
     - type: Transform
@@ -85228,7 +85385,7 @@ entities:
       pos: 43.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13140
     components:
     - type: Transform
@@ -85236,14 +85393,14 @@ entities:
       pos: 38.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13206
     components:
     - type: Transform
       pos: 49.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13210
     components:
     - type: Transform
@@ -85251,7 +85408,7 @@ entities:
       pos: 40.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13237
     components:
     - type: Transform
@@ -85259,7 +85416,7 @@ entities:
       pos: 18.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13239
     components:
     - type: Transform
@@ -85267,7 +85424,7 @@ entities:
       pos: 17.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13240
     components:
     - type: Transform
@@ -85275,7 +85432,7 @@ entities:
       pos: 18.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13244
     components:
     - type: Transform
@@ -85283,7 +85440,7 @@ entities:
       pos: 24.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13268
     components:
     - type: Transform
@@ -85296,7 +85453,7 @@ entities:
       pos: 49.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13505
     components:
     - type: Transform
@@ -85304,7 +85461,7 @@ entities:
       pos: 46.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13506
     components:
     - type: Transform
@@ -85312,7 +85469,7 @@ entities:
       pos: 45.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13507
     components:
     - type: Transform
@@ -85320,14 +85477,14 @@ entities:
       pos: 41.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13508
     components:
     - type: Transform
       pos: 49.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13509
     components:
     - type: Transform
@@ -85335,14 +85492,14 @@ entities:
       pos: 41.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13511
     components:
     - type: Transform
       pos: 49.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13512
     components:
     - type: Transform
@@ -85350,7 +85507,7 @@ entities:
       pos: 44.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13513
     components:
     - type: Transform
@@ -85358,7 +85515,7 @@ entities:
       pos: 43.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13518
     components:
     - type: Transform
@@ -85366,7 +85523,7 @@ entities:
       pos: 38.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13539
     components:
     - type: Transform
@@ -85374,7 +85531,7 @@ entities:
       pos: 17.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13540
     components:
     - type: Transform
@@ -85382,7 +85539,7 @@ entities:
       pos: 18.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13541
     components:
     - type: Transform
@@ -85390,7 +85547,7 @@ entities:
       pos: 19.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13542
     components:
     - type: Transform
@@ -85398,7 +85555,7 @@ entities:
       pos: 18.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13543
     components:
     - type: Transform
@@ -85406,7 +85563,7 @@ entities:
       pos: 19.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13544
     components:
     - type: Transform
@@ -85414,7 +85571,7 @@ entities:
       pos: 20.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13545
     components:
     - type: Transform
@@ -85422,7 +85579,7 @@ entities:
       pos: 21.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13550
     components:
     - type: Transform
@@ -85430,7 +85587,7 @@ entities:
       pos: -32.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13564
     components:
     - type: Transform
@@ -85438,7 +85595,7 @@ entities:
       pos: 23.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13565
     components:
     - type: Transform
@@ -85446,7 +85603,7 @@ entities:
       pos: 24.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13566
     components:
     - type: Transform
@@ -85454,7 +85611,7 @@ entities:
       pos: 39.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13573
     components:
     - type: Transform
@@ -85462,7 +85619,7 @@ entities:
       pos: 13.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13587
     components:
     - type: Transform
@@ -85470,7 +85627,7 @@ entities:
       pos: 26.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13588
     components:
     - type: Transform
@@ -85478,14 +85635,14 @@ entities:
       pos: 3.5,-37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13591
     components:
     - type: Transform
       pos: 49.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13594
     components:
     - type: Transform
@@ -85493,7 +85650,7 @@ entities:
       pos: 27.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13595
     components:
     - type: Transform
@@ -85501,7 +85658,7 @@ entities:
       pos: 28.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13596
     components:
     - type: Transform
@@ -85509,7 +85666,7 @@ entities:
       pos: 29.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13597
     components:
     - type: Transform
@@ -85517,7 +85674,7 @@ entities:
       pos: 30.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13630
     components:
     - type: Transform
@@ -85525,7 +85682,7 @@ entities:
       pos: 32.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13640
     components:
     - type: Transform
@@ -85533,7 +85690,7 @@ entities:
       pos: 12.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13643
     components:
     - type: Transform
@@ -85553,7 +85710,7 @@ entities:
       pos: 33.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13652
     components:
     - type: Transform
@@ -85561,7 +85718,7 @@ entities:
       pos: 34.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13653
     components:
     - type: Transform
@@ -85569,7 +85726,7 @@ entities:
       pos: 35.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13674
     components:
     - type: Transform
@@ -85577,7 +85734,7 @@ entities:
       pos: -8.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13675
     components:
     - type: Transform
@@ -85585,7 +85742,7 @@ entities:
       pos: -8.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13676
     components:
     - type: Transform
@@ -85593,7 +85750,7 @@ entities:
       pos: -8.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13806
     components:
     - type: Transform
@@ -85601,7 +85758,7 @@ entities:
       pos: 36.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13807
     components:
     - type: Transform
@@ -85609,7 +85766,7 @@ entities:
       pos: 37.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13809
     components:
     - type: Transform
@@ -85617,7 +85774,7 @@ entities:
       pos: 39.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13810
     components:
     - type: Transform
@@ -85625,7 +85782,7 @@ entities:
       pos: 22.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13822
     components:
     - type: Transform
@@ -85633,7 +85790,7 @@ entities:
       pos: 25.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13836
     components:
     - type: Transform
@@ -85641,7 +85798,7 @@ entities:
       pos: 25.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13837
     components:
     - type: Transform
@@ -85649,7 +85806,7 @@ entities:
       pos: 26.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13839
     components:
     - type: Transform
@@ -85657,7 +85814,7 @@ entities:
       pos: -26.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13840
     components:
     - type: Transform
@@ -85665,7 +85822,7 @@ entities:
       pos: -26.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13841
     components:
     - type: Transform
@@ -85673,7 +85830,7 @@ entities:
       pos: -26.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13843
     components:
     - type: Transform
@@ -85681,7 +85838,7 @@ entities:
       pos: 27.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13869
     components:
     - type: Transform
@@ -85689,7 +85846,7 @@ entities:
       pos: -30.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13877
     components:
     - type: Transform
@@ -85703,7 +85860,7 @@ entities:
       pos: 28.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13920
     components:
     - type: Transform
@@ -85711,7 +85868,7 @@ entities:
       pos: 29.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13921
     components:
     - type: Transform
@@ -85719,7 +85876,7 @@ entities:
       pos: 30.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13932
     components:
     - type: Transform
@@ -85727,7 +85884,7 @@ entities:
       pos: -14.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13935
     components:
     - type: Transform
@@ -85747,7 +85904,7 @@ entities:
       pos: 31.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14003
     components:
     - type: Transform
@@ -85755,7 +85912,7 @@ entities:
       pos: -26.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14004
     components:
     - type: Transform
@@ -85763,7 +85920,7 @@ entities:
       pos: -26.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14005
     components:
     - type: Transform
@@ -85771,7 +85928,7 @@ entities:
       pos: -26.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14016
     components:
     - type: Transform
@@ -85779,7 +85936,7 @@ entities:
       pos: 33.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14017
     components:
     - type: Transform
@@ -85787,7 +85944,7 @@ entities:
       pos: 34.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14018
     components:
     - type: Transform
@@ -85795,7 +85952,7 @@ entities:
       pos: 35.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14019
     components:
     - type: Transform
@@ -85803,7 +85960,7 @@ entities:
       pos: 36.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14020
     components:
     - type: Transform
@@ -85811,7 +85968,7 @@ entities:
       pos: 37.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14023
     components:
     - type: Transform
@@ -85819,7 +85976,7 @@ entities:
       pos: 16.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14024
     components:
     - type: Transform
@@ -85827,7 +85984,7 @@ entities:
       pos: 17.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14025
     components:
     - type: Transform
@@ -85835,7 +85992,7 @@ entities:
       pos: 18.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14026
     components:
     - type: Transform
@@ -85843,7 +86000,7 @@ entities:
       pos: 19.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14027
     components:
     - type: Transform
@@ -85851,7 +86008,7 @@ entities:
       pos: 20.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14028
     components:
     - type: Transform
@@ -85859,7 +86016,7 @@ entities:
       pos: 21.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14030
     components:
     - type: Transform
@@ -85867,7 +86024,7 @@ entities:
       pos: 23.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14031
     components:
     - type: Transform
@@ -85875,7 +86032,7 @@ entities:
       pos: 24.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14032
     components:
     - type: Transform
@@ -85883,7 +86040,7 @@ entities:
       pos: 25.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14033
     components:
     - type: Transform
@@ -85891,7 +86048,7 @@ entities:
       pos: 26.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14034
     components:
     - type: Transform
@@ -85899,7 +86056,7 @@ entities:
       pos: 27.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14035
     components:
     - type: Transform
@@ -85907,7 +86064,7 @@ entities:
       pos: 28.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14036
     components:
     - type: Transform
@@ -85915,7 +86072,7 @@ entities:
       pos: 29.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14037
     components:
     - type: Transform
@@ -85923,7 +86080,7 @@ entities:
       pos: 30.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14038
     components:
     - type: Transform
@@ -85931,7 +86088,7 @@ entities:
       pos: 31.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14039
     components:
     - type: Transform
@@ -85939,7 +86096,7 @@ entities:
       pos: 32.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14041
     components:
     - type: Transform
@@ -85947,7 +86104,7 @@ entities:
       pos: 34.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14042
     components:
     - type: Transform
@@ -85955,7 +86112,7 @@ entities:
       pos: 35.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14045
     components:
     - type: Transform
@@ -85963,7 +86120,7 @@ entities:
       pos: 37.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14046
     components:
     - type: Transform
@@ -85971,7 +86128,7 @@ entities:
       pos: 38.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14048
     components:
     - type: Transform
@@ -85979,21 +86136,21 @@ entities:
       pos: 40.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14132
     components:
     - type: Transform
       pos: -9.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14153
     components:
     - type: Transform
       pos: -9.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14174
     components:
     - type: Transform
@@ -86001,7 +86158,7 @@ entities:
       pos: -11.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14176
     components:
     - type: Transform
@@ -86009,7 +86166,7 @@ entities:
       pos: -10.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14181
     components:
     - type: Transform
@@ -86017,7 +86174,7 @@ entities:
       pos: -21.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14209
     components:
     - type: Transform
@@ -86025,7 +86182,7 @@ entities:
       pos: -13.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14214
     components:
     - type: Transform
@@ -86033,7 +86190,7 @@ entities:
       pos: -15.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14232
     components:
     - type: Transform
@@ -86041,7 +86198,7 @@ entities:
       pos: -16.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14233
     components:
     - type: Transform
@@ -86049,7 +86206,7 @@ entities:
       pos: -16.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14234
     components:
     - type: Transform
@@ -86057,7 +86214,7 @@ entities:
       pos: -16.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14235
     components:
     - type: Transform
@@ -86065,7 +86222,7 @@ entities:
       pos: -16.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14236
     components:
     - type: Transform
@@ -86073,7 +86230,7 @@ entities:
       pos: -16.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14238
     components:
     - type: Transform
@@ -86081,7 +86238,7 @@ entities:
       pos: -16.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14239
     components:
     - type: Transform
@@ -86089,7 +86246,7 @@ entities:
       pos: -16.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14240
     components:
     - type: Transform
@@ -86097,7 +86254,7 @@ entities:
       pos: -16.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14242
     components:
     - type: Transform
@@ -86105,7 +86262,7 @@ entities:
       pos: -16.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14243
     components:
     - type: Transform
@@ -86113,7 +86270,7 @@ entities:
       pos: -16.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14244
     components:
     - type: Transform
@@ -86121,7 +86278,7 @@ entities:
       pos: -16.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14245
     components:
     - type: Transform
@@ -86129,7 +86286,7 @@ entities:
       pos: -14.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14246
     components:
     - type: Transform
@@ -86137,7 +86294,7 @@ entities:
       pos: -14.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14247
     components:
     - type: Transform
@@ -86145,7 +86302,7 @@ entities:
       pos: -14.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14248
     components:
     - type: Transform
@@ -86153,7 +86310,7 @@ entities:
       pos: -14.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14249
     components:
     - type: Transform
@@ -86161,7 +86318,7 @@ entities:
       pos: -14.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14250
     components:
     - type: Transform
@@ -86169,7 +86326,7 @@ entities:
       pos: -14.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14252
     components:
     - type: Transform
@@ -86177,7 +86334,7 @@ entities:
       pos: -14.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14253
     components:
     - type: Transform
@@ -86185,7 +86342,7 @@ entities:
       pos: -14.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14254
     components:
     - type: Transform
@@ -86193,7 +86350,7 @@ entities:
       pos: -14.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14255
     components:
     - type: Transform
@@ -86201,7 +86358,7 @@ entities:
       pos: -14.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14256
     components:
     - type: Transform
@@ -86209,7 +86366,7 @@ entities:
       pos: -14.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14257
     components:
     - type: Transform
@@ -86217,7 +86374,7 @@ entities:
       pos: -14.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14258
     components:
     - type: Transform
@@ -86225,7 +86382,7 @@ entities:
       pos: -14.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14261
     components:
     - type: Transform
@@ -86233,7 +86390,7 @@ entities:
       pos: -17.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14262
     components:
     - type: Transform
@@ -86241,7 +86398,7 @@ entities:
       pos: -18.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14263
     components:
     - type: Transform
@@ -86249,7 +86406,7 @@ entities:
       pos: -19.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14264
     components:
     - type: Transform
@@ -86257,7 +86414,7 @@ entities:
       pos: -20.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14265
     components:
     - type: Transform
@@ -86265,7 +86422,7 @@ entities:
       pos: -21.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14266
     components:
     - type: Transform
@@ -86273,14 +86430,14 @@ entities:
       pos: -22.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14267
     components:
     - type: Transform
       pos: 49.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14268
     components:
     - type: Transform
@@ -86288,7 +86445,7 @@ entities:
       pos: -24.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14269
     components:
     - type: Transform
@@ -86296,7 +86453,7 @@ entities:
       pos: -25.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14271
     components:
     - type: Transform
@@ -86304,7 +86461,7 @@ entities:
       pos: -27.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14272
     components:
     - type: Transform
@@ -86312,7 +86469,7 @@ entities:
       pos: -28.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14273
     components:
     - type: Transform
@@ -86320,7 +86477,7 @@ entities:
       pos: -29.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14275
     components:
     - type: Transform
@@ -86328,7 +86485,7 @@ entities:
       pos: -15.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14276
     components:
     - type: Transform
@@ -86336,7 +86493,7 @@ entities:
       pos: -16.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14277
     components:
     - type: Transform
@@ -86344,7 +86501,7 @@ entities:
       pos: -17.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14278
     components:
     - type: Transform
@@ -86352,7 +86509,7 @@ entities:
       pos: -18.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14281
     components:
     - type: Transform
@@ -86360,7 +86517,7 @@ entities:
       pos: -21.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14282
     components:
     - type: Transform
@@ -86368,7 +86525,7 @@ entities:
       pos: -22.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14283
     components:
     - type: Transform
@@ -86376,7 +86533,7 @@ entities:
       pos: -23.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14284
     components:
     - type: Transform
@@ -86384,7 +86541,7 @@ entities:
       pos: -25.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14290
     components:
     - type: Transform
@@ -86398,7 +86555,7 @@ entities:
       pos: -13.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14292
     components:
     - type: Transform
@@ -86406,7 +86563,7 @@ entities:
       pos: -12.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14294
     components:
     - type: Transform
@@ -86414,7 +86571,7 @@ entities:
       pos: -10.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14296
     components:
     - type: Transform
@@ -86422,7 +86579,7 @@ entities:
       pos: -8.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14298
     components:
     - type: Transform
@@ -86430,7 +86587,7 @@ entities:
       pos: -7.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14299
     components:
     - type: Transform
@@ -86438,7 +86595,7 @@ entities:
       pos: -7.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14300
     components:
     - type: Transform
@@ -86446,7 +86603,7 @@ entities:
       pos: -7.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14301
     components:
     - type: Transform
@@ -86454,7 +86611,7 @@ entities:
       pos: -7.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14304
     components:
     - type: Transform
@@ -86462,7 +86619,7 @@ entities:
       pos: -15.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14305
     components:
     - type: Transform
@@ -86470,7 +86627,7 @@ entities:
       pos: -14.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14306
     components:
     - type: Transform
@@ -86478,7 +86635,7 @@ entities:
       pos: -12.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14307
     components:
     - type: Transform
@@ -86486,7 +86643,7 @@ entities:
       pos: -13.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14309
     components:
     - type: Transform
@@ -86494,7 +86651,7 @@ entities:
       pos: -10.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14310
     components:
     - type: Transform
@@ -86502,7 +86659,7 @@ entities:
       pos: -9.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14314
     components:
     - type: Transform
@@ -86510,7 +86667,7 @@ entities:
       pos: -8.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14315
     components:
     - type: Transform
@@ -86518,7 +86675,7 @@ entities:
       pos: -8.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14316
     components:
     - type: Transform
@@ -86526,7 +86683,7 @@ entities:
       pos: -8.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14317
     components:
     - type: Transform
@@ -86534,7 +86691,7 @@ entities:
       pos: -8.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14318
     components:
     - type: Transform
@@ -86542,49 +86699,49 @@ entities:
       pos: -11.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14320
     components:
     - type: Transform
       pos: -9.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14321
     components:
     - type: Transform
       pos: -9.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14322
     components:
     - type: Transform
       pos: -9.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14323
     components:
     - type: Transform
       pos: -9.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14324
     components:
     - type: Transform
       pos: -9.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14455
     components:
     - type: Transform
       pos: -27.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14456
     components:
     - type: Transform
@@ -86592,7 +86749,7 @@ entities:
       pos: -26.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14457
     components:
     - type: Transform
@@ -86600,7 +86757,7 @@ entities:
       pos: -26.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14458
     components:
     - type: Transform
@@ -86608,7 +86765,7 @@ entities:
       pos: -26.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14459
     components:
     - type: Transform
@@ -86616,7 +86773,7 @@ entities:
       pos: -26.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14460
     components:
     - type: Transform
@@ -86624,7 +86781,7 @@ entities:
       pos: -26.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14461
     components:
     - type: Transform
@@ -86632,119 +86789,119 @@ entities:
       pos: -26.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14462
     components:
     - type: Transform
       pos: -24.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14463
     components:
     - type: Transform
       pos: -24.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14464
     components:
     - type: Transform
       pos: -24.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14465
     components:
     - type: Transform
       pos: -24.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14466
     components:
     - type: Transform
       pos: -24.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14467
     components:
     - type: Transform
       pos: -24.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14469
     components:
     - type: Transform
       pos: -24.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14470
     components:
     - type: Transform
       pos: -24.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14471
     components:
     - type: Transform
       pos: -24.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14472
     components:
     - type: Transform
       pos: -24.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14473
     components:
     - type: Transform
       pos: -24.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14474
     components:
     - type: Transform
       pos: -24.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14475
     components:
     - type: Transform
       pos: -24.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14476
     components:
     - type: Transform
       pos: -24.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14489
     components:
     - type: Transform
       pos: -27.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14495
     components:
     - type: Transform
       pos: -23.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14643
     components:
     - type: Transform
@@ -86752,7 +86909,7 @@ entities:
       pos: -20.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14644
     components:
     - type: Transform
@@ -86760,7 +86917,7 @@ entities:
       pos: -22.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14662
     components:
     - type: Transform
@@ -86773,7 +86930,7 @@ entities:
       pos: -16.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14669
     components:
     - type: Transform
@@ -86781,7 +86938,7 @@ entities:
       pos: -24.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14671
     components:
     - type: Transform
@@ -86789,7 +86946,7 @@ entities:
       pos: -23.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14672
     components:
     - type: Transform
@@ -86797,7 +86954,7 @@ entities:
       pos: -22.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14686
     components:
     - type: Transform
@@ -86838,7 +86995,7 @@ entities:
       pos: 41.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14742
     components:
     - type: Transform
@@ -86846,7 +87003,7 @@ entities:
       pos: -29.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14743
     components:
     - type: Transform
@@ -86854,7 +87011,7 @@ entities:
       pos: -28.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14744
     components:
     - type: Transform
@@ -86862,7 +87019,7 @@ entities:
       pos: -27.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14747
     components:
     - type: Transform
@@ -86870,7 +87027,7 @@ entities:
       pos: -24.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14748
     components:
     - type: Transform
@@ -86878,7 +87035,7 @@ entities:
       pos: -23.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14754
     components:
     - type: Transform
@@ -86886,7 +87043,7 @@ entities:
       pos: -20.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14755
     components:
     - type: Transform
@@ -86894,7 +87051,7 @@ entities:
       pos: -20.5,26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14757
     components:
     - type: Transform
@@ -86902,7 +87059,7 @@ entities:
       pos: -25.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14758
     components:
     - type: Transform
@@ -86910,7 +87067,7 @@ entities:
       pos: -22.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14759
     components:
     - type: Transform
@@ -86918,7 +87075,7 @@ entities:
       pos: -22.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14760
     components:
     - type: Transform
@@ -86926,7 +87083,7 @@ entities:
       pos: -22.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14761
     components:
     - type: Transform
@@ -86934,7 +87091,7 @@ entities:
       pos: -22.5,26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14762
     components:
     - type: Transform
@@ -86942,7 +87099,7 @@ entities:
       pos: -22.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14764
     components:
     - type: Transform
@@ -86950,7 +87107,7 @@ entities:
       pos: -36.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14765
     components:
     - type: Transform
@@ -86958,7 +87115,7 @@ entities:
       pos: -35.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14767
     components:
     - type: Transform
@@ -86966,7 +87123,7 @@ entities:
       pos: -33.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14768
     components:
     - type: Transform
@@ -86974,14 +87131,14 @@ entities:
       pos: -32.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14769
     components:
     - type: Transform
       pos: -41.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14771
     components:
     - type: Transform
@@ -86989,7 +87146,7 @@ entities:
       pos: -35.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14773
     components:
     - type: Transform
@@ -86997,7 +87154,7 @@ entities:
       pos: -29.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14777
     components:
     - type: Transform
@@ -87005,7 +87162,7 @@ entities:
       pos: -26.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14778
     components:
     - type: Transform
@@ -87013,7 +87170,7 @@ entities:
       pos: -25.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14781
     components:
     - type: Transform
@@ -87027,7 +87184,7 @@ entities:
       pos: -28.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14786
     components:
     - type: Transform
@@ -87035,7 +87192,7 @@ entities:
       pos: -31.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14790
     components:
     - type: Transform
@@ -87043,7 +87200,7 @@ entities:
       pos: -34.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14794
     components:
     - type: Transform
@@ -87075,14 +87232,14 @@ entities:
       pos: -27.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14871
     components:
     - type: Transform
       pos: -43.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14878
     components:
     - type: Transform
@@ -87090,7 +87247,7 @@ entities:
       pos: -33.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14879
     components:
     - type: Transform
@@ -87098,7 +87255,7 @@ entities:
       pos: -31.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14883
     components:
     - type: Transform
@@ -87130,7 +87287,7 @@ entities:
       pos: -33.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14897
     components:
     - type: Transform
@@ -87172,7 +87329,7 @@ entities:
       pos: -26.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14934
     components:
     - type: Transform
@@ -87180,7 +87337,7 @@ entities:
       pos: -27.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14935
     components:
     - type: Transform
@@ -87188,7 +87345,7 @@ entities:
       pos: -28.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14936
     components:
     - type: Transform
@@ -87196,7 +87353,7 @@ entities:
       pos: -26.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14938
     components:
     - type: Transform
@@ -87204,7 +87361,7 @@ entities:
       pos: -31.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14940
     components:
     - type: Transform
@@ -87230,14 +87387,14 @@ entities:
       pos: 1.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14987
     components:
     - type: Transform
       pos: -33.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14991
     components:
     - type: Transform
@@ -87441,7 +87598,7 @@ entities:
       pos: -32.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15118
     components:
     - type: Transform
@@ -87527,7 +87684,7 @@ entities:
       pos: -33.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15146
     components:
     - type: Transform
@@ -87547,7 +87704,7 @@ entities:
       pos: 13.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15172
     components:
     - type: Transform
@@ -87631,7 +87788,7 @@ entities:
       pos: -19.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15358
     components:
     - type: Transform
@@ -87639,7 +87796,7 @@ entities:
       pos: -17.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15365
     components:
     - type: Transform
@@ -87954,7 +88111,7 @@ entities:
       pos: -22.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15589
     components:
     - type: Transform
@@ -87962,7 +88119,7 @@ entities:
       pos: -22.5,32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15590
     components:
     - type: Transform
@@ -87970,7 +88127,7 @@ entities:
       pos: -22.5,33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15592
     components:
     - type: Transform
@@ -87978,7 +88135,7 @@ entities:
       pos: -22.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15598
     components:
     - type: Transform
@@ -87986,7 +88143,7 @@ entities:
       pos: -18.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15606
     components:
     - type: Transform
@@ -87994,7 +88151,7 @@ entities:
       pos: -10.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15607
     components:
     - type: Transform
@@ -88002,7 +88159,7 @@ entities:
       pos: -10.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15608
     components:
     - type: Transform
@@ -88010,7 +88167,7 @@ entities:
       pos: -10.5,33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15609
     components:
     - type: Transform
@@ -88018,7 +88175,7 @@ entities:
       pos: -10.5,32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15610
     components:
     - type: Transform
@@ -88026,7 +88183,7 @@ entities:
       pos: -10.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15611
     components:
     - type: Transform
@@ -88034,7 +88191,7 @@ entities:
       pos: -10.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15614
     components:
     - type: Transform
@@ -88042,7 +88199,7 @@ entities:
       pos: -20.5,32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15615
     components:
     - type: Transform
@@ -88050,7 +88207,7 @@ entities:
       pos: -20.5,33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15616
     components:
     - type: Transform
@@ -88058,7 +88215,7 @@ entities:
       pos: -19.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15618
     components:
     - type: Transform
@@ -88066,7 +88223,7 @@ entities:
       pos: -17.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15619
     components:
     - type: Transform
@@ -88074,7 +88231,7 @@ entities:
       pos: -16.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15620
     components:
     - type: Transform
@@ -88082,7 +88239,7 @@ entities:
       pos: -15.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15622
     components:
     - type: Transform
@@ -88090,28 +88247,28 @@ entities:
       pos: -13.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15623
     components:
     - type: Transform
       pos: -12.5,33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15624
     components:
     - type: Transform
       pos: -12.5,32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15625
     components:
     - type: Transform
       pos: -12.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15627
     components:
     - type: Transform
@@ -88119,7 +88276,7 @@ entities:
       pos: -19.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15628
     components:
     - type: Transform
@@ -88127,7 +88284,7 @@ entities:
       pos: -18.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15629
     components:
     - type: Transform
@@ -88135,7 +88292,7 @@ entities:
       pos: -17.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15630
     components:
     - type: Transform
@@ -88143,7 +88300,7 @@ entities:
       pos: -16.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15631
     components:
     - type: Transform
@@ -88151,7 +88308,7 @@ entities:
       pos: -15.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15632
     components:
     - type: Transform
@@ -88159,7 +88316,7 @@ entities:
       pos: -14.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15633
     components:
     - type: Transform
@@ -88167,14 +88324,14 @@ entities:
       pos: -13.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15634
     components:
     - type: Transform
       pos: -12.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15638
     components:
     - type: Transform
@@ -88182,7 +88339,7 @@ entities:
       pos: -16.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15639
     components:
     - type: Transform
@@ -88190,7 +88347,7 @@ entities:
       pos: -16.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15640
     components:
     - type: Transform
@@ -88198,7 +88355,7 @@ entities:
       pos: -16.5,26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15641
     components:
     - type: Transform
@@ -88206,7 +88363,7 @@ entities:
       pos: -15.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15642
     components:
     - type: Transform
@@ -88214,7 +88371,7 @@ entities:
       pos: -14.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15643
     components:
     - type: Transform
@@ -88222,7 +88379,7 @@ entities:
       pos: -13.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15644
     components:
     - type: Transform
@@ -88230,7 +88387,7 @@ entities:
       pos: -12.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15645
     components:
     - type: Transform
@@ -88238,35 +88395,35 @@ entities:
       pos: -11.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15646
     components:
     - type: Transform
       pos: -10.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15655
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15656
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15657
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15658
     components:
     - type: Transform
@@ -88274,7 +88431,7 @@ entities:
       pos: 0.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15659
     components:
     - type: Transform
@@ -88282,21 +88439,21 @@ entities:
       pos: -9.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15662
     components:
     - type: Transform
       pos: 1.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15663
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15746
     components:
     - type: Transform
@@ -88304,14 +88461,14 @@ entities:
       pos: 0.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16562
     components:
     - type: Transform
       pos: -16.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16564
     components:
     - type: Transform
@@ -88319,7 +88476,7 @@ entities:
       pos: -8.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16565
     components:
     - type: Transform
@@ -88327,7 +88484,7 @@ entities:
       pos: -7.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16566
     components:
     - type: Transform
@@ -88335,7 +88492,7 @@ entities:
       pos: -6.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16567
     components:
     - type: Transform
@@ -88343,7 +88500,7 @@ entities:
       pos: -5.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16568
     components:
     - type: Transform
@@ -88351,7 +88508,7 @@ entities:
       pos: -4.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16569
     components:
     - type: Transform
@@ -88359,56 +88516,56 @@ entities:
       pos: -3.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16570
     components:
     - type: Transform
       pos: -2.5,26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16572
     components:
     - type: Transform
       pos: -2.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16573
     components:
     - type: Transform
       pos: -2.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16574
     components:
     - type: Transform
       pos: -2.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16575
     components:
     - type: Transform
       pos: -2.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16577
     components:
     - type: Transform
       pos: -2.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16578
     components:
     - type: Transform
       pos: -2.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16579
     components:
     - type: Transform
@@ -88416,7 +88573,7 @@ entities:
       pos: -1.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16583
     components:
     - type: Transform
@@ -88424,7 +88581,7 @@ entities:
       pos: -11.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16584
     components:
     - type: Transform
@@ -88432,7 +88589,7 @@ entities:
       pos: -10.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16585
     components:
     - type: Transform
@@ -88440,7 +88597,7 @@ entities:
       pos: -9.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16586
     components:
     - type: Transform
@@ -88448,7 +88605,7 @@ entities:
       pos: -8.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16587
     components:
     - type: Transform
@@ -88456,7 +88613,7 @@ entities:
       pos: -7.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16588
     components:
     - type: Transform
@@ -88464,7 +88621,7 @@ entities:
       pos: -6.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16589
     components:
     - type: Transform
@@ -88472,7 +88629,7 @@ entities:
       pos: -5.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16590
     components:
     - type: Transform
@@ -88480,28 +88637,28 @@ entities:
       pos: -4.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16591
     components:
     - type: Transform
       pos: -3.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16592
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16593
     components:
     - type: Transform
       pos: -3.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16595
     components:
     - type: Transform
@@ -88509,28 +88666,28 @@ entities:
       pos: -3.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16596
     components:
     - type: Transform
       pos: -3.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16597
     components:
     - type: Transform
       pos: -3.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16598
     components:
     - type: Transform
       pos: -3.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16600
     components:
     - type: Transform
@@ -88538,7 +88695,7 @@ entities:
       pos: -2.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16601
     components:
     - type: Transform
@@ -88546,7 +88703,7 @@ entities:
       pos: -1.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16602
     components:
     - type: Transform
@@ -88554,7 +88711,7 @@ entities:
       pos: -0.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16603
     components:
     - type: Transform
@@ -88562,7 +88719,7 @@ entities:
       pos: 0.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16606
     components:
     - type: Transform
@@ -88570,7 +88727,7 @@ entities:
       pos: -2.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16607
     components:
     - type: Transform
@@ -88578,7 +88735,7 @@ entities:
       pos: -1.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16609
     components:
     - type: Transform
@@ -88586,7 +88743,7 @@ entities:
       pos: -0.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16610
     components:
     - type: Transform
@@ -88594,7 +88751,7 @@ entities:
       pos: 0.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16613
     components:
     - type: Transform
@@ -88602,7 +88759,7 @@ entities:
       pos: -0.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16614
     components:
     - type: Transform
@@ -88610,7 +88767,7 @@ entities:
       pos: -0.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16617
     components:
     - type: Transform
@@ -88618,7 +88775,7 @@ entities:
       pos: 1.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16618
     components:
     - type: Transform
@@ -88626,7 +88783,7 @@ entities:
       pos: 1.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16622
     components:
     - type: Transform
@@ -88634,7 +88791,7 @@ entities:
       pos: -2.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16624
     components:
     - type: Transform
@@ -88642,7 +88799,7 @@ entities:
       pos: -0.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16625
     components:
     - type: Transform
@@ -88650,7 +88807,7 @@ entities:
       pos: 1.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16626
     components:
     - type: Transform
@@ -88658,7 +88815,7 @@ entities:
       pos: 2.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16627
     components:
     - type: Transform
@@ -88666,7 +88823,7 @@ entities:
       pos: 3.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16628
     components:
     - type: Transform
@@ -88674,7 +88831,7 @@ entities:
       pos: 4.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16629
     components:
     - type: Transform
@@ -88682,7 +88839,7 @@ entities:
       pos: 2.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16630
     components:
     - type: Transform
@@ -88690,7 +88847,7 @@ entities:
       pos: 3.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16631
     components:
     - type: Transform
@@ -88698,35 +88855,35 @@ entities:
       pos: 4.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16637
     components:
     - type: Transform
       pos: -3.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16638
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16639
     components:
     - type: Transform
       pos: -3.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16640
     components:
     - type: Transform
       pos: -2.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16644
     components:
     - type: Transform
@@ -88734,7 +88891,7 @@ entities:
       pos: 2.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16646
     components:
     - type: Transform
@@ -88742,7 +88899,7 @@ entities:
       pos: 1.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16649
     components:
     - type: Transform
@@ -88750,7 +88907,7 @@ entities:
       pos: 5.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16650
     components:
     - type: Transform
@@ -88758,7 +88915,7 @@ entities:
       pos: 6.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16651
     components:
     - type: Transform
@@ -88766,7 +88923,7 @@ entities:
       pos: 7.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16652
     components:
     - type: Transform
@@ -88774,7 +88931,7 @@ entities:
       pos: 8.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16653
     components:
     - type: Transform
@@ -88782,7 +88939,7 @@ entities:
       pos: 9.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16655
     components:
     - type: Transform
@@ -88790,7 +88947,7 @@ entities:
       pos: 11.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16657
     components:
     - type: Transform
@@ -88798,14 +88955,14 @@ entities:
       pos: 3.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16658
     components:
     - type: Transform
       pos: 4.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16660
     components:
     - type: Transform
@@ -88813,7 +88970,7 @@ entities:
       pos: 6.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16661
     components:
     - type: Transform
@@ -88821,7 +88978,7 @@ entities:
       pos: 7.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16662
     components:
     - type: Transform
@@ -88829,7 +88986,7 @@ entities:
       pos: 8.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16663
     components:
     - type: Transform
@@ -88837,7 +88994,7 @@ entities:
       pos: 9.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16665
     components:
     - type: Transform
@@ -88845,7 +89002,7 @@ entities:
       pos: 11.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16671
     components:
     - type: Transform
@@ -88853,7 +89010,7 @@ entities:
       pos: 5.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16676
     components:
     - type: Transform
@@ -88861,7 +89018,7 @@ entities:
       pos: 5.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16677
     components:
     - type: Transform
@@ -88869,7 +89026,7 @@ entities:
       pos: 5.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16742
     components:
     - type: Transform
@@ -88900,7 +89057,7 @@ entities:
       pos: -50.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17458
     components:
     - type: Transform
@@ -88908,7 +89065,7 @@ entities:
       pos: -44.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17506
     components:
     - type: Transform
@@ -88916,7 +89073,7 @@ entities:
       pos: 18.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17507
     components:
     - type: Transform
@@ -88924,7 +89081,7 @@ entities:
       pos: 19.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17508
     components:
     - type: Transform
@@ -88932,7 +89089,7 @@ entities:
       pos: 20.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17510
     components:
     - type: Transform
@@ -88940,7 +89097,7 @@ entities:
       pos: 22.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17511
     components:
     - type: Transform
@@ -88948,7 +89105,7 @@ entities:
       pos: 23.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17512
     components:
     - type: Transform
@@ -88956,7 +89113,7 @@ entities:
       pos: 24.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17513
     components:
     - type: Transform
@@ -88964,7 +89121,7 @@ entities:
       pos: 25.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17514
     components:
     - type: Transform
@@ -88972,7 +89129,7 @@ entities:
       pos: 26.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17515
     components:
     - type: Transform
@@ -88980,7 +89137,7 @@ entities:
       pos: 27.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17516
     components:
     - type: Transform
@@ -88988,7 +89145,7 @@ entities:
       pos: 28.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17517
     components:
     - type: Transform
@@ -88996,7 +89153,7 @@ entities:
       pos: 29.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17518
     components:
     - type: Transform
@@ -89004,7 +89161,7 @@ entities:
       pos: 30.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17519
     components:
     - type: Transform
@@ -89012,7 +89169,7 @@ entities:
       pos: 31.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17520
     components:
     - type: Transform
@@ -89020,7 +89177,7 @@ entities:
       pos: 32.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17521
     components:
     - type: Transform
@@ -89028,7 +89185,7 @@ entities:
       pos: 33.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17522
     components:
     - type: Transform
@@ -89036,7 +89193,7 @@ entities:
       pos: 34.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17524
     components:
     - type: Transform
@@ -89044,7 +89201,7 @@ entities:
       pos: 36.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17526
     components:
     - type: Transform
@@ -89052,7 +89209,7 @@ entities:
       pos: 38.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17527
     components:
     - type: Transform
@@ -89060,7 +89217,7 @@ entities:
       pos: 39.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17528
     components:
     - type: Transform
@@ -89068,105 +89225,105 @@ entities:
       pos: 40.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17530
     components:
     - type: Transform
       pos: 41.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17531
     components:
     - type: Transform
       pos: 41.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17532
     components:
     - type: Transform
       pos: 41.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17533
     components:
     - type: Transform
       pos: 41.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17534
     components:
     - type: Transform
       pos: 41.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17535
     components:
     - type: Transform
       pos: 41.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17536
     components:
     - type: Transform
       pos: 41.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17537
     components:
     - type: Transform
       pos: 41.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17539
     components:
     - type: Transform
       pos: 41.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17540
     components:
     - type: Transform
       pos: 41.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17541
     components:
     - type: Transform
       pos: 41.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17542
     components:
     - type: Transform
       pos: 41.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17543
     components:
     - type: Transform
       pos: 41.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17544
     components:
     - type: Transform
       pos: 41.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17546
     components:
     - type: Transform
@@ -89174,7 +89331,7 @@ entities:
       pos: 40.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17547
     components:
     - type: Transform
@@ -89182,28 +89339,28 @@ entities:
       pos: 39.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17548
     components:
     - type: Transform
       pos: 39.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17549
     components:
     - type: Transform
       pos: 39.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17550
     components:
     - type: Transform
       pos: 39.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17569
     components:
     - type: Transform
@@ -89211,7 +89368,7 @@ entities:
       pos: -37.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17571
     components:
     - type: Transform
@@ -89219,7 +89376,7 @@ entities:
       pos: -39.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17572
     components:
     - type: Transform
@@ -89227,7 +89384,7 @@ entities:
       pos: -40.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17573
     components:
     - type: Transform
@@ -89235,7 +89392,7 @@ entities:
       pos: -41.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17574
     components:
     - type: Transform
@@ -89249,7 +89406,7 @@ entities:
       pos: -37.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17576
     components:
     - type: Transform
@@ -89257,7 +89414,7 @@ entities:
       pos: -38.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17577
     components:
     - type: Transform
@@ -89265,7 +89422,7 @@ entities:
       pos: -39.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17578
     components:
     - type: Transform
@@ -89273,7 +89430,7 @@ entities:
       pos: -40.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17579
     components:
     - type: Transform
@@ -89286,21 +89443,21 @@ entities:
       pos: -43.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17582
     components:
     - type: Transform
       pos: -43.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17584
     components:
     - type: Transform
       pos: -41.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17588
     components:
     - type: Transform
@@ -89308,7 +89465,7 @@ entities:
       pos: -41.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17589
     components:
     - type: Transform
@@ -89316,7 +89473,7 @@ entities:
       pos: -42.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17590
     components:
     - type: Transform
@@ -89324,7 +89481,7 @@ entities:
       pos: -43.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17591
     components:
     - type: Transform
@@ -89332,7 +89489,7 @@ entities:
       pos: -45.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17592
     components:
     - type: Transform
@@ -89340,7 +89497,7 @@ entities:
       pos: -45.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17593
     components:
     - type: Transform
@@ -89348,7 +89505,7 @@ entities:
       pos: -44.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17594
     components:
     - type: Transform
@@ -89362,7 +89519,7 @@ entities:
       pos: -43.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17596
     components:
     - type: Transform
@@ -89370,7 +89527,7 @@ entities:
       pos: -44.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17597
     components:
     - type: Transform
@@ -89378,7 +89535,7 @@ entities:
       pos: -45.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17598
     components:
     - type: Transform
@@ -89386,7 +89543,7 @@ entities:
       pos: -44.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17599
     components:
     - type: Transform
@@ -89394,77 +89551,77 @@ entities:
       pos: -45.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17605
     components:
     - type: Transform
       pos: -38.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17606
     components:
     - type: Transform
       pos: -38.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17607
     components:
     - type: Transform
       pos: -38.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17608
     components:
     - type: Transform
       pos: -38.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17609
     components:
     - type: Transform
       pos: -36.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17610
     components:
     - type: Transform
       pos: -36.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17611
     components:
     - type: Transform
       pos: -36.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17612
     components:
     - type: Transform
       pos: -36.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17613
     components:
     - type: Transform
       pos: -34.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17614
     components:
     - type: Transform
       pos: -34.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17699
     components:
     - type: Transform
@@ -89472,84 +89629,84 @@ entities:
       pos: 23.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17711
     components:
     - type: Transform
       pos: 39.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17746
     components:
     - type: Transform
       pos: 39.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17747
     components:
     - type: Transform
       pos: 39.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17748
     components:
     - type: Transform
       pos: 39.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17842
     components:
     - type: Transform
       pos: 39.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17846
     components:
     - type: Transform
       pos: 39.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17847
     components:
     - type: Transform
       pos: 39.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17848
     components:
     - type: Transform
       pos: 39.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17849
     components:
     - type: Transform
       pos: 39.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17850
     components:
     - type: Transform
       pos: 39.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17862
     components:
     - type: Transform
       pos: 39.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17866
     components:
     - type: Transform
@@ -89557,7 +89714,7 @@ entities:
       pos: 23.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17869
     components:
     - type: Transform
@@ -89565,7 +89722,7 @@ entities:
       pos: 23.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17880
     components:
     - type: Transform
@@ -89573,7 +89730,7 @@ entities:
       pos: 40.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17881
     components:
     - type: Transform
@@ -89581,7 +89738,7 @@ entities:
       pos: 41.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17882
     components:
     - type: Transform
@@ -89589,7 +89746,7 @@ entities:
       pos: 42.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17885
     components:
     - type: Transform
@@ -89597,7 +89754,7 @@ entities:
       pos: 43.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17886
     components:
     - type: Transform
@@ -89605,7 +89762,7 @@ entities:
       pos: 44.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17888
     components:
     - type: Transform
@@ -89613,7 +89770,7 @@ entities:
       pos: 46.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17889
     components:
     - type: Transform
@@ -89621,7 +89778,7 @@ entities:
       pos: 47.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17890
     components:
     - type: Transform
@@ -89629,7 +89786,7 @@ entities:
       pos: 48.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18097
     components:
     - type: Transform
@@ -89637,7 +89794,7 @@ entities:
       pos: 50.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18101
     components:
     - type: Transform
@@ -89645,7 +89802,7 @@ entities:
       pos: 51.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18102
     components:
     - type: Transform
@@ -89653,7 +89810,7 @@ entities:
       pos: 42.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18216
     components:
     - type: Transform
@@ -89661,7 +89818,7 @@ entities:
       pos: -2.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18218
     components:
     - type: Transform
@@ -89669,84 +89826,84 @@ entities:
       pos: 1.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18219
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18220
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18221
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18222
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18224
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18225
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18226
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18227
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18228
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18229
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18230
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18232
     components:
     - type: Transform
@@ -89754,35 +89911,35 @@ entities:
       pos: -0.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18233
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18234
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18235
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18236
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18237
     components:
     - type: Transform
@@ -89790,28 +89947,28 @@ entities:
       pos: 0.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18238
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18240
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18241
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18244
     components:
     - type: Transform
@@ -89819,7 +89976,7 @@ entities:
       pos: -1.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18245
     components:
     - type: Transform
@@ -89827,7 +89984,7 @@ entities:
       pos: 0.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18246
     components:
     - type: Transform
@@ -89835,7 +89992,7 @@ entities:
       pos: -0.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18247
     components:
     - type: Transform
@@ -89843,7 +90000,7 @@ entities:
       pos: -1.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18248
     components:
     - type: Transform
@@ -89851,28 +90008,28 @@ entities:
       pos: -2.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18251
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18252
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18253
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18262
     components:
     - type: Transform
@@ -89880,28 +90037,28 @@ entities:
       pos: -6.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18263
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18264
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18265
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18268
     components:
     - type: Transform
@@ -89909,7 +90066,7 @@ entities:
       pos: -5.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18269
     components:
     - type: Transform
@@ -89917,7 +90074,7 @@ entities:
       pos: -6.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18274
     components:
     - type: Transform
@@ -89925,7 +90082,7 @@ entities:
       pos: -2.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18275
     components:
     - type: Transform
@@ -89933,7 +90090,7 @@ entities:
       pos: -2.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18278
     components:
     - type: Transform
@@ -89941,7 +90098,7 @@ entities:
       pos: -4.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18279
     components:
     - type: Transform
@@ -89949,7 +90106,7 @@ entities:
       pos: -4.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18280
     components:
     - type: Transform
@@ -89957,7 +90114,7 @@ entities:
       pos: -3.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18417
     components:
     - type: Transform
@@ -89965,7 +90122,7 @@ entities:
       pos: 2.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18418
     components:
     - type: Transform
@@ -89973,7 +90130,7 @@ entities:
       pos: 3.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18419
     components:
     - type: Transform
@@ -89981,7 +90138,7 @@ entities:
       pos: 4.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18420
     components:
     - type: Transform
@@ -89989,7 +90146,7 @@ entities:
       pos: 1.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18421
     components:
     - type: Transform
@@ -89997,7 +90154,7 @@ entities:
       pos: 2.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18422
     components:
     - type: Transform
@@ -90005,7 +90162,7 @@ entities:
       pos: 3.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18431
     components:
     - type: Transform
@@ -90013,7 +90170,7 @@ entities:
       pos: -3.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18432
     components:
     - type: Transform
@@ -90021,7 +90178,7 @@ entities:
       pos: -3.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18433
     components:
     - type: Transform
@@ -90029,7 +90186,7 @@ entities:
       pos: -3.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18464
     components:
     - type: Transform
@@ -90037,7 +90194,7 @@ entities:
       pos: -41.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18502
     components:
     - type: Transform
@@ -90045,7 +90202,7 @@ entities:
       pos: -5.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18533
     components:
     - type: Transform
@@ -90053,7 +90210,7 @@ entities:
       pos: 1.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18535
     components:
     - type: Transform
@@ -90061,7 +90218,7 @@ entities:
       pos: 3.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18536
     components:
     - type: Transform
@@ -90069,7 +90226,7 @@ entities:
       pos: 4.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18537
     components:
     - type: Transform
@@ -90077,7 +90234,7 @@ entities:
       pos: 4.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18538
     components:
     - type: Transform
@@ -90085,7 +90242,7 @@ entities:
       pos: 4.5,-2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18543
     components:
     - type: Transform
@@ -90093,7 +90250,7 @@ entities:
       pos: 45.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18545
     components:
     - type: Transform
@@ -90101,7 +90258,7 @@ entities:
       pos: 46.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18551
     components:
     - type: Transform
@@ -90109,7 +90266,7 @@ entities:
       pos: 47.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18585
     components:
     - type: Transform
@@ -90117,7 +90274,7 @@ entities:
       pos: 49.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18648
     components:
     - type: Transform
@@ -90125,7 +90282,7 @@ entities:
       pos: 50.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18650
     components:
     - type: Transform
@@ -90133,7 +90290,7 @@ entities:
       pos: 45.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18651
     components:
     - type: Transform
@@ -90141,7 +90298,7 @@ entities:
       pos: 45.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18654
     components:
     - type: Transform
@@ -90149,7 +90306,7 @@ entities:
       pos: 43.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18655
     components:
     - type: Transform
@@ -90157,7 +90314,7 @@ entities:
       pos: 43.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18656
     components:
     - type: Transform
@@ -90165,21 +90322,21 @@ entities:
       pos: 43.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18660
     components:
     - type: Transform
       pos: 52.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18661
     components:
     - type: Transform
       pos: 52.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18665
     components:
     - type: Transform
@@ -90187,7 +90344,7 @@ entities:
       pos: 51.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18666
     components:
     - type: Transform
@@ -90195,7 +90352,7 @@ entities:
       pos: 50.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18667
     components:
     - type: Transform
@@ -90203,7 +90360,7 @@ entities:
       pos: 49.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18670
     components:
     - type: Transform
@@ -90211,7 +90368,7 @@ entities:
       pos: 51.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18672
     components:
     - type: Transform
@@ -90219,7 +90376,7 @@ entities:
       pos: 51.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18673
     components:
     - type: Transform
@@ -90227,7 +90384,7 @@ entities:
       pos: 51.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18674
     components:
     - type: Transform
@@ -90235,7 +90392,7 @@ entities:
       pos: 51.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18675
     components:
     - type: Transform
@@ -90243,7 +90400,7 @@ entities:
       pos: 51.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18680
     components:
     - type: Transform
@@ -90251,7 +90408,7 @@ entities:
       pos: 50.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18684
     components:
     - type: Transform
@@ -90259,7 +90416,7 @@ entities:
       pos: 49.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18688
     components:
     - type: Transform
@@ -90267,7 +90424,7 @@ entities:
       pos: 52.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18689
     components:
     - type: Transform
@@ -90275,7 +90432,7 @@ entities:
       pos: 52.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18690
     components:
     - type: Transform
@@ -90283,7 +90440,7 @@ entities:
       pos: 39.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18692
     components:
     - type: Transform
@@ -90291,7 +90448,7 @@ entities:
       pos: 39.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18711
     components:
     - type: Transform
@@ -90299,7 +90456,7 @@ entities:
       pos: 39.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18714
     components:
     - type: Transform
@@ -90307,35 +90464,35 @@ entities:
       pos: 38.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18715
     components:
     - type: Transform
       pos: 37.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18716
     components:
     - type: Transform
       pos: 37.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18718
     components:
     - type: Transform
       pos: 37.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18872
     components:
     - type: Transform
       pos: 48.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18892
     components:
     - type: Transform
@@ -90348,21 +90505,21 @@ entities:
       pos: 47.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18912
     components:
     - type: Transform
       pos: 47.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18913
     components:
     - type: Transform
       pos: 47.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18928
     components:
     - type: Transform
@@ -90398,7 +90555,7 @@ entities:
       pos: 16.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 19172
     components:
     - type: Transform
@@ -90406,7 +90563,7 @@ entities:
       pos: 17.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 19173
     components:
     - type: Transform
@@ -90414,7 +90571,7 @@ entities:
       pos: 18.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 19174
     components:
     - type: Transform
@@ -90422,7 +90579,7 @@ entities:
       pos: 19.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 19175
     components:
     - type: Transform
@@ -90430,7 +90587,7 @@ entities:
       pos: 20.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 19176
     components:
     - type: Transform
@@ -90438,7 +90595,7 @@ entities:
       pos: 18.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 19177
     components:
     - type: Transform
@@ -90446,7 +90603,7 @@ entities:
       pos: 19.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 19178
     components:
     - type: Transform
@@ -90454,7 +90611,7 @@ entities:
       pos: 20.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 19786
     components:
     - type: Transform
@@ -90462,7 +90619,7 @@ entities:
       pos: -48.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 19794
     components:
     - type: Transform
@@ -90470,7 +90627,7 @@ entities:
       pos: -48.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 19879
     components:
     - type: Transform
@@ -90478,7 +90635,7 @@ entities:
       pos: -47.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21289
     components:
     - type: Transform
@@ -90486,7 +90643,7 @@ entities:
       pos: -56.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21301
     components:
     - type: Transform
@@ -90494,7 +90651,7 @@ entities:
       pos: -57.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21302
     components:
     - type: Transform
@@ -90502,7 +90659,7 @@ entities:
       pos: -58.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21304
     components:
     - type: Transform
@@ -90510,7 +90667,7 @@ entities:
       pos: -58.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21305
     components:
     - type: Transform
@@ -90518,7 +90675,7 @@ entities:
       pos: -59.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21306
     components:
     - type: Transform
@@ -90526,7 +90683,7 @@ entities:
       pos: -60.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21307
     components:
     - type: Transform
@@ -90534,7 +90691,7 @@ entities:
       pos: -61.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21308
     components:
     - type: Transform
@@ -90542,7 +90699,7 @@ entities:
       pos: -62.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21309
     components:
     - type: Transform
@@ -90550,7 +90707,7 @@ entities:
       pos: -63.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21310
     components:
     - type: Transform
@@ -90558,7 +90715,7 @@ entities:
       pos: -64.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21311
     components:
     - type: Transform
@@ -90566,7 +90723,7 @@ entities:
       pos: -65.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21312
     components:
     - type: Transform
@@ -90574,7 +90731,7 @@ entities:
       pos: -66.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21313
     components:
     - type: Transform
@@ -90582,7 +90739,7 @@ entities:
       pos: -67.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21314
     components:
     - type: Transform
@@ -90590,7 +90747,7 @@ entities:
       pos: -68.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21315
     components:
     - type: Transform
@@ -90598,7 +90755,7 @@ entities:
       pos: -69.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21316
     components:
     - type: Transform
@@ -90606,7 +90763,7 @@ entities:
       pos: -70.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21317
     components:
     - type: Transform
@@ -90614,7 +90771,7 @@ entities:
       pos: -71.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21319
     components:
     - type: Transform
@@ -90622,7 +90779,7 @@ entities:
       pos: -73.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21320
     components:
     - type: Transform
@@ -90630,7 +90787,7 @@ entities:
       pos: -74.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21321
     components:
     - type: Transform
@@ -90638,7 +90795,7 @@ entities:
       pos: -75.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21322
     components:
     - type: Transform
@@ -90646,7 +90803,7 @@ entities:
       pos: -76.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21323
     components:
     - type: Transform
@@ -90654,7 +90811,7 @@ entities:
       pos: -77.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21324
     components:
     - type: Transform
@@ -90662,7 +90819,7 @@ entities:
       pos: -78.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21329
     components:
     - type: Transform
@@ -90692,7 +90849,7 @@ entities:
       pos: -32.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21412
     components:
     - type: Transform
@@ -90715,7 +90872,7 @@ entities:
       pos: -7.5,-39.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21659
     components:
     - type: Transform
@@ -90723,7 +90880,7 @@ entities:
       pos: -23.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21660
     components:
     - type: Transform
@@ -90731,7 +90888,7 @@ entities:
       pos: -24.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21661
     components:
     - type: Transform
@@ -90739,7 +90896,7 @@ entities:
       pos: -25.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21662
     components:
     - type: Transform
@@ -90747,7 +90904,7 @@ entities:
       pos: -26.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21663
     components:
     - type: Transform
@@ -90755,7 +90912,7 @@ entities:
       pos: -27.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21664
     components:
     - type: Transform
@@ -90763,7 +90920,7 @@ entities:
       pos: -28.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22790
     components:
     - type: Transform
@@ -90771,7 +90928,7 @@ entities:
       pos: -79.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22791
     components:
     - type: Transform
@@ -90779,7 +90936,7 @@ entities:
       pos: -80.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22792
     components:
     - type: Transform
@@ -90787,7 +90944,7 @@ entities:
       pos: -81.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22793
     components:
     - type: Transform
@@ -90795,7 +90952,7 @@ entities:
       pos: -82.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22794
     components:
     - type: Transform
@@ -90803,7 +90960,7 @@ entities:
       pos: -83.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22795
     components:
     - type: Transform
@@ -90811,7 +90968,7 @@ entities:
       pos: -84.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22796
     components:
     - type: Transform
@@ -90819,7 +90976,7 @@ entities:
       pos: -85.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22797
     components:
     - type: Transform
@@ -90827,7 +90984,7 @@ entities:
       pos: -86.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22798
     components:
     - type: Transform
@@ -90835,7 +90992,7 @@ entities:
       pos: -87.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22799
     components:
     - type: Transform
@@ -90843,7 +91000,7 @@ entities:
       pos: -88.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22800
     components:
     - type: Transform
@@ -90851,7 +91008,7 @@ entities:
       pos: -89.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22801
     components:
     - type: Transform
@@ -90859,7 +91016,7 @@ entities:
       pos: -90.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22802
     components:
     - type: Transform
@@ -90867,7 +91024,7 @@ entities:
       pos: -91.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22803
     components:
     - type: Transform
@@ -90875,7 +91032,7 @@ entities:
       pos: -92.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22804
     components:
     - type: Transform
@@ -90883,7 +91040,7 @@ entities:
       pos: -93.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22805
     components:
     - type: Transform
@@ -90891,7 +91048,7 @@ entities:
       pos: -94.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22806
     components:
     - type: Transform
@@ -90899,7 +91056,7 @@ entities:
       pos: -95.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22807
     components:
     - type: Transform
@@ -90907,7 +91064,7 @@ entities:
       pos: -96.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22808
     components:
     - type: Transform
@@ -90915,7 +91072,7 @@ entities:
       pos: -97.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22809
     components:
     - type: Transform
@@ -90923,7 +91080,7 @@ entities:
       pos: -98.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22811
     components:
     - type: Transform
@@ -90931,7 +91088,7 @@ entities:
       pos: -100.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22812
     components:
     - type: Transform
@@ -90939,7 +91096,7 @@ entities:
       pos: -101.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22813
     components:
     - type: Transform
@@ -90947,7 +91104,7 @@ entities:
       pos: -102.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22815
     components:
     - type: Transform
@@ -90955,7 +91112,7 @@ entities:
       pos: -104.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22816
     components:
     - type: Transform
@@ -90963,7 +91120,7 @@ entities:
       pos: -105.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22817
     components:
     - type: Transform
@@ -90971,7 +91128,7 @@ entities:
       pos: -106.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22818
     components:
     - type: Transform
@@ -90979,7 +91136,7 @@ entities:
       pos: -107.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22819
     components:
     - type: Transform
@@ -90987,7 +91144,7 @@ entities:
       pos: -108.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22820
     components:
     - type: Transform
@@ -90995,7 +91152,7 @@ entities:
       pos: -109.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22821
     components:
     - type: Transform
@@ -91003,7 +91160,7 @@ entities:
       pos: -110.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22824
     components:
     - type: Transform
@@ -91011,7 +91168,7 @@ entities:
       pos: -113.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22825
     components:
     - type: Transform
@@ -91019,7 +91176,7 @@ entities:
       pos: -114.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22826
     components:
     - type: Transform
@@ -91027,7 +91184,7 @@ entities:
       pos: -115.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22827
     components:
     - type: Transform
@@ -91035,7 +91192,7 @@ entities:
       pos: -116.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22830
     components:
     - type: Transform
@@ -91043,7 +91200,7 @@ entities:
       pos: -111.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22831
     components:
     - type: Transform
@@ -91051,7 +91208,7 @@ entities:
       pos: -111.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22832
     components:
     - type: Transform
@@ -91059,7 +91216,7 @@ entities:
       pos: -111.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22833
     components:
     - type: Transform
@@ -91067,7 +91224,7 @@ entities:
       pos: -111.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22834
     components:
     - type: Transform
@@ -91075,7 +91232,7 @@ entities:
       pos: -111.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22835
     components:
     - type: Transform
@@ -91083,7 +91240,7 @@ entities:
       pos: -111.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22836
     components:
     - type: Transform
@@ -91091,7 +91248,7 @@ entities:
       pos: -111.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22837
     components:
     - type: Transform
@@ -91099,7 +91256,7 @@ entities:
       pos: -111.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22838
     components:
     - type: Transform
@@ -91107,7 +91264,7 @@ entities:
       pos: -111.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22840
     components:
     - type: Transform
@@ -91115,7 +91272,7 @@ entities:
       pos: -111.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22841
     components:
     - type: Transform
@@ -91123,7 +91280,7 @@ entities:
       pos: -111.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22842
     components:
     - type: Transform
@@ -91131,7 +91288,7 @@ entities:
       pos: -111.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22843
     components:
     - type: Transform
@@ -91139,7 +91296,7 @@ entities:
       pos: -111.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22844
     components:
     - type: Transform
@@ -91147,7 +91304,7 @@ entities:
       pos: -111.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22845
     components:
     - type: Transform
@@ -91155,7 +91312,7 @@ entities:
       pos: -111.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22848
     components:
     - type: Transform
@@ -91163,7 +91320,7 @@ entities:
       pos: -99.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22849
     components:
     - type: Transform
@@ -91171,7 +91328,7 @@ entities:
       pos: -99.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22850
     components:
     - type: Transform
@@ -91179,7 +91336,7 @@ entities:
       pos: -99.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22851
     components:
     - type: Transform
@@ -91187,7 +91344,7 @@ entities:
       pos: -100.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22852
     components:
     - type: Transform
@@ -91195,91 +91352,91 @@ entities:
       pos: -101.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22853
     components:
     - type: Transform
       pos: -102.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22854
     components:
     - type: Transform
       pos: -102.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22855
     components:
     - type: Transform
       pos: -102.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22856
     components:
     - type: Transform
       pos: -102.5,26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22857
     components:
     - type: Transform
       pos: -102.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22858
     components:
     - type: Transform
       pos: -102.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22859
     components:
     - type: Transform
       pos: -102.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22860
     components:
     - type: Transform
       pos: -102.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22861
     components:
     - type: Transform
       pos: -102.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22862
     components:
     - type: Transform
       pos: -102.5,32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22863
     components:
     - type: Transform
       pos: -102.5,33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22864
     components:
     - type: Transform
       pos: -102.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22865
     components:
     - type: Transform
@@ -91287,7 +91444,7 @@ entities:
       pos: -103.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22866
     components:
     - type: Transform
@@ -91295,7 +91452,7 @@ entities:
       pos: -104.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22867
     components:
     - type: Transform
@@ -91303,7 +91460,7 @@ entities:
       pos: -105.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22868
     components:
     - type: Transform
@@ -91311,7 +91468,7 @@ entities:
       pos: -106.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22869
     components:
     - type: Transform
@@ -91319,7 +91476,7 @@ entities:
       pos: -107.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22870
     components:
     - type: Transform
@@ -91327,7 +91484,7 @@ entities:
       pos: -108.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22871
     components:
     - type: Transform
@@ -91335,7 +91492,7 @@ entities:
       pos: -109.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22900
     components:
     - type: Transform
@@ -91343,35 +91500,35 @@ entities:
       pos: -112.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22901
     components:
     - type: Transform
       pos: -113.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22902
     components:
     - type: Transform
       pos: -113.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22903
     components:
     - type: Transform
       pos: -113.5,26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22904
     components:
     - type: Transform
       pos: -113.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22905
     components:
     - type: Transform
@@ -91379,7 +91536,7 @@ entities:
       pos: -112.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22919
     components:
     - type: Transform
@@ -92456,7 +92613,7 @@ entities:
       pos: -30.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 23652
     components:
     - type: Transform
@@ -92464,7 +92621,7 @@ entities:
       pos: -30.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 23977
     components:
     - type: Transform
@@ -92472,7 +92629,7 @@ entities:
       pos: 15.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24128
     components:
     - type: Transform
@@ -92480,7 +92637,7 @@ entities:
       pos: -6.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24130
     components:
     - type: Transform
@@ -92488,7 +92645,7 @@ entities:
       pos: -7.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24131
     components:
     - type: Transform
@@ -92496,7 +92653,7 @@ entities:
       pos: -8.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24132
     components:
     - type: Transform
@@ -92504,7 +92661,7 @@ entities:
       pos: -7.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24135
     components:
     - type: Transform
@@ -92512,7 +92669,7 @@ entities:
       pos: -6.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24357
     components:
     - type: Transform
@@ -92520,7 +92677,7 @@ entities:
       pos: 46.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24750
     components:
     - type: Transform
@@ -92528,7 +92685,7 @@ entities:
       pos: 54.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24827
     components:
     - type: Transform
@@ -92536,7 +92693,7 @@ entities:
       pos: 53.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24828
     components:
     - type: Transform
@@ -92544,7 +92701,7 @@ entities:
       pos: 52.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24829
     components:
     - type: Transform
@@ -92552,7 +92709,7 @@ entities:
       pos: 51.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24830
     components:
     - type: Transform
@@ -92560,7 +92717,7 @@ entities:
       pos: 50.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24831
     components:
     - type: Transform
@@ -92568,7 +92725,7 @@ entities:
       pos: 49.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24832
     components:
     - type: Transform
@@ -92576,7 +92733,7 @@ entities:
       pos: 48.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24833
     components:
     - type: Transform
@@ -92584,7 +92741,7 @@ entities:
       pos: 47.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24835
     components:
     - type: Transform
@@ -92592,7 +92749,7 @@ entities:
       pos: 44.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24836
     components:
     - type: Transform
@@ -92600,7 +92757,7 @@ entities:
       pos: 43.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24837
     components:
     - type: Transform
@@ -92608,7 +92765,7 @@ entities:
       pos: 42.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24838
     components:
     - type: Transform
@@ -92616,7 +92773,7 @@ entities:
       pos: 46.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24839
     components:
     - type: Transform
@@ -92624,7 +92781,7 @@ entities:
       pos: 42.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24840
     components:
     - type: Transform
@@ -92632,7 +92789,7 @@ entities:
       pos: 44.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24841
     components:
     - type: Transform
@@ -92640,7 +92797,7 @@ entities:
       pos: 45.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24842
     components:
     - type: Transform
@@ -92648,7 +92805,7 @@ entities:
       pos: 46.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24843
     components:
     - type: Transform
@@ -92656,7 +92813,7 @@ entities:
       pos: 47.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24844
     components:
     - type: Transform
@@ -92664,7 +92821,7 @@ entities:
       pos: 48.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24846
     components:
     - type: Transform
@@ -92672,7 +92829,7 @@ entities:
       pos: 49.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24847
     components:
     - type: Transform
@@ -92680,7 +92837,7 @@ entities:
       pos: 50.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24848
     components:
     - type: Transform
@@ -92688,7 +92845,7 @@ entities:
       pos: 51.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24849
     components:
     - type: Transform
@@ -92696,7 +92853,7 @@ entities:
       pos: 52.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24850
     components:
     - type: Transform
@@ -92704,7 +92861,7 @@ entities:
       pos: 55.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24851
     components:
     - type: Transform
@@ -92712,7 +92869,7 @@ entities:
       pos: 55.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24852
     components:
     - type: Transform
@@ -92720,7 +92877,7 @@ entities:
       pos: 55.5,26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24853
     components:
     - type: Transform
@@ -92728,7 +92885,7 @@ entities:
       pos: 55.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24854
     components:
     - type: Transform
@@ -92736,7 +92893,7 @@ entities:
       pos: 55.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24855
     components:
     - type: Transform
@@ -92744,7 +92901,7 @@ entities:
       pos: 55.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24856
     components:
     - type: Transform
@@ -92752,7 +92909,7 @@ entities:
       pos: 55.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24857
     components:
     - type: Transform
@@ -92760,7 +92917,7 @@ entities:
       pos: 55.5,32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24858
     components:
     - type: Transform
@@ -92768,7 +92925,7 @@ entities:
       pos: 55.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24859
     components:
     - type: Transform
@@ -92776,7 +92933,7 @@ entities:
       pos: 55.5,33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24860
     components:
     - type: Transform
@@ -92784,7 +92941,7 @@ entities:
       pos: 55.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24861
     components:
     - type: Transform
@@ -92792,7 +92949,7 @@ entities:
       pos: 55.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24862
     components:
     - type: Transform
@@ -92800,7 +92957,7 @@ entities:
       pos: 55.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24863
     components:
     - type: Transform
@@ -92808,7 +92965,7 @@ entities:
       pos: 55.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24864
     components:
     - type: Transform
@@ -92816,7 +92973,7 @@ entities:
       pos: 55.5,40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24865
     components:
     - type: Transform
@@ -92824,7 +92981,7 @@ entities:
       pos: 55.5,41.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24866
     components:
     - type: Transform
@@ -92832,7 +92989,7 @@ entities:
       pos: 55.5,38.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24867
     components:
     - type: Transform
@@ -92840,7 +92997,7 @@ entities:
       pos: 55.5,43.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24868
     components:
     - type: Transform
@@ -92848,7 +93005,7 @@ entities:
       pos: 55.5,44.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24869
     components:
     - type: Transform
@@ -92856,7 +93013,7 @@ entities:
       pos: 55.5,45.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24870
     components:
     - type: Transform
@@ -92864,7 +93021,7 @@ entities:
       pos: 55.5,42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24872
     components:
     - type: Transform
@@ -92872,7 +93029,7 @@ entities:
       pos: 53.5,44.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24873
     components:
     - type: Transform
@@ -92880,7 +93037,7 @@ entities:
       pos: 53.5,43.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24874
     components:
     - type: Transform
@@ -92888,7 +93045,7 @@ entities:
       pos: 53.5,42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24875
     components:
     - type: Transform
@@ -92896,7 +93053,7 @@ entities:
       pos: 53.5,41.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24876
     components:
     - type: Transform
@@ -92904,7 +93061,7 @@ entities:
       pos: 53.5,39.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24877
     components:
     - type: Transform
@@ -92912,7 +93069,7 @@ entities:
       pos: 53.5,38.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24879
     components:
     - type: Transform
@@ -92920,7 +93077,7 @@ entities:
       pos: 53.5,40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24880
     components:
     - type: Transform
@@ -92928,7 +93085,7 @@ entities:
       pos: 53.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24881
     components:
     - type: Transform
@@ -92936,7 +93093,7 @@ entities:
       pos: 53.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24882
     components:
     - type: Transform
@@ -92944,7 +93101,7 @@ entities:
       pos: 53.5,33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24883
     components:
     - type: Transform
@@ -92952,7 +93109,7 @@ entities:
       pos: 53.5,32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24884
     components:
     - type: Transform
@@ -92960,7 +93117,7 @@ entities:
       pos: 53.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24885
     components:
     - type: Transform
@@ -92968,7 +93125,7 @@ entities:
       pos: 53.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24886
     components:
     - type: Transform
@@ -92976,7 +93133,7 @@ entities:
       pos: 53.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24887
     components:
     - type: Transform
@@ -92984,7 +93141,7 @@ entities:
       pos: 53.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24888
     components:
     - type: Transform
@@ -92992,7 +93149,7 @@ entities:
       pos: 53.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24889
     components:
     - type: Transform
@@ -93000,7 +93157,7 @@ entities:
       pos: 53.5,26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24890
     components:
     - type: Transform
@@ -93008,7 +93165,7 @@ entities:
       pos: 53.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24892
     components:
     - type: Transform
@@ -93016,7 +93173,7 @@ entities:
       pos: 33.5,26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24893
     components:
     - type: Transform
@@ -93024,7 +93181,7 @@ entities:
       pos: 33.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24894
     components:
     - type: Transform
@@ -93032,7 +93189,7 @@ entities:
       pos: 33.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24895
     components:
     - type: Transform
@@ -93040,7 +93197,7 @@ entities:
       pos: 33.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24896
     components:
     - type: Transform
@@ -93048,7 +93205,7 @@ entities:
       pos: 33.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24897
     components:
     - type: Transform
@@ -93056,7 +93213,7 @@ entities:
       pos: 33.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24898
     components:
     - type: Transform
@@ -93064,7 +93221,7 @@ entities:
       pos: 33.5,32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24899
     components:
     - type: Transform
@@ -93072,7 +93229,7 @@ entities:
       pos: 33.5,33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24900
     components:
     - type: Transform
@@ -93080,7 +93237,7 @@ entities:
       pos: 33.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24901
     components:
     - type: Transform
@@ -93088,7 +93245,7 @@ entities:
       pos: 33.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24903
     components:
     - type: Transform
@@ -93096,7 +93253,7 @@ entities:
       pos: 33.5,38.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24904
     components:
     - type: Transform
@@ -93104,7 +93261,7 @@ entities:
       pos: 33.5,39.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24905
     components:
     - type: Transform
@@ -93112,7 +93269,7 @@ entities:
       pos: 33.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24906
     components:
     - type: Transform
@@ -93120,7 +93277,7 @@ entities:
       pos: 33.5,40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24907
     components:
     - type: Transform
@@ -93128,7 +93285,7 @@ entities:
       pos: 33.5,41.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24908
     components:
     - type: Transform
@@ -93136,7 +93293,7 @@ entities:
       pos: 33.5,42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24909
     components:
     - type: Transform
@@ -93144,7 +93301,7 @@ entities:
       pos: 33.5,43.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24910
     components:
     - type: Transform
@@ -93152,7 +93309,7 @@ entities:
       pos: 33.5,44.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24911
     components:
     - type: Transform
@@ -93160,7 +93317,7 @@ entities:
       pos: 35.5,44.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24912
     components:
     - type: Transform
@@ -93168,7 +93325,7 @@ entities:
       pos: 35.5,43.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24913
     components:
     - type: Transform
@@ -93176,7 +93333,7 @@ entities:
       pos: 35.5,42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24914
     components:
     - type: Transform
@@ -93184,7 +93341,7 @@ entities:
       pos: 35.5,41.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24915
     components:
     - type: Transform
@@ -93192,7 +93349,7 @@ entities:
       pos: 35.5,40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24917
     components:
     - type: Transform
@@ -93200,7 +93357,7 @@ entities:
       pos: 35.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24918
     components:
     - type: Transform
@@ -93208,7 +93365,7 @@ entities:
       pos: 35.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24919
     components:
     - type: Transform
@@ -93216,7 +93373,7 @@ entities:
       pos: 35.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24920
     components:
     - type: Transform
@@ -93224,7 +93381,7 @@ entities:
       pos: 35.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24921
     components:
     - type: Transform
@@ -93232,7 +93389,7 @@ entities:
       pos: 35.5,38.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24922
     components:
     - type: Transform
@@ -93240,7 +93397,7 @@ entities:
       pos: 35.5,32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24923
     components:
     - type: Transform
@@ -93248,7 +93405,7 @@ entities:
       pos: 35.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24924
     components:
     - type: Transform
@@ -93256,7 +93413,7 @@ entities:
       pos: 35.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24925
     components:
     - type: Transform
@@ -93264,7 +93421,7 @@ entities:
       pos: 35.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24926
     components:
     - type: Transform
@@ -93272,7 +93429,7 @@ entities:
       pos: 35.5,33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24927
     components:
     - type: Transform
@@ -93280,7 +93437,7 @@ entities:
       pos: 35.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24928
     components:
     - type: Transform
@@ -93288,7 +93445,7 @@ entities:
       pos: 35.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24929
     components:
     - type: Transform
@@ -93296,7 +93453,7 @@ entities:
       pos: 35.5,26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24930
     components:
     - type: Transform
@@ -93304,7 +93461,7 @@ entities:
       pos: 35.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24931
     components:
     - type: Transform
@@ -93312,7 +93469,7 @@ entities:
       pos: 35.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25169
     components:
     - type: Transform
@@ -93320,7 +93477,7 @@ entities:
       pos: 35.5,45.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25170
     components:
     - type: Transform
@@ -93328,14 +93485,14 @@ entities:
       pos: 35.5,46.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25171
     components:
     - type: Transform
       pos: 55.5,46.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25187
     components:
     - type: Transform
@@ -93343,7 +93500,7 @@ entities:
       pos: 53.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 25188
     components:
     - type: Transform
@@ -93351,7 +93508,7 @@ entities:
       pos: 53.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
 - proto: GasPipeTJunction
   entities:
   - uid: 46
@@ -93361,7 +93518,7 @@ entities:
       pos: -33.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 220
     components:
     - type: Transform
@@ -93369,7 +93526,7 @@ entities:
       pos: 23.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 306
     components:
     - type: Transform
@@ -93377,7 +93534,7 @@ entities:
       pos: 21.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 409
     components:
     - type: Transform
@@ -93385,7 +93542,7 @@ entities:
       pos: 1.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 417
     components:
     - type: Transform
@@ -93393,7 +93550,7 @@ entities:
       pos: -0.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 429
     components:
     - type: Transform
@@ -93401,7 +93558,7 @@ entities:
       pos: 45.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 474
     components:
     - type: Transform
@@ -93409,7 +93566,7 @@ entities:
       pos: 1.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 479
     components:
     - type: Transform
@@ -93417,7 +93574,7 @@ entities:
       pos: -0.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 499
     components:
     - type: Transform
@@ -93425,21 +93582,21 @@ entities:
       pos: -14.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 508
     components:
     - type: Transform
       pos: 3.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 511
     components:
     - type: Transform
       pos: -3.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 795
     components:
     - type: Transform
@@ -93447,7 +93604,7 @@ entities:
       pos: -38.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 840
     components:
     - type: Transform
@@ -93455,21 +93612,21 @@ entities:
       pos: -21.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 877
     components:
     - type: Transform
       pos: -4.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 878
     components:
     - type: Transform
       pos: -8.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 887
     components:
     - type: Transform
@@ -93477,14 +93634,14 @@ entities:
       pos: -10.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 896
     components:
     - type: Transform
       pos: -9.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 953
     components:
     - type: Transform
@@ -93492,7 +93649,7 @@ entities:
       pos: -36.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 960
     components:
     - type: Transform
@@ -93500,21 +93657,21 @@ entities:
       pos: -9.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1036
     components:
     - type: Transform
       pos: 11.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1043
     components:
     - type: Transform
       pos: 7.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1045
     components:
     - type: Transform
@@ -93522,7 +93679,7 @@ entities:
       pos: 15.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1047
     components:
     - type: Transform
@@ -93530,14 +93687,14 @@ entities:
       pos: 12.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1051
     components:
     - type: Transform
       pos: 16.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1052
     components:
     - type: Transform
@@ -93545,7 +93702,7 @@ entities:
       pos: 17.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1059
     components:
     - type: Transform
@@ -93553,7 +93710,7 @@ entities:
       pos: 17.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1061
     components:
     - type: Transform
@@ -93561,7 +93718,7 @@ entities:
       pos: 15.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1066
     components:
     - type: Transform
@@ -93569,7 +93726,7 @@ entities:
       pos: 9.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1077
     components:
     - type: Transform
@@ -93577,7 +93734,7 @@ entities:
       pos: 17.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1079
     components:
     - type: Transform
@@ -93585,7 +93742,7 @@ entities:
       pos: 15.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1096
     components:
     - type: Transform
@@ -93593,7 +93750,7 @@ entities:
       pos: 15.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1114
     components:
     - type: Transform
@@ -93601,7 +93758,7 @@ entities:
       pos: -14.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1115
     components:
     - type: Transform
@@ -93609,14 +93766,14 @@ entities:
       pos: -16.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1116
     components:
     - type: Transform
       pos: -24.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1128
     components:
     - type: Transform
@@ -93624,7 +93781,7 @@ entities:
       pos: -16.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1148
     components:
     - type: Transform
@@ -93632,7 +93789,7 @@ entities:
       pos: -14.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1150
     components:
     - type: Transform
@@ -93640,28 +93797,28 @@ entities:
       pos: -16.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1226
     components:
     - type: Transform
       pos: -10.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1259
     components:
     - type: Transform
       pos: 13.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1262
     components:
     - type: Transform
       pos: 10.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1265
     components:
     - type: Transform
@@ -93669,14 +93826,14 @@ entities:
       pos: 12.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1269
     components:
     - type: Transform
       pos: 9.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1273
     components:
     - type: Transform
@@ -93684,7 +93841,7 @@ entities:
       pos: 15.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1275
     components:
     - type: Transform
@@ -93692,7 +93849,7 @@ entities:
       pos: 15.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1276
     components:
     - type: Transform
@@ -93700,7 +93857,7 @@ entities:
       pos: 17.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1410
     components:
     - type: Transform
@@ -93708,7 +93865,7 @@ entities:
       pos: 3.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1417
     components:
     - type: Transform
@@ -93716,7 +93873,7 @@ entities:
       pos: -0.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1419
     components:
     - type: Transform
@@ -93724,7 +93881,7 @@ entities:
       pos: 1.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1498
     components:
     - type: Transform
@@ -93732,7 +93889,7 @@ entities:
       pos: -19.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1579
     components:
     - type: Transform
@@ -93740,21 +93897,21 @@ entities:
       pos: -18.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1608
     components:
     - type: Transform
       pos: -29.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1610
     components:
     - type: Transform
       pos: -23.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1665
     components:
     - type: Transform
@@ -93762,7 +93919,7 @@ entities:
       pos: -21.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1708
     components:
     - type: Transform
@@ -93770,14 +93927,14 @@ entities:
       pos: -34.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1714
     components:
     - type: Transform
       pos: -28.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1715
     components:
     - type: Transform
@@ -93785,7 +93942,7 @@ entities:
       pos: -30.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1719
     components:
     - type: Transform
@@ -93793,7 +93950,7 @@ entities:
       pos: -22.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1727
     components:
     - type: Transform
@@ -93801,14 +93958,14 @@ entities:
       pos: -32.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1756
     components:
     - type: Transform
       pos: -22.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1775
     components:
     - type: Transform
@@ -93816,7 +93973,7 @@ entities:
       pos: -20.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1781
     components:
     - type: Transform
@@ -93824,7 +93981,7 @@ entities:
       pos: -25.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1785
     components:
     - type: Transform
@@ -93832,7 +93989,7 @@ entities:
       pos: -28.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1814
     components:
     - type: Transform
@@ -93840,14 +93997,14 @@ entities:
       pos: -33.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1820
     components:
     - type: Transform
       pos: -15.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1830
     components:
     - type: Transform
@@ -93855,7 +94012,7 @@ entities:
       pos: -22.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1834
     components:
     - type: Transform
@@ -93863,7 +94020,7 @@ entities:
       pos: -30.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1848
     components:
     - type: Transform
@@ -93871,7 +94028,7 @@ entities:
       pos: -36.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1994
     components:
     - type: Transform
@@ -93879,7 +94036,7 @@ entities:
       pos: -36.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2105
     components:
     - type: Transform
@@ -93887,7 +94044,7 @@ entities:
       pos: -30.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2127
     components:
     - type: Transform
@@ -93895,7 +94052,7 @@ entities:
       pos: -26.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2182
     components:
     - type: Transform
@@ -93903,7 +94060,7 @@ entities:
       pos: -30.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2276
     components:
     - type: Transform
@@ -93911,7 +94068,7 @@ entities:
       pos: 32.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2358
     components:
     - type: Transform
@@ -93919,7 +94076,7 @@ entities:
       pos: 32.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2359
     components:
     - type: Transform
@@ -93927,21 +94084,21 @@ entities:
       pos: 30.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2377
     components:
     - type: Transform
       pos: 24.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2380
     components:
     - type: Transform
       pos: 25.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2473
     components:
     - type: Transform
@@ -93949,21 +94106,21 @@ entities:
       pos: 23.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2481
     components:
     - type: Transform
       pos: 30.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2482
     components:
     - type: Transform
       pos: 32.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2486
     components:
     - type: Transform
@@ -93971,7 +94128,7 @@ entities:
       pos: 34.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2498
     components:
     - type: Transform
@@ -93979,7 +94136,7 @@ entities:
       pos: 29.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2499
     components:
     - type: Transform
@@ -93987,7 +94144,7 @@ entities:
       pos: 33.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2537
     components:
     - type: Transform
@@ -93995,7 +94152,7 @@ entities:
       pos: 32.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2578
     components:
     - type: Transform
@@ -94003,14 +94160,14 @@ entities:
       pos: -21.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2693
     components:
     - type: Transform
       pos: 40.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2694
     components:
     - type: Transform
@@ -94018,7 +94175,7 @@ entities:
       pos: 40.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2799
     components:
     - type: Transform
@@ -94026,7 +94183,7 @@ entities:
       pos: 19.5,-33.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2802
     components:
     - type: Transform
@@ -94034,7 +94191,7 @@ entities:
       pos: 17.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2812
     components:
     - type: Transform
@@ -94042,7 +94199,7 @@ entities:
       pos: 17.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2869
     components:
     - type: Transform
@@ -94050,7 +94207,7 @@ entities:
       pos: 44.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2881
     components:
     - type: Transform
@@ -94058,7 +94215,7 @@ entities:
       pos: 35.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2902
     components:
     - type: Transform
@@ -94066,7 +94223,7 @@ entities:
       pos: 44.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2981
     components:
     - type: Transform
@@ -94082,7 +94239,7 @@ entities:
       pos: 45.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2989
     components:
     - type: Transform
@@ -94090,7 +94247,7 @@ entities:
       pos: 44.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3001
     components:
     - type: Transform
@@ -94106,7 +94263,7 @@ entities:
       pos: 44.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3121
     components:
     - type: Transform
@@ -94121,7 +94278,7 @@ entities:
       pos: 47.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3189
     components:
     - type: Transform
@@ -94129,7 +94286,7 @@ entities:
       pos: 33.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3205
     components:
     - type: Transform
@@ -94137,7 +94294,7 @@ entities:
       pos: 45.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3209
     components:
     - type: Transform
@@ -94160,7 +94317,7 @@ entities:
       pos: 45.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3367
     components:
     - type: Transform
@@ -94168,7 +94325,7 @@ entities:
       pos: -3.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3573
     components:
     - type: Transform
@@ -94176,7 +94333,7 @@ entities:
       pos: 45.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3915
     components:
     - type: Transform
@@ -94184,7 +94341,7 @@ entities:
       pos: 1.5,-37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3918
     components:
     - type: Transform
@@ -94192,7 +94349,7 @@ entities:
       pos: -0.5,-39.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3920
     components:
     - type: Transform
@@ -94200,7 +94357,7 @@ entities:
       pos: -0.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3924
     components:
     - type: Transform
@@ -94208,7 +94365,7 @@ entities:
       pos: 1.5,-46.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3929
     components:
     - type: Transform
@@ -94216,7 +94373,7 @@ entities:
       pos: 1.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3930
     components:
     - type: Transform
@@ -94224,7 +94381,7 @@ entities:
       pos: 1.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3950
     components:
     - type: Transform
@@ -94232,7 +94389,7 @@ entities:
       pos: -8.5,-42.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3984
     components:
     - type: Transform
@@ -94240,7 +94397,7 @@ entities:
       pos: -0.5,-45.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3998
     components:
     - type: Transform
@@ -94248,7 +94405,7 @@ entities:
       pos: -54.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4110
     components:
     - type: Transform
@@ -94256,7 +94413,7 @@ entities:
       pos: 34.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4117
     components:
     - type: Transform
@@ -94264,7 +94421,7 @@ entities:
       pos: 45.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4123
     components:
     - type: Transform
@@ -94272,7 +94429,7 @@ entities:
       pos: 33.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4146
     components:
     - type: Transform
@@ -94280,7 +94437,7 @@ entities:
       pos: 33.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4154
     components:
     - type: Transform
@@ -94288,7 +94445,7 @@ entities:
       pos: 34.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4220
     components:
     - type: Transform
@@ -94296,14 +94453,14 @@ entities:
       pos: -31.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4336
     components:
     - type: Transform
       pos: 39.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4354
     components:
     - type: Transform
@@ -94311,7 +94468,7 @@ entities:
       pos: 39.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4483
     components:
     - type: Transform
@@ -94319,14 +94476,14 @@ entities:
       pos: 34.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4541
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4630
     components:
     - type: Transform
@@ -94334,7 +94491,7 @@ entities:
       pos: -0.5,-61.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4834
     components:
     - type: Transform
@@ -94342,7 +94499,7 @@ entities:
       pos: -0.5,-47.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4835
     components:
     - type: Transform
@@ -94350,7 +94507,7 @@ entities:
       pos: 1.5,-48.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4915
     components:
     - type: Transform
@@ -94358,7 +94515,7 @@ entities:
       pos: 1.5,-72.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4965
     components:
     - type: Transform
@@ -94366,7 +94523,7 @@ entities:
       pos: 1.5,-61.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4990
     components:
     - type: Transform
@@ -94374,7 +94531,7 @@ entities:
       pos: -0.5,-72.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5472
     components:
     - type: Transform
@@ -94382,7 +94539,7 @@ entities:
       pos: -27.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5476
     components:
     - type: Transform
@@ -94390,7 +94547,7 @@ entities:
       pos: -38.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5532
     components:
     - type: Transform
@@ -94398,7 +94555,7 @@ entities:
       pos: 17.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5562
     components:
     - type: Transform
@@ -94406,7 +94563,7 @@ entities:
       pos: -14.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5583
     components:
     - type: Transform
@@ -94420,7 +94577,7 @@ entities:
       pos: -0.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5730
     components:
     - type: Transform
@@ -94428,7 +94585,7 @@ entities:
       pos: 1.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5733
     components:
     - type: Transform
@@ -94436,7 +94593,7 @@ entities:
       pos: -0.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5736
     components:
     - type: Transform
@@ -94444,7 +94601,7 @@ entities:
       pos: 1.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5746
     components:
     - type: Transform
@@ -94452,7 +94609,7 @@ entities:
       pos: -9.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5765
     components:
     - type: Transform
@@ -94460,14 +94617,14 @@ entities:
       pos: 16.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5817
     components:
     - type: Transform
       pos: 18.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5829
     components:
     - type: Transform
@@ -94475,7 +94632,7 @@ entities:
       pos: 34.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5847
     components:
     - type: Transform
@@ -94483,7 +94640,7 @@ entities:
       pos: 1.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5865
     components:
     - type: Transform
@@ -94491,21 +94648,21 @@ entities:
       pos: -36.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5890
     components:
     - type: Transform
       pos: 12.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5891
     components:
     - type: Transform
       pos: -36.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5892
     components:
     - type: Transform
@@ -94513,7 +94670,7 @@ entities:
       pos: -28.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5921
     components:
     - type: Transform
@@ -94521,7 +94678,7 @@ entities:
       pos: 30.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5922
     components:
     - type: Transform
@@ -94529,21 +94686,21 @@ entities:
       pos: 32.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5942
     components:
     - type: Transform
       pos: -37.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5953
     components:
     - type: Transform
       pos: -37.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5971
     components:
     - type: Transform
@@ -94551,7 +94708,7 @@ entities:
       pos: -30.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6005
     components:
     - type: Transform
@@ -94559,7 +94716,7 @@ entities:
       pos: -41.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6008
     components:
     - type: Transform
@@ -94567,7 +94724,7 @@ entities:
       pos: -38.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6012
     components:
     - type: Transform
@@ -94575,14 +94732,14 @@ entities:
       pos: -36.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6020
     components:
     - type: Transform
       pos: -49.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6024
     components:
     - type: Transform
@@ -94590,7 +94747,7 @@ entities:
       pos: -44.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6026
     components:
     - type: Transform
@@ -94598,14 +94755,14 @@ entities:
       pos: -42.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6037
     components:
     - type: Transform
       pos: -42.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6109
     components:
     - type: Transform
@@ -94613,7 +94770,7 @@ entities:
       pos: -49.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6120
     components:
     - type: Transform
@@ -94621,14 +94778,14 @@ entities:
       pos: -49.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6214
     components:
     - type: Transform
       pos: 0.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6278
     components:
     - type: Transform
@@ -94636,7 +94793,7 @@ entities:
       pos: 15.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6280
     components:
     - type: Transform
@@ -94644,7 +94801,7 @@ entities:
       pos: 15.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6282
     components:
     - type: Transform
@@ -94652,7 +94809,7 @@ entities:
       pos: 15.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6333
     components:
     - type: Transform
@@ -94660,35 +94817,35 @@ entities:
       pos: -18.5,-24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6380
     components:
     - type: Transform
       pos: -41.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6426
     components:
     - type: Transform
       pos: 0.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6660
     components:
     - type: Transform
       pos: -42.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6662
     components:
     - type: Transform
       pos: -42.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6810
     components:
     - type: Transform
@@ -94696,7 +94853,7 @@ entities:
       pos: 17.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7285
     components:
     - type: Transform
@@ -94704,7 +94861,7 @@ entities:
       pos: -36.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7464
     components:
     - type: Transform
@@ -94712,7 +94869,7 @@ entities:
       pos: -38.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7603
     components:
     - type: Transform
@@ -94720,7 +94877,7 @@ entities:
       pos: -16.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7682
     components:
     - type: Transform
@@ -94728,7 +94885,7 @@ entities:
       pos: -38.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7683
     components:
     - type: Transform
@@ -94736,7 +94893,7 @@ entities:
       pos: -38.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7902
     components:
     - type: Transform
@@ -94744,7 +94901,7 @@ entities:
       pos: -31.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8030
     components:
     - type: Transform
@@ -94752,7 +94909,7 @@ entities:
       pos: -22.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8079
     components:
     - type: Transform
@@ -94775,14 +94932,14 @@ entities:
       pos: -36.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8224
     components:
     - type: Transform
       pos: -31.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8228
     components:
     - type: Transform
@@ -94790,7 +94947,7 @@ entities:
       pos: -21.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8241
     components:
     - type: Transform
@@ -94798,14 +94955,14 @@ entities:
       pos: -36.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8245
     components:
     - type: Transform
       pos: -24.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8248
     components:
     - type: Transform
@@ -94813,7 +94970,7 @@ entities:
       pos: -20.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8260
     components:
     - type: Transform
@@ -94821,7 +94978,7 @@ entities:
       pos: -37.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8353
     components:
     - type: Transform
@@ -94829,7 +94986,7 @@ entities:
       pos: -44.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8537
     components:
     - type: Transform
@@ -94837,7 +94994,7 @@ entities:
       pos: 15.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8548
     components:
     - type: Transform
@@ -94845,7 +95002,7 @@ entities:
       pos: 15.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8570
     components:
     - type: Transform
@@ -94853,7 +95010,7 @@ entities:
       pos: -45.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8884
     components:
     - type: Transform
@@ -94861,14 +95018,14 @@ entities:
       pos: 23.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8941
     components:
     - type: Transform
       pos: -42.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9148
     components:
     - type: Transform
@@ -94876,7 +95033,7 @@ entities:
       pos: -19.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9233
     components:
     - type: Transform
@@ -94884,7 +95041,7 @@ entities:
       pos: 17.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9455
     components:
     - type: Transform
@@ -94892,21 +95049,21 @@ entities:
       pos: -55.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9458
     components:
     - type: Transform
       pos: -52.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9637
     components:
     - type: Transform
       pos: -55.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11153
     components:
     - type: Transform
@@ -94914,14 +95071,14 @@ entities:
       pos: 41.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 11722
     components:
     - type: Transform
       pos: 42.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 11734
     components:
     - type: Transform
@@ -94929,7 +95086,7 @@ entities:
       pos: 15.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 11761
     components:
     - type: Transform
@@ -94937,7 +95094,7 @@ entities:
       pos: 17.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12196
     components:
     - type: Transform
@@ -94961,7 +95118,7 @@ entities:
       pos: 39.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12626
     components:
     - type: Transform
@@ -94969,7 +95126,7 @@ entities:
       pos: 38.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12744
     components:
     - type: Transform
@@ -94977,28 +95134,28 @@ entities:
       pos: 49.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13113
     components:
     - type: Transform
       pos: 48.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13245
     components:
     - type: Transform
       pos: 23.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13443
     components:
     - type: Transform
       pos: -21.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13447
     components:
     - type: Transform
@@ -95006,7 +95163,7 @@ entities:
       pos: -21.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13448
     components:
     - type: Transform
@@ -95014,14 +95171,14 @@ entities:
       pos: -21.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13504
     components:
     - type: Transform
       pos: 47.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13534
     components:
     - type: Transform
@@ -95029,14 +95186,14 @@ entities:
       pos: 43.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13546
     components:
     - type: Transform
       pos: 21.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13612
     components:
     - type: Transform
@@ -95044,7 +95201,7 @@ entities:
       pos: 31.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13673
     components:
     - type: Transform
@@ -95052,7 +95209,7 @@ entities:
       pos: -8.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13808
     components:
     - type: Transform
@@ -95060,56 +95217,56 @@ entities:
       pos: 38.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13914
     components:
     - type: Transform
       pos: 49.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14015
     components:
     - type: Transform
       pos: 32.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14021
     components:
     - type: Transform
       pos: 38.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14022
     components:
     - type: Transform
       pos: 17.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14029
     components:
     - type: Transform
       pos: 36.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14044
     components:
     - type: Transform
       pos: 22.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14047
     components:
     - type: Transform
       pos: 39.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14237
     components:
     - type: Transform
@@ -95117,7 +95274,7 @@ entities:
       pos: -16.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14251
     components:
     - type: Transform
@@ -95125,7 +95282,7 @@ entities:
       pos: -16.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14259
     components:
     - type: Transform
@@ -95133,21 +95290,21 @@ entities:
       pos: -16.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14270
     components:
     - type: Transform
       pos: -26.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14274
     components:
     - type: Transform
       pos: -36.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14280
     components:
     - type: Transform
@@ -95155,14 +95312,14 @@ entities:
       pos: -22.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14295
     components:
     - type: Transform
       pos: -9.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14308
     components:
     - type: Transform
@@ -95170,7 +95327,7 @@ entities:
       pos: -9.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14312
     components:
     - type: Transform
@@ -95178,7 +95335,7 @@ entities:
       pos: -8.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14313
     components:
     - type: Transform
@@ -95186,7 +95343,7 @@ entities:
       pos: -8.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14468
     components:
     - type: Transform
@@ -95194,7 +95351,7 @@ entities:
       pos: -23.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14478
     components:
     - type: Transform
@@ -95202,7 +95359,7 @@ entities:
       pos: -24.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14490
     components:
     - type: Transform
@@ -95210,7 +95367,7 @@ entities:
       pos: -26.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14491
     components:
     - type: Transform
@@ -95218,7 +95375,7 @@ entities:
       pos: -27.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14492
     components:
     - type: Transform
@@ -95226,7 +95383,7 @@ entities:
       pos: -24.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14496
     components:
     - type: Transform
@@ -95234,7 +95391,7 @@ entities:
       pos: -23.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14735
     components:
     - type: Transform
@@ -95242,20 +95399,22 @@ entities:
       pos: -22.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14736
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,29.5
       parent: 60
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 14745
     components:
     - type: Transform
       pos: -29.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14746
     components:
     - type: Transform
@@ -95263,7 +95422,7 @@ entities:
       pos: -25.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14750
     components:
     - type: Transform
@@ -95271,7 +95430,7 @@ entities:
       pos: -22.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14751
     components:
     - type: Transform
@@ -95279,7 +95438,7 @@ entities:
       pos: -16.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14753
     components:
     - type: Transform
@@ -95287,7 +95446,7 @@ entities:
       pos: -20.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14763
     components:
     - type: Transform
@@ -95295,28 +95454,28 @@ entities:
       pos: -20.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14800
     components:
     - type: Transform
       pos: -34.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14827
     components:
     - type: Transform
       pos: -20.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14866
     components:
     - type: Transform
       pos: -24.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14880
     components:
     - type: Transform
@@ -95346,7 +95505,7 @@ entities:
       pos: -16.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15138
     components:
     - type: Transform
@@ -95362,7 +95521,7 @@ entities:
       pos: -32.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15164
     components:
     - type: Transform
@@ -95496,14 +95655,14 @@ entities:
       pos: -11.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15605
     components:
     - type: Transform
       pos: -21.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15617
     components:
     - type: Transform
@@ -95511,7 +95670,7 @@ entities:
       pos: -18.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15621
     components:
     - type: Transform
@@ -95519,7 +95678,7 @@ entities:
       pos: -14.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15626
     components:
     - type: Transform
@@ -95527,7 +95686,7 @@ entities:
       pos: -10.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15635
     components:
     - type: Transform
@@ -95535,7 +95694,7 @@ entities:
       pos: -12.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15637
     components:
     - type: Transform
@@ -95543,7 +95702,7 @@ entities:
       pos: -10.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15647
     components:
     - type: Transform
@@ -95551,7 +95710,7 @@ entities:
       pos: -12.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15661
     components:
     - type: Transform
@@ -95559,7 +95718,7 @@ entities:
       pos: -0.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15664
     components:
     - type: Transform
@@ -95567,14 +95726,14 @@ entities:
       pos: -3.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16563
     components:
     - type: Transform
       pos: -2.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16571
     components:
     - type: Transform
@@ -95582,7 +95741,7 @@ entities:
       pos: -2.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16576
     components:
     - type: Transform
@@ -95590,14 +95749,14 @@ entities:
       pos: -3.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16580
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16581
     components:
     - type: Transform
@@ -95605,14 +95764,14 @@ entities:
       pos: -2.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16582
     components:
     - type: Transform
       pos: -3.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16594
     components:
     - type: Transform
@@ -95620,7 +95779,7 @@ entities:
       pos: -3.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16599
     components:
     - type: Transform
@@ -95628,7 +95787,7 @@ entities:
       pos: -2.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16608
     components:
     - type: Transform
@@ -95636,7 +95795,7 @@ entities:
       pos: -0.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16612
     components:
     - type: Transform
@@ -95644,7 +95803,7 @@ entities:
       pos: -1.5,27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16632
     components:
     - type: Transform
@@ -95652,28 +95811,28 @@ entities:
       pos: 1.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16645
     components:
     - type: Transform
       pos: 1.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16647
     components:
     - type: Transform
       pos: 5.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16648
     components:
     - type: Transform
       pos: 4.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16654
     components:
     - type: Transform
@@ -95681,14 +95840,14 @@ entities:
       pos: 10.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16656
     components:
     - type: Transform
       pos: 2.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16659
     components:
     - type: Transform
@@ -95696,7 +95855,7 @@ entities:
       pos: 3.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16664
     components:
     - type: Transform
@@ -95704,7 +95863,7 @@ entities:
       pos: 10.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16971
     components:
     - type: Transform
@@ -95720,7 +95879,7 @@ entities:
       pos: 37.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17525
     components:
     - type: Transform
@@ -95728,14 +95887,14 @@ entities:
       pos: 21.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17529
     components:
     - type: Transform
       pos: 41.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17538
     components:
     - type: Transform
@@ -95743,28 +95902,28 @@ entities:
       pos: 39.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17570
     components:
     - type: Transform
       pos: -38.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17580
     components:
     - type: Transform
       pos: -43.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17583
     components:
     - type: Transform
       pos: -30.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17585
     components:
     - type: Transform
@@ -95772,7 +95931,7 @@ entities:
       pos: -31.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17629
     components:
     - type: Transform
@@ -95780,7 +95939,7 @@ entities:
       pos: 22.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17841
     components:
     - type: Transform
@@ -95788,7 +95947,7 @@ entities:
       pos: 41.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18067
     components:
     - type: Transform
@@ -95802,7 +95961,7 @@ entities:
       pos: -0.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18223
     components:
     - type: Transform
@@ -95810,28 +95969,28 @@ entities:
       pos: -0.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18242
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18243
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18255
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18256
     components:
     - type: Transform
@@ -95839,7 +95998,7 @@ entities:
       pos: -3.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18424
     components:
     - type: Transform
@@ -95847,7 +96006,7 @@ entities:
       pos: -0.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18440
     components:
     - type: Transform
@@ -95855,7 +96014,7 @@ entities:
       pos: 44.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18504
     components:
     - type: Transform
@@ -95863,7 +96022,7 @@ entities:
       pos: -43.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18531
     components:
     - type: Transform
@@ -95871,7 +96030,7 @@ entities:
       pos: 2.5,0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18649
     components:
     - type: Transform
@@ -95879,7 +96038,7 @@ entities:
       pos: 51.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18659
     components:
     - type: Transform
@@ -95887,21 +96046,21 @@ entities:
       pos: 52.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18662
     components:
     - type: Transform
       pos: 52.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18669
     components:
     - type: Transform
       pos: 51.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18717
     components:
     - type: Transform
@@ -95909,7 +96068,7 @@ entities:
       pos: 37.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21168
     components:
     - type: Transform
@@ -95917,7 +96076,7 @@ entities:
       pos: -16.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21318
     components:
     - type: Transform
@@ -95925,7 +96084,7 @@ entities:
       pos: -72.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21408
     components:
     - type: Transform
@@ -95933,7 +96092,7 @@ entities:
       pos: -31.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21416
     components:
     - type: Transform
@@ -95973,7 +96132,7 @@ entities:
       pos: -29.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22810
     components:
     - type: Transform
@@ -95981,28 +96140,28 @@ entities:
       pos: -99.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22814
     components:
     - type: Transform
       pos: -103.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22823
     components:
     - type: Transform
       pos: -112.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22828
     components:
     - type: Transform
       pos: -117.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22839
     components:
     - type: Transform
@@ -96010,7 +96169,7 @@ entities:
       pos: -111.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22847
     components:
     - type: Transform
@@ -96018,7 +96177,7 @@ entities:
       pos: -99.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22883
     components:
     - type: Transform
@@ -96026,7 +96185,7 @@ entities:
       pos: -118.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22892
     components:
     - type: Transform
@@ -96034,7 +96193,7 @@ entities:
       pos: -111.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22930
     components:
     - type: Transform
@@ -96127,7 +96286,7 @@ entities:
       pos: -6.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24658
     components:
     - type: Transform
@@ -96135,7 +96294,7 @@ entities:
       pos: -1.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24748
     components:
     - type: Transform
@@ -96143,7 +96302,7 @@ entities:
       pos: 55.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24749
     components:
     - type: Transform
@@ -96151,14 +96310,14 @@ entities:
       pos: 53.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24845
     components:
     - type: Transform
       pos: 43.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24871
     components:
     - type: Transform
@@ -96166,7 +96325,7 @@ entities:
       pos: 55.5,39.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24916
     components:
     - type: Transform
@@ -96174,7 +96333,7 @@ entities:
       pos: 35.5,39.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25168
     components:
     - type: Transform
@@ -96182,7 +96341,7 @@ entities:
       pos: 33.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 25172
     components:
     - type: Transform
@@ -96190,7 +96349,7 @@ entities:
       pos: 53.5,37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 25182
     components:
     - type: Transform
@@ -96198,7 +96357,7 @@ entities:
       pos: 45.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
 - proto: GasPort
   entities:
   - uid: 111
@@ -96275,14 +96434,14 @@ entities:
       pos: -16.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14721
     components:
     - type: Transform
       pos: -15.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15005
     components:
     - type: Transform
@@ -96331,7 +96490,7 @@ entities:
       pos: -8.5,-37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21667
     components:
     - type: Transform
@@ -96339,7 +96498,7 @@ entities:
       pos: -30.5,34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21668
     components:
     - type: Transform
@@ -96347,13 +96506,15 @@ entities:
       pos: -30.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21673
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,30.5
       parent: 60
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 22887
     components:
     - type: Transform
@@ -96405,6 +96566,16 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#03FCD3FF'
+  - uid: 1162
+    components:
+    - type: MetaData
+      name: Distro Cannister Pump
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,30.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 3013
     components:
     - type: MetaData
@@ -96414,7 +96585,7 @@ entities:
       pos: 48.5,-22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8074
     components:
     - type: Transform
@@ -96465,7 +96636,7 @@ entities:
       pos: -33.5,32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 14774
     components:
     - type: Transform
@@ -96537,7 +96708,7 @@ entities:
       pos: -34.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15143
     components:
     - type: Transform
@@ -96545,7 +96716,7 @@ entities:
       pos: -34.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15281
     components:
     - type: Transform
@@ -96568,30 +96739,20 @@ entities:
       parent: 60
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 21714
-    components:
-    - type: MetaData
-      name: Distro Can Pump
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,30.5
-      parent: 60
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 22884
     components:
     - type: Transform
       pos: -119.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22885
     components:
     - type: Transform
       pos: -118.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 23049
     components:
     - type: Transform
@@ -96693,6 +96854,8 @@ entities:
     - type: Transform
       pos: -17.5,30.5
       parent: 60
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 15375
     components:
     - type: Transform
@@ -96720,6 +96883,8 @@ entities:
     - type: Transform
       pos: -18.5,30.5
       parent: 60
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 15362
     components:
     - type: Transform
@@ -96732,6 +96897,16 @@ entities:
       parent: 60
 - proto: GasValve
   entities:
+  - uid: 1257
+    components:
+    - type: MetaData
+      name: Distro Temp Control
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,29.5
+      parent: 60
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 1460
     components:
     - type: MetaData
@@ -96771,18 +96946,6 @@ entities:
       open: False
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 14730
-    components:
-    - type: MetaData
-      name: Distro Temp Control
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,29.5
-      parent: 60
-    - type: GasValve
-      open: False
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 14837
     components:
     - type: Transform
@@ -96825,7 +96988,7 @@ entities:
     - type: GasValve
       open: False
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15345
     components:
     - type: Transform
@@ -96887,14 +97050,14 @@ entities:
       pos: -9.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 114
     components:
     - type: Transform
       pos: 49.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 116
     components:
     - type: Transform
@@ -96905,14 +97068,14 @@ entities:
       deviceLists:
       - 8483
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 127
     components:
     - type: Transform
       pos: 20.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 179
     components:
     - type: Transform
@@ -96920,7 +97083,7 @@ entities:
       pos: 20.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 275
     components:
     - type: Transform
@@ -96928,7 +97091,7 @@ entities:
       pos: 21.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 426
     components:
     - type: Transform
@@ -96936,7 +97099,7 @@ entities:
       pos: 0.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 482
     components:
     - type: Transform
@@ -96944,7 +97107,7 @@ entities:
       pos: 0.5,-25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 777
     components:
     - type: Transform
@@ -96955,7 +97118,7 @@ entities:
       deviceLists:
       - 148
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 778
     components:
     - type: Transform
@@ -96966,7 +97129,7 @@ entities:
       deviceLists:
       - 231
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 792
     components:
     - type: Transform
@@ -96978,7 +97141,7 @@ entities:
       - 1960
       - 4709
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 910
     components:
     - type: Transform
@@ -96986,7 +97149,7 @@ entities:
       pos: -3.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 928
     components:
     - type: Transform
@@ -96997,7 +97160,7 @@ entities:
       deviceLists:
       - 57
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 946
     components:
     - type: Transform
@@ -97005,7 +97168,7 @@ entities:
       pos: -48.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1133
     components:
     - type: Transform
@@ -97016,7 +97179,7 @@ entities:
       deviceLists:
       - 4709
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1385
     components:
     - type: Transform
@@ -97032,7 +97195,7 @@ entities:
       pos: 5.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1429
     components:
     - type: Transform
@@ -97040,7 +97203,7 @@ entities:
       pos: 0.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1455
     components:
     - type: Transform
@@ -97048,7 +97211,7 @@ entities:
       pos: 11.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1511
     components:
     - type: Transform
@@ -97059,7 +97222,7 @@ entities:
       deviceLists:
       - 57
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1660
     components:
     - type: Transform
@@ -97069,7 +97232,7 @@ entities:
       deviceLists:
       - 21507
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1682
     components:
     - type: Transform
@@ -97079,7 +97242,7 @@ entities:
       deviceLists:
       - 8516
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1731
     components:
     - type: Transform
@@ -97087,14 +97250,14 @@ entities:
       pos: -19.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1780
     components:
     - type: Transform
       pos: -20.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1787
     components:
     - type: Transform
@@ -97106,7 +97269,7 @@ entities:
       - 21612
       - 12
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1845
     components:
     - type: Transform
@@ -97117,7 +97280,7 @@ entities:
       deviceLists:
       - 5933
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1966
     components:
     - type: Transform
@@ -97128,7 +97291,7 @@ entities:
       deviceLists:
       - 148
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1971
     components:
     - type: Transform
@@ -97139,7 +97302,7 @@ entities:
       deviceLists:
       - 231
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1983
     components:
     - type: Transform
@@ -97149,14 +97312,14 @@ entities:
       deviceLists:
       - 178
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1996
     components:
     - type: Transform
       pos: -33.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2027
     components:
     - type: Transform
@@ -97164,7 +97327,7 @@ entities:
       pos: -22.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2208
     components:
     - type: Transform
@@ -97172,7 +97335,7 @@ entities:
       pos: 34.5,-36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2215
     components:
     - type: Transform
@@ -97180,7 +97343,7 @@ entities:
       pos: 34.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2370
     components:
     - type: Transform
@@ -97188,7 +97351,7 @@ entities:
       pos: 24.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2371
     components:
     - type: Transform
@@ -97196,7 +97359,7 @@ entities:
       pos: 25.5,-26.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2560
     components:
     - type: Transform
@@ -97204,7 +97367,7 @@ entities:
       pos: 31.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2706
     components:
     - type: Transform
@@ -97212,7 +97375,7 @@ entities:
       pos: 18.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2826
     components:
     - type: Transform
@@ -97220,7 +97383,7 @@ entities:
       pos: 44.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2984
     components:
     - type: Transform
@@ -97228,7 +97391,7 @@ entities:
       pos: 47.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3002
     components:
     - type: Transform
@@ -97251,7 +97414,7 @@ entities:
       pos: 45.5,-39.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3692
     components:
     - type: Transform
@@ -97259,21 +97422,21 @@ entities:
       pos: 16.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3964
     components:
     - type: Transform
       pos: -13.5,-41.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3965
     components:
     - type: Transform
       pos: -8.5,-41.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 3986
     components:
     - type: Transform
@@ -97281,7 +97444,7 @@ entities:
       pos: 0.5,-40.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4537
     components:
     - type: Transform
@@ -97289,7 +97452,7 @@ entities:
       pos: -2.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 4953
     components:
     - type: Transform
@@ -97297,7 +97460,7 @@ entities:
       pos: 0.5,-48.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5364
     components:
     - type: Transform
@@ -97308,14 +97471,14 @@ entities:
       deviceLists:
       - 3204
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5412
     components:
     - type: Transform
       pos: 12.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5439
     components:
     - type: Transform
@@ -97323,7 +97486,7 @@ entities:
       pos: 43.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5445
     components:
     - type: Transform
@@ -97331,14 +97494,14 @@ entities:
       pos: 29.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5446
     components:
     - type: Transform
       pos: 33.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5518
     components:
     - type: Transform
@@ -97346,14 +97509,14 @@ entities:
       pos: 39.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5585
     components:
     - type: Transform
       pos: -44.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5739
     components:
     - type: Transform
@@ -97361,7 +97524,7 @@ entities:
       pos: 2.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5822
     components:
     - type: Transform
@@ -97369,7 +97532,7 @@ entities:
       pos: 17.5,-34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5824
     components:
     - type: Transform
@@ -97377,7 +97540,7 @@ entities:
       pos: 34.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5843
     components:
     - type: Transform
@@ -97385,7 +97548,7 @@ entities:
       pos: 0.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5929
     components:
     - type: Transform
@@ -97393,7 +97556,7 @@ entities:
       pos: -28.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5938
     components:
     - type: Transform
@@ -97401,7 +97564,7 @@ entities:
       pos: -52.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5951
     components:
     - type: Transform
@@ -97409,7 +97572,7 @@ entities:
       pos: -41.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5952
     components:
     - type: Transform
@@ -97421,7 +97584,7 @@ entities:
       - 21612
       - 12
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5954
     components:
     - type: Transform
@@ -97429,7 +97592,7 @@ entities:
       pos: 10.5,-16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5955
     components:
     - type: Transform
@@ -97437,7 +97600,7 @@ entities:
       pos: 12.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5956
     components:
     - type: Transform
@@ -97445,7 +97608,7 @@ entities:
       pos: 11.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5980
     components:
     - type: Transform
@@ -97453,14 +97616,14 @@ entities:
       pos: -43.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5987
     components:
     - type: Transform
       pos: -43.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 5990
     components:
     - type: Transform
@@ -97468,7 +97631,7 @@ entities:
       pos: -34.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6002
     components:
     - type: Transform
@@ -97476,21 +97639,21 @@ entities:
       pos: -29.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6032
     components:
     - type: Transform
       pos: -52.5,4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6203
     components:
     - type: Transform
       pos: -22.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6300
     components:
     - type: Transform
@@ -97498,7 +97661,7 @@ entities:
       pos: 11.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6417
     components:
     - type: Transform
@@ -97506,7 +97669,7 @@ entities:
       pos: 2.5,-61.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6418
     components:
     - type: Transform
@@ -97514,7 +97677,7 @@ entities:
       pos: 2.5,-72.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6770
     components:
     - type: Transform
@@ -97522,7 +97685,7 @@ entities:
       pos: 9.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6789
     components:
     - type: Transform
@@ -97530,7 +97693,7 @@ entities:
       pos: -42.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 6835
     components:
     - type: Transform
@@ -97538,7 +97701,7 @@ entities:
       pos: 40.5,-13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7387
     components:
     - type: Transform
@@ -97546,7 +97709,7 @@ entities:
       pos: 1.5,-76.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7476
     components:
     - type: Transform
@@ -97557,7 +97720,7 @@ entities:
       deviceLists:
       - 24769
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7484
     components:
     - type: Transform
@@ -97565,7 +97728,7 @@ entities:
       pos: 0.5,-56.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7485
     components:
     - type: Transform
@@ -97573,7 +97736,7 @@ entities:
       pos: -9.5,-55.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7916
     components:
     - type: Transform
@@ -97581,7 +97744,7 @@ entities:
       pos: -33.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8087
     components:
     - type: Transform
@@ -97613,7 +97776,7 @@ entities:
       pos: -3.5,-46.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8267
     components:
     - type: Transform
@@ -97621,7 +97784,7 @@ entities:
       pos: -33.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8388
     components:
     - type: Transform
@@ -97633,7 +97796,7 @@ entities:
       - 21612
       - 12
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8619
     components:
     - type: Transform
@@ -97641,7 +97804,7 @@ entities:
       pos: 16.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8962
     components:
     - type: Transform
@@ -97649,7 +97812,7 @@ entities:
       pos: 32.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9016
     components:
     - type: Transform
@@ -97657,7 +97820,7 @@ entities:
       pos: 47.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9046
     components:
     - type: Transform
@@ -97665,7 +97828,7 @@ entities:
       pos: 40.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9063
     components:
     - type: Transform
@@ -97673,7 +97836,7 @@ entities:
       pos: 29.5,-20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9150
     components:
     - type: Transform
@@ -97684,7 +97847,7 @@ entities:
       deviceLists:
       - 8516
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9157
     components:
     - type: Transform
@@ -97695,7 +97858,7 @@ entities:
       deviceLists:
       - 105
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9471
     components:
     - type: Transform
@@ -97706,7 +97869,7 @@ entities:
       deviceLists:
       - 7065
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9472
     components:
     - type: Transform
@@ -97717,7 +97880,7 @@ entities:
       deviceLists:
       - 11464
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9607
     components:
     - type: Transform
@@ -97725,7 +97888,7 @@ entities:
       pos: -42.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9651
     components:
     - type: Transform
@@ -97736,7 +97899,7 @@ entities:
       deviceLists:
       - 11464
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 9678
     components:
     - type: Transform
@@ -97744,14 +97907,14 @@ entities:
       pos: -37.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 10586
     components:
     - type: Transform
       pos: -27.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 10678
     components:
     - type: Transform
@@ -97759,7 +97922,7 @@ entities:
       pos: -19.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12589
     components:
     - type: Transform
@@ -97767,7 +97930,7 @@ entities:
       pos: 16.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12592
     components:
     - type: Transform
@@ -97775,7 +97938,7 @@ entities:
       pos: 16.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12623
     components:
     - type: Transform
@@ -97783,7 +97946,7 @@ entities:
       pos: 43.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12624
     components:
     - type: Transform
@@ -97791,7 +97954,7 @@ entities:
       pos: 41.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12839
     components:
     - type: Transform
@@ -97799,21 +97962,21 @@ entities:
       pos: -48.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 12868
     components:
     - type: Transform
       pos: 40.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13074
     components:
     - type: Transform
       pos: 38.5,10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13241
     components:
     - type: Transform
@@ -97821,7 +97984,7 @@ entities:
       pos: 19.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13242
     components:
     - type: Transform
@@ -97829,7 +97992,7 @@ entities:
       pos: 16.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13248
     components:
     - type: Transform
@@ -97839,14 +98002,14 @@ entities:
       deviceLists:
       - 1229
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13536
     components:
     - type: Transform
       pos: 16.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13548
     components:
     - type: Transform
@@ -97854,7 +98017,7 @@ entities:
       pos: 21.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13589
     components:
     - type: Transform
@@ -97862,21 +98025,21 @@ entities:
       pos: 4.5,-37.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 13800
     components:
     - type: Transform
       pos: -30.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14302
     components:
     - type: Transform
       pos: -7.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14325
     components:
     - type: Transform
@@ -97884,7 +98047,7 @@ entities:
       pos: -8.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14501
     components:
     - type: Transform
@@ -97892,14 +98055,14 @@ entities:
       pos: -23.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14502
     components:
     - type: Transform
       pos: -23.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14642
     components:
     - type: Transform
@@ -97907,7 +98070,7 @@ entities:
       pos: -19.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14752
     components:
     - type: Transform
@@ -97915,7 +98078,7 @@ entities:
       pos: -21.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 14770
     components:
     - type: Transform
@@ -97925,21 +98088,21 @@ entities:
       deviceLists:
       - 23956
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15651
     components:
     - type: Transform
       pos: -18.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 15652
     components:
     - type: Transform
       pos: -14.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16559
     components:
     - type: Transform
@@ -97947,7 +98110,7 @@ entities:
       pos: -29.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16604
     components:
     - type: Transform
@@ -97955,14 +98118,14 @@ entities:
       pos: -11.5,30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16619
     components:
     - type: Transform
       pos: -0.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16620
     components:
     - type: Transform
@@ -97970,7 +98133,7 @@ entities:
       pos: 0.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16635
     components:
     - type: Transform
@@ -97981,7 +98144,7 @@ entities:
       deviceLists:
       - 15745
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16643
     components:
     - type: Transform
@@ -97989,7 +98152,7 @@ entities:
       pos: -2.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16666
     components:
     - type: Transform
@@ -97997,14 +98160,14 @@ entities:
       pos: 12.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16669
     components:
     - type: Transform
       pos: 10.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16670
     components:
     - type: Transform
@@ -98012,7 +98175,7 @@ entities:
       pos: -2.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16682
     components:
     - type: Transform
@@ -98020,7 +98183,7 @@ entities:
       pos: 5.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16683
     components:
     - type: Transform
@@ -98028,14 +98191,14 @@ entities:
       pos: 2.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16684
     components:
     - type: Transform
       pos: -32.5,32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 16718
     components:
     - type: Transform
@@ -98045,7 +98208,7 @@ entities:
       deviceLists:
       - 21710
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17601
     components:
     - type: Transform
@@ -98053,7 +98216,7 @@ entities:
       pos: -46.5,25.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17602
     components:
     - type: Transform
@@ -98061,7 +98224,7 @@ entities:
       pos: -46.5,21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17624
     components:
     - type: Transform
@@ -98069,7 +98232,7 @@ entities:
       pos: -36.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17625
     components:
     - type: Transform
@@ -98077,7 +98240,7 @@ entities:
       pos: -38.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17627
     components:
     - type: Transform
@@ -98085,7 +98248,7 @@ entities:
       pos: -15.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 17628
     components:
     - type: Transform
@@ -98093,7 +98256,7 @@ entities:
       pos: -30.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18139
     components:
     - type: Transform
@@ -98101,7 +98264,7 @@ entities:
       pos: -2.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18270
     components:
     - type: Transform
@@ -98109,7 +98272,7 @@ entities:
       pos: -7.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18426
     components:
     - type: Transform
@@ -98117,7 +98280,7 @@ entities:
       pos: 0.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18427
     components:
     - type: Transform
@@ -98125,7 +98288,7 @@ entities:
       pos: 5.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18429
     components:
     - type: Transform
@@ -98133,7 +98296,7 @@ entities:
       pos: 0.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18539
     components:
     - type: Transform
@@ -98141,7 +98304,7 @@ entities:
       pos: 0.5,1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18540
     components:
     - type: Transform
@@ -98149,7 +98312,7 @@ entities:
       pos: 4.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18560
     components:
     - type: Transform
@@ -98162,7 +98325,7 @@ entities:
       pos: 45.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18653
     components:
     - type: Transform
@@ -98170,7 +98333,7 @@ entities:
       pos: 45.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18663
     components:
     - type: Transform
@@ -98178,7 +98341,7 @@ entities:
       pos: 53.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18664
     components:
     - type: Transform
@@ -98186,7 +98349,7 @@ entities:
       pos: 53.5,9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18668
     components:
     - type: Transform
@@ -98194,7 +98357,7 @@ entities:
       pos: 48.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18906
     components:
     - type: Transform
@@ -98205,7 +98368,7 @@ entities:
       deviceLists:
       - 24792
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 18937
     components:
     - type: Transform
@@ -98221,7 +98384,7 @@ entities:
       pos: 36.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 19054
     components:
     - type: Transform
@@ -98229,7 +98392,7 @@ entities:
       pos: 32.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 19056
     components:
     - type: Transform
@@ -98240,7 +98403,7 @@ entities:
       deviceLists:
       - 25155
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 19057
     components:
     - type: Transform
@@ -98251,7 +98414,7 @@ entities:
       deviceLists:
       - 25155
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 19179
     components:
     - type: Transform
@@ -98259,7 +98422,7 @@ entities:
       pos: 21.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 19403
     components:
     - type: Transform
@@ -98267,14 +98430,14 @@ entities:
       pos: 40.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21327
     components:
     - type: Transform
       pos: -72.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 21407
     components:
     - type: Transform
@@ -98285,14 +98448,14 @@ entities:
       deviceLists:
       - 1960
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22876
     components:
     - type: Transform
       pos: -110.5,36.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22878
     components:
     - type: Transform
@@ -98300,7 +98463,7 @@ entities:
       pos: -110.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22879
     components:
     - type: Transform
@@ -98308,7 +98471,7 @@ entities:
       pos: -103.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22881
     components:
     - type: Transform
@@ -98316,7 +98479,7 @@ entities:
       pos: -98.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22882
     components:
     - type: Transform
@@ -98324,7 +98487,7 @@ entities:
       pos: -112.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22886
     components:
     - type: Transform
@@ -98332,7 +98495,7 @@ entities:
       pos: -117.5,16.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22891
     components:
     - type: Transform
@@ -98340,7 +98503,7 @@ entities:
       pos: -112.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22893
     components:
     - type: Transform
@@ -98348,7 +98511,7 @@ entities:
       pos: -112.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 22894
     components:
     - type: Transform
@@ -98356,7 +98519,7 @@ entities:
       pos: -110.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 23505
     components:
     - type: Transform
@@ -98372,7 +98535,7 @@ entities:
       pos: -5.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24136
     components:
     - type: Transform
@@ -98380,7 +98543,7 @@ entities:
       pos: -9.5,-15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 24834
     components:
     - type: Transform
@@ -98391,7 +98554,7 @@ entities:
       deviceLists:
       - 25157
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 25173
     components:
     - type: Transform
@@ -98402,7 +98565,7 @@ entities:
       deviceLists:
       - 25162
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 25174
     components:
     - type: Transform
@@ -98413,7 +98576,7 @@ entities:
       deviceLists:
       - 25162
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 25179
     components:
     - type: Transform
@@ -98424,7 +98587,7 @@ entities:
       deviceLists:
       - 25163
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 25180
     components:
     - type: Transform
@@ -98435,7 +98598,7 @@ entities:
       deviceLists:
       - 25163
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 25185
     components:
     - type: Transform
@@ -98446,7 +98609,7 @@ entities:
       deviceLists:
       - 25157
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
   - uid: 61
@@ -98456,7 +98619,7 @@ entities:
       pos: 35.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 157
     components:
     - type: Transform
@@ -98466,7 +98629,7 @@ entities:
       deviceLists:
       - 231
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 223
     components:
     - type: Transform
@@ -98474,7 +98637,7 @@ entities:
       pos: 26.5,-12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 263
     components:
     - type: Transform
@@ -98482,7 +98645,7 @@ entities:
       pos: 22.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 337
     components:
     - type: Transform
@@ -98490,7 +98653,7 @@ entities:
       pos: 47.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 428
     components:
     - type: Transform
@@ -98498,7 +98661,7 @@ entities:
       pos: 0.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 473
     components:
     - type: Transform
@@ -98506,7 +98669,7 @@ entities:
       pos: 0.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 516
     components:
     - type: Transform
@@ -98516,7 +98679,7 @@ entities:
       deviceLists:
       - 57
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 629
     components:
     - type: Transform
@@ -98524,7 +98687,7 @@ entities:
       pos: 19.5,-35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 719
     components:
     - type: Transform
@@ -98532,7 +98695,7 @@ entities:
       pos: -22.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 779
     components:
     - type: Transform
@@ -98543,7 +98706,7 @@ entities:
       deviceLists:
       - 231
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 788
     components:
     - type: Transform
@@ -98555,7 +98718,7 @@ entities:
       - 1960
       - 4709
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 841
     components:
     - type: Transform
@@ -98566,7 +98729,7 @@ entities:
       deviceLists:
       - 5933
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 871
     components:
     - type: Transform
@@ -98574,7 +98737,7 @@ entities:
       pos: 41.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 904
     components:
     - type: Transform
@@ -98584,7 +98747,7 @@ entities:
       deviceLists:
       - 57
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 912
     components:
     - type: Transform
@@ -98592,7 +98755,7 @@ entities:
       pos: -8.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 913
     components:
     - type: Transform
@@ -98600,7 +98763,7 @@ entities:
       pos: -4.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1136
     components:
     - type: Transform
@@ -98611,7 +98774,7 @@ entities:
       deviceLists:
       - 4709
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1246
     components:
     - type: Transform
@@ -98619,7 +98782,7 @@ entities:
       pos: 37.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1397
     components:
     - type: Transform
@@ -98627,7 +98790,7 @@ entities:
       pos: 4.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1398
     components:
     - type: Transform
@@ -98635,7 +98798,7 @@ entities:
       pos: 3.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1430
     components:
     - type: Transform
@@ -98643,14 +98806,14 @@ entities:
       pos: 0.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1456
     components:
     - type: Transform
       pos: 12.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1581
     components:
     - type: Transform
@@ -98661,7 +98824,7 @@ entities:
       deviceLists:
       - 21507
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1659
     components:
     - type: Transform
@@ -98672,7 +98835,7 @@ entities:
       deviceLists:
       - 148
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1739
     components:
     - type: Transform
@@ -98680,7 +98843,7 @@ entities:
       pos: -19.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 1750
     components:
     - type: Transform
@@ -98688,7 +98851,7 @@ entities:
       pos: -19.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1768
     components:
     - type: Transform
@@ -98696,7 +98859,7 @@ entities:
       pos: -33.5,-11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1771
     components:
     - type: Transform
@@ -98708,7 +98871,7 @@ entities:
       - 21612
       - 12
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 1974
     components:
     - type: Transform
@@ -98718,7 +98881,7 @@ entities:
       deviceLists:
       - 148
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2009
     components:
     - type: Transform
@@ -98729,7 +98892,7 @@ entities:
       deviceLists:
       - 178
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2026
     components:
     - type: Transform
@@ -98737,7 +98900,7 @@ entities:
       pos: -22.5,-29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2205
     components:
     - type: Transform
@@ -98745,7 +98908,7 @@ entities:
       pos: 29.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2360
     components:
     - type: Transform
@@ -98753,28 +98916,28 @@ entities:
       pos: 23.5,-34.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2374
     components:
     - type: Transform
       pos: 23.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2563
     components:
     - type: Transform
       pos: 29.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2704
     components:
     - type: Transform
       pos: 39.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2772
     components:
     - type: Transform
@@ -98786,7 +98949,7 @@ entities:
       - 21612
       - 12
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2821
     components:
     - type: Transform
@@ -98794,7 +98957,7 @@ entities:
       pos: 44.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 2983
     components:
     - type: Transform
@@ -98826,7 +98989,7 @@ entities:
       pos: 44.5,-39.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3693
     components:
     - type: Transform
@@ -98834,7 +98997,7 @@ entities:
       pos: 16.5,-18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3962
     components:
     - type: Transform
@@ -98842,14 +99005,14 @@ entities:
       pos: -7.5,-41.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3963
     components:
     - type: Transform
       pos: -13.5,-39.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 3985
     components:
     - type: Transform
@@ -98857,7 +99020,7 @@ entities:
       pos: 0.5,-39.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4218
     components:
     - type: Transform
@@ -98865,14 +99028,14 @@ entities:
       pos: -33.5,-7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4502
     components:
     - type: Transform
       pos: 39.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4944
     components:
     - type: Transform
@@ -98880,7 +99043,7 @@ entities:
       pos: 0.5,-47.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 4971
     components:
     - type: Transform
@@ -98888,7 +99051,7 @@ entities:
       pos: 0.5,-54.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5404
     components:
     - type: Transform
@@ -98896,7 +99059,7 @@ entities:
       pos: 43.5,-8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5411
     components:
     - type: Transform
@@ -98904,21 +99067,21 @@ entities:
       pos: 10.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5440
     components:
     - type: Transform
       pos: 34.5,-14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5581
     components:
     - type: Transform
       pos: -42.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5688
     components:
     - type: Transform
@@ -98929,7 +99092,7 @@ entities:
       deviceLists:
       - 3204
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5738
     components:
     - type: Transform
@@ -98937,7 +99100,7 @@ entities:
       pos: -1.5,11.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5745
     components:
     - type: Transform
@@ -98945,7 +99108,7 @@ entities:
       pos: -10.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5766
     components:
     - type: Transform
@@ -98953,7 +99116,7 @@ entities:
       pos: 16.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5820
     components:
     - type: Transform
@@ -98961,7 +99124,7 @@ entities:
       pos: 18.5,-28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5823
     components:
     - type: Transform
@@ -98969,7 +99132,7 @@ entities:
       pos: 29.5,-32.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5831
     components:
     - type: Transform
@@ -98977,7 +99140,7 @@ entities:
       pos: 43.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5930
     components:
     - type: Transform
@@ -98985,14 +99148,14 @@ entities:
       pos: -29.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 5962
     components:
     - type: Transform
       pos: -30.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6015
     components:
     - type: Transform
@@ -99000,7 +99163,7 @@ entities:
       pos: -34.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6018
     components:
     - type: Transform
@@ -99012,7 +99175,7 @@ entities:
       - 21612
       - 12
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6028
     components:
     - type: Transform
@@ -99020,7 +99183,7 @@ entities:
       pos: -41.5,2.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6058
     components:
     - type: Transform
@@ -99028,7 +99191,7 @@ entities:
       pos: -43.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6290
     components:
     - type: Transform
@@ -99036,7 +99199,7 @@ entities:
       pos: 16.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6299
     components:
     - type: Transform
@@ -99044,7 +99207,7 @@ entities:
       pos: 11.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6474
     components:
     - type: Transform
@@ -99052,7 +99215,7 @@ entities:
       pos: -1.5,-72.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 6475
     components:
     - type: Transform
@@ -99060,7 +99223,7 @@ entities:
       pos: -1.5,-61.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7099
     components:
     - type: Transform
@@ -99071,7 +99234,7 @@ entities:
       deviceLists:
       - 8483
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7177
     components:
     - type: Transform
@@ -99079,7 +99242,7 @@ entities:
       pos: -27.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7343
     components:
     - type: Transform
@@ -99087,7 +99250,7 @@ entities:
       pos: -42.5,22.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7368
     components:
     - type: Transform
@@ -99095,7 +99258,7 @@ entities:
       pos: -0.5,-76.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7463
     components:
     - type: Transform
@@ -99103,7 +99266,7 @@ entities:
       pos: -10.5,-53.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7488
     components:
     - type: Transform
@@ -99114,7 +99277,7 @@ entities:
       deviceLists:
       - 24769
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7686
     components:
     - type: Transform
@@ -99122,7 +99285,7 @@ entities:
       pos: -31.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7811
     components:
     - type: Transform
@@ -99130,14 +99293,14 @@ entities:
       pos: -20.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7901
     components:
     - type: Transform
       pos: -25.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8137
     components:
     - type: Transform
@@ -99145,7 +99308,7 @@ entities:
       pos: -3.5,-45.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8416
     components:
     - type: Transform
@@ -99156,7 +99319,7 @@ entities:
       deviceLists:
       - 105
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8439
     components:
     - type: Transform
@@ -99167,7 +99330,7 @@ entities:
       deviceLists:
       - 8516
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8620
     components:
     - type: Transform
@@ -99175,7 +99338,7 @@ entities:
       pos: 16.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8942
     components:
     - type: Transform
@@ -99186,7 +99349,7 @@ entities:
       deviceLists:
       - 8516
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8960
     components:
     - type: Transform
@@ -99194,14 +99357,14 @@ entities:
       pos: -48.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9017
     components:
     - type: Transform
       pos: -47.5,3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9061
     components:
     - type: Transform
@@ -99209,7 +99372,7 @@ entities:
       pos: 29.5,-17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9062
     components:
     - type: Transform
@@ -99217,7 +99380,7 @@ entities:
       pos: 29.5,-19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9155
     components:
     - type: Transform
@@ -99228,7 +99391,7 @@ entities:
       deviceLists:
       - 1960
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9160
     components:
     - type: Transform
@@ -99236,7 +99399,7 @@ entities:
       pos: 22.5,-23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9428
     components:
     - type: Transform
@@ -99246,14 +99409,14 @@ entities:
       deviceLists:
       - 11464
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9608
     components:
     - type: Transform
       pos: -41.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9631
     components:
     - type: Transform
@@ -99264,7 +99427,7 @@ entities:
       deviceLists:
       - 11464
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9641
     components:
     - type: Transform
@@ -99272,7 +99435,7 @@ entities:
       pos: -41.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9674
     components:
     - type: Transform
@@ -99283,14 +99446,14 @@ entities:
       deviceLists:
       - 7065
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 9677
     components:
     - type: Transform
       pos: -38.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 11525
     components:
     - type: Transform
@@ -99300,7 +99463,7 @@ entities:
       deviceLists:
       - 1229
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12001
     components:
     - type: Transform
@@ -99308,7 +99471,7 @@ entities:
       pos: 16.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12591
     components:
     - type: Transform
@@ -99316,7 +99479,7 @@ entities:
       pos: 16.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12594
     components:
     - type: Transform
@@ -99331,7 +99494,7 @@ entities:
       pos: 38.5,-31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12632
     components:
     - type: Transform
@@ -99339,14 +99502,14 @@ entities:
       pos: 41.5,-30.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12633
     components:
     - type: Transform
       pos: 38.5,-27.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 12897
     components:
     - type: Transform
@@ -99354,7 +99517,7 @@ entities:
       pos: 13.5,5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13073
     components:
     - type: Transform
@@ -99362,7 +99525,7 @@ entities:
       pos: 40.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13075
     components:
     - type: Transform
@@ -99370,7 +99533,7 @@ entities:
       pos: 38.5,6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13238
     components:
     - type: Transform
@@ -99378,7 +99541,7 @@ entities:
       pos: 19.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13444
     components:
     - type: Transform
@@ -99391,14 +99554,14 @@ entities:
       pos: 36.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13563
     components:
     - type: Transform
       pos: 22.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 13754
     components:
     - type: Transform
@@ -99411,7 +99574,7 @@ entities:
       pos: -27.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15648
     components:
     - type: Transform
@@ -99419,7 +99582,7 @@ entities:
       pos: -21.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15649
     components:
     - type: Transform
@@ -99427,7 +99590,7 @@ entities:
       pos: -16.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 15650
     components:
     - type: Transform
@@ -99435,14 +99598,14 @@ entities:
       pos: -11.5,35.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16560
     components:
     - type: Transform
       pos: -25.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16605
     components:
     - type: Transform
@@ -99450,21 +99613,21 @@ entities:
       pos: -11.5,29.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16615
     components:
     - type: Transform
       pos: 1.5,31.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16621
     components:
     - type: Transform
       pos: -1.5,28.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16633
     components:
     - type: Transform
@@ -99475,7 +99638,7 @@ entities:
       deviceLists:
       - 21710
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16634
     components:
     - type: Transform
@@ -99486,7 +99649,7 @@ entities:
       deviceLists:
       - 15745
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16642
     components:
     - type: Transform
@@ -99494,7 +99657,7 @@ entities:
       pos: -2.5,15.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16667
     components:
     - type: Transform
@@ -99502,21 +99665,21 @@ entities:
       pos: 12.5,17.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16668
     components:
     - type: Transform
       pos: 10.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16672
     components:
     - type: Transform
       pos: 3.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16673
     components:
     - type: Transform
@@ -99524,7 +99687,7 @@ entities:
       pos: -3.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16675
     components:
     - type: Transform
@@ -99532,7 +99695,7 @@ entities:
       pos: 0.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 16681
     components:
     - type: Transform
@@ -99540,7 +99703,7 @@ entities:
       pos: 4.5,14.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17603
     components:
     - type: Transform
@@ -99548,7 +99711,7 @@ entities:
       pos: -46.5,23.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17604
     components:
     - type: Transform
@@ -99556,7 +99719,7 @@ entities:
       pos: -46.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17621
     components:
     - type: Transform
@@ -99564,7 +99727,7 @@ entities:
       pos: -34.5,20.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17626
     components:
     - type: Transform
@@ -99576,7 +99739,7 @@ entities:
       pos: -31.5,24.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 17632
     components:
     - type: Transform
@@ -99584,7 +99747,7 @@ entities:
       pos: -15.5,19.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18257
     components:
     - type: Transform
@@ -99592,7 +99755,7 @@ entities:
       pos: -4.5,-5.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18258
     components:
     - type: Transform
@@ -99600,7 +99763,7 @@ entities:
       pos: -7.5,-4.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18260
     components:
     - type: Transform
@@ -99608,7 +99771,7 @@ entities:
       pos: 0.5,-0.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18425
     components:
     - type: Transform
@@ -99616,7 +99779,7 @@ entities:
       pos: 0.5,-3.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18428
     components:
     - type: Transform
@@ -99624,7 +99787,7 @@ entities:
       pos: 4.5,-6.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18430
     components:
     - type: Transform
@@ -99632,7 +99795,7 @@ entities:
       pos: 0.5,-10.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18434
     components:
     - type: Transform
@@ -99640,21 +99803,21 @@ entities:
       pos: -2.5,-9.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18657
     components:
     - type: Transform
       pos: 43.5,12.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18658
     components:
     - type: Transform
       pos: 44.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18685
     components:
     - type: Transform
@@ -99662,7 +99825,7 @@ entities:
       pos: 48.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18686
     components:
     - type: Transform
@@ -99670,7 +99833,7 @@ entities:
       pos: 53.5,13.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18687
     components:
     - type: Transform
@@ -99678,7 +99841,7 @@ entities:
       pos: 53.5,7.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18884
     components:
     - type: Transform
@@ -99689,7 +99852,7 @@ entities:
       deviceLists:
       - 24792
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18915
     components:
     - type: Transform
@@ -99697,7 +99860,7 @@ entities:
       pos: 48.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 18938
     components:
     - type: Transform
@@ -99712,7 +99875,7 @@ entities:
       pos: 31.5,8.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 19058
     components:
     - type: Transform
@@ -99722,7 +99885,7 @@ entities:
       deviceLists:
       - 25155
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 19059
     components:
     - type: Transform
@@ -99732,7 +99895,7 @@ entities:
       deviceLists:
       - 25155
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 19180
     components:
     - type: Transform
@@ -99740,7 +99903,7 @@ entities:
       pos: 21.5,18.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 21328
     components:
     - type: Transform
@@ -99754,7 +99917,7 @@ entities:
       pos: -34.5,-1.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 22906
     components:
     - type: Transform
@@ -99842,7 +100005,7 @@ entities:
       deviceLists:
       - 23956
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 24358
     components:
     - type: Transform
@@ -99850,7 +100013,7 @@ entities:
       pos: 47.5,-21.5
       parent: 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25175
     components:
     - type: Transform
@@ -99861,7 +100024,7 @@ entities:
       deviceLists:
       - 25162
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25176
     components:
     - type: Transform
@@ -99872,7 +100035,7 @@ entities:
       deviceLists:
       - 25162
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25177
     components:
     - type: Transform
@@ -99883,7 +100046,7 @@ entities:
       deviceLists:
       - 25163
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25178
     components:
     - type: Transform
@@ -99894,7 +100057,7 @@ entities:
       deviceLists:
       - 25163
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25183
     components:
     - type: Transform
@@ -99904,7 +100067,7 @@ entities:
       deviceLists:
       - 25157
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 25186
     components:
     - type: Transform
@@ -99915,7 +100078,7 @@ entities:
       deviceLists:
       - 25157
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
 - proto: GasVolumePump
   entities:
   - uid: 14850
@@ -100069,6 +100232,11 @@ entities:
     - type: Transform
       pos: -55.5,-24.5
       parent: 60
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -35.5,-5.5
+      parent: 60
   - uid: 71
     components:
     - type: Transform
@@ -100078,6 +100246,11 @@ entities:
     components:
     - type: Transform
       pos: 50.5,19.5
+      parent: 60
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -17.5,-9.5
       parent: 60
   - uid: 137
     components:
@@ -100111,6 +100284,11 @@ entities:
     - type: Transform
       pos: -32.5,-17.5
       parent: 60
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -35.5,-7.5
+      parent: 60
   - uid: 258
     components:
     - type: Transform
@@ -100120,11 +100298,6 @@ entities:
     components:
     - type: Transform
       pos: -29.5,-16.5
-      parent: 60
-  - uid: 284
-    components:
-    - type: Transform
-      pos: -17.5,-9.5
       parent: 60
   - uid: 369
     components:
@@ -100241,6 +100414,11 @@ entities:
     - type: Transform
       pos: 14.5,-4.5
       parent: 60
+  - uid: 617
+    components:
+    - type: Transform
+      pos: -35.5,-9.5
+      parent: 60
   - uid: 631
     components:
     - type: Transform
@@ -100309,11 +100487,6 @@ entities:
     - type: Transform
       pos: -72.5,-26.5
       parent: 60
-  - uid: 963
-    components:
-    - type: Transform
-      pos: -35.5,-10.5
-      parent: 60
   - uid: 979
     components:
     - type: Transform
@@ -100338,11 +100511,6 @@ entities:
     components:
     - type: Transform
       pos: -28.5,-7.5
-      parent: 60
-  - uid: 1162
-    components:
-    - type: Transform
-      pos: -35.5,-11.5
       parent: 60
   - uid: 1174
     components:
@@ -100464,16 +100632,6 @@ entities:
     - type: Transform
       pos: -32.5,-6.5
       parent: 60
-  - uid: 1529
-    components:
-    - type: Transform
-      pos: -35.5,-9.5
-      parent: 60
-  - uid: 1532
-    components:
-    - type: Transform
-      pos: -35.5,-5.5
-      parent: 60
   - uid: 1536
     components:
     - type: Transform
@@ -100482,32 +100640,37 @@ entities:
   - uid: 1537
     components:
     - type: Transform
-      pos: -35.5,-6.5
+      pos: -35.5,-10.5
       parent: 60
   - uid: 1540
     components:
     - type: Transform
       pos: -29.5,-9.5
       parent: 60
-  - uid: 1541
-    components:
-    - type: Transform
-      pos: -17.5,-11.5
-      parent: 60
-  - uid: 1542
-    components:
-    - type: Transform
-      pos: -35.5,-7.5
-      parent: 60
   - uid: 1545
     components:
     - type: Transform
       pos: -17.5,-10.5
       parent: 60
+  - uid: 1558
+    components:
+    - type: Transform
+      pos: -35.5,-6.5
+      parent: 60
+  - uid: 1560
+    components:
+    - type: Transform
+      pos: -17.5,-11.5
+      parent: 60
   - uid: 1562
     components:
     - type: Transform
       pos: -24.5,-9.5
+      parent: 60
+  - uid: 1564
+    components:
+    - type: Transform
+      pos: -35.5,-11.5
       parent: 60
   - uid: 1571
     components:
@@ -111044,8 +111207,6 @@ entities:
     - type: Transform
       pos: -23.5,-7.5
       parent: 60
-    - type: Lock
-      locked: False
     - type: Label
       currentLabel: Cell 3
     - type: NameModifier
@@ -111408,8 +111569,11 @@ entities:
   - uid: 1917
     components:
     - type: Transform
+      anchored: True
       pos: -28.5,-11.5
       parent: 60
+    - type: Physics
+      bodyType: Static
 - proto: LockerWeldingSuppliesFilled
   entities:
   - uid: 3316
@@ -120327,6 +120491,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 7.5,-18.5
       parent: 60
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -17.5,-9.5
+      parent: 60
   - uid: 236
     components:
     - type: Transform
@@ -120341,6 +120510,11 @@ entities:
     components:
     - type: Transform
       pos: -19.5,-21.5
+      parent: 60
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -35.5,-9.5
       parent: 60
   - uid: 249
     components:
@@ -122477,11 +122651,6 @@ entities:
     - type: Transform
       pos: 22.5,3.5
       parent: 60
-  - uid: 10685
-    components:
-    - type: Transform
-      pos: -17.5,-9.5
-      parent: 60
   - uid: 10686
     components:
     - type: Transform
@@ -122511,11 +122680,6 @@ entities:
     components:
     - type: Transform
       pos: -32.5,-6.5
-      parent: 60
-  - uid: 11338
-    components:
-    - type: Transform
-      pos: -35.5,-9.5
       parent: 60
   - uid: 11438
     components:
@@ -125436,88 +125600,16 @@ entities:
       parent: 60
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 132
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-10.5
-      parent: 60
   - uid: 147
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-32.5
       parent: 60
-  - uid: 182
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-11.5
-      parent: 60
-  - uid: 233
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-9.5
-      parent: 60
-  - uid: 234
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-5.5
-      parent: 60
-  - uid: 242
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-7.5
-      parent: 60
-  - uid: 246
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,-6.5
-      parent: 60
   - uid: 1454
     components:
     - type: Transform
       pos: 41.5,-25.5
-      parent: 60
-  - uid: 1558
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -35.5,-7.5
-      parent: 60
-  - uid: 1560
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -35.5,-9.5
-      parent: 60
-  - uid: 1561
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -35.5,-10.5
-      parent: 60
-  - uid: 1564
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -35.5,-11.5
-      parent: 60
-  - uid: 1568
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -35.5,-6.5
-      parent: 60
-  - uid: 1569
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -35.5,-5.5
       parent: 60
   - uid: 1631
     components:
@@ -126566,92 +126658,94 @@ entities:
       linkedPorts:
         24785:
         - Pressed: Toggle
-- proto: SignalSwitchDirectional
+- proto: SignalSwitch
   entities:
-  - uid: 617
+  - uid: 10
     components:
     - type: MetaData
-      name: Cell Shutters Switch
+      name: Cell 2 Blast Doors Switch
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -32.5,-10.5
+      pos: -27.520407,-9.605577
       parent: 60
     - type: SignalSwitch
       state: True
     - type: DeviceLinkSource
       linkedPorts:
-        1564:
+        8282:
         - On: Open
         - Off: Close
-        1561:
+        8278:
         - On: Open
         - Off: Close
-        1560:
+        7166:
         - On: Open
         - Off: Close
-  - uid: 667
+  - uid: 8670
     components:
     - type: MetaData
-      name: Cell Shutters Switch
+      name: Cell 1 Blast Doors Switch
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -27.513927,-9.2159
+      parent: 60
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        8335:
+        - On: Open
+        - Off: Close
+        8296:
+        - On: Open
+        - Off: Close
+        6365:
+        - On: Open
+        - Off: Close
+  - uid: 14055
+    components:
+    - type: MetaData
+      name: Cell 3 Blast Doors Switch
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -20.5,-6.5
+      pos: -25.503086,-9.2209425
       parent: 60
     - type: SignalSwitch
       state: True
     - type: DeviceLinkSource
       linkedPorts:
-        242:
+        1981:
         - On: Open
         - Off: Close
-        246:
+        5201:
         - On: Open
         - Off: Close
-        234:
+        1947:
         - On: Open
         - Off: Close
-  - uid: 1257
+  - uid: 14226
     components:
     - type: MetaData
-      name: Cell Shutters Switch
+      name: Cell 4 Blast Doors Switch
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -32.5,-6.5
+      rot: -1.5707963267948966 rad
+      pos: -25.503086,-9.637609
       parent: 60
     - type: SignalSwitch
       state: True
     - type: DeviceLinkSource
       linkedPorts:
-        1569:
+        1720:
         - On: Open
         - Off: Close
         1568:
         - On: Open
         - Off: Close
-        1558:
+        1569:
         - On: Open
         - Off: Close
-  - uid: 1293
-    components:
-    - type: MetaData
-      name: Cell Shutters Switch
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,-10.5
-      parent: 60
-    - type: SignalSwitch
-      state: True
-    - type: DeviceLinkSource
-      linkedPorts:
-        233:
-        - On: Open
-        - Off: Close
-        132:
-        - On: Open
-        - Off: Close
-        182:
-        - On: Open
-        - Off: Close
+- proto: SignalSwitchDirectional
+  entities:
   - uid: 7563
     components:
     - type: Transform
@@ -126694,6 +126788,45 @@ entities:
         - On: Open
         - Off: Close
         5432:
+        - On: Open
+        - Off: Close
+  - uid: 8340
+    components:
+    - type: MetaData
+      name: Inner Door Switch
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -32.5,-10.5
+      parent: 60
+    - type: DeviceLinkSource
+      linkedPorts:
+        8720:
+        - On: Open
+        - Off: Close
+  - uid: 8418
+    components:
+    - type: MetaData
+      name: Inner Door Switch
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -32.5,-6.5
+      parent: 60
+    - type: DeviceLinkSource
+      linkedPorts:
+        8920:
+        - On: Open
+        - Off: Close
+  - uid: 8429
+    components:
+    - type: MetaData
+      name: Inner Door Switch
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-10.5
+      parent: 60
+    - type: DeviceLinkSource
+      linkedPorts:
+        8349:
         - On: Open
         - Off: Close
   - uid: 8433
@@ -126751,55 +126884,6 @@ entities:
         9679:
         - On: Open
         - Off: Close
-  - uid: 8670
-    components:
-    - type: MetaData
-      name: Lockdown
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -27.593151,-9.505666
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        1569:
-        - On: Open
-        - Off: Close
-        1568:
-        - Off: Close
-        - On: Open
-        1558:
-        - On: Open
-        - Off: Close
-        1560:
-        - On: Open
-        - Off: Close
-        1561:
-        - Off: Close
-        - On: Open
-        1564:
-        - On: Open
-        - Off: Close
-        234:
-        - On: Open
-        - Off: Close
-        246:
-        - On: Open
-        - Off: Close
-        242:
-        - On: Open
-        - Off: Close
-        233:
-        - On: Open
-        - Off: Close
-        132:
-        - On: Open
-        - Off: Close
-        182:
-        - Off: Close
-        - On: Open
-        16425:
-        - On: Open
-        - Off: Close
   - uid: 8677
     components:
     - type: MetaData
@@ -126811,6 +126895,19 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         8678:
+        - On: Open
+        - Off: Close
+  - uid: 8898
+    components:
+    - type: MetaData
+      name: Inner Door Switch
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-6.5
+      parent: 60
+    - type: DeviceLinkSource
+      linkedPorts:
+        8908:
         - On: Open
         - Off: Close
   - uid: 9309
@@ -131757,11 +131854,6 @@ entities:
       parent: 60
 - proto: SpawnPointSecurityCadet
   entities:
-  - uid: 1981
-    components:
-    - type: Transform
-      pos: -30.5,-19.5
-      parent: 60
   - uid: 1990
     components:
     - type: Transform
@@ -135131,11 +135223,6 @@ entities:
     - type: Transform
       pos: 0.5,17.5
       parent: 60
-  - uid: 721
-    components:
-    - type: Transform
-      pos: -27.5,-9.5
-      parent: 60
   - uid: 730
     components:
     - type: Transform
@@ -135515,6 +135602,12 @@ entities:
     components:
     - type: Transform
       pos: -58.5,-17.5
+      parent: 60
+  - uid: 8438
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -27.5,-9.5
       parent: 60
   - uid: 8607
     components:
@@ -154518,22 +154611,6 @@ entities:
         - DoorStatus: Close
         8462:
         - DoorStatus: Close
-  - uid: 5201
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-18.5
-      parent: 60
-    - type: DeviceLinkSink
-      invokeCounter: 5
-    - type: DeviceLinkSource
-      linkedPorts:
-        8473:
-        - DoorStatus: Close
-        5757:
-        - DoorStatus: Close
-        8297:
-        - DoorStatus: Close
   - uid: 5825
     components:
     - type: Transform
@@ -154556,46 +154633,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 38.5,-25.5
       parent: 60
-  - uid: 7166
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-19.5
-      parent: 60
-    - type: DeviceLinkSink
-      invokeCounter: 5
-    - type: DeviceLinkSource
-      linkedPorts:
-        8473:
-        - DoorStatus: Close
-        5757:
-        - DoorStatus: Close
-        8297:
-        - DoorStatus: Close
-  - uid: 8278
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -32.5,-11.5
-      parent: 60
-    - type: DeviceLinkSink
-      invokeCounter: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        7917:
-        - DoorStatus: Close
-  - uid: 8296
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-11.5
-      parent: 60
-    - type: DeviceLinkSink
-      invokeCounter: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        7920:
-        - DoorStatus: Close
   - uid: 8341
     components:
     - type: Transform
@@ -154612,30 +154649,6 @@ entities:
         - DoorStatus: Close
         8462:
         - DoorStatus: Close
-  - uid: 8349
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-7.5
-      parent: 60
-    - type: DeviceLinkSink
-      invokeCounter: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        8264:
-        - DoorStatus: Close
-  - uid: 8438
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -32.5,-7.5
-      parent: 60
-    - type: DeviceLinkSink
-      invokeCounter: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        8232:
-        - DoorStatus: Close
   - uid: 8681
     components:
     - type: Transform
@@ -154643,7 +154656,7 @@ entities:
       pos: -21.5,-20.5
       parent: 60
     - type: DeviceLinkSink
-      invokeCounter: 5
+      invokeCounter: 3
     - type: DeviceLinkSource
       linkedPorts:
         8473:
@@ -154651,6 +154664,38 @@ entities:
         5757:
         - DoorStatus: Close
         8297:
+        - DoorStatus: Close
+  - uid: 8713
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-19.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 3
+    - type: DeviceLinkSource
+      linkedPorts:
+        8297:
+        - DoorStatus: Close
+        5757:
+        - DoorStatus: Close
+        8473:
+        - DoorStatus: Close
+  - uid: 9030
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-18.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 3
+    - type: DeviceLinkSource
+      linkedPorts:
+        8297:
+        - DoorStatus: Close
+        5757:
+        - DoorStatus: Close
+        8473:
         - DoorStatus: Close
   - uid: 10854
     components:
@@ -155230,14 +155275,14 @@ entities:
       pos: -21.5,-19.5
       parent: 60
     - type: DeviceLinkSink
-      invokeCounter: 3
+      invokeCounter: 6
     - type: DeviceLinkSource
       linkedPorts:
+        9030:
+        - DoorStatus: Close
+        8713:
+        - DoorStatus: Close
         8681:
-        - DoorStatus: Close
-        7166:
-        - DoorStatus: Close
-        5201:
         - DoorStatus: Close
   - uid: 7917
     components:
@@ -155247,10 +155292,6 @@ entities:
       parent: 60
     - type: DeviceLinkSink
       invokeCounter: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        8278:
-        - DoorStatus: Close
   - uid: 7920
     components:
     - type: Transform
@@ -155259,10 +155300,6 @@ entities:
       parent: 60
     - type: DeviceLinkSink
       invokeCounter: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        8296:
-        - DoorStatus: Close
   - uid: 8232
     components:
     - type: Transform
@@ -155271,10 +155308,6 @@ entities:
       parent: 60
     - type: DeviceLinkSink
       invokeCounter: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        8438:
-        - DoorStatus: Close
   - uid: 8264
     components:
     - type: Transform
@@ -155290,15 +155323,21 @@ entities:
       pos: -21.5,-18.5
       parent: 60
     - type: DeviceLinkSink
-      invokeCounter: 4
+      invokeCounter: 7
     - type: DeviceLinkSource
       linkedPorts:
+        9030:
+        - DoorStatus: Close
+        8713:
+        - DoorStatus: Close
         8681:
         - DoorStatus: Close
-        7166:
-        - DoorStatus: Close
-        5201:
-        - DoorStatus: Close
+  - uid: 8349
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-11.5
+      parent: 60
   - uid: 8454
     components:
     - type: Transform
@@ -155338,15 +155377,33 @@ entities:
       pos: -21.5,-20.5
       parent: 60
     - type: DeviceLinkSink
-      invokeCounter: 3
+      invokeCounter: 6
     - type: DeviceLinkSource
       linkedPorts:
-        5201:
+        9030:
         - DoorStatus: Close
-        7166:
+        8713:
         - DoorStatus: Close
         8681:
         - DoorStatus: Close
+  - uid: 8720
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -32.5,-11.5
+      parent: 60
+  - uid: 8908
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-7.5
+      parent: 60
+  - uid: 8920
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -32.5,-7.5
+      parent: 60
   - uid: 12596
     components:
     - type: Transform

--- a/Resources/Maps/bagel.yml
+++ b/Resources/Maps/bagel.yml
@@ -125,7 +125,7 @@ entities:
           version: 6
         -2,-1:
           ind: -2,-1
-          tiles: XQAAAAAAXQAAAAABHwAAAAAALgAAAAAALgAAAAAATgAAAAABLgAAAAAALgAAAAAAHwAAAAAAXQAAAAADXQAAAAACXQAAAAAAXQAAAAABXQAAAAACfgAAAAAAXQAAAAADXQAAAAACXQAAAAADfgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAAfgAAAAAAXQAAAAADXQAAAAABXQAAAAADXQAAAAAAXQAAAAABfgAAAAAAXQAAAAADXQAAAAADXQAAAAABfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACXQAAAAACHwAAAAADHwAAAAADHwAAAAACfgAAAAAAXQAAAAAATQAAAAACTQAAAAABfgAAAAAAHwAAAAAAHwAAAAADHwAAAAADHwAAAAABHwAAAAACfgAAAAAATQAAAAABTQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAfgAAAAAAHwAAAAABHwAAAAACHwAAAAADHwAAAAAAHwAAAAABfgAAAAAAXQAAAAACXQAAAAAAHwAAAAADHwAAAAADHwAAAAADfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAHwAAAAABHwAAAAADHwAAAAABHwAAAAABHwAAAAACHwAAAAADHwAAAAADXQAAAAABXQAAAAAAfgAAAAAAHwAAAAADHwAAAAACfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAfgAAAAAAfgAAAAAAHwAAAAADHwAAAAADHwAAAAADfgAAAAAAfgAAAAAAXQAAAAACXQAAAAABXQAAAAABHwAAAAABHwAAAAADfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAXQAAAAABfgAAAAAAHwAAAAABHwAAAAACHwAAAAACfgAAAAAAXQAAAAABXQAAAAABXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAAAXQAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAHwAAAAABHwAAAAACHwAAAAADfgAAAAAAXQAAAAADXQAAAAACXQAAAAABXQAAAAADXQAAAAACXQAAAAADXQAAAAADXQAAAAABXQAAAAABXQAAAAABXQAAAAAAXQAAAAACfgAAAAAAHwAAAAABHwAAAAACfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAXQAAAAADXQAAAAABXQAAAAACXQAAAAADXQAAAAACXQAAAAAAXQAAAAAAXQAAAAACXQAAAAAAXQAAAAABHwAAAAADHwAAAAACfgAAAAAAXQAAAAADXQAAAAAAXQAAAAACXQAAAAADXQAAAAADXQAAAAAAXQAAAAAAXQAAAAABXQAAAAADXQAAAAABXQAAAAACXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAADXQAAAAACXQAAAAADXQAAAAACXQAAAAABXQAAAAABXQAAAAACXQAAAAABXQAAAAABXQAAAAADfgAAAAAAHwAAAAADHwAAAAAAfgAAAAAAXQAAAAACHwAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAfgAAAAAATQAAAAACHwAAAAABHwAAAAAAfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAHwAAAAABHwAAAAAAHwAAAAACHwAAAAADfgAAAAAAXQAAAAADXQAAAAABHwAAAAAAHwAAAAACfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAegAAAAADegAAAAABegAAAAADegAAAAACfgAAAAAAXQAAAAADXQAAAAAC
+          tiles: XQAAAAAAXQAAAAABHwAAAAAALgAAAAAALgAAAAAATgAAAAABLgAAAAAALgAAAAAAHwAAAAAAXQAAAAADXQAAAAACXQAAAAAAXQAAAAABXQAAAAACfgAAAAAAXQAAAAADXQAAAAACXQAAAAADfgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAAfgAAAAAAXQAAAAADXQAAAAABXQAAAAADXQAAAAAAXQAAAAABfgAAAAAAXQAAAAADXQAAAAADXQAAAAABfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACXQAAAAACHwAAAAADHwAAAAADHwAAAAACfgAAAAAAXQAAAAAATQAAAAACTQAAAAABfgAAAAAAHwAAAAAAHwAAAAADHwAAAAADHwAAAAABHwAAAAACfgAAAAAATQAAAAABTQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAfgAAAAAAHwAAAAABHwAAAAACHwAAAAADHwAAAAAAHwAAAAABfgAAAAAAXQAAAAACXQAAAAAAHwAAAAADHwAAAAADHwAAAAADfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAHwAAAAABHwAAAAADHwAAAAABHwAAAAABHwAAAAACHwAAAAADHwAAAAADXQAAAAABXQAAAAAAfgAAAAAAHwAAAAADHwAAAAACfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAfgAAAAAAfgAAAAAAHwAAAAADHwAAAAADHwAAAAADfgAAAAAAfgAAAAAAXQAAAAACXQAAAAABXQAAAAABHwAAAAABHwAAAAADfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAXQAAAAABfgAAAAAAHwAAAAABHwAAAAACHwAAAAACfgAAAAAAXQAAAAABXQAAAAABXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAAAXQAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAACXQAAAAABXQAAAAAAHwAAAAABHwAAAAACHwAAAAADfgAAAAAAXQAAAAADXQAAAAACXQAAAAABXQAAAAADXQAAAAACXQAAAAADXQAAAAADXQAAAAABXQAAAAABXQAAAAABXQAAAAAAXQAAAAACfgAAAAAAHwAAAAABHwAAAAACfgAAAAAAXQAAAAAAXQAAAAABXQAAAAAAXQAAAAADXQAAAAABXQAAAAACXQAAAAADXQAAAAACXQAAAAAAXQAAAAAAXQAAAAACXQAAAAAAXQAAAAABHwAAAAADHwAAAAACfgAAAAAAXQAAAAADXQAAAAAAXQAAAAACXQAAAAADXQAAAAADXQAAAAAAXQAAAAAAXQAAAAABXQAAAAADXQAAAAABXQAAAAACXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAADXQAAAAACXQAAAAADXQAAAAACXQAAAAABXQAAAAABXQAAAAACXQAAAAABXQAAAAABXQAAAAADfgAAAAAAHwAAAAADHwAAAAAAfgAAAAAAXQAAAAACbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAHwAAAAAAfgAAAAAAfgAAAAAATQAAAAACHwAAAAABHwAAAAAAfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAHwAAAAABHwAAAAAAHwAAAAACHwAAAAADfgAAAAAAXQAAAAADXQAAAAABHwAAAAAAHwAAAAACfgAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAfgAAAAAAegAAAAADegAAAAABegAAAAADegAAAAACfgAAAAAAXQAAAAADXQAAAAAC
           version: 6
         -2,0:
           ind: -2,0
@@ -1047,7 +1047,6 @@ entities:
             5094: -19,5
             5095: -20,5
             5096: -25,5
-            5227: -25,-12
             5352: -14,11
         - node:
             cleanable: True
@@ -1108,6 +1107,9 @@ entities:
           decals:
             2385: 39,-6
             5078: -25,-1
+            5377: -25,0
+            5389: -25,-12
+            5390: -25,-13
         - node:
             color: '#FFFFFFFF'
             id: BotRight
@@ -1124,7 +1126,6 @@ entities:
             3300: -15,46
             5048: -24,-21
             5070: -28,1
-            5225: -29,-12
         - node:
             color: '#FF8FC9FF'
             id: BotRightGreyscale
@@ -1137,7 +1138,8 @@ entities:
             5067: -29,-1
             5068: -29,0
             5083: -29,-2
-            5226: -29,-13
+            5387: -29,-12
+            5388: -29,-13
         - node:
             color: '#FFFFFFFF'
             id: Box
@@ -1154,6 +1156,7 @@ entities:
             4880: 0,23
             5079: -28,-1
             5080: -26,-1
+            5378: -25,-21
         - node:
             color: '#DE3A3A96'
             id: BoxGreyscale
@@ -1810,8 +1813,8 @@ entities:
             color: '#DE3A3A96'
             id: BrickTileWhiteCornerSe
           decals:
-            5220: -25,-13
             5282: -31,-17
+            5382: -25,-13
         - node:
             color: '#EFD54193'
             id: BrickTileWhiteCornerSe
@@ -1866,8 +1869,8 @@ entities:
             color: '#DE3A3A96'
             id: BrickTileWhiteCornerSw
           decals:
-            5219: -29,-13
             5275: -23,-17
+            5381: -29,-13
         - node:
             color: '#EFCC4196'
             id: BrickTileWhiteCornerSw
@@ -2007,7 +2010,6 @@ entities:
             id: BrickTileWhiteLineE
           decals:
             5214: -26,-10
-            5223: -25,-12
             5236: -22,-12
             5237: -22,-11
             5238: -22,-10
@@ -2018,6 +2020,8 @@ entities:
             5243: -22,-5
             5280: -31,-14
             5281: -31,-15
+            5385: -25,-12
+            5386: -31,-12
         - node:
             color: '#EFCC4193'
             id: BrickTileWhiteLineE
@@ -2187,12 +2191,12 @@ entities:
             id: BrickTileWhiteLineS
           decals:
             5221: -28,-13
-            5222: -26,-13
             5273: -20,-17
             5274: -22,-17
             5283: -32,-17
             5284: -33,-17
             5285: -35,-17
+            5383: -26,-13
         - node:
             zIndex: 5
             color: '#EFCC4193'
@@ -2286,7 +2290,6 @@ entities:
             id: BrickTileWhiteLineW
           decals:
             5213: -28,-10
-            5224: -29,-12
             5254: -32,-5
             5255: -32,-6
             5256: -32,-7
@@ -2297,6 +2300,7 @@ entities:
             5261: -32,-12
             5276: -23,-15
             5277: -23,-14
+            5384: -29,-12
         - node:
             color: '#EFCC4196'
             id: BrickTileWhiteLineW
@@ -5452,7 +5456,6 @@ entities:
             3177: 39,-47
             3302: -17,48
             5071: -25,1
-            5228: -25,-13
         - node:
             color: '#FFFFFFFF'
             id: WarnCorner
@@ -6515,7 +6518,8 @@ entities:
           -4,-3:
             0: 15295
           -5,-3:
-            0: 35771
+            0: 35259
+            2: 512
           -4,-2:
             0: 13107
             1: 34952
@@ -6813,10 +6817,10 @@ entities:
             0: 56797
           5,-8:
             0: 15359
-            2: 32768
+            3: 32768
           5,-7:
             0: 61491
-            2: 136
+            3: 136
           5,-6:
             0: 65535
           5,-5:
@@ -6827,9 +6831,9 @@ entities:
             0: 65311
           6,-8:
             0: 255
-            2: 28672
+            3: 28672
           6,-7:
-            2: 119
+            3: 119
             0: 61952
           6,-6:
             0: 61695
@@ -6987,19 +6991,23 @@ entities:
           -9,-2:
             0: 3694
           -8,-1:
-            0: 47903
+            0: 13087
+            4: 34816
           -9,-1:
             0: 61038
           -8,0:
-            0: 9131
+            0: 9123
+            4: 8
           -7,-3:
             0: 30719
           -7,-2:
             0: 65520
           -7,-1:
-            0: 65327
+            0: 30511
+            2: 34816
           -7,0:
-            0: 255
+            0: 175
+            2: 80
           -6,-3:
             0: 32382
           -6,-2:
@@ -8046,7 +8054,7 @@ entities:
             0: 255
             1: 16384
           17,-7:
-            3: 1
+            5: 1
             1: 4104
           17,-6:
             1: 4593
@@ -8156,8 +8164,8 @@ entities:
           -13,7:
             1: 39408
           -12,8:
-            4: 12
-            5: 3072
+            6: 12
+            7: 3072
           -11,5:
             0: 63351
           -11,6:
@@ -8166,9 +8174,9 @@ entities:
           -11,7:
             1: 17532
           -11,8:
-            4: 1
+            6: 1
             1: 17476
-            5: 256
+            7: 256
           -10,5:
             0: 62139
           -10,6:
@@ -8264,10 +8272,10 @@ entities:
             0: 255
             1: 57344
           -8,11:
-            6: 816
+            8: 816
             1: 34952
           -9,11:
-            6: 2176
+            8: 2176
             1: 8738
           -8,12:
             1: 34959
@@ -8287,7 +8295,7 @@ entities:
           -6,11:
             0: 4095
           -6,12:
-            6: 61166
+            8: 61166
           -5,9:
             0: 65528
           -5,10:
@@ -8295,7 +8303,7 @@ entities:
           -5,11:
             0: 36863
           -5,12:
-            6: 30515
+            8: 30515
             0: 12
           -4,9:
             0: 65528
@@ -8305,7 +8313,7 @@ entities:
             0: 4095
           -4,12:
             0: 1
-            6: 65518
+            8: 65518
           -4,13:
             1: 61680
           -5,13:
@@ -8319,7 +8327,7 @@ entities:
           -5,15:
             1: 17487
           -3,12:
-            6: 13107
+            8: 13107
             1: 34944
           -3,13:
             1: 47792
@@ -8385,7 +8393,7 @@ entities:
             1: 61713
           -12,9:
             0: 16
-            6: 3084
+            8: 3084
           -13,9:
             1: 39305
           -13,10:
@@ -8394,19 +8402,19 @@ entities:
             1: 35033
             0: 12544
           -12,10:
-            3: 12
-            6: 3072
+            5: 12
+            8: 3072
           -12,11:
-            6: 12
+            8: 12
           -11,9:
-            6: 257
+            8: 257
             1: 17476
           -11,10:
-            3: 1
-            6: 256
+            5: 1
+            8: 256
             1: 17476
           -11,11:
-            6: 1
+            8: 1
             1: 17476
           -11,12:
             1: 17487
@@ -8460,8 +8468,8 @@ entities:
             1: 15
           -13,12:
             1: 34952
-            5: 48
-            4: 12288
+            7: 48
+            6: 12288
           -12,13:
             1: 61455
           -13,13:
@@ -8494,11 +8502,11 @@ entities:
             1: 62671
           -7,14:
             1: 244
-            6: 57344
+            8: 57344
             0: 1024
           -7,15:
             1: 61440
-            6: 238
+            8: 238
             0: 1024
           -7,16:
             1: 65524
@@ -8557,8 +8565,8 @@ entities:
           -14,12:
             0: 1
             1: 8738
-            5: 128
-            4: 32768
+            7: 128
+            6: 32768
           -17,12:
             0: 52232
           -16,13:
@@ -9119,10 +9127,40 @@ entities:
           - 0
           - 0
         - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
           temperature: 235
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.1495
+          moles:
+          - 20.078888
+          - 75.53487
           - 0
           - 0
           - 0
@@ -9490,11 +9528,6 @@ entities:
     - type: Transform
       pos: 31.477634,-79.4623
       parent: 60
-  - uid: 14226
-    components:
-    - type: Transform
-      pos: -23.537233,-10.44661
-      parent: 60
 - proto: ActionToggleInternals
   entities:
   - uid: 13159
@@ -9584,6 +9617,7 @@ entities:
       - 1975
       - 1983
       - 2009
+      - 1856
   - uid: 231
     components:
     - type: Transform
@@ -9597,6 +9631,7 @@ entities:
       - 157
       - 779
       - 778
+      - 1856
   - uid: 1229
     components:
     - type: Transform
@@ -10790,6 +10825,8 @@ entities:
       parent: 60
   - uid: 8471
     components:
+    - type: MetaData
+      name: Armory
     - type: Transform
       pos: -26.5,-2.5
       parent: 60
@@ -10898,35 +10935,26 @@ entities:
       parent: 60
 - proto: AirlockBrigGlassLocked
   entities:
-  - uid: 242
-    components:
-    - type: Transform
-      pos: -20.5,-21.5
-      parent: 60
   - uid: 243
     components:
+    - type: MetaData
+      name: Security Entrance
     - type: Transform
       pos: -20.5,-17.5
       parent: 60
   - uid: 245
     components:
+    - type: MetaData
+      name: Security Entrance
     - type: Transform
       pos: -18.5,-17.5
       parent: 60
   - uid: 1919
     components:
+    - type: MetaData
+      name: Security Entrance
     - type: Transform
       pos: -33.5,-17.5
-      parent: 60
-  - uid: 8297
-    components:
-    - type: Transform
-      pos: -35.5,-19.5
-      parent: 60
-  - uid: 8454
-    components:
-    - type: Transform
-      pos: -18.5,-21.5
       parent: 60
 - proto: AirlockBrigLocked
   entities:
@@ -13153,12 +13181,10 @@ entities:
       parent: 60
 - proto: AirlockMaintSecLocked
   entities:
-  - uid: 18781
+  - uid: 81
     components:
-    - type: MetaData
-      name: Security Maint
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: 3.141592653589793 rad
       pos: -30.5,3.5
       parent: 60
 - proto: AirlockMaintTheatreLocked
@@ -13416,6 +13442,32 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -54.5,10.5
+      parent: 60
+- proto: AirlockSecurityGlass
+  entities:
+  - uid: 20
+    components:
+    - type: MetaData
+      name: Security Entrance (Unlocked)
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,-21.5
+      parent: 60
+  - uid: 72
+    components:
+    - type: MetaData
+      name: Security Entrance (Unlocked)
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -35.5,-19.5
+      parent: 60
+  - uid: 76
+    components:
+    - type: MetaData
+      name: Security Entrance (Unlocked)
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-21.5
       parent: 60
 - proto: AirlockSecurityGlassLocked
   entities:
@@ -14188,7 +14240,7 @@ entities:
   - uid: 124
     components:
     - type: MetaData
-      name: Security Ready Room APC
+      name: Ready Room APC
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,-21.5
@@ -16335,66 +16387,6 @@ entities:
     - type: Transform
       pos: -4.5,1.5
       parent: 60
-  - uid: 1238
-    components:
-    - type: Transform
-      pos: -17.5,-10.5
-      parent: 60
-  - uid: 1257
-    components:
-    - type: Transform
-      pos: -17.5,-11.5
-      parent: 60
-  - uid: 1293
-    components:
-    - type: Transform
-      pos: -17.5,-9.5
-      parent: 60
-  - uid: 1354
-    components:
-    - type: Transform
-      pos: -17.5,-7.5
-      parent: 60
-  - uid: 1384
-    components:
-    - type: Transform
-      pos: -17.5,-6.5
-      parent: 60
-  - uid: 1638
-    components:
-    - type: Transform
-      pos: -35.5,-11.5
-      parent: 60
-  - uid: 1639
-    components:
-    - type: Transform
-      pos: -35.5,-10.5
-      parent: 60
-  - uid: 1640
-    components:
-    - type: Transform
-      pos: -35.5,-9.5
-      parent: 60
-  - uid: 1652
-    components:
-    - type: Transform
-      pos: -17.5,-5.5
-      parent: 60
-  - uid: 1653
-    components:
-    - type: Transform
-      pos: -35.5,-7.5
-      parent: 60
-  - uid: 1655
-    components:
-    - type: Transform
-      pos: -35.5,-6.5
-      parent: 60
-  - uid: 1656
-    components:
-    - type: Transform
-      pos: -35.5,-5.5
-      parent: 60
   - uid: 1681
     components:
     - type: Transform
@@ -16809,19 +16801,17 @@ entities:
     - type: Transform
       pos: 40.456047,-10.342315
       parent: 60
+  - uid: 2103
+    components:
+    - type: Transform
+      pos: -18.36419,-13.358363
+      parent: 60
 - proto: BoxFlare
   entities:
   - uid: 16379
     components:
     - type: Transform
       pos: 36.484776,-1.3655467
-      parent: 60
-- proto: BoxFlashbang
-  entities:
-  - uid: 23646
-    components:
-    - type: Transform
-      pos: -27.693483,-9.22786
       parent: 60
 - proto: BoxFolderBlack
   entities:
@@ -16977,7 +16967,7 @@ entities:
   - uid: 8517
     components:
     - type: Transform
-      pos: -25.770853,-6.4264956
+      pos: -30.754217,-20.587437
       parent: 60
 - proto: BoxLatexGloves
   entities:
@@ -17009,11 +16999,6 @@ entities:
     components:
     - type: Transform
       pos: 1.5511138,15.604638
-      parent: 60
-  - uid: 6704
-    components:
-    - type: Transform
-      pos: -22.497168,-20.37416
       parent: 60
   - uid: 7217
     components:
@@ -17096,12 +17081,7 @@ entities:
   - uid: 13148
     components:
     - type: Transform
-      pos: -30.92134,-20.595226
-      parent: 60
-  - uid: 21067
-    components:
-    - type: Transform
-      pos: -27.615358,-9.430985
+      pos: -22.254217,-20.587437
       parent: 60
 - proto: BrbSign
   entities:
@@ -17179,13 +17159,6 @@ entities:
     components:
     - type: Transform
       pos: -56.485756,52.334377
-      parent: 60
-- proto: Brutepack
-  entities:
-  - uid: 9030
-    components:
-    - type: Transform
-      pos: -19.411993,-13.214928
       parent: 60
 - proto: Bucket
   entities:
@@ -17369,6 +17342,12 @@ entities:
       parent: 60
 - proto: ButtonFrameCautionSecurity
   entities:
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -27.58968,-9.505666
+      parent: 60
   - uid: 4299
     components:
     - type: Transform
@@ -17459,25 +17438,10 @@ entities:
     - type: Transform
       pos: 1.5,-77.5
       parent: 60
-  - uid: 72
-    components:
-    - type: Transform
-      pos: -32.5,-5.5
-      parent: 60
-  - uid: 76
-    components:
-    - type: Transform
-      pos: -33.5,-5.5
-      parent: 60
   - uid: 79
     components:
     - type: Transform
       pos: -31.5,-6.5
-      parent: 60
-  - uid: 81
-    components:
-    - type: Transform
-      pos: -31.5,-5.5
       parent: 60
   - uid: 96
     components:
@@ -17544,6 +17508,11 @@ entities:
     - type: Transform
       pos: -29.5,-10.5
       parent: 60
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -33.5,-10.5
+      parent: 60
   - uid: 332
     components:
     - type: Transform
@@ -17599,10 +17568,20 @@ entities:
     - type: Transform
       pos: -8.5,2.5
       parent: 60
+  - uid: 564
+    components:
+    - type: Transform
+      pos: -34.5,-6.5
+      parent: 60
   - uid: 570
     components:
     - type: Transform
       pos: -10.5,5.5
+      parent: 60
+  - uid: 584
+    components:
+    - type: Transform
+      pos: -34.5,-10.5
       parent: 60
   - uid: 643
     components:
@@ -17649,6 +17628,11 @@ entities:
     - type: Transform
       pos: -59.5,-20.5
       parent: 60
+  - uid: 1238
+    components:
+    - type: Transform
+      pos: -33.5,-6.5
+      parent: 60
   - uid: 1252
     components:
     - type: Transform
@@ -17663,6 +17647,11 @@ entities:
     components:
     - type: Transform
       pos: -58.5,-18.5
+      parent: 60
+  - uid: 1354
+    components:
+    - type: Transform
+      pos: -19.5,-10.5
       parent: 60
   - uid: 1356
     components:
@@ -17693,6 +17682,16 @@ entities:
     components:
     - type: Transform
       pos: -11.5,25.5
+      parent: 60
+  - uid: 1530
+    components:
+    - type: Transform
+      pos: -19.5,-6.5
+      parent: 60
+  - uid: 1552
+    components:
+    - type: Transform
+      pos: -18.5,-10.5
       parent: 60
   - uid: 1628
     components:
@@ -17738,11 +17737,6 @@ entities:
     components:
     - type: Transform
       pos: 1.5,-6.5
-      parent: 60
-  - uid: 1717
-    components:
-    - type: Transform
-      pos: -18.5,-5.5
       parent: 60
   - uid: 1720
     components:
@@ -17869,16 +17863,6 @@ entities:
     - type: Transform
       pos: -27.5,-15.5
       parent: 60
-  - uid: 1935
-    components:
-    - type: Transform
-      pos: -19.5,-9.5
-      parent: 60
-  - uid: 1938
-    components:
-    - type: Transform
-      pos: -34.5,-5.5
-      parent: 60
   - uid: 1947
     components:
     - type: Transform
@@ -17888,11 +17872,6 @@ entities:
     components:
     - type: Transform
       pos: -31.5,-10.5
-      parent: 60
-  - uid: 1958
-    components:
-    - type: Transform
-      pos: -18.5,-9.5
       parent: 60
   - uid: 1965
     components:
@@ -18292,7 +18271,7 @@ entities:
   - uid: 4516
     components:
     - type: Transform
-      pos: -20.5,-9.5
+      pos: -18.5,-6.5
       parent: 60
   - uid: 4528
     components:
@@ -19019,11 +18998,6 @@ entities:
     - type: Transform
       pos: -33.5,-19.5
       parent: 60
-  - uid: 6828
-    components:
-    - type: Transform
-      pos: -20.5,-5.5
-      parent: 60
   - uid: 6858
     components:
     - type: Transform
@@ -19324,11 +19298,6 @@ entities:
     - type: Transform
       pos: -18.5,-3.5
       parent: 60
-  - uid: 7790
-    components:
-    - type: Transform
-      pos: -21.5,-5.5
-      parent: 60
   - uid: 7793
     components:
     - type: Transform
@@ -19338,11 +19307,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,-10.5
-      parent: 60
-  - uid: 7917
-    components:
-    - type: Transform
-      pos: -19.5,-5.5
       parent: 60
   - uid: 8190
     components:
@@ -19458,11 +19422,6 @@ entities:
     components:
     - type: Transform
       pos: -35.5,-7.5
-      parent: 60
-  - uid: 8341
-    components:
-    - type: Transform
-      pos: -33.5,-9.5
       parent: 60
   - uid: 8347
     components:
@@ -22504,16 +22463,6 @@ entities:
     - type: Transform
       pos: 8.5,-24.5
       parent: 60
-  - uid: 10657
-    components:
-    - type: Transform
-      pos: -33.5,-24.5
-      parent: 60
-  - uid: 10658
-    components:
-    - type: Transform
-      pos: -37.5,-24.5
-      parent: 60
   - uid: 10673
     components:
     - type: Transform
@@ -25393,11 +25342,6 @@ entities:
     components:
     - type: Transform
       pos: -32.5,0.5
-      parent: 60
-  - uid: 13158
-    components:
-    - type: Transform
-      pos: -34.5,-9.5
       parent: 60
   - uid: 13203
     components:
@@ -29313,11 +29257,6 @@ entities:
     components:
     - type: Transform
       pos: -44.5,15.5
-      parent: 60
-  - uid: 18104
-    components:
-    - type: Transform
-      pos: -32.5,-9.5
       parent: 60
   - uid: 18213
     components:
@@ -36835,11 +36774,6 @@ entities:
     - type: Transform
       pos: -5.5,-49.5
       parent: 60
-  - uid: 11510
-    components:
-    - type: Transform
-      pos: -17.5,-7.5
-      parent: 60
   - uid: 11515
     components:
     - type: Transform
@@ -40360,16 +40294,6 @@ entities:
     - type: Transform
       pos: -36.5,5.5
       parent: 60
-  - uid: 17959
-    components:
-    - type: Transform
-      pos: -35.5,-6.5
-      parent: 60
-  - uid: 17962
-    components:
-    - type: Transform
-      pos: -35.5,-11.5
-      parent: 60
   - uid: 17963
     components:
     - type: Transform
@@ -40425,11 +40349,6 @@ entities:
     - type: Transform
       pos: 11.5,-3.5
       parent: 60
-  - uid: 17987
-    components:
-    - type: Transform
-      pos: -35.5,-7.5
-      parent: 60
   - uid: 18001
     components:
     - type: Transform
@@ -40444,16 +40363,6 @@ entities:
     components:
     - type: Transform
       pos: -16.5,2.5
-      parent: 60
-  - uid: 18092
-    components:
-    - type: Transform
-      pos: -35.5,-9.5
-      parent: 60
-  - uid: 18103
-    components:
-    - type: Transform
-      pos: -17.5,-11.5
       parent: 60
   - uid: 18108
     components:
@@ -40775,11 +40684,6 @@ entities:
     - type: Transform
       pos: -0.5,-8.5
       parent: 60
-  - uid: 18463
-    components:
-    - type: Transform
-      pos: -35.5,-5.5
-      parent: 60
   - uid: 18509
     components:
     - type: Transform
@@ -40789,11 +40693,6 @@ entities:
     components:
     - type: Transform
       pos: -16.5,-1.5
-      parent: 60
-  - uid: 18592
-    components:
-    - type: Transform
-      pos: -35.5,-10.5
       parent: 60
   - uid: 18594
     components:
@@ -40810,20 +40709,10 @@ entities:
     - type: Transform
       pos: -16.5,-0.5
       parent: 60
-  - uid: 18597
-    components:
-    - type: Transform
-      pos: -17.5,-9.5
-      parent: 60
   - uid: 18598
     components:
     - type: Transform
       pos: -16.5,-2.5
-      parent: 60
-  - uid: 18599
-    components:
-    - type: Transform
-      pos: -17.5,-10.5
       parent: 60
   - uid: 18600
     components:
@@ -42570,11 +42459,6 @@ entities:
     - type: Transform
       pos: -16.5,-22.5
       parent: 60
-  - uid: 21765
-    components:
-    - type: Transform
-      pos: -17.5,-6.5
-      parent: 60
   - uid: 22475
     components:
     - type: Transform
@@ -42634,11 +42518,6 @@ entities:
     components:
     - type: Transform
       pos: -17.5,3.5
-      parent: 60
-  - uid: 23830
-    components:
-    - type: Transform
-      pos: -17.5,-5.5
       parent: 60
   - uid: 24416
     components:
@@ -46503,11 +46382,6 @@ entities:
     components:
     - type: Transform
       pos: -3.5,37.5
-      parent: 60
-  - uid: 14055
-    components:
-    - type: Transform
-      pos: -19.5,-0.5
       parent: 60
   - uid: 14091
     components:
@@ -57390,31 +57264,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 12.52908,-13.379191
       parent: 60
-- proto: ChairFoldingSpawnFolded
-  entities:
-  - uid: 1762
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -33.5,-11.5
-      parent: 60
-  - uid: 1764
-    components:
-    - type: Transform
-      pos: -19.5,-11.5
-      parent: 60
-  - uid: 1909
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -33.5,-7.5
-      parent: 60
-  - uid: 8232
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,-7.5
-      parent: 60
 - proto: ChairOfficeDark
   entities:
   - uid: 238
@@ -57429,10 +57278,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 7.5,-27.5
       parent: 60
-  - uid: 1573
+  - uid: 1625
     components:
     - type: Transform
-      pos: -26.5,-9.5
+      rot: 3.141592653589793 rad
+      pos: -26.468517,-9.490956
       parent: 60
   - uid: 2094
     components:
@@ -58171,7 +58021,7 @@ entities:
   - uid: 16150
     components:
     - type: Transform
-      pos: -19.84328,-13.204234
+      pos: -19.803661,-13.215049
       parent: 60
 - proto: ChemDispenser
   entities:
@@ -59955,13 +59805,6 @@ entities:
     - type: Transform
       pos: -12.506187,-1.5083885
       parent: 7536
-- proto: ClothingBeltSecurityFilled
-  entities:
-  - uid: 6546
-    components:
-    - type: Transform
-      pos: -30.497168,-20.40541
-      parent: 60
 - proto: ClothingBeltUtilityEngineering
   entities:
   - uid: 14118
@@ -60229,6 +60072,13 @@ entities:
     components:
     - type: Transform
       pos: -38.320274,19.65635
+      parent: 60
+- proto: ClothingHeadHatBeretWarden
+  entities:
+  - uid: 1833
+    components:
+    - type: Transform
+      pos: -25.777082,-12.42127
       parent: 60
 - proto: ClothingHeadHatBowlerHat
   entities:
@@ -60514,20 +60364,20 @@ entities:
       parent: 60
 - proto: ClothingHeadHelmetRiot
   entities:
-  - uid: 6308
+  - uid: 1639
     components:
     - type: Transform
-      pos: -24.634363,-12.292603
+      pos: -28.392082,1.5054817
       parent: 60
-  - uid: 6707
+  - uid: 1640
     components:
     - type: Transform
-      pos: -24.634363,-12.292603
+      pos: -28.392082,1.3648567
       parent: 60
-  - uid: 7747
+  - uid: 1909
     components:
     - type: Transform
-      pos: -24.634363,-12.292603
+      pos: -28.423332,1.6929817
       parent: 60
 - proto: ClothingHeadHelmetTemplar
   entities:
@@ -60845,39 +60695,51 @@ entities:
     - type: Transform
       pos: -12.119702,-50.42532
       parent: 60
+- proto: ClothingOuterArmorBulletproof
+  entities:
+  - uid: 1656
+    components:
+    - type: Transform
+      pos: -28.173332,1.6929817
+      parent: 60
+  - uid: 1699
+    components:
+    - type: Transform
+      pos: -28.142082,1.5211067
+      parent: 60
+  - uid: 1717
+    components:
+    - type: Transform
+      pos: -28.126457,1.3804817
+      parent: 60
 - proto: ClothingOuterArmorReflective
   entities:
-  - uid: 5010
+  - uid: 1653
     components:
     - type: Transform
-      pos: -24.587488,-12.605103
+      pos: -28.532707,1.5992317
       parent: 60
-  - uid: 5909
+  - uid: 7649
     components:
     - type: Transform
-      pos: -24.587488,-12.605103
+      pos: -28.552244,1.4924954
+      parent: 60
+- proto: ClothingOuterArmorRiot
+  entities:
+  - uid: 2100
+    components:
+    - type: Transform
+      pos: -28.610832,1.5836067
+      parent: 60
+  - uid: 2806
+    components:
+    - type: Transform
+      pos: -28.626457,1.3492317
       parent: 60
   - uid: 7785
     components:
     - type: Transform
-      pos: -24.587488,-12.605103
-      parent: 60
-- proto: ClothingOuterArmorRiot
-  entities:
-  - uid: 5201
-    components:
-    - type: Transform
-      pos: -24.384363,-12.511353
-      parent: 60
-  - uid: 5849
-    components:
-    - type: Transform
-      pos: -24.384363,-12.511353
-      parent: 60
-  - uid: 21723
-    components:
-    - type: Transform
-      pos: -24.384363,-12.511353
+      pos: -28.626457,1.4586067
       parent: 60
 - proto: ClothingOuterCardborg
   entities:
@@ -60932,23 +60794,6 @@ entities:
     components:
     - type: Transform
       pos: -47.44876,21.462833
-      parent: 60
-- proto: ClothingOuterHardsuitSecurity
-  entities:
-  - uid: 1862
-    components:
-    - type: Transform
-      pos: -28.693623,1.6351235
-      parent: 60
-  - uid: 5313
-    components:
-    - type: Transform
-      pos: -28.552998,1.5257485
-      parent: 60
-  - uid: 6367
-    components:
-    - type: Transform
-      pos: -28.381123,1.4163735
       parent: 60
 - proto: ClothingOuterHoodieBlack
   entities:
@@ -61708,6 +61553,16 @@ entities:
       parent: 60
 - proto: ComputerCrewMonitoring
   entities:
+  - uid: 1764
+    components:
+    - type: Transform
+      pos: -25.5,-8.5
+      parent: 60
+  - uid: 1821
+    components:
+    - type: Transform
+      pos: -29.5,-18.5
+      parent: 60
   - uid: 2144
     components:
     - type: Transform
@@ -61739,15 +61594,10 @@ entities:
       parent: 60
 - proto: ComputerCriminalRecords
   entities:
-  - uid: 617
+  - uid: 1762
     components:
     - type: Transform
-      pos: -30.5,-18.5
-      parent: 60
-  - uid: 667
-    components:
-    - type: Transform
-      pos: -22.5,-18.5
+      pos: -23.5,-18.5
       parent: 60
   - uid: 2024
     components:
@@ -61759,6 +61609,12 @@ entities:
     components:
     - type: Transform
       pos: -27.5,-8.5
+      parent: 60
+  - uid: 6779
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-6.5
       parent: 60
   - uid: 8213
     components:
@@ -61954,11 +61810,6 @@ entities:
       parent: 60
 - proto: ComputerStationRecords
   entities:
-  - uid: 584
-    components:
-    - type: Transform
-      pos: -23.5,-18.5
-      parent: 60
   - uid: 10938
     components:
     - type: Transform
@@ -61977,11 +61828,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 32.5,-12.5
       parent: 60
-  - uid: 15898
-    components:
-    - type: Transform
-      pos: -25.5,-8.5
-      parent: 60
   - uid: 19686
     components:
     - type: Transform
@@ -61990,15 +61836,20 @@ entities:
       parent: 60
 - proto: ComputerSurveillanceCameraMonitor
   entities:
-  - uid: 564
+  - uid: 1635
     components:
     - type: Transform
-      pos: -29.5,-18.5
+      pos: -22.5,-18.5
       parent: 60
   - uid: 1658
     components:
     - type: Transform
       pos: -26.5,-8.5
+      parent: 60
+  - uid: 1749
+    components:
+    - type: Transform
+      pos: -30.5,-18.5
       parent: 60
   - uid: 2068
     components:
@@ -62037,10 +61888,30 @@ entities:
     - type: Transform
       pos: -25.5,-26.5
       parent: 60
+  - uid: 6828
+    components:
+    - type: Transform
+      pos: -34.5,-5.5
+      parent: 60
   - uid: 6853
     components:
     - type: Transform
       pos: -47.5,24.5
+      parent: 60
+  - uid: 7014
+    components:
+    - type: Transform
+      pos: -18.5,-9.5
+      parent: 60
+  - uid: 7045
+    components:
+    - type: Transform
+      pos: -34.5,-9.5
+      parent: 60
+  - uid: 7048
+    components:
+    - type: Transform
+      pos: -18.5,-5.5
       parent: 60
 - proto: ContainmentFieldGenerator
   entities:
@@ -63175,11 +63046,6 @@ entities:
       available: False
 - proto: Crowbar
   entities:
-  - uid: 1977
-    components:
-    - type: Transform
-      pos: -27.476547,-12.57161
-      parent: 60
   - uid: 23156
     components:
     - type: Transform
@@ -63437,10 +63303,10 @@ entities:
       parent: 60
 - proto: DefaultStationBeaconArmory
   entities:
-  - uid: 8462
+  - uid: 1485
     components:
     - type: Transform
-      pos: -26.5,-1.5
+      pos: -26.5,-0.5
       parent: 60
 - proto: DefaultStationBeaconArrivals
   entities:
@@ -63795,10 +63661,10 @@ entities:
       parent: 60
 - proto: DefaultStationBeaconWardensOffice
   entities:
-  - uid: 8458
+  - uid: 5424
     components:
     - type: Transform
-      pos: -27.5,-11.5
+      pos: -26.5,-11.5
       parent: 60
 - proto: DefibrillatorCabinetFilled
   entities:
@@ -63852,6 +63718,34 @@ entities:
       parent: 60
 - proto: DeskBell
   entities:
+  - uid: 4201
+    components:
+    - type: Transform
+      pos: -29.635107,-10.20195
+      parent: 60
+    missingComponents:
+    - Item
+  - uid: 5909
+    components:
+    - type: Transform
+      pos: -31.626514,-18.84643
+      parent: 60
+    missingComponents:
+    - Item
+  - uid: 7650
+    components:
+    - type: Transform
+      pos: -21.391321,-18.825403
+      parent: 60
+    missingComponents:
+    - Item
+  - uid: 7747
+    components:
+    - type: Transform
+      pos: -23.369482,-10.159093
+      parent: 60
+    missingComponents:
+    - Item
   - uid: 8279
     components:
     - type: Transform
@@ -68677,6 +68571,11 @@ entities:
       parent: 60
 - proto: DogBed
   entities:
+  - uid: 1822
+    components:
+    - type: Transform
+      pos: -25.5,-12.5
+      parent: 60
   - uid: 2036
     components:
     - type: MetaData
@@ -68698,11 +68597,6 @@ entities:
     components:
     - type: Transform
       pos: 6.5,-29.5
-      parent: 60
-  - uid: 7920
-    components:
-    - type: Transform
-      pos: -25.5,-11.5
       parent: 60
   - uid: 11557
     components:
@@ -68869,6 +68763,13 @@ entities:
     - type: Transform
       pos: -40.5,9.5
       parent: 60
+- proto: DresserWardenFilled
+  entities:
+  - uid: 1903
+    components:
+    - type: Transform
+      pos: -28.5,-12.5
+      parent: 60
 - proto: DrinkDoctorsDelightGlass
   entities:
   - uid: 16136
@@ -68942,10 +68843,10 @@ entities:
       parent: 60
 - proto: DrinkMugMetal
   entities:
-  - uid: 1915
+  - uid: 291
     components:
     - type: Transform
-      pos: -26.325293,-20.46791
+      pos: -26.316717,-20.291592
       parent: 60
   - uid: 16127
     components:
@@ -68968,10 +68869,10 @@ entities:
       parent: 60
 - proto: DrinkMugRed
   entities:
-  - uid: 9546
+  - uid: 1652
     components:
     - type: Transform
-      pos: -26.590918,-20.34291
+      pos: -26.676092,-20.479092
       parent: 60
 - proto: DrinkSakeBottleFull
   entities:
@@ -69387,13 +69288,6 @@ entities:
     components:
     - type: Transform
       pos: 51.5,25.5
-      parent: 60
-- proto: EmergencyMedipen
-  entities:
-  - uid: 17955
-    components:
-    - type: Transform
-      pos: -18.983906,-13.563609
       parent: 60
 - proto: EmergencyOxygenTankFilled
   entities:
@@ -69967,7 +69861,7 @@ entities:
       - 1975
       - 2002
       - 1993
-      - 182
+      - 1856
       - 180
       - 210
       - 1972
@@ -69982,7 +69876,7 @@ entities:
     - type: DeviceList
       devices:
       - 180
-      - 182
+      - 1856
       - 1969
       - 1985
   - uid: 1962
@@ -71410,15 +71304,6 @@ entities:
       deviceLists:
       - 230
       - 177
-  - uid: 182
-    components:
-    - type: Transform
-      pos: -31.5,-12.5
-      parent: 60
-    - type: DeviceNetwork
-      deviceLists:
-      - 230
-      - 177
   - uid: 210
     components:
     - type: Transform
@@ -71517,6 +71402,17 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 21558
+  - uid: 1856
+    components:
+    - type: Transform
+      pos: -31.5,-12.5
+      parent: 60
+    - type: DeviceNetwork
+      deviceLists:
+      - 177
+      - 178
+      - 231
+      - 230
   - uid: 1972
     components:
     - type: Transform
@@ -72499,13 +72395,6 @@ entities:
     components:
     - type: Transform
       pos: -70.59139,20.353971
-      parent: 60
-- proto: FlashlightSeclite
-  entities:
-  - uid: 323
-    components:
-    - type: Transform
-      pos: -21.5,-20.5
       parent: 60
 - proto: FlippoLighter
   entities:
@@ -109235,39 +109124,154 @@ entities:
       parent: 60
 - proto: GunSafeDisabler
   entities:
-  - uid: 1558
+  - uid: 2584
     components:
     - type: Transform
-      pos: -28.5,-12.5
+      pos: -24.5,-20.5
       parent: 60
 - proto: GunSafeLaserCarbine
   entities:
   - uid: 1861
     components:
+    - type: MetaData
+      desc: A standard-issue Nanotrasen storage unit, containing 4 laser carbines.
     - type: Transform
+      anchored: True
       pos: -24.5,-0.5
       parent: 60
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1907
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: GunSafePistolMk58
+  entities:
+  - uid: 2602
+    components:
+    - type: MetaData
+      desc: A standard-issue Nanotrasen storage unit, containing 4 Mk58 pistols.
+    - type: Transform
+      anchored: True
+      pos: -24.5,0.5
+      parent: 60
+    - type: Physics
+      bodyType: Static
 - proto: GunSafeRifleLecter
   entities:
-  - uid: 10682
+  - uid: 1910
     components:
+    - type: MetaData
+      desc: A standard-issue Nanotrasen storage unit, containing 2 Lecter combat rifles.
     - type: Transform
-      pos: -28.5,0.5
-      parent: 60
-- proto: GunSafeShotgunKammerer
-  entities:
-  - uid: 1749
-    components:
-    - type: Transform
-      pos: -28.5,-0.5
-      parent: 60
-- proto: GunSafeSubMachineGunDrozd
-  entities:
-  - uid: 7649
-    components:
-    - type: Transform
+      anchored: True
       pos: -28.5,-1.5
       parent: 60
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1465
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: GunSafeShotgunKammerer
+  entities:
+  - uid: 1638
+    components:
+    - type: MetaData
+      desc: A standard-issue Nanotrasen storage unit, containing 2 Kammerer shotguns.
+    - type: Transform
+      anchored: True
+      pos: -28.5,0.5
+      parent: 60
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1465
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: GunSafeSubMachineGunDrozd
+  entities:
+  - uid: 1908
+    components:
+    - type: MetaData
+      desc: A standard-issue Nanotrasen storage unit, containing 2 Drozd submachine guns.
+    - type: Transform
+      anchored: True
+      pos: -28.5,-0.5
+      parent: 60
+    - type: Physics
+      bodyType: Static
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1465
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
 - proto: HandheldGPSBasic
   entities:
   - uid: 3712
@@ -110360,6 +110364,22 @@ entities:
     - type: Transform
       pos: 5.43841,-38.31682
       parent: 60
+- proto: JetpackSecurityFilled
+  entities:
+  - uid: 5428
+    components:
+    - type: Transform
+      parent: 1740
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 5430
+    components:
+    - type: Transform
+      parent: 1904
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: KitchenElectricGrill
   entities:
   - uid: 2227
@@ -110997,24 +111017,50 @@ entities:
   entities:
   - uid: 1534
     components:
+    - type: MetaData
+      name: evidence locker (Cell 4)
     - type: Transform
       pos: -23.5,-8.5
       parent: 60
-  - uid: 1564
+    - type: Label
+      currentLabel: Cell 4
+    - type: NameModifier
+      baseName: evidence locker
+  - uid: 1913
     components:
-    - type: Transform
-      pos: -23.5,-7.5
-      parent: 60
-  - uid: 1568
-    components:
+    - type: MetaData
+      name: evidence locker (Cell 2)
     - type: Transform
       pos: -29.5,-8.5
       parent: 60
-  - uid: 1569
+    - type: Label
+      currentLabel: Cell 2
+    - type: NameModifier
+      baseName: evidence locker
+  - uid: 1915
     components:
+    - type: MetaData
+      name: evidence locker (Cell 3)
+    - type: Transform
+      pos: -23.5,-7.5
+      parent: 60
+    - type: Lock
+      locked: False
+    - type: Label
+      currentLabel: Cell 3
+    - type: NameModifier
+      baseName: evidence locker
+  - uid: 1916
+    components:
+    - type: MetaData
+      name: evidence locker (Cell 1)
     - type: Transform
       pos: -29.5,-7.5
       parent: 60
+    - type: Label
+      currentLabel: Cell 1
+    - type: NameModifier
+      baseName: evidence locker
   - uid: 13610
     components:
     - type: Transform
@@ -111148,8 +111194,11 @@ entities:
   - uid: 5456
     components:
     - type: Transform
+      anchored: True
       pos: -20.5,1.5
       parent: 60
+    - type: Physics
+      bodyType: Static
 - proto: LockerMedicalFilled
   entities:
   - uid: 2900
@@ -111354,9 +111403,9 @@ entities:
     - type: Transform
       pos: 29.5,-18.5
       parent: 60
-- proto: LockerWardenFilledHardsuit
+- proto: LockerWardenFilled
   entities:
-  - uid: 1560
+  - uid: 1917
     components:
     - type: Transform
       pos: -28.5,-11.5
@@ -111850,6 +111899,11 @@ entities:
       parent: 60
 - proto: MedkitBruteFilled
   entities:
+  - uid: 8682
+    components:
+    - type: Transform
+      pos: -20.288036,-13.496299
+      parent: 60
   - uid: 21581
     components:
     - type: Transform
@@ -112827,70 +112881,30 @@ entities:
       parent: 60
 - proto: Paper
   entities:
-  - uid: 307
-    components:
-    - type: Transform
-      pos: -34.514378,-11.291034
-      parent: 60
   - uid: 934
     components:
     - type: Transform
       pos: -10.55104,-28.480585
       parent: 60
-  - uid: 1908
+  - uid: 1573
     components:
     - type: Transform
-      pos: -34.514378,-11.291034
+      pos: -32.425873,-7.253234
       parent: 60
-  - uid: 1913
+  - uid: 1624
     components:
     - type: Transform
-      pos: -34.514378,-11.291034
+      pos: -20.394625,-11.268859
       parent: 60
-  - uid: 2098
+  - uid: 1977
     components:
     - type: Transform
-      pos: -34.514378,-7.2774615
+      pos: -32.363373,-11.253234
       parent: 60
-  - uid: 5368
+  - uid: 6709
     components:
     - type: Transform
-      pos: -18.493418,-11.280288
-      parent: 60
-  - uid: 5424
-    components:
-    - type: Transform
-      pos: -18.493418,-11.280288
-      parent: 60
-  - uid: 6648
-    components:
-    - type: Transform
-      pos: -18.483002,-7.265358
-      parent: 60
-  - uid: 6683
-    components:
-    - type: Transform
-      pos: -34.514378,-7.2774615
-      parent: 60
-  - uid: 6819
-    components:
-    - type: Transform
-      pos: -18.493418,-11.280288
-      parent: 60
-  - uid: 7166
-    components:
-    - type: Transform
-      pos: -18.483002,-7.265358
-      parent: 60
-  - uid: 8264
-    components:
-    - type: Transform
-      pos: -34.514378,-7.2774615
-      parent: 60
-  - uid: 8278
-    components:
-    - type: Transform
-      pos: -18.483002,-7.265358
+      pos: -20.379,-7.300109
       parent: 60
   - uid: 8760
     components:
@@ -113362,30 +113376,30 @@ entities:
     - type: Transform
       pos: -10.316665,-28.324335
       parent: 60
-  - uid: 1856
+  - uid: 1580
     components:
     - type: Transform
-      pos: -34.5,-7.5
+      pos: -32.629,-7.331359
       parent: 60
-  - uid: 1903
+  - uid: 1935
     components:
     - type: Transform
-      pos: -34.5,-11.5
+      pos: -20.66025,-11.346984
+      parent: 60
+  - uid: 1980
+    components:
+    - type: Transform
+      pos: -32.66025,-11.346984
       parent: 60
   - uid: 4668
     components:
     - type: Transform
       pos: 6.7427726,-42.739647
       parent: 60
-  - uid: 5428
+  - uid: 6707
     components:
     - type: Transform
-      pos: -18.5,-11.5
-      parent: 60
-  - uid: 6041
-    components:
-    - type: Transform
-      pos: -18.5,-7.5
+      pos: -20.66025,-7.346984
       parent: 60
   - uid: 9088
     components:
@@ -113421,11 +113435,6 @@ entities:
     components:
     - type: Transform
       pos: -32.5,-0.5
-      parent: 60
-  - uid: 18462
-    components:
-    - type: Transform
-      pos: -31.435102,-20.467825
       parent: 60
   - uid: 23152
     components:
@@ -113795,13 +113804,6 @@ entities:
     components:
     - type: Transform
       pos: 68.494286,-27.490837
-      parent: 60
-- proto: PortableFlasher
-  entities:
-  - uid: 10680
-    components:
-    - type: Transform
-      pos: -26.5,-0.5
       parent: 60
 - proto: PortableGeneratorJrPacman
   entities:
@@ -115394,11 +115396,6 @@ entities:
       parent: 60
     - type: Physics
       canCollide: False
-  - uid: 21154
-    components:
-    - type: Transform
-      pos: -18.5,-13.5
-      parent: 60
   - uid: 23114
     components:
     - type: Transform
@@ -118512,11 +118509,6 @@ entities:
     - type: Transform
       pos: -31.5,-30.5
       parent: 60
-  - uid: 1907
-    components:
-    - type: Transform
-      pos: -22.5,-20.5
-      parent: 60
   - uid: 2174
     components:
     - type: Transform
@@ -118622,11 +118614,6 @@ entities:
     - type: Transform
       pos: -55.5,-16.5
       parent: 60
-  - uid: 5430
-    components:
-    - type: Transform
-      pos: -24.5,-20.5
-      parent: 60
   - uid: 5777
     components:
     - type: Transform
@@ -118636,11 +118623,6 @@ entities:
     components:
     - type: Transform
       pos: -67.5,11.5
-      parent: 60
-  - uid: 6206
-    components:
-    - type: Transform
-      pos: -24.5,0.5
       parent: 60
   - uid: 6240
     components:
@@ -118686,11 +118668,6 @@ entities:
     components:
     - type: Transform
       pos: 13.5,-15.5
-      parent: 60
-  - uid: 7650
-    components:
-    - type: Transform
-      pos: -24.5,-12.5
       parent: 60
   - uid: 7703
     components:
@@ -118876,11 +118853,6 @@ entities:
     components:
     - type: Transform
       pos: 28.5,-7.5
-      parent: 60
-  - uid: 21162
-    components:
-    - type: Transform
-      pos: -27.5,-12.5
       parent: 60
   - uid: 21610
     components:
@@ -125327,7 +125299,7 @@ entities:
   - uid: 6149
     components:
     - type: Transform
-      pos: -24.474873,0.5569985
+      pos: -23.494482,-10.474598
       parent: 60
   - uid: 6590
     components:
@@ -125464,16 +125436,88 @@ entities:
       parent: 60
 - proto: ShuttersNormalOpen
   entities:
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-10.5
+      parent: 60
   - uid: 147
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-32.5
       parent: 60
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-11.5
+      parent: 60
+  - uid: 233
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-9.5
+      parent: 60
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-5.5
+      parent: 60
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-7.5
+      parent: 60
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,-6.5
+      parent: 60
   - uid: 1454
     components:
     - type: Transform
       pos: 41.5,-25.5
+      parent: 60
+  - uid: 1558
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -35.5,-7.5
+      parent: 60
+  - uid: 1560
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -35.5,-9.5
+      parent: 60
+  - uid: 1561
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -35.5,-10.5
+      parent: 60
+  - uid: 1564
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -35.5,-11.5
+      parent: 60
+  - uid: 1568
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -35.5,-6.5
+      parent: 60
+  - uid: 1569
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -35.5,-5.5
       parent: 60
   - uid: 1631
     components:
@@ -125992,6 +126036,20 @@ entities:
       parent: 60
 - proto: SignalButton
   entities:
+  - uid: 1655
+    components:
+    - type: MetaData
+      name: Inner Doors Button
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,-20.5
+      parent: 60
+    - type: DeviceLinkSource
+      linkedPorts:
+        243:
+        - Pressed: Open
+        245:
+        - Pressed: Open
   - uid: 2770
     components:
     - type: Transform
@@ -126016,6 +126074,18 @@ entities:
       linkedPorts:
         7729:
         - Pressed: Toggle
+  - uid: 5010
+    components:
+    - type: MetaData
+      name: Inner Doors Button
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,-20.5
+      parent: 60
+    - type: DeviceLinkSource
+      linkedPorts:
+        1919:
+        - Pressed: Open
   - uid: 5346
     components:
     - type: Transform
@@ -126498,145 +126568,88 @@ entities:
         - Pressed: Toggle
 - proto: SignalSwitchDirectional
   entities:
-  - uid: 1580
+  - uid: 617
     components:
     - type: MetaData
-      name: Cell 2 Blast Door Switch
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -27.502918,-9.625589
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        1638:
-        - On: Open
-        - Off: Close
-        1639:
-        - Off: Close
-        - On: Open
-        1640:
-        - On: Open
-        - Off: Close
-  - uid: 1583
-    components:
-    - type: MetaData
-      name: Cell 4 Blast Door Switch
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -25.502918,-9.625589
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        1293:
-        - On: Open
-        - Off: Close
-        1238:
-        - Off: Close
-        - On: Open
-        1257:
-        - On: Open
-        - Off: Close
-  - uid: 1624
-    components:
-    - type: MetaData
-      name: Cell 3 Blast Door Switch
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -25.502918,-9.222812
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        1354:
-        - On: Open
-        - Off: Close
-        1384:
-        - On: Open
-        - Off: Close
-        1652:
-        - On: Open
-        - Off: Close
-  - uid: 1699
-    components:
-    - type: MetaData
-      name: Cell 1 Blast Door Switch
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -27.502918,-9.222812
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        1653:
-        - On: Open
-        - Off: Close
-        1655:
-        - On: Open
-        - Off: Close
-        1656:
-        - On: Open
-        - Off: Close
-  - uid: 2103
-    components:
-    - type: MetaData
-      name: Interior Door Open/Close
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -31.496037,-18.715696
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        1919:
-        - On: Open
-        - Off: Close
-  - uid: 4506
-    components:
-    - type: MetaData
-      name: Inner Windoor Switch
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -32.5,-6.5
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        5825:
-        - On: Open
-        - Off: Close
-  - uid: 5758
-    components:
-    - type: MetaData
-      name: Inner Windoor Switch
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,-10.5
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        1530:
-        - On: Open
-        - Off: Close
-  - uid: 5835
-    components:
-    - type: MetaData
-      name: Inner Windoor Switch
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,-6.5
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        4201:
-        - On: Open
-        - Off: Close
-  - uid: 6307
-    components:
-    - type: MetaData
-      name: Inner Windoor Switch
+      name: Cell Shutters Switch
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,-10.5
       parent: 60
+    - type: SignalSwitch
+      state: True
     - type: DeviceLinkSource
       linkedPorts:
-        1485:
+        1564:
+        - On: Open
+        - Off: Close
+        1561:
+        - On: Open
+        - Off: Close
+        1560:
+        - On: Open
+        - Off: Close
+  - uid: 667
+    components:
+    - type: MetaData
+      name: Cell Shutters Switch
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-6.5
+      parent: 60
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        242:
+        - On: Open
+        - Off: Close
+        246:
+        - On: Open
+        - Off: Close
+        234:
+        - On: Open
+        - Off: Close
+  - uid: 1257
+    components:
+    - type: MetaData
+      name: Cell Shutters Switch
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -32.5,-6.5
+      parent: 60
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        1569:
+        - On: Open
+        - Off: Close
+        1568:
+        - On: Open
+        - Off: Close
+        1558:
+        - On: Open
+        - Off: Close
+  - uid: 1293
+    components:
+    - type: MetaData
+      name: Cell Shutters Switch
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-10.5
+      parent: 60
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        233:
+        - On: Open
+        - Off: Close
+        132:
+        - On: Open
+        - Off: Close
+        182:
         - On: Open
         - Off: Close
   - uid: 7563
@@ -126670,6 +126683,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -20.5,-2.5
       parent: 60
+    - type: SignalSwitch
+      state: True
     - type: DeviceLinkSource
       linkedPorts:
         1681:
@@ -126679,19 +126694,6 @@ entities:
         - On: Open
         - Off: Close
         5432:
-        - On: Open
-        - Off: Close
-  - uid: 8349
-    components:
-    - type: MetaData
-      name: Exterior Door Open/Close
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -31.502981,-20.229586
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        8297:
         - On: Open
         - Off: Close
   - uid: 8433
@@ -126752,17 +126754,50 @@ entities:
   - uid: 8670
     components:
     - type: MetaData
-      name: Exterior Door Open/Close
+      name: Lockdown
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -21.498095,-20.215696
+      rot: 1.5707963267948966 rad
+      pos: -27.593151,-9.505666
       parent: 60
     - type: DeviceLinkSource
       linkedPorts:
+        1569:
+        - On: Open
+        - Off: Close
+        1568:
+        - Off: Close
+        - On: Open
+        1558:
+        - On: Open
+        - Off: Close
+        1560:
+        - On: Open
+        - Off: Close
+        1561:
+        - Off: Close
+        - On: Open
+        1564:
+        - On: Open
+        - Off: Close
+        234:
+        - On: Open
+        - Off: Close
+        246:
+        - On: Open
+        - Off: Close
         242:
         - On: Open
         - Off: Close
-        8454:
+        233:
+        - On: Open
+        - Off: Close
+        132:
+        - On: Open
+        - Off: Close
+        182:
+        - Off: Close
+        - On: Open
+        16425:
         - On: Open
         - Off: Close
   - uid: 8677
@@ -126776,22 +126811,6 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         8678:
-        - On: Open
-        - Off: Close
-  - uid: 8908
-    components:
-    - type: MetaData
-      name: Interior Door Open/Close
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -21.498095,-18.722641
-      parent: 60
-    - type: DeviceLinkSource
-      linkedPorts:
-        243:
-        - On: Open
-        - Off: Close
-        245:
         - On: Open
         - Off: Close
   - uid: 9309
@@ -131246,10 +131265,10 @@ entities:
       parent: 60
 - proto: SpawnMobMcGriff
   entities:
-  - uid: 2806
+  - uid: 1384
     components:
     - type: Transform
-      pos: -25.5,-11.5
+      pos: -25.5,-12.5
       parent: 60
 - proto: SpawnMobMonkeyPunpun
   entities:
@@ -131848,10 +131867,10 @@ entities:
       parent: 60
 - proto: SpawnPointWarden
   entities:
-  - uid: 1980
+  - uid: 5368
     components:
     - type: Transform
-      pos: -26.5,-11.5
+      pos: -26.5,-9.5
       parent: 60
 - proto: SpawnVendingMachineRestockFoodDrink
   entities:
@@ -132735,15 +132754,90 @@ entities:
     - type: Transform
       pos: -27.5,1.5
       parent: 60
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 5428
   - uid: 1904
     components:
     - type: Transform
       pos: -25.5,1.5
       parent: 60
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 5430
   - uid: 1906
     components:
     - type: Transform
       pos: -24.5,-1.5
+      parent: 60
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: SuitStorageWarden
+  entities:
+  - uid: 8458
+    components:
+    - type: Transform
+      pos: -24.5,-12.5
       parent: 60
 - proto: SurveillanceCameraCommand
   entities:
@@ -134558,6 +134652,17 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Lawyer Office
+  - uid: 5313
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,-18.5
+      parent: 60
+    - type: SurveillanceCamera
+      setupAvailableNetworks:
+      - SurveillanceCameraSecurity
+      nameSet: True
+      id: Security West Entrance
   - uid: 6705
     components:
     - type: Transform
@@ -134568,17 +134673,6 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Security East Entrance
-  - uid: 6779
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -31.5,-18.5
-      parent: 60
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraSecurity
-      nameSet: True
-      id: Security West Entrance
   - uid: 8428
     components:
     - type: Transform
@@ -134995,23 +135089,18 @@ entities:
       tags: []
 - proto: SyringeInaprovaline
   entities:
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -19.100536,-13.371299
+      parent: 60
   - uid: 14618
     components:
     - type: Transform
-      pos: -19.265156,-13.438609
+      pos: -19.288036,-13.324424
       parent: 60
 - proto: Table
   entities:
-  - uid: 10
-    components:
-    - type: Transform
-      pos: -32.5,-7.5
-      parent: 60
-  - uid: 20
-    components:
-    - type: Transform
-      pos: -31.5,-20.5
-      parent: 60
   - uid: 78
     components:
     - type: Transform
@@ -135026,16 +135115,6 @@ entities:
     components:
     - type: Transform
       pos: -12.5,-14.5
-      parent: 60
-  - uid: 233
-    components:
-    - type: Transform
-      pos: -21.5,-18.5
-      parent: 60
-  - uid: 246
-    components:
-    - type: Transform
-      pos: -20.5,-7.5
       parent: 60
   - uid: 328
     components:
@@ -135102,35 +135181,20 @@ entities:
     - type: Transform
       pos: -25.5,-6.5
       parent: 60
-  - uid: 1635
-    components:
-    - type: Transform
-      pos: -26.5,-20.5
-      parent: 60
   - uid: 1678
     components:
     - type: Transform
       pos: 9.5,-51.5
       parent: 60
-  - uid: 1822
+  - uid: 1840
     components:
     - type: Transform
-      pos: -32.5,-11.5
-      parent: 60
-  - uid: 1833
-    components:
-    - type: Transform
-      pos: -23.5,-10.5
+      pos: -26.5,-20.5
       parent: 60
   - uid: 1914
     components:
     - type: Transform
       pos: -28.5,-20.5
-      parent: 60
-  - uid: 1917
-    components:
-    - type: Transform
-      pos: -21.5,-20.5
       parent: 60
   - uid: 1920
     components:
@@ -135452,16 +135516,6 @@ entities:
     - type: Transform
       pos: -58.5,-17.5
       parent: 60
-  - uid: 8438
-    components:
-    - type: Transform
-      pos: -20.5,-11.5
-      parent: 60
-  - uid: 8466
-    components:
-    - type: Transform
-      pos: -30.5,-20.5
-      parent: 60
   - uid: 8607
     components:
     - type: Transform
@@ -135473,25 +135527,10 @@ entities:
     - type: Transform
       pos: -32.5,-0.5
       parent: 60
-  - uid: 8713
-    components:
-    - type: Transform
-      pos: -31.5,-19.5
-      parent: 60
-  - uid: 8720
-    components:
-    - type: Transform
-      pos: -21.5,-19.5
-      parent: 60
   - uid: 8756
     components:
     - type: Transform
       pos: -64.5,0.5
-      parent: 60
-  - uid: 8898
-    components:
-    - type: Transform
-      pos: -29.5,-10.5
       parent: 60
   - uid: 8909
     components:
@@ -135517,11 +135556,6 @@ entities:
     components:
     - type: Transform
       pos: -44.5,-10.5
-      parent: 60
-  - uid: 9159
-    components:
-    - type: Transform
-      pos: -31.5,-18.5
       parent: 60
   - uid: 9171
     components:
@@ -136300,38 +136334,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -19.5,21.5
       parent: 60
-- proto: TableFancyBlue
-  entities:
-  - uid: 5757
-    components:
-    - type: Transform
-      pos: -34.5,-11.5
-      parent: 60
 - proto: TableFancyGreen
   entities:
-  - uid: 1840
-    components:
-    - type: Transform
-      pos: -34.5,-7.5
-      parent: 60
   - uid: 14211
     components:
     - type: Transform
       pos: -12.5,21.5
-      parent: 60
-- proto: TableFancyOrange
-  entities:
-  - uid: 8682
-    components:
-    - type: Transform
-      pos: -18.5,-7.5
-      parent: 60
-- proto: TableFancyPurple
-  entities:
-  - uid: 2579
-    components:
-    - type: Transform
-      pos: -18.5,-11.5
       parent: 60
 - proto: TableGlass
   entities:
@@ -136526,6 +136534,12 @@ entities:
     - type: Transform
       pos: -25.5,-14.5
       parent: 60
+  - uid: 2098
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-20.5
+      parent: 60
   - uid: 2212
     components:
     - type: Transform
@@ -136596,6 +136610,11 @@ entities:
     - type: Transform
       pos: 32.5,-25.5
       parent: 60
+  - uid: 2579
+    components:
+    - type: Transform
+      pos: -22.5,-20.5
+      parent: 60
   - uid: 2878
     components:
     - type: Transform
@@ -136631,20 +136650,67 @@ entities:
     - type: Transform
       pos: -110.5,8.5
       parent: 60
+  - uid: 5758
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -32.5,-7.5
+      parent: 60
   - uid: 5821
     components:
     - type: Transform
       pos: 15.5,-33.5
+      parent: 60
+  - uid: 5835
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-20.5
+      parent: 60
+  - uid: 5849
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-7.5
       parent: 60
   - uid: 5983
     components:
     - type: Transform
       pos: -24.5,1.5
       parent: 60
+  - uid: 6041
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -32.5,-11.5
+      parent: 60
   - uid: 6158
     components:
     - type: Transform
       pos: -113.5,8.5
+      parent: 60
+  - uid: 6206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,-10.5
+      parent: 60
+  - uid: 6307
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-19.5
+      parent: 60
+  - uid: 6308
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-11.5
+      parent: 60
+  - uid: 6367
+    components:
+    - type: Transform
+      pos: -30.5,-20.5
       parent: 60
   - uid: 6544
     components:
@@ -136656,10 +136722,34 @@ entities:
     - type: Transform
       pos: 9.5,18.5
       parent: 60
+  - uid: 6546
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-19.5
+      parent: 60
   - uid: 6629
     components:
     - type: Transform
       pos: 9.5,17.5
+      parent: 60
+  - uid: 6648
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-18.5
+      parent: 60
+  - uid: 6683
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -29.5,-10.5
+      parent: 60
+  - uid: 6704
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-18.5
       parent: 60
   - uid: 6970
     components:
@@ -138465,11 +138555,6 @@ entities:
     - type: Transform
       pos: -4.5,-44.5
       parent: 60
-  - uid: 1552
-    components:
-    - type: Transform
-      pos: -24.5,-6.5
-      parent: 60
   - uid: 3408
     components:
     - type: Transform
@@ -138696,7 +138781,7 @@ entities:
   - uid: 11369
     components:
     - type: Transform
-      pos: -22.478699,3.461222
+      pos: -22.506462,3.5714545
       parent: 60
 - proto: VendingMachineRoboDrobe
   entities:
@@ -138847,12 +138932,6 @@ entities:
       parent: 60
 - proto: WallmountTelescreen
   entities:
-  - uid: 1910
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -21.5,-19.5
-      parent: 60
   - uid: 2611
     components:
     - type: Transform
@@ -138867,6 +138946,12 @@ entities:
     components:
     - type: Transform
       pos: -25.5,-28.5
+      parent: 60
+  - uid: 6819
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-20.5
       parent: 60
   - uid: 7582
     components:
@@ -153926,25 +154011,25 @@ entities:
         - 0
 - proto: WardrobePrisonFilled
   entities:
-  - uid: 291
+  - uid: 1583
     components:
     - type: Transform
-      pos: -34.5,-5.5
+      pos: -18.5,-11.5
       parent: 60
-  - uid: 8240
+  - uid: 1938
     components:
     - type: Transform
-      pos: -18.5,-9.5
+      pos: -34.5,-11.5
       parent: 60
-  - uid: 8473
+  - uid: 1958
     components:
     - type: Transform
-      pos: -34.5,-9.5
+      pos: -34.5,-7.5
       parent: 60
-  - uid: 8681
+  - uid: 1968
     components:
     - type: Transform
-      pos: -18.5,-5.5
+      pos: -18.5,-7.5
       parent: 60
 - proto: WardrobeSalvageFilled
   entities:
@@ -154197,6 +154282,12 @@ entities:
     - type: Transform
       pos: -27.5,-6.5
       parent: 60
+  - uid: 8466
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-18.5
+      parent: 60
   - uid: 8468
     components:
     - type: Transform
@@ -154219,28 +154310,15 @@ entities:
       parent: 60
     - type: Physics
       canCollide: False
-  - uid: 19155
-    components:
-    - type: Transform
-      pos: -21.5,-18.5
-      parent: 60
-- proto: WeaponDisabler
+- proto: WeaponLaserCarbine
   entities:
-  - uid: 7014
+  - uid: 1907
     components:
     - type: Transform
-      pos: -24.520348,-20.458258
-      parent: 60
-  - uid: 7045
-    components:
-    - type: Transform
-      pos: -24.442223,-20.567633
-      parent: 60
-  - uid: 7048
-    components:
-    - type: Transform
-      pos: -24.614098,-20.348883
-      parent: 60
+      parent: 1861
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: WeaponRifleAk
   entities:
   - uid: 6136
@@ -154424,12 +154502,156 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 42.5,-27.5
       parent: 60
+  - uid: 4506
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-19.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 3
+    - type: DeviceLinkSource
+      linkedPorts:
+        8454:
+        - DoorStatus: Close
+        1862:
+        - DoorStatus: Close
+        8462:
+        - DoorStatus: Close
+  - uid: 5201
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-18.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 5
+    - type: DeviceLinkSource
+      linkedPorts:
+        8473:
+        - DoorStatus: Close
+        5757:
+        - DoorStatus: Close
+        8297:
+        - DoorStatus: Close
+  - uid: 5825
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-20.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 3
+    - type: DeviceLinkSource
+      linkedPorts:
+        8454:
+        - DoorStatus: Close
+        1862:
+        - DoorStatus: Close
+        8462:
+        - DoorStatus: Close
   - uid: 6821
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 38.5,-25.5
       parent: 60
+  - uid: 7166
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-19.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 5
+    - type: DeviceLinkSource
+      linkedPorts:
+        8473:
+        - DoorStatus: Close
+        5757:
+        - DoorStatus: Close
+        8297:
+        - DoorStatus: Close
+  - uid: 8278
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -32.5,-11.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        7917:
+        - DoorStatus: Close
+  - uid: 8296
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-11.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        7920:
+        - DoorStatus: Close
+  - uid: 8341
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-18.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 3
+    - type: DeviceLinkSource
+      linkedPorts:
+        8454:
+        - DoorStatus: Close
+        1862:
+        - DoorStatus: Close
+        8462:
+        - DoorStatus: Close
+  - uid: 8349
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,-7.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        8264:
+        - DoorStatus: Close
+  - uid: 8438
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -32.5,-7.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        8232:
+        - DoorStatus: Close
+  - uid: 8681
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,-20.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 5
+    - type: DeviceLinkSource
+      linkedPorts:
+        8473:
+        - DoorStatus: Close
+        5757:
+        - DoorStatus: Close
+        8297:
+        - DoorStatus: Close
   - uid: 10854
     components:
     - type: Transform
@@ -154599,14 +154821,6 @@ entities:
       parent: 60
 - proto: WindoorSecureArmoryLocked
   entities:
-  - uid: 1625
-    components:
-    - type: MetaData
-      name: Riot Gear
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,-12.5
-      parent: 60
   - uid: 4898
     components:
     - type: Transform
@@ -154618,12 +154832,24 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -23.5,-10.5
       parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        8240:
+        - DoorStatus: Close
   - uid: 15897
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-10.5
       parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        7790:
+        - DoorStatus: Close
 - proto: WindoorSecureAtmosphericsLocked
   entities:
   - uid: 13959
@@ -154639,35 +154865,35 @@ entities:
       parent: 60
 - proto: WindoorSecureBrigLocked
   entities:
-  - uid: 234
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,-10.5
-      parent: 60
-  - uid: 2584
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,-7.5
-      parent: 60
-  - uid: 2602
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -32.5,-7.5
-      parent: 60
   - uid: 4198
     components:
     - type: Transform
       pos: -43.5,-18.5
       parent: 60
-  - uid: 6709
+  - uid: 7790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -20.5,-11.5
+      pos: -29.5,-10.5
       parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        15897:
+        - DoorStatus: Close
+  - uid: 8240
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -23.5,-10.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        8413:
+        - DoorStatus: Close
   - uid: 8514
     components:
     - type: Transform
@@ -154677,18 +154903,6 @@ entities:
     components:
     - type: Transform
       pos: -19.5,-13.5
-      parent: 60
-  - uid: 8920
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,-10.5
-      parent: 60
-  - uid: 9176
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -32.5,-11.5
       parent: 60
   - uid: 17466
     components:
@@ -154963,12 +155177,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -32.5,-5.5
       parent: 60
-  - uid: 1485
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -32.5,-11.5
-      parent: 60
   - uid: 1487
     components:
     - type: MetaData
@@ -154976,12 +155184,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-9.5
-      parent: 60
-  - uid: 1530
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-11.5
       parent: 60
   - uid: 1548
     components:
@@ -154999,36 +155201,152 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -32.5,-9.5
       parent: 60
-  - uid: 1821
+  - uid: 1862
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,-19.5
-      parent: 60
-  - uid: 2100
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -31.5,-19.5
       parent: 60
-  - uid: 4201
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-7.5
-      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 5
+    - type: DeviceLinkSource
+      linkedPorts:
+        5825:
+        - DoorStatus: Close
+        4506:
+        - DoorStatus: Close
+        8341:
+        - DoorStatus: Close
   - uid: 4298
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.5,-15.5
       parent: 60
-  - uid: 5825
+  - uid: 5757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
+      pos: -21.5,-19.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 3
+    - type: DeviceLinkSource
+      linkedPorts:
+        8681:
+        - DoorStatus: Close
+        7166:
+        - DoorStatus: Close
+        5201:
+        - DoorStatus: Close
+  - uid: 7917
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -32.5,-11.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        8278:
+        - DoorStatus: Close
+  - uid: 7920
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-11.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        8296:
+        - DoorStatus: Close
+  - uid: 8232
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -32.5,-7.5
       parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        8438:
+        - DoorStatus: Close
+  - uid: 8264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-7.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 8297
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-18.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 4
+    - type: DeviceLinkSource
+      linkedPorts:
+        8681:
+        - DoorStatus: Close
+        7166:
+        - DoorStatus: Close
+        5201:
+        - DoorStatus: Close
+  - uid: 8454
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -31.5,-18.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 3
+    - type: DeviceLinkSource
+      linkedPorts:
+        5825:
+        - DoorStatus: Close
+        4506:
+        - DoorStatus: Close
+        8341:
+        - DoorStatus: Close
+  - uid: 8462
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -31.5,-20.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 3
+    - type: DeviceLinkSource
+      linkedPorts:
+        5825:
+        - DoorStatus: Close
+        4506:
+        - DoorStatus: Close
+        8341:
+        - DoorStatus: Close
+  - uid: 8473
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-20.5
+      parent: 60
+    - type: DeviceLinkSink
+      invokeCounter: 3
+    - type: DeviceLinkSource
+      linkedPorts:
+        5201:
+        - DoorStatus: Close
+        7166:
+        - DoorStatus: Close
+        8681:
+        - DoorStatus: Close
   - uid: 12596
     components:
     - type: Transform
@@ -155542,12 +155860,6 @@ entities:
       parent: 60
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 132
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-18.5
-      parent: 60
   - uid: 493
     components:
     - type: Transform
@@ -155585,12 +155897,6 @@ entities:
     - type: Transform
       pos: 7.5,-24.5
       parent: 60
-  - uid: 1561
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,-12.5
-      parent: 60
   - uid: 1646
     components:
     - type: Transform
@@ -155608,12 +155914,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,1.5
-      parent: 60
-  - uid: 1916
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-20.5
       parent: 60
   - uid: 2417
     components:
@@ -156043,12 +156343,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -10.5,-10.5
       parent: 60
-  - uid: 8296
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-18.5
-      parent: 60
   - uid: 8385
     components:
     - type: Transform
@@ -156095,12 +156389,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 46.5,-16.5
-      parent: 60
-  - uid: 9089
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,-20.5
       parent: 60
   - uid: 10850
     components:
@@ -159458,11 +159746,6 @@ entities:
       parent: 60
 - proto: Wrench
   entities:
-  - uid: 1968
-    components:
-    - type: Transform
-      pos: -27.476547,-12.50911
-      parent: 60
   - uid: 9120
     components:
     - type: Transform

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -46,9 +46,9 @@
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
+            SecurityOfficer: [ 6, 6 ]
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 3, 3 ]
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Restocked Bagel's armory to fit the new standard, changed the max secoff count to 6, and made a few QOL changes in the security department.

## Why / Balance
These changes generally make the new security area a bit more polished.
New armory content: 2 Lecter, 2 Drozd, 2 Kammerer, 1 AKMS, 4 Laser, 3 Hardsuit, 3 Bulletproof, 3 Riot, 2 Reflective, 2 Jetpack.

## Media
![Bagel-0](https://github.com/user-attachments/assets/7a6783bd-9f8b-4105-b235-b39fbaebe14f)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->