### PR TITLE
Made forensic scanner classified as contraband.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: forensic scanner
-  parent: BaseItem
+  parent: [ BaseItem, BaseSecurityContraband ]
   id: ForensicScanner
   description: A handheld device that can scan objects for fingerprints and fibers.
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I made the forensic scanner restricted to security.

## Why / Balance
Helps secoffs determine if it is a stolen item or something like that because it is a thief objective.

## Technical details
Added the: BaseSecurityContraband parent to the forensic scanner.

## Media
![image](https://github.com/user-attachments/assets/cebd4e67-e6e9-4c72-86d6-a852e899089e)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Added the BaseSecurityContraband parent to the forensic scanner.

**Changelog**
- tweak: Changed the Forensic Scanner to be classified as contraband.

