### PR TITLE
version watermark

### DIFF
--- a/Content.Client/Changelog/ChangelogManager.cs
+++ b/Content.Client/Changelog/ChangelogManager.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Content.Shared.CCVar;
+using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Serialization.Manager;
@@ -123,6 +124,27 @@ namespace Content.Client.Changelog
         public void PostInject()
         {
             _sawmill = _logManager.GetSawmill(SawmillName);
+        }
+
+        /// <summary>
+        ///     Tries to return a human-readable version number from the build.json file
+        /// </summary>
+        public string GetClientVersion()
+        {
+            var fork = _configManager.GetCVar(CVars.BuildForkId);
+            var version = _configManager.GetCVar(CVars.BuildVersion);
+
+            // This trimming might become annoying if down the line some codebases want to switch to a real
+            // version format like "104.11.3" while others are still using the git hashes
+            if (version.Length > 7)
+                version = version[..7];
+
+            if (string.IsNullOrEmpty(version) || string.IsNullOrEmpty(fork))
+                return Loc.GetString("changelog-version-unknown");
+
+            return Loc.GetString("changelog-version-tag",
+                ("fork", fork),
+                ("version", version));
         }
 
         [DataDefinition]

--- a/Content.Client/Changelog/ChangelogWindow.xaml.cs
+++ b/Content.Client/Changelog/ChangelogWindow.xaml.cs
@@ -70,22 +70,7 @@ namespace Content.Client.Changelog
                 Tabs.SetTabTitle(i++, Loc.GetString($"changelog-tab-title-{changelog.Name}"));
             }
 
-            // Try to get the current version from the build.json file
-            var version = _cfg.GetCVar(CVars.BuildVersion);
-            var forkId = _cfg.GetCVar(CVars.BuildForkId);
-
-            var versionText = Loc.GetString("changelog-version-unknown");
-
-            // Make sure these aren't empty, like in a dev env
-            if (!string.IsNullOrEmpty(version) && !string.IsNullOrEmpty(forkId))
-            {
-                versionText = Loc.GetString("changelog-version-tag",
-                    ("fork", forkId),
-                    ("version", version[..7])); // Only show the first 7 characters
-            }
-
-            // if else statements are ugly, shut up
-            VersionLabel.Text = versionText;
+            VersionLabel.Text = _changelog.GetClientVersion();
 
             TabsUpdated();
         }

--- a/Content.Client/Gameplay/GameplayState.cs
+++ b/Content.Client/Gameplay/GameplayState.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+using Content.Client.Changelog;
 using Content.Client.Hands;
 using Content.Client.UserInterface.Controls;
 using Content.Client.UserInterface.Screens;
@@ -7,6 +9,7 @@ using Content.Shared.CCVar;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Configuration;
 using Robust.Shared.Timing;
@@ -20,9 +23,11 @@ namespace Content.Client.Gameplay
         [Dependency] private readonly IOverlayManager _overlayManager = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
+        [Dependency] private readonly ChangelogManager _changelog = default!;
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
         private FpsCounter _fpsCounter = default!;
+        private Label _version = default!;
 
         public MainViewport Viewport => _uiManager.ActiveScreen!.GetWidget<MainViewport>()!;
 
@@ -40,6 +45,7 @@ namespace Content.Client.Gameplay
             base.Startup();
 
             LoadMainScreen();
+            _configurationManager.OnValueChanged(CCVars.UILayout, ReloadMainScreenValueChange);
 
             // Add the hand-item overlay.
             _overlayManager.AddOverlay(new ShowHandItemOverlay());
@@ -50,7 +56,24 @@ namespace Content.Client.Gameplay
             UserInterfaceManager.PopupRoot.AddChild(_fpsCounter);
             _fpsCounter.Visible = _configurationManager.GetCVar(CCVars.HudFpsCounterVisible);
             _configurationManager.OnValueChanged(CCVars.HudFpsCounterVisible, (show) => { _fpsCounter.Visible = show; });
-            _configurationManager.OnValueChanged(CCVars.UILayout, ReloadMainScreenValueChange);
+
+            // Version number watermark.
+            _version = new Label();
+            _version.Text = _changelog.GetClientVersion();
+            _version.Visible = VersionVisible();
+            UserInterfaceManager.PopupRoot.AddChild(_version);
+            _configurationManager.OnValueChanged(CCVars.HudVersionWatermark, (show) => { _version.Visible = VersionVisible(); });
+            _configurationManager.OnValueChanged(CCVars.ForceClientHudVersionWatermark, (show) => { _version.Visible = VersionVisible(); });
+            // TODO make this centered or something
+            LayoutContainer.SetPosition(_version, new Vector2(800, 0));
+        }
+
+        // This allows servers to force the watermark on clients
+        private bool VersionVisible()
+        {
+            var client = _configurationManager.GetCVar(CCVars.HudVersionWatermark);
+            var server = _configurationManager.GetCVar(CCVars.ForceClientHudVersionWatermark);
+            return client || server;
         }
 
         protected override void Shutdown()

--- a/Content.Shared/CCVar/CCVars.Hud.cs
+++ b/Content.Shared/CCVar/CCVars.Hud.cs
@@ -19,6 +19,15 @@ public sealed partial class CCVars
     public static readonly CVarDef<float> HudHeldItemOffset =
         CVarDef.Create("hud.held_item_offset", 28f, CVar.ARCHIVE | CVar.CLIENTONLY);
 
+    /// <summary>
+    ///     Displays framerate counter
+    /// </summary>
     public static readonly CVarDef<bool> HudFpsCounterVisible =
         CVarDef.Create("hud.fps_counter_visible", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    ///     Displays the fork ID and version number
+    /// </summary>
+    public static readonly CVarDef<bool> HudVersionWatermark =
+        CVarDef.Create("hud.version_watermark", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/CCVar/CCVars.Server.cs
+++ b/Content.Shared/CCVar/CCVars.Server.cs
@@ -53,4 +53,10 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<int> ServerLobbyRightPanelWidth =
         CVarDef.Create("server.lobby_right_panel_width", 650, CVar.REPLICATED | CVar.SERVER);
+
+    /// <summary>
+    ///     Forces clients to display version watermark, as if HudVersionWatermark was true
+    /// </summary>
+    public static readonly CVarDef<bool> ForceClientHudVersionWatermark =
+        CVarDef.Create("server.force_client_hud_version_watermark", false, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Resources/ConfigPresets/WizardsDen/vulture.toml
+++ b/Resources/ConfigPresets/WizardsDen/vulture.toml
@@ -10,6 +10,7 @@ tags = "lang:en,region:am_n_e,rp:low"
 [server]
 # This needs to be specified even though it's identical to the hostname, because fallback lobby name is "Lobby <hostname>" which would be too long and go out of bounds
 lobby_name = "[EN][Testing] Wizard's Den Vulture [US East 2]"
+force_client_hud_version_watermark = true
 
 [chat]
 motd = "\n########################################################\n\n[font size=17]This is a test server. You can play with the newest changes to the game, but these [color=red]changes may not be final or stable[/color], and may be reverted. Please report bugs via our GitHub, forum, or community Discord.[/font]\n\n########################################################\n"


### PR DESCRIPTION
## About the PR
Makes it possible via cvar to display the current version on top of the screen. Additionally, servers can force all clients to show the watermark, ignoring the client setting.   Both cvars default to off, but Vulture has it enabled.

Ideally, this should also be a toggle in Options, but I didn't do that yet since it did not seem like a very high-demand feature

## Why / Balance
This would be useful to automatically mark screenshots/videos from test servers so we can skip the whole "was this on stable or master" minigame

## Technical details
Moved the existing code to generate the version string from the changelogwindow (which already used it) to ChangelogManager and made both systems refer to this new helper function

## Media

version number faked in for the shot (dev build doesn't have any)
![Screenshot_2025-02-18_152532](https://github.com/user-attachments/assets/de4afa3d-cd44-4a6a-9b90-1ee6309f3df6)

wiiide chat
![Screenshot_2025-02-18_190350](https://github.com/user-attachments/assets/04042e2e-4598-4401-bb05-d9d7c5646040)

newchat
![Screenshot_2025-02-18_190413](https://github.com/user-attachments/assets/c85fddd6-1008-48ec-ba69-9190a0ff1932)

high res with no scaling makes my lazy placement code apparent, but who would choose to live like that
![Screenshot_2025-02-18_190445](https://github.com/user-attachments/assets/52011ad4-9f9f-402a-90d0-e70fa8badd23)
![Screenshot_2025-02-18_190507](https://github.com/user-attachments/assets/bb773313-410e-4c5b-b337-0a198f05f876)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: Errant
- add: The game version can now be displayed as an optional watermark on the hud. Servers can force this watermark to be displayed.