### PR TITLE
Change `visualize` command perms to VarEdit instead of Admin

### DIFF
--- a/Content.Server/Toolshed/Commands/VisualizeCommand.cs
+++ b/Content.Server/Toolshed/Commands/VisualizeCommand.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Toolshed.Errors;
 
 namespace Content.Server.Toolshed.Commands;
 
-[ToolshedCommand, AdminCommand(AdminFlags.Admin)]
+[ToolshedCommand, AdminCommand(AdminFlags.VarEdit)]
 public sealed class VisualizeCommand : ToolshedCommand
 {
     [Dependency] private readonly EuiManager _euiManager = default!;


### PR DESCRIPTION
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

People with VarEdit can use VV but can't use visualize, makes no sense. 
Maintainers don't get the admin flag because that opens up too many things for them, but we get Query, Mapping etc. so we could do `> entities with X comp:rm MetaData` but can't do `> entities with X visualize`. 

Has headmin approval here: https://canary.discord.com/channels/310555209753690112/1193403928096821358/1340756276371787827

