### PR TITLE
Separate Udder examine into ExamineableHunger

### DIFF
--- a/Content.Shared/Animals/UdderSystem.cs
+++ b/Content.Shared/Animals/UdderSystem.cs
@@ -1,7 +1,6 @@
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.DoAfter;
-using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Nutrition.Components;
@@ -32,7 +31,6 @@ public sealed class UdderSystem : EntitySystem
         SubscribeLocalEvent<UdderComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<UdderComponent, GetVerbsEvent<AlternativeVerb>>(AddMilkVerb);
         SubscribeLocalEvent<UdderComponent, MilkingDoAfterEvent>(OnDoAfter);
-        SubscribeLocalEvent<UdderComponent, ExaminedEvent>(OnExamine);
     }
 
     private void OnMapInit(EntityUid uid, UdderComponent component, MapInitEvent args)
@@ -139,51 +137,5 @@ public sealed class UdderSystem : EntitySystem
             Priority = 2
         };
         args.Verbs.Add(verb);
-    }
-
-    /// <summary>
-    ///     Defines the text provided on examine.
-    ///     Changes depending on the amount of hunger the target has.
-    /// </summary>
-    private void OnExamine(Entity<UdderComponent> entity, ref ExaminedEvent args)
-    {
-
-        var entityIdentity = Identity.Entity(args.Examined, EntityManager);
-
-        string message;
-
-        // Check if the target has hunger, otherwise return not hungry.
-        if (!TryComp<HungerComponent>(entity, out var hunger))
-        {
-            message = Loc.GetString("udder-system-examine-none", ("entity", entityIdentity));
-            args.PushMarkup(message);
-            return;
-        }
-
-        // Choose the correct examine string based on HungerThreshold.
-        switch (_hunger.GetHungerThreshold(hunger))
-        {
-            case >= HungerThreshold.Overfed:
-                message = Loc.GetString("udder-system-examine-overfed", ("entity", entityIdentity));
-                break;
-
-            case HungerThreshold.Okay:
-                message = Loc.GetString("udder-system-examine-okay", ("entity", entityIdentity));
-                break;
-
-            case HungerThreshold.Peckish:
-                message = Loc.GetString("udder-system-examine-hungry", ("entity", entityIdentity));
-                break;
-
-            // There's a final hunger threshold called "dead" but animals don't actually die so we'll re-use this.
-            case <= HungerThreshold.Starving:
-                message = Loc.GetString("udder-system-examine-starved", ("entity", entityIdentity));
-                break;
-
-            default:
-                return;
-        }
-
-        args.PushMarkup(message);
     }
 }

--- a/Content.Shared/Nutrition/Components/ExamineableHungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/ExamineableHungerComponent.cs
@@ -1,0 +1,31 @@
+using Content.Shared.Nutrition.EntitySystems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Nutrition.Components;
+
+/// <summary>
+/// Adds text to the entity's description box based on its current hunger threshold.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(ExamineableHungerSystem))]
+public sealed partial class ExamineableHungerComponent : Component
+{
+    /// <summary>
+    /// Dictionary of hunger thresholds to LocIds of the messages to display.
+    /// </summary>
+    [DataField]
+    public Dictionary<HungerThreshold, LocId> Descriptions = new()
+    {
+        { HungerThreshold.Overfed, "examineable-hunger-component-examine-overfed"},
+        { HungerThreshold.Okay, "examineable-hunger-component-examine-okay"},
+        { HungerThreshold.Peckish, "examineable-hunger-component-examine-peckish"},
+        { HungerThreshold.Starving, "examineable-hunger-component-examine-starving"},
+        { HungerThreshold.Dead, "examineable-hunger-component-examine-dead"}
+    };
+
+    /// <summary>
+    /// LocId of a fallback message to display if the entity has no <see cref="HungerComponent"/>
+    /// or does not have a value in <see cref="Descriptions"/> for the current threshold.
+    /// </summary>
+    public LocId NoHungerDescription = "examineable-hunger-component-examine-none";
+}

--- a/Content.Shared/Nutrition/Components/ExamineableHungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/ExamineableHungerComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class ExamineableHungerComponent : Component
         { HungerThreshold.Okay, "examineable-hunger-component-examine-okay"},
         { HungerThreshold.Peckish, "examineable-hunger-component-examine-peckish"},
         { HungerThreshold.Starving, "examineable-hunger-component-examine-starving"},
-        { HungerThreshold.Dead, "examineable-hunger-component-examine-dead"}
+        { HungerThreshold.Dead, "examineable-hunger-component-examine-starving"}
     };
 
     /// <summary>

--- a/Content.Shared/Nutrition/EntitySystems/ExamineableHungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/ExamineableHungerSystem.cs
@@ -1,0 +1,41 @@
+using Content.Shared.Examine;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Nutrition.Components;
+
+namespace Content.Shared.Nutrition.EntitySystems;
+
+/// <inheritdoc cref="ExamineableHungerComponent"/>
+public sealed class ExamineableHungerSystem : EntitySystem
+{
+    [Dependency] private readonly HungerSystem _hunger = default!;
+    private EntityQuery<HungerComponent> _hungerQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _hungerQuery = GetEntityQuery<HungerComponent>();
+
+        SubscribeLocalEvent<ExamineableHungerComponent, ExaminedEvent>(OnExamine);
+    }
+
+    /// <summary>
+    ///     Defines the text provided on examine.
+    ///     Changes depending on the amount of hunger the target has.
+    /// </summary>
+    private void OnExamine(Entity<ExamineableHungerComponent> entity, ref ExaminedEvent args)
+    {
+        var identity = Identity.Entity(entity, EntityManager);
+
+        if (!_hungerQuery.TryComp(entity, out var hungerComp)
+            || !entity.Comp.Descriptions.TryGetValue(_hunger.GetHungerThreshold(hungerComp), out var locId))
+        {
+            // Use a fallback message if the entity has no HungerComponent
+            // or is missing a description for the current threshold
+            locId = entity.Comp.NoHungerDescription;
+        }
+
+        var msg = Loc.GetString(locId, ("entity", identity));
+        args.PushMarkup(msg);
+    }
+}

--- a/Resources/Locale/en-US/animals/udder/udder-system.ftl
+++ b/Resources/Locale/en-US/animals/udder/udder-system.ftl
@@ -5,9 +5,3 @@ udder-system-success = You fill {THE($target)} with {$amount}u from the udder.
 udder-system-dry = The udder is dry.
 
 udder-system-verb-milk = Milk
-
-udder-system-examine-overfed = {CAPITALIZE(SUBJECT($entity))} looks stuffed!
-udder-system-examine-okay = {CAPITALIZE(SUBJECT($entity))} looks content.
-udder-system-examine-hungry = {CAPITALIZE(SUBJECT($entity))} looks hungry.
-udder-system-examine-starved = {CAPITALIZE(SUBJECT($entity))} looks starved!
-udder-system-examine-none = {CAPITALIZE(SUBJECT($entity))} seems not to get hungry.

--- a/Resources/Locale/en-US/nutrition/components/examineable-hunger-component.ftl
+++ b/Resources/Locale/en-US/nutrition/components/examineable-hunger-component.ftl
@@ -2,5 +2,4 @@ examineable-hunger-component-examine-overfed = {CAPITALIZE(SUBJECT($entity))} {C
 examineable-hunger-component-examine-okay = {CAPITALIZE(SUBJECT($entity))} {CONJUGATE-BASIC($entity, "look", "looks")} content.
 examineable-hunger-component-examine-peckish = {CAPITALIZE(SUBJECT($entity))} {CONJUGATE-BASIC($entity, "look", "looks")} hungry.
 examineable-hunger-component-examine-starving = {CAPITALIZE(SUBJECT($entity))} {CONJUGATE-BASIC($entity, "look", "looks")} starved!
-examineable-hunger-component-examine-dead = {CAPITALIZE(SUBJECT($entity))} {CONJUGATE-BE($entity)} no longer concerned with eating.
 examineable-hunger-component-examine-none = {CAPITALIZE(SUBJECT($entity))} {CONJUGATE-BASIC($entity, "seem", "seems")} not to get hungry.

--- a/Resources/Locale/en-US/nutrition/components/examineable-hunger-component.ftl
+++ b/Resources/Locale/en-US/nutrition/components/examineable-hunger-component.ftl
@@ -1,0 +1,6 @@
+examineable-hunger-component-examine-overfed = {CAPITALIZE(SUBJECT($entity))} looks stuffed!
+examineable-hunger-component-examine-okay = {CAPITALIZE(SUBJECT($entity))} looks content.
+examineable-hunger-component-examine-peckish = {CAPITALIZE(SUBJECT($entity))} looks hungry.
+examineable-hunger-component-examine-starving = {CAPITALIZE(SUBJECT($entity))} looks starved!
+examineable-hunger-component-examine-dead = {CAPITALIZE(SUBJECT($entity))} is no longer concerned with eating.
+examineable-hunger-component-examine-none = {CAPITALIZE(SUBJECT($entity))} seems not to get hungry.

--- a/Resources/Locale/en-US/nutrition/components/examineable-hunger-component.ftl
+++ b/Resources/Locale/en-US/nutrition/components/examineable-hunger-component.ftl
@@ -1,6 +1,6 @@
-examineable-hunger-component-examine-overfed = {CAPITALIZE(SUBJECT($entity))} looks stuffed!
-examineable-hunger-component-examine-okay = {CAPITALIZE(SUBJECT($entity))} looks content.
-examineable-hunger-component-examine-peckish = {CAPITALIZE(SUBJECT($entity))} looks hungry.
-examineable-hunger-component-examine-starving = {CAPITALIZE(SUBJECT($entity))} looks starved!
-examineable-hunger-component-examine-dead = {CAPITALIZE(SUBJECT($entity))} is no longer concerned with eating.
-examineable-hunger-component-examine-none = {CAPITALIZE(SUBJECT($entity))} seems not to get hungry.
+examineable-hunger-component-examine-overfed = {CAPITALIZE(SUBJECT($entity))} {CONJUGATE-BASIC($entity, "look", "looks")} stuffed!
+examineable-hunger-component-examine-okay = {CAPITALIZE(SUBJECT($entity))} {CONJUGATE-BASIC($entity, "look", "looks")} content.
+examineable-hunger-component-examine-peckish = {CAPITALIZE(SUBJECT($entity))} {CONJUGATE-BASIC($entity, "look", "looks")} hungry.
+examineable-hunger-component-examine-starving = {CAPITALIZE(SUBJECT($entity))} {CONJUGATE-BASIC($entity, "look", "looks")} starved!
+examineable-hunger-component-examine-dead = {CAPITALIZE(SUBJECT($entity))} {CONJUGATE-BE($entity)} no longer concerned with eating.
+examineable-hunger-component-examine-none = {CAPITALIZE(SUBJECT($entity))} {CONJUGATE-BASIC($entity, "seem", "seems")} not to get hungry.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -828,6 +828,7 @@
     reagentId: Milk
     quantityPerUpdate: 25
     growthDelay: 30
+  - type: ExamineableHunger
   - type: Butcherable
     spawned:
     - id: FoodMeat
@@ -984,6 +985,7 @@
     reagentId: MilkGoat
     quantityPerUpdate: 25
     growthDelay: 20
+  - type: ExamineableHunger
   - type: Wooly
   - type: Food
     solution: wool

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -229,6 +229,7 @@
   - type: EggLayer
     eggSpawn:
     - id: FoodEgg
+  - type: ExamineableHunger
   - type: ReplacementAccent
     accent: chicken
   - type: SentienceTarget
@@ -663,6 +664,7 @@
   - type: EggLayer
     eggSpawn:
     - id: FoodEgg
+  - type: ExamineableHunger
   - type: ReplacementAccent
     accent: duck
   - type: SentienceTarget


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Extracted functionality from `UdderSystem` that handles displaying "They look content/hungry/starved" in the entity's description and moved it to a new component & system `ExamineableHunger`. Chickens and ducks now show hunger level on examine.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There's nothing udder-specific about the examine code, so there's no reason for it to be part of `UdderSystem`. It can now be reused on other entities that experience hunger.

## Technical details
<!-- Summary of code changes for easier review. -->
Pulled `OnExamine` and subscription out of `UdderSystem`.
Added `ExamineableHungerComponent` and `ExamineableHungerSystem` to handle this functionality.
Refactored the examine code a bit to make it more compatible with potential future changes to hunger.
Moved LocIds out of the system and onto the component so they can be customized for different entity prototypes.
Tweaked the Fluent messages to be more robust about grammar.
Added `ExamineableHunger` components to cow, goat, chicken, and duck prototypes.

Note to testers: the reported hunger threshold will desync between the client and server. This bug exists in the current master too and is unrelated to these changes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Looks the same as it used to.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`UdderComponent` no longer adds a description of an entity's current hunger level to its examine text. Add `ExamineableHungerComponent` for this functionality.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Chickens and ducks now report hunger levels when examined.