### PR TITLE
Make CharacterPickerButton the same height for dwarves as for non-dwarves

### DIFF
--- a/Content.Client/Lobby/UI/CharacterPickerButton.xaml
+++ b/Content.Client/Lobby/UI/CharacterPickerButton.xaml
@@ -8,7 +8,8 @@
         <SpriteView Scale="2 2"
                     Margin="0 4 4 4"
                     OverrideDirection="South"
-                    Name="View"/>
+                    Name="View"
+                    SetSize="64 64"/>
         <Label Name="DescriptionLabel"
                ClipText="True"
                HorizontalExpand="True"/>


### PR DESCRIPTION
## About the PR
CharacterPickerButton was shorter for dwarves than for other species. This change makes it the same height for all characters.

## Why / Balance
I just thought it looked odd.

## Technical details
CharacterPickerButton's height is determined by the height of its contents, the tallest of which is usually the SpriteView showing the character sprite at double size. Dwarf sprites are shorter than other character sprites. I gave the SpriteView a SetSize so that it is 64 pixels tall even if the sprite it is displaying is shorter than 32 pixels.

## Media
Before:
![image](https://github.com/user-attachments/assets/2e85543a-a54d-4491-be58-3a287cf3f85b)
After:
![image](https://github.com/user-attachments/assets/a6294d52-bf8f-4837-90d5-73e43237727b)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.