### PR TITLE
Filter prototypes checked by NoStaticPriceAndStackPrice test and skip spawning

### DIFF
--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -128,23 +128,20 @@ public sealed class CargoTest
             {
                 var ent = entManager.SpawnEntity(proto, coord);
 
+                Assert.That(entManager.TryGetComponent<StaticPriceComponent>(ent, out var staticPriceComp), Is.True,
+                    $"The prototype {proto} has a StaticPriceComponent but somehow does not when spawned?"); // Sanity check
+
                 if (entManager.TryGetComponent<StackPriceComponent>(ent, out var stackpricecomp)
                     && stackpricecomp.Price > 0)
                 {
-                    if (entManager.TryGetComponent<StaticPriceComponent>(ent, out var staticpricecomp))
-                    {
-                        Assert.That(staticpricecomp.Price, Is.EqualTo(0),
-                            $"The prototype {proto} has a StackPriceComponent and StaticPriceComponent whose values are not compatible with each other.");
-                    }
+                    Assert.That(staticPriceComp.Price, Is.EqualTo(0),
+                        $"The prototype {proto} has a StackPriceComponent and StaticPriceComponent whose values are not compatible with each other.");
                 }
 
                 if (entManager.HasComponent<StackComponent>(ent))
                 {
-                    if (entManager.TryGetComponent<StaticPriceComponent>(ent, out var staticpricecomp))
-                    {
-                        Assert.That(staticpricecomp.Price, Is.EqualTo(0),
-                            $"The prototype {proto} has a StackComponent and StaticPriceComponent whose values are not compatible with each other.");
-                    }
+                    Assert.That(staticPriceComp.Price, Is.EqualTo(0),
+                        $"The prototype {proto} has a StackComponent and StaticPriceComponent whose values are not compatible with each other.");
                 }
 
                 entManager.DeleteEntity(ent);

--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -105,7 +105,6 @@ public sealed class CargoTest
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
 
-        var entManager = server.EntMan;
         var protoManager = server.ProtoMan;
         var compFact = server.ResolveDependency<IComponentFactory>();
 

--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -106,9 +106,9 @@ public sealed class CargoTest
 
         var testMap = await pair.CreateTestMap();
 
-        var entManager = server.ResolveDependency<IEntityManager>();
-        var mapManager = server.ResolveDependency<IMapManager>();
-        var protoManager = server.ResolveDependency<IPrototypeManager>();
+        var entManager = server.EntMan;
+        var mapManager = server.MapMan;
+        var protoManager = server.ProtoMan;
 
         await server.WaitAssertion(() =>
         {

--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -7,6 +7,7 @@ using Content.Server.Nutrition.Components;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Cargo.Prototypes;
 using Content.Shared.IdentityManagement;
+using Content.Shared.Prototypes;
 using Content.Shared.Stacks;
 using Content.Shared.Tag;
 using Content.Shared.Whitelist;
@@ -104,49 +105,36 @@ public sealed class CargoTest
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
 
-        var testMap = await pair.CreateTestMap();
-
         var entManager = server.EntMan;
-        var mapManager = server.MapMan;
         var protoManager = server.ProtoMan;
+        var compFact = server.ResolveDependency<IComponentFactory>();
 
         await server.WaitAssertion(() =>
         {
-            var mapId = testMap.MapId;
-            var grid = mapManager.CreateGridEntity(mapId);
-            var coord = new EntityCoordinates(grid.Owner, 0, 0);
-
             var protoIds = protoManager.EnumeratePrototypes<EntityPrototype>()
                 .Where(p => !p.Abstract)
                 .Where(p => !pair.IsTestPrototype(p))
                 .Where(p => p.Components.ContainsKey("StaticPrice"))
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // Grids are not for sale.
-                .Select(p => p.ID)
                 .ToList();
 
             foreach (var proto in protoIds)
             {
-                var ent = entManager.SpawnEntity(proto, coord);
+                // Sanity check
+                Assert.That(proto.TryGetComponent<StaticPriceComponent>(out var staticPriceComp, compFact), Is.True);
 
-                Assert.That(entManager.TryGetComponent<StaticPriceComponent>(ent, out var staticPriceComp), Is.True,
-                    $"The prototype {proto} has a StaticPriceComponent but somehow does not when spawned?"); // Sanity check
-
-                if (entManager.TryGetComponent<StackPriceComponent>(ent, out var stackpricecomp)
-                    && stackpricecomp.Price > 0)
+                if (proto.TryGetComponent<StackPriceComponent>(out var stackPriceComp, compFact) && stackPriceComp.Price > 0)
                 {
                     Assert.That(staticPriceComp.Price, Is.EqualTo(0),
                         $"The prototype {proto} has a StackPriceComponent and StaticPriceComponent whose values are not compatible with each other.");
                 }
 
-                if (entManager.HasComponent<StackComponent>(ent))
+                if (proto.HasComponent<StackComponent>(compFact))
                 {
                     Assert.That(staticPriceComp.Price, Is.EqualTo(0),
                         $"The prototype {proto} has a StackComponent and StaticPriceComponent whose values are not compatible with each other.");
                 }
-
-                entManager.DeleteEntity(ent);
             }
-            mapManager.DeleteMap(mapId);
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -115,7 +115,6 @@ public sealed class CargoTest
                 .Where(p => !p.Abstract)
                 .Where(p => !pair.IsTestPrototype(p))
                 .Where(p => p.Components.ContainsKey("StaticPrice"))
-                .Where(p => !p.Components.ContainsKey("MapGrid")) // Grids are not for sale.
                 .ToList();
 
             foreach (var proto in protoIds)

--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -119,6 +119,7 @@ public sealed class CargoTest
             var protoIds = protoManager.EnumeratePrototypes<EntityPrototype>()
                 .Where(p => !p.Abstract)
                 .Where(p => !pair.IsTestPrototype(p))
+                .Where(p => p.Components.ContainsKey("StaticPrice"))
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // Grids are not for sale.
                 .Select(p => p.ID)
                 .ToList();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
NoStaticPriceAndStackPrice now only checks entity prototypes that have a `StaticPriceComponent`. It also no longer bothers to spawn and delete each entity; instead it just examines the prototype data.

## Technical details
<!-- Summary of code changes for easier review. -->
Currently the test spawns and checks every `EntityPrototype` that does not have a `MapGridComponent` (and isn't abstract or a test prototype), but the logic of the test only actually cares about entities that have a `StaticPriceComponent`.

Now the prototypes are filtered before spawning, which massively cuts down on the number of entities that need to be spawned (from ~9000 to ~4000).

I suspect that this was also the reason why this test sometimes randomly failed, since it wasn't filtering out some prototypes that could do weird things (possibly with `RoomFillComponent`?).

There's also no reason to actually spawn in the entities - the test only examines a couple of component fields that are set in YAML. So the test no longer spawns a test map or any of the entities; it just iterates through the prototypes and checks the values there. I don't think this was a particularly slow test before, but it should be faster now without having to do that work.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.