### PR TITLE
Purges uses of TransformComponent.WorldMatrix and TransformComponent.InvWorldMatrix

### DIFF
--- a/Content.Client/Maps/GridDraggingSystem.cs
+++ b/Content.Client/Maps/GridDraggingSystem.cs
@@ -102,7 +102,7 @@ public sealed class GridDraggingSystem : SharedGridDraggingSystem
             if (!_mapManager.TryFindGridAt(mousePos, out var gridUid, out var grid))
                 return;
 
-            StartDragging(gridUid, Vector2.Transform(mousePos.Position, Transform(gridUid).InvWorldMatrix));
+            StartDragging(gridUid, Vector2.Transform(mousePos.Position, _transformSystem.GetInvWorldMatrix(gridUid)));
         }
 
         if (!TryComp(_dragging, out TransformComponent? xform))

--- a/Content.Client/Maps/GridDraggingSystem.cs
+++ b/Content.Client/Maps/GridDraggingSystem.cs
@@ -117,7 +117,7 @@ public sealed class GridDraggingSystem : SharedGridDraggingSystem
             return;
         }
 
-        var localToWorld = Vector2.Transform(_localPosition, xform.WorldMatrix);
+        var localToWorld = Vector2.Transform(_localPosition, _transformSystem.GetWorldMatrix(xform));
 
         if (localToWorld.EqualsApprox(mousePos.Position, 0.01f)) return;
 

--- a/Content.Client/Shuttles/Systems/ShuttleSystem.EmergencyConsole.cs
+++ b/Content.Client/Shuttles/Systems/ShuttleSystem.EmergencyConsole.cs
@@ -23,7 +23,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
 
             if (_enableShuttlePosition)
             {
-                _overlay = new EmergencyShuttleOverlay(EntityManager);
+                _overlay = new EmergencyShuttleOverlay(EntityManager.TransformQuery, XformSystem);
                 overlayManager.AddOverlay(_overlay);
                 RaiseNetworkEvent(new EmergencyShuttleRequestPositionMessage());
             }
@@ -57,23 +57,26 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
 /// </summary>
 public sealed class EmergencyShuttleOverlay : Overlay
 {
-    private IEntityManager _entManager;
+    private readonly EntityQuery<TransformComponent> _transformQuery;
+    private readonly SharedTransformSystem _transformSystem;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
     public EntityUid? StationUid;
     public Box2? Position;
 
-    public EmergencyShuttleOverlay(IEntityManager entManager)
+    public EmergencyShuttleOverlay(EntityQuery<TransformComponent> transformQuery, SharedTransformSystem transformSystem)
     {
-        _entManager = entManager;
+        _transformQuery = transformQuery;
+        _transformSystem = transformSystem;
     }
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (Position == null || !_entManager.TryGetComponent<TransformComponent>(StationUid, out var xform)) return;
+        if (Position == null || !_transformQuery.TryGetComponent(StationUid, out var xform))
+            return;
 
-        args.WorldHandle.SetTransform(xform.WorldMatrix);
+        args.WorldHandle.SetTransform(_transformSystem.GetWorldMatrix(xform));
         args.WorldHandle.DrawRect(Position.Value, Color.Red.WithAlpha(100));
         args.WorldHandle.SetTransform(Matrix3x2.Identity);
     }

--- a/Content.Server/Explosion/EntitySystems/ExplosionGridTileFlood.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionGridTileFlood.cs
@@ -69,13 +69,15 @@ public sealed class ExplosionGridTileFlood : ExplosionTileFlood
             return;
 
         _needToTransform = true;
-        var transform = IoCManager.Resolve<IEntityManager>().GetComponent<TransformComponent>(Grid.Owner);
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var transformSystem = entityManager.System<SharedTransformSystem>();
+        var transform = entityManager.GetComponent<TransformComponent>(Grid.Owner);
         var size = (float) Grid.TileSize;
 
         _matrix.M31 = size / 2;
         _matrix.M32 = size / 2;
         Matrix3x2.Invert(spaceMatrix, out var invSpace);
-        _matrix *= transform.WorldMatrix * invSpace;
+        _matrix *= transformSystem.GetWorldMatrix(transform) * invSpace;
         var relativeAngle = transform.WorldRotation - spaceAngle;
         _offset = relativeAngle.RotateVec(new Vector2(size / 4, size / 4));
     }

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs
@@ -72,7 +72,7 @@ public sealed partial class ExplosionSystem
             var targetGrid = Comp<MapGridComponent>(referenceGrid.Value);
             var xform = Transform(referenceGrid.Value);
             targetAngle = xform.WorldRotation;
-            targetMatrix = xform.InvWorldMatrix;
+            targetMatrix = _transformSystem.GetInvWorldMatrix(xform);
             tileSize = targetGrid.TileSize;
         }
 

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.TileFill.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.TileFill.cs
@@ -89,7 +89,7 @@ public sealed partial class ExplosionSystem
         if (referenceGrid != null)
         {
             var xform = Transform(Comp<MapGridComponent>(referenceGrid.Value).Owner);
-            spaceMatrix = xform.WorldMatrix;
+            spaceMatrix = _transformSystem.GetWorldMatrix(xform);
             spaceAngle = xform.WorldRotation;
         }
 

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -423,7 +423,7 @@ namespace Content.Server.GameTicking
                 {
                     var gridXform = Transform(gridUid);
 
-                    return new EntityCoordinates(gridUid, Vector2.Transform(toMap.Position, gridXform.InvWorldMatrix));
+                    return new EntityCoordinates(gridUid, Vector2.Transform(toMap.Position, _transform.GetInvWorldMatrix(gridXform)));
                 }
 
                 return spawn;

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Distance.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Distance.cs
@@ -36,7 +36,7 @@ public sealed partial class PathfindingSystem
                 return Vector2.Zero;
             }
 
-            endPos = Vector2.Transform(Vector2.Transform(endPos, _transform.GetWorldMatrix(endXform)), startXform.InvWorldMatrix);
+            endPos = Vector2.Transform(Vector2.Transform(endPos, _transform.GetWorldMatrix(endXform)), _transform.GetInvWorldMatrix(startXform));
         }
 
         // TODO: Numerics when we changeover.

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Distance.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Distance.cs
@@ -36,7 +36,7 @@ public sealed partial class PathfindingSystem
                 return Vector2.Zero;
             }
 
-            endPos = Vector2.Transform(Vector2.Transform(endPos, endXform.WorldMatrix), startXform.InvWorldMatrix);
+            endPos = Vector2.Transform(Vector2.Transform(endPos, _transform.GetWorldMatrix(endXform)), startXform.InvWorldMatrix);
         }
 
         // TODO: Numerics when we changeover.

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.cs
@@ -405,7 +405,7 @@ namespace Content.Server.NPC.Pathfinding
                 return null;
             }
 
-            var localPos = Vector2.Transform(coordinates.ToMapPos(EntityManager, _transform), xform.InvWorldMatrix);
+            var localPos = Vector2.Transform(coordinates.ToMapPos(EntityManager, _transform), _transform.GetInvWorldMatrix(xform));
             var origin = GetOrigin(localPos);
 
             if (!TryGetChunk(origin, comp, out var chunk))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
See technical changes

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
TransformComponent ECSing

## Technical details
<!-- Summary of code changes for easier review. -->
`TransformComponent.WorldMatrix` -> `SharedTransformSystem.GetWorldMatrix`
`TransformComponent.InvWorldMatrix` -> `SharedTransformSystem.GetInvWorldMatrix`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->