### PR TITLE
Make pressure damage respect species damage modifiers

### DIFF
--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -237,7 +237,7 @@ namespace Content.Server.Atmos.EntitySystems
                 if (pressure <= Atmospherics.HazardLowPressure)
                 {
                     // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false);
+                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false, damageable, alwaysApplyBaseDamageModifier: true);
 
                     if (!barotrauma.TakingDamage)
                     {
@@ -252,7 +252,7 @@ namespace Content.Server.Atmos.EntitySystems
                     var damageScale = MathF.Min(((pressure / Atmospherics.HazardHighPressure) - 1) * Atmospherics.PressureDamageCoefficient, Atmospherics.MaxHighPressureDamage);
 
                     // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale, true, false);
+                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale, true, false, damageable, alwaysApplyBaseDamageModifier: true);
 
                     if (!barotrauma.TakingDamage)
                     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Make species damage resistances (innate damage resistances for species, e.g. blunt resistance for dionas/slimes) apply to pressure damage, without applying armor/etc. damage resistances

## Why / Balance
This is a bug.

## Technical details
Adds new bool, alwaysApplyBaseDamageModifier to TryChangeDamage() of DamageableSystem. if true, base damage modifiers (the ones applied by ApplyModifierSet, like those of species, not the ones applied by armor etc.) will ignore the ignoreResistances bool; TLDR lets you apply damage onto something with it's inherent damage modifiers while still ignoring other damage modifiers such as armor (see video if you didnt understand). Yes, this can be used for more than just pressure damage

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fix barotrauma damage not respecting 