### PR TITLE
Forced sleep threshold for Chloral Hydrate

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -69,19 +69,11 @@
         time: 4
         type: Add
         refresh: false
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
-          reagent: ChloralHydrate
-          min: 30
-        damage:
-          types:
-            Poison: 1.5
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
           reagent: ChloralHydrate
-          min: 30
+          min: 25
         key: ForcedSleep
         component: ForcedSleeping
         refresh: false

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -73,10 +73,19 @@
         conditions:
         - !type:ReagentThreshold
           reagent: ChloralHydrate
-          min: 20
+          min: 30
         damage:
           types:
             Poison: 1.5
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          reagent: ChloralHydrate
+          min: 30
+        key: ForcedSleep
+        component: ForcedSleeping
+        refresh: false
+        type: Add
 
 - type: reagent
   id: GastroToxin


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Chloral Hydrate now has a forced sleep threshold. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Chloral Hydrate has a reputation of being a knockout drug, meant to forcefully put people to sleep (as mentioned in its description). This purpose was effectively replaced with Nocturine, a drug which is effectively antag-only. This PR brings back the knockout effect at a much higher threshold, making it useful again while limiting its effectiveness in combat. Additionally it no longer gives poison damage.

- Forced sleep threshold is at 25u

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/27df4de7-63a5-435b-98a2-b93548f8b3f6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Chloral Hydrate now has a forced sleep threshold
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
