### PR TITLE
Add interaction tests for prying airlocks

### DIFF
--- a/Content.IntegrationTests/Tests/Doors/AirlockPryingTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockPryingTest.cs
@@ -1,0 +1,44 @@
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server.Doors.Systems;
+using Content.Server.Power.Components;
+using Content.Shared.Doors.Components;
+
+namespace Content.IntegrationTests.Tests.Doors;
+
+public sealed class AirlockPryingTest : InteractionTest
+{
+    [Test]
+    public async Task UnpoweredAirlock_PryOpen_Opens()
+    {
+        await SpawnTarget(Airlock);
+
+        Assert.That(TryComp<AirlockComponent>(out var airlockComp), "Airlock does not have AirlockComponent?");
+        Assert.That(airlockComp.Powered, Is.False, "Airlock should not be powered for this test.");
+
+        Assert.That(TryComp<DoorComponent>(out var doorComp), "Airlock does not have DoorComponent?");
+        Assert.That(doorComp.State, Is.EqualTo(DoorState.Closed), "Airlock did not start closed.");
+
+        await InteractUsing(Pry);
+
+        Assert.That(doorComp.State, Is.EqualTo(DoorState.Opening), "Airlock failed to pry open.");
+    }
+
+    [Test]
+    public async Task UnpoweredAirlock_PryClosed_Closes()
+    {
+        await SpawnTarget(Airlock);
+
+        Assert.That(TryComp<AirlockComponent>(out var airlockComp), "Airlock does not have AirlockComponent?");
+        Assert.That(airlockComp.Powered, Is.False, "Airlock should not be powered for this test.");
+
+        var doorSys = SEntMan.System<DoorSystem>();
+        await Server.WaitPost(() => doorSys.SetState(SEntMan.GetEntity(Target.Value), DoorState.Open));
+
+        Assert.That(TryComp<DoorComponent>(out var doorComp), "Airlock does not have DoorComponent?");
+        Assert.That(doorComp.State, Is.EqualTo(DoorState.Open), "Airlock did not start open.");
+
+        await InteractUsing(Pry);
+
+        Assert.That(doorComp.State, Is.EqualTo(DoorState.Closing), "Airlock failed to pry closed.");
+    }
+}

--- a/Content.IntegrationTests/Tests/Doors/AirlockPryingTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockPryingTest.cs
@@ -1,12 +1,52 @@
 using Content.IntegrationTests.Tests.Interaction;
 using Content.Server.Doors.Systems;
-using Content.Server.Power.Components;
 using Content.Shared.Doors.Components;
 
 namespace Content.IntegrationTests.Tests.Doors;
 
 public sealed class AirlockPryingTest : InteractionTest
 {
+    [Test]
+    public async Task PoweredAirlock_PryOpen_DoesNotOpen()
+    {
+        await SpawnTarget(Airlock);
+        await SpawnEntity("APCBasic", SEntMan.GetCoordinates(TargetCoords));
+
+        await RunTicks(1);
+
+        Assert.That(TryComp<AirlockComponent>(out var airlockComp), "Airlock does not have AirlockComponent?");
+        Assert.That(airlockComp.Powered, "Airlock should be powered for this test.");
+
+        Assert.That(TryComp<DoorComponent>(out var doorComp), "Airlock does not have DoorComponent?");
+        Assert.That(doorComp.State, Is.EqualTo(DoorState.Closed), "Airlock did not start closed.");
+
+        await InteractUsing(Pry);
+
+        Assert.That(doorComp.State, Is.EqualTo(DoorState.Closed), "Powered airlock was pried open.");
+    }
+
+    [Test]
+    public async Task PoweredAirlock_PryClosed_DoesNotClosed()
+    {
+        await SpawnTarget(Airlock);
+        await SpawnEntity("APCBasic", SEntMan.GetCoordinates(TargetCoords));
+
+        await RunTicks(1);
+
+        Assert.That(TryComp<AirlockComponent>(out var airlockComp), "Airlock does not have AirlockComponent?");
+        Assert.That(airlockComp.Powered, "Airlock should be powered for this test.");
+
+        var doorSys = SEntMan.System<DoorSystem>();
+        await Server.WaitPost(() => doorSys.SetState(SEntMan.GetEntity(Target.Value), DoorState.Open));
+
+        Assert.That(TryComp<DoorComponent>(out var doorComp), "Airlock does not have DoorComponent?");
+        Assert.That(doorComp.State, Is.EqualTo(DoorState.Open), "Airlock did not start open.");
+
+        await InteractUsing(Pry);
+
+        Assert.That(doorComp.State, Is.EqualTo(DoorState.Open), "Powered airlock was pried closed.");
+    }
+
     [Test]
     public async Task UnpoweredAirlock_PryOpen_Opens()
     {
@@ -20,7 +60,7 @@ public sealed class AirlockPryingTest : InteractionTest
 
         await InteractUsing(Pry);
 
-        Assert.That(doorComp.State, Is.EqualTo(DoorState.Opening), "Airlock failed to pry open.");
+        Assert.That(doorComp.State, Is.EqualTo(DoorState.Opening), "Unpowered airlock failed to pry open.");
     }
 
     [Test]
@@ -39,6 +79,6 @@ public sealed class AirlockPryingTest : InteractionTest
 
         await InteractUsing(Pry);
 
-        Assert.That(doorComp.State, Is.EqualTo(DoorState.Closing), "Airlock failed to pry closed.");
+        Assert.That(doorComp.State, Is.EqualTo(DoorState.Closing), "Unpowerd airlock failed to pry closed.");
     }
 }

--- a/Content.IntegrationTests/Tests/Doors/AirlockPryingTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockPryingTest.cs
@@ -79,6 +79,6 @@ public sealed class AirlockPryingTest : InteractionTest
 
         await InteractUsing(Pry);
 
-        Assert.That(doorComp.State, Is.EqualTo(DoorState.Closing), "Unpowerd airlock failed to pry closed.");
+        Assert.That(doorComp.State, Is.EqualTo(DoorState.Closing), "Unpowered airlock failed to pry closed.");
     }
 }

--- a/Content.IntegrationTests/Tests/Doors/AirlockPryingTest.cs
+++ b/Content.IntegrationTests/Tests/Doors/AirlockPryingTest.cs
@@ -7,7 +7,7 @@ namespace Content.IntegrationTests.Tests.Doors;
 public sealed class AirlockPryingTest : InteractionTest
 {
     [Test]
-    public async Task PoweredAirlock_PryOpen_DoesNotOpen()
+    public async Task PoweredClosedAirlock_Pry_DoesNotOpen()
     {
         await SpawnTarget(Airlock);
         await SpawnEntity("APCBasic", SEntMan.GetCoordinates(TargetCoords));
@@ -26,7 +26,7 @@ public sealed class AirlockPryingTest : InteractionTest
     }
 
     [Test]
-    public async Task PoweredAirlock_PryClosed_DoesNotClosed()
+    public async Task PoweredOpenAirlock_Pry_DoesNotClose()
     {
         await SpawnTarget(Airlock);
         await SpawnEntity("APCBasic", SEntMan.GetCoordinates(TargetCoords));
@@ -48,7 +48,7 @@ public sealed class AirlockPryingTest : InteractionTest
     }
 
     [Test]
-    public async Task UnpoweredAirlock_PryOpen_Opens()
+    public async Task UnpoweredClosedAirlock_Pry_Opens()
     {
         await SpawnTarget(Airlock);
 
@@ -64,7 +64,7 @@ public sealed class AirlockPryingTest : InteractionTest
     }
 
     [Test]
-    public async Task UnpoweredAirlock_PryClosed_Closes()
+    public async Task UnpoweredOpenAirlock_Pry_Closes()
     {
         await SpawnTarget(Airlock);
 

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.Constants.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.Constants.cs
@@ -10,6 +10,7 @@ public abstract partial class InteractionTest
     protected const string Plating = "Plating";
     protected const string Lattice = "Lattice";
 
+    // Structures
     protected const string Airlock = "Airlock";
 
     // Tools/steps

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.Constants.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.Constants.cs
@@ -10,6 +10,8 @@ public abstract partial class InteractionTest
     protected const string Plating = "Plating";
     protected const string Lattice = "Lattice";
 
+    protected const string Airlock = "Airlock";
+
     // Tools/steps
     protected const string Wrench = "Wrench";
     protected const string Screw = "Screwdriver";

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -149,7 +149,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         RaiseLocalEvent(ent, new DoorStateChangedEvent(door.State));
     }
 
-    protected bool SetState(EntityUid uid, DoorState state, DoorComponent? door = null)
+    public bool SetState(EntityUid uid, DoorState state, DoorComponent? door = null)
     {
         if (!Resolve(uid, ref door))
             return false;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added tests for prying airlocks - powered and unpowered, open and shut.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prying unpowered airlocks shut was broken for months (#35380). Embarrassing. Let's not let that happen again.

## Technical details
<!-- Summary of code changes for easier review. -->
Leverages the `InteractionTest` base to make four simple tests.
Adds the Airlock prototype to InteractionTests.Constants.
`SharedDoorSystem.SetState` is now public to allow the tests to instantly open/close the airlock for testing.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nah.