### PR TITLE
Fix fax spamming

### DIFF
--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -451,6 +451,9 @@ public sealed class FaxSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
+        if (component.SendTimeoutRemaining > 0)
+            return;
+
         var sendEntity = component.PaperSlot.Item;
         if (sendEntity == null)
             return;

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -495,6 +495,9 @@ public sealed class FaxSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
+        if (component.SendTimeoutRemaining > 0)
+            return;
+
         var sendEntity = component.PaperSlot.Item;
         if (sendEntity == null)
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR fixes being able to send multiple faxes in quick succession.

Fixes #35115 

## Technical details
<!-- Summary of code changes for easier review. -->

Faxes already have a sending cooldown, but it was only being enforced on client-side through disabling the Send button.
If you click quickly (or use macros, etc.) before the server can send the new disabled state back, you can push through multiple faxes.

This PR just adds a simple server-side check. (The client-side check is still useful for communicating the cooldown to the user.)

Edit: I also noticed that the Copy function has the same issue (and uses the same cooldown), so I added the check there too.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:

https://github.com/user-attachments/assets/ffae9c7d-8079-4de6-8b17-75347a001d9c

After:

https://github.com/user-attachments/assets/2fb50bb9-c1ca-44fb-8324-e8503832d8ad

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed being able to fax multiple times in quick succession
