### PR TITLE
Wizard Recall shows Disappearing text at Coordinate

### DIFF
--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -125,7 +125,7 @@ namespace Content.Client.Popups
 
         public override void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
         {
-            if (recipient != null && _timing.IsFirstTimePredicted)
+            if (_playerManager.LocalSession == recipient & _timing.IsFirstTimePredicted)
                 PopupCoordinates(message, coordinates, type);
         }
 

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -123,6 +123,12 @@ namespace Content.Client.Popups
                 PopupMessage(message, type, coordinates, null, true);
         }
 
+        public override void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
+        {
+            if (recipient != null && _timing.IsFirstTimePredicted)
+                PopupCoordinates(message, coordinates, type);
+        }
+
         private void PopupCursorInternal(string? message, PopupType type, bool recordReplay)
         {
             if (message == null)

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -125,8 +125,8 @@ namespace Content.Client.Popups
 
         public override void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
         {
-            if (_playerManager.LocalEntity == recipient && _timing.IsFirstTimePredicted)
-                PopupCoordinates(message, coordinates, type);
+            if (recipient != null && _timing.IsFirstTimePredicted)
+                PopupCoordinates(message, coordinates, recipient.Value, type);
         }
 
         private void PopupCursorInternal(string? message, PopupType type, bool recordReplay)

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -125,7 +125,7 @@ namespace Content.Client.Popups
 
         public override void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
         {
-            if (_playerManager.LocalSession == recipient & _timing.IsFirstTimePredicted)
+            if (_playerManager.LocalEntity == recipient && _timing.IsFirstTimePredicted)
                 PopupCoordinates(message, coordinates, type);
         }
 

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -75,18 +75,13 @@ namespace Content.Server.Popups
                 return;
 
             var mapPos = _transform.ToMapCoordinates(coordinates);
+            var filter = Filter.Empty().AddPlayersByPvs(mapPos, entManager: EntityManager, playerMan: _player, cfgMan: _cfg);
             if (recipient != null)
             {
                 // Don't send to recipient, since they predicted it locally
-                var filter = Filter.PvsExcept(recipient.Value, entityManager: EntityManager);
-                RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), filter);
+                filter = filter.RemovePlayerByAttachedEntity(recipient.Value);
             }
-            else
-            {
-                // No prediction, send to everyone including recipient.
-                var filter = Filter.Empty().AddPlayersByPvs(mapPos, entManager: EntityManager, playerMan: _player, cfgMan: _cfg);
-                RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), filter);
-            }
+            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), filter);
         }
 
         public override void PopupEntity(string? message, EntityUid uid, PopupType type = PopupType.Small)

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -11,7 +11,7 @@ namespace Content.Server.Popups
     {
         [Dependency] private readonly IPlayerManager _player = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
-        [Dependency] private readonly TransformSystem _xform = default!;
+        [Dependency] private readonly SharedTransformSystem _transform = default!;
 
         public override void PopupCursor(string? message, PopupType type = PopupType.Small)
         {
@@ -47,8 +47,7 @@ namespace Content.Server.Popups
         {
             if (message == null)
                 return;
-
-            var mapPos = coordinates.ToMap(EntityManager, _xform);
+            var mapPos = _transform.ToMapCoordinates(coordinates);
             var filter = Filter.Empty().AddPlayersByPvs(mapPos, entManager: EntityManager, playerMan: _player, cfgMan: _cfg);
             RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), filter);
         }
@@ -75,7 +74,7 @@ namespace Content.Server.Popups
             if (message == null)
                 return;
 
-            var mapPos = coordinates.ToMap(EntityManager, _xform);
+            var mapPos = _transform.ToMapCoordinates(coordinates);
             if (recipient != null)
             {
                 // Don't send to recipient, since they predicted it locally

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -70,6 +70,26 @@ namespace Content.Server.Popups
                 RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), actor.PlayerSession);
         }
 
+        public override void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
+        {
+            if (message == null)
+                return;
+
+            var mapPos = coordinates.ToMap(EntityManager, _xform);
+            if (recipient != null)
+            {
+                // Don't send to recipient, since they predicted it locally
+                var filter = Filter.PvsExcept(recipient.Value, entityManager: EntityManager);
+                RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), filter);
+            }
+            else
+            {
+                // No prediction, send to everyone including recipient.
+                var filter = Filter.Empty().AddPlayersByPvs(mapPos, entManager: EntityManager, playerMan: _player, cfgMan: _cfg);
+                RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), filter);
+            }
+        }
+
         public override void PopupEntity(string? message, EntityUid uid, PopupType type = PopupType.Small)
         {
             if (message == null)

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -84,8 +84,8 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
         if (TryComp<EmbeddableProjectileComponent>(ent, out var projectile))
             _proj.EmbedDetach(ent, projectile, actionOwner.Value);
 
-        _popups.PopupPredicted(Loc.GetString("item-recall-item-summon", ("item", ent)),
-                               Loc.GetString("item-recall-item-summon-witness", ("item", ent), ("name", Identity.Entity(actionOwner.Value, EntityManager))),
+        _popups.PopupPredicted(Loc.GetString("item-recall-item-summon-self", ("item", ent)),
+                               Loc.GetString("item-recall-item-summon-other", ("item", ent), ("name", Identity.Entity(actionOwner.Value, EntityManager))),
                                actionOwner.Value, actionOwner.Value);
         _popups.PopupPredictedCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates, actionOwner.Value);
 

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -83,7 +83,7 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
         if (TryComp<EmbeddableProjectileComponent>(ent, out var projectile))
             _proj.EmbedDetach(ent, projectile, actionOwner.Value);
 
-        _popups.PopupPredicted(Loc.GetString("item-recall-item-summon", ("item", ent)), actionOwner.Value, actionOwner.Value);
+        _popups.PopupClient(Loc.GetString("item-recall-item-summon", ("item", ent)), actionOwner.Value, actionOwner.Value);
 
         _popups.PopupPredictedCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates, actionOwner.Value);
 

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -85,6 +85,8 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
 
         _popups.PopupPredicted(Loc.GetString("item-recall-item-summon", ("item", ent)), actionOwner.Value, actionOwner.Value);
 
+        _popups.PopupPredictedCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates, actionOwner.Value);
+
         _hands.TryForcePickupAnyHand(actionOwner.Value, ent);
     }
 

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -83,8 +83,7 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
         if (TryComp<EmbeddableProjectileComponent>(ent, out var projectile))
             _proj.EmbedDetach(ent, projectile, actionOwner.Value);
 
-        _popups.PopupClient(Loc.GetString("item-recall-item-summon", ("item", ent)), actionOwner.Value, actionOwner.Value);
-
+        _popups.PopupPredicted(Loc.GetString("item-recall-item-summon", ("item", ent)), Loc.GetString("item-recall-item-summon-witness", ("item", ent), ("name", actionOwner)), actionOwner.Value, actionOwner.Value);
         _popups.PopupPredictedCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates, actionOwner.Value);
 
         _hands.TryForcePickupAnyHand(actionOwner.Value, ent);

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Popups;
 using Content.Shared.Projectiles;
 using Robust.Shared.GameStates;
 using Robust.Shared.Player;
+using Content.Shared.IdentityManagement;
 
 namespace Content.Shared.ItemRecall;
 
@@ -83,7 +84,9 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
         if (TryComp<EmbeddableProjectileComponent>(ent, out var projectile))
             _proj.EmbedDetach(ent, projectile, actionOwner.Value);
 
-        _popups.PopupPredicted(Loc.GetString("item-recall-item-summon", ("item", ent)), Loc.GetString("item-recall-item-summon-witness", ("item", ent), ("name", Identity.Entity(actionOwner, EntityManager))), actionOwner.Value, actionOwner.Value);
+        _popups.PopupPredicted(Loc.GetString("item-recall-item-summon", ("item", ent)),
+                               Loc.GetString("item-recall-item-summon-witness", ("item", ent), ("name", Identity.Entity(actionOwner.Value, EntityManager))),
+                               actionOwner.Value, actionOwner.Value);
         _popups.PopupPredictedCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates, actionOwner.Value);
 
         _hands.TryForcePickupAnyHand(actionOwner.Value, ent);

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -1,11 +1,11 @@
 using Content.Shared.Actions;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Popups;
 using Content.Shared.Projectiles;
 using Robust.Shared.GameStates;
 using Robust.Shared.Player;
-using Content.Shared.IdentityManagement;
 
 namespace Content.Shared.ItemRecall;
 

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -85,7 +85,7 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
             _proj.EmbedDetach(ent, projectile, actionOwner.Value);
 
         _popups.PopupPredicted(Loc.GetString("item-recall-item-summon-self", ("item", ent)),
-                               Loc.GetString("item-recall-item-summon-other", ("item", ent), ("name", Identity.Entity(actionOwner.Value, EntityManager))),
+                               Loc.GetString("item-recall-item-summon-others", ("item", ent), ("name", Identity.Entity(actionOwner.Value, EntityManager))),
                                actionOwner.Value, actionOwner.Value);
         _popups.PopupPredictedCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates, actionOwner.Value);
 

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -83,7 +83,7 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
         if (TryComp<EmbeddableProjectileComponent>(ent, out var projectile))
             _proj.EmbedDetach(ent, projectile, actionOwner.Value);
 
-        _popups.PopupPredicted(Loc.GetString("item-recall-item-summon", ("item", ent)), Loc.GetString("item-recall-item-summon-witness", ("item", ent), ("name", actionOwner)), actionOwner.Value, actionOwner.Value);
+        _popups.PopupPredicted(Loc.GetString("item-recall-item-summon", ("item", ent)), Loc.GetString("item-recall-item-summon-witness", ("item", ent), ("name", Identity.Entity(actionOwner, EntityManager))), actionOwner.Value, actionOwner.Value);
         _popups.PopupPredictedCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates, actionOwner.Value);
 
         _hands.TryForcePickupAnyHand(actionOwner.Value, ent);

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -59,6 +59,13 @@ namespace Content.Shared.Popups
         public abstract void PopupCoordinates(string? message, EntityCoordinates coordinates, ICommonSession recipient, PopupType type = PopupType.Small);
 
         /// <summary>
+        /// Varient of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/> for use with prediction. The local client will
+        /// the popup to the recipient, and the server will show it to every other player in PVS range. If recipient is null, the local 
+        //  client will do nothing and the server will show the message to every player in PVS range.
+        /// </summary>
+        public abstract void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small);
+
+        /// <summary>
         ///     Shows a popup above an entity for every player in pvs range.
         /// </summary>
         /// <param name="message">The message to display.</param>

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -59,9 +59,9 @@ namespace Content.Shared.Popups
         public abstract void PopupCoordinates(string? message, EntityCoordinates coordinates, ICommonSession recipient, PopupType type = PopupType.Small);
 
         /// <summary>
-        /// Varient of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/> for use with prediction. The local client will
-        /// the popup to the recipient, and the server will show it to every other player in PVS range. If recipient is null, the local 
-        //  client will do nothing and the server will show the message to every player in PVS range.
+        ///    Variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/> for use with prediction. The local client will
+        ///    the popup to the recipient, and the server will show it to every other player in PVS range. If recipient is null, the local 
+        //     client will do nothing and the server will show the message to every player in PVS range.
         /// </summary>
         public abstract void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small);
 

--- a/Resources/Locale/en-US/item-recall/item-recall.ftl
+++ b/Resources/Locale/en-US/item-recall/item-recall.ftl
@@ -5,6 +5,7 @@ item-recall-item-marked = You draw a magical sigil on {THE($item)}.
 item-recall-item-already-marked = {CAPITALIZE(THE($item))} is already marked!
 item-recall-item-mark-empty = You must be holding an item!
 item-recall-item-summon = {CAPITALIZE(THE($item))} appears in your hand!
+item-recall-item-summon-witness = {CAPITALIZE(THE($item))} appears in {$name}'s hand!
 item-recall-item-disappear = {CAPITALIZE(THE($item))} disappears!
 item-recall-item-unmark = You feel your connection with {THE($item)} sever.
 

--- a/Resources/Locale/en-US/item-recall/item-recall.ftl
+++ b/Resources/Locale/en-US/item-recall/item-recall.ftl
@@ -4,8 +4,8 @@ item-recall-marked-description = Recall {THE($item)} back into your hand.
 item-recall-item-marked = You draw a magical sigil on {THE($item)}.
 item-recall-item-already-marked = {CAPITALIZE(THE($item))} is already marked!
 item-recall-item-mark-empty = You must be holding an item!
-item-recall-item-summon = {CAPITALIZE(THE($item))} appears in your hand!
-item-recall-item-summon-witness = {CAPITALIZE(THE($item))} appears in {$name}'s hand!
+item-recall-item-summon-self = {CAPITALIZE(THE($item))} appears in your hand!
+item-recall-item-summon-others = {CAPITALIZE(THE($item))} appears in {$name}'s hand!
 item-recall-item-disappear = {CAPITALIZE(THE($item))} disappears!
 item-recall-item-unmark = You feel your connection with {THE($item)} sever.
 

--- a/Resources/Locale/en-US/item-recall/item-recall.ftl
+++ b/Resources/Locale/en-US/item-recall/item-recall.ftl
@@ -5,5 +5,6 @@ item-recall-item-marked = You draw a magical sigil on {THE($item)}.
 item-recall-item-already-marked = {CAPITALIZE(THE($item))} is already marked!
 item-recall-item-mark-empty = You must be holding an item!
 item-recall-item-summon = {CAPITALIZE(THE($item))} appears in your hand!
+item-recall-item-disappear = {CAPITALIZE(THE($item))} disappears!
 item-recall-item-unmark = You feel your connection with {THE($item)} sever.
 

--- a/Resources/Locale/en-US/item-recall/item-recall.ftl
+++ b/Resources/Locale/en-US/item-recall/item-recall.ftl
@@ -5,7 +5,7 @@ item-recall-item-marked = You draw a magical sigil on {THE($item)}.
 item-recall-item-already-marked = {CAPITALIZE(THE($item))} is already marked!
 item-recall-item-mark-empty = You must be holding an item!
 item-recall-item-summon-self = {CAPITALIZE(THE($item))} appears in your hand!
-item-recall-item-summon-others = {CAPITALIZE(THE($item))} appears in {$name}'s hand!
+item-recall-item-summon-others = {CAPITALIZE(THE($item))} appears in {THE($name)}'s hand!
 item-recall-item-disappear = {CAPITALIZE(THE($item))} disappears!
 item-recall-item-unmark = You feel your connection with {THE($item)} sever.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a Popup prediction based upon a certain coordinate
Display disappearing text at the last location of the item being recalled
Addresses https://github.com/space-wizards/space-station-14/issues/35210


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Text can now be produced at a certain location with an event triggered by an action. 
In this specific PR, the recall of an item has a message displayed where it was last located.

## Technical details
<!-- Summary of code changes for easier review. -->
PopupPredictedCoordinates merges PopupPredicted and PopupCoordinates

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/37dafbdf-ce40-4e6d-bec6-d954c36e6a83)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!`
-->
:cl:
- add: A popup is now displayed at the item's previous location when it is recalled by the recall wizard spell.