### PR TITLE
Security Shield Naming Structure Inconsistency Change

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -66,7 +66,7 @@
   name: riot shield
   parent: [ BaseShield, BaseRestrictedContraband ]
   id: RiotShield
-  description: A large tower shield. Good for controlling crowds.
+  description: A shield built for protecting against melee attacks.
   components:
     - type: StaticPrice
       price: 90
@@ -84,10 +84,10 @@
           Slash: 1
 
 - type: entity
-  name: ablative shield
+  name: laser shield
   parent: [ BaseShield, BaseRestrictedContraband ]
   id: RiotLaserShield
-  description: An ablative shield built for withstanding lasers, but not much else.
+  description: A shield built for withstanding lasers.
   components:
     - type: Sprite
       state: riot_laser-icon
@@ -107,7 +107,7 @@
   name: ballistic shield
   parent: [ BaseShield, BaseRestrictedContraband ]
   id: RiotBulletShield
-  description: A ballistic shield built for protecting against firearms, but not much else.
+  description: A shield built for protecting against ballistics.
   components:
     - type: Sprite
       state: riot_bullet-icon

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -66,7 +66,7 @@
   name: riot shield
   parent: [ BaseShield, BaseRestrictedContraband ]
   id: RiotShield
-  description: A shield built for protecting against melee attacks.
+  description: A large tower shield. Good for controlling crowds.
   components:
     - type: StaticPrice
       price: 90
@@ -87,7 +87,7 @@
   name: laser shield
   parent: [ BaseShield, BaseRestrictedContraband ]
   id: RiotLaserShield
-  description: A shield built for withstanding lasers.
+  description: A shield built for withstanding lasers, but not much else.
   components:
     - type: Sprite
       state: riot_laser-icon
@@ -107,7 +107,7 @@
   name: ballistic shield
   parent: [ BaseShield, BaseRestrictedContraband ]
   id: RiotBulletShield
-  description: A shield built for protecting against ballistics.
+  description: A shield built for protecting against ballistics, but not much else.
   components:
     - type: Sprite
       state: riot_bullet-icon


### PR DESCRIPTION
## About the PR
<!-- What did you change? --> Changed "Ablative Shield" to "Laser Shield" to match the Ballistic and Riot shield naming structure. Changed descriptions to properly represent their use case.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> Ablative is not a word that fits a shield as the definition of Ablative does not mean to reduce damage, instead it means to "surgically remove body tissue" or "loss of material via wearing down (evaporation, melting, erosion, etc.)" which doesn't fit the naming structure of the shield being named after what it protects against.

## Technical details
<!-- Summary of code changes for easier review. -->
``Resources/Prototypes/Entities/Objects/Shields/shields.yml`` -- Changed laser shield name, changed security shield descriptions

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Renamed ablative shield to laser shield
- tweak: Changed description for laser shield & ballistic shield