### PR TITLE
Makes the Long-Range Holopad Constructible

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/holopad.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/holopad.yml
@@ -2,7 +2,7 @@
   id: HolopadMachineCircuitboard
   parent: BaseMachineCircuitboard
   name: holopad machine board
-  description: A machine printed circuit board for a holopad.
+  description: A machine printed circuit board for a holopad. Looks like you could use a screwdriver to change the board type.
   components:
     - type: MachineBoard
       prototype: Holopad
@@ -10,3 +10,24 @@
         Capacitor: 4
         Cable: 4
         Glass: 2
+    - type: Construction
+      deconstructionTarget: null
+      graph: HolopadBoard
+      node: normal
+
+- type: entity
+  id: HolopadLongRangeMachineCircuitboard
+  parent: BaseMachineCircuitboard
+  name: long-range holopad machine board
+  description: A machine printed circuit board for a long-range holopad. Looks like you could use a screwdriver to change the board type.
+  components:
+  - type: MachineBoard
+    prototype: HolopadLongRange
+    stackRequirements:
+      Capacitor: 8
+      Cable: 4
+      Glass: 2
+  - type: Construction
+    deconstructionTarget: null
+    graph: HolopadBoard
+    node: long-range

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -117,10 +117,12 @@
     - Map
     - Unlimited
     ignoreTelephonesOnSameGrid: true
+  - type: Machine
+    board: HolopadLongRangeMachineCircuitboard
 
 - type: entity
   name: quantum entangling holopad
-  description: "An floor-mounted device for projecting holographic images to similar devices at extreme distances."
+  description: "A floor-mounted device for projecting holographic images to similar devices at extreme distances."
   parent: Holopad
   id: HolopadUnlimitedRange
   components:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/holopad-circuitboard.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/holopad-circuitboard.yml
@@ -1,0 +1,18 @@
+- type: constructionGraph
+  id: HolopadBoard
+  start: normal
+  graph:
+  - node: normal
+    entity: HolopadMachineCircuitboard
+    edges:
+    - to: long-range
+      steps:
+      - tool: Screwing
+        doAfter: 2
+  - node: long-range
+    entity: HolopadLongRangeMachineCircuitboard
+    edges:
+    - to: normal
+      steps:
+      - tool: Screwing
+        doAfter: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Added Long-Range holopad circuit board
- Long range holopads can be constructed with their board
- Normal holopad boards and long-range boards can swap into each other, like freezer/heater boards

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Made a shuttle last night, was sad when I couldn't put a long range holopad in it

"Balance": LR pads take 8 capacitors while normal ones take 4 because, uh, I guess the capacitance determines the range or something.

## Technical details
<!-- Summary of code changes for easier review. -->
- Added the LR board
- Made it so the LR pad uses the LR board
- Made a construction graph so that the boards can swap between each other, and applied the graph to the boards

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 

https://github.com/user-attachments/assets/e1ec460c-ca45-464a-96d0-af5924287cae

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No C# changes.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Long-Range Holopad circuitboards, which can be obtained by using a screwdriver on a holopad board (similar to thermomachine boards), and which can be used to construct Long-Range Holopads.