### PR TITLE
Make the version watermark less annoying

### DIFF
--- a/Content.Client/Gameplay/GameplayState.cs
+++ b/Content.Client/Gameplay/GameplayState.cs
@@ -61,10 +61,9 @@ namespace Content.Client.Gameplay
             _version = new Label();
             _version.FontColorOverride = Color.FromHex("#FFFFFF20");
             _version.Text = _changelog.GetClientVersion();
-            _version.Visible = VersionVisible();
             UserInterfaceManager.PopupRoot.AddChild(_version);
-            _configurationManager.OnValueChanged(CCVars.HudVersionWatermark, (show) => { _version.Visible = VersionVisible(); });
-            _configurationManager.OnValueChanged(CCVars.ForceClientHudVersionWatermark, (show) => { _version.Visible = VersionVisible(); });
+            _configurationManager.OnValueChanged(CCVars.HudVersionWatermark, (show) => { _version.Visible = VersionVisible(); }, true);
+            _configurationManager.OnValueChanged(CCVars.ForceClientHudVersionWatermark, (show) => { _version.Visible = VersionVisible(); }, true);
             // TODO make this centered or something
             LayoutContainer.SetPosition(_version, new Vector2(70, 0));
         }

--- a/Content.Client/Gameplay/GameplayState.cs
+++ b/Content.Client/Gameplay/GameplayState.cs
@@ -59,13 +59,14 @@ namespace Content.Client.Gameplay
 
             // Version number watermark.
             _version = new Label();
+            _version.FontColorOverride = Color.FromHex("#FFFFFF20");
             _version.Text = _changelog.GetClientVersion();
             _version.Visible = VersionVisible();
             UserInterfaceManager.PopupRoot.AddChild(_version);
             _configurationManager.OnValueChanged(CCVars.HudVersionWatermark, (show) => { _version.Visible = VersionVisible(); });
             _configurationManager.OnValueChanged(CCVars.ForceClientHudVersionWatermark, (show) => { _version.Visible = VersionVisible(); });
             // TODO make this centered or something
-            LayoutContainer.SetPosition(_version, new Vector2(800, 0));
+            LayoutContainer.SetPosition(_version, new Vector2(70, 0));
         }
 
         // This allows servers to force the watermark on clients


### PR DESCRIPTION
## About the PR
Watermark is now in the top left corner, after the FPS counter (it's position is fixed whether the FPS counter is active or not). It's also highly transparent now. The screen space it takes up is "not useful" to begin with, because it's covered by the hotbar or some UI buttons, depending on Hud mode. It's also transparent enough to not meaningfully obstruct these UI elements.

## Why / Balance
People complained

## Media
Before:
![Screenshot_2025-02-24_234912](https://github.com/user-attachments/assets/361d43a1-62ea-47a4-931c-e0f16723ad76)

After:
![Screenshot_2025-02-24_234511](https://github.com/user-attachments/assets/f2f654c5-3d29-4c11-8ce6-60978abd447b)
![Screenshot_2025-02-24_234529](https://github.com/user-attachments/assets/b09589f9-322a-4b34-91b2-7d4893ff6b75)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Errant
- tweak: The version watermark is now less visually annoying.