### PR TITLE
Fix winter coats turning you to ash

### DIFF
--- a/Content.Server/Temperature/Components/TemperatureProtectionComponent.cs
+++ b/Content.Server/Temperature/Components/TemperatureProtectionComponent.cs
@@ -13,10 +13,34 @@ public sealed partial class TemperatureProtectionComponent : Component
     public float HeatingCoefficient = 1.0f;
 
     /// <summary>
+    ///     If the temperature is above this value, the heating coefficient will not be applied.
+    /// </summary>
+    [DataField]
+    public float? HeatingCoefficientMaxTemp;
+
+    /// <summary>
+    ///     If the temperature is below this value, the heating coefficient will not be applied.
+    /// </summary>
+    [DataField]
+    public float? HeatingCoefficientMinTemp;
+
+    /// <summary>
     ///     Multiplier for the transferred heat when cooling down
     /// </summary>
     [DataField]
     public float CoolingCoefficient = 1.0f;
+
+    /// <summary>
+    ///     If the temperature is above this value, the cooling coefficient will not be applied.
+    /// </summary>
+    [DataField]
+    public float? CoolingCoefficientMaxTemp;
+
+    /// <summary>
+    ///     If the temperature is below this value, the cooling coefficient will not be applied.
+    /// </summary>
+    [DataField]
+    public float? CoolingCoefficientMinTemp;
 }
 
 /// <summary>

--- a/Content.Shared/Temperature/TemperatureEvents.cs
+++ b/Content.Shared/Temperature/TemperatureEvents.cs
@@ -6,11 +6,14 @@ public sealed class ModifyChangedTemperatureEvent : EntityEventArgs, IInventoryR
 {
     public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
 
+    public readonly float CurrentTemperature;
+
     public float TemperatureDelta;
 
-    public ModifyChangedTemperatureEvent(float temperature)
+    public ModifyChangedTemperatureEvent(float temperatureDelta, float currentTemperature)
     {
-        TemperatureDelta = temperature;
+        TemperatureDelta = temperatureDelta;
+        CurrentTemperature = currentTemperature;
     }
 }
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -10,7 +10,9 @@
     sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
   - type: TemperatureProtection
     heatingCoefficient: 1.1
+    heatingCoefficientMaxTemp: 330
     coolingCoefficient: 0.1
+    coolingCoefficientMaxTemp: 330
   - type: Item
     size: Normal
   - type: Armor

--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -70,4 +70,6 @@
   components:
   - type: TemperatureProtection
     heatingCoefficient: 1.025
+    heatingCoefficientMaxTemp: 325
     coolingCoefficient: 0.5
+    coolingCoefficientMaxTemp: 325


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes #33596! There are a few ways I could have approached this, but I think this is the simplest solution. I added a maximum and minimum values for the heating coefficients, this means if you are super heated (E.g 600K) you will cool down like normal instead of 10x slower until you hit the upper limit. There are probably a few other clothing items that need this but I'm not sure what they are and what their values should be.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Winter coats will now not turn you to ash at extremely high temperatures.