### PR TITLE
Cleanup: Use ``Volatile.Read`` instead of ``Thread.VolatileRead`` in ``RoundEndTest``

### DIFF
--- a/Content.IntegrationTests/Tests/RoundEndTest.cs
+++ b/Content.IntegrationTests/Tests/RoundEndTest.cs
@@ -128,8 +128,8 @@ namespace Content.IntegrationTests.Tests
             async Task WaitForEvent()
             {
                 var timeout = Task.Delay(TimeSpan.FromSeconds(10));
-                var currentCount = Thread.VolatileRead(ref sys.RoundCount);
-                while (currentCount == Thread.VolatileRead(ref sys.RoundCount) && !timeout.IsCompleted)
+                var currentCount = Volatile.Read(ref sys.RoundCount);
+                while (currentCount == Volatile.Read(ref sys.RoundCount) && !timeout.IsCompleted)
                 {
                     await pair.RunTicksSync(5);
                 }


### PR DESCRIPTION
## About the PR
Title.

## Why / Balance
Obsolete. #33279.

## Technical details

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
Nope.