### PR TITLE
Fix Oasis evac timer

### DIFF
--- a/Resources/Maps/Shuttles/emergency_accordia.yml
+++ b/Resources/Maps/Shuttles/emergency_accordia.yml
@@ -66,6 +66,11 @@ entities:
       bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
+      deviceNetId: Wireless
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes Oasis' emergency shuttle transmit its ETA timer.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.
## Technical details
<!-- Summary of code changes for easier review. -->
Adds the DeviceNetwork component to emergency_accordia's grid with the appropriate settings for it to transmit its timer.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![Ye289o8](https://github.com/user-attachments/assets/637c4be9-260a-450f-86aa-7fae1311e5d7)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

No cl, small map-specific fix.

