### PR TITLE
Fix IDs without station records not being able to have nonstandard contents

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -174,7 +174,8 @@ namespace Content.Client.Access.UI
                                        new List<ProtoId<AccessLevelPrototype>>());
 
             var jobIndex = _jobPrototypeIds.IndexOf(state.TargetIdJobPrototype);
-            // If the job index is < 0 that means they don't have a job registered in the station records.
+            // If the job index is < 0 that means they don't have a job registered in the station records
+            // or the IdCardComponent's JobPrototype field.
             // For example, a new ID from a box would have no job index.
             if (jobIndex < 0)
             {

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -124,9 +124,7 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
 
         if (component.TargetIdSlot.Item is not { Valid: true } targetId || !PrivilegedIdIsAuthorized(uid, component))
             return;
-
-        var targetIdComponent = EntityManager.GetComponent<IdCardComponent>(targetId);
-
+        
         _idCard.TryChangeFullName(targetId, newFullName, player: player);
         _idCard.TryChangeJobTitle(targetId, newJobTitle, player: player);
 
@@ -140,10 +138,10 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         UpdateStationRecord(uid, targetId, newFullName, newJobTitle, job);
         if ((!TryComp<StationRecordKeyStorageComponent>(targetId, out var keyStorage)
             || keyStorage.Key is not { } key
-            || !_record.TryGetRecord<GeneralStationRecord>(key, out var record))
+            || !_record.TryGetRecord<GeneralStationRecord>(key, out _))
             && newJobProto != string.Empty)
         {
-            targetIdComponent.JobPrototype = newJobProto;
+            Comp<IdCardComponent>(targetId).JobPrototype = newJobProto;
         }
 
         if (!newAccessList.TrueForAll(x => component.AccessLevels.Contains(x)))

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -124,7 +124,7 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
 
         if (component.TargetIdSlot.Item is not { Valid: true } targetId || !PrivilegedIdIsAuthorized(uid, component))
             return;
-        
+
         _idCard.TryChangeFullName(targetId, newFullName, player: player);
         _idCard.TryChangeJobTitle(targetId, newJobTitle, player: player);
 

--- a/Content.Shared/Access/Components/IdCardComponent.cs
+++ b/Content.Shared/Access/Components/IdCardComponent.cs
@@ -37,6 +37,13 @@ public sealed partial class IdCardComponent : Component
     public ProtoId<JobIconPrototype> JobIcon = "JobIconUnknown";
 
     /// <summary>
+    /// Holds the job prototype when the ID card has no associated station record
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public ProtoId<AccessLevelPrototype>? JobPrototype;
+
+    /// <summary>
     /// The proto IDs of the departments associated with the job
     /// </summary>
     [DataField]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The ID card computer will now not reset to passenger constantly when editing an ID without an associated station record

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fixes #33738

## Technical details
<!-- Summary of code changes for easier review. -->
added a JobPrototype field to the IdCardComponent which is null when there's a valid station record for that card

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/1a594ab8-891d-411e-bb85-f9756336b0d5

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: CheesePlated
- fix: The ID card console now works properly when setting job presets for replacement IDs

