### PR TITLE
Cleanup: Use ``MapSystem.DeleteMap`` instead of ``IMapManager.DeleteMap`` in ``HumanInventoryUniformSlotsTest``

### DIFF
--- a/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
+++ b/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Inventory;
 using Robust.Shared.GameObjects;
-using Robust.Shared.Map;
 
 namespace Content.IntegrationTests.Tests
 {
@@ -67,7 +66,7 @@ namespace Content.IntegrationTests.Tests
             EntityUid pocketItem = default;
 
             InventorySystem invSystem = default!;
-            var mapMan = server.ResolveDependency<IMapManager>();
+            var mapSystem = server.ResolveDependency<SharedMapSystem>();
             var entityMan = server.ResolveDependency<IEntityManager>();
 
             await server.WaitAssertion(() =>
@@ -129,7 +128,7 @@ namespace Content.IntegrationTests.Tests
                     Assert.That(!invSystem.TryGetSlotEntity(human, "pocket1", out _));
                 });
 
-                mapMan.DeleteMap(testMap.MapId);
+                mapSystem.DeleteMap(testMap.MapId);
             });
 
             await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
+++ b/Content.IntegrationTests/Tests/HumanInventoryUniformSlotsTest.cs
@@ -66,7 +66,7 @@ namespace Content.IntegrationTests.Tests
             EntityUid pocketItem = default;
 
             InventorySystem invSystem = default!;
-            var mapSystem = server.ResolveDependency<SharedMapSystem>();
+            var mapSystem = server.System<SharedMapSystem>();
             var entityMan = server.ResolveDependency<IEntityManager>();
 
             await server.WaitAssertion(() =>


### PR DESCRIPTION
## About the PR
Title.

## Why / Balance
Obsolete. #33279.

## Technical details

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
Nope.
