### PR TITLE
ConfirmableAction for DNA Scrambler implant

### DIFF
--- a/Resources/Locale/en-US/actions/actions/dna-scrambler.ftl
+++ b/Resources/Locale/en-US/actions/actions/dna-scrambler.ftl
@@ -1,0 +1,1 @@
+dna-scrambler-action-popup = THIS ACTION WILL IRREVERSIBLY CHANGE YOUR APPEARANCE! Use it again to confirm.

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -153,6 +153,8 @@
   name: Scramble DNA
   description:  Randomly changes your name and appearance.
   components:
+  - type: ConfirmableAction
+    popup: dna-scrambler-action-popup
   - type: InstantAction
     charges: 1
     itemIconStyle: BigAction


### PR DESCRIPTION
## About the PR
DNA Scrambler now requires confirmation to activate, like Micro Bomb, Death Acidifier, etc.

## Why / Balance
Accidentally pressing DNA Scrambler at a wrong time can ruin a match.

## Technical details
Added a `ConfirmableAction` component to prototype.

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- add: DNA Scrambler implant now requires confirmation to activate
