### PR TITLE
Make hacking energy swords predicted

### DIFF
--- a/Content.Shared/Weapons/Melee/EnergySword/EnergySwordComponent.cs
+++ b/Content.Shared/Weapons/Melee/EnergySword/EnergySwordComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class EnergySwordComponent : Component
     /// causing the blade to cycle RGB colors.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public bool Hacked = false;
+    public bool Hacked;
 
     /// <summary>
     ///     RGB cycle rate for hacked e-swords.

--- a/Content.Shared/Weapons/Melee/EnergySword/EnergySwordComponent.cs
+++ b/Content.Shared/Weapons/Melee/EnergySword/EnergySwordComponent.cs
@@ -6,13 +6,16 @@ namespace Content.Shared.Weapons.Melee.EnergySword;
 [AutoGenerateComponentState]
 public sealed partial class EnergySwordComponent : Component
 {
+    /// <summary>
+    /// What color the blade will be when activated.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public Color ActivatedColor = Color.DodgerBlue;
 
     /// <summary>
     ///     A color option list for the random color picker.
     /// </summary>
-    [DataField("colorOptions")]
+    [DataField]
     public List<Color> ColorOptions = new()
     {
         Color.Tomato,
@@ -22,11 +25,16 @@ public sealed partial class EnergySwordComponent : Component
         Color.MediumOrchid
     };
 
+    /// <summary>
+    /// Whether the energy sword has been pulsed by a multitool,
+    /// causing the blade to cycle RGB colors.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public bool Hacked = false;
+
     /// <summary>
     ///     RGB cycle rate for hacked e-swords.
     /// </summary>
-    [DataField("cycleRate")]
+    [DataField]
     public float CycleRate = 1f;
 }

--- a/Content.Shared/Weapons/Melee/EnergySword/EnergySwordComponent.cs
+++ b/Content.Shared/Weapons/Melee/EnergySword/EnergySwordComponent.cs
@@ -2,7 +2,7 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.Weapons.Melee.EnergySword;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, Access(typeof(EnergySwordSystem))]
 [AutoGenerateComponentState]
 public sealed partial class EnergySwordComponent : Component
 {

--- a/Content.Shared/Weapons/Melee/EnergySword/EnergySwordComponent.cs
+++ b/Content.Shared/Weapons/Melee/EnergySword/EnergySwordComponent.cs
@@ -1,9 +1,12 @@
-namespace Content.Server.Weapons.Melee.EnergySword;
+using Robust.Shared.GameStates;
 
-[RegisterComponent]
-internal sealed partial class EnergySwordComponent : Component
+namespace Content.Shared.Weapons.Melee.EnergySword;
+
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+public sealed partial class EnergySwordComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite), DataField("activatedColor"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public Color ActivatedColor = Color.DodgerBlue;
 
     /// <summary>
@@ -19,6 +22,7 @@ internal sealed partial class EnergySwordComponent : Component
         Color.MediumOrchid
     };
 
+    [DataField, AutoNetworkedField]
     public bool Hacked = false;
     /// <summary>
     ///     RGB cycle rate for hacked e-swords.

--- a/Content.Shared/Weapons/Melee/EnergySword/EnergySwordSystem.cs
+++ b/Content.Shared/Weapons/Melee/EnergySword/EnergySwordSystem.cs
@@ -27,7 +27,7 @@ public sealed class EnergySwordSystem : EntitySystem
         if (entity.Comp.ColorOptions.Count != 0)
         {
             entity.Comp.ActivatedColor = _random.Pick(entity.Comp.ColorOptions);
-            Dirty(entity, entity.Comp);
+            Dirty(entity);
         }
 
         if (!TryComp(entity, out AppearanceComponent? appearanceComponent))
@@ -56,6 +56,6 @@ public sealed class EnergySwordSystem : EntitySystem
         else
             RemComp<RgbLightControllerComponent>(entity);
 
-        Dirty(entity, entity.Comp);
+        Dirty(entity);
     }
 }

--- a/Content.Shared/Weapons/Melee/EnergySword/EnergySwordSystem.cs
+++ b/Content.Shared/Weapons/Melee/EnergySword/EnergySwordSystem.cs
@@ -25,7 +25,10 @@ public sealed class EnergySwordSystem : EntitySystem
     private void OnMapInit(Entity<EnergySwordComponent> entity, ref MapInitEvent args)
     {
         if (entity.Comp.ColorOptions.Count != 0)
+        {
             entity.Comp.ActivatedColor = _random.Pick(entity.Comp.ColorOptions);
+            Dirty(entity, entity.Comp);
+        }
 
         if (!TryComp(entity, out AppearanceComponent? appearanceComponent))
             return;

--- a/Content.Shared/Weapons/Melee/EnergySword/EnergySwordSystem.cs
+++ b/Content.Shared/Weapons/Melee/EnergySword/EnergySwordSystem.cs
@@ -5,7 +5,7 @@ using Content.Shared.Toggleable;
 using Content.Shared.Tools.Systems;
 using Robust.Shared.Random;
 
-namespace Content.Server.Weapons.Melee.EnergySword;
+namespace Content.Shared.Weapons.Melee.EnergySword;
 
 public sealed class EnergySwordSystem : EntitySystem
 {
@@ -22,18 +22,19 @@ public sealed class EnergySwordSystem : EntitySystem
         SubscribeLocalEvent<EnergySwordComponent, InteractUsingEvent>(OnInteractUsing);
     }
     // Used to pick a random color for the blade on map init.
-    private void OnMapInit(EntityUid uid, EnergySwordComponent comp, MapInitEvent args)
+    private void OnMapInit(Entity<EnergySwordComponent> entity, ref MapInitEvent args)
     {
-        if (comp.ColorOptions.Count != 0)
-            comp.ActivatedColor = _random.Pick(comp.ColorOptions);
+        if (entity.Comp.ColorOptions.Count != 0)
+            entity.Comp.ActivatedColor = _random.Pick(entity.Comp.ColorOptions);
 
-        if (!TryComp(uid, out AppearanceComponent? appearanceComponent))
+        if (!TryComp(entity, out AppearanceComponent? appearanceComponent))
             return;
-        _appearance.SetData(uid, ToggleableLightVisuals.Color, comp.ActivatedColor, appearanceComponent);
+
+        _appearance.SetData(entity, ToggleableLightVisuals.Color, entity.Comp.ActivatedColor, appearanceComponent);
     }
 
-    // Used to make the make the blade multicolored when using a multitool on it.
-    private void OnInteractUsing(EntityUid uid, EnergySwordComponent comp, InteractUsingEvent args)
+    // Used to make the blade multicolored when using a multitool on it.
+    private void OnInteractUsing(Entity<EnergySwordComponent> entity, ref InteractUsingEvent args)
     {
         if (args.Handled)
             return;
@@ -42,14 +43,16 @@ public sealed class EnergySwordSystem : EntitySystem
             return;
 
         args.Handled = true;
-        comp.Hacked = !comp.Hacked;
+        entity.Comp.Hacked = !entity.Comp.Hacked;
 
-        if (comp.Hacked)
+        if (entity.Comp.Hacked)
         {
-            var rgb = EnsureComp<RgbLightControllerComponent>(uid);
-            _rgbSystem.SetCycleRate(uid, comp.CycleRate, rgb);
+            var rgb = EnsureComp<RgbLightControllerComponent>(entity);
+            _rgbSystem.SetCycleRate(entity, entity.Comp.CycleRate, rgb);
         }
         else
-            RemComp<RgbLightControllerComponent>(uid);
+            RemComp<RgbLightControllerComponent>(entity);
+
+        Dirty(entity, entity.Comp);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Pulsing an energy sword with a multitool to change its color is now predicted

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I'm just looking for stuff to make predicted

## Technical details
<!-- Summary of code changes for easier review. -->
- Moved the Component and System to Content.Shared
- Added NetworkedComponent and AutoGenerateComponentState to to the EnergySwordComponent
- Added AutoNetworkedField to the ActivatedColor and Hacked datafields
- Updated EnergySwordSystem to use the `Entity<T> entity` format
- Added a dirty call at the end of the InteractUsing handler to update the energy sword after changes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:

https://github.com/user-attachments/assets/a9e17073-862b-43f8-8698-693ab58d4004

After:

https://github.com/user-attachments/assets/cd08ffd3-57f8-47ee-a3ca-8c458c4cd2c8


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
EnergySwordComponent and EnergySwordSystem moved from Content.Server to Content.Shared
EnergySwordSystem functions updated to use the `Entity<T>` format