### PR TITLE
add forceghost admin command

### DIFF
--- a/Content.Server/Administration/Commands/ForceGhostCommand.cs
+++ b/Content.Server/Administration/Commands/ForceGhostCommand.cs
@@ -5,7 +5,6 @@ using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Robust.Server.Player;
 using Robust.Shared.Console;
-using System.Linq;
 
 namespace Content.Server.Administration.Commands;
 
@@ -52,8 +51,9 @@ public sealed class ForceGhostCommand : LocalizedCommands
     {
         if (args.Length == 1)
         {
-            var options = _playerManager.Sessions.Select(c => c.Name).Order().ToArray();
-            return CompletionResult.FromHintOptions(options, LocalizationManager.GetString("cmd-forceghost-hint"));
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.SessionNames(players: _playerManager),
+                Loc.GetString("cmd-forceghost-hint"));
         }
 
         return CompletionResult.Empty;

--- a/Content.Server/Administration/Commands/ForceGhostCommand.cs
+++ b/Content.Server/Administration/Commands/ForceGhostCommand.cs
@@ -1,0 +1,61 @@
+using Content.Server.GameTicking;
+using Content.Server.Ghost;
+using Content.Shared.Administration;
+using Content.Shared.GameTicking;
+using Content.Shared.Mind;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using System.Linq;
+
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class ForceGhostCommand : LocalizedCommands
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+
+    public override string Command => "forceghost";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length == 0 || args.Length > 1)
+        {
+            shell.WriteError(LocalizationManager.GetString("shell-wrong-arguments-number"));
+            return;
+        }
+
+        if (!_playerManager.TryGetSessionByUsername(args[0], out var player))
+        {
+            shell.WriteError(LocalizationManager.GetString("shell-target-player-does-not-exist"));
+            return;
+        }
+
+        var gameTicker = _entityManager.System<GameTicker>();
+        if (!gameTicker.PlayerGameStatuses.TryGetValue(player.UserId, out var playerStatus) ||
+            playerStatus is not PlayerGameStatus.JoinedGame)
+        {
+            shell.WriteLine(Loc.GetString("cmd-forceghost-error-lobby"));
+            return;
+        }
+
+        var mindSys = _entityManager.System<SharedMindSystem>();
+        if (!mindSys.TryGetMind(player, out var mindId, out var mind))
+            (mindId, mind) = mindSys.CreateMind(player.UserId);
+
+        var ghostSys = _entityManager.System<GhostSystem>();
+        if (!ghostSys.OnGhostAttempt(mindId, false, true, true, mind))
+            shell.WriteLine(Loc.GetString("cmd-forceghost-denied"));
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            var options = _playerManager.Sessions.Select(c => c.Name).Order().ToArray();
+            return CompletionResult.FromHintOptions(options, LocalizationManager.GetString("cmd-forceghost-hint"));
+        }
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Content.Server/Ghost/GhostCommand.cs
+++ b/Content.Server/Ghost/GhostCommand.cs
@@ -50,7 +50,7 @@ namespace Content.Server.Ghost
                 mind = _entities.GetComponent<MindComponent>(mindId);
             }
 
-            if (!_entities.System<GhostSystem>().OnGhostAttempt(mindId, true, true, mind))
+            if (!_entities.System<GhostSystem>().OnGhostAttempt(mindId, true, true, mind: mind))
             {
                 shell.WriteLine(Loc.GetString("ghost-command-denied"));
             }

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -507,10 +507,12 @@ namespace Content.Server.Ghost
             var playerEntity = mind.CurrentEntity;
 
             if (playerEntity != null && viaCommand)
+            {
                 if (forced)
                     _adminLog.Add(LogType.Mind, $"{EntityManager.ToPrettyString(playerEntity.Value):player} was forced to ghost via command");
                 else
                     _adminLog.Add(LogType.Mind, $"{EntityManager.ToPrettyString(playerEntity.Value):player} is attempting to ghost via command");
+            }
 
             var handleEv = new GhostAttemptHandleEvent(mind, canReturnGlobal);
             RaiseLocalEvent(handleEv);

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -499,7 +499,7 @@ namespace Content.Server.Ghost
             return ghost;
         }
 
-        public bool OnGhostAttempt(EntityUid mindId, bool canReturnGlobal, bool viaCommand = false, MindComponent? mind = null)
+        public bool OnGhostAttempt(EntityUid mindId, bool canReturnGlobal, bool viaCommand = false, bool forced = false, MindComponent? mind = null)
         {
             if (!Resolve(mindId, ref mind))
                 return false;
@@ -507,7 +507,10 @@ namespace Content.Server.Ghost
             var playerEntity = mind.CurrentEntity;
 
             if (playerEntity != null && viaCommand)
-                _adminLog.Add(LogType.Mind, $"{EntityManager.ToPrettyString(playerEntity.Value):player} is attempting to ghost via command");
+                if (forced)
+                    _adminLog.Add(LogType.Mind, $"{EntityManager.ToPrettyString(playerEntity.Value):player} was forced to ghost via command");
+                else
+                    _adminLog.Add(LogType.Mind, $"{EntityManager.ToPrettyString(playerEntity.Value):player} is attempting to ghost via command");
 
             var handleEv = new GhostAttemptHandleEvent(mind, canReturnGlobal);
             RaiseLocalEvent(handleEv);
@@ -516,7 +519,7 @@ namespace Content.Server.Ghost
             if (handleEv.Handled)
                 return handleEv.Result;
 
-            if (mind.PreventGhosting)
+            if (mind.PreventGhosting && !forced)
             {
                 if (mind.Session != null) // Logging is suppressed to prevent spam from ghost attempts caused by movement attempts
                 {

--- a/Resources/Locale/en-US/administration/commands/forceghost.ftl
+++ b/Resources/Locale/en-US/administration/commands/forceghost.ftl
@@ -1,0 +1,6 @@
+﻿cmd-forceghost-desc = Makes a player an observer.
+cmd-forceghost-help = Usage: forceghost <player>
+
+cmd-forceghost-error-lobby = Target player can't ghost right now. They are not in the game!
+cmd-forceghost-denied = Failed to ghost the target player.
+cmd-forceghost-hint = <player>


### PR DESCRIPTION
## About the PR
New command that forces a selected player to ghost.

## Why / Balance
From the admin wishlist https://github.com/space-wizards/space-station-14/issues/35493

## Technical details
Similar to the ghost command, but bypasses some checks and the target player can be selected.

## Media

https://github.com/user-attachments/assets/1cbc63d4-a289-48e7-9512-b7fe137ff0a0

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Added a new parameter to `GhostSystem.OnGhostAttempt`.

**Changelog**
:cl:
ADMIN:
- add: Added the 'forceghost < player >' command which forces someone to become an observer.
