### PR TITLE
Engineers can now choose to wear no head piece

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -729,6 +729,7 @@
 - type: loadoutGroup
   id: StationEngineerHead
   name: loadout-group-station-engineer-head
+  minLimit: 0
   loadouts:
   - StationEngineerHardhatYellow
   - StationEngineerHardhatOrange


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- Engineers couldn't wear nothing on their head before like every other loadout and now they can!! -->
 Engineers couldn't wear nothing on their head before like every other loadout and now they can!!

## Why / Balance
<!-- Every other job lets you and i don't see why the engineers wouldn't be able to as well. -->
Every other job lets you and i don't see why the engineers wouldn't be able to as well.

## Technical details
<!-- Literally just adds 1 line to loadout_groups.yml  -->
Literally just adds 1 line to loadout_groups.yml

## Media
<!-- Not necessary -->Not necessary

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Engineers can choose to not wear a helmet now.
-->
:cl:
- fix: Engineers can choose to not wear a headpiece now.
