### PR TITLE
Fixed character menu button still being toggled when closed

### DIFF
--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -56,7 +56,7 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
         _window = UIManager.CreateWindow<CharacterWindow>();
         LayoutContainer.SetAnchorPreset(_window, LayoutContainer.LayoutPreset.CenterTop);
 
-
+        LoadButton();
 
         CommandBinds.Builder
             .Bind(ContentKeyFunctions.OpenCharacterMenu,
@@ -66,6 +66,8 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
 
     public void OnStateExited(GameplayState state)
     {
+        UnloadButton();
+
         if (_window != null)
         {
             _window.Dispose();


### PR DESCRIPTION
## About the PR
This PR ensures that the Character Menu button properly untoggles when you close the menu via the **X** button, fixing an issue where it would remain toggled. Fixes #35016 

## Why / Balance
Pressing **X** on the Character Window did not un-toggle the Character Button, creating inconsistent UI behavior.

## Technical details
- Calls `LoadButton()` in `OnStateEntered` and `UnloadButton()` in `OnStateExited`.
- Subscribes the Character Window’s `OnOpen` and `OnClose` events to toggle the button state correctly.

## Media
No visual changes beyond fixing the button toggle. No media needed.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Character Menu button now properly untoggles when the window is closed with the X button.
