### PR TITLE
[Bugfix] ContrabandSystem checks jobs correctly

### DIFF
--- a/Content.Shared/Contraband/ContrabandSystem.cs
+++ b/Content.Shared/Contraband/ContrabandSystem.cs
@@ -56,7 +56,8 @@ public sealed class ContrabandSystem : EntitySystem
         // one, the actual informative 'this is restricted'
         // then, the 'you can/shouldn't carry this around' based on the ID the user is wearing
         var localizedDepartments = component.AllowedDepartments.Select(p => Loc.GetString("contraband-department-plural", ("department", Loc.GetString(_proto.Index(p).Name))));
-        var localizedJobs = component.AllowedJobs.Select(p => Loc.GetString("contraband-job-plural", ("job", _proto.Index(p).LocalizedName)));
+        var jobs = component.AllowedJobs.Select(p => _proto.Index(p).LocalizedName).ToArray();
+        var localizedJobs = jobs.Select(p => Loc.GetString("contraband-job-plural", ("job", p)));
         var severity = _proto.Index(component.Severity);
         String departmentExamineMessage;
         if (severity.ShowDepartmentsAndJobs)
@@ -86,7 +87,7 @@ public sealed class ContrabandSystem : EntitySystem
         String carryingMessage;
         // either its fully restricted, you have no departments, or your departments dont intersect with the restricted departments
         if (departments.Intersect(component.AllowedDepartments).Any()
-            || component.AllowedJobs.Select(p => _proto.Index(p).LocalizedName).Contains(jobId))
+            || jobs.Contains(jobId))
         {
             carryingMessage = Loc.GetString("contraband-examine-text-in-the-clear");
         }

--- a/Content.Shared/Contraband/ContrabandSystem.cs
+++ b/Content.Shared/Contraband/ContrabandSystem.cs
@@ -86,7 +86,7 @@ public sealed class ContrabandSystem : EntitySystem
         String carryingMessage;
         // either its fully restricted, you have no departments, or your departments dont intersect with the restricted departments
         if (departments.Intersect(component.AllowedDepartments).Any()
-            || localizedJobs.Contains(jobId))
+            || component.AllowedJobs.Select(p => _proto.Index(p).LocalizedName).Contains(jobId))
         {
             carryingMessage = Loc.GetString("contraband-examine-text-in-the-clear");
         }


### PR DESCRIPTION
## About the PR
Right now ContrabandSystem makes job checks incorrectly: for example, janitors are told that they're not allowed to have galoshes by the examine text. This PR fixes that.

## Why / Balance
bug bad, me fix bug

## Technical details
Right now, it checks if player's job is in the list of allowed jobs *in plural*, which is most likely not true. Instead, I rewrited it to check if player's list is in actual list of allowed jobs (by names). This is still not ideal, but it works and further improvements need refactors in IdCardComponent, so not today.

## Media
![image](https://github.com/user-attachments/assets/f11b14d2-dec5-4927-b624-dda047269bd0)
![image](https://github.com/user-attachments/assets/c789ddc7-ed1b-44cd-bc5f-628c9a0f8681)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
:cl:
- fix: Contraband examines now correctly tell you if you can possess the object.
