### PR TITLE
Fix bogus AdminNameOverlay Rider error

### DIFF
--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -85,7 +85,7 @@ internal sealed class AdminNameOverlay : Overlay
             {
                args.ScreenHandle.DrawString(_font, screenCoordinates + (lineoffset * 2), _antagLabelClassic, uiScale, _antagColorClassic);
             }
-            else if (!classic && _filter.Contains(playerInfo.RoleProto.ID))
+            else if (!classic && _filter.Contains(playerInfo.RoleProto))
             {
                var label = Loc.GetString(playerInfo.RoleProto.Name).ToUpper();
                var color = playerInfo.RoleProto.Color;


### PR DESCRIPTION
Idk Rider ahs trouble with the implicit cast in this context. For some reason switching to another works. Who knows why!
