### PR TITLE
Hotfix: Hristov wielding delay

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/GunRequiresWieldComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunRequiresWieldComponent.cs
@@ -18,4 +18,10 @@ public sealed partial class GunRequiresWieldComponent : Component
 
     [DataField]
     public LocId? WieldRequiresExamineMessage  = "gunrequireswield-component-examine";
+
+    [DataField, AutoNetworkedField]
+    public float WieldDelay;
+
+    [DataField]
+    public LocId? WieldDelayExamineMessage  = "gunrequireswield-component-delay-examine";
 }

--- a/Content.Shared/Weapons/Ranged/Components/GunRequiresWieldComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunRequiresWieldComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class GunRequiresWieldComponent : Component
     public LocId? WieldRequiresExamineMessage  = "gunrequireswield-component-examine";
 
     [DataField, AutoNetworkedField]
-    public float WieldDelay;
+    public TimeSpan WieldDelay;
 
     [DataField]
     public LocId? WieldDelayExamineMessage  = "gunrequireswield-component-delay-examine";

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -113,55 +113,9 @@ public abstract partial class SharedGunSystem
 
     private void OnGunSelected(EntityUid uid, GunComponent component, HandSelectedEvent args)
     {
-        if (Timing.ApplyingState)
-             return;
-
-        if (component.FireRateModified <= 0)
-            return;
-
-        var fireDelay = 1f / component.FireRateModified;
-        if (fireDelay.Equals(0f))
-            return;
-
         if (!component.ResetOnHandSelected)
             return;
 
-        if (Paused(uid))
-            return;
-
-        // If someone swaps to this weapon then reset its cd.
-        var curTime = Timing.CurTime;
-        var minimum = curTime + TimeSpan.FromSeconds(fireDelay);
-
-        if (minimum < component.NextFire)
-            return;
-
-        component.NextFire = minimum;
-        Dirty(uid, component);
-    }
-
-    private void OnGunWielded(Entity<GunComponent> ent, ref ItemWieldedEvent args)
-    {
-        if (!TryComp<GunRequiresWieldComponent>(ent, out var gunReqWield))
-            return;
-
-        if (Timing.ApplyingState)
-            return;
-
-        if (ent.Comp.FireRateModified <= 0)
-            return;
-
-        if (Paused(ent.Owner))
-            return;
-
-        // If someone swaps to this weapon then reset its cd.
-        var curTime = Timing.CurTime;
-        var minimum = curTime + gunReqWield.WieldDelay;
-
-        if (minimum < ent.Comp.NextFire)
-            return;
-
-        ent.Comp.NextFire = minimum;
-        Dirty(ent);
+        AddFireDelay(uid, TimeSpan.FromSeconds(1f / component.FireRateModified));
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -115,6 +115,9 @@ public abstract partial class SharedGunSystem
         if (!component.ResetOnHandSelected)
             return;
 
+        if (component.FireRateModified <= 0)
+            return;
+
         AddFireDelay(uid, TimeSpan.FromSeconds(1f / component.FireRateModified));
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -3,7 +3,6 @@ using Content.Shared.Examine;
 using Content.Shared.Hands;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
-using Content.Shared.Wieldable;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Weapons.Ranged.Systems;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -142,26 +142,26 @@ public abstract partial class SharedGunSystem
 
     private void OnGunWielded(Entity<GunComponent> ent, ref ItemWieldedEvent args)
     {
-        if (TryComp<GunRequiresWieldComponent>(ent, out var gunReqWield))
-        {
-            if (Timing.ApplyingState)
-                return;
+        if (!TryComp<GunRequiresWieldComponent>(ent, out var gunReqWield))
+            return;
 
-            if (ent.Comp.FireRateModified <= 0)
-                return;
+        if (Timing.ApplyingState)
+            return;
 
-            if (Paused(ent.Owner))
-                return;
+        if (ent.Comp.FireRateModified <= 0)
+            return;
 
-            // If someone swaps to this weapon then reset its cd.
-            var curTime = Timing.CurTime;
-            var minimum = curTime + TimeSpan.FromSeconds(gunReqWield.WieldDelay);
+        if (Paused(ent.Owner))
+            return;
 
-            if (minimum < ent.Comp.NextFire)
-                return;
+        // If someone swaps to this weapon then reset its cd.
+        var curTime = Timing.CurTime;
+        var minimum = curTime + gunReqWield.WieldDelay;
 
-            ent.Comp.NextFire = minimum;
-            Dirty(ent);
-        }
+        if (minimum < ent.Comp.NextFire)
+            return;
+
+        ent.Comp.NextFire = minimum;
+        Dirty(ent);
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Whitelist;
+using Content.Shared.Wieldable;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
@@ -96,6 +97,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         SubscribeLocalEvent<GunComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<GunComponent, CycleModeEvent>(OnCycleMode);
         SubscribeLocalEvent<GunComponent, HandSelectedEvent>(OnGunSelected);
+        SubscribeLocalEvent<GunComponent, ItemWieldedEvent>(OnGunWielded);
         SubscribeLocalEvent<GunComponent, MapInitEvent>(OnMapInit);
     }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -97,7 +97,6 @@ public abstract partial class SharedGunSystem : EntitySystem
         SubscribeLocalEvent<GunComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<GunComponent, CycleModeEvent>(OnCycleMode);
         SubscribeLocalEvent<GunComponent, HandSelectedEvent>(OnGunSelected);
-        SubscribeLocalEvent<GunComponent, ItemWieldedEvent>(OnGunWielded);
         SubscribeLocalEvent<GunComponent, MapInitEvent>(OnMapInit);
     }
 
@@ -522,6 +521,29 @@ public abstract partial class SharedGunSystem : EntitySystem
         const float impulseStrength = 25.0f;
         var impulseVector =  shotDirection * impulseStrength;
         Physics.ApplyLinearImpulse(user, -impulseVector, body: userPhysics);
+    }
+
+    public void AddFireDelay(Entity<GunComponent?> ent, TimeSpan addedDelay)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return;
+
+        if (Timing.ApplyingState)
+            return;
+
+        if (ent.Comp.FireRateModified <= 0)
+            return;
+
+        if (Paused(ent.Owner))
+            return;
+
+        var minimum = Timing.CurTime + addedDelay;
+
+        if (minimum < ent.Comp.NextFire)
+            return;
+
+        ent.Comp.NextFire = minimum;
+        Dirty(ent);
     }
 
     public void RefreshModifiers(Entity<GunComponent?> gun)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -531,9 +531,6 @@ public abstract partial class SharedGunSystem : EntitySystem
         if (Timing.ApplyingState)
             return;
 
-        if (ent.Comp.FireRateModified <= 0)
-            return;
-
         if (Paused(ent.Owner))
             return;
 

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -56,6 +56,7 @@ public abstract class SharedWieldableSystem : EntitySystem
         SubscribeLocalEvent<MeleeRequiresWieldComponent, AttemptMeleeEvent>(OnMeleeAttempt);
         SubscribeLocalEvent<GunRequiresWieldComponent, ExaminedEvent>(OnExamineRequires);
         SubscribeLocalEvent<GunRequiresWieldComponent, ShotAttemptedEvent>(OnShootAttempt);
+        SubscribeLocalEvent<GunRequiresWieldComponent, ItemWieldedEvent>(OnRequiresGunWielded);
         SubscribeLocalEvent<GunWieldBonusComponent, ItemWieldedEvent>(OnGunWielded);
         SubscribeLocalEvent<GunWieldBonusComponent, ItemUnwieldedEvent>(OnGunUnwielded);
         SubscribeLocalEvent<GunWieldBonusComponent, GunRefreshModifiersEvent>(OnGunRefreshModifiers);
@@ -104,6 +105,11 @@ public abstract class SharedWieldableSystem : EntitySystem
     private void OnGunWielded(EntityUid uid, GunWieldBonusComponent component, ref ItemWieldedEvent args)
     {
         _gun.RefreshModifiers(uid);
+    }
+
+    private void OnRequiresGunWielded(EntityUid uid, GunRequiresWieldComponent component, ref ItemWieldedEvent args)
+    {
+        _gun.AddFireDelay(uid, component.WieldDelay);
     }
 
     private void OnDeselectWieldable(EntityUid uid, WieldableComponent component, HandDeselectedEvent args)

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -40,6 +40,8 @@ public abstract class SharedWieldableSystem : EntitySystem
     [Dependency] private readonly SharedVirtualItemSystem _virtualItem = default!;
     [Dependency] private readonly UseDelaySystem _delay = default!;
 
+    protected const string GunWieldDelayExamineColor = "yellow";
+
     public override void Initialize()
     {
         base.Initialize();
@@ -148,6 +150,9 @@ public abstract class SharedWieldableSystem : EntitySystem
     {
         if (entity.Comp.WieldRequiresExamineMessage != null)
             args.PushText(Loc.GetString(entity.Comp.WieldRequiresExamineMessage));
+
+        if (entity.Comp.WieldDelay > 0 && entity.Comp.WieldDelayExamineMessage != null)
+            args.PushMarkup(Loc.GetString(entity.Comp.WieldDelayExamineMessage, ("color", GunWieldDelayExamineColor), ("delay", entity.Comp.WieldDelay)));
     }
 
     private void OnExamine(EntityUid uid, GunWieldBonusComponent component, ref ExaminedEvent args)

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -151,8 +151,8 @@ public abstract class SharedWieldableSystem : EntitySystem
         if (entity.Comp.WieldRequiresExamineMessage != null)
             args.PushText(Loc.GetString(entity.Comp.WieldRequiresExamineMessage));
 
-        if (entity.Comp.WieldDelay > 0 && entity.Comp.WieldDelayExamineMessage != null)
-            args.PushMarkup(Loc.GetString(entity.Comp.WieldDelayExamineMessage, ("color", GunWieldDelayExamineColor), ("delay", entity.Comp.WieldDelay)));
+        if (entity.Comp.WieldDelay > TimeSpan.Zero && entity.Comp.WieldDelayExamineMessage != null)
+            args.PushMarkup(Loc.GetString(entity.Comp.WieldDelayExamineMessage, ("color", GunWieldDelayExamineColor), ("delay", entity.Comp.WieldDelay.TotalSeconds)));
     }
 
     private void OnExamine(EntityUid uid, GunWieldBonusComponent component, ref ExaminedEvent args)

--- a/Resources/Locale/en-US/wieldable/wieldable-component.ftl
+++ b/Resources/Locale/en-US/wieldable/wieldable-component.ftl
@@ -20,3 +20,7 @@ wieldable-component-requires = { CAPITALIZE(THE($item))} must be wielded!
 gunwieldbonus-component-examine = This weapon has improved accuracy when wielded.
 
 gunrequireswield-component-examine = This weapon can only be fired when wielded.
+
+gunrequireswield-component-delay-examine = This weapon has a [color={$color}]{ $delay }[/color] second firing delay upon wielding.
+
+

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -58,6 +58,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
   - type: GunRequiresWield
+    wieldDelay: 2.5
   - type: Gun
     fireRate: 0.4
     selectedMode: SemiAuto


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR fixes a missing mechanic with the Hristov; upon wielding the gun, there should be a delay before being able to shoot. It was assumed this was already the case during testing, but as it turns out the delay that was observed was caused by making the gun hand the active hand, which triggered a firing delay. By holding the gun in your active hand but not wielding you could bypass the delay.

Also provides this delay in the examine text.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Hristov is intended to require setup and punishing if you miss. Being able to instantly wield and fire makes the weapon busted.

This delay is optional and as such, no other gun is affected.

## Technical details
<!-- Summary of code changes for easier review. -->

GunRequiresWieldComponent now has a delay property, which when set causes that delay upon wield (unless a longer cooldown is active).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed bug with Hristov being able to fire instantly upon wielding.
