### PR TITLE
Smart gas vents, open/close with approximate derivative of external pressure

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -36,6 +36,23 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         [DataField]
         public bool UnderPressureLockout { get; set; } = false;
 
+        [DataField]
+        public float VelocityPressureLockoutValue { get; set; } = 1.0f;
+
+        [DataField]
+        public bool VelocityPressureLockoutEnabled { get; set; } = true;
+
+        public float VelocityPressureModifier => VelocityPressureLockoutEnabled && !PressureLockoutOverride ? VelocityPressureLockoutValue : 1.0f;
+
+        [DataField]
+        public float VelocityPressureValueMin { get; set; } = 0.0001f;
+
+        [DataField]
+        public float PreviousPressure { get; set; } = 0.0f;
+
+        [DataField]
+        public float VelocityPressureAcceleration { get; set; } = 2.0f;
+
         /// <summary>
         ///     In releasing mode, do not pump when environment pressure is below this limit.
         /// </summary>

--- a/Resources/Locale/en-US/atmos/gas-vent-pump.ftl
+++ b/Resources/Locale/en-US/atmos/gas-vent-pump.ftl
@@ -1,1 +1,2 @@
 gas-vent-pump-uvlo = It is in [color=red]under-pressure lock out[/color].
+gas-vent-pump-close-value = It is [color=yellow]{$percent}%[/color] opened.


### PR DESCRIPTION
Add a virtual "internal valve" to the gas vents that _open and close_ depending on the _change_ in external pressure over time.

## About the PR

Right now this is a super draft, just want to get some feedback.

Gas vents in this mode have a variable from 0.0 to 1.0 that represents how "open" the vent is from 0% to 100%, this can restrict the gas release flow. This value will get updated depending on the change of external pressure.

Additionally, the old lockout behavior would probably still be useful on shuttles and such where air is a super valuable commodity, as the strict lockout system is much more conservative.

Todo:
- [ ] Clean up variable names, open/close distictions
- [ ] Add air alarm UI to toggle "velocity based lockout" vs "static/strict lockout"
- [ ] Ensure old mapped air alarms use the strict lockout behavior
- [ ] Test minimum "open" value and measure how many mols get leaked compared to old lockout
- [ ] Graph pressure values and "open" value over time for sanity checks
- [ ] Test with larger room sizes (oasis junction)
- [ ] add more todo items when I think of them

## Why / Balance

I hate fixing depressurization when I'm atmos.

With power, when you fix it, the power comes back nearly immediately everywhere and everyone claps.

With atmos, when there is an issue, it takes so much time to fix it, and pressure needs to slowly equalize, and you have to literally click every single air alarm on the station until there's enough pressure to handle the drops via equalization when people open doors.

I feel like any time anyone gasps people beg to call for evac because atmos just cannot get pressure back fast enough.

Vents should be smart enough to detect if they are in vacuum or not...

## Technical details

On every update, the gas vent will compare the external pressure with the last update, then the vent will "open" or "close" by an amount scaled to this difference (open if the pressure is increasing, close if the pressure is decreasing) and also scaled to an "acceleration" parameter. This acceleration parameter is currently multiplied by 10 for positive (opening) increases in order to minimize the effects of room pressure equalization ticks by the Monstermos system.

## Media

https://github.com/user-attachments/assets/e192fdf0-3ece-4fc5-858e-75fa8d5e806c

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
When it's finished I hope there won't be any breaking changes, I'd like to make it so that mapped air alarms default to the old behavior.

**Changelog**

TBD
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
