### PR TITLE
Fix ninja spawning with jetpack internals

### DIFF
--- a/Content.Shared/Clothing/LoadoutSystem.cs
+++ b/Content.Shared/Clothing/LoadoutSystem.cs
@@ -150,7 +150,7 @@ public sealed class LoadoutSystem : EntitySystem
     {
         // First, randomly pick a startingGear profile from those specified, and equip it.
         if (startingGear != null && startingGear.Count > 0)
-            _station.EquipStartingGear(uid, _random.Pick(startingGear));
+            _station.EquipStartingGear(uid, _random.Pick(startingGear), false);
 
         if (loadoutGroups == null)
         {


### PR DESCRIPTION
## About the PR
Ninja now spawns breathing from his gas tank instead of jetpack.
Fixes #32333.

## Why / Balance
No reason to drain jetpack when we have a proper gas tank.

## Technical details
Removed redundant `StartingGearEquippedEvent`, which fired after issuing ninja gear, but before issuing `RoleSurvivalEVA` loadout. This effectively turned on internals when player only had a jetpack equipped.

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Not that I know of

**Changelog**
:cl:
- fix: Ninja now spawns breathing from his gas tank instead of jetpack
