### PR TITLE
Flippo Engraved Lighter is now in detective locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -125,7 +125,8 @@
       - id: ClothingHeadHatFedoraBrown
       - id: ClothingNeckTieDet
       - id: ClothingOuterVestDetective
-      - id: ClothingOuterCoatDetective
+      - id: ClothingOuterCoatDetectiveLoadout
+      - id: FlippoEngravedLighter
       - id: FlashlightSeclite
       - id: ForensicScanner
       - id: LogProbeCartridge


### PR DESCRIPTION
## About the PR
This pull request was made to resolve #35163 

Summary of the issue is that the detective coat in the locker is actually a unique coat that contains the flippo engraved lighter (steal objective). The coat is like a regular detective coat with nothing special about it so people never look inside of it.

This PR will make it so that the detective's flippo engraved lighter is in the locker right away instead of a coat. I also made sure the coat that is in the locker does not contain the special lighter anymore.

## Why / Balance
I saw the issue and kind of agreed with the original poster. As a detective player myself I also did not know this thing even existed! This PR will help make the item visible instead of being in some obscure coat pocket.

## Technical details
The item with id FlippoEngravedLighter is now added to the LockerDetectiveFilled.
The item with id ClothingOuterCoatDetective is now replaced with ClothingOuterCoatDetectiveLoadout in the LockerDetectiveFilled. Which is basically the same coat but without the flippo engraved lighter.

## Media
https://github.com/user-attachments/assets/806de646-a3cc-49fc-8e7a-64714f2179cf

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Tested it. No breaking changes.

**Changelog**
This is such a small change. I don't think it requires a changelog addition.
