### PR TITLE
Add screens to oasis evac shuttle

### DIFF
--- a/Resources/Maps/Shuttles/emergency_accordia.yml
+++ b/Resources/Maps/Shuttles/emergency_accordia.yml
@@ -67,10 +67,10 @@ entities:
     - type: Fixtures
       fixtures: {}
     - type: DeviceNetwork
+      deviceNetId: Wireless
       configurators: []
       deviceLists: []
       transmitFrequencyId: ShuttleTimer
-      deviceNetId: Wireless
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
@@ -5175,11 +5175,10 @@ entities:
       parent: 1
 - proto: PosterLegitVacation
   entities:
-  - uid: 912
+  - uid: 1017
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-22.5
+      pos: 4.5,-25.5
       parent: 1
 - proto: PosterLegitWorkForAFuture
   entities:
@@ -5649,6 +5648,53 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-17.5
+      parent: 1
+- proto: Screen
+  entities:
+  - uid: 912
+    components:
+    - type: Transform
+      pos: 4.5,-22.5
+      parent: 1
+  - uid: 1011
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 1012
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 1013
+    components:
+    - type: Transform
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 1014
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 1015
+    components:
+    - type: Transform
+      pos: -4.5,-20.5
+      parent: 1
+  - uid: 1016
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 1
+  - uid: 1018
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 1019
+    components:
+    - type: Transform
+      pos: 5.5,13.5
       parent: 1
 - proto: ShotGunCabinetFilled
   entities:


### PR DESCRIPTION
## About the PR
Adds screens to oasis evac shuttle, that way people know when evac is about to leave. Like all other shuttles.

Fixes #31278 

I didn't save it as a map (godo)

## Why / Balance
Simple fix. Parity with other shuttles.

## Media
![image](https://github.com/user-attachments/assets/1bb69203-e678-45fc-984f-4f8925899e26)

![image](https://github.com/user-attachments/assets/325a5800-c69c-417b-9d64-d715dc6baa8b)
![image](https://github.com/user-attachments/assets/7107cdcb-d048-45a0-9afc-ff322743c07a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no cl no fun