### PR TITLE
DNA scrambler examine fixes

### DIFF
--- a/Content.Server/IdentityManagement/IdentitySystem.cs
+++ b/Content.Server/IdentityManagement/IdentitySystem.cs
@@ -103,6 +103,8 @@ public sealed class IdentitySystem : SharedIdentitySystem
             // If presumed name is null and we're using that, we set proper noun to be false ("the old woman")
             if (name != representation.TrueName && representation.PresumedName == null)
                 identityGrammar.ProperNoun = false;
+
+            Dirty(ident, identityGrammar);
         }
 
         if (name == Name(ident))

--- a/Content.Server/Implants/SubdermalImplantSystem.cs
+++ b/Content.Server/Implants/SubdermalImplantSystem.cs
@@ -22,10 +22,10 @@ using System.Numerics;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Server.IdentityManagement;
+using Content.Server.DetailExaminable;
 using Content.Shared.Store.Components;
 using Robust.Shared.Collections;
 using Robust.Shared.Map.Components;
-using Content.Server.DetailExaminable;
 
 namespace Content.Server.Implants;
 

--- a/Content.Server/Implants/SubdermalImplantSystem.cs
+++ b/Content.Server/Implants/SubdermalImplantSystem.cs
@@ -25,6 +25,7 @@ using Content.Server.IdentityManagement;
 using Content.Shared.Store.Components;
 using Robust.Shared.Collections;
 using Robust.Shared.Map.Components;
+using Content.Server.DetailExaminable;
 
 namespace Content.Server.Implants;
 
@@ -225,6 +226,7 @@ public sealed class SubdermalImplantSystem : SharedSubdermalImplantSystem
             {
                 fingerprint.Fingerprint = _forensicsSystem.GenerateFingerprint();
             }
+            RemComp<DetailExaminableComponent>(ent); // remove MRP+ custom description if one exists 
             _identity.QueueIdentityUpdate(ent); // manually queue identity update since we don't raise the event
             _popup.PopupEntity(Loc.GetString("scramble-implant-activated-popup"), ent, ent);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes the following two bugs related to examining a player who has used a DNA scrambler:
- Custom character descriptions persisting after activating the implant
- Examine text briefly displaying the original identity's pronouns before being corrected by the server

Resolves #25025.

## Technical details
<!-- Summary of code changes for easier review. -->
Activating a DNA scrambler implant now removes the `DetailExaminableComponent` from the entity.

When updating an entity's identity, `IdentitySystem` now marks that entity's `GrammarComponent` as dirty, ensuring that the client's version is properly synced with the server.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Previous behavior (Note the examine text switching between "He" and "She"): 

https://github.com/user-attachments/assets/0790f5f5-69fd-4ef3-bafc-c10de5e2e6df

New behavior: 

https://github.com/user-attachments/assets/eae7138d-1d2b-42b1-9b1f-f5c921b07179




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Activating a DNA scrambler implant no longer retains the previous identity's description.

