### PR TITLE
hide icons for invisible entities

### DIFF
--- a/Content.Client/StatusIcon/StatusIconSystem.cs
+++ b/Content.Client/StatusIcon/StatusIconSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Whitelist;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Configuration;
@@ -83,6 +84,9 @@ public sealed class StatusIconSystem : SharedStatusIconSystem
             return false;
 
         if (data.HideOnStealth && TryComp<StealthComponent>(ent, out var stealth) && stealth.Enabled)
+            return false;
+
+        if (TryComp<SpriteComponent>(ent, out var sprite) && !sprite.Visible)
             return false;
 
         if (data.ShowTo != null && !_entityWhitelist.IsValid(data.ShowTo, viewer))


### PR DESCRIPTION
## About the PR
huds no longer show if the target is invisible

## Why / Balance
fixes #34820

## Technical details
check if its sprite isnt visible

## Media
![12:12:28](https://github.com/user-attachments/assets/377147a4-5bc6-4519-9d1d-d9a419602aab)

tank is a chameleoned urist

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed huds showing for chameleon projector users.
