### PR TITLE
Fix prototypes so they pass analyzer checks

### DIFF
--- a/Content.Server/AlertLevel/AlertLevelPrototype.cs
+++ b/Content.Server/AlertLevel/AlertLevelPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Server.AlertLevel;
 [Prototype("alertLevels")]
 public sealed partial class AlertLevelPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     /// <summary>
     /// Dictionary of alert levels. Keyed by string - the string key is the most important

--- a/Content.Server/Antag/Components/AntagRandomObjectivesComponent.cs
+++ b/Content.Server/Antag/Components/AntagRandomObjectivesComponent.cs
@@ -28,7 +28,7 @@ public sealed partial class AntagRandomObjectivesComponent : Component
 /// Difficulty is checked over all sets, but each set has its own probability and pick count.
 /// </summary>
 [DataRecord]
-public record struct AntagObjectiveSet()
+public partial record struct AntagObjectiveSet()
 {
     /// <summary>
     /// The grouping used by the objective system to pick random objectives.

--- a/Content.Server/Botany/SeedPrototype.cs
+++ b/Content.Server/Botany/SeedPrototype.cs
@@ -14,7 +14,7 @@ namespace Content.Server.Botany;
 [Prototype("seed")]
 public sealed partial class SeedPrototype : SeedData, IPrototype
 {
-    [IdDataField] public string ID { get; private init; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 }
 
 public enum HarvestType : byte

--- a/Content.Server/Connection/Whitelist/WhitelistPrototype.cs
+++ b/Content.Server/Connection/Whitelist/WhitelistPrototype.cs
@@ -18,25 +18,25 @@ namespace Content.Server.Connection.Whitelist;
 /// If the condition doesn't match, the next condition is checked.
 /// </summary>
 [Prototype("playerConnectionWhitelist")]
-public sealed class PlayerConnectionWhitelistPrototype : IPrototype
+public sealed partial class PlayerConnectionWhitelistPrototype : IPrototype
 {
     [IdDataField]
-    public string ID { get; } = default!;
+    public string ID { get; private set; } = default!;
 
     /// <summary>
     /// Minimum number of players required for this whitelist to be active.
     /// If there are less players than this, the whitelist will be ignored and the next one in the list will be used.
     /// </summary>
     [DataField]
-    public int MinimumPlayers { get; } = 0;
+    public int MinimumPlayers = 0;
 
     /// <summary>
     /// Maximum number of players allowed for this whitelist to be active.
     /// If there are more players than this, the whitelist will be ignored and the next one in the list will be used.
     /// </summary>
     [DataField]
-    public int MaximumPlayers { get; } = int.MaxValue;
+    public int MaximumPlayers = int.MaxValue;
 
     [DataField]
-    public WhitelistCondition[] Conditions { get; } = default!;
+    public WhitelistCondition[] Conditions = default!;
 }

--- a/Content.Server/Ghost/Roles/Raffles/GhostRoleRaffleDeciderPrototype.cs
+++ b/Content.Server/Ghost/Roles/Raffles/GhostRoleRaffleDeciderPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Server.Ghost.Roles.Raffles;
 /// Allows getting a <see cref="IGhostRoleRaffleDecider"/> as prototype.
 /// </summary>
 [Prototype("ghostRoleRaffleDecider")]
-public sealed class GhostRoleRaffleDeciderPrototype : IPrototype
+public sealed partial class GhostRoleRaffleDeciderPrototype : IPrototype
 {
     /// <inheritdoc />
     [IdDataField]

--- a/Content.Server/NPC/HTN/HTNCompoundPrototype.cs
+++ b/Content.Server/NPC/HTN/HTNCompoundPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Server.NPC.HTN;
 [Prototype("htnCompound")]
 public sealed partial class HTNCompoundPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = string.Empty;
+    [IdDataField] public string ID { get; private set; } = string.Empty;
 
     [DataField("branches", required: true)]
     public List<HTNBranch> Branches = new();

--- a/Content.Server/NPC/Queries/Curves/UtilityCurvePresetPrototype.cs
+++ b/Content.Server/NPC/Queries/Curves/UtilityCurvePresetPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Server.NPC.Queries.Curves;
 [Prototype("utilityCurvePreset")]
 public sealed partial class UtilityCurvePresetPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = string.Empty;
+    [IdDataField] public string ID { get; private set; } = string.Empty;
 
     [DataField("curve", required: true)] public IUtilityCurve Curve = default!;
 }

--- a/Content.Server/Shuttles/Components/GridSpawnComponent.cs
+++ b/Content.Server/Shuttles/Components/GridSpawnComponent.cs
@@ -62,7 +62,7 @@ public interface IGridSpawnGroup
 }
 
 [DataRecord]
-public sealed class DungeonSpawnGroup : IGridSpawnGroup
+public sealed partial class DungeonSpawnGroup : IGridSpawnGroup
 {
     /// <summary>
     /// Prototypes we can choose from to spawn.
@@ -97,7 +97,7 @@ public sealed class DungeonSpawnGroup : IGridSpawnGroup
 }
 
 [DataRecord]
-public sealed class GridSpawnGroup : IGridSpawnGroup
+public sealed partial class GridSpawnGroup : IGridSpawnGroup
 {
     public List<ResPath> Paths = new();
 

--- a/Content.Server/Wires/WireLayout.cs
+++ b/Content.Server/Wires/WireLayout.cs
@@ -20,7 +20,7 @@ public sealed partial class WireLayoutPrototype : IPrototype, IInheritingPrototy
     public string[]? Parents { get; private set; }
 
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 
     /// <summary>
     ///     How many wires in this layout will do

--- a/Content.Server/Worldgen/Prototypes/BiomePrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/BiomePrototype.cs
@@ -14,12 +14,12 @@ public sealed partial class BiomePrototype : IPrototype, IInheritingPrototype
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<EntityPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     /// <inheritdoc />
     [NeverPushInheritance]
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 
     /// <inheritdoc />
     [IdDataField]
@@ -42,7 +42,7 @@ public sealed partial class BiomePrototype : IPrototype, IInheritingPrototype
     /// </summary>
     [DataField("chunkComponents")]
     [AlwaysPushInheritance]
-    public ComponentRegistry ChunkComponents { get; } = new();
+    public ComponentRegistry ChunkComponents = new();
 
     //TODO: Get someone to make this a method on componentregistry that does it Correctly.
     /// <summary>

--- a/Content.Server/Worldgen/Prototypes/NoiseChannelPrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/NoiseChannelPrototype.cs
@@ -84,12 +84,12 @@ public sealed partial class NoiseChannelPrototype : NoiseChannelConfig, IPrototy
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<EntityPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     /// <inheritdoc />
     [NeverPushInheritance]
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 
     /// <inheritdoc />
     [IdDataField]

--- a/Content.Shared/Alert/AlertCategoryPrototype.cs
+++ b/Content.Shared/Alert/AlertCategoryPrototype.cs
@@ -10,5 +10,5 @@ public sealed partial class AlertCategoryPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]
-    public string ID { get; } = default!;
+    public string ID { get; private set; } = default!;
 }

--- a/Content.Shared/Audio/AmbientMusicPrototype.cs
+++ b/Content.Shared/Audio/AmbientMusicPrototype.cs
@@ -12,7 +12,7 @@ namespace Content.Shared.Audio;
 [Prototype("ambientMusic")]
 public sealed partial class AmbientMusicPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = string.Empty;
+    [IdDataField] public string ID { get; private set; } = string.Empty;
 
     /// <summary>
     /// Traditionally you'd prioritise most rules to least as priority but in our case we'll just be explicit.

--- a/Content.Shared/Audio/Jukebox/JukeboxPrototype.cs
+++ b/Content.Shared/Audio/Jukebox/JukeboxPrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Audio.Jukebox;
 public sealed partial class JukeboxPrototype : IPrototype
 {
     [IdDataField]
-    public string ID { get; } = string.Empty;
+    public string ID { get; private set; } = string.Empty;
 
     /// <summary>
     /// User friendly name to use in UI.

--- a/Content.Shared/Body/Prototypes/BodyPrototype.cs
+++ b/Content.Shared/Body/Prototypes/BodyPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Body.Prototypes;
 [Prototype("body")]
 public sealed partial class BodyPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     [DataField("name")]
     public string Name { get; private set; } = "";
@@ -26,4 +26,4 @@ public sealed partial class BodyPrototype : IPrototype
 }
 
 [DataRecord]
-public sealed record BodyPrototypeSlot(EntProtoId? Part, HashSet<string> Connections, Dictionary<string, string> Organs);
+public sealed partial record BodyPrototypeSlot(EntProtoId? Part, HashSet<string> Connections, Dictionary<string, string> Organs);

--- a/Content.Shared/Cargo/Prototypes/CargoProductPrototype.cs
+++ b/Content.Shared/Cargo/Prototypes/CargoProductPrototype.cs
@@ -10,12 +10,12 @@ namespace Content.Shared.Cargo.Prototypes
     {
         /// <inheritdoc />
         [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<CargoProductPrototype>))]
-        public string[]? Parents { get; }
+        public string[]? Parents { get; private set; }
 
         /// <inheritdoc />
         [NeverPushInheritance]
         [AbstractDataField]
-        public bool Abstract { get; }
+        public bool Abstract { get; private set; }
 
         [DataField("name")] private string _name = string.Empty;
 

--- a/Content.Shared/CartridgeLoader/Cartridges/LogProbeUiState.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/LogProbeUiState.cs
@@ -17,7 +17,7 @@ public sealed class LogProbeUiState : BoundUserInterfaceState
 }
 
 [Serializable, NetSerializable, DataRecord]
-public sealed class PulledAccessLog
+public sealed partial class PulledAccessLog
 {
     public readonly TimeSpan Time;
     public readonly string Accessor;

--- a/Content.Shared/CartridgeLoader/Cartridges/NetProbeUiState.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/NetProbeUiState.cs
@@ -17,7 +17,7 @@ public sealed class NetProbeUiState : BoundUserInterfaceState
 }
 
 [Serializable, NetSerializable, DataRecord]
-public sealed class ProbedNetworkDevice
+public sealed partial class ProbedNetworkDevice
 {
     public readonly string Name;
     public readonly string Address;

--- a/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Chat.Prototypes;
 ///     Different entities may use different sounds collections.
 /// </summary>
 [Prototype("emoteSounds"), Serializable, NetSerializable]
-public sealed class EmoteSoundsPrototype : IPrototype
+public sealed partial class EmoteSoundsPrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Chemistry/Dispenser/ReagentDispenserInventoryPrototype.cs
+++ b/Content.Shared/Chemistry/Dispenser/ReagentDispenserInventoryPrototype.cs
@@ -18,6 +18,6 @@ namespace Content.Shared.Chemistry.Dispenser
         public List<string> Inventory = new();
 
         [ViewVariables, IdDataField]
-        public string ID { get; } = default!;
+        public string ID { get; private set; } = default!;
     }
 }

--- a/Content.Shared/Chemistry/Reaction/MixingCategoryPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/MixingCategoryPrototype.cs
@@ -11,7 +11,7 @@ public sealed partial class MixingCategoryPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]
-    public string ID { get; } = default!;
+    public string ID { get; private set; } = default!;
 
     /// <summary>
     /// A locale string used in the guidebook to describe this mixing category.

--- a/Content.Shared/Contraband/ContrabandSeverityPrototype.cs
+++ b/Content.Shared/Contraband/ContrabandSeverityPrototype.cs
@@ -10,7 +10,7 @@ public sealed partial class ContrabandSeverityPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]
-    public string ID { get; } = default!;
+    public string ID { get; private set; } = default!;
 
     /// <summary>
     /// Text shown for this severity level when the contraband is examined.

--- a/Content.Shared/CriminalRecords/CriminalRecord.cs
+++ b/Content.Shared/CriminalRecords/CriminalRecord.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.CriminalRecords;
 /// Can be viewed and edited in a criminal records console by security.
 /// </summary>
 [Serializable, NetSerializable, DataRecord]
-public sealed record CriminalRecord
+public sealed partial record CriminalRecord
 {
     /// <summary>
     /// Status of the person (None, Wanted, Detained).

--- a/Content.Shared/Damage/Prototypes/DamageGroupPrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageGroupPrototype.cs
@@ -15,7 +15,7 @@ namespace Content.Shared.Damage.Prototypes
     [Serializable, NetSerializable]
     public sealed partial class DamageGroupPrototype : IPrototype
     {
-        [IdDataField] public string ID { get; } = default!;
+        [IdDataField] public string ID { get; private set; } = default!;
 
         [DataField(required: true)]
         private LocId Name { get; set; }

--- a/Content.Shared/Decals/ColorPalettePrototype.cs
+++ b/Content.Shared/Decals/ColorPalettePrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Decals;
 [Prototype("palette")]
 public sealed partial class ColorPalettePrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = null!;
+    [IdDataField] public string ID { get; private set; } = null!;
     [DataField("name")] public string Name { get; private set; } = null!;
     [DataField("colors")] public Dictionary<string, Color> Colors { get; private set; } = null!;
 }

--- a/Content.Shared/Decals/DecalGridComponent.cs
+++ b/Content.Shared/Decals/DecalGridComponent.cs
@@ -55,7 +55,7 @@ namespace Content.Shared.Decals
         }
 
         [DataRecord, Serializable, NetSerializable]
-        public record DecalGridChunkCollection(Dictionary<Vector2i, DecalChunk> ChunkCollection)
+        public partial record DecalGridChunkCollection(Dictionary<Vector2i, DecalChunk> ChunkCollection)
         {
             public uint NextDecalId;
         }

--- a/Content.Shared/Decals/DecalPrototype.cs
+++ b/Content.Shared/Decals/DecalPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Decals
     [Prototype("decal")]
     public sealed partial class DecalPrototype : IPrototype, IInheritingPrototype
     {
-        [IdDataField] public string ID { get; } = null!;
+        [IdDataField] public string ID { get; private set; } = null!;
         [DataField("sprite")] public SpriteSpecifier Sprite { get; private set; } = SpriteSpecifier.Invalid;
         [DataField("tags")] public List<string> Tags = new();
         [DataField("showMenu")] public bool ShowMenu = true;
@@ -36,11 +36,11 @@ namespace Content.Shared.Decals
         public bool DefaultSnap = true;
 
         [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<DecalPrototype>))]
-        public string[]? Parents { get; }
+        public string[]? Parents { get; private set; }
 
         [NeverPushInheritance]
         [AbstractDataField]
-        public bool Abstract { get; }
+        public bool Abstract { get; private set; }
 
     }
 }

--- a/Content.Shared/EntityTable/EntityTablePrototype.cs
+++ b/Content.Shared/EntityTable/EntityTablePrototype.cs
@@ -11,7 +11,7 @@ public sealed partial class EntityTablePrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]
-    public string ID { get; } = default!;
+    public string ID { get; private set; } = default!;
 
     [DataField(required: true)]
     public EntityTableSelector Table = default!;

--- a/Content.Shared/Ghost/Roles/Raffles/GhostRoleRaffleSettingsPrototype.cs
+++ b/Content.Shared/Ghost/Roles/Raffles/GhostRoleRaffleSettingsPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Ghost.Roles.Raffles;
 /// Allows specifying the settings for a ghost role raffle as a prototype.
 /// </summary>
 [Prototype("ghostRoleRaffleSettings")]
-public sealed class GhostRoleRaffleSettingsPrototype : IPrototype
+public sealed partial class GhostRoleRaffleSettingsPrototype : IPrototype
 {
     /// <inheritdoc />
     [IdDataField]

--- a/Content.Shared/GridPreloader/Prototypes/PreloadedGridPrototype.cs
+++ b/Content.Shared/GridPreloader/Prototypes/PreloadedGridPrototype.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.GridPreloader.Prototypes;
 [Prototype("preloadedGrid")]
 public sealed partial class PreloadedGridPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = string.Empty;
+    [IdDataField] public string ID { get; private set; } = string.Empty;
 
     [DataField(required: true)]
     public ResPath Path;

--- a/Content.Shared/Humanoid/Markings/MarkingPoints.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPoints.cs
@@ -37,7 +37,7 @@ public sealed partial class MarkingPoints
 [Prototype("markingPoints")]
 public sealed partial class MarkingPointsPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     /// <summary>
     ///     If the user of this marking point set is only allowed to

--- a/Content.Shared/Humanoid/Prototypes/RandomHumanoidSettingsPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/RandomHumanoidSettingsPrototype.cs
@@ -9,14 +9,14 @@ namespace Content.Shared.Humanoid.Prototypes;
 [Prototype("randomHumanoidSettings")]
 public sealed partial class RandomHumanoidSettingsPrototype : IPrototype, IInheritingPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     [ParentDataField(typeof(PrototypeIdArraySerializer<RandomHumanoidSettingsPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     [AbstractDataField]
     [NeverPushInheritance]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 
     /// <summary>
     ///     Whether the humanoid's name should take from the randomized profile or not.

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Inventory;
 [Prototype("inventoryTemplate")]
 public sealed partial class InventoryTemplatePrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = string.Empty;
+    [IdDataField] public string ID { get; private set; } = string.Empty;
 
     [DataField("slots")] public SlotDefinition[] Slots { get; private set; } = Array.Empty<SlotDefinition>();
 }

--- a/Content.Shared/Item/ItemSizePrototype.cs
+++ b/Content.Shared/Item/ItemSizePrototype.cs
@@ -10,19 +10,19 @@ public sealed partial class ItemSizePrototype : IPrototype, IComparable<ItemSize
 {
     /// <inheritdoc/>
     [IdDataField]
-    public string ID { get; } = default!;
+    public string ID { get; private set; } = default!;
 
     /// <summary>
     /// The amount of space in a bag an item of this size takes.
     /// </summary>
     [DataField]
-    public readonly int Weight = 1;
+    public int Weight = 1;
 
     /// <summary>
     /// A player-facing name used to describe this size.
     /// </summary>
     [DataField]
-    public readonly LocId Name;
+    public LocId Name;
 
     /// <summary>
     /// The default inventory shape associated with this item size.

--- a/Content.Shared/Lathe/Prototypes/LatheCategoryPrototype.cs
+++ b/Content.Shared/Lathe/Prototypes/LatheCategoryPrototype.cs
@@ -11,7 +11,7 @@ public sealed partial class LatheCategoryPrototype : IPrototype
 {
     /// <inheritdoc/>
     [IdDataField]
-    public string ID { get; } = default!;
+    public string ID { get; private set; } = default!;
 
     /// <summary>
     /// A localized string used in the UI

--- a/Content.Shared/Lathe/Prototypes/LatheRecipePackPrototype.cs
+++ b/Content.Shared/Lathe/Prototypes/LatheRecipePackPrototype.cs
@@ -16,11 +16,11 @@ public sealed partial class LatheRecipePackPrototype : IPrototype, IInheritingPr
     public string ID { get; private set; } = default!;
 
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<LatheRecipePackPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     [NeverPushInheritance]
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 
     /// <summary>
     /// The lathe recipes contained by this pack.

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -27,7 +27,7 @@ namespace Content.Shared.Maps
         [AbstractDataFieldAttribute]
         public bool Abstract { get; private set; }
 
-        [IdDataField] public string ID { get; } = string.Empty;
+        [IdDataField] public string ID { get; private set; } = string.Empty;
 
         public ushort TileId { get; private set; }
 

--- a/Content.Shared/Materials/MaterialPrototype.cs
+++ b/Content.Shared/Materials/MaterialPrototype.cs
@@ -13,11 +13,11 @@ namespace Content.Shared.Materials
     {
         [ViewVariables]
         [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<MaterialPrototype>))]
-        public string[]? Parents { get; }
+        public string[]? Parents { get; private set; }
 
         [ViewVariables]
         [AbstractDataField]
-        public bool Abstract { get; } = false;
+        public bool Abstract { get; private set; } = false;
 
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Mind/RoleTypePrototype.cs
+++ b/Content.Shared/Mind/RoleTypePrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Mind;
 ///     The core properties of Role Types
 /// </summary>
 [Prototype, Serializable]
-public sealed class RoleTypePrototype : IPrototype
+public sealed partial class RoleTypePrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Ninja/Components/NinjaGlovesComponent.cs
+++ b/Content.Shared/Ninja/Components/NinjaGlovesComponent.cs
@@ -33,7 +33,7 @@ public sealed partial class NinjaGlovesComponent : Component
 /// An ability that adds components to the user when the gloves are enabled.
 /// </summary>
 [DataRecord]
-public record struct NinjaGloveAbility()
+public partial record struct NinjaGloveAbility()
 {
     /// <summary>
     /// If not null, checks if an objective with this prototype has been completed.

--- a/Content.Shared/Nutrition/Components/FoodSequenceStartPointComponent.cs
+++ b/Content.Shared/Nutrition/Components/FoodSequenceStartPointComponent.cs
@@ -124,7 +124,7 @@ public sealed partial class FoodSequenceStartPointComponent : Component
 /// Stores all the necessary information for rendering the FoodSequence element
 /// </summary>
 [DataRecord, Serializable, NetSerializable]
-public record struct FoodSequenceVisualLayer
+public partial record struct FoodSequenceVisualLayer
 {
     /// <summary>
     /// reference to the original prototype of the layer. Used to edit visual layers.

--- a/Content.Shared/Parallax/Biomes/BiomeTemplatePrototype.cs
+++ b/Content.Shared/Parallax/Biomes/BiomeTemplatePrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Parallax.Biomes;
 [Prototype("biomeTemplate")]
 public sealed partial class BiomeTemplatePrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     [DataField("layers")]
     public List<IBiomeLayer> Layers = new();

--- a/Content.Shared/Parallax/Biomes/Markers/BiomeMarkerLayerPrototype.cs
+++ b/Content.Shared/Parallax/Biomes/Markers/BiomeMarkerLayerPrototype.cs
@@ -7,9 +7,9 @@ namespace Content.Shared.Parallax.Biomes.Markers;
 /// Spawns entities inside of the specified area with the minimum specified radius.
 /// </summary>
 [Prototype("biomeMarkerLayer")]
-public sealed class BiomeMarkerLayerPrototype : IBiomeMarkerLayer
+public sealed partial class BiomeMarkerLayerPrototype : IBiomeMarkerLayer
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     /// <summary>
     /// Checks for the relevant entity for the tile before spawning. Useful for substituting walls with ore veins for example.
@@ -21,7 +21,7 @@ public sealed class BiomeMarkerLayerPrototype : IBiomeMarkerLayer
     /// Default prototype to spawn. If null will fall back to entity mask.
     /// </summary>
     [DataField]
-    public string? Prototype { get; }
+    public string? Prototype { get; private set; }
 
     /// <summary>
     /// Minimum radius between 2 points

--- a/Content.Shared/Players/PlayTimeTracking/PlayTimeTrackerPrototype.cs
+++ b/Content.Shared/Players/PlayTimeTracking/PlayTimeTrackerPrototype.cs
@@ -8,5 +8,5 @@ namespace Content.Shared.Players.PlayTimeTracking;
 [Prototype("playTimeTracker")]
 public sealed partial class PlayTimeTrackerPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 }

--- a/Content.Shared/Preferences/Loadouts/Effects/LoadoutEffectGroupPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/LoadoutEffectGroupPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Preferences.Loadouts.Effects;
 public sealed partial class LoadoutEffectGroupPrototype : IPrototype
 {
     [IdDataField]
-    public string ID { get; } = string.Empty;
+    public string ID { get; private set; } = string.Empty;
 
     [DataField(required: true)]
     public List<LoadoutEffect> Effects = new();

--- a/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Preferences.Loadouts;
 public sealed partial class LoadoutGroupPrototype : IPrototype
 {
     [IdDataField]
-    public string ID { get; } = string.Empty;
+    public string ID { get; private set; } = string.Empty;
 
     /// <summary>
     /// User-friendly name for the group.

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Preferences.Loadouts;
 public sealed partial class LoadoutPrototype : IPrototype, IEquipmentLoadout
 {
     [IdDataField]
-    public string ID { get; } = string.Empty;
+    public string ID { get; private set; } = string.Empty;
 
     /*
      * You can either use an existing StartingGearPrototype or specify it inline to avoid bloating yaml.

--- a/Content.Shared/Preferences/Loadouts/RoleLoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadoutPrototype.cs
@@ -14,7 +14,7 @@ public sealed partial class RoleLoadoutPrototype : IPrototype
      */
 
     [IdDataField]
-    public string ID { get; } = string.Empty;
+    public string ID { get; private set; } = string.Empty;
 
     /// <summary>
     /// Can the user edit their entity name for this role loadout?

--- a/Content.Shared/Procedural/DungeonConfig.cs
+++ b/Content.Shared/Procedural/DungeonConfig.cs
@@ -49,7 +49,7 @@ public partial class DungeonConfig
 }
 
 [Prototype]
-public sealed class DungeonConfigPrototype : DungeonConfig, IPrototype
+public sealed partial class DungeonConfigPrototype : DungeonConfig, IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Procedural/DungeonData.cs
+++ b/Content.Shared/Procedural/DungeonData.cs
@@ -14,7 +14,7 @@ namespace Content.Shared.Procedural;
 /// This lets us share data between different dungeon configs without having to repeat entire configs.
 /// </remarks>
 [DataRecord]
-public sealed class DungeonData
+public sealed partial class DungeonData
 {
     // I hate this but it also significantly reduces yaml bloat if we add like 10 variations on the same set of layers
     // e.g. science rooms, engi rooms, cargo rooms all under PlanetBase for example.

--- a/Content.Shared/Procedural/DungeonGenerators/NoiseDunGen.cs
+++ b/Content.Shared/Procedural/DungeonGenerators/NoiseDunGen.cs
@@ -39,7 +39,7 @@ public sealed partial class NoiseDunGen : IDunGenLayer
 }
 
 [DataRecord]
-public record struct NoiseDunGenLayer
+public partial record struct NoiseDunGenLayer
 {
     /// <summary>
     /// If the noise value is above this then it gets output.

--- a/Content.Shared/Procedural/DungeonGenerators/ReplaceTileDunGen.cs
+++ b/Content.Shared/Procedural/DungeonGenerators/ReplaceTileDunGen.cs
@@ -20,7 +20,7 @@ public sealed partial class ReplaceTileDunGen : IDunGenLayer
 }
 
 [DataRecord]
-public record struct ReplaceTileLayer
+public partial record struct ReplaceTileLayer
 {
     public ProtoId<ContentTileDefinition> Tile;
 

--- a/Content.Shared/Procedural/DungeonPresetPrototype.cs
+++ b/Content.Shared/Procedural/DungeonPresetPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Procedural;
 [Prototype("dungeonPreset")]
 public sealed partial class DungeonPresetPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     /// <summary>
     /// The room pack bounds we need to fill.

--- a/Content.Shared/Procedural/DungeonRoomPrototype.cs
+++ b/Content.Shared/Procedural/DungeonRoomPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Procedural;
 [Prototype("dungeonRoom")]
 public sealed partial class DungeonRoomPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = string.Empty;
+    [IdDataField] public string ID { get; private set; } = string.Empty;
 
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public List<ProtoId<TagPrototype>> Tags = new();

--- a/Content.Shared/Procedural/Loot/SalvageLootPrototype.cs
+++ b/Content.Shared/Procedural/Loot/SalvageLootPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Procedural.Loot;
 [Prototype("salvageLoot")]
 public sealed partial class SalvageLootPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     /// <summary>
     /// Should this loot always spawn if possible. Used for stuff such as ore.

--- a/Content.Shared/Procedural/SalvageDifficultyPrototype.cs
+++ b/Content.Shared/Procedural/SalvageDifficultyPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Procedural;
 [Prototype("salvageDifficulty")]
 public sealed partial class SalvageDifficultyPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = string.Empty;
+    [IdDataField] public string ID { get; private set; } = string.Empty;
 
     /// <summary>
     /// Color to be used in UI.

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -27,7 +27,7 @@ public sealed partial class RadioChannelPrototype : IPrototype
     public Color Color { get; private set; } = Color.Lime;
 
     [IdDataField, ViewVariables]
-    public string ID { get; } = default!;
+    public string ID { get; private set; } = default!;
 
     /// <summary>
     /// If channel is long range it doesn't require telecommunication server

--- a/Content.Shared/Random/RandomPlantMutationListPrototype.cs
+++ b/Content.Shared/Random/RandomPlantMutationListPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Random;
 [Prototype("RandomPlantMutationList")]
 public sealed partial class RandomPlantMutationListPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     /// <summary>
     ///     List of RandomFills that can be picked from.

--- a/Content.Shared/Random/Rules/RulesSystem.cs
+++ b/Content.Shared/Random/Rules/RulesSystem.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Random.Rules;
 [Prototype("rules")]
 public sealed partial class RulesPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = string.Empty;
+    [IdDataField] public string ID { get; private set; } = string.Empty;
 
     [DataField("rules", required: true)]
     public List<RulesRule> Rules = new();

--- a/Content.Shared/Random/WeightedRandomEntityPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomEntityPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Random;
 /// Linter-friendly version of weightedRandom for Entity prototypes.
 /// </summary>
 [Prototype("weightedRandomEntity")]
-public sealed class WeightedRandomEntityPrototype : IWeightedRandomPrototype
+public sealed partial class WeightedRandomEntityPrototype : IWeightedRandomPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Random/WeightedRandomFillSolutionPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomFillSolutionPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Random;
 [Prototype("weightedRandomFillSolution")]
 public sealed partial class WeightedRandomFillSolutionPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     /// <summary>
     ///     List of RandomFills that can be picked from.

--- a/Content.Shared/Random/WeightedRandomOrePrototype.cs
+++ b/Content.Shared/Random/WeightedRandomOrePrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Random;
 /// Linter-friendly version of weightedRandom for Ore prototypes.
 /// </summary>
 [Prototype("weightedRandomOre")]
-public sealed class WeightedRandomOrePrototype : IWeightedRandomPrototype
+public sealed partial class WeightedRandomOrePrototype : IWeightedRandomPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Random/WeightedRandomPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Random;
 /// Generic random weighting dataset to use.
 /// </summary>
 [Prototype("weightedRandom")]
-public sealed class WeightedRandomPrototype : IWeightedRandomPrototype
+public sealed partial class WeightedRandomPrototype : IWeightedRandomPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Random/WeightedRandomSpeciesPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomSpeciesPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Random;
 /// Linter-friendly version of weightedRandom for Species prototypes.
 /// </summary>
 [Prototype("weightedRandomSpecies")]
-public sealed class WeightedRandomSpeciesPrototype : IWeightedRandomPrototype
+public sealed partial class WeightedRandomSpeciesPrototype : IWeightedRandomPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Research/Prototypes/LatheRecipePrototype.cs
+++ b/Content.Shared/Research/Prototypes/LatheRecipePrototype.cs
@@ -18,12 +18,12 @@ namespace Content.Shared.Research.Prototypes
 
         /// <inheritdoc/>
         [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<LatheRecipePrototype>))]
-        public string[]? Parents { get; }
+        public string[]? Parents { get; private set; }
 
         /// <inheritdoc />
         [NeverPushInheritance]
         [AbstractDataField]
-        public bool Abstract { get; }
+        public bool Abstract { get; private set; }
 
         /// <summary>
         ///     Name displayed in the lathe GUI.

--- a/Content.Shared/Robotics/RoboticsConsoleUi.cs
+++ b/Content.Shared/Robotics/RoboticsConsoleUi.cs
@@ -58,7 +58,7 @@ public sealed class RoboticsConsoleDestroyMessage : BoundUserInterfaceMessage
 /// Created by <c>BorgTransponderComponent</c> and sent to clients by <c>RoboticsConsoleComponent</c>.
 /// </summary>
 [DataRecord, Serializable, NetSerializable]
-public record struct CyborgControlData
+public partial record struct CyborgControlData
 {
     /// <summary>
     /// Texture of the borg chassis.

--- a/Content.Shared/Roles/DepartmentPrototype.cs
+++ b/Content.Shared/Roles/DepartmentPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Roles;
 public sealed partial class DepartmentPrototype : IPrototype
 {
     [IdDataField]
-    public string ID { get; } = string.Empty;
+    public string ID { get; private set; } = string.Empty;
 
     /// <summary>
     /// The name LocId of the department that will be displayed in the various menus.

--- a/Content.Shared/Roles/StartingGearPrototype.cs
+++ b/Content.Shared/Roles/StartingGearPrototype.cs
@@ -17,7 +17,7 @@ public sealed partial class StartingGearPrototype : IPrototype, IInheritingProto
 
     /// <inheritdoc/>
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 
     /// <inheritdoc />
     [DataField]

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageBiomeModPrototype.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageBiomeModPrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 [Prototype("salvageBiomeMod")]
 public sealed partial class SalvageBiomeModPrototype : IPrototype, ISalvageMod
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     [DataField("desc")] public LocId Description { get; private set; } = string.Empty;
 

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageDungeonModPrototype.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageDungeonModPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 [Prototype("salvageDungeonMod")]
 public sealed partial class SalvageDungeonModPrototype : IPrototype, IBiomeSpecificMod
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     [DataField("desc")] public LocId Description { get; private set; } = string.Empty;
 

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageLightMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageLightMod.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 [Prototype("salvageLightMod")]
 public sealed partial class SalvageLightMod : IPrototype, IBiomeSpecificMod
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     [DataField("desc")] public LocId Description { get; private set; } = string.Empty;
 

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageMod.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 [Prototype("salvageMod")]
 public sealed partial class SalvageMod : IPrototype, ISalvageMod
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     [DataField("desc")] public LocId Description { get; private set; } = string.Empty;
 

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTemperatureMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTemperatureMod.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 [Prototype("salvageTemperatureMod")]
 public sealed partial class SalvageTemperatureMod : IPrototype, IBiomeSpecificMod
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     [DataField("desc")] public LocId Description { get; private set; } = string.Empty;
 

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageWeatherMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageWeatherMod.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 [Prototype("salvageWeatherMod")]
 public sealed partial class SalvageWeatherMod : IPrototype, IBiomeSpecificMod
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     [DataField("desc")] public LocId Description { get; private set; } = string.Empty;
 

--- a/Content.Shared/Salvage/Expeditions/SalvageFactionPrototype.cs
+++ b/Content.Shared/Salvage/Expeditions/SalvageFactionPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Salvage.Expeditions;
 [Prototype("salvageFaction")]
 public sealed partial class SalvageFactionPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     [DataField("desc")] public LocId Description { get; private set; } = string.Empty;
 

--- a/Content.Shared/Salvage/SalvageMapPrototype.cs
+++ b/Content.Shared/Salvage/SalvageMapPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Salvage;
 [Prototype]
 public sealed partial class SalvageMapPrototype : IPrototype
 {
-    [ViewVariables] [IdDataField] public string ID { get; } = default!;
+    [ViewVariables] [IdDataField] public string ID { get; private set; } = default!;
 
     /// <summary>
     /// Relative directory path to the given map, i.e. `Maps/Salvage/template.yml`

--- a/Content.Shared/Silicons/Borgs/BorgTypePrototype.cs
+++ b/Content.Shared/Silicons/Borgs/BorgTypePrototype.cs
@@ -19,7 +19,7 @@ public sealed partial class BorgTypePrototype : IPrototype
     private static readonly ProtoId<SoundCollectionPrototype> DefaultFootsteps = new("FootstepBorg");
 
     [IdDataField]
-    public required string ID { get; init; }
+    public required string ID { get; set; }
 
     //
     // Description info (name/desc) is configured via localization strings directly.
@@ -29,7 +29,7 @@ public sealed partial class BorgTypePrototype : IPrototype
     /// The prototype displayed in the selection menu for this type.
     /// </summary>
     [DataField]
-    public required EntProtoId DummyPrototype { get; init; }
+    public required EntProtoId DummyPrototype;
 
     //
     // Functional information

--- a/Content.Shared/Speech/SpeechVerbPrototype.cs
+++ b/Content.Shared/Speech/SpeechVerbPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Speech;
 [Prototype("speechVerb")]
 public sealed partial class SpeechVerbPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     /// <summary>
     ///     Loc strings to be passed to the chat wrapper. 'says', 'states', etc.

--- a/Content.Shared/Spreader/EdgeSpreaderPrototype.cs
+++ b/Content.Shared/Spreader/EdgeSpreaderPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Spreader;
 [Prototype("edgeSpreader")]
 public sealed partial class EdgeSpreaderPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = string.Empty;
+    [IdDataField] public string ID { get; private set; } = string.Empty;
     [DataField(required:true)] public int UpdatesPerSecond;
 
     /// <summary>

--- a/Content.Shared/StatusIcon/StatusIconPrototype.cs
+++ b/Content.Shared/StatusIcon/StatusIconPrototype.cs
@@ -97,12 +97,12 @@ public sealed partial class JobIconPrototype : StatusIconPrototype, IInheritingP
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<JobIconPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     /// <inheritdoc />
     [NeverPushInheritance]
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 
     /// <summary>
     /// Name of the icon used for menu tooltips.
@@ -128,12 +128,12 @@ public sealed partial class HealthIconPrototype : StatusIconPrototype, IInheriti
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<HealthIconPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     /// <inheritdoc />
     [NeverPushInheritance]
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 }
 
 /// <summary>
@@ -144,12 +144,12 @@ public sealed partial class SatiationIconPrototype : StatusIconPrototype, IInher
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<SatiationIconPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     /// <inheritdoc />
     [NeverPushInheritance]
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 }
 
 /// <summary>
@@ -160,12 +160,12 @@ public sealed partial class SecurityIconPrototype : StatusIconPrototype, IInheri
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<SecurityIconPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     /// <inheritdoc />
     [NeverPushInheritance]
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 }
 
 /// <summary>
@@ -176,12 +176,12 @@ public sealed partial class FactionIconPrototype : StatusIconPrototype, IInherit
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<FactionIconPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     /// <inheritdoc />
     [NeverPushInheritance]
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 }
 
 /// <summary>
@@ -192,12 +192,12 @@ public sealed partial class DebugIconPrototype : StatusIconPrototype, IInheritin
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<DebugIconPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     /// <inheritdoc />
     [NeverPushInheritance]
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 }
 
 /// <summary>
@@ -208,12 +208,12 @@ public sealed partial class SsdIconPrototype : StatusIconPrototype, IInheritingP
 {
     /// <inheritdoc />
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<SsdIconPrototype>))]
-    public string[]? Parents { get; }
+    public string[]? Parents { get; private set; }
 
     /// <inheritdoc />
     [NeverPushInheritance]
     [AbstractDataField]
-    public bool Abstract { get; }
+    public bool Abstract { get; private set; }
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Storage/EntitySpawnEntry.cs
+++ b/Content.Shared/Storage/EntitySpawnEntry.cs
@@ -9,10 +9,10 @@ namespace Content.Shared.Storage;
 /// Prototype wrapper around <see cref="EntitySpawnEntry"/>
 /// </summary>
 [Prototype]
-public sealed class EntitySpawnEntryPrototype : IPrototype
+public sealed partial class EntitySpawnEntryPrototype : IPrototype
 {
     [IdDataField]
-    public string ID { get; } = string.Empty;
+    public string ID { get; private set; } = string.Empty;
 
     [DataField]
     public List<EntitySpawnEntry> Entries = new();

--- a/Content.Shared/StoryGen/Prototypes/StoryTemplatePrototype.cs
+++ b/Content.Shared/StoryGen/Prototypes/StoryTemplatePrototype.cs
@@ -20,7 +20,7 @@ public sealed partial class StoryTemplatePrototype : IPrototype
     /// Localization ID of the Fluent string that forms the structure of this story.
     /// </summary>
     [DataField(required: true)]
-    public LocId LocId { get; } = default!;
+    public LocId LocId;
 
     /// <summary>
     /// Dictionary containing the name of each variable to pass to the template and the ID of the
@@ -29,5 +29,5 @@ public sealed partial class StoryTemplatePrototype : IPrototype
     /// dataset which can then be used in the template by <c>{$name}</c>.
     /// </summary>
     [DataField]
-    public Dictionary<string, ProtoId<LocalizedDatasetPrototype>> Variables { get; } = default!;
+    public Dictionary<string, ProtoId<LocalizedDatasetPrototype>> Variables = [];
 }

--- a/Content.Shared/Tag/TagPrototype.cs
+++ b/Content.Shared/Tag/TagPrototype.cs
@@ -11,5 +11,5 @@ namespace Content.Shared.Tag;
 public sealed partial class TagPrototype : IPrototype
 {
     [IdDataField, ViewVariables]
-    public string ID { get; } = string.Empty;
+    public string ID { get; private set; } = string.Empty;
 }

--- a/Content.Shared/Weather/WeatherPrototype.cs
+++ b/Content.Shared/Weather/WeatherPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Weather;
 [Prototype("weather")]
 public sealed partial class WeatherPrototype : IPrototype
 {
-    [IdDataField] public string ID { get; } = default!;
+    [IdDataField] public string ID { get; private set; } = default!;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("sprite", required: true)]
     public SpriteSpecifier Sprite = default!;


### PR DESCRIPTION
Content changes to fix errors detected by https://github.com/space-wizards/RobustToolbox/pull/5699.

This consists of a whole lot of little changes all over the place. Mostly making classes `partial` and giving `ID` fields private setters. Any `DataField`s without a setter (other than `ID`, `Parents`, or `Abstract`) had the setter removed and are now just plain fields.