### PR TITLE
Hotfix: Fix uplinks allowing buying conditionally restricted items

### DIFF
--- a/Content.Server/Store/Systems/StoreSystem.Listings.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Listings.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Mind;
 using Content.Shared.Store;
 using Content.Shared.Store.Components;
 using Robust.Shared.Prototypes;
@@ -117,7 +118,15 @@ public sealed partial class StoreSystem
 
             if (listing.Conditions != null)
             {
-                var args = new ListingConditionArgs(buyer, storeEntity, listing, EntityManager);
+                var argBuyer = buyer;
+
+                // If a mind isn't provided, check for one. If neither hits, it's probably an object (e.g. surplus) doing the listing.
+                if (!HasComp<MindComponent>(argBuyer) && _mind.TryGetMind(buyer, out var buyerMind, out var _))
+                {
+                    argBuyer = buyerMind;
+                }
+
+                var args = new ListingConditionArgs(argBuyer, storeEntity, listing, EntityManager);
                 var conditionsMet = true;
 
                 foreach (var condition in listing.Conditions)

--- a/Content.Server/Store/Systems/StoreSystem.Listings.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Listings.cs
@@ -118,13 +118,7 @@ public sealed partial class StoreSystem
 
             if (listing.Conditions != null)
             {
-                var argBuyer = buyer;
-
-                // If a mind isn't provided, check for one. If neither hits, it's probably an object (e.g. surplus) doing the listing.
-                if (!HasComp<MindComponent>(argBuyer) && _mind.TryGetMind(buyer, out var buyerMind, out var _))
-                    argBuyer = buyerMind;
-
-                var args = new ListingConditionArgs(argBuyer, storeEntity, listing, EntityManager);
+                var args = new ListingConditionArgs(GetBuyerMind(buyer), storeEntity, listing, EntityManager);
                 var conditionsMet = true;
 
                 foreach (var condition in listing.Conditions)
@@ -142,6 +136,19 @@ public sealed partial class StoreSystem
 
             yield return listing;
         }
+    }
+
+    /// <summary>
+    /// Returns the entity's mind entity, if it has one, to be used for listing conditions.
+    /// If it doesn't have one, or is a mind entity already, it returns itself.
+    /// </summary>
+    /// <param name="buyer">The buying entity.</param>
+    public EntityUid GetBuyerMind(EntityUid buyer)
+    {
+        if (!HasComp<MindComponent>(buyer) && _mind.TryGetMind(buyer, out var buyerMind, out var _))
+            return buyerMind;
+
+        return buyer;
     }
 
     /// <summary>

--- a/Content.Server/Store/Systems/StoreSystem.Listings.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Listings.cs
@@ -122,9 +122,7 @@ public sealed partial class StoreSystem
 
                 // If a mind isn't provided, check for one. If neither hits, it's probably an object (e.g. surplus) doing the listing.
                 if (!HasComp<MindComponent>(argBuyer) && _mind.TryGetMind(buyer, out var buyerMind, out var _))
-                {
                     argBuyer = buyerMind;
-                }
 
                 var args = new ListingConditionArgs(argBuyer, storeEntity, listing, EntityManager);
                 var conditionsMet = true;

--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -146,7 +146,15 @@ public sealed partial class StoreSystem
         //condition checking because why not
         if (listing.Conditions != null)
         {
-            var args = new ListingConditionArgs(component.AccountOwner ?? buyer, uid, listing, EntityManager);
+            var argBuyer = buyer;
+
+            // If a mind isn't provided, check for one. If neither hits, it's probably an object (e.g. surplus) doing the listing.
+            if (!HasComp<MindComponent>(argBuyer) && _mind.TryGetMind(buyer, out var buyerMind, out var _))
+            {
+                argBuyer = buyerMind;
+            }
+
+            var args = new ListingConditionArgs(component.AccountOwner ?? argBuyer, uid, listing, EntityManager);
             var conditionsMet = listing.Conditions.All(condition => condition.Condition(args));
 
             if (!conditionsMet)

--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -150,9 +150,7 @@ public sealed partial class StoreSystem
 
             // If a mind isn't provided, check for one. If neither hits, it's probably an object (e.g. surplus) doing the listing.
             if (!HasComp<MindComponent>(argBuyer) && _mind.TryGetMind(buyer, out var buyerMind, out var _))
-            {
                 argBuyer = buyerMind;
-            }
 
             var args = new ListingConditionArgs(component.AccountOwner ?? argBuyer, uid, listing, EntityManager);
             var conditionsMet = listing.Conditions.All(condition => condition.Condition(args));

--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -146,13 +146,7 @@ public sealed partial class StoreSystem
         //condition checking because why not
         if (listing.Conditions != null)
         {
-            var argBuyer = buyer;
-
-            // If a mind isn't provided, check for one. If neither hits, it's probably an object (e.g. surplus) doing the listing.
-            if (!HasComp<MindComponent>(argBuyer) && _mind.TryGetMind(buyer, out var buyerMind, out var _))
-                argBuyer = buyerMind;
-
-            var args = new ListingConditionArgs(component.AccountOwner ?? argBuyer, uid, listing, EntityManager);
+            var args = new ListingConditionArgs(component.AccountOwner ?? GetBuyerMind(buyer), uid, listing, EntityManager);
             var conditionsMet = listing.Conditions.All(condition => condition.Condition(args));
 
             if (!conditionsMet)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes #35274.
The bug where Nukies can buy job-restricted items.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bugfix 

## Technical details
<!-- Summary of code changes for easier review. -->

#33553 changed so that conditions check for the `MindComponent` when evaluating whether something should show in the uplink. This works for PDA uplinks, since they register the owner's mind as the owner, but Nukie uplinks have no owner and thus use the buyer entity for evaluations. Problem is, the buyer entity is the mind entity container, and therefore doesn't have a `MindComponent` to evaluate against. 

You can't guarantee that the buyer has a mind however, since surplus crates "buy" items.

So now we check if the buyer has a `MindComponent` (PDA uplinks), and if they don't we check to see if they contain a mind entity. If they do, we make that the buyer instead (Nukie uplinks). If they don't, they're a non-mind entity buying (Surplus crate). 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Nukies no longer have access to job-restricted items.
