### PR TITLE
[ADMIN minor update] Add Autocompletion for Player Usernames in SetMind Command

### DIFF
--- a/Content.Server/Administration/Commands/SetMindCommand.cs
+++ b/Content.Server/Administration/Commands/SetMindCommand.cs
@@ -79,7 +79,7 @@ namespace Content.Server.Administration.Commands
         {
             if (args.Length == 2)
             {
-                return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), "username");
+                return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), Loc.GetString("cmd-mind-command-hint");
             }
 
             return CompletionResult.Empty;

--- a/Content.Server/Administration/Commands/SetMindCommand.cs
+++ b/Content.Server/Administration/Commands/SetMindCommand.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Players;
 using Content.Shared.Administration;
 using Content.Shared.Mind;
@@ -13,7 +12,6 @@ namespace Content.Server.Administration.Commands
     sealed class SetMindCommand : IConsoleCommand
     {
         [Dependency] private readonly IEntityManager _entManager = default!;
-        [Dependency] private readonly IPlayerManager _playerManager = default!;
 
         public string Command => "setmind";
 
@@ -81,8 +79,7 @@ namespace Content.Server.Administration.Commands
         {
             if (args.Length == 2)
             {
-                var options = _playerManager.Sessions.Select(c => c.Name).OrderBy(c => c).ToArray();
-                return CompletionResult.FromHintOptions(options, "username");
+                return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), "username");
             }
 
             return CompletionResult.Empty;

--- a/Content.Server/Administration/Commands/SetMindCommand.cs
+++ b/Content.Server/Administration/Commands/SetMindCommand.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Players;
 using Content.Shared.Administration;
 using Content.Shared.Mind;
@@ -12,6 +13,7 @@ namespace Content.Server.Administration.Commands
     sealed class SetMindCommand : IConsoleCommand
     {
         [Dependency] private readonly IEntityManager _entManager = default!;
+        [Dependency] private readonly IPlayerManager _playerManager = default!;
 
         public string Command => "setmind";
 
@@ -73,6 +75,17 @@ namespace Content.Server.Administration.Commands
             var mind = playerCData.Mind ?? mindSystem.CreateMind(session.UserId, metadata.EntityName);
 
             mindSystem.TransferTo(mind, eUid, ghostOverride);
+        }
+
+        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            if (args.Length == 2)
+            {
+                var options = _playerManager.Sessions.Select(c => c.Name).OrderBy(c => c).ToArray();
+                return CompletionResult.FromHintOptions(options, "username");
+            }
+
+            return CompletionResult.Empty;
         }
     }
 }

--- a/Content.Server/Administration/Commands/SetMindCommand.cs
+++ b/Content.Server/Administration/Commands/SetMindCommand.cs
@@ -79,7 +79,7 @@ namespace Content.Server.Administration.Commands
         {
             if (args.Length == 2)
             {
-                return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), Loc.GetString("cmd-mind-command-hint");
+                return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), Loc.GetString("cmd-mind-command-hint"));
             }
 
             return CompletionResult.Empty;

--- a/Resources/Locale/en-US/administration/commands/set-mind-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/set-mind-command.ftl
@@ -2,3 +2,4 @@ set-mind-command-description = Transfers a mind to the specified entity. The ent
 set-mind-command-help-text = Usage: {$command} <entityUid> <username> [unvisit]
 set-mind-command-target-has-no-content-data-message = Target player does not have content data (wtf?)
 set-mind-command-target-has-no-mind-message = Target entity does not have a mind (did you forget to make sentient?)
+cmd-mind-command-hint = username


### PR DESCRIPTION
## About the PR
This PR adds a command completion feature to the existing `SetMindCommand`. Specifically, it introduces the `GetCompletion` method, which provides autocomplete functionality for the player usernames when the command is executed. The addition allows admins to quickly select a player by name when setting the mind of an entity.

## Why / Balance
This change improves the usability of the `setmind` command by streamlining the process of selecting a player. This reduces the chance of errors when specifying the target player for the mind transfer and enhances the admin experience.

## Technical details
- Added the `GetCompletion` method to the `SetMindCommand` class.

## Media
![image](https://github.com/user-attachments/assets/f828b7d2-13cc-4119-a2a3-2b7250c9d1cc)


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
No breaking changes introduced.

**Changelog**
:cl: Schrodinger71
ADMIN:
- add: Added autocompletion for player usernames in setmind command.