### PR TITLE
Make actions use a list of events

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -286,7 +286,7 @@ namespace Content.Client.Actions
 
             if (action.ClientExclusive)
             {
-                PerformAction(user, actions, actionId, instantAction, instantAction.Event, GameTiming.CurTime);
+                PerformAction(user, actions, actionId, instantAction, instantAction.BaseEvents, GameTiming.CurTime);
             }
             else
             {

--- a/Content.Client/Decals/DecalPlacementSystem.cs
+++ b/Content.Client/Decals/DecalPlacementSystem.cs
@@ -142,6 +142,7 @@ public sealed class DecalPlacementSystem : EntitySystem
         if (_decalId == null || !_protoMan.TryIndex<DecalPrototype>(_decalId, out var decalProto))
             return;
 
+        var worldTargetActionEventList = new List<WorldTargetActionEvent>();
         var actionEvent = new PlaceDecalActionEvent()
         {
             DecalId = _decalId,
@@ -151,20 +152,22 @@ public sealed class DecalPlacementSystem : EntitySystem
             ZIndex = _zIndex,
             Cleanable = _cleanable,
         };
+        worldTargetActionEventList.Add(actionEvent);
 
         var actionId = Spawn(null);
-        AddComp(actionId, new WorldTargetActionComponent
-        {
-            // non-unique actions may be considered duplicates when saving/loading.
-            Icon = decalProto.Sprite,
-            Repeat = true,
-            ClientExclusive = true,
-            CheckCanAccess = false,
-            CheckCanInteract = false,
-            Range = -1,
-            Event = actionEvent,
-            IconColor = _decalColor,
-        });
+        AddComp(actionId,
+            new WorldTargetActionComponent
+            {
+                // non-unique actions may be considered duplicates when saving/loading.
+                Icon = decalProto.Sprite,
+                Repeat = true,
+                ClientExclusive = true,
+                CheckCanAccess = false,
+                CheckCanInteract = false,
+                Range = -1,
+                Events = worldTargetActionEventList,
+                IconColor = _decalColor,
+            });
 
         _metaData.SetEntityName(actionId, $"{_decalId} ({_decalColor.ToHex()}, {(int) _decalAngle.Degrees})");
 

--- a/Content.Client/Mapping/MappingSystem.cs
+++ b/Content.Client/Mapping/MappingSystem.cs
@@ -46,6 +46,7 @@ public sealed partial class MappingSystem : EntitySystem
         if (ev.Action != null)
             return;
 
+        var instantActionEventList = new List<InstantActionEvent>();
         var actionEvent = new StartPlacementActionEvent();
         ITileDefinition? tileDef = null;
 
@@ -67,6 +68,7 @@ public sealed partial class MappingSystem : EntitySystem
         else
             return;
 
+        instantActionEventList.Add(actionEvent);
         InstantActionComponent action;
         string name;
 
@@ -79,11 +81,12 @@ public sealed partial class MappingSystem : EntitySystem
                 ? _spaceIcon
                 : new Texture(contentTileDef.Sprite!.Value);
 
+
             action = new InstantActionComponent
             {
                 ClientExclusive = true,
                 CheckCanInteract = false,
-                Event = actionEvent,
+                Events = instantActionEventList,
                 Icon = tileIcon
             };
 
@@ -95,7 +98,7 @@ public sealed partial class MappingSystem : EntitySystem
             {
                 ClientExclusive = true,
                 CheckCanInteract = false,
-                Event = actionEvent,
+                Events = instantActionEventList,
                 Icon = _deleteIcon,
             };
 
@@ -110,7 +113,7 @@ public sealed partial class MappingSystem : EntitySystem
             {
                 ClientExclusive = true,
                 CheckCanInteract = false,
-                Event = actionEvent,
+                Events = instantActionEventList,
                 Icon = new EntityPrototype(actionEvent.EntityType),
             };
 

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -216,12 +216,12 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         if (action.ClientExclusive)
         {
-            if (action.Event != null)
+            foreach (var worldTargetActionEvent in action.Events)
             {
-                action.Event.Target = coords;
+                worldTargetActionEvent.Target = coords;
             }
 
-            _actionsSystem.PerformAction(user, actionComp, actionId, action, action.Event, _timing.CurTime);
+            _actionsSystem.PerformAction(user, actionComp, actionId, action, action.BaseEvents, _timing.CurTime);
         }
         else
             EntityManager.RaisePredictiveEvent(new RequestPerformActionEvent(EntityManager.GetNetEntity(actionId), EntityManager.GetNetCoordinates(coords)));
@@ -249,12 +249,12 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         if (action.ClientExclusive)
         {
-            if (action.Event != null)
+            foreach (var entityTargetActionEvent in action.Events)
             {
-                action.Event.Target = entity;
+                entityTargetActionEvent.Target = entity;
             }
 
-            _actionsSystem.PerformAction(user, actionComp, actionId, action, action.Event, _timing.CurTime);
+            _actionsSystem.PerformAction(user, actionComp, actionId, action, action.BaseEvents, _timing.CurTime);
         }
         else
             EntityManager.RaisePredictiveEvent(new RequestPerformActionEvent(EntityManager.GetNetEntity(actionId), EntityManager.GetNetEntity(args.EntityUid)));
@@ -287,13 +287,13 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         if (action.ClientExclusive)
         {
-            if (action.Event != null)
+            foreach (var entityWorldTargetActionEvent in action.Events)
             {
-                action.Event.Entity = entity;
-                action.Event.Coords = coords;
+                entityWorldTargetActionEvent.Entity = entity;
+                entityWorldTargetActionEvent.Coords = coords;
             }
 
-            _actionsSystem.PerformAction(user, actionComp, actionId, action, action.Event, _timing.CurTime);
+            _actionsSystem.PerformAction(user, actionComp, actionId, action, action.BaseEvents, _timing.CurTime);
         }
         else
             EntityManager.RaisePredictiveEvent(new RequestPerformActionEvent(EntityManager.GetNetEntity(actionId), EntityManager.GetNetEntity(args.EntityUid), EntityManager.GetNetCoordinates(coords)));

--- a/Content.IntegrationTests/Tests/Actions/ActionsAddedTest.cs
+++ b/Content.IntegrationTests/Tests/Actions/ActionsAddedTest.cs
@@ -47,9 +47,9 @@ public sealed class ActionsAddedTest
         var evType = typeof(ToggleCombatActionEvent);
 
         var sActions = sActionSystem.GetActions(serverEnt).Where(
-            x => x.Comp is InstantActionComponent act && act.Event?.GetType() == evType).ToArray();
+            x => x.Comp is InstantActionComponent act && act.Events?[0].GetType() == evType).ToArray();
         var cActions = cActionSystem.GetActions(clientEnt).Where(
-            x => x.Comp is InstantActionComponent act && act.Event?.GetType() == evType).ToArray();
+            x => x.Comp is InstantActionComponent act && act.Events?[0].GetType() == evType).ToArray();
 
         Assert.That(sActions.Length, Is.EqualTo(1));
         Assert.That(cActions.Length, Is.EqualTo(1));
@@ -63,7 +63,7 @@ public sealed class ActionsAddedTest
         // Finally, these two actions are not the same object
         // required, because integration tests do not respect the [NonSerialized] attribute and will simply events by reference.
         Assert.That(ReferenceEquals(sAct, cAct), Is.False);
-        Assert.That(ReferenceEquals(sAct.BaseEvent, cAct.BaseEvent), Is.False);
+        Assert.That(ReferenceEquals(sAct.BaseEvents, cAct.BaseEvents), Is.False);
 
         await pair.CleanReturnAsync();
     }

--- a/Content.Server/Actions/ActionOnInteractSystem.cs
+++ b/Content.Server/Actions/ActionOnInteractSystem.cs
@@ -55,7 +55,7 @@ public sealed class ActionOnInteractSystem : EntitySystem
             return;
 
         var (actId, act) = _random.Pick(options);
-        _actions.PerformAction(args.User, null, actId, act, act.Event, _timing.CurTime, false);
+        _actions.PerformAction(args.User, null, actId, act, act.BaseEvents, _timing.CurTime, false);
         args.Handled = true;
     }
 
@@ -86,12 +86,12 @@ public sealed class ActionOnInteractSystem : EntitySystem
             if (entOptions.Count > 0)
             {
                 var (entActId, entAct) = _random.Pick(entOptions);
-                if (entAct.Event != null)
+                foreach (var instantActionEvent in entAct.Events)
                 {
-                    entAct.Event.Target = args.Target.Value;
+                    instantActionEvent.Target = args.Target.Value;
                 }
 
-                _actions.PerformAction(args.User, null, entActId, entAct, entAct.Event, _timing.CurTime, false);
+                _actions.PerformAction(args.User, null, entActId, entAct, entAct.BaseEvents, _timing.CurTime, false);
                 args.Handled = true;
                 return;
             }
@@ -109,13 +109,13 @@ public sealed class ActionOnInteractSystem : EntitySystem
         if (entWorldOptions.Count > 0)
         {
             var (entActId, entAct) = _random.Pick(entWorldOptions);
-            if (entAct.Event != null)
+            foreach (var entityWorldTargetActionEvent in entAct.Events)
             {
-                entAct.Event.Entity = args.Target;
-                entAct.Event.Coords = args.ClickLocation;
+                entityWorldTargetActionEvent.Entity = args.Target;
+                entityWorldTargetActionEvent.Coords = args.ClickLocation;
             }
 
-            _actions.PerformAction(args.User, null, entActId, entAct, entAct.Event, _timing.CurTime, false);
+            _actions.PerformAction(args.User, null, entActId, entAct, entAct.BaseEvents, _timing.CurTime, false);
             args.Handled = true;
             return;
         }
@@ -133,12 +133,12 @@ public sealed class ActionOnInteractSystem : EntitySystem
             return;
 
         var (actId, act) = _random.Pick(options);
-        if (act.Event != null)
+        foreach (var worldTargetAction in act.Events)
         {
-            act.Event.Target = args.ClickLocation;
+            worldTargetAction.Target = args.ClickLocation;
         }
 
-        _actions.PerformAction(args.User, null, actId, act, act.Event, _timing.CurTime, false);
+        _actions.PerformAction(args.User, null, actId, act, act.BaseEvents, _timing.CurTime, false);
         args.Handled = true;
     }
 

--- a/Content.Server/NPC/Systems/NPCUseActionOnTargetSystem.cs
+++ b/Content.Server/NPC/Systems/NPCUseActionOnTargetSystem.cs
@@ -34,18 +34,12 @@ public sealed class NPCUseActionOnTargetSystem : EntitySystem
         if (!_actions.ValidAction(action))
             return false;
 
-        if (action.Event != null)
+        foreach (var entityWorldTargetActionEvent in action.Events)
         {
-            action.Event.Coords = Transform(target).Coordinates;
+            entityWorldTargetActionEvent.Coords = Transform(target).Coordinates;
         }
 
-        _actions.PerformAction(user,
-            null,
-            user.Comp.ActionEnt.Value,
-            action,
-            action.BaseEvent,
-            _timing.CurTime,
-            false);
+        _actions.PerformAction(user, null, user.Comp.ActionEnt.Value, action, action.BaseEvents, _timing.CurTime, false);
         return true;
     }
 

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -379,7 +379,7 @@ public sealed partial class PolymorphSystem : EntitySystem
 
         baseAction.Icon = new SpriteSpecifier.EntityPrototype(polyProto.Configuration.Entity);
         if (baseAction is InstantActionComponent action)
-            action.Event = new PolymorphActionEvent(id);
+            action.Events.Add(new PolymorphActionEvent(id));
     }
 
     public void RemovePolymorphAction(ProtoId<PolymorphPrototype> id, Entity<PolymorphableComponent> target)

--- a/Content.Shared/Actions/BaseActionComponent.cs
+++ b/Content.Shared/Actions/BaseActionComponent.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Actions;
 [EntityCategory("Actions")]
 public abstract partial class BaseActionComponent : Component
 {
-    public abstract BaseActionEvent? BaseEvent { get; }
+    public abstract List<BaseActionEvent> BaseEvents { get; }
 
     /// <summary>
     ///     Icon representing this action in the UI.

--- a/Content.Shared/Actions/EntityTargetActionComponent.cs
+++ b/Content.Shared/Actions/EntityTargetActionComponent.cs
@@ -10,25 +10,37 @@ namespace Content.Shared.Actions;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class EntityTargetActionComponent : BaseTargetActionComponent
 {
-    public override BaseActionEvent? BaseEvent => Event;
+    public override List<BaseActionEvent> BaseEvents
+    {
+        get
+        {
+            var list = new List<BaseActionEvent>();
+            foreach (var ev in Events)
+            {
+                list.Add(ev);
+            }
+
+            return list;
+        }
+    }
 
     /// <summary>
     ///     The local-event to raise when this action is performed.
     /// </summary>
-    [DataField("event")]
+    [DataField]
     [NonSerialized]
-    public EntityTargetActionEvent? Event;
+    public List<EntityTargetActionEvent> Events;
 
     /// <summary>
     /// Determines which entities are valid targets for this action.
     /// </summary>
     /// <remarks>No whitelist check when null.</remarks>
-    [DataField("whitelist")] public EntityWhitelist? Whitelist;
+    [DataField] public EntityWhitelist? Whitelist;
 
     /// <summary>
     /// Whether this action considers the user as a valid target entity when using this action.
     /// </summary>
-    [DataField("canTargetSelf")] public bool CanTargetSelf = true;
+    [DataField] public bool CanTargetSelf = true;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Actions/EntityWorldTargetActionComponent.cs
+++ b/Content.Shared/Actions/EntityWorldTargetActionComponent.cs
@@ -10,14 +10,26 @@ namespace Content.Shared.Actions;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class EntityWorldTargetActionComponent : BaseTargetActionComponent
 {
-    public override BaseActionEvent? BaseEvent => Event;
+    public override List<BaseActionEvent> BaseEvents
+    {
+        get
+        {
+            var list = new List<BaseActionEvent>();
+            foreach (var ev in Events)
+            {
+                list.Add(ev);
+            }
+
+            return list;
+        }
+    }
 
     /// <summary>
     ///     The local-event to raise when this action is performed.
     /// </summary>
     [DataField]
     [NonSerialized]
-    public EntityWorldTargetActionEvent? Event;
+    public List<EntityWorldTargetActionEvent> Events;
 
     /// <summary>
     /// Determines which entities are valid targets for this action.

--- a/Content.Shared/Actions/InstantActionComponent.cs
+++ b/Content.Shared/Actions/InstantActionComponent.cs
@@ -6,14 +6,26 @@ namespace Content.Shared.Actions;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class InstantActionComponent : BaseActionComponent
 {
-    public override BaseActionEvent? BaseEvent => Event;
+    public override List<BaseActionEvent> BaseEvents
+    {
+        get
+        {
+            var list = new List<BaseActionEvent>();
+            foreach (var ev in Events)
+            {
+                list.Add(ev);
+            }
+
+            return list;
+        }
+    }
 
     /// <summary>
     ///     The local-event to raise when this action is performed.
     /// </summary>
-    [DataField("event")]
+    [DataField]
     [NonSerialized]
-    public InstantActionEvent? Event;
+    public List<InstantActionEvent> Events;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Actions/WorldTargetActionComponent.cs
+++ b/Content.Shared/Actions/WorldTargetActionComponent.cs
@@ -9,14 +9,26 @@ namespace Content.Shared.Actions;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class WorldTargetActionComponent : BaseTargetActionComponent
 {
-    public override BaseActionEvent? BaseEvent => Event;
+    public override List<BaseActionEvent> BaseEvents
+    {
+        get
+        {
+            var list = new List<BaseActionEvent>();
+            foreach (var ev in Events)
+            {
+                list.Add(ev);
+            }
+
+            return list;
+        }
+    }
 
     /// <summary>
     ///     The local-event to raise when this action is performed.
     /// </summary>
-    [DataField("event")]
+    [DataField]
     [NonSerialized]
-    public WorldTargetActionEvent? Event;
+    public List<WorldTargetActionEvent> Events;
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Prototypes/Actions/anomaly.yml
+++ b/Resources/Prototypes/Actions/anomaly.yml
@@ -5,5 +5,6 @@
   components:
   - type: InstantAction
     icon: Structures/Specific/anomaly.rsi/anom1.png
-    event: !type:ActionAnomalyPulseEvent
+    events:
+    - !type:ActionAnomalyPulseEvent
     useDelay: 30

--- a/Resources/Prototypes/Actions/borgs.yml
+++ b/Resources/Prototypes/Actions/borgs.yml
@@ -10,7 +10,8 @@
     icon:
       sprite: Interface/Actions/actions_borg.rsi
       state: state-laws
-    event: !type:ToggleLawsScreenEvent
+    events:
+    - !type:ToggleLawsScreenEvent
     useDelay: 0.5
 
 - type: entity
@@ -22,5 +23,6 @@
     icon:
       sprite: Interface/Actions/actions_borg.rsi
       state: select-type
-    event: !type:BorgToggleSelectTypeEvent
+    events:
+    - !type:BorgToggleSelectTypeEvent
     useDelay: 0.5

--- a/Resources/Prototypes/Actions/crit.yml
+++ b/Resources/Prototypes/Actions/crit.yml
@@ -11,7 +11,8 @@
     icon:
       sprite: Mobs/Ghosts/ghost_human.rsi
       state: icon
-    event: !type:CritSuccumbEvent
+    events:
+    - !type:CritSuccumbEvent
     startDelay: true
     useDelay: 10
 
@@ -27,7 +28,8 @@
     icon:
       sprite: Interface/Actions/actions_crit.rsi
       state: fakedeath
-    event: !type:CritFakeDeathEvent
+    events:
+    - !type:CritFakeDeathEvent
     useDelay: 30
 
 - type: entity
@@ -42,6 +44,7 @@
     icon:
       sprite: Interface/Actions/actions_crit.rsi
       state: lastwords
-    event: !type:CritLastWordsEvent
+    events:
+    - !type:CritLastWordsEvent
     startDelay: true
     useDelay: 10

--- a/Resources/Prototypes/Actions/diona.yml
+++ b/Resources/Prototypes/Actions/diona.yml
@@ -7,7 +7,8 @@
     icon:
       sprite: Mobs/Species/Diona/organs.rsi
       state: brain
-    event: !type:GibActionEvent {}
+    events:
+    - !type:GibActionEvent {}
     checkCanInteract: false
     checkConsciousness: false
 
@@ -20,5 +21,6 @@
     icon:
       sprite: Mobs/Species/Diona/parts.rsi
       state: full
-    event: !type:ReformEvent {}
+    events:
+    - !type:ReformEvent {}
     useDelay: 600 # Once every 10 minutes. Keep them dead for a fair bit before reforming

--- a/Resources/Prototypes/Actions/internals.yml
+++ b/Resources/Prototypes/Actions/internals.yml
@@ -10,5 +10,6 @@
     iconOn:
       sprite: Interface/Alerts/internals.rsi
       state: internal1
-    event: !type:ToggleActionEvent
+    events:
+    - !type:ToggleActionEvent
     useDelay: 1

--- a/Resources/Prototypes/Actions/mech.yml
+++ b/Resources/Prototypes/Actions/mech.yml
@@ -8,7 +8,8 @@
     icon:
       sprite: Interface/Actions/actions_mecha.rsi
       state: mech_cycle_equip_on
-    event: !type:MechToggleEquipmentEvent
+    events:
+    - !type:MechToggleEquipmentEvent
     useDelay: 0.5
 
 - type: entity
@@ -21,7 +22,8 @@
     icon:
       sprite: Interface/Actions/actions_mecha.rsi
       state: mech_view_stats
-    event: !type:MechOpenUiEvent
+    events:
+    - !type:MechOpenUiEvent
     useDelay: 1
 
 - type: entity
@@ -34,4 +36,5 @@
     icon:
       sprite: Interface/Actions/actions_mecha.rsi
       state: mech_eject
-    event: !type:MechEjectPilotEvent
+    events:
+    - !type:MechEjectPilotEvent

--- a/Resources/Prototypes/Actions/ninja.yml
+++ b/Resources/Prototypes/Actions/ninja.yml
@@ -6,7 +6,8 @@
   components:
   - type: InstantAction
     priority: -13
-    event: !type:ToggleActionEvent {}
+    events:
+    - !type:ToggleActionEvent {}
 
 # suit
 - type: entity
@@ -21,7 +22,8 @@
       state: icon
     itemIconStyle: NoItem
     priority: -10
-    event: !type:CreateItemEvent {}
+    events:
+    - !type:CreateItemEvent {}
 
 - type: entity
   id: ActionRecallKatana
@@ -35,7 +37,8 @@
       state: icon
     itemIconStyle: NoItem
     priority: -11
-    event: !type:RecallKatanaEvent {}
+    events:
+    - !type:RecallKatanaEvent {}
 
 - type: entity
   id: ActionNinjaEmp
@@ -48,7 +51,8 @@
       state: icon
     itemIconStyle: BigAction
     priority: -13
-    event: !type:NinjaEmpEvent {}
+    events:
+    - !type:NinjaEmpEvent {}
 
 - type: entity
   id: ActionTogglePhaseCloak
@@ -59,7 +63,8 @@
     # have to plan (un)cloaking ahead of time
     useDelay: 5
     priority: -9
-    event: !type:ToggleActionEvent
+    events:
+    - !type:ToggleActionEvent
 
 # katana
 - type: entity
@@ -77,6 +82,7 @@
       params:
         volume: 5
     priority: -12
-    event: !type:DashEvent
+    events:
+    - !type:DashEvent
     checkCanAccess: false
     range: 0

--- a/Resources/Prototypes/Actions/polymorph.yml
+++ b/Resources/Prototypes/Actions/polymorph.yml
@@ -4,13 +4,15 @@
   description: Revert back into your original form.
   components:
   - type: InstantAction
-    event: !type:RevertPolymorphActionEvent
+    events:
+    - !type:RevertPolymorphActionEvent
 
 - type: entity
   id: ActionPolymorph
   components:
   - type: InstantAction
-    event: !type:PolymorphActionEvent
+    events:
+    - !type:PolymorphActionEvent
     itemIconStyle: NoItem
 
 - type: entity
@@ -20,7 +22,8 @@
   components:
   - type: InstantAction
     useDelay: 60
-    event: !type:PolymorphActionEvent
+    events:
+    - !type:PolymorphActionEvent
       protoId: WizardSpider
     itemIconStyle: NoItem
     icon:
@@ -34,7 +37,8 @@
   components:
   - type: InstantAction
     useDelay: 60
-    event: !type:PolymorphActionEvent
+    events:
+    - !type:PolymorphActionEvent
       protoId: WizardRod
     itemIconStyle: NoItem
     icon:
@@ -49,7 +53,8 @@
   - type: Magic
   - type: InstantAction
     useDelay: 30
-    event: !type:PolymorphActionEvent
+    events:
+    - !type:PolymorphActionEvent
       protoId: Jaunt
     itemIconStyle: NoItem
     icon:
@@ -69,7 +74,8 @@
   components:
   - type: InstantAction
     useDelay: 25
-    event: !type:PolymorphActionEvent
+    events:
+    - !type:PolymorphActionEvent
       protoId: Jaunt
     itemIconStyle: NoItem
     icon:
@@ -84,7 +90,8 @@
   components:
   - type: InstantAction
     useDelay: 20
-    event: !type:PolymorphActionEvent
+    events:
+    - !type:PolymorphActionEvent
       protoId: Jaunt
     itemIconStyle: NoItem
     icon:

--- a/Resources/Prototypes/Actions/revenant.yml
+++ b/Resources/Prototypes/Actions/revenant.yml
@@ -5,7 +5,8 @@
   components:
   - type: InstantAction
     icon: Interface/Actions/shop.png
-    event: !type:RevenantShopActionEvent
+    events:
+    - !type:RevenantShopActionEvent
 
 - type: entity
   id: ActionRevenantDefile
@@ -14,7 +15,8 @@
   components:
   - type: InstantAction
     icon: Interface/Actions/defile.png
-    event: !type:RevenantDefileActionEvent
+    events:
+    - !type:RevenantDefileActionEvent
     useDelay: 15
 
 - type: entity
@@ -24,7 +26,8 @@
   components:
   - type: InstantAction
     icon: Interface/Actions/overloadlight.png
-    event: !type:RevenantOverloadLightsActionEvent
+    events:
+    - !type:RevenantOverloadLightsActionEvent
     useDelay: 20
 
 #- type: entity
@@ -44,5 +47,6 @@
   components:
   - type: InstantAction
     icon: Interface/Actions/malfunction.png
-    event: !type:RevenantMalfunctionActionEvent
+    events:
+    - !type:RevenantMalfunctionActionEvent
     useDelay: 20

--- a/Resources/Prototypes/Actions/speech.yml
+++ b/Resources/Prototypes/Actions/speech.yml
@@ -7,4 +7,5 @@
     itemIconStyle: BigItem
     priority: -20
     useDelay: 1
-    event: !type:MeleeSpeechConfigureActionEvent
+    events:
+    - !type:MeleeSpeechConfigureActionEvent

--- a/Resources/Prototypes/Actions/spider.yml
+++ b/Resources/Prototypes/Actions/spider.yml
@@ -5,7 +5,8 @@
   components:
   - type: InstantAction
     icon: Interface/Actions/web.png
-    event: !type:SpiderWebActionEvent
+    events:
+    - !type:SpiderWebActionEvent
     useDelay: 25
 
 - type: entity
@@ -15,5 +16,6 @@
   components:
   - type: InstantAction
     icon: Interface/Actions/web.png
-    event: !type:SericultureActionEvent
+    events:
+    - !type:SericultureActionEvent
     useDelay: 1

--- a/Resources/Prototypes/Actions/station_ai.yml
+++ b/Resources/Prototypes/Actions/station_ai.yml
@@ -10,7 +10,8 @@
     icon:
       sprite: Interface/Actions/actions_ai.rsi
       state: ai_core
-    event: !type:JumpToCoreEvent
+    events:
+    - !type:JumpToCoreEvent
 
 - type: entity
   id: ActionSurvCameraLights
@@ -23,7 +24,8 @@
     icon:
       sprite: Interface/Actions/actions_ai.rsi
       state: camera_light
-    event: !type:RelayedActionComponentChangeEvent
+    events:
+    - !type:RelayedActionComponentChangeEvent
       components:
       - type: LightOnCollideCollider
       - type: FixturesChange
@@ -51,5 +53,6 @@
     icon:
       sprite: Interface/Actions/actions_ai.rsi
       state: state_laws
-    event: !type:ToggleLawsScreenEvent
+    events:
+    - !type:ToggleLawsScreenEvent
     useDelay: 0.5

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -17,7 +17,8 @@
   - type: InstantAction
     useDelay: 10
     icon: Interface/Actions/scream.png
-    event: !type:ScreamActionEvent
+    events:
+    - !type:ScreamActionEvent
     checkCanInteract: false
 
 - type: entity
@@ -29,7 +30,8 @@
     checkCanInteract: false
     checkConsciousness: false
     icon: Interface/Actions/zombie-turn.png
-    event: !type:ZombifySelfActionEvent
+    events:
+    - !type:ZombifySelfActionEvent
 
 - type: entity
   id: ActionToggleLight
@@ -40,7 +42,8 @@
     useDelay: 1
     icon: { sprite: Objects/Tools/flashlight.rsi, state: flashlight }
     iconOn: { sprite: Objects/Tools/flashlight.rsi, state: flashlight-on }
-    event: !type:ToggleActionEvent
+    events:
+    - !type:ToggleActionEvent
 
 - type: entity
   id: ActionOpenStorageImplant
@@ -53,7 +56,8 @@
     icon:
       sprite: Clothing/Back/Backpacks/backpack.rsi
       state: icon
-    event: !type:OpenStorageImplantEvent
+    events:
+    - !type:OpenStorageImplantEvent
     useDelay: 1
 
 - type: entity
@@ -70,7 +74,8 @@
     icon:
       sprite: Actions/Implants/implants.rsi
       state: explosive
-    event: !type:ActivateImplantEvent
+    events:
+    - !type:ActivateImplantEvent
 
 - type: entity
   parent: BaseSuicideAction
@@ -86,7 +91,8 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: gib
-    event: !type:ActivateImplantEvent
+    events:
+    - !type:ActivateImplantEvent
 
 - type: entity
   id: ActionActivateFreedomImplant
@@ -101,7 +107,8 @@
     icon:
       sprite: Actions/Implants/implants.rsi
       state: freedom
-    event: !type:UseFreedomImplantEvent
+    events:
+    - !type:UseFreedomImplantEvent
 
 - type: entity
   id: ActionOpenUplinkImplant
@@ -114,7 +121,8 @@
     icon:
       sprite: Objects/Devices/communication.rsi
       state: old-radio
-    event: !type:OpenUplinkImplantEvent
+    events:
+    - !type:OpenUplinkImplantEvent
 
 - type: entity
   id: ActionActivateEmpImplant
@@ -130,7 +138,8 @@
     icon:
       sprite: Objects/Weapons/Grenades/empgrenade.rsi
       state: icon
-    event: !type:ActivateImplantEvent
+    events:
+    - !type:ActivateImplantEvent
 
 - type: entity
   id: ActionActivateScramImplant
@@ -146,7 +155,8 @@
     icon:
       sprite: Structures/Specific/anomaly.rsi
       state: anom4
-    event: !type:UseScramImplantEvent
+    events:
+    - !type:UseScramImplantEvent
 
 - type: entity
   id: ActionActivateDnaScramblerImplant
@@ -160,7 +170,8 @@
     icon:
       sprite: Clothing/OuterClothing/Hardsuits/lingspacesuit.rsi
       state: icon
-    event: !type:UseDnaScramblerImplantEvent
+    events:
+    - !type:UseDnaScramblerImplantEvent
 
 - type: entity
   id: ActionToggleSuitPiece
@@ -170,7 +181,8 @@
   - type: InstantAction
     itemIconStyle: BigItem
     useDelay: 1 # equip noise spam.
-    event: !type:ToggleClothingEvent
+    events:
+    - !type:ToggleClothingEvent
 
 - type: entity
   id: ActionCombatModeToggle
@@ -182,7 +194,8 @@
     checkConsciousness: false
     icon: Interface/Actions/harmOff.png
     iconOn: Interface/Actions/harm.png
-    event: !type:ToggleCombatActionEvent
+    events:
+    - !type:ToggleCombatActionEvent
     priority: -100
 
 - type: entity
@@ -203,7 +216,8 @@
   components:
   - type: InstantAction
     icon: { sprite: Interface/Actions/voice-mask.rsi, state: icon }
-    event: !type:VoiceMaskSetNameEvent
+    events:
+    - !type:VoiceMaskSetNameEvent
 
 - type: entity
   id: ActionVendingThrow
@@ -212,7 +226,8 @@
   components:
   - type: InstantAction
     useDelay: 30
-    event: !type:VendingMachineSelfDispenseEvent
+    events:
+    - !type:VendingMachineSelfDispenseEvent
 
 - type: entity
   id: ActionArtifactActivate
@@ -224,7 +239,8 @@
       sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
       state: ano01
     useDelay: 60
-    event: !type:ArtifactSelfActivateEvent
+    events:
+    - !type:ArtifactSelfActivateEvent
 
 - type: entity
   id: ActionToggleBlock
@@ -234,7 +250,8 @@
   - type: InstantAction
     icon: { sprite: Objects/Weapons/Melee/shields.rsi, state: teleriot-icon }
     iconOn: Objects/Weapons/Melee/shields.rsi/teleriot-on.png
-    event: !type:ToggleActionEvent
+    events:
+    - !type:ToggleActionEvent
 
 - type: entity
   id: ActionClearNetworkLinkOverlays
@@ -247,7 +264,8 @@
     checkConsciousness: false
     temporary: true
     icon: { sprite: Objects/Tools/multitool.rsi, state: icon }
-    event: !type:ClearAllOverlaysEvent
+    events:
+    - !type:ClearAllOverlaysEvent
 
 - type: entity
   id: ActionAnimalLayEgg
@@ -257,7 +275,8 @@
   - type: InstantAction
     icon: { sprite: Objects/Consumable/Food/egg.rsi, state: icon }
     useDelay: 60
-    event: !type:EggLayInstantActionEvent
+    events:
+    - !type:EggLayInstantActionEvent
 
 - type: entity
   id: ActionSleep
@@ -268,7 +287,8 @@
     checkCanInteract: false
     checkConsciousness: false
     icon: { sprite: Clothing/Head/Hats/pyjamasyndicatered.rsi, state: icon }
-    event: !type:SleepActionEvent
+    events:
+    - !type:SleepActionEvent
 
 - type: entity
   id: ActionWake
@@ -279,7 +299,8 @@
     icon: { sprite: Clothing/Head/Hats/pyjamasyndicatered.rsi, state: icon }
     checkCanInteract: false
     checkConsciousness: false
-    event: !type:WakeActionEvent
+    events:
+    - !type:WakeActionEvent
     startDelay: true
     useDelay: 2
 
@@ -290,7 +311,8 @@
   components:
   - type: InstantAction
     icon: { sprite: Objects/Fun/bikehorn.rsi, state: icon }
-    event: !type:ActivateImplantEvent
+    events:
+    - !type:ActivateImplantEvent
     useDelay: 1
 
 - type: entity
@@ -302,7 +324,8 @@
     priority: -1
     useDelay: 30
     icon: Interface/Actions/firestarter.png
-    event: !type:FireStarterActionEvent
+    events:
+    - !type:FireStarterActionEvent
 
 - type: entity
   id: ActionToggleEyes
@@ -312,7 +335,8 @@
   - type: InstantAction
     icon: Interface/Actions/eyeopen.png
     iconOn: Interface/Actions/eyeclose.png
-    event: !type:ToggleEyesActionEvent
+    events:
+    - !type:ToggleEyesActionEvent
     useDelay: 1 # so u cant give yourself and observers eyestrain by rapidly spamming the action
     checkCanInteract: false
     checkConsciousness: false
@@ -327,7 +351,8 @@
       iconOn: { sprite: Mobs/Customization/reptilian_parts.rsi, state: tail_smooth_behind }
       itemIconStyle: NoItem
       useDelay: 1 # emote spam
-      event: !type:ToggleActionEvent
+      events:
+    - !type:ToggleActionEvent
 
 - type: entity
   id: FakeMindShieldToggleAction
@@ -339,4 +364,5 @@
     iconOn: { sprite: Interface/Actions/actions_fakemindshield.rsi, state: icon-on }
     itemIconStyle: NoItem
     useDelay: 1
-    event: !type:FakeMindShieldToggleEvent
+    events:
+    - !type:FakeMindShieldToggleEvent

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -346,12 +346,12 @@
   name: Wagging Tail
   description: Start or stop wagging your tail.
   components:
-    - type: InstantAction
-      icon: { sprite: Mobs/Customization/reptilian_parts.rsi, state: tail_smooth_behind }
-      iconOn: { sprite: Mobs/Customization/reptilian_parts.rsi, state: tail_smooth_behind }
-      itemIconStyle: NoItem
-      useDelay: 1 # emote spam
-      events:
+  - type: InstantAction
+    icon: { sprite: Mobs/Customization/reptilian_parts.rsi, state: tail_smooth_behind }
+    iconOn: { sprite: Mobs/Customization/reptilian_parts.rsi, state: tail_smooth_behind }
+    itemIconStyle: NoItem
+    useDelay: 1 # emote spam
+    events:
     - !type:ToggleActionEvent
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -503,4 +503,5 @@
   - type: InstantAction
     useDelay: 1
     itemIconStyle: BigItem
-    event: !type:ToggleActionEvent
+    events:
+    - !type:ToggleActionEvent

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -215,7 +215,8 @@
   description: "*notices your killsign* owo whats this"
   components:
   - type: InstantAction
-    event: !type:ToggleActionEvent
+    events:
+    - !type:ToggleActionEvent
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Masks/base_clothingmask.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/base_clothingmask.yml
@@ -27,7 +27,8 @@
   - type: InstantAction
     icon: { sprite: Clothing/Mask/gas.rsi, state: icon }
     iconOn: Interface/Default/blocked.png
-    event: !type:ToggleMaskEvent
+    events:
+    - !type:ToggleMaskEvent
 
 - type: entity
   id: ClothingMaskBaseButcherable

--- a/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
@@ -75,7 +75,8 @@
     icon:
       sprite: Clothing/Neck/Misc/stethoscope.rsi
       state: icon
-    event: !type:StethoscopeActionEvent
+    events:
+    - !type:StethoscopeActionEvent
     checkCanInteract: false
     priority: -1
 

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -117,4 +117,5 @@
   components:
   - type: InstantAction
     itemIconStyle: BigItem
-    event: !type:ToggleActionEvent
+    events:
+    - !type:ToggleActionEvent

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -129,7 +129,8 @@
   components:
   - type: InstantAction
     itemIconStyle: BigItem
-    event: !type:ToggleActionEvent
+    events:
+    - !type:ToggleActionEvent
 
 - type: entity
   parent: ClothingShoesBase

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -107,7 +107,8 @@
       state: goliath_tentacle_wiggle
     sound:
       path: "/Audio/Weapons/slash.ogg"
-    event: !type:GoliathSummonTentacleAction
+    events:
+    - !type:GoliathSummonTentacleAction
     useDelay: 8
     range: 10
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -343,7 +343,7 @@
       state: stay
     events:
     - !type:RatKingOrderActionEvent
-        type: Stay
+      type: Stay
     priority: 5
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -341,8 +341,8 @@
     iconOn:
       sprite: Interface/Actions/actions_rat_king.rsi
       state: stay
-    event:
-      !type:RatKingOrderActionEvent
+    events:
+    - !type:RatKingOrderActionEvent
         type: Stay
     priority: 5
 
@@ -359,8 +359,8 @@
     iconOn:
       sprite: Interface/Actions/actions_rat_king.rsi
       state: follow
-    event:
-      !type:RatKingOrderActionEvent
+    events:
+    - !type:RatKingOrderActionEvent
       type: Follow
     priority: 6
 
@@ -377,8 +377,8 @@
     iconOn:
       sprite: Interface/Actions/actions_rat_king.rsi
       state: attack
-    event:
-      !type:RatKingOrderActionEvent
+    events:
+    - !type:RatKingOrderActionEvent
       type: CheeseEm
     priority: 7
 
@@ -395,7 +395,7 @@
     iconOn:
       sprite: Interface/Actions/actions_rat_king.rsi
       state: loose
-    event:
-      !type:RatKingOrderActionEvent
+    events:
+    - !type:RatKingOrderActionEvent
       type: Loose
     priority: 8

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -312,7 +312,8 @@
     icon:
       sprite: Interface/Actions/actions_rat_king.rsi
       state: ratKingArmy
-    event: !type:RatKingRaiseArmyActionEvent
+    events:
+    - !type:RatKingRaiseArmyActionEvent
 
 - type: entity
   id: ActionRatKingDomain
@@ -324,7 +325,8 @@
     icon:
       sprite: Interface/Actions/actions_rat_king.rsi
       state: ratKingDomain
-    event: !type:RatKingDomainActionEvent
+    events:
+    - !type:RatKingDomainActionEvent
 
 - type: entity
   id: ActionRatKingOrderStay

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -104,7 +104,8 @@
     iconOn: Structures/Machines/parts.rsi/box_2.png
     keywords: [ "AI", "console", "interface" ]
     priority: -10
-    event: !type:ToggleIntrinsicUIEvent { key: enum.SolarControlConsoleUiKey.Key }
+    events:
+    - !type:ToggleIntrinsicUIEvent { key: enum.SolarControlConsoleUiKey.Key }
 
 - type: entity
   id: ActionAGhostShowCommunications
@@ -116,7 +117,8 @@
     iconOn: Interface/Actions/actions_ai.rsi/comms_console.png
     keywords: [ "AI", "console", "interface" ]
     priority: -4
-    event: !type:ToggleIntrinsicUIEvent { key: enum.CommunicationsConsoleUiKey.Key }
+    events:
+    - !type:ToggleIntrinsicUIEvent { key: enum.CommunicationsConsoleUiKey.Key }
 
 - type: entity
   id: ActionAGhostShowRadar
@@ -128,7 +130,8 @@
     iconOn: Interface/Actions/actions_ai.rsi/mass_scanner.png
     keywords: [ "AI", "console", "interface" ]
     priority: -6
-    event: !type:ToggleIntrinsicUIEvent { key: enum.RadarConsoleUiKey.Key }
+    events:
+    - !type:ToggleIntrinsicUIEvent { key: enum.RadarConsoleUiKey.Key }
 
 - type: entity
   id: ActionAGhostShowCargo
@@ -140,7 +143,8 @@
     iconOn: Structures/Machines/parts.rsi/box_2.png
     keywords: [ "AI", "console", "interface" ]
     priority: -10
-    event: !type:ToggleIntrinsicUIEvent { key: enum.CargoConsoleUiKey.Orders }
+    events:
+    - !type:ToggleIntrinsicUIEvent { key: enum.CargoConsoleUiKey.Orders }
 
 - type: entity
   id: ActionAGhostShowCrewMonitoring
@@ -152,7 +156,8 @@
     iconOn: Interface/Actions/actions_ai.rsi/crew_monitor.png
     keywords: [ "AI", "console", "interface" ]
     priority: -8
-    event: !type:ToggleIntrinsicUIEvent { key: enum.CrewMonitoringUIKey.Key }
+    events:
+    - !type:ToggleIntrinsicUIEvent { key: enum.CrewMonitoringUIKey.Key }
 
 - type: entity
   id: ActionAGhostShowStationRecords
@@ -164,4 +169,5 @@
     iconOn: Interface/Actions/actions_ai.rsi/station_records.png
     keywords: [ "AI", "console", "interface" ]
     priority: -7
-    event: !type:ToggleIntrinsicUIEvent { key: enum.GeneralStationRecordConsoleKey.Key }
+    events:
+    - !type:ToggleIntrinsicUIEvent { key: enum.GeneralStationRecordConsoleKey.Key }

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -224,7 +224,8 @@
     icon:
       sprite: Interface/Actions/carp_rift.rsi
       state: icon
-    event: !type:DragonSpawnRiftActionEvent
+    events:
+    - !type:DragonSpawnRiftActionEvent
     useDelay: 1
     priority: 3
 
@@ -236,7 +237,8 @@
   - type: EntityTargetAction
     icon: { sprite : Interface/Actions/devour.rsi, state: icon }
     iconOn: { sprite : Interface/Actions/devour.rsi, state: icon-on }
-    event: !type:DevourActionEvent
+    events:
+    - !type:DevourActionEvent
     priority: 1
 
 - type: entity
@@ -247,7 +249,8 @@
   - type: WorldTargetAction
     # TODO: actual sprite
     icon: { sprite : Objects/Weapons/Guns/Projectiles/magic.rsi, state: fireball }
-    event: !type:ActionGunShootEvent
+    events:
+    - !type:ActionGunShootEvent
     priority: 2
     checkCanAccess: false
     range: 0

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -267,7 +267,8 @@
   components:
   - type: InstantAction
     icon: Interface/Actions/manifest.png
-    event: !type:GuardianToggleActionEvent
+    events:
+    - !type:GuardianToggleActionEvent
     useDelay: 2
     checkCanInteract: false
     checkConsciousness: false

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -79,7 +79,8 @@
   - type: InstantAction
     icon: Interface/Actions/scream.png
     checkCanInteract: false
-    event: !type:BooActionEvent
+    events:
+    - !type:BooActionEvent
     startDelay: true
     useDelay: 120
 
@@ -92,7 +93,8 @@
     icon: Interface/VerbIcons/light.svg.192dpi.png
     clientExclusive: true
     checkCanInteract: false
-    event: !type:ToggleLightingActionEvent
+    events:
+    - !type:ToggleLightingActionEvent
 
 - type: entity
   id: ActionToggleFov
@@ -103,7 +105,8 @@
     icon: Interface/VerbIcons/vv.svg.192dpi.png
     clientExclusive: true
     checkCanInteract: false
-    event: !type:ToggleFoVActionEvent
+    events:
+    - !type:ToggleFoVActionEvent
 
 - type: entity
   id: ActionToggleGhosts
@@ -114,7 +117,8 @@
     icon: { sprite: Mobs/Ghosts/ghost_human.rsi, state: icon }
     clientExclusive: true
     checkCanInteract: false
-    event: !type:ToggleGhostsActionEvent
+    events:
+    - !type:ToggleGhostsActionEvent
 
 - type: entity
   id: ActionToggleGhostHearing
@@ -127,4 +131,5 @@
       sprite: Clothing/Ears/Headsets/base.rsi
       state: icon
     iconOn: Interface/Actions/ghostHearingToggled.png
-    event: !type:ToggleGhostHearingActionEvent
+    events:
+    - !type:ToggleGhostHearingActionEvent

--- a/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
@@ -12,7 +12,7 @@
       components:
       - Anchorable
       - Item
-      tags: 
+      tags:
       - Bot # for funny bot moments
     blacklist:
       components:
@@ -46,7 +46,8 @@
   - type: InstantAction
     icon: Interface/VerbIcons/refresh.svg.192dpi.png
     itemIconStyle: BigAction
-    event: !type:DisguiseToggleNoRotEvent
+    events:
+    - !type:DisguiseToggleNoRotEvent
 
 - type: entity
   id: ActionDisguiseAnchor
@@ -58,4 +59,5 @@
       sprite: Objects/Tools/wrench.rsi
       state: icon
     itemIconStyle: BigAction
-    event: !type:DisguiseToggleAnchoredEvent
+    events:
+    - !type:DisguiseToggleAnchoredEvent

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -164,5 +164,5 @@
       checkConsciousness: false
       icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
       events:
-    - !type:OpenUiActionEvent
+      - !type:OpenUiActionEvent
         key: enum.StationMapUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -150,7 +150,8 @@
     checkCanInteract: false
     checkConsciousness: false
     icon: Interface/Actions/pai-midi.png
-    event: !type:OpenUiActionEvent
+    events:
+    - !type:OpenUiActionEvent
       key: enum.InstrumentUiKey.Key
 
 - type: entity
@@ -162,5 +163,6 @@
       checkCanInteract: false
       checkConsciousness: false
       icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
-      event: !type:OpenUiActionEvent
+      events:
+    - !type:OpenUiActionEvent
         key: enum.StationMapUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -159,10 +159,10 @@
   name: Open Map
   description: Open your map interface and guide your owner.
   components:
-    - type: InstantAction
-      checkCanInteract: false
-      checkConsciousness: false
-      icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
-      events:
-      - !type:OpenUiActionEvent
-        key: enum.StationMapUiKey.Key
+  - type: InstantAction
+    checkCanInteract: false
+    checkConsciousness: false
+    icon: { sprite: Interface/Actions/pai-map.rsi, state: icon }
+    events:
+    - !type:OpenUiActionEvent
+      key: enum.StationMapUiKey.Key

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -90,5 +90,6 @@
   components:
   - type: InstantAction
     icon: { sprite: Clothing/Head/Hats/witch.rsi, state: icon }
-    event: !type:SummonActionEvent
+    events:
+    - !type:SummonActionEvent
     useDelay: 1

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -39,7 +39,8 @@
   - type: InstantAction
     itemIconStyle: BigAction
     useDelay: 0.5
-    event: !type:BorgModuleActionSelectedEvent
+    events:
+    - !type:BorgModuleActionSelectedEvent
 
 - type: entity
   id: BaseBorgModuleCargo

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -71,7 +71,8 @@
       sprite: Objects/Tanks/Jetpacks/blue.rsi
       state: icon-on
     useDelay: 1.0
-    event: !type:ToggleJetpackEvent
+    events:
+    - !type:ToggleJetpackEvent
 
 #Empty blue
 - type: entity

--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -9,7 +9,8 @@
     icon:
       sprite: Mobs/Ghosts/ghost_human.rsi
       state: icon
-    event: !type:ToggleGhostVisibilityToAllEvent
+    events:
+    - !type:ToggleGhostVisibilityToAllEvent
 
 # TODO: Add Whitelist/Blacklist and Component support to EntitySpawnLists (to avoid making huge hardcoded lists like below).
 
@@ -25,7 +26,8 @@
     icon:
       sprite: Objects/Weapons/Guns/Rifles/ak.rsi
       state: base
-    event: !type:RandomGlobalSpawnSpellEvent
+    events:
+    - !type:RandomGlobalSpawnSpellEvent
       spawns:
       - id: WeaponPistolViper
         orGroup: Guns
@@ -158,7 +160,7 @@
       - id: RevolverCapGunFake
         orGroup: Guns
       speech: action-speech-spell-summon-guns
-      
+
 - type: entity
   id: ActionSummonMagic
   name: Summon Magic
@@ -171,7 +173,8 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: magicmissile
-    event: !type:RandomGlobalSpawnSpellEvent
+    events:
+    - !type:RandomGlobalSpawnSpellEvent
       spawns:
       - id: SpawnSpellbook
         orGroup: Magics

--- a/Resources/Prototypes/Magic/forcewall_spells.yml
+++ b/Resources/Prototypes/Magic/forcewall_spells.yml
@@ -11,7 +11,8 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: shield
-    event: !type:InstantSpawnSpellEvent
+    events:
+    - !type:InstantSpawnSpellEvent
       prototype: WallForce
       posData: !type:TargetInFront
       speech: action-speech-spell-forcewall

--- a/Resources/Prototypes/Magic/knock_spell.yml
+++ b/Resources/Prototypes/Magic/knock_spell.yml
@@ -11,5 +11,6 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: knock
-    event: !type:KnockSpellEvent
+    events:
+    - !type:KnockSpellEvent
       speech: action-speech-spell-knock

--- a/Resources/Prototypes/Magic/mindswap_spell.yml
+++ b/Resources/Prototypes/Magic/mindswap_spell.yml
@@ -17,5 +17,6 @@
     icon:
       sprite: Mobs/Species/Human/organs.rsi
       state: brain
-    event: !type:MindSwapSpellEvent
+    events:
+    - !type:MindSwapSpellEvent
       speech: action-speech-spell-mind-swap

--- a/Resources/Prototypes/Magic/projectile_spells.yml
+++ b/Resources/Prototypes/Magic/projectile_spells.yml
@@ -15,7 +15,8 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: fireball
-    event: !type:ProjectileSpellEvent
+    events:
+    - !type:ProjectileSpellEvent
       prototype: ProjectileFireball
       speech: action-speech-spell-fireball
   - type: ActionUpgrade
@@ -41,7 +42,8 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: fireball
-    event: !type:ProjectileSpellEvent
+    events:
+    - !type:ProjectileSpellEvent
       prototype: ProjectileFireball
       speech: action-speech-spell-fireball
 
@@ -63,6 +65,7 @@
       icon:
         sprite: Objects/Magic/magicactions.rsi
         state: fireball
-      event: !type:ProjectileSpellEvent
+      events:
+      - !type:ProjectileSpellEvent
         prototype: ProjectileFireball
         speech: action-speech-spell-fireball

--- a/Resources/Prototypes/Magic/rune_spells.yml
+++ b/Resources/Prototypes/Magic/rune_spells.yml
@@ -9,7 +9,8 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: spell_default
-    event: !type:InstantSpawnSpellEvent
+    events:
+    - !type:InstantSpawnSpellEvent
       prototype: FlashRune
 
 - type: entity
@@ -23,7 +24,8 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: spell_default
-    event: !type:InstantSpawnSpellEvent
+    events:
+    - !type:InstantSpawnSpellEvent
       prototype: ExplosionRune
 
 - type: entity
@@ -37,7 +39,8 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: spell_default
-    event: !type:InstantSpawnSpellEvent
+    events:
+    - !type:InstantSpawnSpellEvent
       prototype: IgniteRune
 
 - type: entity
@@ -51,5 +54,6 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: spell_default
-    event: !type:InstantSpawnSpellEvent
+    events:
+    - !type:InstantSpawnSpellEvent
       prototype: StunRune

--- a/Resources/Prototypes/Magic/spawn_spells.yml
+++ b/Resources/Prototypes/Magic/spawn_spells.yml
@@ -10,7 +10,8 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: spell_default
-    event: !type:WorldSpawnSpellEvent
+    events:
+    - !type:WorldSpawnSpellEvent
       prototypes:
       - id: MobCarpMagic
         amount: 3

--- a/Resources/Prototypes/Magic/staves.yml
+++ b/Resources/Prototypes/Magic/staves.yml
@@ -39,6 +39,7 @@
     whitelist: { components: [ PointLight ] }
     charges: 25
     sound: /Audio/Magic/blink.ogg
-    event: !type:ChangeComponentsSpellEvent
+    events:
+    - !type:ChangeComponentsSpellEvent
       toAdd:
       - type: RgbLightController

--- a/Resources/Prototypes/Magic/teleport_spells.yml
+++ b/Resources/Prototypes/Magic/teleport_spells.yml
@@ -15,7 +15,8 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: blink
-    event: !type:TeleportSpellEvent
+    events:
+    - !type:TeleportSpellEvent
 
 # TODO: Second level upgrade sometime that allows swapping with all objects
 - type: entity
@@ -39,5 +40,6 @@
     icon:
       sprite: Objects/Magic/Eldritch/eldritch_actions.rsi
       state: voidblink
-    event: !type:VoidApplauseSpellEvent
+    events:
+    - !type:VoidApplauseSpellEvent
       effect: EffectVoidBlink

--- a/Resources/Prototypes/Magic/touch_spells.yml
+++ b/Resources/Prototypes/Magic/touch_spells.yml
@@ -16,7 +16,8 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: gib
-    event: !type:SmiteSpellEvent
+    events:
+    - !type:SmiteSpellEvent
       speech: action-speech-spell-smite
   - type: Magic
     requiresClothes: true
@@ -48,7 +49,8 @@
     icon:
       sprite: Clothing/Mask/cluwne.rsi
       state: icon
-    event: !type:ChangeComponentsSpellEvent
+    events:
+    - !type:ChangeComponentsSpellEvent
       speech: action-speech-spell-cluwne
       toAdd:
       - type: Cluwne
@@ -73,7 +75,8 @@
     icon:
       sprite: Objects/Specific/Janitorial/soap.rsi
       state: omega-4
-    event: !type:ChangeComponentsSpellEvent
+    events:
+    - !type:ChangeComponentsSpellEvent
       speech: action-speech-spell-slip
       toAdd:
       - type: Slippery

--- a/Resources/Prototypes/Magic/utility_spells.yml
+++ b/Resources/Prototypes/Magic/utility_spells.yml
@@ -9,6 +9,7 @@
     icon:
       sprite: Objects/Weapons/Guns/Basic/wands.rsi
       state: nothing
-    event: !type:ChargeSpellEvent
+    events:
+    - !type:ChargeSpellEvent
       charge: 1
       speech: DI'RI CEL!

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
@@ -96,7 +96,8 @@
         - to: machineFrame
           completed:
             - !type:RaiseEvent
-              event: !type:MachineDeconstructedEvent
+              events:
+    - !type:MachineDeconstructedEvent
               broadcast: false
           conditions:
             - !type:EntityAnchored

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
@@ -96,8 +96,7 @@
         - to: machineFrame
           completed:
             - !type:RaiseEvent
-              events:
-              - !type:MachineDeconstructedEvent
+              event: !type:MachineDeconstructedEvent
               broadcast: false
           conditions:
             - !type:EntityAnchored

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/machine.yml
@@ -97,7 +97,7 @@
           completed:
             - !type:RaiseEvent
               events:
-    - !type:MachineDeconstructedEvent
+              - !type:MachineDeconstructedEvent
               broadcast: false
           conditions:
             - !type:EntityAnchored

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -42,4 +42,5 @@
     icon:
       sprite: Structures/Walls/solid.rsi
       state: full
-    event: !type:InvisibleWallActionEvent
+    events:
+    - !type:InvisibleWallActionEvent

--- a/Resources/mapping_actions.yml
+++ b/Resources/mapping_actions.yml
@@ -6,7 +6,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: AlignTileAny
       tileId: Space
   assignments:
@@ -20,7 +21,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       eraser: True
   assignments:
   - 0: 9
@@ -33,7 +35,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: AlignTileAny
       tileId: Plating
   assignments:
@@ -48,7 +51,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: Grille
   assignments:
@@ -63,7 +67,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: WallSolid
   assignments:
@@ -78,7 +83,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: Window
   assignments:
@@ -93,7 +99,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: WallReinforced
   assignments:
@@ -108,7 +115,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: ReinforcedWindow
   assignments:
@@ -123,7 +131,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: Firelock
   assignments:
@@ -138,7 +147,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: GasPipeStraight
   assignments:
@@ -153,7 +163,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: GasPipeBend
   assignments:
@@ -168,7 +179,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: GasPipeTJunction
   assignments:
@@ -183,7 +195,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: GasPipeFourway
   assignments:
@@ -198,7 +211,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: GasVentScrubber
   assignments:
@@ -213,7 +227,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: GasVentPump
   assignments:
@@ -228,7 +243,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: AirAlarm
   assignments:
@@ -243,7 +259,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: FireAlarm
   assignments:
@@ -258,7 +275,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: APCBasic
   assignments:
@@ -273,7 +291,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: CableApcExtension
   assignments:
@@ -288,7 +307,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: CableMV
   assignments:
@@ -303,7 +323,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: CableHV
   assignments:
@@ -318,7 +339,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: SubstationBasic
   assignments:
@@ -333,7 +355,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: Poweredlight
   assignments:
@@ -348,7 +371,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: PlaceFree
       entityType: EmergencyLight
   assignments:
@@ -363,7 +387,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: SMESBasic
   assignments:
@@ -378,7 +403,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: TableWood
   assignments:
@@ -393,7 +419,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: Table
   assignments:
@@ -408,7 +435,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: ChairWood
   assignments:
@@ -423,7 +451,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: Chair
   assignments:
@@ -438,7 +467,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: ChairOfficeLight
   assignments:
@@ -453,7 +483,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: StoolBar
   assignments:
@@ -468,7 +499,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: Stool
   assignments:
@@ -483,7 +515,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: Rack
   assignments:
@@ -498,7 +531,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: ChairOfficeDark
   assignments:
@@ -513,7 +547,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: PlaceFree
       entityType: LampGold
   assignments:
@@ -528,7 +563,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: DisposalPipe
   assignments:
@@ -543,7 +579,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: DisposalBend
   assignments:
@@ -558,7 +595,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: DisposalJunction
   assignments:
@@ -573,7 +611,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: DisposalJunctionFlipped
   assignments:
@@ -588,7 +627,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: DisposalRouter
   assignments:
@@ -603,7 +643,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: DisposalRouterFlipped
   assignments:
@@ -618,7 +659,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: DisposalUnit
   assignments:
@@ -633,7 +675,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: DisposalTrunk
   assignments:
@@ -648,7 +691,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: SignDisposalSpace
   assignments:
@@ -663,7 +707,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: Windoor
   assignments:
@@ -678,7 +723,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: WindowDirectional
   assignments:
@@ -693,7 +739,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: WindowReinforcedDirectional
   assignments:
@@ -708,7 +755,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: PlasmaWindowDirectional
   assignments:
@@ -723,7 +771,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: Railing
   assignments:
@@ -738,7 +787,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: RailingCorner
   assignments:
@@ -753,7 +803,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: RailingCornerSmall
   assignments:
@@ -769,7 +820,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: RailingRound
   assignments:
@@ -783,7 +835,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: AirlockMaintLocked
   assignments:
@@ -798,7 +851,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: AirlockGlass
   assignments:
@@ -813,7 +867,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: AirlockServiceLocked
   assignments:
@@ -828,7 +883,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: AirlockSecurityLocked
   assignments:
@@ -843,7 +899,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: AirlockCommand
   assignments:
@@ -858,7 +915,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: AirlockScience
   assignments:
@@ -873,7 +931,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: AirlockMedical
   assignments:
@@ -888,7 +947,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: AirlockEngineering
   assignments:
@@ -903,7 +963,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: SnapgridCenter
       entityType: AirlockCargo
   assignments:
@@ -923,7 +984,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:PlaceDecalActionEvent
+    events:
+    - !type:PlaceDecalActionEvent
       snap: True
       color: '#EFB34196'
       decalId: BotLeft
@@ -944,7 +1006,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:PlaceDecalActionEvent
+    events:
+    - !type:PlaceDecalActionEvent
       snap: True
       color: '#EFB34196'
       decalId: Delivery
@@ -965,7 +1028,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:PlaceDecalActionEvent
+    events:
+    - !type:PlaceDecalActionEvent
       snap: True
       color: '#EFB34196'
       decalId: WarnFull
@@ -986,7 +1050,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:PlaceDecalActionEvent
+    events:
+    - !type:PlaceDecalActionEvent
       snap: True
       color: '#EFB34196'
       decalId: HalfTileOverlayGreyscale
@@ -1007,7 +1072,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:PlaceDecalActionEvent
+    events:
+    - !type:PlaceDecalActionEvent
       snap: True
       color: '#334E6DC8'
       decalId: HalfTileOverlayGreyscale
@@ -1028,7 +1094,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:PlaceDecalActionEvent
+    events:
+    - !type:PlaceDecalActionEvent
       snap: True
       color: '#52B4E996'
       decalId: HalfTileOverlayGreyscale
@@ -1049,7 +1116,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:PlaceDecalActionEvent
+    events:
+    - !type:PlaceDecalActionEvent
       snap: True
       color: '#9FED5896'
       decalId: HalfTileOverlayGreyscale
@@ -1070,7 +1138,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:PlaceDecalActionEvent
+    events:
+    - !type:PlaceDecalActionEvent
       snap: True
       color: '#DE3A3A96'
       decalId: HalfTileOverlayGreyscale
@@ -1091,7 +1160,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:PlaceDecalActionEvent
+    events:
+    - !type:PlaceDecalActionEvent
       snap: True
       color: '#D381C996'
       decalId: HalfTileOverlayGreyscale
@@ -1112,7 +1182,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:PlaceDecalActionEvent
+    events:
+    - !type:PlaceDecalActionEvent
       snap: True
       color: '#A4610696'
       decalId: HalfTileOverlayGreyscale
@@ -1127,7 +1198,8 @@
     clientExclusive: True
     autoPopulate: False
     temporary: True
-    event: !type:StartPlacementActionEvent
+    events:
+    - !type:StartPlacementActionEvent
       placementOption: AlignTileAny
       tileId: FloorSteel
   assignments:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made all actions accept a list of events rather than just a single event

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/34599

## Technical details
<!-- Summary of code changes for easier review. -->
The conversion from `xActionEvent` to `BaseEvent` was previously just done through `BaseEvent` => `Event`
Since it's now `List<xActionEvent>` to List<BaseEvent>, we do the conversion by creating a new empty `List<BaseEvent>`, add each `xActionEvent` one by one, and then return the filled `List<BaseEvent>`

Whenever the event was submitted for performAction(), the event submitted most often was the xActionEvent instead of the BaseEvent. It was implicitly converted from xActionEvent to BaseEvent. Now that it's a list, we can instead just submit the action's BaseEvents field, which does the convertion from `List<xActionEvent>` automatically.

Every yml action was updated from using a single event to a list of events. Nothing was optimized, it was just converted.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Display of actions working:

https://github.com/user-attachments/assets/1f3f59ac-77f8-4c00-8db4-1ef013f74bd1


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
BaseActionComponents's BaseActionEvent BaseEvent field was updated to `List<BaseActionEvent> BaseEvents`, and their specific Events, such as WorldTargetActionEvent for example, were converted to also be a list, such as `List<WorldTargetActionEvent> Events>`.

SharedActionSystems PerformAction()'s parameter `BaseActionEvent actionEvent` was updated to `List<BaseActionEvent> actionEvents`. You can typically submit the BaseEvents field whenever this is asked for.

To convert from a singular Event to a `List<BaseActionEvent>`, create a new `List<BaseActionEvent>()` and `.Add()` it as an item.

Update all yml actions from event to events, and make it a list.