### PR TITLE
HOTFIX: fix minibomb implant and syndicats not exploding

### DIFF
--- a/Content.Server/Implants/ImplantedSystem.cs
+++ b/Content.Server/Implants/ImplantedSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Body.Components;
 using Content.Shared.Implants.Components;
+using Content.Shared.Storage;
 using Robust.Shared.Containers;
 
 namespace Content.Server.Implants;
@@ -13,21 +14,26 @@ public sealed partial class ImplanterSystem
         SubscribeLocalEvent<ImplantedComponent, BeingGibbedEvent>(OnGibbed);
     }
 
-    private void OnImplantedInit(EntityUid uid, ImplantedComponent component, ComponentInit args)
+    private void OnImplantedInit(Entity<ImplantedComponent> ent, ref ComponentInit args)
     {
-        component.ImplantContainer = _container.EnsureContainer<Container>(uid, ImplanterComponent.ImplantSlotId);
-        component.ImplantContainer.OccludesLight = false;
+        ent.Comp.ImplantContainer = _container.EnsureContainer<Container>(ent.Owner, ImplanterComponent.ImplantSlotId);
+        ent.Comp.ImplantContainer.OccludesLight = false;
     }
 
-    private void OnShutdown(EntityUid uid, ImplantedComponent component, ComponentShutdown args)
+    private void OnShutdown(Entity<ImplantedComponent> ent, ref ComponentShutdown args)
     {
         //If the entity is deleted, get rid of the implants
-        _container.CleanContainer(component.ImplantContainer);
+        _container.CleanContainer(ent.Comp.ImplantContainer);
     }
 
     private void OnGibbed(Entity<ImplantedComponent> ent, ref BeingGibbedEvent args)
     {
-        //If the entity is gibbed, get rid of the implants
-        _container.CleanContainer(ent.Comp.ImplantContainer);
+        // Drop the storage implant contents before the implants are deleted by the body being gibbed
+        foreach (var implant in ent.Comp.ImplantContainer.ContainedEntities)
+        {
+            if (TryComp<StorageComponent>(implant, out var storage))
+                _container.EmptyContainer(storage.Container, destination: Transform(ent).Coordinates);
+        }
+
     }
 }

--- a/Content.Shared/Implants/Components/ImplantedComponent.cs
+++ b/Content.Shared/Implants/Components/ImplantedComponent.cs
@@ -10,5 +10,6 @@ namespace Content.Shared.Implants.Components;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class ImplantedComponent : Component
 {
+    [ViewVariables(VVAccess.ReadOnly)]
     public Container ImplantContainer = default!;
 }


### PR DESCRIPTION
## About the PR
See title.

## Technical details
https://github.com/space-wizards/space-station-14/pull/33493 was a bugfix that intended to drop storage implant contents when being gibbed instead of deleting them. It did so by deleting all implants, which caused the implanter to drop its storage. However, this also caused the microbomb implant to be deleted before exploding because it first gibs the user.
We solve this by only emptying the storage implant on gibbing.
It is still deleted when the user's body is deleted.

Also added readonly VV access to the ImplantedComponent because that annoyed me every time I had to debug implants.
(probably should be a DataField, but that is out of scope)

## Media

https://github.com/user-attachments/assets/d16b0ed7-58e1-4345-80d1-ccaf8307fec7

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed microbomb implants and syndiecats not exploding.
