### PR TITLE
Made the admeme teleporter usable on different grids/maps

### DIFF
--- a/Resources/Prototypes/Entities/Effects/portal.yml
+++ b/Resources/Prototypes/Entities/Effects/portal.yml
@@ -26,6 +26,14 @@
   - type: Portal
 
 - type: entity
+  abstract: true
+  parent: BasePortal
+  id: BasePortalInterMap
+  components:
+  - type: Portal
+    canTeleportToOtherMaps: true
+
+- type: entity
   id: PortalRed
   parent: BasePortal
   description: This one looks more like a redspace portal.
@@ -54,7 +62,7 @@
     
 - type: entity
   id: PortalArtifact
-  parent: BasePortal
+  parent: BasePortalInterMap
   components:
   - type: Sprite
     layers:
@@ -66,8 +74,6 @@
     netsync: false
   - type: TimedDespawn
     lifetime: 1
-  - type: Portal
-    canTeleportToOtherMaps: true
 
 - type: entity
   id: PortalGatewayBlue
@@ -123,3 +129,11 @@
     volume: -3
     sound:
       path: /Audio/Ambience/anomaly_scary.ogg
+
+- type: entity
+  parent: [ PortalGatewayOrange, BasePortalInterMap ]
+  id: PortalAdminRed
+
+- type: entity
+  parent: [ PortalGatewayBlue, BasePortalInterMap ]
+  id: PortalAdminBlue

--- a/Resources/Prototypes/Entities/Effects/portal.yml
+++ b/Resources/Prototypes/Entities/Effects/portal.yml
@@ -132,7 +132,7 @@
 
 - type: entity
   parent: [ PortalGatewayOrange, BasePortalInterMap ]
-  id: PortalAdminRed
+  id: PortalAdminOrange
 
 - type: entity
   parent: [ PortalGatewayBlue, BasePortalInterMap ]

--- a/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
@@ -30,4 +30,4 @@
   - type: HandTeleporter
     allowPortalsOnDifferentGrids: true
     firstPortalPrototype: PortalAdminBlue
-    secondPortalPrototype: PortalAdminRed
+    secondPortalPrototype: PortalAdminOrange

--- a/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
@@ -28,5 +28,6 @@
     - state: icon
       color: green
   - type: HandTeleporter
-    firstPortalPrototype: PortalGatewayBlue
-    secondPortalPrototype: PortalGatewayOrange
+    allowPortalsOnDifferentGrids: true
+    firstPortalPrototype: PortalAdminBlue
+    secondPortalPrototype: PortalAdminRed


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The admeme teleporter felt underwhelming considering it's an administrator-only item.

## Why / Balance
More freedom with less setup.

## Technical details
Created a new base prototype: `BasePortalInterMap`
Assigned this prototype as parent to the `PortalArtifact` and the two new `PortalAdminRed`, `PortalAdminBlue`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/4b38426e-52b7-4298-bb47-24b81660aa11


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
ADMIN:
- tweak: The interdimensional teleporter now is able to work on separate grids and maps.
