### PR TITLE
Purges the one remaining use of TransformComponent.WorldPosition in content.

### DIFF
--- a/Content.Client/UserInterface/Systems/Viewport/ViewportUIController.cs
+++ b/Content.Client/UserInterface/Systems/Viewport/ViewportUIController.cs
@@ -16,7 +16,7 @@ public sealed class ViewportUIController : UIController
     [Dependency] private readonly IPlayerManager _playerMan = default!;
     [Dependency] private readonly IEntityManager _entMan = default!;
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
-    [UISystemDependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [UISystemDependency] private readonly SharedTransformSystem? _transformSystem = default!;
     public static readonly Vector2i ViewportSize = (EyeManager.PixelsPerMeter * 21, EyeManager.PixelsPerMeter * 15);
     public const int ViewportHeight = 15;
     private MainViewport? Viewport => UIManager.ActiveScreen?.GetWidget<MainViewport>();
@@ -95,7 +95,7 @@ public sealed class ViewportUIController : UIController
         _entMan.TryGetComponent(ent, out EyeComponent? eye);
 
         if (eye?.Eye == _eyeManager.CurrentEye
-            && _transformSystem.GetWorldPosition(ent.Value) == default)
+            && (_transformSystem is null || _transformSystem.GetWorldPosition(ent.Value) == default))
             return; // nothing to worry about, the player is just in null space... actually that is probably a problem?
 
         // Currently, this shouldn't happen. This likely happened because the main eye was set to null. When this

--- a/Content.Client/UserInterface/Systems/Viewport/ViewportUIController.cs
+++ b/Content.Client/UserInterface/Systems/Viewport/ViewportUIController.cs
@@ -3,6 +3,7 @@ using Content.Client.UserInterface.Systems.Gameplay;
 using Content.Shared.CCVar;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
+using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controllers;
 using Robust.Shared.Configuration;
 using Robust.Shared.Timing;
@@ -15,6 +16,7 @@ public sealed class ViewportUIController : UIController
     [Dependency] private readonly IPlayerManager _playerMan = default!;
     [Dependency] private readonly IEntityManager _entMan = default!;
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+    [UISystemDependency] private readonly SharedTransformSystem _transformSystem = default!;
     public static readonly Vector2i ViewportSize = (EyeManager.PixelsPerMeter * 21, EyeManager.PixelsPerMeter * 15);
     public const int ViewportHeight = 15;
     private MainViewport? Viewport => UIManager.ActiveScreen?.GetWidget<MainViewport>();
@@ -93,7 +95,7 @@ public sealed class ViewportUIController : UIController
         _entMan.TryGetComponent(ent, out EyeComponent? eye);
 
         if (eye?.Eye == _eyeManager.CurrentEye
-            && _entMan.GetComponent<TransformComponent>(ent.Value).WorldPosition == default)
+            && _transformSystem.GetWorldPosition(ent.Value) == default)
             return; // nothing to worry about, the player is just in null space... actually that is probably a problem?
 
         // Currently, this shouldn't happen. This likely happened because the main eye was set to null. When this


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
See title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
ECSing TransformComponent

## Technical details
<!-- Summary of code changes for easier review. -->
`TransformComponent.WorldPosition` -> `SharedTransformSystem.GetWorldPosition`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->