### PR TITLE
Fix "Manage Laws" button appearing with insufficient permissions

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -370,7 +370,7 @@ namespace Content.Server.Administration.Systems
 
                 }
 
-                if (lawBoundComponent != null && target != null)
+                if (lawBoundComponent != null && target != null && _adminManager.HasAdminFlag(player, AdminFlags.Moderator))
                 {
                     args.Verbs.Add(new Verb()
                     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
simple bug fix.
Permissions check was already in the UI system, the verb just checked for "is admin" not if they actually have the permissions that were needed for the UI.

**Changelog**
no cl, super simple bug fix