### PR TITLE
Hotfix: Camera offset for "Separated Chat" HUD fix & targetting fix

### DIFF
--- a/Content.Client/Movement/Systems/ContentEyeSystem.cs
+++ b/Content.Client/Movement/Systems/ContentEyeSystem.cs
@@ -63,4 +63,14 @@ public sealed class ContentEyeSystem : SharedContentEyeSystem
             UpdateEyeOffset((entity, eyeComponent));
         }
     }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        var eyeEntities = AllEntityQuery<ContentEyeComponent, EyeComponent>();
+        while (eyeEntities.MoveNext(out var entity, out ContentEyeComponent? contentComponent, out EyeComponent? eyeComponent))
+        {
+            UpdateEyeOffset((entity, eyeComponent));
+        }
+    }
 }

--- a/Content.Client/Movement/Systems/EyeCursorOffsetSystem.cs
+++ b/Content.Client/Movement/Systems/EyeCursorOffsetSystem.cs
@@ -1,12 +1,12 @@
 using System.Numerics;
 using Content.Client.Movement.Components;
+using Content.Client.UserInterface.Controls;
 using Content.Shared.Camera;
-using Content.Shared.Inventory;
-using Content.Shared.Movement.Systems;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Shared.Map;
 using Robust.Client.Player;
+using Robust.Client.UserInterface;
 
 namespace Content.Client.Movement.Systems;
 
@@ -14,11 +14,9 @@ public partial class EyeCursorOffsetSystem : EntitySystem
 {
     [Dependency] private readonly IEyeManager _eyeManager = default!;
     [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
-    [Dependency] private readonly SharedContentEyeSystem _contentEye = default!;
-    [Dependency] private readonly IMapManager _mapManager = default!;
-    [Dependency] private readonly IClyde _clyde = default!;
 
     // This value is here to make sure the user doesn't have to move their mouse
     // all the way out to the edge of the screen to get the full offset.
@@ -42,9 +40,16 @@ public partial class EyeCursorOffsetSystem : EntitySystem
 
     public Vector2? OffsetAfterMouse(EntityUid uid, EyeCursorOffsetComponent? component)
     {
+        // We need the main viewport where the game content is displayed, as certain UI layouts (e.g. Separated Chat)
+        // can make it a different size to the game window.
+        if (_uiManager.ActiveScreen == null ||!_uiManager.ActiveScreen!.TryGetWidget<MainViewport>(out var mainViewport))
+            return null;
+
         var localPlayer = _player.LocalPlayer?.ControlledEntity;
         var mousePos = _inputManager.MouseScreenPosition;
-        var screenSize = _clyde.MainWindow.Size;
+        var screenSize = mainViewport.Size;
+
+        // Defines the circle at which the offset is capped.
         var minValue = MathF.Min(screenSize.X / 2, screenSize.Y / 2) * _edgeOffset;
 
         var mouseNormalizedPos = new Vector2(-(mousePos.X - screenSize.X / 2) / minValue, (mousePos.Y - screenSize.Y / 2) / minValue); // X needs to be inverted here for some reason, otherwise it ends up flipped.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR fixes some major bugs with the camera offset introduced in `EyeCursorOffsetSystem`:

- Previously the offset was calculated using the full application window size, which worked fine for the standard HUD view but broke the direction/offset for the separated chat HUD, where the game viewport is offset from the middle of the application window. 
- Previously trying to aim at specific targets (e.g. prone players) would fail. This was more noticeable when entering placement mode while offset, as the placement ghost would flip back and forth between the non-offset and offset positions your cursor hovered over. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

bugs bad

## Technical details
<!-- Summary of code changes for easier review. -->

For the window size, it now queries the UserInterfaceManager's ActiveScreen and gets the correct viewport. There are many different ways to get window sizes and viewports; this was the only way I found that corresponded with the actual game view (other methods I tried either gave the full application window size, or some unsized windows).

For the aiming issue, it turns out that the rendering is ran after every FrameUpdate, however some selection stuff ends up running after Update. This caused a hidden issue where the offset kept being reset to `0,0`, selection code ran, and then the FrameUpdate caught up and adjusted the rendering, making everything appear visually legit. So now we just run the offset query on both the FrameUpdate and Update. It felt a bit iffy just copying code, so if there's a better solution, let me know!

## Steps to reproduce bugs

Note: Since this is a *fix*, these are only noticeable in the current master. 

1. Set your HUD to Separated in the General options menu.
2. Wield the Hristov
3. Try to shoot diagonally

Expected behavior: The bullet flies towards the direction you're aiming.
Result: The bullet will be slightly offset from the direction you're aiming.

1. Wield the Hristov
2. Press P on an entity to enter sandbox Copy placement mode

Expected behavior: The item placement ghost is located underneath the cursor
Result: The item placement ghost flickers between underneath the cursor and whatever location the cursor would hover if the Hristov wasn't wielded.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Aiming with the Hristov is now working correctly when using the Separated Chat HUD mode.
- fix: Cursor targetting with the Hristov now correctly selects the target underneath the cursor.
