### PR TITLE
Don't count lobby players for latejoin antag ratio

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -19,11 +19,12 @@ public sealed partial class AntagSelectionSystem
     /// Tries to get the next non-filled definition based on the current amount of selected minds and other factors.
     /// </summary>
     public bool TryGetNextAvailableDefinition(Entity<AntagSelectionComponent> ent,
-        [NotNullWhen(true)] out AntagSelectionDefinition? definition)
+        [NotNullWhen(true)] out AntagSelectionDefinition? definition,
+        int? players = null)
     {
         definition = null;
 
-        var totalTargetCount = GetTargetAntagCount(ent);
+        var totalTargetCount = GetTargetAntagCount(ent, players);
         var mindCount = ent.Comp.SelectedMinds.Count;
         if (mindCount >= totalTargetCount)
             return false;

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -144,7 +144,10 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
             DebugTools.AssertEqual(antag.SelectionTime, AntagSelectionTime.PostPlayerSpawn);
 
-            if (!TryGetNextAvailableDefinition((uid, antag), out var def))
+            // do not count players in the lobby for the antag ratio
+            var players = _playerManager.NetworkedSessions.Count(x => x.AttachedEntity != null);
+
+            if (!TryGetNextAvailableDefinition((uid, antag), out var def, players))
                 continue;
 
             if (TryMakeAntag((uid, antag), args.Player, def.Value))


### PR DESCRIPTION
## About the PR
When a player latejoins, the number of players used to calculate the available antag slots includes players in the lobby, unlike the roundstart calculation. This means that if a **lot** of players do not join at roundstart, there might be a few extra antag slots available immediately after roundstart. Those who join the quickest after roundstart will have a high chance of getting one of these antag slots. This is somewhat exploitable, but imo not reliably so, it relies on too many hard-to-account-for factors. And the more people try it the less reliable it gets, but if just a few players try it then nothing happens as there won't be any "additional" antag slots from the latejoiners. 
Additional antag slots now become available gradually, as 1-sec latejoiners enter the game.

## Why / Balance
There is no reason to "frontload" latejoin antags based on players still in the lobby

## Technical details
TryGetNextAvailableDefinition() can now optionally accept playercount, and will pass it to GetTargetAntagCount() . It defaults to passing null when no input is provided, preserving its current behavior.
Number of Joined players is: all connected players with any AttachedEntity

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->