### PR TITLE
Make holoparasite's damage transfer ignore the host's armor

### DIFF
--- a/Content.Server/Guardian/GuardianSystem.cs
+++ b/Content.Server/Guardian/GuardianSystem.cs
@@ -269,6 +269,7 @@ namespace Content.Server.Guardian
                 component.Host,
                 args.DamageDelta * component.DamageShare,
                 origin: args.Origin,
+                ignoreResistances: true,
                 interruptsDoAfters: false);
             _popupSystem.PopupEntity(Loc.GetString("guardian-entity-taking-damage"), component.Host.Value, component.Host.Value);
 


### PR DESCRIPTION
## About the PR
Hitting a holoparasite will now apply the full* damage to the host, ignoring whatever armor host may be wearing.
*Holoparasites still have an innate 35% resist to all damage.

## Why / Balance
- It logicaly makes sense (holoparasite directly transfers any damage to the host's body, why would it care about armor?)
- Combining a holoparasite with a good armor (like a jugsuit) makes the host way too strong.
- It already has 35% resistance, very good melee damage (36 blunt and 36 structural per second), ignores bullets and can act semi-independently from it's host, which is pretty damn good for 14 TC.

## Technical details
![изображение](https://github.com/user-attachments/assets/c1718a01-bdd1-48b4-b1a6-88efdd1acfd8)

## Media
![изображение](https://github.com/user-attachments/assets/df02f169-6a89-452c-b01b-50774af9da06)
A person in bloodred has taken 65 damage when their holoparasite was hit with a 100 damage stick due to the holoparasite's 35% resist.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Hitting a holoparasite will now ignore the host's armor.
