### PR TITLE
Exclude "Die a Glorious Death" traitors from "Keep alive" target pool

### DIFF
--- a/Content.Server/Objectives/Systems/KeepAliveCondition.cs
+++ b/Content.Server/Objectives/Systems/KeepAliveCondition.cs
@@ -58,6 +58,18 @@ public sealed class KeepAliveConditionSystem : EntitySystem
             }
         }
 
+        // Not gonna save someone who's aimed to die a glorious death
+        foreach (var traitor in traitors)
+        {
+            foreach (var objective in traitor.Mind.Objectives)
+            {
+                if (TryComp<DieConditionComponent>(objective, out var _))
+                {
+                    traitors.RemoveWhere(x => x.Id == traitor.Id);
+                }
+            }
+        }
+
         // You are the first/only traitor.
         if (traitors.Count == 0)
         {


### PR DESCRIPTION
## About the PR
"Keep alive" objective now excludes traitors with "Die a Glorious Death" objective.

## Why / Balance
On paper, this combination has comedic value, but in practice such players often ghost after a fight/bombing to greentext and it ends up being frustrating for the helping traitor.

## Technical details
`KeepAliveConditionSystem` now excludes traitors with `DieConditionComponent` objective.

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Not that I know of

**Changelog**
:cl:
- tweak: "Keep alive" objective now excludes traitors with "Die a Glorious Death" objective
