### PR TITLE
fix use in hand for uplink items

### DIFF
--- a/Content.Server/Store/Systems/StoreSystem.Refund.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Refund.cs
@@ -38,7 +38,6 @@ public sealed partial class StoreSystem
 
     private void OnUseInHand(Entity<StoreRefundComponent> ent, ref UseInHandEvent args)
     {
-        args.Handled = true;
         CheckDisableRefund(ent);
     }
 


### PR DESCRIPTION
## About the PR
At the moment all uplink items cannot be used in hand.
This include for example unpacking edagger boxes or activating grenades or C4.

## Why / Balance
bugfix

## Technical details
Caused by https://github.com/space-wizards/space-station-14/pull/34671
It added an UseInHandEventSubscription that disables refund for items bought in stores.
It marks the event a handled, which blocks other interactions.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed uplink items not being able to be used in your hand.
