### PR TITLE
Fixed rotating anchored shuttle consoles

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -112,8 +112,6 @@
     radius: 1.5
     energy: 1.6
     color: "#43ccb5"
-  - type: Rotatable
-    rotateWhileAnchored: true
 
 - type: entity
   parent: BaseComputer
@@ -138,8 +136,6 @@
     radius: 1.5
     energy: 1.6
     color: "#43ccb5"
-  - type: Rotatable
-    rotateWhileAnchored: true
   - type: ItemSlots
     slots:
       disk_slot:


### PR DESCRIPTION
## About the PR
As stated in the title, this PR fixes #34885 

## Why / Balance
Shuttle consoles should not be able to be rotated when anchored.

## Technical details
Just removed the component `Rotatable` from the .yml for `ComputerEmergencyShuttle` and `BaseComputerShuttle`

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A (or that I know of)

**Changelog**
:cl:
- fix: Anchored shuttle console will no longer rotate.
