### PR TITLE
remove redundant `rainbowcarpplush` yaml lines

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -713,7 +713,6 @@
   - type: RgbLightController
     layers: [ 0 ]
   - type: Item
-    heldPrefix: rainbowcarpplush
     inhandVisuals:
       left:
       - state: rainbowcarpplush-inhand-left


### PR DESCRIPTION
## About the PR
Removes `heldprefix` from the `rainbowcarpplush` YAML

## Why / Balance
It was unnecessary and a duplicate of what we already do in `type: Sprite`

I might clean up `toys.yml` a bit more later on but for now this PR is just straight petty.

## Media
![Content Client_H0b7LkRtwl](https://github.com/user-attachments/assets/208e2c4f-8880-436d-91fe-83be23161e20)
![Content Client_KnXWDcusmR](https://github.com/user-attachments/assets/0c8dbc7b-6fd3-449a-8a98-8867a4593482)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no cl no fun
