### PR TITLE
Proposal for new PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,17 +11,16 @@
 This will not affect game balance.
 
 ## Technical details
-<!-- Summarize what code you changed, if any. This will speed up your review time. -->
+<!-- High level technical details that would help reviewers understand the code changes you made. Explain the strategy of your changes and how they work at a high level. Required for all but the most blindingly obvious changes. -->
 
 ## Media
-<!-- Attach media if the PR makes changes that affect the in-game experience, such as new clothing, items, features, or important bug fixes.
-Use screenshots or recorded videos as appropriate. Small fixes and refactors are exempt. Media may be used in progress reports with credit. -->
+<!-- Attach screenshots or screen recordings demonstrating that new features or fixes work as intended according to the test steps (see below).
+Media attached here may also be used in progress reports with credit. -->
 
 ## Requirements
 <!-- Confirm the following by placing an X in the brackets [X]: -->
 - [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
-- [ ] I have added media to this PR or it does not require an ingame showcase.
-- [ ] I have added test steps to this PR, or it does not require testing.
+- [ ] I have added test steps to this PR, or sufficient testing is shown in media.
 <!-- IMPORTANT: Not following the above will get your PR closed at the discretion of the maintainers. -->
 
 ## Breaking changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,11 +29,10 @@ Use screenshots or recorded videos as appropriate. Small fixes and refactors are
 This will be posted in #codebase-changes. -->
 
 ## Test steps
-<!-- Write some test steps that prove your PR works as intended. This will speed up your review time. An example is included below -->
-1. Open the game and load into the Dev station
-2. Use the entity spawn window to spawn Ian
-3. Pet Ian
-4. You should hear Ian bark and little love hearts appear
+<!-- Write some test steps that prove your PR works as intended. The first step is assumed to be "Load the Dev station" unless stated otherwise. This will speed up your review time. An example is included below -->
+1. Use the entity spawn window to spawn Ian
+2. Pet Ian
+3. You should hear Ian bark and little love hearts appear
 
 **Change log**
 <!-- Add a change log entry to make players aware of new features or changes that could affect gameplay.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,36 +1,65 @@
 <!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
 
 ## About the PR
-<!-- What did you change? -->
+<!-- Summarize what you changed here. -->
 
-## Why / Balance
-<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
+## Reason for change
+<!-- Explain why it was changed. Link any relevant discussions or issues. -->
+
+## Effect on game alance
+<!-- Explain how this will affect game balance. -->
+This will not affect game balance.
 
 ## Technical details
-<!-- Summary of code changes for easier review. -->
+<!-- Summarize what code you changed, if any. This will speed up your review time. -->
 
 ## Media
-<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
-Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
+<!-- Attach media if the PR makes changes that affect the in-game experience, such as new clothing, items, features, or important bug fixes.
+Use screenshots or recorded videos as appropriate. Small fixes and refactors are exempt. Media may be used in progress reports with credit. -->
 
 ## Requirements
 <!-- Confirm the following by placing an X in the brackets [X]: -->
 - [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
 - [ ] I have added media to this PR or it does not require an ingame showcase.
-<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
+- [ ] I have added test steps to this PR, or it does not require testing.
+<!-- IMPORTANT: Not following the above will get your PR closed at the discretion of the maintainers. -->
 
 ## Breaking changes
 <!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
 This will be posted in #codebase-changes. -->
 
-**Changelog**
-<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
-Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
-Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
+## Test steps
+<!-- Write some test steps that prove your PR works as intended. This will speed up your review time. An example is included below -->
+1. Open the game and load into the Dev station
+2. Use the entity spawn window to spawn Ian
+3. Pet Ian
+4. You should hear Ian bark and little love hearts appear
+
+**Change log**
+<!-- Add a change log entry to make players aware of new features or changes that could affect gameplay.
+Make sure to read the guidelines. Your change log must have a :cl: symbol, so our bot recognizes the changes
+and adds them to the game's change log. An example change log is below.
+-->
 <!--
 :cl:
-- add: Added fun!
-- remove: Removed fun!
-- tweak: Changed fun!
-- fix: Fixed fun!
+- add: Candy bowls can now be found near waiting lines.
+- remove: The syndicate headset has been removed from the uplink.
+- tweak: The detective’s revolver now contains cap bullets instead of lethals.
+- fix: Fixed reflected projectiles dealing stamina damage unintentionally.
+ADMIN:
+- add: Candy bowls can now be found near waiting lines.
+- remove: The syndicate headset has been removed from the uplink.
+- tweak: The detective’s revolver now contains cap bullets instead of lethals.
+- fix: Fixed reflected projectiles dealing stamina damage unintentionally.
 -->
+
+:cl:
+- add:
+- remove:
+- tweak:
+- fix:
+ADMIN:
+- add:
+- remove:
+- tweak:
+- fix

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 ## Reason for change
 <!-- Explain why it was changed. Link any relevant discussions or issues. -->
 
-## Effect on game alance
+## Effect on game balance
 <!-- Explain how this will affect game balance. -->
 This will not affect game balance.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,7 +50,7 @@ ADMIN:
 - add: Candy bowls can now be found near waiting lines.
 - remove: The syndicate headset has been removed from the uplink.
 - tweak: The detective’s revolver now contains cap bullets instead of lethals.
-- fix: Fixed reflected projectiles dealing stamina damage unintentionally.
+- fix:  Reflected projectiles no longer deal stamina damage unintentionally.
 -->
 
 :cl:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the PR template to add a section requiring test steps to be added to aid testing by maintainers. This avoids maintainers being unable to correctly test a PR, or - worse - avoiding testing a PR due to percieved difficulty. This also means that historic PRs will begin to build a library of test steps that can be referred to, helping prevent knowledge loss.

## Why / Balance
It can be challenging for a contributor, triager or maintainer to know where to begin when reviewing a PR. This extends review times and causes reviews to become stale. In addition, creates a mandated proof-of-work check that proves that a PR submitter understands what they have changed and can replicate it at will. This will increase their time testing their own code, and obvious bugs can be caught more often before reviewing begins.

## Technical details
None. This is just a change to a single markdown file.

This was inspired by @Errant-4's comments on the Maintainers channel yesterday, and I'm probably scooping a PR they want to make (sorry!)

## Media
Just check the MD file to see the changes. Github happily makes this easy.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nope.

**Changelog**
Nope.
