### PR TITLE
Fix role timer string formatting.

### DIFF
--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -147,7 +147,7 @@ namespace Content.Shared.Localizations
         /// </summary>
         public static string FormatPlaytime(TimeSpan time)
         {
-            time = TimeSpan.FromSeconds(Math.Ceiling(time.TotalSeconds));
+            time = TimeSpan.FromMinutes(Math.Ceiling(time.TotalMinutes));
             var hours = (int)time.TotalHours;
             var minutes = time.Minutes;
             return Loc.GetString($"zzzz-fmt-playtime", ("hours", hours), ("minutes", minutes));

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -147,10 +147,9 @@ namespace Content.Shared.Localizations
         /// </summary>
         public static string FormatPlaytime(TimeSpan time)
         {
+            time = TimeSpan.FromSeconds(Math.Ceiling(time.TotalSeconds));
             var hours = (int)time.TotalHours;
             var minutes = time.Minutes;
-            if (hours == 0 && minutes == 0)
-                minutes = 1;
             return Loc.GetString($"zzzz-fmt-playtime", ("hours", hours), ("minutes", minutes));
         }
 

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -148,7 +148,8 @@ namespace Content.Shared.Localizations
         public static string FormatPlaytime(TimeSpan time)
         {
             var hours = (int)time.TotalHours;
-            var minutes = (int)Math.Ceiling(time.TotalMinutes);
+            var rounded = (int)Math.Ceiling(time.TotalMinutes);
+            var minutes = rounded - hours * 60;
             return Loc.GetString($"zzzz-fmt-playtime", ("hours", hours), ("minutes", minutes));
         }
 

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -148,8 +148,9 @@ namespace Content.Shared.Localizations
         public static string FormatPlaytime(TimeSpan time)
         {
             var hours = (int)time.TotalHours;
-            var rounded = (int)Math.Ceiling(time.TotalMinutes);
-            var minutes = rounded - hours * 60;
+            var minutes = time.Minutes;
+            if (hours == 0 && minutes == 0)
+                minutes = 1;
             return Loc.GetString($"zzzz-fmt-playtime", ("hours", hours), ("minutes", minutes));
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes role timers showing total minutes to next role as appose to minutes in the hour.

## Why / Balance
Fixes #35217

## Technical details
Reverts #34961 and appends a suggestion by @Centronias

## Media
![{245887D6-CF83-4AEA-B306-62AB438EA77B}](https://github.com/user-attachments/assets/87611902-76a2-4188-b630-e2014b0eaa65)
![{B819CDF2-1AA2-4DE6-8E09-5490B99B3276}](https://github.com/user-attachments/assets/9620fb3e-8d66-4587-a6d5-5c4abcb64a22)
![image](https://github.com/user-attachments/assets/684c44a2-8f14-4d5d-8fa2-7ed3f0029b11)
![image](https://github.com/user-attachments/assets/5e22990b-dd5e-4950-96c9-168cf02199a2)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
No CL No Fun.
