### PR TITLE
Fix build ghosts not being placeable on a new round.

### DIFF
--- a/Content.Client/Construction/ConstructionGhostComponent.cs
+++ b/Content.Client/Construction/ConstructionGhostComponent.cs
@@ -7,6 +7,7 @@ namespace Content.Client.Construction
     [RegisterComponent]
     public sealed partial class ConstructionGhostComponent : Component
     {
+        public int GhostId { get; set; }
         [ViewVariables] public ConstructionPrototype? Prototype { get; set; }
     }
 }

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -60,7 +60,7 @@ namespace Content.Client.Construction
 
         private void HandleGhostComponentShutdown(EntityUid uid, ConstructionGhostComponent component, ComponentShutdown args)
         {
-            ClearAllGhosts();
+            ClearGhost(component.GhostId);
         }
 
         private void OnConstructionGuideReceived(ResponseConstructionGuide ev)
@@ -211,8 +211,9 @@ namespace Content.Client.Construction
             ghost = EntityManager.SpawnEntity("constructionghost", loc);
             var comp = EntityManager.GetComponent<ConstructionGhostComponent>(ghost.Value);
             comp.Prototype = prototype;
+            comp.GhostId = ghost.GetHashCode();
             EntityManager.GetComponent<TransformComponent>(ghost.Value).LocalRotation = dir.ToAngle();
-            _ghosts.Add(ghost.GetHashCode(), ghost.Value);
+            _ghosts.Add(comp.GhostId, ghost.Value);
             var sprite = EntityManager.GetComponent<SpriteComponent>(ghost.Value);
             sprite.Color = new Color(48, 255, 48, 128);
 

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -55,6 +55,12 @@ namespace Content.Client.Construction
                 .Register<ConstructionSystem>();
 
             SubscribeLocalEvent<ConstructionGhostComponent, ExaminedEvent>(HandleConstructionGhostExamined);
+            SubscribeLocalEvent<ConstructionGhostComponent, ComponentShutdown>(HandleGhostComponentShutdown);
+        }
+
+        private void HandleGhostComponentShutdown(EntityUid uid, ConstructionGhostComponent component, ComponentShutdown args)
+        {
+            ClearAllGhosts();
         }
 
         private void OnConstructionGuideReceived(ResponseConstructionGuide ev)

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -91,7 +91,10 @@ namespace Content.Client.Construction.UI
 
             // This is required so that if we load after the system is initialized, we can bind to it immediately
             if (_systemManager.TryGetEntitySystem<ConstructionSystem>(out var constructionSystem))
+            {
+                constructionSystem.ClearAllGhosts();
                 SystemBindingChanged(constructionSystem);
+            }
 
             _systemManager.SystemLoaded += OnSystemLoaded;
             _systemManager.SystemUnloaded += OnSystemUnloaded;

--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -91,10 +91,7 @@ namespace Content.Client.Construction.UI
 
             // This is required so that if we load after the system is initialized, we can bind to it immediately
             if (_systemManager.TryGetEntitySystem<ConstructionSystem>(out var constructionSystem))
-            {
-                constructionSystem.ClearAllGhosts();
                 SystemBindingChanged(constructionSystem);
-            }
 
             _systemManager.SystemLoaded += OnSystemLoaded;
             _systemManager.SystemUnloaded += OnSystemUnloaded;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes an issue where left over ghosts from the previous shift cause you to be inable to place new ones until you either reconn or clear ghosts.

Fixes #33623

## Why / Balance
It's a bug.

## Technical details
Adds a handler for ConstructionGhostComponent ComponentShutdown to clear the ghost attached to the component.
Attaches the ghost id to the component so this is possible.

## Media
Before:

https://github.com/user-attachments/assets/7d6f453a-bc08-4e22-bebb-6e24bb1861f1

After:

https://github.com/user-attachments/assets/2274ddf9-3418-4084-afcc-614812efd607




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
I don't believe this needs a cl? Smite me if I'm wrong.
