### PR TITLE
Fix prying shut unpowered doors

### DIFF
--- a/Content.Shared/Doors/DoorEvents.cs
+++ b/Content.Shared/Doors/DoorEvents.cs
@@ -44,15 +44,20 @@ namespace Content.Shared.Doors
     /// </summary>
     /// <remarks>
     /// This event is raised both when the door is initially closed, and when it is just about to become "partially"
-    /// closed (opaque & collidable). If canceled while partially closing, it will start opening again. Useful in case
+    /// closed (opaque &amp; collidable). If canceled while partially closing, it will start opening again. Useful in case
     /// an entity entered the door just as it was about to become "solid".
     /// </remarks>
     public sealed class BeforeDoorClosedEvent : CancellableEntityEventArgs
     {
+        /// <summary>
+        /// If true, this check is being performed when the door is partially closing.
+        /// </summary>
+        public bool Partial;
         public bool PerformCollisionCheck;
 
-        public BeforeDoorClosedEvent(bool performCollisionCheck)
+        public BeforeDoorClosedEvent(bool performCollisionCheck, bool partial = false)
         {
+            Partial = partial;
             PerformCollisionCheck = performCollisionCheck;
         }
     }

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -42,7 +42,7 @@ public abstract class SharedAirlockSystem : EntitySystem
         // the initial power-check.
 
         if (TryComp(uid, out DoorComponent? door)
-            && !door.Partial
+            && !args.Partial
             && !CanChangeState(uid, airlock))
         {
             args.Cancel();

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -427,7 +427,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
     /// <param name="uid"> The uid of the door</param>
     /// <param name="door"> The doorcomponent of the door</param>
     /// <param name="user"> The user (if any) opening the door</param>
-    public bool CanClose(EntityUid uid, DoorComponent? door = null, EntityUid? user = null)
+    public bool CanClose(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool partial = false)
     {
         if (!Resolve(uid, ref door))
             return false;
@@ -437,7 +437,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (door.State is DoorState.Welded or DoorState.Closed)
             return false;
 
-        var ev = new BeforeDoorClosedEvent(door.PerformCollisionCheck);
+        var ev = new BeforeDoorClosedEvent(door.PerformCollisionCheck, partial);
         RaiseLocalEvent(uid, ev);
         if (ev.Cancelled)
             return false;
@@ -472,7 +472,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
             return false;
 
         // Make sure no entity walked into the airlock when it started closing.
-        if (!CanClose(uid, door))
+        if (!CanClose(uid, door, partial: true))
         {
             door.NextStateChange = GameTiming.CurTime + door.OpenTimeTwo;
             door.State = DoorState.Open;


### PR DESCRIPTION
Anyways, yes point and laugh at the dysfunctional Wizden maintainer team because nobody stepped up to fix a critical game-breaking bug like this. Jesus christ.

The core of the issue is that door prying code is complete spaghetti, and prying code bypasses all normal door closing checks, instead substituting it with its own. Except door closing checks are done *twice*, once when the door starts closing and once halfway through. Prying only skips the first.

Airlocks had special code to skip the second by checking whether the door was already in "Partial" state. This is of course a complete nightmare, and unsurprisingly it broke when Sloth rearranged the state logic in #33481. At least it says in a common clearly what the intent of that logic was.

Because I don't want to sit here and rewrite all this prying code spaghetti for what should be a CRITICAL HOTFIX TO A GAME BREAKING BUG WE'VE BEEN SLACKING ON FOR THE PAST **2 FUCKING MONTHS**, I'm just gonna fix the original hack by passing the "second check" explicitly as a boolean in the event instead of storing it as state in the component data.

WHY THIS IS BETTER THAN THE OTHER PRS:

#33968 adds even more state to the component to add another layer of cruft, and did not root cause the issue to remove the original (now dysfunctional) hack.

#33843 similarly does not root cause the issue and also does not remove the original dysfunctional hack.

Christ man. We're maintainers, this wasn't even that hard.

Fixes #33795

:cl:
- fix: Fixed prying shut unpowered doors with a crowbar.