### PR TITLE
A new event, Holopad Malfunctions!

### DIFF
--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -1,17 +1,89 @@
 ﻿using Content.Server.StationEvents.Events;
 using Content.Shared.Storage;
+using Robust.Shared.GameObjects;
+using Content.Server.GameObjects.Components;
+using Content.Server.GameObjects.EntitySystems;
+using Robust.Shared.IoC;
 
-namespace Content.Server.StationEvents.Components;
-
-[RegisterComponent, Access(typeof(VentCrittersRule))]
-public sealed partial class VentCrittersRuleComponent : Component
+namespace Content.Server.StationEvents.Components
 {
-    [DataField("entries")]
-    public List<EntitySpawnEntry> Entries = new();
+    [RegisterComponent, Access(typeof(VentCrittersRule))]
+    public sealed partial class VentCrittersRuleComponent : Component
+    {
+        public List<EntitySpawnEntry> Entries = new();
 
-    /// <summary>
-    /// At least one special entry is guaranteed to spawn
-    /// </summary>
-    [DataField("specialEntries")]
-    public List<EntitySpawnEntry> SpecialEntries = new();
+        /// <summary>
+        /// At least one special entry is guaranteed to spawn
+        /// </summary>
+        public List<EntitySpawnEntry> SpecialEntries = new();
+
+        /// <summary>
+        /// Defines the maximum number of critters that can be spawned
+        /// </summary>
+        public int CritterCapacity { get; set; } = 10; // Default capacity is 10 critters
+
+        // List of holopad spawn points
+        public List<EntityUid> HolopadSpawnPoints { get; set; } = new();
+
+        // Method to check if the capacity has been reached
+        public bool CanSpawnMoreCritters(int currentCritterCount)
+        {
+            return currentCritterCount < CritterCapacity;
+        }
+
+        // Method to spawn a specific special entity on holopads
+        public void SpawnSpecialEntityOnHolopads(EntitySpawnEntry specialEntity, int numberToSpawn)
+        {
+            var entitySystemManager = IoCManager.Resolve<IEntitySystemManager>();
+            var entitySystem = entitySystemManager.GetEntitySystem<EntitySpawnSystem>();
+
+            int spawnedCount = 0;
+            foreach (var holopad in HolopadSpawnPoints)
+            {
+                for (int i = 0; i < numberToSpawn; i++)
+                {
+                    // Actual spawn logic
+                    entitySystem.SpawnEntity(specialEntity.EntityId, holopad.Transform.Coordinates);
+
+                    spawnedCount++;
+                    if (spawnedCount >= numberToSpawn)
+                    {
+                        break;
+                    }
+                }
+
+                if (spawnedCount >= numberToSpawn)
+                {
+                    break;
+                }
+            }
+        }
+
+        // Method to spawn multiple instances of a specific entity on holopads
+        public void SpawnMultipleSpecialEntitiesOnHolopads(string entityId, int numberToSpawn)
+        {
+            foreach (var specialEntry in SpecialEntries)
+            {
+                if (specialEntry.EntityId == entityId)
+                {
+                    SpawnSpecialEntityOnHolopads(specialEntry, numberToSpawn);
+                    break; // Assuming you only need to spawn a specific number of this entity
+                }
+            }
+        }
+    }
 }
+
+public sealed partial class EntitySpawnEntry
+{
+    public string EntityId { get; set; } = default!;
+    public int SpawnCount { get; set; } = 1;
+    public EntitySpawnLocation SpawnLocation { get; set; } = default!;
+}
+
+public sealed partial class EntitySpawnLocation
+{
+    public string TargetEntityId { get; set; } = default!;
+    public bool IsOnTop { get; set; } = true;
+}
+

--- a/Resources/Locale/en-US/station-events/events/holopad-malfunction.ftl
+++ b/Resources/Locale/en-US/station-events/events/holopad-malfunction.ftl
@@ -1,0 +1,1 @@
+﻿station-event-holopad-malfunction-start-announcement = Attention. The station's holopads have malfunctioned, leading to the appearance of holographic entities. Please eliminate the threat before productivity is affected.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -11,6 +11,7 @@
     - id: CockroachMigration
     - id: GasLeak
     - id: GreytideVirus
+    - id: HoloCarpSpawn
     - id: IonStorm # its calm like 90% of the time smh
     - id: KudzuGrowth
     - id: MassHallucinations
@@ -584,3 +585,22 @@
       min: 1
       max: 1
       pickPlayer: false
+
+- type: entity
+  id: HoloCarpSpawn
+  parent: BaseStationEventShortDelay
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-holopad-malfunction-start-announcement
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    earliestStart: 20
+    minimumPlayers: 20
+    weight: 4
+    duration: 60
+  - type: VentCrittersRule
+    entries:
+    - id: MobCarpHolo
+      prob: 0.05
+
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A new station event was added, known as Holopad Malfunctions, its similar to the vent critter events, however it has a different announcement and it spawns holocarps.
Future plans would be to make it so they only spawn out of holopads
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More variety in station events, along with them not being an issue with balancing because they are pretty weak.
## Technical details
<!-- Summary of code changes for easier review. -->
Made a new station announcement and added a new station event, using the vent critter code right now but that shouldn't be too much of a problem.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (cant record media due to my system not being able to handle it)
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**

🆑 
- add: A new station event known as the Holopad malfunction, spawning Holocarps.
