### PR TITLE
DocumentParsingManager: Ignore XML comments in guidebook pages

### DIFF
--- a/Content.Client/Guidebook/DocumentParsingManager.cs
+++ b/Content.Client/Guidebook/DocumentParsingManager.cs
@@ -36,15 +36,17 @@ public sealed partial class DocumentParsingManager
             .Assert(_tagControlParsers.ContainsKey, tag => $"unknown tag: {tag}")
             .Bind(tag => _tagControlParsers[tag]);
 
+        Parser<char, Unit> whitespaceAndCommentParser = SkipWhitespaces.Then(Try(String("<!--").Then(Parser<char>.Any.SkipUntil(Try(String("-->"))))).SkipMany());
+
         _controlParser = OneOf(_tagParser, TryHeaderControl, ListControlParser, TextControlParser)
-            .Before(SkipWhitespaces);
+            .Before(whitespaceAndCommentParser);
 
         foreach (var typ in _reflectionManager.GetAllChildren<IDocumentTag>())
         {
             _tagControlParsers.Add(typ.Name, CreateTagControlParser(typ.Name, typ, _sandboxHelper));
         }
 
-        ControlParser = SkipWhitespaces.Then(_controlParser.Many());
+        ControlParser = whitespaceAndCommentParser.Then(_controlParser.Many());
 
         _sawmill = Logger.GetSawmill("Guidebook");
     }

--- a/Content.Client/Guidebook/DocumentParsingManager.cs
+++ b/Content.Client/Guidebook/DocumentParsingManager.cs
@@ -36,7 +36,7 @@ public sealed partial class DocumentParsingManager
             .Assert(_tagControlParsers.ContainsKey, tag => $"unknown tag: {tag}")
             .Bind(tag => _tagControlParsers[tag]);
 
-        Parser<char, Unit> whitespaceAndCommentParser = SkipWhitespaces.Then(Try(String("<!--").Then(Parser<char>.Any.SkipUntil(Try(String("-->"))))).SkipMany());
+        var whitespaceAndCommentParser = SkipWhitespaces.Then(Try(String("<!--").Then(Parser<char>.Any.SkipUntil(Try(String("-->"))))).SkipMany());
 
         _controlParser = OneOf(_tagParser, TryHeaderControl, ListControlParser, TextControlParser)
             .Before(whitespaceAndCommentParser);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Adds a parser to ignore XML comments in guidebook pages.  Ports https://github.com/new-frontiers-14/frontier-station-14/pull/2979 with a minor fix for end tag parsing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Currently, adding a comment will be treated as a "!--" tag, which will fail to parse and cause a large error window in the guidebook.  It's useful to be able to document changes within a document itself, especially for forks, without causing errors in the guidebook.

## Technical details
<!-- Summary of code changes for easier review. -->

A parser was added that consumes both whitespace and comments if they exist.  Any combination of whitespace and complete XML comments, even split between lines, should be accepted.

The test bench used to check this feature is as follows:
1. Edit APE.xml to the following text.
```xml
<Document>
# A.P.E.
<!-- - - > --><!-- A comment?  In my APE guidebook entry?  At this time of year?

 Does it really work?
 are you sure? --><!--really?
-->The Anomalous Particle Emitter is a machine used to interface with anomalies. It is the primary way of manipulating the stats of an anomaly.

<Box>
<GuideEntityEmbed Entity="MachineAPE"/>
</Box>

<!-- Jank Station: Added Psi particles, Collapse effect -->
The A.P.E. can shoot four different kinds of anomalous particles: Delta, Epsilon, Sigma, Psi and Zeta. Each particle type has certain effects:

- [color=crimson]Danger:[/color] Increases the severity of an anomaly.
- [color=plum]Unstable:[/color] Increases the instability of an anomaly.
- [color=goldenrod]Containment:[/color] Increases anomaly stability at the cost of its health - if an anomaly is struck by too many containment particles, it will collapse, leaving behind an anomaly core.
- [color=#6b75fa]Transformation:[/color] Increases anomaly severity with a chance of changing its behavior.
- [color=#33ee33]Collapse:[/color] Greatly reduces the instability of an anomaly, but may delete any accumulated research and the anomaly core with it.
<!-- End Jank Station -->

Which particle type corresponds to each effect is unique and can be learned by scanning the anomaly.

The A.P.E. can also be locked by anyone with science access, which prevents it from being deconstructed, turned on or off, or having the particle type switched.

</Document>
```
2. Run the game, view the page.  There should be no errors, and the page should look like the Media result below.  Note that the comments are not visible.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

The result of step 2 of the test bench above.
![image](https://github.com/user-attachments/assets/db311f28-3e4f-4e68-bc2a-bf1e32a53b28)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No in-game effect, no changelog.