### PR TITLE
Wizard Fix - Rod Polymorph - Prevent gibbing & slows speed

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -66,7 +66,6 @@
   suffix: Wizard
   components:
   - type: ImmovableRod
-    minSpeed: 25
     maxSpeed: 25
     destroyTiles: false
     randomizeVelocity: false

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -66,13 +66,14 @@
   suffix: Wizard
   components:
   - type: ImmovableRod
-    minSpeed: 35
+    minSpeed: 25
+    maxSpeed: 25
     destroyTiles: false
     randomizeVelocity: false
     shouldGib: false
     damage:
       types:
-        Blunt: 200
+        Blunt: 190
   - type: MovementIgnoreGravity
     gravityState: true
   - type: InputMover


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Reduced the damage Wizard Rod does from 200 to 190 so it doesn't auto gib players, but will still kill them.
Max Speed capped at 25 so they don't go TOO far.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Mass dying is fine, gibbing is not. Use Smite if you want to gib.
Slight speed adjustment so you don't go extremely far.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/35a5c278-311e-4c39-8a42-5a98b5059eb3

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
