### PR TITLE
Fix colornetwork command not checking for correct permissions

### DIFF
--- a/Content.Server/Sandbox/Commands/ColorNetworkCommand.cs
+++ b/Content.Server/Sandbox/Commands/ColorNetworkCommand.cs
@@ -19,7 +19,7 @@ namespace Content.Server.Sandbox.Commands
         {
             var sandboxManager = _entManager.System<SandboxSystem>();
             var adminManager = IoCManager.Resolve<IAdminManager>();
-            if (shell.IsClient && (!sandboxManager.IsSandboxEnabled && !adminManager.HasAdminFlag(shell.Player!, AdminFlags.Mapping)))
+            if (shell.IsClient || (!sandboxManager.IsSandboxEnabled && !adminManager.HasAdminFlag(shell.Player!, AdminFlags.Mapping)))
             {
                 shell.WriteError(Loc.GetString("cmd-colornetwork-no-access"));
             }


### PR DESCRIPTION
What is shell.IsClient even?? And why is it checked on a server side command?

???

Fixes #32466