### PR TITLE
fix observer ghost spawn error

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -359,6 +359,7 @@ namespace Content.Server.GameTicking
             if (DummyTicker)
                 return;
 
+            var makeObserver = false;
             Entity<MindComponent?>? mind = player.GetMind();
             if (mind == null)
             {
@@ -366,10 +367,13 @@ namespace Content.Server.GameTicking
                 var (mindId, mindComp) = _mind.CreateMind(player.UserId, name);
                 mind = (mindId, mindComp);
                 _mind.SetUserId(mind.Value, player.UserId);
-                _roles.MindAddRole(mind.Value, "MindRoleObserver");
+                makeObserver = true;
             }
 
             var ghost = _ghost.SpawnGhost(mind.Value);
+            if (makeObserver)
+                _roles.MindAddRole(mind.Value, "MindRoleObserver");
+
             _adminLogger.Add(LogType.LateJoin,
                 LogImpact.Low,
                 $"{player.Name} late joined the round as an Observer with {ToPrettyString(ghost):entity}.");


### PR DESCRIPTION
## About the PR
Spawning as an Observer no longer triggers an error in the log.
It is now (more) possible for MapRenderer to draw the CentComm map (this probably also needs #35241 and possibly more)

## Why / Balance
Bug

## Technical details
When an observer ghost spawns ((without already having a mind entity)), gameticker tried to add a mindrole to the newly created mind before the ghost entity has been attached to the mind. This causes an issue in SharedRoleSystem where it tries to log mind role changes under the owning entity, not the mind (logs make more sense that way)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
