### PR TITLE
Don't force-show storage windows when their contents change

### DIFF
--- a/Content.Client/Storage/Systems/StorageSystem.cs
+++ b/Content.Client/Storage/Systems/StorageSystem.cs
@@ -74,10 +74,6 @@ public sealed class StorageSystem : SharedStorageSystem
             {
                 containerBui.Hide();
             }
-            else
-            {
-                storageBui.Show();
-            }
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR makes it so that the client StorageSystem doesn't force a storage BUI to show when its state changes.

## Why / Balance
The only time a storage BUI is instantiated but hidden is in the case of nested storage, and code wants parent storages to be hidden whilst a child storage is displayed. The force-showing here causes glitchy behaviour as other code attempts to enforce that invariant.

## Technical details
- comment out a storageBui shown

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## How to reproduce the bug
- have 2 storages able to opened
- open your bag storage with something nested in it (e.g. roundstart backpack with survival box)
- open nested storage
- take an item out
- shift-b to smart equip it into the bag containing the nested container that's currently open
- observed w/o PR: parent window is re-shown, and glitches out due to code fighting over whether it should be hidden or shown
- observed w/ PR: parent window is not re-shown

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Smart equipping into your backpack w/ a nested storage window open no longer bugs out 
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
