### PR TITLE
Remove unnecessary prototype reloading in integration tests

### DIFF
--- a/Content.IntegrationTests/Pair/TestPair.Prototypes.cs
+++ b/Content.IntegrationTests/Pair/TestPair.Prototypes.cs
@@ -26,11 +26,7 @@ public sealed partial class TestPair
             instance.ProtoMan.LoadString(file, changed: changed);
         }
 
-        await instance.WaitPost(() =>
-        {
-            instance.ProtoMan.ResolveResults();
-            instance.ProtoMan.ReloadPrototypes(changed);
-        });
+        await instance.WaitPost(() => instance.ProtoMan.ReloadPrototypes(changed));
 
         foreach (var (kind, ids) in changed)
         {


### PR DESCRIPTION
## About the PR
Removes an unnecessary `IPrototyopeManager.ResolveResults()` call, which should make test pair creation for integration tests a bit faster.
