### PR TITLE
Fix egg cooking and make microwave code a little less bad

### DIFF
--- a/Content.Server/Kitchen/Components/ActivelyMicrowavedComponent.cs
+++ b/Content.Server/Kitchen/Components/ActivelyMicrowavedComponent.cs
@@ -1,5 +1,3 @@
-using Content.Shared.Kitchen;
-
 namespace Content.Server.Kitchen.Components;
 
 /// <summary>
@@ -8,4 +6,9 @@ namespace Content.Server.Kitchen.Components;
 [RegisterComponent]
 public sealed partial class ActivelyMicrowavedComponent : Component
 {
+    /// <summary>
+    /// The microwave this entity is actively being microwaved by.
+    /// </summary>
+    [DataField]
+    public EntityUid? Microwave;
 }

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/egg.yml
@@ -11,7 +11,7 @@
       - Egg
       - Meat
   - type: Food
-    trash: 
+    trash:
     - Eggshells
   - type: Sprite
     sprite: Objects/Consumable/Food/egg.rsi
@@ -61,13 +61,6 @@
   # all below are for egg cooking/exploding
   - type: AtmosExposed
   - type: Temperature
-    currentTemperature: 290
-  - type: InternalTemperature
-    # ~1mm shell and ~1cm of albumen
-    thickness: 0.011
-    area: 0.04
-    # conductivity of egg shell based on a paper from Romanoff and Romanoff (1949)
-    conductivity: 0.456
 
 # Splat
 - type: entity
@@ -135,6 +128,3 @@
   - type: Temperature
     # preserve temperature from the boiling step
     currentTemperature: 344
-  - type: Construction
-    graph: Egg
-    node: boiled

--- a/Resources/Prototypes/Recipes/Construction/Graphs/food/egg.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/food/egg.yml
@@ -5,12 +5,6 @@
   graph:
   - node: start
     edges:
-    - to: boiled
-      steps:
-      - minTemperature: 344
-  - node: boiled
-    entity: FoodEggBoiled
-    edges:
     - to: explode
       completed:
       - !type:DamageEntity
@@ -18,6 +12,7 @@
           types:
             Blunt: 10
       steps:
-      # egg explodes some time after the water in it boils and increases pressure, guessing ~110C
-      - minTemperature: 383
+      # egg explodes some time after the water in it boils and increases pressure
+      # high enough so you can still microwave them for 5 seconds safely
+      - minTemperature: 473.15 # 200°C
   - node: explode

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -262,10 +262,11 @@
   result: FoodBurgerMcguffin
   time: 10
   group: Savory
+  reagents:
+    Egg: 12
   solids:
     FoodBreadBun: 1
     FoodCheeseSlice: 1
-    FoodEgg: 2
 
 - type: microwaveMealRecipe
   id: RecipeBurgerMcrib
@@ -348,12 +349,12 @@
   group: Savory
   reagents:
     TableSalt: 5
+    Egg: 12
   solids:
     FoodBreadBun: 1
     FoodMeat: 2
     FoodCheeseSlice: 2
     FoodTomato: 2
-    FoodEgg: 2
 
 - type: microwaveMealRecipe
   id: RecipeTofuBurger


### PR DESCRIPTION
## About the PR
You no longer get both cooked egg and the recipe result when cooking any recipe that uses the egg reagent.
Fixes https://github.com/space-wizards/space-station-14/issues/30259
The microwave can no longer use reagents while they are inside a food item, you need to crack eggs into a beaker first.

Replaces https://github.com/space-wizards/space-station-14/pull/30294
Thanks to @Katzenminer for the initial investigation into the bug.

## Why / Balance
bugfix

## Technical details
The microwave decides which recipe it will spawn when it is activated, however the reagents used for this are only removed at the end of the cooking time. This results in any reagents that are transformed during cooking to be duplicated. For example when cooking a pancake (5 milk, 5 flour, 5 raw egg) the egg turns into cooked egg from being heated up.
We solve this by stopping the reaction when the reagent has been reserved for a recipe. Other reactions still happen normally.

Some recipes have been changed to use liquid eggs instead of whole eggs. These were either overlooked in https://github.com/space-wizards/space-station-14/pull/30262 or added later.

Microwave code has been changed to no longer use *any* solution for the recipes, but only drainable (i.e. accessible) ones. Before you could put whole eggs inside and the reagents would magically be used without damaging the shell. Now you need to crack the eggs first if you want to use them in a recipe.
Similarly other food items could be drained of their reagents before.

Previously eggs had an construction graph replacing them with a boiled egg at a certain temperature. However, this deleted any other reagents inside. We simply removed this contruction graph step, since the egg boiling is already handled by the reagent inside reacting from the heat.

Eggs have another construction graph step, which is supposed to cause them to explode when heated up too much, but it did not trigger correctly because the values in the `InternalTemperatureComponent` were off, causing the internal temperature to only raise by a few degrees when microwaved.
Essentially eggs had 3 different temperatures before: Internal, external, and the reagent temperature inside.
Since the reagent temperature already handles the cooking correctly now, we removed the redundant `InternalTemperatureComponent`. This causes the construction graph to use the external temperature instead and we adjusted the threshold accordingly.
Eggs will now cook when microwaved for 5 seconds and explode when microwaved longer (or they get heated up by atmos).

## Media

https://github.com/user-attachments/assets/5a278ff6-3c71-4dd4-b0e9-41e4b269b395

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Katzenminer, slarticodefast
- tweak: You now need to break eggs when using them for microwave recipes. Some recipes have been adjusted accordingly.
- fix: Fixed a reagent duplication bug when microwaving eggs.