### PR TITLE
Guide Control Button Now Redirects Properly

### DIFF
--- a/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/Controls/Controls.xml
@@ -2,7 +2,7 @@
 # Controls
 
 <Box>You can change your keybinds at any time here:</Box>
-<Box Orientation="Vertical"><CommandButton Text="ui-options-tab-controls" Command="options 1"/></Box>
+<Box Orientation="Vertical"><CommandButton Text="ui-options-tab-controls" Command="options 2"/></Box>
 
 ## Movement
 You can move around the game world by using [color=yellow][bold][keybind="MoveUp"][keybind="MoveLeft"][keybind="MoveDown"][keybind="MoveRight"][/bold][/color].


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
**TL;DR:**
Guidebook Control Button never properly redirected to Controls, but instead to the settings menu 1 left of Controls.
This fixes that.

**Long Version:**
A minor bug that AFAIK hasn't been documented.

In the Guidebook if you go to the Controls section and then press the Controls button it doesn't link you directly to your Controls in the settings menu... Instead it links to a settings tab 1 left of your Controls in the settings! With this PR, it is now fixed.

Perhaps in a former version of the game "options 1" was the Controls menu, but now "options 2" is.

(Insanely game breaking and riveting I know.)

---

_[Note: This is a complete separate problem to the bug report I am making around the same time as this. Read them carefully.]_

## Why / Balance
Bugfix.

## Technical details
A single character has been changed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Control Button in Guidebook has been redirected to Controls properly