### PR TITLE
[april fools] adds a flash to all command items

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -553,6 +553,12 @@
     attributes:
       proper: true
       gender: female
+  - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Weapons/flash.ogg
+  - type: FlashOnTrigger
+    range: 3
+  - type: TriggerOnVoice
   - type: Tag
     tags:
     - CannotSuicide
@@ -656,6 +662,12 @@
     thresholds:
       0: Alive
       150: Dead
+  - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Weapons/flash.ogg
+  - type: FlashOnTrigger
+    range: 3
+  - type: TriggerOnVoice
   - type: MeleeWeapon
     angle: 0
     animation: WeaponArcBite

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -47,6 +47,21 @@
   components:
   - type: Contraband
     allowedDepartments: [ Command ]
+  - type: TriggerOnVoice
+  - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Weapons/flash.ogg
+  - type: FlashOnTrigger
+    range: 3
+  - type: TriggerOnSignal
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSink
+    ports:
+    - Trigger
 
 - type: entity
   id: BaseSecurityContraband
@@ -112,6 +127,21 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security, Command ]
+  - type: TriggerOnVoice
+  - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Weapons/flash.ogg
+  - type: FlashOnTrigger
+    range: 3
+  - type: TriggerOnSignal
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSink
+    ports:
+    - Trigger
 
 - type: entity
   id: BaseSecurityScienceCommandContraband


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
all command items now have a voice-trigger activated flash

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
this makes it harder for them to be stolen

## Technical details
<!-- Summary of code changes for easier review. -->
added voice trigger + flash on trigger + sound on trigger components to base contraband prototypes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/9ff21209-2763-4545-af5c-3c0629daa9b7



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Security measures to protect station staff.