### PR TITLE
add mass scanner to the utility belt whilelist

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -44,6 +44,7 @@
         - TrayScanner
         - GasAnalyzer
         - HandLabeler
+        - RadarConsole
   - type: ItemMapper
     mapLayers:
       drill:


### PR DESCRIPTION
## About the PR
Added RadarConcole component to the utility whitelist.

## Why / Balance
Salvage gameplay.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Handheld mass scanner now fits in utility belt
