### PR TITLE
allow to publish news without ui

### DIFF
--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -143,9 +143,7 @@ public sealed class NewsSystem : SharedNewsSystem
         var title = msg.Title.Trim();
         var content = msg.Content.Trim();
 
-        AddNews(ent, title, content, authorName, out var article);
-
-        if (article.HasValue)
+        if (TryAddNews(ent, title, content, authorName, out var article))
         {
             _audio.PlayPvs(ent.Comp.ConfirmSound, ent);
 
@@ -163,12 +161,13 @@ public sealed class NewsSystem : SharedNewsSystem
         }
     }
 
-    public void AddNews(EntityUid uid, string title, string content, string? author, out NewsArticle? article)
+    public bool TryAddNews(EntityUid uid, string title, string content, string? author, [NotNullWhen(true)] out NewsArticle? article)
     {
-        article = null;
-
         if (!TryGetArticles(uid, out var articles))
-            return;
+        {
+            article = default;
+            return false;
+        }
 
         article = new NewsArticle
         {
@@ -189,6 +188,8 @@ public sealed class NewsSystem : SharedNewsSystem
         }
 
         UpdateWriterDevices();
+
+        return true;
     }
     #endregion
 

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -199,15 +199,15 @@ public sealed class NewsSystem : SharedNewsSystem
         if (Comp<CartridgeComponent>(ent).LoaderUid is not { } loaderUid)
             return;
 
-            UpdateReaderUi(ent, loaderUid);
+        UpdateReaderUi(ent, loaderUid);
 
-            if (!ent.Comp.NotificationOn)
-                return;
+        if (!ent.Comp.NotificationOn)
+            return;
 
         _cartridgeLoaderSystem.SendNotification(
             loaderUid,
             Loc.GetString("news-pda-notification-header"),
-                                                args.Article.Title);
+            args.Article.Title);
     }
 
     private void OnArticleDeleted(Entity<NewsReaderCartridgeComponent> ent, ref NewsArticleDeletedEvent args)
@@ -215,7 +215,7 @@ public sealed class NewsSystem : SharedNewsSystem
         if (Comp<CartridgeComponent>(ent).LoaderUid is not { } loaderUid)
             return;
 
-            UpdateReaderUi(ent, loaderUid);
+        UpdateReaderUi(ent, loaderUid);
     }
 
     private void OnReaderUiMessage(Entity<NewsReaderCartridgeComponent> ent, ref CartridgeMessageEvent args)

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -143,7 +143,7 @@ public sealed class NewsSystem : SharedNewsSystem
         var title = msg.Title.Trim();
         var content = msg.Content.Trim();
 
-        if (TryAddNews(ent, title, content, authorName, out var article, msg.Actor))
+        if (TryAddNews(ent, title, content, out var article, authorName, msg.Actor))
         {
             _audio.PlayPvs(ent.Comp.ConfirmSound, ent);
 

--- a/Content.Server/MassMedia/Systems/NewsSystem.cs
+++ b/Content.Server/MassMedia/Systems/NewsSystem.cs
@@ -163,7 +163,7 @@ public sealed class NewsSystem : SharedNewsSystem
     /// <param name="content">Content of the news article.</param>
     /// <param name="author">Author of the news article.</param>
     /// <param name="actor">Entity which caused the news article to publish. Used for admin logs.</param>
-    public bool TryAddNews(EntityUid uid, string title, string content, string? author, [NotNullWhen(true)] out NewsArticle? article, EntityUid? actor)
+    public bool TryAddNews(EntityUid uid, string title, string content, [NotNullWhen(true)] out NewsArticle? article, string? author = null, EntityUid? actor = null)
     {
         if (!TryGetArticles(uid, out var articles))
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
split OnWriteUiDeleteMessage in two, allowing to use a new AddNews method for publishing news from other systems, without need to go through client

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
do it for a fork, but i suppose it could have some usage in upstream in the future or may be helpful to other forks, as Slam said

![image](https://github.com/user-attachments/assets/fb2bc337-90a5-4db1-a07a-993888ac9efb)


## Technical details
<!-- Summary of code changes for easier review. -->
described in about pr

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

OnWriteUiDeleteMessage method has been split in two.
Now it's OnWriteUiDeleteMessage, which raised on client, and AddNews, which can be accessed from other systems.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no playerfacing cl no fun