### PR TITLE
Remove batong etc from emagged autolathe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -133,7 +133,6 @@
   - type: EmagLatheRecipes
     emagStaticPacks:
     - SecurityAmmoStatic
-    - SecurityWeaponsStatic
   - type: BlueprintReceiver
     whitelist:
       tags:


### PR DESCRIPTION
## About the PR
removed batong, flash, knife, riot shield from emag autolathe

## Why / Balance
slarticodefast wanted it

**Changelog**
not real