### PR TITLE
use manual component state for BaseEmitSoundComponent

### DIFF
--- a/Content.Shared/Sound/Components/BaseEmitSoundComponent.cs
+++ b/Content.Shared/Sound/Components/BaseEmitSoundComponent.cs
@@ -1,4 +1,6 @@
 using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Sound.Components;
 
@@ -8,10 +10,9 @@ namespace Content.Shared.Sound.Components;
 /// </summary>
 public abstract partial class BaseEmitSoundComponent : Component
 {
-    public static readonly AudioParams DefaultParams = AudioParams.Default.WithVolume(-2f);
-
-    [AutoNetworkedField]
-    [ViewVariables(VVAccess.ReadWrite)]
+    /// <summary>
+    /// The <see cref="SoundSpecifier"/> to play.
+    /// </summary>
     [DataField(required: true)]
     public SoundSpecifier? Sound;
 
@@ -21,4 +22,16 @@ public abstract partial class BaseEmitSoundComponent : Component
     /// </summary>
     [DataField]
     public bool Positional;
+}
+
+/// <summary>
+/// Represents the state of <see cref="BaseEmitSoundComponent"/>.
+/// </summary>
+/// <remarks>This is obviously very cursed, but since the BaseEmitSoundComponent is abstract, we cannot network it.
+/// AutoGenerateComponentState attribute won't work here, and since everything revolves around inheritance for some fucking reason,
+/// there's no better way of doing this.</remarks>
+[Serializable, NetSerializable]
+public struct EmitSoundComponentState(SoundSpecifier? sound) : IComponentState
+{
+    public SoundSpecifier? Sound { get; } = sound;
 }

--- a/Content.Shared/Sound/Components/EmitSoundOnActivateComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnActivateComponent.cs
@@ -17,6 +17,6 @@ public sealed partial class EmitSoundOnActivateComponent : BaseEmitSoundComponen
     ///     otherwise this might enable sound spamming, as use-delays are only initiated if the interaction was
     ///     handled.
     /// </remarks>
-    [DataField("handle")]
+    [DataField]
     public bool Handle = true;
 }

--- a/Content.Shared/Sound/Components/EmitSoundOnCollideComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnCollideComponent.cs
@@ -11,13 +11,12 @@ public sealed partial class EmitSoundOnCollideComponent : BaseEmitSoundComponent
     /// <summary>
     /// Minimum velocity required for the sound to play.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("minVelocity")]
+    [DataField("minVelocity")]
     public float MinimumVelocity = 3f;
 
     /// <summary>
     /// To avoid sound spam add a cooldown to it.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("nextSound", customTypeSerializer: typeof(TimeOffsetSerializer))]
-    [AutoPausedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan NextSound;
 }

--- a/Content.Shared/Sound/Components/EmitSoundOnDropComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnDropComponent.cs
@@ -6,6 +6,4 @@ namespace Content.Shared.Sound.Components;
 /// Simple sound emitter that emits sound on entity drop
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class EmitSoundOnDropComponent : BaseEmitSoundComponent
-{
-}
+public sealed partial class EmitSoundOnDropComponent : BaseEmitSoundComponent;

--- a/Content.Shared/Sound/Components/EmitSoundOnInteractUsingComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnInteractUsingComponent.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Whitelist;
-using Robust.Shared.Prototypes;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Sound.Components;
@@ -10,6 +9,9 @@ namespace Content.Shared.Sound.Components;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class EmitSoundOnInteractUsingComponent : BaseEmitSoundComponent
 {
+    /// <summary>
+    /// The <see cref="EntityWhitelist"/> for the entities that can use this item.
+    /// </summary>
     [DataField(required: true)]
     public EntityWhitelist Whitelist = new();
 }

--- a/Content.Shared/Sound/Components/EmitSoundOnLandComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnLandComponent.cs
@@ -6,6 +6,4 @@ namespace Content.Shared.Sound.Components;
 /// Simple sound emitter that emits sound on LandEvent
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class EmitSoundOnLandComponent : BaseEmitSoundComponent
-{
-}
+public sealed partial class EmitSoundOnLandComponent : BaseEmitSoundComponent;

--- a/Content.Shared/Sound/Components/EmitSoundOnPickupComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnPickupComponent.cs
@@ -6,6 +6,4 @@ namespace Content.Shared.Sound.Components;
 /// Simple sound emitter that emits sound on entity pickup
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class EmitSoundOnPickupComponent : BaseEmitSoundComponent
-{
-}
+public sealed partial class EmitSoundOnPickupComponent : BaseEmitSoundComponent;

--- a/Content.Shared/Sound/Components/EmitSoundOnSpawnComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnSpawnComponent.cs
@@ -6,6 +6,4 @@ namespace Content.Shared.Sound.Components;
 ///     Simple sound emitter that emits sound on entity spawn.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class EmitSoundOnSpawnComponent : BaseEmitSoundComponent
-{
-}
+public sealed partial class EmitSoundOnSpawnComponent : BaseEmitSoundComponent;

--- a/Content.Shared/Sound/Components/EmitSoundOnThrowComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnThrowComponent.cs
@@ -6,6 +6,4 @@ namespace Content.Shared.Sound.Components;
 /// Simple sound emitter that emits sound on ThrowEvent
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class EmitSoundOnThrowComponent : BaseEmitSoundComponent
-{
-}
+public sealed partial class EmitSoundOnThrowComponent : BaseEmitSoundComponent;

--- a/Content.Shared/Sound/Components/EmitSoundOnUseComponent.cs
+++ b/Content.Shared/Sound/Components/EmitSoundOnUseComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Sound.Components;
 /// <summary>
 /// Simple sound emitter that emits sound on UseInHand
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class EmitSoundOnUseComponent : BaseEmitSoundComponent
 {
     /// <summary>
@@ -17,6 +17,6 @@ public sealed partial class EmitSoundOnUseComponent : BaseEmitSoundComponent
     ///     otherwise this might enable sound spamming, as use-delays are only initiated if the interaction was
     ///     handled.
     /// </remarks>
-    [DataField("handle")]
+    [DataField]
     public bool Handle = true;
 }

--- a/Content.Shared/Sound/Components/SpamEmitSoundComponent.cs
+++ b/Content.Shared/Sound/Components/SpamEmitSoundComponent.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Sound.Components;
 
@@ -12,7 +13,7 @@ public sealed partial class SpamEmitSoundComponent : BaseEmitSoundComponent
     /// <summary>
     /// The time at which the next sound will play.
     /// </summary>
-    [DataField, AutoPausedField, AutoNetworkedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, AutoNetworkedField]
     public TimeSpan NextSound;
 
     /// <summary>

--- a/Content.Shared/Sound/Components/SpamEmitSoundRequirePowerComponent.cs
+++ b/Content.Shared/Sound/Components/SpamEmitSoundRequirePowerComponent.cs
@@ -5,6 +5,4 @@ namespace Content.Shared.Sound.Components;
 /// on the powered state of the entity.
 /// </summary>
 [RegisterComponent]
-public sealed partial class SpamEmitSoundRequirePowerComponent : Component
-{
-}
+public sealed partial class SpamEmitSoundRequirePowerComponent : Component;

--- a/Content.Shared/Sound/SharedEmitSoundSystem.cs
+++ b/Content.Shared/Sound/SharedEmitSoundSystem.cs
@@ -78,15 +78,24 @@ public abstract class SharedEmitSoundSystem : EntitySystem
         }
     }
 
-    private static void GetBaseEmitState<T>(EntityUid uid, T component, ref ComponentGetState args) where T : BaseEmitSoundComponent
+    private static void GetBaseEmitState<T>(Entity<T> ent, ref ComponentGetState args) where T : BaseEmitSoundComponent
     {
-        args.State = new EmitSoundComponentState(component.Sound);
+        args.State = new EmitSoundComponentState(ent.Comp.Sound);
     }
 
-    private static void HandleBaseEmitState<T>(EntityUid uid, T component, ref ComponentHandleState args) where T : BaseEmitSoundComponent
+    private static void HandleBaseEmitState<T>(Entity<T> ent, ref ComponentHandleState args) where T : BaseEmitSoundComponent
     {
-        if (args.Current is EmitSoundComponentState state)
-            component.Sound = state.Sound;
+        if (args.Current is not EmitSoundComponentState state)
+            return;
+
+        ent.Comp.Sound = state.Sound switch
+        {
+            SoundPathSpecifier pathSpec => new SoundPathSpecifier(pathSpec.Path, pathSpec.Params),
+            SoundCollectionSpecifier collectionSpec => collectionSpec.Collection != null
+                ? new SoundCollectionSpecifier(collectionSpec.Collection, collectionSpec.Params)
+                : null,
+            _ => null,
+        };
     }
 
     private void HandleEmitSoundOnUIOpen(EntityUid uid, EmitSoundOnUIOpenComponent component, AfterActivatableUIOpenEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
:death:
abstract components cannot be networked, attributes arent inherited, you cant put the AutoGenerateComponentState attribute on a component that has no AutoNetworkedFields because those exist in the other class
this isnt how ECS was supposed to be played
but it is what it is and thats better than no networking at all, especially since sounds are predicted

## Technical details
<!-- Summary of code changes for easier review. -->
minor cleanup, added manual handling for most components that inherit off of BaseEmitSoundComponent
we cannot do it for `SpamEmitSound` because it uses autonetworking for something else, and `EmitSoundOnTrigger` is in Server so not predicted 
i swear there was a better way of subscribing to multiple events but maybe im tripping?? the Initialize method is a mess either way

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no fun