### PR TITLE
Autoclose most recently opened inv when opening a new one past limits

### DIFF
--- a/Content.Shared/Storage/Components/RecentlyInteractedStoragesComponent.cs
+++ b/Content.Shared/Storage/Components/RecentlyInteractedStoragesComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Storage.Components;
+
+/// <summary>
+///     Attached to an actor to keep track of which storages it's opened in which order in order to close inventories on a LIFO basis if a new one past the limit is opened
+/// </summary>
+[RegisterComponent, Access(typeof(SharedStorageSystem)), AutoGenerateComponentState, NetworkedComponent]
+public sealed partial class RecentlyOpenedStoragesComponent : Component
+{
+    /// <summary>
+    ///     A list of lists of entities whose storages this actor has opened. Nested inventories (e.g. folder in a briefcase) belong to the same sublist.
+    /// </summary>
+    [DataField, ViewVariables, AutoNetworkedField]
+    public List<List<NetEntity>> OpenedStorages = new();
+}

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -298,6 +298,13 @@ public abstract class SharedStorageSystem : EntitySystem
             if (!_tag.HasTag(args.Actor, storageComp.SilentStorageUserTag))
                 Audio.PlayPredicted(storageComp.StorageCloseSound, uid, args.Actor);
         }
+
+        if (TryComp<RecentlyOpenedStoragesComponent>(args.Actor, out var recently))
+        {
+            recently.OpenedStorages.ForEach(it => it.Remove(GetNetEntity(uid)));
+            recently.OpenedStorages.RemoveAll(it => it.Count == 0);
+            Dirty(args.Actor, recently);
+        }
     }
 
     private void AddUiVerb(EntityUid uid, StorageComponent component, GetVerbsEvent<ActivationVerb> args)
@@ -397,6 +404,25 @@ public abstract class SharedStorageSystem : EntitySystem
         if (!UI.TryOpenUi(uid, StorageComponent.StorageUiKey.Key, entity))
             return;
 
+        var recently = EnsureComp<RecentlyOpenedStoragesComponent>(entity);
+
+        if (!recently.OpenedStorages.Any(inner => inner.Contains(GetNetEntity(uid))))
+        {
+            if (ContainerSystem.TryGetContainingContainer((uid, null, null), out var container))
+            {
+                var parentList = recently.OpenedStorages.Find(it => it.Contains(GetNetEntity(container.Owner)));
+                if (parentList is null)
+                    recently.OpenedStorages.Add(new() { GetNetEntity(uid) });
+                else
+                    parentList.Add(GetNetEntity(uid));
+            }
+            else
+            {
+                recently.OpenedStorages.Add(new() { GetNetEntity(uid) });
+            }
+            Dirty(entity, recently);
+        }
+
         if (!silent && !_tag.HasTag(entity, storageComp.SilentStorageUserTag))
         {
             Audio.PlayPredicted(storageComp.StorageOpenSound, uid, entity);
@@ -469,7 +495,22 @@ public abstract class SharedStorageSystem : EntitySystem
         }
         else
         {
-            OpenStorageUI(uid, args.User, storageComp, false);
+            // Handle recursively opening nested storages.
+            if (ContainerSystem.TryGetContainingContainer((args.Target, null, null), out var container) &&
+                UI.IsUiOpen(container.Owner, StorageComponent.StorageUiKey.Key, args.User))
+            {
+                _nestedCheck = true;
+                HideStorageWindow(container.Owner, args.User);
+                OpenStorageUI(uid, args.User, storageComp, false);
+                _nestedCheck = false;
+            }
+            else
+            {
+                if (_openStorageLimit == 1)
+                    UI.CloseUserUis<StorageComponent.StorageUiKey>(args.User);
+
+                OpenStorageUI(uid, args.User, storageComp, false);
+            }
         }
 
         args.Handled = true;
@@ -807,6 +848,33 @@ public abstract class SharedStorageSystem : EntitySystem
         UpdateAppearance((ent.Owner, ent.Comp, null));
     }
 
+    private int CountOpenInterfaces(EntityUid actor, EntityUid? excluding)
+    {
+        var count = 0;
+
+        if (!_userQuery.TryComp(actor, out var userComp))
+        {
+            return count;
+        }
+
+        foreach (var (ui, keys) in userComp.OpenInterfaces)
+        {
+            if (excluding is not null && ui == excluding)
+                continue;
+
+            foreach (var key in keys)
+            {
+                if (key is not StorageComponent.StorageUiKey)
+                    continue;
+
+                count++;
+                break;
+            }
+        }
+
+        return count;
+    }
+
     private void OnBoundUIAttempt(Entity<StorageComponent> ent, ref BoundUserInterfaceMessageAttempt args)
     {
         if (args.UiKey is not StorageComponent.StorageUiKey.Key ||
@@ -817,30 +885,19 @@ public abstract class SharedStorageSystem : EntitySystem
 
         var uid = args.Target;
         var actor = args.Actor;
-        var count = 0;
 
-        if (_userQuery.TryComp(actor, out var userComp))
+        var openInterfaces = CountOpenInterfaces(actor, uid);
+
+        if (openInterfaces >= _openStorageLimit)
         {
-            foreach (var (ui, keys) in userComp.OpenInterfaces)
+            var comp = EnsureComp<RecentlyOpenedStoragesComponent>(actor);
+            var lastItem = comp.OpenedStorages.Last();
+            comp.OpenedStorages.RemoveAt(comp.OpenedStorages.Count - 1);
+            foreach (var storage in lastItem)
             {
-                if (ui == uid)
-                    continue;
-
-                foreach (var key in keys)
-                {
-                    if (key is not StorageComponent.StorageUiKey)
-                        continue;
-
-                    count++;
-
-                    if (count >= _openStorageLimit)
-                    {
-                        args.Cancel();
-                    }
-
-                    break;
-                }
+                UI.CloseUi(GetEntity(storage), StorageComponent.StorageUiKey.Key, actor);
             }
+            Dirty(actor, comp);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
When opening multiple inventories, and you attempt to open a new one when you're already at the limit, the most recently opened inventory will be closed.

## Why / Balance
This allows scanning through multiple inventories in a multi-inv setup without needing to worry about closing out existing ones, similarly to what can be done in a single-inv setup.

## Technical details
- new component, `RecentlyOpenedStoragesComponent` that keeps a LIFO stack of open inventories, grouping together ones that are nested into sublists
- `SharedStorageSystem` now keeps track of opened inventories in the above component

## Media

https://github.com/user-attachments/assets/b7495f42-54df-4b57-950a-008454801a0a



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl:
- fix: You can now open a new inventory when at the limit in a multi-inventory setup, which will cause the most recently opened one to be closed.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
