### PR TITLE
Plasma evac shuttle timer fix

### DIFF
--- a/Resources/Maps/Shuttles/emergency_plasma.yml
+++ b/Resources/Maps/Shuttles/emergency_plasma.yml
@@ -541,7 +541,11 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
-    - type: EmergencyShuttle
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
+      deviceNetId: Wireless
 - proto: AirAlarm
   entities:
   - uid: 218


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes Plasma Station's evac shuttle not showing it's ETA, as per https://github.com/space-wizards/space-station-14/pull/34602#discussion_r1938720853

## Why / Balance

## Technical details
Adds the "DeviceNetwork" component to the evac shuttle, replacing the "EmergencyShuttle" component which isn't needed.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
No CL needed as this is just a map-specific bug fix
