### PR TITLE
Put screwdrivers in the vendomat

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
@@ -3,7 +3,8 @@
   startingInventory:
     RemoteSignaller: 1
     Igniter: 2
-    Wirecutter: 1
+    Wirecutter: 2
+    Screwdriver: 2
     CableApcStack: 2
     FlashlightLantern: 2
     PowerCellSmallPrinted: 3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added two screwdrivers and one extra wirecutter to the vendomat inventory.

## Why / Balance
A purple guy asked me to do this, and they used the word "merge" in the same sentence, activating my primal contributor instincts and compelling me to make this PR.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Vendomats now contain 2 Screwdrivers, and an addition Wirecutter.