### PR TITLE
Double bullet speeds

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -417,7 +417,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         EntityUid? user = null,
         bool throwItems = false);
 
-    public void ShootProjectile(EntityUid uid, Vector2 direction, Vector2 gunVelocity, EntityUid gunUid, EntityUid? user = null, float speed = 20f)
+    public void ShootProjectile(EntityUid uid, Vector2 direction, Vector2 gunVelocity, EntityUid gunUid, EntityUid? user = null, float speed = 40f)
     {
         var physics = EnsureComp<PhysicsComponent>(uid);
         Physics.SetBodyStatus(uid, physics, BodyStatus.InAir);

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -42,7 +42,7 @@
       projectile:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.1,-0.1,0.1,0.1"
+          bounds: "-0.1,-0.10,0.1,0.30"
         hard: false
         mask:
         - Impassable


### PR DESCRIPTION
The only reason we had it at 20m/s was tunneling reasons.

The quick maths is (BodyA size + BodyB size) / frametime. Currently the game is doing substepping AFAIK so we can use 0.016 as the frametime therefore with a 0.40 width body we can get up to 40.625 (assuming the target is no narrower than 0.25 which given my thindows change last year should be a decently safe assumption).

Draft because I need to adjust the other values and want to put them all in the one spot.

:cl:
- tweak: Doubled bullet speeds.