### PR TITLE
Fire resist now can be examined.

### DIFF
--- a/Content.Shared/Clothing/Components/FireProtectionComponent.cs
+++ b/Content.Shared/Clothing/Components/FireProtectionComponent.cs
@@ -14,4 +14,11 @@ public sealed partial class FireProtectionComponent : Component
     /// </summary>
     [DataField(required: true)]
     public float Reduction;
+
+    /// <summary>
+    /// LocId for message that will be shown on detailed examine.
+    /// Actually can be moved into system
+    /// </summary>
+    [DataField]
+    public LocId ExamineMessage = "fire-protection-reduction-value";
 }

--- a/Content.Shared/Clothing/Components/FireProtectionComponent.cs
+++ b/Content.Shared/Clothing/Components/FireProtectionComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Clothing.EntitySystems;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Clothing.Components;
 
@@ -15,3 +16,6 @@ public sealed partial class FireProtectionComponent : Component
     [DataField(required: true)]
     public float Reduction;
 }
+
+[ByRefEvent]
+public record struct FireProtectionExamineEvent(FormattedMessage Msg);

--- a/Content.Shared/Clothing/Components/FireProtectionComponent.cs
+++ b/Content.Shared/Clothing/Components/FireProtectionComponent.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Clothing.EntitySystems;
-using Robust.Shared.Utility;
 
 namespace Content.Shared.Clothing.Components;
 
@@ -16,6 +15,3 @@ public sealed partial class FireProtectionComponent : Component
     [DataField(required: true)]
     public float Reduction;
 }
-
-[ByRefEvent]
-public record struct FireProtectionExamineEvent(FormattedMessage Msg);

--- a/Content.Shared/Clothing/EntitySystems/FireProtectionSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/FireProtectionSystem.cs
@@ -1,6 +1,9 @@
 using Content.Shared.Atmos;
 using Content.Shared.Clothing.Components;
+using Content.Shared.Examine;
 using Content.Shared.Inventory;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Clothing.EntitySystems;
 
@@ -9,15 +12,40 @@ namespace Content.Shared.Clothing.EntitySystems;
 /// </summary>
 public sealed class FireProtectionSystem : EntitySystem
 {
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<FireProtectionComponent, InventoryRelayedEvent<GetFireProtectionEvent>>(OnGetProtection);
+        SubscribeLocalEvent<FireProtectionComponent, GetVerbsEvent<ExamineVerb>>(OnFireProtectionVerbExamine);
     }
 
     private void OnGetProtection(Entity<FireProtectionComponent> ent, ref InventoryRelayedEvent<GetFireProtectionEvent> args)
     {
         args.Args.Reduce(ent.Comp.Reduction);
+    }
+
+    private void OnFireProtectionVerbExamine(EntityUid uid, FireProtectionComponent component, GetVerbsEvent<ExamineVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        var examineMarkup = GetFireProtectionExamine(component.Reduction);
+
+        var ev = new FireProtectionExamineEvent(examineMarkup);
+        RaiseLocalEvent(uid, ref ev);
+
+        _examine.AddDetailedExamineVerb(args, component, examineMarkup,
+            Loc.GetString("fire-protection-examinable-verb-text"), "/Textures/Interface/VerbIcons/dot.svg.192dpi.png",
+            Loc.GetString("fire-protection-examinable-verb-message"));
+    }
+
+    private FormattedMessage GetFireProtectionExamine(float reduction)
+    {
+        var msg = new FormattedMessage();
+        msg.AddMarkupOrThrow(Loc.GetString("fire-protection-reduction-value", ("value", MathF.Round((1f - reduction) * 100, 1))));
+
+        return msg;
     }
 }

--- a/Content.Shared/Clothing/EntitySystems/FireProtectionSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/FireProtectionSystem.cs
@@ -32,10 +32,6 @@ public sealed class FireProtectionSystem : EntitySystem
             return;
 
         var examineMarkup = GetFireProtectionExamine(component.Reduction);
-
-        var ev = new FireProtectionExamineEvent(examineMarkup);
-        RaiseLocalEvent(uid, ref ev);
-
         _examine.AddDetailedExamineVerb(args, component, examineMarkup,
             Loc.GetString("fire-protection-examinable-verb-text"), "/Textures/Interface/VerbIcons/dot.svg.192dpi.png",
             Loc.GetString("fire-protection-examinable-verb-message"));

--- a/Content.Shared/Examine/GroupExamineComponent.cs
+++ b/Content.Shared/Examine/GroupExamineComponent.cs
@@ -22,6 +22,7 @@ namespace Content.Shared.Examine
                 {
                     "Armor",
                     "ClothingSpeedModifier",
+                    "FireProtection",
                 },
             },
         };

--- a/Content.Shared/Examine/GroupExamineComponent.cs
+++ b/Content.Shared/Examine/GroupExamineComponent.cs
@@ -22,7 +22,6 @@ namespace Content.Shared.Examine
                 {
                     "Armor",
                     "ClothingSpeedModifier",
-                    "FireProtection",
                 },
             },
         };

--- a/Resources/Locale/en-US/clothing/components/fire-protection-component.ftl
+++ b/Resources/Locale/en-US/clothing/components/fire-protection-component.ftl
@@ -1,3 +1,3 @@
 fire-protection-examinable-verb-text = Fire reduction
 fire-protection-examinable-verb-message = Examine the fire reduction values.
-fire-protection-reduction-value = - [color=orange]Fire damage[/color] reduced by [color=lightblue]{$value}%[/color].
+fire-protection-reduction-value = - [color=orange]Fire[/color] damage reduced by [color=lightblue]{$value}%[/color].

--- a/Resources/Locale/en-US/clothing/components/fire-protection-component.ftl
+++ b/Resources/Locale/en-US/clothing/components/fire-protection-component.ftl
@@ -1,0 +1,3 @@
+fire-protection-examinable-verb-text = Fire reduction
+fire-protection-examinable-verb-message = Examine the fire reduction values.
+fire-protection-reduction-value = - [color=orange]Fire damage[/color] reduced by [color=lightblue]{$value}%[/color].

--- a/Resources/Locale/en-US/clothing/components/fire-protection-component.ftl
+++ b/Resources/Locale/en-US/clothing/components/fire-protection-component.ftl
@@ -1,3 +1,1 @@
-fire-protection-examinable-verb-text = Fire reduction
-fire-protection-examinable-verb-message = Examine the fire reduction values.
-fire-protection-reduction-value = - [color=orange]Fire[/color] damage reduced by [color=lightblue]{$value}%[/color].
+fire-protection-reduction-value = - [color=orange]Fire damage[/color] reduced by [color=lightblue]{$value}%[/color].

--- a/Resources/Locale/en-US/clothing/components/fire-protection-component.ftl
+++ b/Resources/Locale/en-US/clothing/components/fire-protection-component.ftl
@@ -1,1 +1,1 @@
-fire-protection-reduction-value = - [color=orange]Fire damage[/color] reduced by [color=lightblue]{$value}%[/color].
+fire-protection-reduction-value = - [color=orange]Fire[/color] damage reduced by [color=lightblue]{$value}%[/color].


### PR DESCRIPTION
## About the PR
Fire resist now can be examined.

## Why / Balance
Fire resist are pretty new-player-unfrendly thing, because right now players can't discover them without watching on the code. Some of players still think that thermal resist protects players from the fire. It should be fixed

## Media
![fire](https://github.com/user-attachments/assets/acc273f1-83cf-4f15-98fa-f0922fdcd47d)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Fire resists now can be examined.
