### PR TITLE
fix liar accent adding quotes to message

### DIFF
--- a/Resources/Locale/en-US/speech/speech-liar.ftl
+++ b/Resources/Locale/en-US/speech/speech-liar.ftl
@@ -35,7 +35,7 @@ liar-word-12 = will
 liar-word-replacement-12 = wont
 
 liar-word-13 = dont
-liar-word-replacement-13 = ""
+liar-word-replacement-13 = {""}
 
 liar-word-14 = can
 liar-word-replacement-14 = cant
@@ -59,7 +59,7 @@ liar-word-20 = did
 liar-word-replacement-20 = didnt
 
 liar-word-21 = didnt
-liar-word-replacement-21 = ""
+liar-word-replacement-21 = {""}
 
 liar-word-22 = nothing
 liar-word-replacement-22 = something
@@ -86,7 +86,7 @@ liar-word-29 = do
 liar-word-replacement-29 = "don't"
 
 liar-word-30 = "don't"
-liar-word-replacement-30 = ""
+liar-word-replacement-30 = {""}
 
 liar-word-31 = does
 liar-word-replacement-31 = "doesn't"
@@ -129,4 +129,4 @@ liar-word-43 = want
 liar-word-replacement-43 = "don't want"
 
 liar-word-44 = not
-liar-word-replacement-44 = ""
+liar-word-replacement-44 = {""}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
fix pathological liar accent changing words into double quotes `""` instead of changing into nothing. 

## Media

before
![image](https://github.com/user-attachments/assets/e3ea10a1-9786-40c2-8101-da70eb1e0e8c)


after
![image](https://github.com/user-attachments/assets/057d7e13-1e9d-4812-a72e-f3cba9523182)


## Technical details
fluent empty string needs to be encased in curly brackets, otherwise it's treated as actual quote characters.

If a message like "dont" is changed into empty message nothing is sent, as expected.
