### PR TITLE
Update RSI JSON schema to have copyright info on every line

### DIFF
--- a/.github/rsi-schema.json
+++ b/.github/rsi-schema.json
@@ -1,185 +1,190 @@
 {
-   "$schema":"http://json-schema.org/draft-07/schema",
-   "default":{
-      
-   },
-   "description":"JSON Schema for SS14 RSI validation.",
-   "examples":[
-      {
-         "version":1,
-         "license":"CC-BY-SA-3.0",
-         "copyright":"Taken from CODEBASE at COMMIT LINK",
-         "size":{
-            "x":32,
-            "y":32
-         },
-         "states":[
-            {
-               "name":"basic"
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "default": {
+
+    },
+    "description": "JSON Schema for SS14 RSI validation.",
+    "examples": [
+        {
+            "version": 1,
+            "license": "CC-BY-SA-3.0",
+            "copyright": "Taken from CODEBASE at COMMIT LINK",
+            "size": {
+                "x": 32,
+                "y": 32
             },
-            {
-               "name":"basic-directions",
-               "directions":4
-            },
-            {
-               "name":"basic-delays",
-               "delays":[
-                  [
-                     0.1,
-                     0.1
-                  ]
-               ]
-            },
-            {
-               "name":"basic-delays-directions",
-               "directions":4,
-               "delays":[
-                  [
-                     0.1,
-                     0.1
-                  ],
-                  [
-                     0.1,
-                     0.1
-                  ],
-                  [
-                     0.1,
-                     0.1
-                  ],
-                  [
-                     0.1,
-                     0.1
-                  ]
-               ]
-            }
-         ]
-      }
-   ],
-   "required":[
-      "version",
-      "license",
-      "copyright",
-      "size",
-      "states"
-   ],
-   "title":"RSI Schema",
-   "type":"object",
-   "properties":{
-      "version":{
-         "$id":"#/properties/version",
-         "default":"",
-         "description":"RSI version integer.",
-         "title":"The version schema",
-         "type":"integer"
-      },
-      "license":{
-         "$id":"#/properties/license",
-         "default":"",
-         "description":"The license for the associated icon states. Restricted to SS14-compatible asset licenses.",
-         "enum":[
-            "CC-BY-SA-3.0",
-            "CC-BY-SA-4.0",
-            "CC-BY-NC-3.0",
-            "CC-BY-NC-4.0",
-            "CC-BY-NC-SA-3.0",
-            "CC-BY-NC-SA-4.0",
-            "CC0-1.0"
-         ],
-         "examples":[
-            "CC-BY-SA-3.0"
-         ],
-         "title":"License",
-         "type":"string"
-      },
-      "copyright":{
-         "$id":"#/properties/copyright",
-         "type":"string",
-         "title":"Copyright Info",
-         "description":"The copyright holder. This is typically a link to the commit of the codebase that the icon is pulled from.",
-         "default":"",
-         "examples":[
-            "Taken from CODEBASE at COMMIT LINK"
-         ]
-      },
-      "size":{
-         "$id":"#/properties/size",
-         "default":{
-            
-         },
-         "description":"The dimensions of the sprites inside the RSI.  This is not the size of the PNG files that store the sprite sheet.",
-         "examples":[
-            {
-               "x":32,
-               "y":32
-            }
-         ],
-         "title":"Sprite Dimensions",
-         "required":[
-            "x",
-            "y"
-         ],
-         "type":"object",
-         "properties":{
-            "x":{
-               "$id":"#/properties/size/properties/x",
-               "type":"integer",
-               "default":32,
-               "examples":[
-                  32
-               ]
-            },
-            "y":{
-               "$id":"#/properties/size/properties/y",
-               "type":"integer",
-               "default":32,
-               "examples":[
-                  32
-               ]
-            }
-         },
-         "additionalProperties":true
-      },
-      "states":{
-         "$id":"#/properties/states",
-         "type":"array",
-         "title":"Icon States",
-         "description":"Metadata for icon states. Includes name, directions, delays, etc.",
-         "default":[
-            
-         ],
-         "examples":[
-            [
-               {
-                  "name":"basic"
-               },
-               {
-                  "name":"basic-directions",
-                  "directions":4
-               }
+            "states": [
+                {
+                    "name": "basic",
+                    "copyright": "Taken from CODEBASE at COMMIT LINK"
+                },
+                {
+                    "name": "basic-directions",
+                    "copyright": "Taken from CODEBASE at COMMIT LINK",
+                    "directions": 4
+                },
+                {
+                    "name": "basic-delays",
+                    "copyright": "Taken from CODEBASE at COMMIT LINK",
+                    "delays": [
+                        [
+                            0.1,
+                            0.1
+                        ]
+                    ]
+                },
+                {
+                    "name": "basic-delays-directions",
+                    "copyright": "Taken from CODEBASE at COMMIT LINK",
+                    "directions": 4,
+                    "delays": [
+                        [
+                            0.1,
+                            0.1
+                        ],
+                        [
+                            0.1,
+                            0.1
+                        ],
+                        [
+                            0.1,
+                            0.1
+                        ],
+                        [
+                            0.1,
+                            0.1
+                        ]
+                    ]
+                }
             ]
-         ],
-         "additionalItems":true,
-         "items":{
-            "$id":"#/properties/states/items",
-            "type":"object",
-            "required":[
-               "name"
+        }
+    ],
+    "required": [
+        "version",
+        "license",
+        "copyright",
+        "size",
+        "states"
+    ],
+    "title": "RSI Schema",
+    "type": "object",
+    "properties": {
+        "version": {
+            "$id": "#/properties/version",
+            "default": "",
+            "description": "RSI version integer.",
+            "title": "The version schema",
+            "type": "integer"
+        },
+        "license": {
+            "$id": "#/properties/license",
+            "default": "",
+            "description": "The license for the associated icon states. Restricted to SS14-compatible asset licenses.",
+            "enum": [
+                "CC-BY-SA-3.0",
+                "CC-BY-SA-4.0",
+                "CC-BY-NC-3.0",
+                "CC-BY-NC-4.0",
+                "CC-BY-NC-SA-3.0",
+                "CC-BY-NC-SA-4.0",
+                "CC0-1.0"
             ],
-            "properties":{
-               "name":{
-                  "type":"string"
-               },
-               "directions":{
-                  "type":"integer",
-                  "enum":[
-                     1,
-                     4,
-                     8
-                  ]
-               }
+            "examples": [
+                "CC-BY-SA-3.0"
+            ],
+            "title": "License",
+            "type": "string"
+        },
+        "copyright": {
+            "$id": "#/properties/copyright",
+            "type": "string",
+            "title": "Copyright Info",
+            "description": "The copyright holder. This is typically a link to the commit of the codebase that the icon is pulled from.",
+            "default": "",
+            "examples": [
+                "Taken from CODEBASE at COMMIT LINK"
+            ]
+        },
+        "size": {
+            "$id": "#/properties/size",
+            "default": {},
+            "description": "The dimensions of the sprites inside the RSI.  This is not the size of the PNG files that store the sprite sheet.",
+            "examples": [
+                {
+                    "x": 32,
+                    "y": 32
+                }
+            ],
+            "title": "Sprite Dimensions",
+            "required": [
+                "x",
+                "y"
+            ],
+            "type": "object",
+            "properties": {
+                "x": {
+                    "$id": "#/properties/size/properties/x",
+                    "type": "integer",
+                    "default": 32,
+                    "examples": [
+                        32
+                    ]
+                },
+                "y": {
+                    "$id": "#/properties/size/properties/y",
+                    "type": "integer",
+                    "default": 32,
+                    "examples": [
+                        32
+                    ]
+                }
+            },
+            "additionalProperties": true
+        },
+        "states": {
+            "$id": "#/properties/states",
+            "type": "array",
+            "title": "Icon States",
+            "description": "Metadata for icon states. Includes name, directions, delays, etc.",
+            "default": [],
+            "examples": [
+                [
+                    {
+                        "name": "basic",
+                        "copyright": "Taken from CODEBASE at COMMIT LINK"
+                    },
+                    {
+                        "name": "basic-directions",
+                        "copyright": "Taken from CODEBASE at COMMIT LINK",
+                        "directions": 4
+                    }
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "$id": "#/properties/states/items",
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "copyright": {
+                        "type": "string"
+                    },
+                    "directions": {
+                        "type": "integer",
+                        "enum": [
+                            1,
+                            4,
+                            8
+                        ]
+                    }
+                }
             }
-         }
-      }
-   },
-   "additionalProperties":true
+        }
+    },
+    "additionalProperties": true
 }


### PR DESCRIPTION
## About the PR
Updates the RSI JSON schema to allow appending copyright information to every sprite state, individually.

Let me know if you want the "license" line extended as well however the license is usually applied to all files and never individual ones.

Also changed the whitespace in the file from 3 spaced to 4 spaced. You can choose to hide whitespace changes in github when reviewing. Let me know if you want it reverted, but I thought that our schema should at least match our defined conventions.

## Why / Balance
https://github.com/space-wizards/space-station-14/blob/c62ed868546a3251d7f9867bac016534080a1a7d/Resources/Textures/Objects/Fun/toys.rsi/meta.json#L4

![image](https://github.com/user-attachments/assets/da7de2e1-3c40-409b-851d-214becff1d33)

Meme explanation aside, having a one-line copyright attribution for a collection of files is truly painful. It's horrible for VCS, and it causes a million bajillion merge conflicts when multiple backlogged PRs are targeting the file (see `toys.rsi`).

This change will lead to less painful merge conflicts and VCS history.

I've been wanting to clean up JSON files and do some YAML atomization on high traffic files. I need this because when I go to do my atomizations this allows me to knock out two birds with one stone.

## Technical details
Added new copyright fields in `rsi-schema.json`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
no cl no fun
