### PR TITLE
Remove disablers from emagged lathe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -399,6 +399,7 @@
     - SecurityExplosives
     - SecurityAmmo
     - SecurityWeapons
+    - SecurityDisablers
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -124,8 +124,12 @@
   recipes:
   - Truncheon
   - WeaponAdvancedLaser
-  - WeaponDisabler
-  - WeaponDisablerSMG
   - WeaponLaserCannon
   - WeaponLaserCarbine
   - WeaponXrayCannon
+
+- type: latheRecipePack
+  id: SecurityDisablers
+  recipes:
+  - WeaponDisabler
+  - WeaponDisablerSMG


### PR DESCRIPTION
## About the PR
This was accidentally introduced in https://github.com/space-wizards/space-station-14/pull/33095, which was a technical refactor.
Same for stun batons, which were already reverted in https://github.com/space-wizards/space-station-14/pull/35014
This was brought up in the maintainer meeting and agreed upon that it should be fixed for balance reasons, but looks like we forgot to do this before publishing.
See https://docs.spacestation14.com/en/maintainer-meetings/maintainer-meeting-2025-02-15.html

## Why / Balance
Disablers and stun batons were originally left out from the emagged lathe on purpose.
The recent disabler buff made this even more powerful.
On top of that the emag was split into two items, so you now get a disabler SMG for only 4TC.

## Technical details
change lathe packs

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
- tweak: Removed the disabler recipe from the emagged protolathe. This was introduced by accident in a refactor.

