### PR TITLE
Added the Ability to Cycle the Light Replacer.

### DIFF
--- a/Content.Shared/Light/Components/LightBulbComponent.cs
+++ b/Content.Shared/Light/Components/LightBulbComponent.cs
@@ -73,6 +73,12 @@ public sealed partial class LightBulbComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     public SoundSpecifier BreakSound = new SoundCollectionSpecifier("GlassBreak", AudioParams.Default.WithVolume(-6f));
 
+    /// <summary>
+    /// The sound produced when the lightbulb falls on the ground and doesn't break.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier DropSound = new SoundCollectionSpecifier("GlassCrack", AudioParams.Default.WithVolume(-6f));
+
     #region Appearance
 
     /// <summary>

--- a/Content.Shared/Light/Components/LightReplacerComponent.cs
+++ b/Content.Shared/Light/Components/LightReplacerComponent.cs
@@ -22,6 +22,9 @@ public sealed partial class LightReplacerComponent : Component
         }
     };
 
+    [DataField]
+    public SoundSpecifier CycleSound = new SoundPathSpecifier("/Audio/Weapons/Guns/Cock/smg_cock.ogg");
+
     /// <summary>
     /// Bulbs that were inserted inside light replacer
     /// </summary>

--- a/Resources/Locale/en-US/light/components/light-replacer-component.ftl
+++ b/Resources/Locale/en-US/light/components/light-replacer-component.ftl
@@ -21,3 +21,6 @@ comp-light-replacer-light-listing = {$amount ->
     [one] [color=yellow]{$amount}[/color] [color=gray]{$name}[/color]
     *[other] [color=yellow]{$amount}[/color] [color=gray]{$name}s[/color]
 }
+
+# Shown when the player successfully ejects a light from the light replacer
+comp-light-replacer-eject-light = You eject {INDEFINITE($bulb)} {$bulb} onto the floor.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

With many different lights that exist in the game, it can be a bit inconvenient to remove lights you don't want to use from the light replacer. Especially when you get a pack of colored lights, but only want to use regular ones, or are trying to single out the right lights for the job. 

This PR helps improve the experience of janitors everywhere by making it easy to remove lights from the light replacer, by dumping them on the floor.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

QoL mostly. 

## Technical details
<!-- Summary of code changes for easier review. -->

Added new sound specifiers to the light replacer and light bulb components.

In `LightReplacerComponent.cs`
```csharp
[DataField]
public SoundSpecifier CycleSound = new SoundPathSpecifier("/Audio/Weapons/Guns/Cock/smg_cock.ogg");
```

In `LightBulbComponent.cs`
```csharp
[DataField]
public SoundSpecifier DropSound = new SoundCollectionSpecifier("GlassCrack", AudioParams.Default.WithVolume(-6f));
```

---

Subscribed the `LightReplacerSystem` to the `UseInHandEvent` which when fired activates the new method `HandleUseInHand` which will attempt to eject a bulb onto the ground. 

---

Also added a new loc string for the eject action.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/f8a426c5-41ad-40e9-b9cc-52644784171d

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Southbridge
- add: Light Replacers can now be cycled to empty bulbs onto the floor.
