### PR TITLE
Purge uses of TransformComponent.AttachToGridOrMap

### DIFF
--- a/Content.Server/Administration/Commands/WarpCommand.cs
+++ b/Content.Server/Administration/Commands/WarpCommand.cs
@@ -118,8 +118,9 @@ namespace Content.Server.Administration.Commands
                 }
 
                 var xform = _entManager.GetComponent<TransformComponent>(playerEntity);
+                var xformSystem = _entManager.System<SharedTransformSystem>();
                 xform.Coordinates = coords;
-                xform.AttachToGridOrMap();
+                xformSystem.AttachToGridOrMap(playerEntity, xform);
                 if (_entManager.TryGetComponent(playerEntity, out PhysicsComponent? physics))
                 {
                     _entManager.System<SharedPhysicsSystem>().SetLinearVelocity(playerEntity, Vector2.Zero, body: physics);

--- a/Content.Server/Construction/ConstructionSystem.Graph.cs
+++ b/Content.Server/Construction/ConstructionSystem.Graph.cs
@@ -304,8 +304,8 @@ namespace Content.Server.Construction
                 return null;
 
             // [Optional] Exit if the new entity's prototype is a parent of the original
-            // E.g., if an entity with the 'AirlockCommand' prototype was to be replaced with a new entity that 
-            // had the 'Airlock' prototype, and DoNotReplaceInheritingEntities was true, the code block would 
+            // E.g., if an entity with the 'AirlockCommand' prototype was to be replaced with a new entity that
+            // had the 'Airlock' prototype, and DoNotReplaceInheritingEntities was true, the code block would
             // exit here because 'AirlockCommand' is derived from 'Airlock'
             if (GetCurrentNode(uid, construction)?.DoNotReplaceInheritingEntities == true &&
                 metaData.EntityPrototype?.ID != null)
@@ -362,7 +362,7 @@ namespace Content.Server.Construction
 
             // Transform transferring.
             var newTransform = Transform(newUid);
-            newTransform.AttachToGridOrMap(); // in case in hands or a container
+            TransformSystem.AttachToGridOrMap(newUid, newTransform); // in case in hands or a container
             newTransform.LocalRotation = transform.LocalRotation;
             newTransform.Anchored = transform.Anchored;
 

--- a/Content.Shared/Construction/SharedConstructionSystem.cs
+++ b/Content.Shared/Construction/SharedConstructionSystem.cs
@@ -10,6 +10,7 @@ namespace Content.Shared.Construction
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] protected readonly IPrototypeManager PrototypeManager = default!;
+        [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
 
         /// <summary>
         ///     Get predicate for construction obstruction checks.

--- a/Content.Shared/Containers/ContainerFillSystem.cs
+++ b/Content.Shared/Containers/ContainerFillSystem.cs
@@ -40,7 +40,7 @@ public sealed class ContainerFillSystem : EntitySystem
                 if (!_containerSystem.Insert(ent, container, containerXform: xform))
                 {
                     Log.Error($"Entity {ToPrettyString(uid)} with a {nameof(ContainerFillComponent)} failed to insert an entity: {ToPrettyString(ent)}.");
-                    Transform(ent).AttachToGridOrMap();
+                    _transform.AttachToGridOrMap(ent);
                     break;
                 }
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed a couple obsolete `TransformComponent` method calls.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
ECSification of `TransformComponent`

## Technical details
<!-- Summary of code changes for easier review. -->
Switches over all extant uses of `TransformComponent.AttachToGridOrMap` to use `SharedTransformSystem.AttachToGridOrMap` instead.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->