### PR TITLE
fix mousetraps

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/mousetrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/mousetrap.yml
@@ -22,6 +22,7 @@
           Blunt: 2 # base damage, scales based on mass
     - type: EmitSoundOnUse
       sound: "/Audio/Items/Handcuffs/cuff_end.ogg"
+      handle: false
     - type: EmitSoundOnTrigger
       sound: "/Audio/Items/snap.ogg"
     - type: Item
@@ -62,5 +63,9 @@
   id: MousetrapArmed
   description: Useful for catching rodents sneaking into your kitchen.
   components:
-    - type: Mousetrap
-      isActive: true
+  - type: Sprite
+    layers:
+    - state: mousetraparmed
+      map: ["base"]
+  - type: Mousetrap
+    isActive: true


### PR DESCRIPTION
## About the PR
You could no longer arm it.

## Why / Balance
bugfix

## Technical details
Don't let `EmitSoundOnUse` mark the interaction as handled because that was blocking it from being armed.
I also fixed the initial sprite for the pre-armed prototype.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed mousetraps not being armed when used.
