### PR TITLE
remove usages of obsolete EntityUid method variants

### DIFF
--- a/Content.Server/Beam/BeamSystem.cs
+++ b/Content.Server/Beam/BeamSystem.cs
@@ -96,7 +96,7 @@ public sealed class BeamSystem : SharedBeamSystem
 
         _physics.SetBodyType(ent, BodyType.Dynamic, manager: manager, body: physics);
         _physics.SetCanCollide(ent, true, manager: manager, body: physics);
-        _broadphase.RegenerateContacts(ent, physics, manager);
+        _broadphase.RegenerateContacts((ent, physics, manager));
 
         var distanceLength = distanceCorrection.Length();
 

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.Proximity.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.Proximity.cs
@@ -36,7 +36,7 @@ public sealed partial class TriggerSystem
         // Re-check for contacts as we cleared them.
         else if (TryComp<PhysicsComponent>(uid, out var body))
         {
-            _broadphase.RegenerateContacts(uid, body);
+            _broadphase.RegenerateContacts((uid, body));
         }
     }
 

--- a/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
@@ -228,7 +228,7 @@ public sealed class SmokeSystem : EntitySystem
             var xform = Transform(uid);
             _physics.SetBodyType(uid, BodyType.Dynamic, fixtures, body, xform);
             _physics.SetCanCollide(uid, true, manager: fixtures, body: body);
-            _broadphase.RegenerateContacts(uid, body, fixtures, xform);
+            _broadphase.RegenerateContacts((uid, body, fixtures, xform));
         }
 
         var timer = EnsureComp<TimedDespawnComponent>(uid);

--- a/Content.Server/Physics/Controllers/ConveyorController.cs
+++ b/Content.Server/Physics/Controllers/ConveyorController.cs
@@ -109,7 +109,7 @@ public sealed class ConveyorController : SharedConveyorController
         component.State = state;
 
         if (TryComp<PhysicsComponent>(uid, out var physics))
-            _broadphase.RegenerateContacts(uid, physics);
+            _broadphase.RegenerateContacts((uid, physics));
 
         UpdateAppearance(uid, component);
         Dirty(uid, component);

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -116,7 +116,7 @@ public abstract class SharedStunSystem : EntitySystem
     private void OnStunOnContactStartup(Entity<StunOnContactComponent> ent, ref ComponentStartup args)
     {
         if (TryComp<PhysicsComponent>(ent, out var body))
-            _broadphase.RegenerateContacts(ent, body);
+            _broadphase.RegenerateContacts((ent, body));
     }
 
     private void OnStunOnContactCollide(Entity<StunOnContactComponent> ent, ref StartCollideEvent args)

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -95,7 +95,7 @@ namespace Content.Shared.Throwing
                 _physics.SetBodyStatus(uid, physics, BodyStatus.OnGround);
 
                 if (physics.Awake)
-                    _broadphase.RegenerateContacts(uid, physics);
+                    _broadphase.RegenerateContacts((uid, physics));
             }
 
             if (EntityManager.TryGetComponent(uid, out FixturesComponent? manager))
@@ -123,7 +123,7 @@ namespace Content.Shared.Throwing
             if (thrownItem.Thrower is not null)
                 _adminLogger.Add(LogType.Landed, LogImpact.Low, $"{ToPrettyString(uid):entity} thrown by {ToPrettyString(thrownItem.Thrower.Value):thrower} landed.");
 
-            _broadphase.RegenerateContacts(uid, physics);
+            _broadphase.RegenerateContacts((uid, physics));
             var landEvent = new LandEvent(thrownItem.Thrower, playSound);
             RaiseLocalEvent(uid, ref landEvent);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

content version of https://github.com/space-wizards/RobustToolbox/pull/5675
yes it really is just adding braces

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no fun