### PR TITLE
fix ion storm code readability

### DIFF
--- a/Content.Server/Silicons/Laws/IonStormSystem.cs
+++ b/Content.Server/Silicons/Laws/IonStormSystem.cs
@@ -200,11 +200,11 @@ public sealed class IonStormSystem : EntitySystem
         // i dont think theres a way to do this in fluent
         var (who, plural) = _robustRandom.Next(0, 5) switch
         {
-            0 => (Loc.GetString("ion-storm-you"), false),
-            1 => (Loc.GetString("ion-storm-the-station"), true),
-            2 => (Loc.GetString("ion-storm-the-crew"), true),
-            3 => (Loc.GetString("ion-storm-the-job", ("job", crew2)), false),
-            _ => (area, true) // THE SINGULARITY REQUIRES THE HAPPY CLOWNS
+            0 => (Loc.GetString("ion-storm-you"), true),
+            1 => (Loc.GetString("ion-storm-the-station"), false),
+            2 => (Loc.GetString("ion-storm-the-crew"), false),
+            3 => (Loc.GetString("ion-storm-the-job", ("job", crew2)), true),
+            _ => (area, false) // THE SINGULARITY REQUIRES THE HAPPY CLOWNS
         };
         var jobChange = _robustRandom.Next(0, 3) switch
         {

--- a/Resources/Locale/en-US/station-events/events/ion-storm.ftl
+++ b/Resources/Locale/en-US/station-events/events/ion-storm.ftl
@@ -33,21 +33,21 @@ ion-storm-law-not-having-harmful = NOT HAVING {$adjective} {$thing} IS HARMFUL T
 
 # thing is a concept or require
 ion-storm-law-requires = {$who} {$plural ->
-    [true] REQUIRES
-    *[false] REQUIRE
+    [true] REQUIRE
+    *[false] REQUIRES
 } {$thing}
 ion-storm-law-requires-subjects = {$who} {$plural ->
-    [true] REQUIRES
-    *[false] REQUIRE
+    [true] REQUIRE
+    *[false] REQUIRES
 } {$joined} {$subjects}
 
 ion-storm-law-allergic = {$who} {$plural ->
-    [true] IS
-    *[false] ARE
+    [true] ARE
+    *[false] IS
 } {$severity} ALLERGIC TO {$allergy}
 ion-storm-law-allergic-subjects = {$who} {$plural ->
-    [true] IS
-    *[false] ARE
+    [true] ARE
+    *[false] IS
 } {$severity} ALLERGIC TO {$adjective} {$subjects}
 
 ion-storm-law-feeling = {$who} {$feeling} {$concept}

--- a/Resources/Prototypes/Datasets/ion_storm.yml
+++ b/Resources/Prototypes/Datasets/ion_storm.yml
@@ -418,7 +418,7 @@
   - CRAVE
   - DESIRE
   - FEAR
-  - HAS
+  - HAVE
   - HUNGER FOR
   - ARE AFRAID OF
   - ARE BUILT FOR


### PR DESCRIPTION
it was inconvenient to read, because if `plural = true` you actually get singular version, tweaked it
also a small fix in the dataset `HAS -> HAVE` for plural dataset 