### PR TITLE
Cleanup: Use ``SoundSpecifier`` instead of string literals in ``EyeClosingComponent``

### DIFF
--- a/Content.Shared/Eye/Blinding/Components/EyeClosingComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/EyeClosingComponent.cs
@@ -12,6 +12,18 @@ namespace Content.Shared.Eye.Blinding.Components;
 public sealed partial class EyeClosingComponent : Component
 {
     /// <summary>
+    /// Default eyes opening sound.
+    /// </summary>
+    [ValidatePrototypeId<SoundCollectionPrototype>]
+    private static readonly ProtoId<SoundCollectionPrototype> DefaultEyeOpen = new("EyeOpen");
+
+    /// <summary>
+    /// Default eyes closing sound.
+    /// </summary>
+    [ValidatePrototypeId<SoundCollectionPrototype>]
+    private static readonly ProtoId<SoundCollectionPrototype> DefaultEyeClose = new("EyeClose");
+
+    /// <summary>
     /// The prototype to grant to enable eye-toggling action.
     /// </summary>
     [DataField("eyeToggleAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
@@ -24,16 +36,16 @@ public sealed partial class EyeClosingComponent : Component
     public EntityUid? EyeToggleActionEntity;
 
     /// <summary>
-    /// Path to sound to play when opening eyes
+    /// Sound to play when opening eyes.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
-    public SoundSpecifier EyeOpenSound = new SoundCollectionSpecifier("EyeOpen");
+    public SoundSpecifier EyeOpenSound = new SoundCollectionSpecifier(DefaultEyeOpen);
 
     /// <summary>
-    /// Path to sound to play when closing eyes
+    /// Sound to play when closing eyes.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
-    public SoundSpecifier EyeCloseSound = new SoundCollectionSpecifier("EyeClose");
+    public SoundSpecifier EyeCloseSound = new SoundCollectionSpecifier(DefaultEyeClose);
 
     /// <summary>
     /// Toggles whether the eyes are open or closed. This is really just exactly what it says on the tin. Honest.

--- a/Content.Shared/Eye/Blinding/Components/EyeClosingComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/EyeClosingComponent.cs
@@ -27,13 +27,13 @@ public sealed partial class EyeClosingComponent : Component
     /// Path to sound to play when opening eyes
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
-    public SoundSpecifier EyeOpenSound = new SoundPathSpecifier("/Audio/Effects/eye_open.ogg");
+    public SoundSpecifier EyeOpenSound = new SoundCollectionSpecifier("EyeOpen");
 
     /// <summary>
     /// Path to sound to play when closing eyes
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
-    public SoundSpecifier EyeCloseSound = new SoundPathSpecifier("/Audio/Effects/eye_close.ogg");
+    public SoundSpecifier EyeCloseSound = new SoundCollectionSpecifier("EyeClose");
 
     /// <summary>
     /// Toggles whether the eyes are open or closed. This is really just exactly what it says on the tin. Honest.

--- a/Content.Shared/Eye/Blinding/Components/EyeClosingComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/EyeClosingComponent.cs
@@ -14,13 +14,11 @@ public sealed partial class EyeClosingComponent : Component
     /// <summary>
     /// Default eyes opening sound.
     /// </summary>
-    [ValidatePrototypeId<SoundCollectionPrototype>]
     private static readonly ProtoId<SoundCollectionPrototype> DefaultEyeOpen = new("EyeOpen");
 
     /// <summary>
     /// Default eyes closing sound.
     /// </summary>
-    [ValidatePrototypeId<SoundCollectionPrototype>]
     private static readonly ProtoId<SoundCollectionPrototype> DefaultEyeClose = new("EyeClose");
 
     /// <summary>

--- a/Content.Shared/Eye/Blinding/Components/EyeClosingComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/EyeClosingComponent.cs
@@ -1,7 +1,6 @@
-using Content.Shared.Eye.Blinding.Systems;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Eye.Blinding.Components;
@@ -28,13 +27,13 @@ public sealed partial class EyeClosingComponent : Component
     /// Path to sound to play when opening eyes
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
-    public string EyeOpenSound = "/Audio/Effects/eye_open.ogg";
+    public SoundSpecifier EyeOpenSound = new SoundPathSpecifier("/Audio/Effects/eye_open.ogg");
 
     /// <summary>
     /// Path to sound to play when closing eyes
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
-    public string EyeCloseSound = "/Audio/Effects/eye_close.ogg";
+    public SoundSpecifier EyeCloseSound = new SoundPathSpecifier("/Audio/Effects/eye_close.ogg");
 
     /// <summary>
     /// Toggles whether the eyes are open or closed. This is really just exactly what it says on the tin. Honest.

--- a/Resources/Prototypes/SoundCollections/eyes.yml
+++ b/Resources/Prototypes/SoundCollections/eyes.yml
@@ -1,0 +1,9 @@
+- type: soundCollection
+  id: EyeOpen
+  files:
+  - /Audio/Effects/eye_open.ogg
+
+- type: soundCollection
+  id: EyeClose
+  files:
+  - /Audio/Effects/eye_close.ogg


### PR DESCRIPTION
## About the PR
Title.

## Why / Balance
Obsolete. #33279.

## Technical details

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
Nope.
