### PR TITLE
Make two inventories not dance around as much when opening/closing them

### DIFF
--- a/Content.Client/UserInterface/Systems/Hotbar/Widgets/HotbarGui.xaml
+++ b/Content.Client/UserInterface/Systems/Hotbar/Widgets/HotbarGui.xaml
@@ -9,11 +9,31 @@
     Orientation="Vertical"
     HorizontalAlignment="Center">
     <BoxContainer Orientation="Vertical">
-        <BoxContainer Name="StorageContainer"
+        <BoxContainer Name="SingleStorageContainer"
                       Access="Public"
                       HorizontalAlignment="Center"
                       HorizontalExpand="True"
                       Margin="10">
+        </BoxContainer>
+        <BoxContainer Name="DoubleStorageContainer"
+                      Access="Public"
+                      HorizontalAlignment="Stretch"
+                      HorizontalExpand="True"
+                      Margin="10">
+            <BoxContainer Name="LeftStorageContainer"
+                          Access="Public"
+                          HorizontalAlignment="Left"
+                          HorizontalExpand="True"
+                          VerticalAlignment="Bottom"
+                          Margin="10">
+            </BoxContainer>
+            <BoxContainer Name="RightStorageContainer"
+                          Access="Public"
+                          HorizontalAlignment="Right"
+                          HorizontalExpand="True"
+                          VerticalAlignment="Bottom"
+                          Margin="10">
+            </BoxContainer>
         </BoxContainer>
         <BoxContainer Orientation="Horizontal" Name="Hotbar" HorizontalAlignment="Center">
             <inventory:ItemSlotButtonContainer

--- a/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
+++ b/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
@@ -128,7 +128,7 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
 
             if (_openStorageLimit == 2)
             {
-                if (hotbar?.LeftStorageContainer.Children.Count(c => c.Visible) == 0)
+                if (hotbar?.LeftStorageContainer.Children.Any(c => c.Visible) == false) // we're comparing booleans because it's bool? and not bool from the optional chaining
                 {
                     hotbar?.LeftStorageContainer.AddChild(window);
                     reorder(hotbar?.LeftStorageContainer, window);

--- a/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
+++ b/Content.Client/UserInterface/Systems/Storage/StorageUIController.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Numerics;
 using Content.Client.Examine;
 using Content.Client.Hands.Systems;
@@ -48,6 +49,7 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
     public Angle DraggingRotation = Angle.Zero;
     public bool StaticStorageUIEnabled;
     public bool OpaqueStorageWindow;
+    private int _openStorageLimit = -1;
 
     public bool IsDragging => _menuDragHelper.IsDragging;
     public ItemGridPiece? CurrentlyDragging => _menuDragHelper.Dragged;
@@ -66,6 +68,12 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
         _configuration.OnValueChanged(CCVars.StaticStorageUI, OnStaticStorageChanged, true);
         _configuration.OnValueChanged(CCVars.OpaqueStorageWindow, OnOpaqueWindowChanged, true);
         _configuration.OnValueChanged(CCVars.StorageWindowTitle, OnStorageWindowTitle, true);
+        _configuration.OnValueChanged(CCVars.StorageLimit, OnStorageLimitChanged, true);
+    }
+
+    private void OnStorageLimitChanged(int obj)
+    {
+        _openStorageLimit = obj;
     }
 
     private void OnStorageWindowTitle(bool obj)
@@ -99,7 +107,43 @@ public sealed class StorageUIController : UIController, IOnSystemChanged<Storage
 
         if (StaticStorageUIEnabled)
         {
-            UIManager.GetActiveUIWidgetOrNull<HotbarGui>()?.StorageContainer.AddChild(window);
+            var hotbar = UIManager.GetActiveUIWidgetOrNull<HotbarGui>();
+            // this lambda handles the nested storage case
+            // during nested storage, a parent window hides and a child window is
+            // immediately inserted to the end of the list
+            // we can reorder the newly inserted to the same index as the invisible
+            // window in order to prevent an invisible window from being replaced
+            // with a visible one in a different position
+            Action<Control?, Control> reorder = (parent, child) =>
+            {
+                if (parent is null)
+                    return;
+
+                var parentChildren = parent.Children.ToList();
+                var invisibleIndex = parentChildren.FindIndex(c => c.Visible == false);
+                if (invisibleIndex == -1)
+                    return;
+                child.SetPositionInParent(invisibleIndex);
+            };
+
+            if (_openStorageLimit == 2)
+            {
+                if (hotbar?.LeftStorageContainer.Children.Count(c => c.Visible) == 0)
+                {
+                    hotbar?.LeftStorageContainer.AddChild(window);
+                    reorder(hotbar?.LeftStorageContainer, window);
+                }
+                else
+                {
+                    hotbar?.RightStorageContainer.AddChild(window);
+                    reorder(hotbar?.RightStorageContainer, window);
+                }
+            }
+            else
+            {
+                hotbar?.SingleStorageContainer.AddChild(window);
+                reorder(hotbar?.SingleStorageContainer, window);
+            }
             _closeRecentWindowUIController.SetMostRecentlyInteractedWindow(window);
         }
         else

--- a/Content.IntegrationTests/Tests/Storage/StorageInteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Storage/StorageInteractionTest.cs
@@ -81,7 +81,7 @@ public sealed class StorageInteractionTest : InteractionTest
     {
         var uid = ToClient(target);
         var hotbar = GetWidget<HotbarGui>();
-        var storageContainer  = GetControlFromField<Control>(nameof(HotbarGui.StorageContainer), hotbar);
+        var storageContainer  = GetControlFromField<Control>(nameof(HotbarGui.SingleStorageContainer), hotbar);
         return GetControlFromChildren<ItemGridPiece>(c => c.Entity == uid, storageContainer);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR makes the two-inventory usecase not cause inventories to dance around as much by aligning one inventory to the left, and another one to the right, which allows them space to grow without causing the other to shift around.

## Why / Balance
UI elements moving around generally makes them harder to target and can breed user discontent.

## Technical details
- create a `DoubleStorageContainer` box container with a `LeftStorageContainer` and a `RightStorageContainer` for the usecase where two inventories can be open at a time, and insert the inventory window into whichever one is free

## Media

https://github.com/user-attachments/assets/8edd39cc-caee-4c1c-aec9-b298edb5f889



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Servers with the number of open inventories set to two have a new alignment that doesn't shift as much when opening and closing multiple inventories
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
