### PR TITLE
Don't open the Radial Emote Wheel if there's nothing in it

### DIFF
--- a/Content.Client/Chat/UI/EmotesMenu.xaml.cs
+++ b/Content.Client/Chat/UI/EmotesMenu.xaml.cs
@@ -20,6 +20,7 @@ public sealed partial class EmotesMenu : RadialMenu
     [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
 
     public event Action<ProtoId<EmotePrototype>>? OnPlayEmote;
+    public readonly bool IsEmpty = true;
 
     public EmotesMenu()
     {
@@ -65,6 +66,7 @@ public sealed partial class EmotesMenu : RadialMenu
 
             button.AddChild(tex);
             parent.AddChild(button);
+            IsEmpty = false;
             foreach (var child in main.Children)
             {
                 if (child is not RadialMenuTextureButton castChild)
@@ -103,7 +105,6 @@ public sealed partial class EmotesMenu : RadialMenu
         }
     }
 }
-
 
 public sealed class EmoteMenuButton : RadialMenuTextureButtonWithSector
 {

--- a/Content.Client/UserInterface/Systems/Emotes/EmotesUIController.cs
+++ b/Content.Client/UserInterface/Systems/Emotes/EmotesUIController.cs
@@ -43,12 +43,19 @@ public sealed class EmotesUIController : UIController, IOnStateChanged<GameplayS
         {
             // setup window
             _menu = UIManager.CreateWindow<EmotesMenu>();
+
+            if (_menu.IsEmpty)
+            {
+                _menu.Dispose();
+                _menu = null;
+                return;
+            }
+
             _menu.OnClose += OnWindowClosed;
             _menu.OnOpen += OnWindowOpen;
             _menu.OnPlayEmote += OnPlayEmote;
 
-            if (EmotesButton != null)
-                EmotesButton.SetClickPressed(true);
+            EmotesButton?.SetClickPressed(true);
 
             if (centered)
             {
@@ -67,8 +74,7 @@ public sealed class EmotesUIController : UIController, IOnStateChanged<GameplayS
             _menu.OnOpen -= OnWindowOpen;
             _menu.OnPlayEmote -= OnPlayEmote;
 
-            if (EmotesButton != null)
-                EmotesButton.SetClickPressed(false);
+            EmotesButton?.SetClickPressed(false);
 
             CloseMenu();
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Prevents the emote wheel from displaying if there're no emotes to press in it.

## Why / Balance
Empty menu make me go 😕

## Technical details
It's just a quick and dirty implementation which:
- When constructing the emote wheel UI tracks if any emotes have been put into it
- and if none have been, it aborts the initialization of the radial menu and cleans up what it's done so far.

I am certain there's a better way to deal with this, but I haven't looked at it too hard.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/211edc60-a719-4ec3-abe9-0db8413add49

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: It is no longer possible to open the emote wheel in the case that it'd contain no emotes (e.g. as a ghost)