### PR TITLE
Fixes debug assertion thrown when chopping logs

### DIFF
--- a/Content.Server/Botany/Systems/LogSystem.cs
+++ b/Content.Server/Botany/Systems/LogSystem.cs
@@ -45,5 +45,6 @@ public sealed class LogSystem : EntitySystem
         }
 
         QueueDel(uid);
+        args.Handled = true;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes the debug assertion crash when chopping logs with a sharp object

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/34789

## Technical details
<!-- Summary of code changes for easier review. -->
Same solution as this PR: https://github.com/space-wizards/space-station-14/pull/33205
Marking the event arg as handled prevents the debug assertion from being thrown

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/3f4b1824-67b7-4166-862e-7b673a4a09c6

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->