### PR TITLE
[HOTFIX] Altered Silicon removal fails to trigger role update

### DIFF
--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -168,11 +168,9 @@ public abstract class SharedRoleSystem : EntitySystem
         var update = MindRolesUpdate((mindId, mind));
 
         // RoleType refresh, Role time tracking, Update Admin playerlist
-        if (mind.OwnedEntity != null)
-        {
-            var message = new RoleAddedEvent(mindId, mind, update, silent);
-            RaiseLocalEvent(mind.OwnedEntity.Value, message, true);
-        }
+
+        var message = new RoleAddedEvent(mindId, mind, update, silent);
+        RaiseLocalEvent(mindId, message, true);
 
         var name = Loc.GetString(protoEnt.Name);
         if (mind.OwnedEntity is not null)
@@ -311,11 +309,8 @@ public abstract class SharedRoleSystem : EntitySystem
 
         var update = MindRolesUpdate(mind);
 
-        if (mind.Comp.OwnedEntity != null)
-        {
-            var message = new RoleRemovedEvent(mind.Owner, mind.Comp, update);
-            RaiseLocalEvent(mind.Comp.OwnedEntity.Value, message, true);
-        }
+        var message = new RoleRemovedEvent(mind.Owner, mind.Comp, update);
+        RaiseLocalEvent(mind, message, true);
 
         _adminLogger.Add(LogType.Mind,
             LogImpact.Low,


### PR DESCRIPTION
## About the PR
Removing an emagged borg's brain now correctly reverts it to Silicon on the Character window and admin UI.

(Note, currently the Altered Silicon role isn't **added** in the first place for emagged borgs, that will be fixed by #35394)

## Why / Balance
bug

## Media

35394 + 35399

https://github.com/user-attachments/assets/5e852476-5a8e-47b0-84af-55591049d5dc


## Technical details
A check that was originally for safeguarding against the rare/unexpected situation where Mind.OwnedEntity is null, is being triggered when called as the borg's brain is removed, as apparently at that point it's not owning either the old or the new mob entity.  This check was there to prevent the update event from being raised on a null entity, but the event was at some point changed to be broadcast, so it's irrelevant _what_ entity it gets raised on - all the important details are in the event args and no component is used to subscribe to them. Thus, I have simply changed the target entity to the mind entity itself and removed the check for OwnedEntity

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
RoleAddedEvent and RoleRemovedEvent messages are now raised on the mind entity, rather than the mind's owned entity. If any codebase is sending these events as non-broadcast, the events will now be sent to a different entity and probably no longer do what they were changed to do.

**Changelog**
:cl: Errant
- fix: Removing an emagged borg's brain now correctly reverts it to Silicon mind role.