### PR TITLE
Reduce health damage from ethanol

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -171,7 +171,7 @@
           shouldHave: false
         damage:
           types:
-            Poison: 1
+            Poison: 0.3
       # dwarves take less toxin damage and heal a marginal amount of brute
       - !type:HealthChange
         conditions:
@@ -181,7 +181,7 @@
           type: Dwarf
         damage:
           types:
-            Poison: 0.2
+            Poison: 0.05
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold

--- a/runclient.sh
+++ b/runclient.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+*#!/bin/sh
 dotnet run --project Content.Client
 read -p "Press enter to continue"


### PR DESCRIPTION
Fixes: ethanol is too toxic

Reduces health damage from ethanol from 1 to 0.3 for all and from 0.2 to 0.05 for dwarves.