### PR TITLE
UseInHandEvent cleanup

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
@@ -76,14 +76,13 @@ public sealed class GasAnalyzerSystem : EntitySystem
     /// </summary>
     private void OnUseInHand(Entity<GasAnalyzerComponent> entity, ref UseInHandEvent args)
     {
+        // Not checking for Handled because ActivatableUISystem already marks it as such.
+
         if (!entity.Comp.Enabled)
-        {
             ActivateAnalyzer(entity, args.User);
-        }
         else
-        {
             DisableAnalyzer(entity, args.User);
-        }
+
         args.Handled = true;
     }
 

--- a/Content.Server/Mousetrap/MousetrapSystem.cs
+++ b/Content.Server/Mousetrap/MousetrapSystem.cs
@@ -27,6 +27,9 @@ public sealed class MousetrapSystem : EntitySystem
 
     private void OnUseInHand(EntityUid uid, MousetrapComponent component, UseInHandEvent args)
     {
+        if (args.Handled)
+            return;
+
         component.IsActive = !component.IsActive;
         _popupSystem.PopupEntity(component.IsActive
             ? Loc.GetString("mousetrap-on-activate")
@@ -35,6 +38,8 @@ public sealed class MousetrapSystem : EntitySystem
             args.User);
 
         UpdateVisuals(uid);
+
+        args.Handled = true;
     }
 
     private void OnStepTriggerAttempt(EntityUid uid, MousetrapComponent component, ref StepTriggerAttemptEvent args)

--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -37,6 +37,8 @@ public sealed class PAISystem : SharedPAISystem
 
     private void OnUseInHand(EntityUid uid, PAIComponent component, UseInHandEvent args)
     {
+        // Not checking for Handled because ToggleableGhostRoleSystem already marks it as such.
+
         if (!TryComp<MindContainerComponent>(uid, out var mind) || !mind.HasMind)
             component.LastUser = args.User;
     }

--- a/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
+++ b/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
@@ -80,26 +80,20 @@ namespace Content.Server.Storage.EntitySystems
                 _adminLogger.Add(LogType.EntitySpawn, LogImpact.Low, $"{ToPrettyString(args.User)} used {ToPrettyString(uid)} which spawned {ToPrettyString(entityToPlaceInHands.Value)}");
             }
 
+            // The entity is often deleted, so play the sound at its position rather than parenting
             if (component.Sound != null)
-            {
-                // The entity is often deleted, so play the sound at its position rather than parenting
-                var coordinates = Transform(uid).Coordinates;
-                _audio.PlayPvs(component.Sound, coordinates);
-            }
+                _audio.PlayPvs(component.Sound, coords);
 
             component.Uses--;
 
             // Delete entity only if component was successfully used
             if (component.Uses <= 0)
-            {
-                args.Handled = true;
-                EntityManager.DeleteEntity(uid);
-            }
+                Del(uid);
 
             if (entityToPlaceInHands != null)
-            {
                 _hands.PickupOrDrop(args.User, entityToPlaceInHands.Value);
-            }
+
+            args.Handled = true;
         }
     }
 }

--- a/Content.Server/Storage/EntitySystems/SpawnTableOnUseSystem.cs
+++ b/Content.Server/Storage/EntitySystems/SpawnTableOnUseSystem.cs
@@ -25,17 +25,16 @@ public sealed class SpawnTableOnUseSystem : EntitySystem
         if (args.Handled)
             return;
 
-        args.Handled = true;
-
         var coords = Transform(ent).Coordinates;
         var spawns = _entityTable.GetSpawns(ent.Comp.Table);
         foreach (var id in spawns)
         {
             var spawned = Spawn(id, coords);
             _adminLogger.Add(LogType.EntitySpawn, LogImpact.Low, $"{ToPrettyString(args.User):user} used {ToPrettyString(ent):spawner} which spawned {ToPrettyString(spawned)}");
-            _hands.TryPickupAnyHand(args.User, spawned);
+            _hands.PickupOrDrop(args.User, spawned);
         }
 
         Del(ent);
+        args.Handled = true;
     }
 }

--- a/Content.Server/Store/Systems/StoreSystem.Refund.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Refund.cs
@@ -74,6 +74,10 @@ public sealed partial class StoreSystem
 
     private void CheckDisableRefund(Entity<StoreRefundComponent> ent)
     {
+        // we don't check if the interactions are handled and some of them may delete the entity
+        if (TerminatingOrDeleted(ent.Owner))
+            return;
+
         var component = ent.Comp;
 
         if (component.StoreEntity == null || !TryComp<StoreComponent>(component.StoreEntity.Value, out var storeComp) || !storeComp.RefundAllowed)

--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -41,6 +41,9 @@ public sealed class HandTeleporterSystem : EntitySystem
 
     private void OnUseInHand(EntityUid uid, HandTeleporterComponent component, UseInHandEvent args)
     {
+        if (args.Handled)
+            return;
+
         if (Deleted(component.FirstPortal))
             component.FirstPortal = null;
 
@@ -67,6 +70,8 @@ public sealed class HandTeleporterSystem : EntitySystem
 
             _doafter.TryStartDoAfter(doafterArgs);
         }
+
+        args.Handled = true;
     }
 
 

--- a/Content.Shared/Sound/SharedEmitSoundSystem.cs
+++ b/Content.Shared/Sound/SharedEmitSoundSystem.cs
@@ -103,6 +103,10 @@ public abstract class SharedEmitSoundSystem : EntitySystem
     private void OnEmitSoundOnUseInHand(EntityUid uid, EmitSoundOnUseComponent component, UseInHandEvent args)
     {
         // Intentionally not checking whether the interaction has already been handled.
+        // Some UseInHand subscriptions delete the entity, so we have to check for that.
+        if (TerminatingOrDeleted(uid))
+            return;
+
         TryEmitSound(uid, component, args.User);
 
         if (component.Handle)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Magazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Magazine.cs
@@ -38,6 +38,8 @@ public abstract partial class SharedGunSystem
 
     private void OnMagazineUse(EntityUid uid, MagazineAmmoProviderComponent component, UseInHandEvent args)
     {
+        // not checking for args.Handled or marking as such because we only relay the event to magazine
+
         var magEnt = GetMagazineEntity(uid);
 
         if (magEnt == null)

--- a/Content.Shared/Whistle/WhistleSystem.cs
+++ b/Content.Shared/Whistle/WhistleSystem.cs
@@ -27,11 +27,10 @@ public sealed class WhistleSystem : EntitySystem
 
     public void OnUseInHand(EntityUid uid, WhistleComponent component, UseInHandEvent args)
     {
-        if (!_timing.IsFirstTimePredicted)
+        if (args.Handled || !_timing.IsFirstTimePredicted)
             return;
 
-        TryMakeLoudWhistle(uid, args.User, component);
-        args.Handled = true;
+        args.Handled = TryMakeLoudWhistle(uid, args.User, component);
     }
 
     public bool TryMakeLoudWhistle(EntityUid uid, EntityUid owner, WhistleComponent? component = null)


### PR DESCRIPTION
## About the PR
I went through all UseInHandEvent subscriptions and cleaned them up a little because some combinations might cause errors.

## Why / Balance
bugfix/cleanup

## Technical details
https://github.com/space-wizards/space-station-14/pull/34671 introduced a new UseInHandEvent  subscription that disables store refunds. This subscription cannot mark the event as handled or it will block all other interactions.
However, some systems delete the entitity the event is raised on (SpawnItemsOnUse, SpawnTableOnUse, RandomGiftSystem), so we have to check for the item being deleted there to prevent errors if the subscriptiosn are done in the wrong order. It is a little sus to delete entities in the event bus and that should maybe be replaced with `QueueDel` instead to make sure other subscriptions can be handled properly. But this creates the problem that the newly spawned items cannot be put into your hand because it is still blocked.

I also added some missing Handled checks and comments where they are left out intentionally.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
no player facing changes
