### PR TITLE
move a colon to the localization string

### DIFF
--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
@@ -60,8 +60,6 @@
                                   Margin="0 0 0 5">
                         <Label Text="{Loc 'crew-monitoring-user-interface-job'}"
                                FontColorOverride="DarkGray" />
-                        <Label Text=":"
-                               FontColorOverride="DarkGray" />
                         <TextureRect Name="PersonJobIcon"
                                      TextureScale="2 2"
                                      Margin="6 0"

--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
@@ -58,7 +58,7 @@
                            StyleClasses="LabelBig" />
                     <BoxContainer Orientation="Horizontal"
                                   Margin="0 0 0 5">
-                        <Label Text="{Loc 'crew-monitoring-user-interface-job'}:"
+                        <Label Text="{Loc 'crew-monitoring-user-interface-job'}"
                                FontColorOverride="DarkGray" />
                         <Label Text=":"
                                FontColorOverride="DarkGray" />

--- a/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
+++ b/Content.Client/CriminalRecords/CriminalRecordsConsoleWindow.xaml
@@ -60,6 +60,8 @@
                                   Margin="0 0 0 5">
                         <Label Text="{Loc 'crew-monitoring-user-interface-job'}"
                                FontColorOverride="DarkGray" />
+                        <Label Text=":"
+                               FontColorOverride="DarkGray" />
                         <TextureRect Name="PersonJobIcon"
                                      TextureScale="2 2"
                                      Margin="6 0"

--- a/Resources/Locale/en-US/medical/components/crew-monitoring-component.ftl
+++ b/Resources/Locale/en-US/medical/components/crew-monitoring-component.ftl
@@ -5,7 +5,7 @@ crew-monitoring-user-interface-title = Crew Monitoring Console
 crew-monitor-filter-line-placeholder = Filter
 
 crew-monitoring-user-interface-name = Name
-crew-monitoring-user-interface-job = Job
+crew-monitoring-user-interface-job = Job:
 crew-monitoring-user-interface-status = Status
 crew-monitoring-user-interface-location = Location
 

--- a/Resources/Locale/en-US/medical/components/crew-monitoring-component.ftl
+++ b/Resources/Locale/en-US/medical/components/crew-monitoring-component.ftl
@@ -5,7 +5,7 @@ crew-monitoring-user-interface-title = Crew Monitoring Console
 crew-monitor-filter-line-placeholder = Filter
 
 crew-monitoring-user-interface-name = Name
-crew-monitoring-user-interface-job = Job:
+crew-monitoring-user-interface-job = Job
 crew-monitoring-user-interface-status = Status
 crew-monitoring-user-interface-location = Location
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
As the title says, moves the colon for crew-monitoring-user-interface-job to its respective ftl.

## Why / Balance
Gets rid of the syntax error the linter throws.

## Technical details
Simply changes the location of a colon.

## Media
This would be funny, but no.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Downstreams that use translations may need to make a minor alteration.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL No Fun
