### PR TITLE
Fix references to obsolete TryGetContainingContainer override

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -126,7 +126,7 @@ namespace Content.Server.Explosion.EntitySystems
 
         private void HandleShockTrigger(Entity<ShockOnTriggerComponent> shockOnTrigger, ref TriggerEvent args)
         {
-            if (!_container.TryGetContainingContainer(shockOnTrigger, out var container))
+            if (!_container.TryGetContainingContainer(shockOnTrigger.Owner, out var container))
                 return;
 
             var containerEnt = container.Owner;

--- a/Content.Shared/Inventory/InventorySystem.Helpers.cs
+++ b/Content.Shared/Inventory/InventorySystem.Helpers.cs
@@ -40,7 +40,7 @@ public partial class InventorySystem
     /// </summary>
     public bool TryGetContainingSlot(Entity<TransformComponent?, MetaDataComponent?> entity, [NotNullWhen(true)] out SlotDefinition? slot)
     {
-        if (!_containerSystem.TryGetContainingContainer(entity.Owner, out var container, entity.Comp2, entity.Comp1))
+        if (!_containerSystem.TryGetContainingContainer(entity, out var container))
         {
             slot = null;
             return false;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed two calls to `TryGetContainingContainer` to be compatible with the `Entity<T>` override.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It decreases the number of compile warnings that we get spammed with when we compile.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed one call to explicitly use the `.Owner` for the previously used entity as it can be implicitly converted to the required `Entity<T>` and the entity it was already passing could not.
Changed the other call to pass the correct `Entity<T>` instead of passing the uid and components separately.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
