### PR TITLE
Fixes locker breakout do-after

### DIFF
--- a/Content.Server/Resist/ResistLockerComponent.cs
+++ b/Content.Server/Resist/ResistLockerComponent.cs
@@ -9,12 +9,6 @@ public sealed partial class ResistLockerComponent : Component
     /// <summary>
     /// How long will this locker take to kick open, defaults to 2 minutes
     /// </summary>
-    [DataField("resistTime")]
+    [DataField]
     public float ResistTime = 120f;
-
-    /// <summary>
-    /// For quick exit if the player attempts to move while already resisting
-    /// </summary>
-    [ViewVariables]
-    public bool IsResisting = false;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The do-after for breaking out of lockers now cancels early if the locker is unwelded or unlocked, and the door opens as early as available.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The current do-after is a bit jank, it doesn't stop even when the door was wide open.

## Technical details
<!-- Summary of code changes for easier review. -->
- The `isResisting` checks kind of did nothing besides try to prevent the do-after from getting cancelled. It prevented the do-after from getting cancelled because `ContainerRelayMovementEntityEvent` sends an event on movement keydown and keyup, and it tried to start a new do-after at each instance. The duplicate do-after would cancel the ongoing do-after. We can achieve this by setting the doafter arg `CancelDuplicate` to false, preventing additional do-after attempts from cancelling our ongoing do-after.
- `AttemptFrequency` was set to every tick, this causes `DoAfterAttemptEvent` to get raised every tick. We check whether we can early cancel the do-after every tick in the new `ResistDoafterEarlyCancel()` function, which cancels the do-after if the locker no longer exists (deleted from damage), or if the locker is both unwelded and unlocked. When this happens, it also attempts to open the locker immediately.
- Most of the code updated to use the `Entity<T> entity` code standard.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

**It normally takes two minutes to break out of a locker. The time was edited to five seconds for the videos.**

Before the changes:

https://github.com/user-attachments/assets/e422c072-9562-4e85-9f38-d062e23c74cb

After the changes:
Locked:

https://github.com/user-attachments/assets/e921664a-655f-46b3-9eca-547d6dbb6808

Welded:

https://github.com/user-attachments/assets/710080b4-1677-4317-bba6-af21f17a9335

Welded and locked:

https://github.com/user-attachments/assets/ab8dfc89-3157-421e-9ed5-2f25c66dc844

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
ResistLockerComponent isResisting field has been removed.
ResistLockerSystem functions changed to use the `Entity<T> entity` format. 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Breaking out of lockers is now more responsive.