### PR TITLE
Nukie Name Variety

### DIFF
--- a/Resources/Prototypes/Datasets/Names/syndicate.yml
+++ b/Resources/Prototypes/Datasets/Names/syndicate.yml
@@ -2,27 +2,46 @@
   id: SyndicateNamesNormal
   values:
   - Alfa
+  - Arrow
+  - Blaze
   - Bravo
+  - Buck
   - Charlie
+  - Cotton
   - Delta
+  - Eagle
   - Echo
+  - Falcon
   - Foxtrot
+  - Gabe
+  - Ghost
   - Golf
+  - Hawk
   - Hotel
   - India
+  - Jet
   - Juliett
+  - July
   - Kilo
   - Lima
   - Mike
+  - Nebula
   - November
   - Oscar
   - Papa
+  - Phoenix
+  - Price
   - Quebec
+  - Ramirez
   - Romeo
+  - Russell
+  - Sanders
+  - Saturn
   - Sierra
   - Tango
   - Uniform
   - Victor
+  - Violet
   - Whiskey
   - X-Ray
   - Zulu
@@ -53,6 +72,8 @@
   - Chi
   - Psi
   - Omega
+  - Kappa
+  - Hopper
 
 - type: dataset
   id: SyndicateNamesPrefix


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I added a few more Nuclear Operative name options to the list of names, adding more variety in the names Nukies get.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I kept seeing the same Nukie names over and over again, so I decided to fix the problem myself.
## Technical details
<!-- Summary of code changes for easier review. -->
Simply just added more names to the file.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
🆑 
- tweak: New Nukie names added to the pool of options.