### PR TITLE
Rebalanced Cargo Bounties (And Kalimba is percussion now)

### DIFF
--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -110,11 +110,11 @@
 
 - type: cargoBounty
   id: BountyCrayon
-  reward: 4000
+  reward: 2000
   description: bounty-description-crayon
   entries:
   - name: bounty-item-crayon
-    amount: 24
+    amount: 25
     whitelist:
       tags:
       - Crayon
@@ -133,7 +133,7 @@
 
 - type: cargoBounty
   id: BountyDonut
-  reward: 6000
+  reward: 2400
   description: bounty-description-donut
   idPrefix: CC
   entries:
@@ -145,7 +145,7 @@
 
 - type: cargoBounty
   id: BountyFigurine
-  reward: 8000
+  reward: 4000
   description: bounty-description-figurine
   entries:
   - name: bounty-item-figurine
@@ -282,7 +282,7 @@
 
 - type: cargoBounty
   id: BountyPen
-  reward: 8000
+  reward: 4000
   description: bounty-description-pen
   entries:
   - name: bounty-item-pen
@@ -293,11 +293,11 @@
 
 - type: cargoBounty
   id: BountyPercussion
-  reward: 15000
+  reward: 5000
   description: bounty-description-percussion
   entries:
   - name: bounty-item-percussion
-    amount: 4
+    amount: 5
     whitelist:
       tags:
       - PercussionInstrument

--- a/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_service.yml
@@ -74,7 +74,7 @@
     sprite: Objects/Misc/pens.rsi
     state: pen
   product: CrateServiceBureaucracy
-  cost: 1000
+  cost: 1500
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -156,7 +156,6 @@
       - id: AccordionInstrument
         amount: 2
       - id: KalimbaInstrument
-        amount: 2
       - id: WoodblockInstrument
       - id: GlockenspielInstrument
         amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/vending.yml
@@ -264,4 +264,4 @@
   - type: StorageFill
     contents:
       - id: VendingMachineRestockDonut
-        amount: 2
+        amount: 1

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: BaseHandheldInstrument
   id: GlockenspielInstrument
   name: glockenspiel
@@ -98,7 +98,7 @@
     state: icon
   - type: Tag
     tags:
-    - KeyedInstrument
+    - PercussionInstrument
   - type: Item
     size: Small
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
In short, changed a bunch of cargo bounties so that you can't just buy things and immediately resell them for a profit.
In long...
Changed the Crayon bounty to make only 2000 from 4000, increased the amount of crayons needed from 24 to 25
Changed the donut bounty to make only 2400 from 6000, changed the amount of donut restock boxes in a donut restock crate from 2 to 1
Changed the figurine bounty to make only 4000 from 8000
Changed the percussion instrument bounty to make only 5000 from 15000, made the kalimba a percussion instrument, removed a kalimba from the percussion instrument ensemble crate.

## Why / Balance
Okay, so cargo shouldn't be able to buy things, then slap a bounty tag and sell them instantly for a profit. That's bad!
Instead, these changes make it so that it won't be profitable (but might still break even!) to buy and resell some crates with a bounty.
Also kalimbas are a percussion instrument. They just are.
I did this entire thing because I wanted kalimbas to be percussion, when I changed it, it messed with the percussion bounty. Then I realized bounties were wack, so I fixed them.

Honourable mentions
The artifact bounty can _kinda_ be bought and resold for a profit, as the bounty gives 2500 but an artifact costs 2000. However, artifact containment costs 500, so to package large artifacts it costs 2500. If you get lucky and buy a small artifact you make a profit, though. Overall, this does probably have a chance at giving sci more artifacts, which is good, and honestly this bounty sucks (as artifacts have better uses than being sold for 2500), so I just kept it as is.

The laser bounty is the only bounty where it's substantially better to ask someone for help while still being possible to buy and resell crates for a profit. I think it's okay to keep as is, because buying laser crates does raise questions, and most people will go to sec to print lasers for cheaper, anyways.

## Media
You just need to read. No visual aids can help. If you want a picture of cargo, go play SS14. NOW.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: Adjusted the requirements and rewards of some cargo bounties.
