### PR TITLE
fix chameleon projector ripley bug

### DIFF
--- a/Content.Shared/Polymorph/Systems/SharedChameleonProjectorSystem.cs
+++ b/Content.Shared/Polymorph/Systems/SharedChameleonProjectorSystem.cs
@@ -44,6 +44,8 @@ public abstract class SharedChameleonProjectorSystem : EntitySystem
         SubscribeLocalEvent<ChameleonDisguiseComponent, InsertIntoEntityStorageAttemptEvent>(OnDisguiseInsertAttempt);
         SubscribeLocalEvent<ChameleonDisguiseComponent, ComponentShutdown>(OnDisguiseShutdown);
 
+        SubscribeLocalEvent<ChameleonDisguisedComponent, EntGotInsertedIntoContainerMessage>(OnDisguisedInserted);
+
         SubscribeLocalEvent<ChameleonProjectorComponent, AfterInteractEvent>(OnInteract);
         SubscribeLocalEvent<ChameleonProjectorComponent, GetVerbsEvent<UtilityVerb>>(OnGetVerbs);
         SubscribeLocalEvent<ChameleonProjectorComponent, DisguiseToggleNoRotEvent>(OnToggleNoRot);
@@ -72,11 +74,22 @@ public abstract class SharedChameleonProjectorSystem : EntitySystem
     {
         // stay parented to the user, not the storage
         args.Cancelled = true;
+        TryReveal(ent.Comp.User);
     }
 
     private void OnDisguiseShutdown(Entity<ChameleonDisguiseComponent> ent, ref ComponentShutdown args)
     {
         _actions.RemoveProvidedActions(ent.Comp.User, ent.Comp.Projector);
+    }
+
+    #endregion
+
+    #region Disguised player
+
+    private void OnDisguisedInserted(Entity<ChameleonDisguisedComponent> ent, ref EntGotInsertedIntoContainerMessage args)
+    {
+        // prevent player going into locker/mech/etc while disguised
+        TryReveal((ent, ent));
     }
 
     #endregion
@@ -111,7 +124,7 @@ public abstract class SharedChameleonProjectorSystem : EntitySystem
 
     public bool TryDisguise(Entity<ChameleonProjectorComponent> ent, EntityUid user, EntityUid target)
     {
-        if (_container.IsEntityInContainer(target))
+        if (_container.IsEntityInContainer(target) || _container.IsEntityInContainer(user))
         {
             _popup.PopupClient(Loc.GetString("chameleon-projector-inside-container"), target, user);
             return false;


### PR DESCRIPTION
## About the PR
fixes #35051

## Why / Balance
bug bad and previous thing got broken at some point

## Technical details
if the player goes into any container (ripley, locker, etc) they get revealed

the actual telekinis thing was because mech shitcode ignored pilot insertion failing and still added the funny pilot component when the event was cancelled :trollface:

## Media

going to enter ripley when disguised
![02:26:02](https://github.com/user-attachments/assets/f419412c-6043-4d96-9d66-a9bfd5dba20d)

disguise is lost...
![02:26:10](https://github.com/user-attachments/assets/5f09bcef-4d5e-42b1-ad02-b74422cdafc8)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Entering a mech or other container now ends chameleon projections.
