### PR TITLE
Add table of contents to the guidebook

### DIFF
--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
@@ -9,31 +9,43 @@
     <SplitContainer Orientation="Horizontal" HorizontalExpand="True" Name="Split">
         <!-- Guide select -->
         <BoxContainer Orientation="Horizontal" Name="TreeBox">
-            <fancyTree:FancyTree Name="Tree" VerticalExpand="True" HorizontalExpand="True" Access="Public"/>
+            <BoxContainer Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True">
+                <Label Text="{Loc 'guidebook-pages-header'}" StyleClasses="LabelKeyText" Margin="2"/>
+                <fancyTree:FancyTree Name="Tree" VerticalExpand="True" HorizontalExpand="True" Access="Public"/>
+            </BoxContainer>
             <cc:VSeparator StyleClasses="LowDivider" Margin="0 -2"/>
         </BoxContainer>
-        <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
-            <BoxContainer Name="SearchContainer" Visible="False" HorizontalExpand="True">
-                <LineEdit
-                    Name="SearchBar"
-                    PlaceHolder="{Loc 'guidebook-filter-placeholder-text'}"
-                    HorizontalExpand="True"
-                    Margin="0 5 10 5">
-                </LineEdit>
+        <SplitContainer Orientation="Horizontal" HorizontalExpand="True" Name="Subpplit">
+            <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
+                <BoxContainer Name="SearchContainer" Visible="False" HorizontalExpand="True">
+                    <LineEdit
+                        Name="SearchBar"
+                        PlaceHolder="{Loc 'guidebook-filter-placeholder-text'}"
+                        HorizontalExpand="True"
+                        Margin="0 5 10 5">
+                    </LineEdit>
+                </BoxContainer>
+                <BoxContainer Access="Internal" Name="ReturnContainer" Orientation="Horizontal" HorizontalAlignment="Right" Visible="False">
+                    <Button Name="HomeButton" Text="{Loc 'ui-rules-button-home'}" Margin="0 0 10 0"/>
+                </BoxContainer>
+                <ScrollContainer Name="Scroll" HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True">
+                    <Control>
+                        <BoxContainer Orientation="Vertical" Name="EntryContainer" Margin="5 5 5 5" Visible="False">
+                        </BoxContainer>
+                        <BoxContainer Orientation="Vertical" Name="Placeholder" Margin="5 5 5 5">
+                            <Label HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Loc 'guidebook-placeholder-text'}"/>
+                            <Label HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Loc 'guidebook-placeholder-text-2'}"/>
+                        </BoxContainer>
+                    </Control>
+                </ScrollContainer>
             </BoxContainer>
-            <BoxContainer Access="Internal" Name="ReturnContainer" Orientation="Horizontal" HorizontalAlignment="Right" Visible="False">
-                <Button Name="HomeButton" Text="{Loc 'ui-rules-button-home'}" Margin="0 0 10 0"/>
+            <BoxContainer Orientation="Horizontal" Name="TableOfContentsBox">
+                <cc:VSeparator StyleClasses="LowDivider" Margin="0 -2"/>
+                <BoxContainer Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True">
+                    <Label Text="{Loc 'guidebook-toc-header'}" StyleClasses="LabelKeyText" Margin="2"/>
+                    <fancyTree:FancyTree Name="TableOfContents" VerticalExpand="True" HorizontalExpand="True" Access="Public"/>
+                </BoxContainer>
             </BoxContainer>
-            <ScrollContainer Name="Scroll" HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True">
-                <Control>
-                    <BoxContainer Orientation="Vertical" Name="EntryContainer" Margin="5 5 5 5" Visible="False">
-                    </BoxContainer>
-                    <BoxContainer Orientation="Vertical" Name="Placeholder" Margin="5 5 5 5">
-                        <Label HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Loc 'guidebook-placeholder-text'}"/>
-                        <Label HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Loc 'guidebook-placeholder-text-2'}"/>
-                    </BoxContainer>
-                </Control>
-            </ScrollContainer>
-        </BoxContainer>
+        </SplitContainer>
     </SplitContainer>
 </controls:FancyWindow>

--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
@@ -9,43 +9,32 @@
     <SplitContainer Orientation="Horizontal" HorizontalExpand="True" Name="Split">
         <!-- Guide select -->
         <BoxContainer Orientation="Horizontal" Name="TreeBox">
-            <BoxContainer Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True">
-                <Label Text="{Loc 'guidebook-pages-header'}" StyleClasses="LabelKeyText" Margin="2"/>
-                <fancyTree:FancyTree Name="Tree" VerticalExpand="True" HorizontalExpand="True" Access="Public"/>
-            </BoxContainer>
+            <fancyTree:FancyTree Name="Tree" VerticalExpand="True" HorizontalExpand="True" Access="Public"/>
             <cc:VSeparator StyleClasses="LowDivider" Margin="0 -2"/>
         </BoxContainer>
-        <SplitContainer Orientation="Horizontal" HorizontalExpand="True" Name="Subpplit">
-            <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
-                <BoxContainer Name="SearchContainer" Visible="False" HorizontalExpand="True">
-                    <LineEdit
-                        Name="SearchBar"
-                        PlaceHolder="{Loc 'guidebook-filter-placeholder-text'}"
-                        HorizontalExpand="True"
-                        Margin="0 5 10 5">
-                    </LineEdit>
-                </BoxContainer>
-                <BoxContainer Access="Internal" Name="ReturnContainer" Orientation="Horizontal" HorizontalAlignment="Right" Visible="False">
-                    <Button Name="HomeButton" Text="{Loc 'ui-rules-button-home'}" Margin="0 0 10 0"/>
-                </BoxContainer>
-                <ScrollContainer Name="Scroll" HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True">
-                    <Control>
-                        <BoxContainer Orientation="Vertical" Name="EntryContainer" Margin="5 5 5 5" Visible="False">
-                        </BoxContainer>
-                        <BoxContainer Orientation="Vertical" Name="Placeholder" Margin="5 5 5 5">
-                            <Label HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Loc 'guidebook-placeholder-text'}"/>
-                            <Label HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Loc 'guidebook-placeholder-text-2'}"/>
-                        </BoxContainer>
-                    </Control>
-                </ScrollContainer>
+        <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
+            <fancyTree:FancyTree Name="TableOfContents" HorizontalExpand="True"/>
+            <BoxContainer Name="SearchContainer" Visible="False" HorizontalExpand="True">
+                <LineEdit
+                    Name="SearchBar"
+                    PlaceHolder="{Loc 'guidebook-filter-placeholder-text'}"
+                    HorizontalExpand="True"
+                    Margin="0 5 10 5">
+                </LineEdit>
             </BoxContainer>
-            <BoxContainer Orientation="Horizontal" Name="TableOfContentsBox">
-                <cc:VSeparator StyleClasses="LowDivider" Margin="0 -2"/>
-                <BoxContainer Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True">
-                    <Label Text="{Loc 'guidebook-toc-header'}" StyleClasses="LabelKeyText" Margin="2"/>
-                    <fancyTree:FancyTree Name="TableOfContents" VerticalExpand="True" HorizontalExpand="True" Access="Public"/>
-                </BoxContainer>
+            <BoxContainer Access="Internal" Name="ReturnContainer" Orientation="Horizontal" HorizontalAlignment="Right" Visible="False">
+                <Button Name="HomeButton" Text="{Loc 'ui-rules-button-home'}" Margin="0 0 10 0"/>
             </BoxContainer>
-        </SplitContainer>
+            <ScrollContainer Name="Scroll" HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True">
+                <Control>
+                    <BoxContainer Orientation="Vertical" Name="EntryContainer" Margin="5 5 5 5" Visible="False">
+                    </BoxContainer>
+                    <BoxContainer Orientation="Vertical" Name="Placeholder" Margin="5 5 5 5">
+                        <Label HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Loc 'guidebook-placeholder-text'}"/>
+                        <Label HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Loc 'guidebook-placeholder-text-2'}"/>
+                    </BoxContainer>
+                </Control>
+            </ScrollContainer>
+        </BoxContainer>
     </SplitContainer>
 </controls:FancyWindow>

--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Linq;
 using Content.Client.Guidebook.RichText;
 using Content.Client.UserInterface.ControlExtensions;
@@ -77,7 +76,7 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
 
             UserInterfaceManager.DeferAction(() =>
             {
-                if (control.GetControlScrollPosition() is not {} position)
+                if (control.GetControlScrollPosition() is not { } position)
                     return;
 
                 Scroll.HScrollTarget = position.X;
@@ -109,7 +108,7 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
 
         UserInterfaceManager.DeferAction(() =>
         {
-            if (entry.GetControlScrollPosition() is not {} position)
+            if (entry.GetControlScrollPosition() is not { } position)
                 return;
 
             Scroll.HScrollTarget = position.X;
@@ -167,13 +166,13 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
 
     private int? HeadingDepth(Label control)
     {
-        if (control.StyleClasses.Contains("LabelHeadingBigger")) {
+        if (control.StyleClasses.Contains("LabelHeadingBigger"))
             return 1;
-        } else if (control.StyleClasses.Contains("LabelHeading")) {
+        else if (control.StyleClasses.Contains("LabelHeading"))
             return 2;
-        } else if (control.StyleClasses.Contains("LabelKeyText")) {
+        else if (control.StyleClasses.Contains("LabelKeyText"))
             return 3;
-        }
+
         return null;
     }
 
@@ -181,12 +180,15 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
     {
         TableOfContents.Clear();
 
+        var firstEntry = TableOfContents.AddItem(null);
+        firstEntry.Label.Text = Loc.GetString("guidebook-toc-header");
+
         var labels = EntryContainer.GetControlOfType<Label>(true);
         var stack = new Stack<(TreeItem Item, int Depth)>();
 
         foreach (var label in labels)
         {
-            if (HeadingDepth(label) is not {} depth)
+            if (HeadingDepth(label) is not { } depth)
                 continue;
 
             while (stack.TryPeek(out var previous) && previous.Depth >= depth)
@@ -194,14 +196,18 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
                 stack.Pop();
             }
 
-            var item = stack.TryPeek(out var parent) ? TableOfContents.AddItem(parent.Item) : TableOfContents.AddItem(null);
+            var item = stack.TryPeek(out var parent)
+                ? TableOfContents.AddItem(parent.Item)
+                : TableOfContents.AddItem(firstEntry);
             item.Label.Text = label.Text;
             item.Metadata = label;
 
             stack.Push((item, depth));
         }
 
+        // Expand all entries, but collapse the first one
         TableOfContents.SetAllExpanded(true);
+        firstEntry.SetExpanded(false);
     }
 
     public void UpdateGuides(

--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
@@ -34,6 +34,7 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
         _sawmill = Logger.GetSawmill("guidebook");
 
         Tree.OnSelectedItemChanged += OnSelectionChanged;
+        TableOfContents.OnSelectedItemChanged += OnTableOfContentsSelectionChanged;
 
         SearchBar.OnTextChanged += _ =>
         {
@@ -101,6 +102,21 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
             ClearSelectedGuide();
     }
 
+    private void OnTableOfContentsSelectionChanged(TreeItem? item)
+    {
+        if (item is null || item.Metadata is not Label entry)
+            return;
+
+        UserInterfaceManager.DeferAction(() =>
+        {
+            if (entry.GetControlScrollPosition() is not {} position)
+                return;
+
+            Scroll.HScrollTarget = position.X;
+            Scroll.VScrollTarget = position.Y;
+        });
+    }
+
     public void ClearSelectedGuide()
     {
         Placeholder.Visible = true;
@@ -145,6 +161,47 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
             if (prototype != null && availablePrototypeLinks.Contains(prototype))
                 linkControl.EnablePrototypeLink();
         }
+
+        RepopulateTableOfContents();
+    }
+
+    private int? HeadingDepth(Label control)
+    {
+        if (control.StyleClasses.Contains("LabelHeadingBigger")) {
+            return 1;
+        } else if (control.StyleClasses.Contains("LabelHeading")) {
+            return 2;
+        } else if (control.StyleClasses.Contains("LabelKeyText")) {
+            return 3;
+        }
+        return null;
+    }
+
+    private void RepopulateTableOfContents()
+    {
+        TableOfContents.Clear();
+
+        var labels = EntryContainer.GetControlOfType<Label>(true);
+        var stack = new Stack<(TreeItem Item, int Depth)>();
+
+        foreach (var label in labels)
+        {
+            if (HeadingDepth(label) is not {} depth)
+                continue;
+
+            while (stack.TryPeek(out var previous) && previous.Depth >= depth)
+            {
+                stack.Pop();
+            }
+
+            var item = stack.TryPeek(out var parent) ? TableOfContents.AddItem(parent.Item) : TableOfContents.AddItem(null);
+            item.Label.Text = label.Text;
+            item.Metadata = label;
+
+            stack.Push((item, depth));
+        }
+
+        TableOfContents.SetAllExpanded(true);
     }
 
     public void UpdateGuides(

--- a/Resources/Locale/en-US/guidebook/guidebook.ftl
+++ b/Resources/Locale/en-US/guidebook/guidebook.ftl
@@ -2,6 +2,8 @@ guidebook-window-title = Guidebook
 guidebook-placeholder-text = Select an entry.
 guidebook-placeholder-text-2 = If you're new, head over to "New? Start here!"
 guidebook-filter-placeholder-text = Filter items
+guidebook-pages-header = Pages
+guidebook-toc-header = Contents
 
 guidebook-parser-error = Parser Error
 guidebook-error-message = Error Message

--- a/Resources/Locale/en-US/guidebook/guidebook.ftl
+++ b/Resources/Locale/en-US/guidebook/guidebook.ftl
@@ -3,7 +3,7 @@ guidebook-placeholder-text = Select an entry.
 guidebook-placeholder-text-2 = If you're new, head over to "New? Start here!"
 guidebook-filter-placeholder-text = Filter items
 guidebook-pages-header = Pages
-guidebook-toc-header = Contents
+guidebook-toc-header = Table of Contents
 
 guidebook-parser-error = Parser Error
 guidebook-error-message = Error Message

--- a/Resources/Locale/en-US/guidebook/guidebook.ftl
+++ b/Resources/Locale/en-US/guidebook/guidebook.ftl
@@ -2,7 +2,6 @@ guidebook-window-title = Guidebook
 guidebook-placeholder-text = Select an entry.
 guidebook-placeholder-text-2 = If you're new, head over to "New? Start here!"
 guidebook-filter-placeholder-text = Filter items
-guidebook-pages-header = Pages
 guidebook-toc-header = Table of Contents
 
 guidebook-parser-error = Parser Error


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This adds a table of contents sidebar to the Guidebook that allows jumping to any header present within a document.

## Why / Balance
This is useful for navigating long pages, such as servers that may opt to put their Space Law/Standard Operating Procedures/etc. within the guidebook instead of on a wiki.

## Technical details
- adds a new FancyTree to the GuidebookWindow that gets populated
- the tree is constructed out of labels present in the document, using their style classes to determine heading level

## Media
<img width="676" height="521" alt="image" src="https://github.com/user-attachments/assets/ada9012e-21b7-4dcc-8cb2-fdc6ae580294" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added a table of contents to each guidebook entry
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
