### PR TITLE
adds remote signaller error message when too far away

### DIFF
--- a/Content.Server/DeviceLinking/Components/SignallerComponent.cs
+++ b/Content.Server/DeviceLinking/Components/SignallerComponent.cs
@@ -14,5 +14,11 @@ namespace Content.Server.DeviceLinking.Components
         /// </summary>
         [DataField("port", customTypeSerializer: typeof(PrototypeIdSerializer<SourcePortPrototype>))]
         public string Port = "Pressed";
+
+        /// <summary>
+        ///     The last entity to trigger the signaller.
+        /// </summary>
+        [DataField]
+        public EntityUid LastUser;
     }
 }

--- a/Content.Server/DeviceLinking/Events/SignalFailedEvent.cs
+++ b/Content.Server/DeviceLinking/Events/SignalFailedEvent.cs
@@ -4,4 +4,4 @@ using Content.Shared.DeviceNetwork;
 namespace Content.Server.DeviceLinking.Events;
 
 [ByRefEvent]
-public readonly record struct SignalFailedEvent(EntityUid? uid = null);
+public readonly record struct SignalFailedEvent(EntityUid? uid, bool failed);

--- a/Content.Server/DeviceLinking/Events/SignalFailedEvent.cs
+++ b/Content.Server/DeviceLinking/Events/SignalFailedEvent.cs
@@ -1,7 +1,4 @@
-using Content.Server.DeviceNetwork;
-using Content.Shared.DeviceNetwork;
-
 namespace Content.Server.DeviceLinking.Events;
 
 [ByRefEvent]
-public readonly record struct SignalFailedEvent(EntityUid? uid, bool failed);
+public readonly record struct SignalFailedEvent(EntityUid? uid);

--- a/Content.Server/DeviceLinking/Events/SignalFailedEvent.cs
+++ b/Content.Server/DeviceLinking/Events/SignalFailedEvent.cs
@@ -1,0 +1,7 @@
+using Content.Server.DeviceNetwork;
+using Content.Shared.DeviceNetwork;
+
+namespace Content.Server.DeviceLinking.Events;
+
+[ByRefEvent]
+public readonly record struct SignalFailedEvent(EntityUid? uid = null);

--- a/Content.Server/DeviceLinking/Systems/SignallerSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/SignallerSystem.cs
@@ -5,7 +5,9 @@ using Content.Server.Explosion.EntitySystems;
 using Content.Server.Popups;
 using Content.Shared.Database;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Popups;
 using Content.Shared.Timing;
+using Robust.Shared.Map;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Robust.Shared.Toolshed.Commands.Math;
 
@@ -17,6 +19,7 @@ public sealed class SignallerSystem : EntitySystem
     [Dependency] private readonly UseDelaySystem _useDelay = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
     {
@@ -55,9 +58,15 @@ public sealed class SignallerSystem : EntitySystem
         args.Handled = true;
     }
 
-    private void OnSignalFailed(Entity<SignallerComponent> ent, ref SignalFailedEvent args)
+    private void OnSignalFailed(Entity<SignallerComponent> ent, ref SignalFailedEvent args) // called by WirelessNetworkSystem
     {
-        // makes a popup if the signaller is out of range
-        _popup.PopupEntity(Loc.GetString("signaller-interact-out-of-range-text"), ent.Owner);
+        if (args.failed) // makes a popup if the signaller is out of range
+        {
+            _popup.PopupEntity(Loc.GetString("signaller-interact-out-of-range-text"), ent.Owner, _transform.GetParentUid(ent.Owner), PopupType.SmallCaution);
+        }
+        else // diff popup if it's in-range
+        {
+            _popup.PopupEntity(Loc.GetString("signaller-interact-in-range-text"), ent.Owner, _transform.GetParentUid(ent.Owner));
+        }
     }
 }

--- a/Content.Server/DeviceLinking/Systems/SignallerSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/SignallerSystem.cs
@@ -1,9 +1,13 @@
 using Content.Server.Administration.Logs;
 using Content.Server.DeviceLinking.Components;
+using Content.Server.DeviceLinking.Events;
 using Content.Server.Explosion.EntitySystems;
+using Content.Server.Popups;
 using Content.Shared.Database;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Timing;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Robust.Shared.Toolshed.Commands.Math;
 
 namespace Content.Server.DeviceLinking.Systems;
 
@@ -12,6 +16,7 @@ public sealed class SignallerSystem : EntitySystem
     [Dependency] private readonly DeviceLinkSystem _link = default!;
     [Dependency] private readonly UseDelaySystem _useDelay = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -20,6 +25,7 @@ public sealed class SignallerSystem : EntitySystem
         SubscribeLocalEvent<SignallerComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<SignallerComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<SignallerComponent, TriggerEvent>(OnTrigger);
+        SubscribeLocalEvent<SignallerComponent, SignalFailedEvent>(OnSignalFailed);
     }
 
     private void OnInit(EntityUid uid, SignallerComponent component, ComponentInit args)
@@ -47,5 +53,11 @@ public sealed class SignallerSystem : EntitySystem
 
         _link.InvokePort(uid, component.Port);
         args.Handled = true;
+    }
+
+    private void OnSignalFailed(Entity<SignallerComponent> ent, ref SignalFailedEvent args)
+    {
+        // makes a popup if the signaller is out of range
+        _popup.PopupEntity(Loc.GetString("signaller-interact-out-of-range-text"), ent.Owner);
     }
 }

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Random;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using Content.Server.DeviceLinking.Events;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Examine;
 
@@ -364,7 +365,11 @@ namespace Content.Server.DeviceNetwork.Systems
                 if (!beforeEv.Cancelled)
                     RaiseLocalEvent(connection.Owner, packet, false);
                 else
+                {
                     beforeEv.Uncancel();
+                    var eventArgs = new SignalFailedEvent(packet.Sender); // event so signallers throw an error if they're out of range
+                    RaiseLocalEvent(packet.Sender, ref eventArgs, false);
+                }
             }
         }
     }

--- a/Content.Server/DeviceNetwork/Systems/WirelessNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/WirelessNetworkSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.DeviceNetwork.Components;
 using JetBrains.Annotations;
+using Content.Server.DeviceLinking.Events;
 
 namespace Content.Server.DeviceNetwork.Systems
 {
@@ -29,6 +30,8 @@ namespace Content.Server.DeviceNetwork.Systems
             if (xform.MapID != args.SenderTransform.MapID
                 || (ownPosition - _transformSystem.GetWorldPosition(xform)).Length() > sendingComponent.Range)
             {
+                var eventArgs = new SignalFailedEvent(args.Sender); // event so signallers throw an error if they're out of range
+                RaiseLocalEvent(args.Sender, ref eventArgs, false);
                 args.Cancel();
             }
         }

--- a/Content.Server/DeviceNetwork/Systems/WirelessNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/WirelessNetworkSystem.cs
@@ -1,6 +1,5 @@
 using Content.Server.DeviceNetwork.Components;
 using JetBrains.Annotations;
-using Content.Server.DeviceLinking.Events;
 
 namespace Content.Server.DeviceNetwork.Systems
 {
@@ -30,14 +29,7 @@ namespace Content.Server.DeviceNetwork.Systems
             if (xform.MapID != args.SenderTransform.MapID
                 || (ownPosition - _transformSystem.GetWorldPosition(xform)).Length() > sendingComponent.Range)
             {
-                var eventArgs = new SignalFailedEvent(args.Sender, true); // event so signallers throw an error if they're out of range
-                RaiseLocalEvent(args.Sender, ref eventArgs, false);
                 args.Cancel();
-            }
-            else // so signallers throw a different message on success
-            {
-                var eventArgs = new SignalFailedEvent(args.Sender, false);
-                RaiseLocalEvent(args.Sender, ref eventArgs, false);
             }
         }
     }

--- a/Content.Server/DeviceNetwork/Systems/WirelessNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/WirelessNetworkSystem.cs
@@ -30,9 +30,14 @@ namespace Content.Server.DeviceNetwork.Systems
             if (xform.MapID != args.SenderTransform.MapID
                 || (ownPosition - _transformSystem.GetWorldPosition(xform)).Length() > sendingComponent.Range)
             {
-                var eventArgs = new SignalFailedEvent(args.Sender); // event so signallers throw an error if they're out of range
+                var eventArgs = new SignalFailedEvent(args.Sender, true); // event so signallers throw an error if they're out of range
                 RaiseLocalEvent(args.Sender, ref eventArgs, false);
                 args.Cancel();
+            }
+            else // so signallers throw a different message on success
+            {
+                var eventArgs = new SignalFailedEvent(args.Sender, false);
+                RaiseLocalEvent(args.Sender, ref eventArgs, false);
             }
         }
     }

--- a/Resources/Locale/en-US/devices/remote-signaller.ftl
+++ b/Resources/Locale/en-US/devices/remote-signaller.ftl
@@ -1,1 +1,2 @@
-signaller-interact-out-of-range-text = Too far away!
+signaller-interact-out-of-range-text = Device too far away!
+signaller-interact-in-range-text = Device activated.

--- a/Resources/Locale/en-US/devices/remote-signaller.ftl
+++ b/Resources/Locale/en-US/devices/remote-signaller.ftl
@@ -1,2 +1,1 @@
-signaller-interact-out-of-range-text = Device too far away!
-signaller-interact-in-range-text = Device activated.
+signaller-interact-failed-to-activate-text = Failed to activate device!

--- a/Resources/Locale/en-US/devices/remote-signaller.ftl
+++ b/Resources/Locale/en-US/devices/remote-signaller.ftl
@@ -1,0 +1,1 @@
+signaller-interact-out-of-range-text = Too far away!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
remote signallers make a small popup (*Device too far away!*) when they fail to send a signal due to range
remote signallers make a different small popup (*Device activated.*) when they succeed to send a signal
if you have multiple devices, it'll give multiple popups, stacking as popups usually too, eg *Device too far away! x3*

i'd have liked to add sound to it too (then i could resolve #17389 as well), but when i added `EmitSoundOnUse` to the signaller in yaml, it stopped working as a signaller. so getting sound to work is non-trivial

## Why / Balance
it's nice QoL. remote signallers give very little feedback to the user; this helps alleviate that problem

fixes #34821


## Technical details
new event, `SignalFailedEvent`
`WirelessNetworkSystem` now raises this event when it rejects a packet due to the range being too high
`SignallerSystem` subscribes to this event & makes a popup upon hearing it

update: `WirelessNetworkSystem` *always* raises the event, and attaches a boolean to it
`SignallerSystem` uses this boolean to decide which of the two popups to make

## Media

(video outdated, but i have tested all the new features)
https://github.com/user-attachments/assets/a894cde2-fbf2-4bc2-87d4-dd0a5b2a061e



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Remote signallers now provide a popup upon activation, telling you if you're out of range or not.