### PR TITLE
Make the C-20R no longer wieldable, and have full accuracy one handed.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -96,14 +96,7 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: Clothing
     sprite: Objects/Weapons/Guns/SMGs/c20r.rsi
-  - type: Wieldable
-    unwieldOnUse: false
-  - type: GunWieldBonus
-    minAngle: -19
-    maxAngle: -16
   - type: Gun
-    minAngle: 21
-    maxAngle: 32
     shotsPerBurst: 5
     availableModes:
     - Burst


### PR DESCRIPTION
## About the PR
The C-20R can no longer be wielded, and its accuracy when firing one handed is now the same as what it used to be when wielded.

## Why / Balance
The only reason to use the C-20r as a nukie (not loneop) right now is because you want to budget with the one thats mapped on the table outside for free and combine that with an ammo bundle or to save inventory space, which while the first scenario is fairly common, let me show you why I think this weapon needs some love, and also explain why the above is even true at all, because if as a nukie (excluding loneop) you are BUYING a C-20r bundle, you are truly making a mistake. 

You spend 17 TC on the C-20r.
You get a weapon that has mediocre accuracy when wielded, and horrible accuracy when not wielded, with a firerate of 8 per second, 16 pierce a hit, resulting in 128 DPS, 30 rounds per mag, and a total of 91 rounds in the bundle. You can also buy additional 30 round mags for 2 TC a mag (1tc = 15 rounds), and an ammo bundle comes with another 120 rounds.

However, when I say the above out loud, another weapon comes to mind with mediocre accuracy when wielded, horribly accuracy when not wielded, and a firerate of 8 per second, and while it does cost 30 TC (13 more expensive), heres some improvements that the L6 SAW offers over the C-20r that more then makes up for the steeper price point:
You get 19 pierce a hit (+3), and as you maintain 8 rounds per second, the DPS climbs to 152 (+24), you also get 100 rounds per mag (+70) and a total of 201 rounds in the bundle (+110), and it gets better, as you can buy an ammo box with 60 rounds for 1 TC per box (1 TC = 60 rounds, thats +45 or 4x.) with the only downside being it takes a bit to load em into an empty mag. You also get 200 rounds in the ammo bundle (+80), already in mags.

Now seeing all of those upgrades, the only reason to use the C-20 as a nukie is either as a loneop who would prefer not to blow half of their budget on just the primary weapon, or to grab the one on the table of the nukie planet and work with an ammo bundle, but other then that there is not really any excuse for this beyond horrible inventory management and an occupied back slot, which is just a skill issue atp.


I feel like making the weapon work just fine with one hand opens up a LOT of possibilities for it to actually give it a lot of unique use cases, such as with an energy shield, energy sword, easier reloads, etc. While also giving it its unique position as a one handed weapon back, since the L6 was not changed with the wield update despite pretty much every long-arm except for said L6 getting nerfed with that update. I also don't like how its current status is just "A worse version of the l6 that costs less".


Also, another prime reason is to match the WT550, which I have always seen as the crew variant of the C-20r.
While the C20 has a higher firerate and the 550 is more accurate, there are also plenty of simularities. They each have 30 round mags, they each fire .35 caliber rounds, both nukies AND security can get one for free (HoS Room & Nukie planet gun range) with the ability to buy more if needed (Cargo & Uplink), they are both a 2x4 in your inventory, etc. 
Yet when the change was made that resulted in most weapons having to be wielded in order to be fired accurately, the C-20r got this change while the WT550 did not, despite the fact that IMO the C20 looks like it'd be somewhat easier to use one handed compared to the 550, and since the one handed ability is now a large part of what makes the WT550 so unique, meaning removing that would just be lame, I am buffing the C-20r to work one handed instead.

TLDR: This makes it match the WT550 and gives it an upside over the L6 saw beyond simply being cheaper.

## Technical details
Rest in peace 7 lines of code, you may or may not be missed.

## Media
Not really needed, just shoot the C-20 while its wielded, and now imagine it doing that without being wielded, yippee.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: BramvanZijp
- tweak: The syndicate C-20r submachine gun has been updated to have its standard accuracy while firing it with only one hand.
- remove: The syndicate C-20r submachine gun can no longer be wielded with 2 hands.
