### PR TITLE
Fixed Wehxplosion yaml error

### DIFF
--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -381,21 +381,3 @@
         conditions:
         - !type:ReagentThreshold
           min: 50
-
-- type: reaction
-  id: WehHewExplosion
-  impact: High
-  priority: 20
-  reactants:
-    JuiceThatMakesYouWeh:
-      amount: 1
-    JuiceThatMakesYouHew:
-      amount: 1
-  effects:
-  - !type:ExplosionReactionEffect
-      explosionType: Radioactive
-      maxIntensity: 200
-      intensityPerUnit: 2
-      intensitySlope: 1
-      maxTotalIntensity: 250
-      tileBreakScale: 0.00001

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -227,3 +227,21 @@
   effects:
   - !type:CreateEntityReactionEffect
     entity: IngotSilver1
+
+- type: reaction
+  id: WehHewExplosion
+  impact: High
+  priority: 20
+  reactants:
+    JuiceThatMakesYouWeh:
+      amount: 1
+    JuiceThatMakesYouHew:
+      amount: 1
+  effects:
+  - !type:ExplosionReactionEffect
+    explosionType: Radioactive
+    maxIntensity: 200
+    intensityPerUnit: 2
+    intensitySlope: 1
+    maxTotalIntensity: 250
+    tileBreakScale: 0.00001


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Moved WehHew reaction from Reagents/fun.yml to Recipes/Reactions/fun.yml for consistency
Also fixed a minor indentation error 

## Why / Balance
because apparently your yaml linter sucks balls but the one I had found the error (additionally, ideally the ss14 yaml linter should check to see that prototypes are in the correct folders but it doesnt)

## Technical details
yes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
