### PR TITLE
Internals: prioritize gas tanks over jetpacks

### DIFF
--- a/Content.Shared/Body/Systems/SharedInternalsSystem.cs
+++ b/Content.Shared/Body/Systems/SharedInternalsSystem.cs
@@ -277,7 +277,7 @@ public abstract class SharedInternalsSystem : EntitySystem
             _gasTank.CanConnectToInternals((backEntity.Value, backGasTank)))
         {
             found = (backEntity.Value, backGasTank);
-            if (!TryComp<JetpackComponent>(backEntity.Value, out var _))
+            if (!HasComp<JetpackComponent>(backEntity.Value))
             {
                 return found;
             }
@@ -288,7 +288,7 @@ public abstract class SharedInternalsSystem : EntitySystem
             _gasTank.CanConnectToInternals((entity.Value, gasTank)))
         {
             found ??= (entity.Value, gasTank);
-            if (!TryComp<JetpackComponent>(entity.Value, out var _))
+            if (!HasComp<JetpackComponent>(entity.Value))
             {
                 return (entity.Value, gasTank);
             }
@@ -299,7 +299,7 @@ public abstract class SharedInternalsSystem : EntitySystem
             if (TryComp(item, out gasTank) && _gasTank.CanConnectToInternals((item, gasTank)))
             {
                 found ??= (item, gasTank);
-                if (!TryComp<JetpackComponent>(item, out var _))
+                if (!HasComp<JetpackComponent>(item))
                 {
                     return (item, gasTank);
                 }


### PR DESCRIPTION
## About the PR
Internals now use jetpacks only if there's no other gas tanks.

## Why / Balance
Jetpack internals can be rather confusing and frustrating/deadly if not noticed in time.

## Technical details
`FindBestGasTank` now keeps searching if it finds a jetpack, and uses it only if there's no proper gas tank equipped.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Not that I know of

**Changelog**
:cl:
- tweak: Toggle internals now uses jetpack only if there's no proper gas tank equipped
