### PR TITLE
Predicted dice rolls

### DIFF
--- a/Content.Client/Dice/DiceSystem.cs
+++ b/Content.Client/Dice/DiceSystem.cs
@@ -5,9 +5,9 @@ namespace Content.Client.Dice;
 
 public sealed class DiceSystem : SharedDiceSystem
 {
-    protected override void UpdateVisuals(EntityUid uid, DiceComponent? die = null)
+    protected override void UpdateVisuals(Entity<DiceComponent> entity)
     {
-        if (!Resolve(uid, ref die) || !TryComp(uid, out SpriteComponent? sprite))
+        if (!TryComp(entity, out SpriteComponent? sprite))
             return;
 
         // TODO maybe just move each diue to its own RSI?
@@ -16,6 +16,6 @@ public sealed class DiceSystem : SharedDiceSystem
             return;
 
         var prefix = state.Substring(0, state.IndexOf('_'));
-        sprite.LayerSetState(0, $"{prefix}_{die.CurrentValue}");
+        sprite.LayerSetState(0, $"{prefix}_{entity.Comp.CurrentValue}");
     }
 }

--- a/Content.Server/Dice/DiceSystem.cs
+++ b/Content.Server/Dice/DiceSystem.cs
@@ -1,28 +1,9 @@
 using Content.Shared.Dice;
-using Content.Shared.Popups;
 using JetBrains.Annotations;
-using Robust.Shared.Audio;
-using Robust.Shared.Audio.Systems;
-using Robust.Shared.Random;
 
 namespace Content.Server.Dice;
 
 [UsedImplicitly]
 public sealed class DiceSystem : SharedDiceSystem
 {
-    [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
-
-    public override void Roll(EntityUid uid, DiceComponent? die = null)
-    {
-        if (!Resolve(uid, ref die))
-            return;
-
-        var roll = _random.Next(1, die.Sides + 1);
-        SetCurrentSide(uid, roll, die);
-
-        _popup.PopupEntity(Loc.GetString("dice-component-on-roll-land", ("die", uid), ("currentSide", die.CurrentValue)), uid);
-        _audio.PlayPvs(die.Sound, uid);
-    }
 }

--- a/Content.Shared/Dice/SharedDiceSystem.cs
+++ b/Content.Shared/Dice/SharedDiceSystem.cs
@@ -1,12 +1,18 @@
 using Content.Shared.Examine;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Popups;
 using Content.Shared.Throwing;
-using Robust.Shared.GameStates;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Dice;
 
 public abstract class SharedDiceSystem : EntitySystem
 {
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -17,73 +23,76 @@ public abstract class SharedDiceSystem : EntitySystem
         SubscribeLocalEvent<DiceComponent, AfterAutoHandleStateEvent>(OnDiceAfterHandleState);
     }
 
-    private void OnDiceAfterHandleState(EntityUid uid, DiceComponent component, ref AfterAutoHandleStateEvent args)
+    private void OnDiceAfterHandleState(Entity<DiceComponent> entity, ref AfterAutoHandleStateEvent args)
     {
-        UpdateVisuals(uid, component);
+        UpdateVisuals(entity);
     }
 
-    private void OnUseInHand(EntityUid uid, DiceComponent component, UseInHandEvent args)
+    private void OnUseInHand(Entity<DiceComponent> entity, ref UseInHandEvent args)
     {
         if (args.Handled)
             return;
 
+        Roll(entity, args.User);
         args.Handled = true;
-        Roll(uid, component);
     }
 
-    private void OnLand(EntityUid uid, DiceComponent component, ref LandEvent args)
+    private void OnLand(Entity<DiceComponent> entity, ref LandEvent args)
     {
-        Roll(uid, component);
+        Roll(entity);
     }
 
-    private void OnExamined(EntityUid uid, DiceComponent dice, ExaminedEvent args)
+    private void OnExamined(Entity<DiceComponent> entity, ref ExaminedEvent args)
     {
         //No details check, since the sprite updates to show the side.
         using (args.PushGroup(nameof(DiceComponent)))
         {
-            args.PushMarkup(Loc.GetString("dice-component-on-examine-message-part-1", ("sidesAmount", dice.Sides)));
+            args.PushMarkup(Loc.GetString("dice-component-on-examine-message-part-1", ("sidesAmount", entity.Comp.Sides)));
             args.PushMarkup(Loc.GetString("dice-component-on-examine-message-part-2",
-                ("currentSide", dice.CurrentValue)));
+                ("currentSide", entity.Comp.CurrentValue)));
         }
     }
 
-    public void SetCurrentSide(EntityUid uid, int side, DiceComponent? die = null)
+    private void SetCurrentSide(Entity<DiceComponent> entity, int side)
     {
-        if (!Resolve(uid, ref die))
-            return;
-
-        if (side < 1 || side > die.Sides)
+        if (side < 1 || side > entity.Comp.Sides)
         {
-            Log.Error($"Attempted to set die {ToPrettyString(uid)} to an invalid side ({side}).");
+            Log.Error($"Attempted to set die {ToPrettyString(entity)} to an invalid side ({side}).");
             return;
         }
 
-        die.CurrentValue = (side - die.Offset) * die.Multiplier;
-        Dirty(uid, die);
-        UpdateVisuals(uid, die);
+        entity.Comp.CurrentValue = (side - entity.Comp.Offset) * entity.Comp.Multiplier;
+        Dirty(entity);
+        UpdateVisuals(entity);
     }
 
-    public void SetCurrentValue(EntityUid uid, int value, DiceComponent? die = null)
+    public void SetCurrentValue(Entity<DiceComponent> entity, int value)
     {
-        if (!Resolve(uid, ref die))
-            return;
-
-        if (value % die.Multiplier != 0 || value/ die.Multiplier + die.Offset < 1)
+        if (value % entity.Comp.Multiplier != 0 || value/ entity.Comp.Multiplier + entity.Comp.Offset < 1)
         {
-            Log.Error($"Attempted to set die {ToPrettyString(uid)} to an invalid value ({value}).");
+            Log.Error($"Attempted to set die {ToPrettyString(entity)} to an invalid value ({value}).");
             return;
         }
 
-        SetCurrentSide(uid, value / die.Multiplier + die.Offset, die);
+        SetCurrentSide(entity, value / entity.Comp.Multiplier + entity.Comp.Offset);
     }
 
-    protected virtual void UpdateVisuals(EntityUid uid, DiceComponent? die = null)
+    protected virtual void UpdateVisuals(Entity<DiceComponent> entity)
     {
         // See client system.
     }
 
-    public virtual void Roll(EntityUid uid, DiceComponent? die = null)
+    private void Roll(Entity<DiceComponent> entity, EntityUid? user = null)
     {
-        // See the server system, client cannot predict rolling.
+        var rand = new System.Random((int)_timing.CurTick.Value);
+
+        var roll = rand.Next(1, entity.Comp.Sides + 1);
+        SetCurrentSide(entity, roll);
+
+        var popupString = Loc.GetString("dice-component-on-roll-land",
+            ("die", entity),
+            ("currentSide", entity.Comp.CurrentValue));
+        _popup.PopupPredicted(popupString, entity, user);
+        _audio.PlayPredicted(entity.Comp.Sound, entity, user);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Updates dice system rolls to be predicted

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I'm just browsing for things to make predicted at random and noticed that dice rolls were done in Content.System.

## Technical details
<!-- Summary of code changes for easier review. -->
The previous implementation said that the client couldn't predict rolling, but it technically can if you pass it a seed. Currently the SharedMaskSystem and the SharedClumsySystem make use of `_timing.CurTick.Value` as their seed, so that's what I did as well.

Updated all functions in SharedDiceSystem to use the `Entity<T>` function format.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/9300930e-2f08-418f-8dfc-e0a64010ad9d

![image](https://github.com/user-attachments/assets/2f96439d-6934-44ac-a44c-9723c9f8e16c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
SharedDiceSystem function parameters changed from `EntityUid uid, DiceComponent comp` format to `Entity<DiceComponent> entity`, use entity for the EntityUid and entity.Comp for the DiceComponent.

SharedDiceSystem's SetCurrentSide() and Roll() visibility changed from public to private.