### PR TITLE
Fixing (an instance of) MapRenderer "Entity Does Not Have a Component" Error Having Misleading UID

### DIFF
--- a/Content.MapRenderer/Painters/GridPainter.cs
+++ b/Content.MapRenderer/Painters/GridPainter.cs
@@ -83,6 +83,11 @@ namespace Content.MapRenderer.Painters
                 {
                     continue;
                 }
+                if (prototype.ID.StartsWith("Effect"))
+                {
+                    Console.WriteLine($"Skipping unrenderable entity {prototype.ID}; please remove it from the map.");
+                    continue;
+                }
 
                 var transform = _sEntityManager.GetComponent<TransformComponent>(serverEntity);
                 if (_sEntityManager.TryGetComponent(transform.GridUid, out MapGridComponent? grid))

--- a/Content.MapRenderer/Painters/GridPainter.cs
+++ b/Content.MapRenderer/Painters/GridPainter.cs
@@ -85,7 +85,7 @@ namespace Content.MapRenderer.Painters
                 }
                 if (prototype.ID.StartsWith("Effect"))
                 {
-                    Console.WriteLine($"Skipping unrenderable entity {prototype.ID}; please remove it from the map.");
+                    Console.WriteLine($"Skipping unrenderable entity {prototype.ID}; please remove it from the map");
                     continue;
                 }
 


### PR DESCRIPTION
## About the PR
MapRenderer now reports the name of the problem prototype when it can't be rendered rather than (what I assume is) a client UID which does not correspond to the map file UID. It also skips the object in question and renders the map.

## Why / Balance
There have been a handful of instances where mappers were unable to render their maps due to an entity allegedly not having the transform component. When they checked the given UID in the map file, it would be an object that did indeed have that component, which wasn't particularly helpful for solving the issue.

Addresses https://github.com/space-wizards/space-station-14/issues/34982

## Technical details
I added a check in GridPainter's GetEntities() function after it gets an entity prototype. If that prototype's ID starts with "Effect," we print a message saying to get rid of the object and then ignore it. I checked in the map editor for anything with a name that starts with "Effect" that someone might actually want to place, and I didn't see anything, so I'm fairly confident this shouldn't cause any issues.

I should note that the fix is entirely based on my own experience; I don't know what was causing the issue for other mappers. I expect if there are any other broad groups of objects that generate the error, they can be fairly easily handled in the same if statement.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

:cl:
- fix: MapRenderer should now point the mapper to the correct problem prototype.

