### PR TITLE
give security tasers back

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -164,7 +164,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockSecTechFilled
-  cost: 2200
+  cost: 2215
   category: cargoproduct-category-name-security
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -7,6 +7,7 @@
     TearGasGrenade: 4
     ClusterBangFull: 2
     GrenadeStinger: 4
+    WeaponTaser: 2
     Flash: 5
     Tourniquet: 5
     FlashlightSeclite: 5

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -35,3 +35,4 @@
     - Flash
     - ForensicPad
     - ForensicScanner
+    - WeaponTaser

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -50,3 +50,4 @@
     back:
     - Flash
     - MagazinePistol
+    - WeaponTaser

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -39,3 +39,4 @@
     back:
     - Flash
     - MagazinePistol
+    - WeaponTaser

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -32,3 +32,4 @@
     back:
     - Flash
     - MagazinePistol
+    - WeaponTaser

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -35,3 +35,4 @@
     back:
     - Flash
     - MagazinePistol
+    - WeaponTaser


### PR DESCRIPTION
As it is now, antags are too easy to murderbone on. Admins ban murderboning antags. Security gets wiped routinely by traitors. This solves all of the above issues by letting security be powerful and forcing antags to have to be more careful/play better. 
I expect this pr to be a shitstorm so please be civil.

🆑 
- tweak: Security starts with tasers again.