### PR TITLE
Allow nukeops to buy holoparasites

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1123,11 +1123,6 @@
     Telecrystal: 14
   categories:
   - UplinkAllies
-  conditions:
-  - !type:StoreWhitelistCondition
-    blacklist:
-      tags:
-      - NukeOpsUplink
 
 - type: listing
   id: UplinkReinforcementRadioSyndicate


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Nukie uplink now has access to the holoparasite kit.
Merge after https://github.com/space-wizards/space-station-14/pull/35418 so that holoparasite + jugsuit is not an insanely overpowered combo.

## Why / Balance
- More ghost roles, meaning more players can join the nukies, which are a highly contested role.
- More variety in nukie loadouts, meaning more unique rounds.
- A middle-ground option in terms of allies for nukies (right now there are very cheap monkeys/syndicats and very expensive reinforcements/borgs with nothing inbetween)

## Technical details
Removed nukie blacklist from the respective uplink purchase.

## Media
![изображение](https://github.com/user-attachments/assets/c6effd51-16f5-4650-9952-ba6230e2eeba)
A very bizzare individual.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Nuclear operatives now have access to the holoparasite kit.
