### PR TITLE
Create a Armor CoeffientQuery

### DIFF
--- a/Content.Shared/Armor/ArmorComponent.cs
+++ b/Content.Shared/Armor/ArmorComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Damage;
+using Content.Shared.Inventory;
 using Robust.Shared.GameStates;
 using Robust.Shared.Utility;
 
@@ -30,3 +31,24 @@ public sealed partial class ArmorComponent : Component
 /// <param name="Msg"></param>
 [ByRefEvent]
 public record struct ArmorExamineEvent(FormattedMessage Msg);
+
+/// <summary>
+/// A Relayed inventory event, gets the total Armor for all Inventory slots defined by the Slotflags in TargetSlots
+/// </summary>
+public sealed class CoefficientQueryEvent : EntityEventArgs, IInventoryRelayEvent
+{
+    /// <summary>
+    /// All slots to relay too
+    /// </summary>
+    public SlotFlags TargetSlots { get; set; }
+
+    /// <summary>
+    /// The Total of all Coefficients.
+    /// </summary>
+    public DamageModifierSet DamageModifiers { get; set; } = new DamageModifierSet();
+
+    public CoefficientQueryEvent(SlotFlags slots)
+    {
+        TargetSlots = slots;
+    }
+}

--- a/Content.Shared/Armor/ArmorComponent.cs
+++ b/Content.Shared/Armor/ArmorComponent.cs
@@ -38,7 +38,7 @@ public record struct ArmorExamineEvent(FormattedMessage Msg);
 public sealed class CoefficientQueryEvent : EntityEventArgs, IInventoryRelayEvent
 {
     /// <summary>
-    /// All slots to relay too
+    /// All slots to relay to
     /// </summary>
     public SlotFlags TargetSlots { get; set; }
 

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -19,7 +19,7 @@ public abstract class SharedArmorSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<ArmorComponent, InventoryRelayedEvent<CoeffientQueryEvent>>(OnCoeffientQuery);
+        SubscribeLocalEvent<ArmorComponent, InventoryRelayedEvent<CoefficientQueryEvent>>(OnCoefficientQuery);
         SubscribeLocalEvent<ArmorComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnDamageModify);
         SubscribeLocalEvent<ArmorComponent, BorgModuleRelayedEvent<DamageModifyEvent>>(OnBorgDamageModify);
         SubscribeLocalEvent<ArmorComponent, GetVerbsEvent<ExamineVerb>>(OnArmorVerbExamine);
@@ -28,13 +28,13 @@ public abstract class SharedArmorSystem : EntitySystem
     /// <summary>
     /// Get the total Damage reduction value of all equipment caught by the relay.
     /// </summary>
-    /// <param name="ent"></param>
-    /// <param name="args"></param>
-    private void OnCoeffientQuery(Entity<ArmorComponent> ent, ref InventoryRelayedEvent<CoeffientQueryEvent> args)
+    /// <param name="ent">The item that's being relayed too</param>
+    /// <param name="args">the Event, contains the running count of armor percentage as a coefficient</param>
+    private void OnCoefficientQuery(Entity<ArmorComponent> ent, ref InventoryRelayedEvent<CoefficientQueryEvent> args)
     {
-        foreach (var a in ent.Comp.Modifiers.Coefficients)
+        foreach (var armorCoefficient in ent.Comp.Modifiers.Coefficients)
         {
-            args.Args.DamageModifiers.Coefficients[a.Key] = args.Args.DamageModifiers.Coefficients.TryGetValue(a.Key, out var coefficient) ? coefficient * a.Value : a.Value;
+            args.Args.DamageModifiers.Coefficients[armorCoefficient.Key] = args.Args.DamageModifiers.Coefficients.TryGetValue(armorCoefficient.Key, out var coefficient) ? coefficient * armorCoefficient.Value : armorCoefficient.Value;
         }
     }
 
@@ -95,15 +95,4 @@ public abstract class SharedArmorSystem : EntitySystem
     }
 }
 
-public sealed class CoeffientQueryEvent : EntityEventArgs, IInventoryRelayEvent
-{
-    public SlotFlags TargetSlots { get; set; }
 
-    public DamageModifierSet DamageModifiers { get; set; } = new DamageModifierSet();
-
-    public CoeffientQueryEvent(SlotFlags slots)
-    {
-        TargetSlots = slots;
-
-    }
-}

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -28,8 +28,8 @@ public abstract class SharedArmorSystem : EntitySystem
     /// <summary>
     /// Get the total Damage reduction value of all equipment caught by the relay.
     /// </summary>
-    /// <param name="ent">The item that's being relayed too</param>
-    /// <param name="args">the Event, contains the running count of armor percentage as a coefficient</param>
+    /// <param name="ent">The item that's being relayed to</param>
+    /// <param name="args">The event, contains the running count of armor percentage as a coefficient</param>
     private void OnCoefficientQuery(Entity<ArmorComponent> ent, ref InventoryRelayedEvent<CoefficientQueryEvent> args)
     {
         foreach (var armorCoefficient in ent.Comp.Modifiers.Coefficients)

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -94,5 +94,3 @@ public abstract class SharedArmorSystem : EntitySystem
         return msg;
     }
 }
-
-

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -41,7 +41,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, TargetBeforeHyposprayInjectsEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, SelfBeforeGunShotEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, SelfBeforeClimbEvent>(RelayInventoryEvent);
-        SubscribeLocalEvent<InventoryComponent, CoeffientQueryEvent>(RelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, CoefficientQueryEvent>(RelayInventoryEvent);
 
         // by-ref events
         SubscribeLocalEvent<InventoryComponent, GetExplosionResistanceEvent>(RefRelayInventoryEvent);

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Armor;
 using Content.Shared.Chat;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Hypospray.Events;
@@ -40,6 +41,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, TargetBeforeHyposprayInjectsEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, SelfBeforeGunShotEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, SelfBeforeClimbEvent>(RelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, CoeffientQueryEvent>(RelayInventoryEvent);
 
         // by-ref events
         SubscribeLocalEvent<InventoryComponent, GetExplosionResistanceEvent>(RefRelayInventoryEvent);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a Relay Event for ArmorSystems to query a set of Equipment slots and get the total applied Armor.

Atomizing #34002 which requires this to check `OuterClothing` for protection against devour per the [Documentation](https://github.com/space-wizards/docs/blob/fe0f42ca58a5e89e7da7decc847129309bf7aab6/src/en/space-station-14/round-flow/proposals/changeling.md?plain=1#L50) `This ability cannot be used if the person is wearing an outerclothing piece with more than 10% resistance to any brute damage`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Required for #34002, per documentation, Changeling needs to be able to check the outerclothing's brute damage protection, as a sufficent coefficient would prevent their devour attempt entirely
## Technical details
<!-- Summary of code changes for easier review. -->
Added a RelayedInventoryEvent to SharedArmorSystem
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No CL No Fun