### PR TITLE
Uplink items spawned no longer push player into walls

### DIFF
--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -199,7 +199,7 @@ public sealed partial class StoreSystem
 
                     if (_turf.IsTileBlocked(tile.Value, CollisionGroup.Impassable | CollisionGroup.Opaque))
                     {
-                        _popup.PopupCursor(Loc.GetString("store-ui-spawn-space-blocked"));
+                        _popup.PopupEntity(Loc.GetString("store-ui-spawn-space-blocked"), buyer, buyer);
                         return;
                     }
 

--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -5,15 +5,20 @@ using Content.Server.PDA.Ringer;
 using Content.Server.Stack;
 using Content.Server.Store.Components;
 using Content.Shared.Actions;
+using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Database;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Maps;
 using Content.Shared.Mind;
+using Content.Shared.Physics;
 using Content.Shared.Store;
 using Content.Shared.Store.Components;
 using Content.Shared.UserInterface;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
@@ -30,6 +35,8 @@ public sealed partial class StoreSystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly StackSystem _stack = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
+    [Dependency] private readonly TurfSystem _turf = default!;
+    [Dependency] private readonly IMapManager _mapMan = default!;
 
     private void InitializeUi()
     {
@@ -163,6 +170,46 @@ public sealed partial class StoreSystem
             }
         }
 
+        // For entities that may displace the user when spawned, such as crates
+        // We need an unblocked tile in front of the player to spawn it if it exists
+        EntityCoordinates? offsetSpawnCoords = null;
+        if (listing.ProductEntity != null)
+        {
+            var fixtureProduct = Spawn(listing.ProductEntity);
+            if (TryComp<FixturesComponent>(fixtureProduct, out var fixturesComponent))
+            {
+                foreach (var productFixtures in fixturesComponent.Fixtures)
+                {
+                    if (!productFixtures.Value.Hard)
+                        continue;
+
+                    if ((productFixtures.Value.CollisionLayer &
+                         (int)(CollisionGroup.Impassable | CollisionGroup.Opaque)) == 0)
+                        continue;
+
+                    // If the productEntity occupies the impassible or opaque layers,
+                    // check to see if the tile in the direction the buyer is facing isn't blocked
+                    var buyerXform = Transform(buyer);
+                    var offsetValue = buyerXform.LocalRotation.ToWorldVec();
+                    var coords = buyerXform.Coordinates.Offset(offsetValue).SnapToGrid(EntityManager, _mapMan);
+                    var tile = coords.GetTileRef(EntityManager, _mapMan);
+
+                    if (tile == null)
+                        break;
+
+                    if (_turf.IsTileBlocked(tile.Value, CollisionGroup.Impassable | CollisionGroup.Opaque))
+                    {
+                        _popup.PopupCursor(Loc.GetString("store-ui-spawn-space-blocked"));
+                        return;
+                    }
+
+                    offsetSpawnCoords = _turf.GetTileCenter(tile.Value);
+                    break;
+                }
+            }
+            QueueDel(fixtureProduct);
+        }
+
         if (!IsOnStartingMap(uid, component))
             component.RefundAllowed = false;
 
@@ -179,8 +226,17 @@ public sealed partial class StoreSystem
         //spawn entity
         if (listing.ProductEntity != null)
         {
-            var product = Spawn(listing.ProductEntity, Transform(buyer).Coordinates);
-            _hands.PickupOrDrop(buyer, product);
+            EntityUid product;
+
+            if (offsetSpawnCoords != null)
+            {
+                product = Spawn(listing.ProductEntity, offsetSpawnCoords.Value);
+            }
+            else
+            {
+                product = Spawn(listing.ProductEntity, Transform(buyer).Coordinates);
+                _hands.PickupOrDrop(buyer, product);
+            }
 
             HandleRefundComp(uid, component, product);
 

--- a/Content.Shared/Maps/TurfSystem.cs
+++ b/Content.Shared/Maps/TurfSystem.cs
@@ -48,7 +48,8 @@ public sealed class TurfSystem : EntitySystem
 
         // This is scaled to 95 % so it doesn't encompass walls on other tiles.
         var tileAabb = Box2.UnitCentered.Scale(0.95f * size);
-        var worldBox = new Box2Rotated(tileAabb.Translated(worldPos), gridRot, worldPos);
+        var worldBox = tileAabb.Translated(worldPos);
+        // var worldBox = new Box2Rotated(tileAabb.Translated(worldPos), gridRot, worldPos);
         tileAabb = tileAabb.Translated(localPos);
 
         var intersectionArea = 0f;

--- a/Resources/Locale/en-US/store/store.ftl
+++ b/Resources/Locale/en-US/store/store.ftl
@@ -6,7 +6,7 @@ store-ui-discount-display-with-currency =  {$amount} off on {$currency}
 store-ui-discount-display =  ({$amount} off!)
 store-ui-traitor-flavor = Copyright (C) NT -30643
 store-ui-traitor-warning = Operatives must lock their uplinks after use to avoid detection.
-store-ui-spawn-space-blocked = The spawning location is blocked.
+store-ui-spawn-space-blocked = Purchase failed, the area in front of you is blocked.
 
 
 store-withdraw-button-ui = Withdraw {$currency}

--- a/Resources/Locale/en-US/store/store.ftl
+++ b/Resources/Locale/en-US/store/store.ftl
@@ -6,6 +6,8 @@ store-ui-discount-display-with-currency =  {$amount} off on {$currency}
 store-ui-discount-display =  ({$amount} off!)
 store-ui-traitor-flavor = Copyright (C) NT -30643
 store-ui-traitor-warning = Operatives must lock their uplinks after use to avoid detection.
+store-ui-spawn-space-blocked = The spawning location is blocked.
+
 
 store-withdraw-button-ui = Withdraw {$currency}
 store-ui-button-out-of-stock = {""} (Out of Stock)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Uplink items that spawn impassible objects such as surplus crates or syndicate bombs will now spawn one tile in front of the player, rather than directly on the player which often displaces the player into walls.

This fix also inadvertently fixes mime walls spawning on top of players and RCD being able to deconstruct the floor under tables.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/31604
Fixes https://github.com/space-wizards/space-station-14/issues/34829
Fixes https://github.com/space-wizards/space-station-14/issues/34828

When I think back on my memories of this game, the one that stands out the most is a shift I had on Oasis where I was the psychologist. I was in my office and a thief purchased an invisible crate below my office. The invisible crate pushed the player into the wall suffocating them, and since they were a new player, they did not realize they could have opened the crate to free themselves and died. I did not really have an in-character way of letting them know that it wasn't their fault, and I've wanted to fix this issue ever since.

## Technical details
<!-- Summary of code changes for easier review. -->
For the fix in the turf system, I don't really know why changing from Box2Rotated to just Box2 fixes the issue it has, but it does. 

For the store UI code, the goal is to not displace any object from purchasing the item. This means checking the tile in front of the buyer and ensuring it's empty.

To do that, a dummy entity is spawned in nullspace so that we can access the components from it. If the dummy entity has any fixture with collision layers that could displace the buyer or any other mob on the tile in front of the buyer, we prevent the purchasing of the item.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before the preventative measure:

https://github.com/user-attachments/assets/4efd80fc-0a86-4c30-95f8-c5c9815b9c2e

After the preventative measure:

https://github.com/user-attachments/assets/47fea412-dd7d-422d-aea1-d29e48e0f576

Mime powers fix:

https://github.com/user-attachments/assets/b1cb77eb-e471-42fe-b313-6a6cbbf126da

RCD fix:

https://github.com/user-attachments/assets/2d22838e-f701-41be-8c16-a0f07107e09b

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Crates and large objects purchased from the uplink now spawn one tile in front of the player if the tile is free.
- fix: Mime powers are now correctly blocked by mobs and walls.
- fix: RCD can no longer deconstruct tiles that are occupied.