### PR TITLE
Swapped butter w/ olive oil for making spaghetti

### DIFF
--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -662,7 +662,6 @@
     Egg: 6
     OilOlive: 5
 
-
 - type: microwaveMealRecipe
   id: RecipePastaTomato
   name: pasta tomato recipe

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -660,8 +660,8 @@
   reagents:
     Flour: 15
     Egg: 6
-  solids:
-    FoodButter: 1
+    OilOlive: 5
+
 
 - type: microwaveMealRecipe
   id: RecipePastaTomato


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Swapped the butter in boiled spaghetti with olive oil

## Why / Balance
- IRL spaghetti making doesn't use butter at all - that's for egg noodles
- Olive oil in general is underutilized as a cooking ingredient

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Swapped the stick of butter with 5 u of olive oil in the boiled spaghetti recipe.

