### PR TITLE
Add a tertiary header parser to the guidebook document parser

### DIFF
--- a/Content.Client/Guidebook/DocumentParsingManager.static.cs
+++ b/Content.Client/Guidebook/DocumentParsingManager.static.cs
@@ -109,7 +109,17 @@ public sealed partial class DocumentParsingManager
             .Cast<Control>()))
         .Labelled("subheader");
 
-    private static readonly Parser<char, Control> TryHeaderControl = OneOf(SubHeaderControlParser, HeaderControlParser);
+    private static readonly Parser<char, Control> TertiaryHeaderControlParser = Try(String("###"))
+        .Then(SkipWhitespaces.Then(Map(text => new Label
+                {
+                    Text = text,
+                    StyleClasses = { "LabelKeyText" }
+                },
+                AnyCharExcept('\n').AtLeastOnceString())
+            .Cast<Control>()))
+        .Labelled("tertiaryheader");
+
+    private static readonly Parser<char, Control> TryHeaderControl = OneOf(TertiaryHeaderControlParser, SubHeaderControlParser, HeaderControlParser);
 
     private static readonly Parser<char, Control> ListControlParser = Try(Char('-'))
         .Then(SkipWhitespaces)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a tertiary header parser to the guidebook parser

## Why / Balance
Sometimes two levels of headers isn't enough

## Technical details
- adds a new parser that yields a label styled with `LabelKeyText` class to the header alternates

## Media
![grafik](https://github.com/user-attachments/assets/1108c369-48a8-49f3-b112-89d8aa870876)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
ADMIN:
- add: Added the ability to use tertiary headers in the guidebook
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->