### PR TITLE
Deathsquad revolver ammo fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -109,6 +109,18 @@
       path: /Audio/Weapons/Guns/Gunshots/mateba.ogg
 
 - type: entity
+  parent: WeaponRevolverMateba
+  id: WeaponRevolverMatebaAP # For deathsquad
+  suffix: armor-piercing
+  components:
+  - type: RevolverAmmoProvider
+    whitelist:
+      tags:
+        - CartridgeMagnum
+        - SpeedLoaderMagnum
+    proto: CartridgeMagnumAP
+
+- type: entity
   name: Python
   parent: [BaseWeaponRevolver, BaseSyndicateContraband]
   id: WeaponRevolverPython

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -114,7 +114,6 @@
   suffix: armor-piercing
   components:
   - type: RevolverAmmoProvider
-    whitelist:
     proto: CartridgeMagnumAP
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -115,9 +115,6 @@
   components:
   - type: RevolverAmmoProvider
     whitelist:
-      tags:
-        - CartridgeMagnum
-        - SpeedLoaderMagnum
     proto: CartridgeMagnumAP
 
 - type: entity

--- a/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
@@ -31,7 +31,7 @@
   storage:
     back:
     - WeaponPulsePistol
-    - WeaponRevolverMateba
+    - WeaponRevolverMatebaAP
     - SpeedLoaderMagnumAP
     - SpeedLoaderMagnumAP
     - BoxFlashbang


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a AP variant of the Mateba revolver which comes preloaded with AP (simular to the python) for deathsquad agents.

## Why / Balance
Deathsquad agents come with a extra two AP speedloaders, yet for some reason their revolver was loaded with standard rounds instead of AP rounds.

## Technical details
Added a child of WeaponRevolverMateba with AP rounds in it, and added the new WeaponRevolverMatebaAP to deathsquad's starting equipment.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Nox38
- fix: Deathsquad agents Matebas now come loaded with AP rounds.
