### PR TITLE
Purges uses of TransformComponent.Coordinates.set

### DIFF
--- a/Content.Server/Construction/Completions/SnapToGrid.cs
+++ b/Content.Server/Construction/Completions/SnapToGrid.cs
@@ -1,7 +1,6 @@
 using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Construction;
 using JetBrains.Annotations;
-using Robust.Shared.Map;
 
 namespace Content.Server.Construction.Completions
 {
@@ -14,13 +13,9 @@ namespace Content.Server.Construction.Completions
         public void PerformAction(EntityUid uid, EntityUid? userUid, IEntityManager entityManager)
         {
             var transform = entityManager.GetComponent<TransformComponent>(uid);
-            var transformSystem = entityManager.System<SharedTransformSystem>();
 
             if (!transform.Anchored)
-            {
-                var mapSystem = entityManager.System<SharedMapSystem>();
-                transformSystem.SetCoordinates(uid, transform, mapSystem.AlignToGrid(transform.Coordinates));
-            }
+                entityManager.System<SharedTransformSystem>().SetCoordinates(uid, transform.Coordinates.SnapToGrid(entityManager));
 
             if (SouthRotation)
             {


### PR DESCRIPTION
Moves over all uses of the setter to use SharedTransformSystem.SetCoordinates instead

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This switches over all uses of `TransformComponent.Coordinates.set` to use `SharedTransformSystem.SetCoordinates` instead.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Part of the slot ECSification of `TransformComponent`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->