### PR TITLE
make slime hair less transparent

### DIFF
--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -48,7 +48,7 @@
 - type: humanoidBaseSprite
   id: MobSlimeMarkingFollowSkin
   markingsMatchSkin: true
-  layerAlpha: 0.5
+  layerAlpha: 0.85
 
 - type: humanoidBaseSprite
   id: MobSlimeHead

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -48,7 +48,7 @@
 - type: humanoidBaseSprite
   id: MobSlimeMarkingFollowSkin
   markingsMatchSkin: true
-  layerAlpha: 0.85
+  layerAlpha: 0.88
 
 - type: humanoidBaseSprite
   id: MobSlimeHead

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -48,7 +48,7 @@
 - type: humanoidBaseSprite
   id: MobSlimeMarkingFollowSkin
   markingsMatchSkin: true
-  layerAlpha: 0.88
+  layerAlpha: 0.72
 
 - type: humanoidBaseSprite
   id: MobSlimeHead


### PR DESCRIPTION
## About the PR
changes slimepeople hair from being 50% transparent to 28% transparent
fixes #35137 

## Why / Balance
to fix #35137
and slime hair in general is way too transparent which yeah leads to them looking kinda bald (thats the only reason)

## Technical details
changes layeralpha for mobslimemarkingfollowskin in Resources\Prototypes\Species\slime.yml from .5 to .72

## Media
screenshots are in last comment


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Slimepeople look a bit less bald now.
