### PR TITLE
Remove RD's experimental hardsuit as a steal objective for syndies

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -448,8 +448,6 @@
     clothingPrototype: ClothingHeadHelmetHardsuitRd
   - type: StaticPrice
     price: 750
-  - type: StealTarget
-    stealGroup: ClothingOuterHardsuitRd
 
 #Head of Security's Hardsuit
 - type: entity

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -13,7 +13,6 @@
     CaptainIDStealObjective: 1
     CMOHyposprayStealObjective: 1
     CMOCrewMonitorStealObjective: 1
-    RDHardsuitStealObjective: 1
     NukeDiskStealObjective: 1
     MagbootsStealObjective: 1
     CorgiMeatStealObjective: 1

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -15,13 +15,6 @@
     state: scanner
 
 - type: stealTargetGroup
-  id: ClothingOuterHardsuitRd
-  name: steal-target-groups-clothing-outer-hardsuit-rd
-  sprite:
-    sprite: Clothing/OuterClothing/Hardsuits/rd.rsi
-    state: icon
-
-- type: stealTargetGroup
   id: HandTeleporter
   name: steal-target-groups-hand-teleporter
   sprite:

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -177,16 +177,6 @@
 
 - type: entity
   parent: BaseRDStealObjective
-  id: RDHardsuitStealObjective
-  components:
-  - type: StealCondition
-    stealGroup: ClothingOuterHardsuitRd
-  - type: Objective
-    # This item must be worn or stored in a slowing duffelbag, very hard to hide.
-    difficulty: 3
-
-- type: entity
-  parent: BaseRDStealObjective
   id: HandTeleporterStealObjective
   components:
   - type: StealCondition


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes syndie steal objective for the RD's experimental hardsuit.

## Why / Balance
Currently, having the RD's hardsuit as an objective makes it difficult (and most importantly, annoying) to accomplish any objectives, with you being required to either:
1. Carry the hardsuit with you in a duffelbag, which is obviously not ideal
2. Hide the hardsuit, which is both not very engaging gameplay and not an accessible or guaranteed-to-work strategy.
3. Skip the objective entirely

All 3 of the above aren't very fun for both the thief and everyone else. This leaves only one steal objective related to RD, which is the hand teleporter, which can be:
1. Much easier to be stolen than the hardsuit
2. Can actually be used in way more 'creative' ways than the hardsuit
3. Isn't usually left by the RD in their office, which makes it more engaging to steal (if you arent just using thief gloves that is)

TL;DR: RD's hardsuit isn't fun to steal, and the hand teleporter serves as a way better steal objective than the hardsuit.

## Technical details
N/A, only YAML changes

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- remove: The RD's experimental hardsuit is no longer a steal objective for syndies.
