### PR TITLE
Comment out broken guidebook test speech code

### DIFF
--- a/Content.Client/Guidebook/GuidebookSystem.cs
+++ b/Content.Client/Guidebook/GuidebookSystem.cs
@@ -150,7 +150,9 @@ public sealed class GuidebookSystem : EntitySystem
         if (!TryComp<SpeechComponent>(uid, out var speech) || speech.SpeechSounds is null)
             return;
 
-        _audioSystem.PlayGlobal(speech.SpeechSounds, Filter.Local(), false, speech.AudioParams);
+        // This code is broken because SpeechSounds isn't a file name or sound specifier directly.
+        // Commenting out to avoid compile failure with https://github.com/space-wizards/RobustToolbox/pull/5540
+        // _audioSystem.PlayGlobal(speech.SpeechSounds, Filter.Local(), false, speech.AudioParams);
     }
 
     public void FakeClientActivateInWorld(EntityUid activated)


### PR DESCRIPTION
This code blatantly doesn't work and causes compile failures with https://github.com/space-wizards/RobustToolbox/pull/5540. It's only used for testing purposes, so we're just removing it.

Basically taken from https://github.com/space-wizards/space-station-14/pull/33610 in another PR, so I can merge this first separately.
