### PR TITLE
New Feature: Votekick bans distinguish themselves as votekicks

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -544,7 +544,7 @@ namespace Content.Server.Voting.Managers
 
                         uint minutes = (uint)_cfg.GetCVar(CCVars.VotekickBanDuration);
 
-                        _bans.CreateServerBan(targetUid, target, null, targetIP, targetHWid, minutes, severity, reason);
+                        _bans.CreateServerBan(targetUid, target, null, targetIP, targetHWid, minutes, severity, "Votekick: " + reason);
                     }
                 }
                 else

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -544,7 +544,7 @@ namespace Content.Server.Voting.Managers
 
                         uint minutes = (uint)_cfg.GetCVar(CCVars.VotekickBanDuration);
 
-                        _bans.CreateServerBan(targetUid, target, null, targetIP, targetHWid, minutes, severity, "Votekick: " + reason);
+                        _bans.CreateServerBan(targetUid, target, null, targetIP, targetHWid, minutes, severity, Loc.GetString("votekick-ban-reason", ("reason", reason)));
                     }
                 }
                 else

--- a/Resources/Locale/en-US/discord/vote-notifications.ftl
+++ b/Resources/Locale/en-US/discord/vote-notifications.ftl
@@ -9,3 +9,5 @@ votekick-webhook-description = Initiator: { $initiator }; Target: { $target }
 votekick-webhook-cancelled-admin-online = **Vote cancelled due to admins online**
 votekick-webhook-cancelled-admin-target = **Vote cancelled due to target being admin**
 votekick-webhook-cancelled-antag-target = **Vote cancelled due to target being antag**
+
+votekick-ban-reason = "Votekick: {$reason}"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #33257.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
ADMIN: 
- tweak: Votekick bans now distinguish themselves as votekicks in the "ban reason".
