### PR TITLE
China Lark Nerf Issue: #34980

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -37,6 +37,7 @@
     - Back
     - suitStorage
   - type: AmmoCounter
+  - type: GunRequiresWield
   - type: Gun
     fireRate: 1
     selectedMode: SemiAuto
@@ -48,7 +49,7 @@
     whitelist:
       tags:
         - Grenade
-    capacity: 3
+    capacity: 1
     proto: GrenadeFrag
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes Issue #34980 I made the Chinalake only have the ability to contain 1 round, along with making it a requirement to weld the weapon.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Alot of people in the comments of the original issue, thought it would be a good idea to reduce it to 1 round, I also decided to make the wield change because I feel like somebody shouldn't be able to use a grenade launcher with one hand.
## Technical details
<!-- Summary of code changes for easier review. -->
Capacity of Chinalake reduced to 1, along with the gun having the GunRequiresWield component.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**

🆑 
- tweak: The Chinalake can only hold 1 explosive at a time, along with it needing to be wielded to use it.
