### PR TITLE
Smite Vendor Restock and General Soda Machine Balance

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/gib.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/gib.yml
@@ -1,7 +1,7 @@
 - type: vendingMachineInventory
   id: DrGibbInventory
   startingInventory:
-    DrinkDrGibbCan: 4
+    DrinkDrGibbCan: 6
     DrinkGrapeCan: 2
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/smite.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/smite.yml
@@ -1,13 +1,13 @@
 - type: vendingMachineInventory
   id: SmiteInventory
   startingInventory:
-    DrinkLemonLimeCan: 8
-    DrinkLemonLimeCranberryCan: 6
-    DrinkColaCan: 2
-    DrinkSolDryCan: 2
+    DrinkLemonLimeCan: 7
+    DrinkLemonLimeCranberryCan: 5
+    DrinkColaCan: 3
+    DrinkSolDryCan: 3
   contrabandInventory:
-    ToyHammer: 1
     DrinkStarkistCan: 2
+    ToyHammer: 1
   emaggedInventory:
     DrinkNukieCan: 2
     DrinkChangelingStingCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/smite.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/smite.yml
@@ -1,8 +1,8 @@
 - type: vendingMachineInventory
   id: SmiteInventory
   startingInventory:
-    DrinkLemonLimeCan: 7
-    DrinkLemonLimeCranberryCan: 5
+    DrinkLemonLimeCan: 8
+    DrinkLemonLimeCranberryCan: 6
     DrinkColaCan: 3
     DrinkSolDryCan: 3
   contrabandInventory:

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/smite.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/smite.yml
@@ -1,10 +1,10 @@
 - type: vendingMachineInventory
   id: SmiteInventory
   startingInventory:
-    DrinkLemonLimeCan: 7
-    DrinkLemonLimeCranberryCan: 5
-    DrinkColaCan: 3
-    DrinkSolDryCan: 3
+    DrinkLemonLimeCan: 8
+    DrinkLemonLimeCranberryCan: 6
+    DrinkColaCan: 2
+    DrinkSolDryCan: 2
   contrabandInventory:
     ToyHammer: 1
     DrinkStarkistCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/smite.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/smite.yml
@@ -1,10 +1,10 @@
 - type: vendingMachineInventory
   id: SmiteInventory
   startingInventory:
-    DrinkLemonLimeCan: 4
-    DrinkLemonLimeCranberryCan: 2
-    DrinkColaCan: 2
-    DrinkSolDryCan: 2
+    DrinkLemonLimeCan: 7
+    DrinkLemonLimeCranberryCan: 5
+    DrinkColaCan: 3
+    DrinkSolDryCan: 3
   contrabandInventory:
     ToyHammer: 1
     DrinkStarkistCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
@@ -1,14 +1,12 @@
 - type: vendingMachineInventory
   id: SpaceUpInventory
   startingInventory:
-    DrinkSpaceUpCan: 3
-    DrinkSpaceMountainWindCan: 3
+    DrinkSpaceUpCan: 5
+    DrinkSpaceMountainWindCan: 5
     DrinkGrapeCan: 2
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2
     DrinkSolDryCan: 2
-    DrinkLemonLimeCan: 2
-    DrinkLemonLimeCranberryCan: 2
     DrinkFourteenLokoCan: 2
   contrabandInventory:
     DrinkSpaceMountainWindBottleFull: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
@@ -1,7 +1,7 @@
 - type: vendingMachineInventory
   id: StarkistInventory
   startingInventory:
-    DrinkStarkistCan: 4
+    DrinkStarkistCan: 6
     DrinkGrapeCan: 2
     DrinkRootBeerCan: 2
     DrinkIcedTeaCan: 2

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -336,6 +336,7 @@
     - SpaceUpInventory
     - SodaInventory
     - DrGibbInventory
+    - SmiteInventory 
   - type: Sprite
     layers:
     - state: base


### PR DESCRIPTION
## About the PR
I enabled Smite machines to be restocked by beverage restock boxes. Currently there are no ways to do this.

I've also chance soda quantities in several machines to make their name-brand product more prominent and likely to spawn.

## Why / Balance
Soda machines should restock, because the rest do. It was probably an oversight or part of another plan that hasn't been implemented. Until then, Smite should be able to restock using the existing beverage restocks.

As for soda balance, right now drinks machines have the following balance in terms of number of drinks they spawn/restock with, including MNGR/contrabandInventory menu:
Soda: 18-21 (and sometimes 2 Bottle Sodas, 4 for SpaceUp)
BODA: 20 (and 2 Soda Water Bottles)
Solar's Best Hot Drinks: 25 (and 2 Teapots)

The Smite machine had a stock of 10 (+2 in MNGR), which is well below the average, but with the same .33 spawn chance per drink, which often resulted in these basically being empty and less preferable to check over literally any other drinks machine. I really focused on Smite and Smite Cranberry as the primary stock options.

Likewise with Dr. Gibb, Starkist and Space Up/Space Solar Wind, their numbers have been respectively buffed. Also, it made no sense for Smite to be in the Space Up machine (too many Lemon-Lime sodas), so I cut them to further buff the Space Up/Space Solar Wind numbers.

## Technical details
Some vending machine .yml changes and adding Smite to the relevant line of vending_machine_restock.yml. This is about as simple as this type of PR gets.

## Media
This image shows every machine at their maximum capacity after 3 restocks, with their MNGR wires cut. To calculate their base spawn/restock numbers on any item, divide their numbers by 3, or check the "Files Changed" tab to see them directly.
![image](https://github.com/user-attachments/assets/418d1754-a8f0-4674-b7f2-9278cc427220)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl: AgentSmithRadio
- fix: Smite Vendors can now be restocked using the standard beverage restock box.
- tweak: Smite and other soda vendors now carry more soda, and are less likely to be empty at shift start.