### PR TITLE
add altered silicon to rules

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleTypes.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleTypes.xml
@@ -16,6 +16,7 @@
   ## Familiar
   Familiars are considered non-antagonists, but have instructions to obey someone. They must obey this person even if it causes them to violate roleplay rules or die. You are only a familiar if the game clearly and explicitly tells you that you are a familiar. You are only the familiar of the person the game tells you.
 
-  ## Silicon
+  ## Silicon/Altered Silicon
   Silicons have a set of laws that they must follow above all else except the core rules. You are only silicon if the game clearly and explicitly tells you that you are a silicon.
+  Altered Silicons are functionally identical, this role is used to highlight law-sets that have been hacked, corrupted or are otherwise considered non-standard or dangerous.
 </Document>

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleTypes.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleTypes.xml
@@ -16,7 +16,7 @@
   ## Familiar
   Familiars are considered non-antagonists, but have instructions to obey someone. They must obey this person even if it causes them to violate roleplay rules or die. You are only a familiar if the game clearly and explicitly tells you that you are a familiar. You are only the familiar of the person the game tells you.
 
-  ## Silicon/Altered Silicon
+  ## Silicon / Altered Silicon
   Silicons have a set of laws that they must follow above all else except the core rules. You are only silicon if the game clearly and explicitly tells you that you are a silicon.
   Altered Silicons are functionally identical, this role is used to highlight law-sets that have been hacked, corrupted or are otherwise considered non-standard or dangerous.
 </Document>


### PR DESCRIPTION
## About the PR
Adds a short explanation about Altered Silicon to the Silicon section in RP rules

## Why / Balance
The Altered Silicon role type was created primarily to facilitate the admin antag overlay's shift to using role types instead of the (already somewhat unreliable) Antag bool. It is, however, not obvious from looking at our written rules how it's supposed to be different from regular Silicon, potentially confusing players.

## Media

![image](https://github.com/user-attachments/assets/a9decc01-40e4-492c-a474-67efac3a3f93)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
