### PR TITLE
Cleanup: Use ``MapSystem.DeleteMap`` instead of ``IMapManager.DeleteMap`` in ``MaterialArbitrageTest``

### DIFF
--- a/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
+++ b/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
@@ -346,7 +346,7 @@ public sealed class MaterialArbitrageTest
             }
         });
 
-        await server.WaitPost(() => mapManager.DeleteMap(testMap.MapId));
+        await server.WaitPost(() => mapSystem.DeleteMap(testMap.MapId));
         await pair.CleanReturnAsync();
 
         async Task<double> GetSpawnedPrice(Dictionary<string, int> ents)


### PR DESCRIPTION
## About the PR
Title.

## Why / Balance
Obsolete. #33279.

## Technical details

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
Nope.