### PR TITLE
Prevents the NewsReader PDA app from wrapping around

### DIFF
--- a/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
@@ -18,8 +18,17 @@ public sealed partial class NewsReaderUiFragment : BoxContainer
     {
         RobustXamlLoader.Load(this);
 
-        Next.OnPressed += _ => OnNextButtonPressed?.Invoke();
-        Prev.OnPressed += _ => OnPrevButtonPressed?.Invoke();
+        Next.OnPressed += _ =>
+        {
+            Next.Disabled = true;
+            OnNextButtonPressed?.Invoke();
+        };
+
+        Prev.OnPressed += _ =>
+        {
+            Prev.Disabled = true;
+            OnPrevButtonPressed?.Invoke();
+        };
         NotificationSwitch.OnPressed += _ => OnNotificationSwithPressed?.Invoke();
     }
 


### PR DESCRIPTION
## About the PR
This PR prevents the NewsReader PDA app from wrapping around when you quickly spam the "Next" or "Prev" buttons. When either button is clicked, it is immediately disabled until the UI can update, so additional clicks won’t sneak through in that brief window. Fixes #33283 

## Why / Balance
It fixes a frustrating bug where mashing the navigation buttons could skip past the boundaries (first/last entry).

## Technical details
- Added immediate disabling of the “Next” and “Prev” buttons in their click handlers.
- The buttons are re-enabled (or left disabled) when `UpdateState` is called, based on the current page number.

## Media
No new media is needed; it’s a straightforward UI fix.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- fix: The NewsReader PDA app no longer wraps around news entries when rapidly clicking Next/Prev.
