### PR TITLE
Extended survival box for salvage specialists

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -84,7 +84,7 @@
     - BoxMimeNitrogen
 
 
-# Engineering / Extended
+# Engineering / Salvage / Extended
 - type: loadout
   id: EmergencyOxygenExtended
   effects:

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -235,7 +235,7 @@
   - SalvageSpecialistOuterClothing
   - SalvageSpecialistShoes
   - Glasses
-  - Survival
+  - SurvivalExtended
   - Trinkets
   - GroupSpeciesBreathTool
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Salvage specialists now start with extended survival capacity boxes

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Salvage specialists spend the most time in space out of every other job. It stands to reason they need extended emergency tanks, which are already given to engineers despite them spending most of their time on station.

## Technical details
<!-- Summary of code changes for easier review. -->
yml changes only

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/5b8a0c90-09ff-4f20-bc9a-1e2aef4b0471)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Salvage specialists now start with extended survival capacity boxes.