### PR TITLE
Chameleon vests now act like winter coats

### DIFF
--- a/Content.Shared/Armor/ArmorComponent.cs
+++ b/Content.Shared/Armor/ArmorComponent.cs
@@ -22,6 +22,12 @@ public sealed partial class ArmorComponent : Component
     /// </summary>
     [DataField]
     public float PriceMultiplier = 1;
+
+    /// <summary>
+    /// If true, you can examine the armor to see the protection. If false, the verb won't appear.
+    /// </summary>
+    [DataField]
+    public bool ShowArmorOnExamine = true;
 }
 
 /// <summary>

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -37,7 +37,7 @@ public abstract class SharedArmorSystem : EntitySystem
 
     private void OnArmorVerbExamine(EntityUid uid, ArmorComponent component, GetVerbsEvent<ExamineVerb> args)
     {
-        if (!args.CanInteract || !args.CanAccess)
+        if (!args.CanInteract || !args.CanAccess || !component.ShowArmorOnExamine)
             return;
 
         var examineMarkup = GetArmorExamine(component.Modifiers);

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/specific.yml
@@ -18,3 +18,12 @@
       interfaces:
         enum.ChameleonUiKey.Key:
           type: ChameleonBoundUserInterface
+    - type: TemperatureProtection # Same as a basic winter coat.
+      heatingCoefficient: 1.1
+      coolingCoefficient: 0.1
+    - type: Armor
+      modifiers:
+        coefficients:
+          Slash: 0.95
+          Heat: 0.90
+      showArmorOnExamine: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title! I gave chameleon vests the same stats as winter coats. They now protect you from the cold, and you get hot slightly faster. I also gave them the minor protection (10% heat, 5% slash) protection.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Chameleon clothing isn't used much in general, and on certain maps (Glacier for example but that's Delta), not having the cold protection is actually really annoying.

## Technical details
<!-- Summary of code changes for easier review. -->
I mostly just added a new field to the armor component. I didn't use events because of how the armor component works (I'd have to change the event and also think how I'd want it to interact with explosion resistance). I think this is probably the cleanest solution :thinking:

I'm also not 100% sure I should do it this way or parent from the original winter coat. I'd need to rearrange a few things but maybe its worth it?

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2843ce59-e0e0-474c-86e1-212965aa4625

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Chameleon vests now have the same stats as winter coats (Cold protection, minor heat increase, 5% slash resistance, 10% heat resistance)

