### PR TITLE
Add new freezer atmos devices and fix freezer fixgridatmos marker

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
@@ -61,8 +61,8 @@ public sealed partial class AtmosphereSystem
        mixtures[5].Temperature = 5000f;
 
        // 6: (Walk-In) Freezer
-       mixtures[6].AdjustMoles(Gas.Oxygen, Atmospherics.OxygenMolesStandard);
-       mixtures[6].AdjustMoles(Gas.Nitrogen, Atmospherics.NitrogenMolesStandard);
+       mixtures[6].AdjustMoles(Gas.Oxygen, Atmospherics.OxygenMolesFreezer);
+       mixtures[6].AdjustMoles(Gas.Nitrogen, Atmospherics.NitrogenMolesFreezer);
        mixtures[6].Temperature = 235f; // Little colder than an actual freezer but gives a grace period to get e.g. themomachines set up, should keep warm for a few door openings
 
        // 7: Nitrogen (101kpa) for vox rooms

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -41,6 +41,12 @@ namespace Content.Shared.Atmos
         public const float T20C = 293.15f;
 
         /// <summary>
+        ///     -38.15ºC in K.
+        ///     This is used to initialize roundstart freezer rooms.
+        /// </summary>
+        public const float FreezerTemp = 235f;
+
+        /// <summary>
         ///     Do not allow any gas mixture temperatures to exceed this number. It is occasionally possible
         ///     to have very small heat capacity (e.g. room that was just unspaced) and for large amounts of
         ///     energy to be transferred to it, even for a brief moment. However, this messes up subsequent
@@ -66,6 +72,12 @@ namespace Content.Shared.Atmos
         public const float MolesCellStandard = (OneAtmosphere * CellVolume / (T20C * R));
 
         /// <summary>
+        ///     Moles in a 2.5 m^3 cell at 101.325 kPa and -38.15ºC.
+        ///     This is used in fix atmos freezer markers to ensure the air is at the correct atmospheric pressure while still being cold.
+        /// </summary>
+        public const float MolesCellFreezer = (OneAtmosphere * CellVolume / (FreezerTemp * R));
+
+        /// <summary>
         ///     Moles in a 2.5 m^3 cell at GasMinerDefaultMaxExternalPressure kPa and 20ºC
         /// </summary>
         public const float MolesCellGasMiner = (GasMinerDefaultMaxExternalPressure * CellVolume / (T20C * R));
@@ -80,6 +92,9 @@ namespace Content.Shared.Atmos
 
         public const float OxygenMolesStandard = MolesCellStandard * OxygenStandard;
         public const float NitrogenMolesStandard = MolesCellStandard * NitrogenStandard;
+
+        public const float OxygenMolesFreezer = MolesCellFreezer * OxygenStandard;
+        public const float NitrogenMolesFreezer = MolesCellFreezer * NitrogenStandard;
 
         #endregion
 

--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -114,3 +114,14 @@
     threshold: 0.8 # danger below 80% nitrogen
   lowerWarnAround: !type:AlarmThresholdSetting
     threshold: 1.125 # warning below 90%
+
+- type: alarmThreshold
+  id: freezerTemperature
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 335.15 # T-38.15C (235) + 100
+  lowerBound: !type:AlarmThresholdSetting
+    threshold: 135.15 # T-38.15C (235) - 100
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.8
+  lowerWarnAround: !type:AlarmThresholdSetting
+    threshold: 1.1

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/freezer.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/freezer.yml
@@ -1,0 +1,29 @@
+﻿- type: entity
+  abstract: true
+  parent: AirSensorBase
+  id: AirSensorFreezerBase
+  suffix: Freezer Atmosphere
+  components:
+  - type: AtmosMonitor
+    temperatureThresholdId: freezerTemperature
+
+- type: entity
+  parent: [AirSensorFreezerBase, AirSensor]
+  id: AirSensorFreezer
+
+- type: entity
+  parent: [AirSensorFreezerBase, GasVentPump]
+  id: GasVentPumpFreezer
+
+- type: entity
+  parent: [AirSensorFreezerBase, GasVentScrubber]
+  id: GasVentScrubberFreezer
+
+# air alarm proto with auto: false to prevent the automatic switching of modes overriding the default values
+- type: entity
+  parent: AirAlarm
+  id: AirAlarmFreezer
+  suffix: Freezer Atmosphere, auto mode disabled
+  components:
+  - type: AirAlarm
+    autoMode: false


### PR DESCRIPTION
## About the PR
Adds new Freezer atmos devices for mapping. These devices have their sensors tuned to the roundstart environment of a freezer, with auto mode off. The solution is similar to that employed by custom Vox alarms that are no longer used.

Fixes the Freezer FixGridAtmos marker to properly pressurize freezer rooms. Previously they were only at 80 kPa due to their molar amounts not being adjusted to a colder environment. Freezers now start at 101.325 kPa at their desired temp.

Maps will need to have FixGridAtmos reran in order for the changes to take effect when this PR is merged.

## Why / Balance
Commonly mappers map atmospheric devices into freezers with a connected air alarm. This air alarm will commonly scream at you over the atmospheric alerts computer, because the freezer is not within a safe temperature.

## Technical details
Added new threshold, freezerTemperature.
Added new freezer.yml file for holding all of our custom atmos devices with their changed sensor values.

Added new float, FreezerTemp.
Added new float, MolesCellFreezer for determining how many moles we need for a colder room (we'll need more than standard because the room is colder).
Added new floats, OxygenMolesFreezer and NitrogenMolsFreezer, for usage in FixGridAtmos.
Adjusted mixtures[6].AdjustMoles to include new OxygenMolsFreezer and NitrogenMolsFreezer.

## Media
![image](https://github.com/user-attachments/assets/d75bdf8d-c563-47db-a80e-c5daa0520fe6)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
This unfortunately can't get a CL right now because the player-facing changes haven't been made yet.