### PR TITLE
[ADMIN] New command "swapmind"

### DIFF
--- a/Content.Server/Administration/Commands/SwapMindCommand.cs
+++ b/Content.Server/Administration/Commands/SwapMindCommand.cs
@@ -1,10 +1,9 @@
-using Content.Server.Players;
 using Content.Shared.Administration;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
-using Content.Shared.Players;
 using Robust.Server.Player;
 using Robust.Shared.Console;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Content.Server.Administration.Commands
 {
@@ -12,6 +11,7 @@ namespace Content.Server.Administration.Commands
     sealed class SwapMindCommand : IConsoleCommand
     {
         [Dependency] private readonly IEntityManager _entManager = default!;
+        [Dependency] private readonly IPlayerManager _playerManager = default!;
 
         public string Command => "swapmind";
 
@@ -28,11 +28,11 @@ namespace Content.Server.Administration.Commands
             }
 
             // First player
-            if (!TryParseUid(args[1], shell, _entManager, out var firstEntityUid))
+            if (!TryParseUid(args[0], shell, _entManager, out var firstEntityUid))
                 return;
 
             // Second player
-            if (!TryParseUid(args[2], shell, _entManager, out var secondEntityUid))
+            if (!TryParseUid(args[1], shell, _entManager, out var secondEntityUid))
                 return;
 
             if (!_entManager.HasComponent<MindContainerComponent>(firstEntityUid) ||

--- a/Content.Server/Administration/Commands/SwapMindCommand.cs
+++ b/Content.Server/Administration/Commands/SwapMindCommand.cs
@@ -1,0 +1,71 @@
+using Content.Server.Players;
+using Content.Shared.Administration;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Content.Shared.Players;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+
+namespace Content.Server.Administration.Commands
+{
+    [AdminCommand(AdminFlags.Admin)]
+    sealed class SwapMindCommand : IConsoleCommand
+    {
+        [Dependency] private readonly IEntityManager _entManager = default!;
+
+        public string Command => "swapmind";
+
+        public string Description => Loc.GetString("set-swapmind-command-description", ("requiredComponent", nameof(MindContainerComponent)));
+
+        public string Help => Loc.GetString("set-swapmind-command-help-text", ("command", Command));
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (args.Length < 2)
+            {
+                shell.WriteLine(Loc.GetString("shell-wrong-arguments-number"));
+                return;
+            }
+
+            if (!int.TryParse(args[0], out var firstEntInt) || !int.TryParse(args[1], out var secondEntInt))
+            {
+                shell.WriteLine(Loc.GetString("shell-entity-uid-must-be-number"));
+                return;
+            }
+
+            var firstNetEnt = new NetEntity(firstEntInt);
+            var secondNetEnt = new NetEntity(secondEntInt);
+
+            if (!_entManager.TryGetEntity(firstNetEnt, out var firstEntityUid) ||
+                !_entManager.TryGetEntity(secondNetEnt, out var secondEntityUid))
+            {
+                shell.WriteLine(Loc.GetString("shell-invalid-entity-id"));
+                return;
+            }
+
+            if (!_entManager.HasComponent<MindContainerComponent>(firstEntityUid) ||
+                !_entManager.HasComponent<MindContainerComponent>(secondEntityUid))
+            {
+                shell.WriteLine(Loc.GetString("set-swapmind-command-target-has-no-mind-message"));
+                return;
+            }
+
+            var mindSystem = _entManager.System<SharedMindSystem>();
+
+            var firstMind = _entManager.GetComponent<MindContainerComponent>(firstEntityUid.Value).Mind;
+            var secondMind = _entManager.GetComponent<MindContainerComponent>(secondEntityUid.Value).Mind;
+
+            // Swap the minds
+            if (firstMind != null && secondMind != null)
+            {
+                mindSystem.TransferTo(firstMind.Value, secondEntityUid);
+                mindSystem.TransferTo(secondMind.Value, firstEntityUid);
+                shell.WriteLine(Loc.GetString("set-swapmind-success-message"));
+            }
+            else
+            {
+                shell.WriteLine(Loc.GetString("set-swapmind-command-minds-not-found"));
+            }
+        }
+    }
+}

--- a/Resources/Locale/en-US/administration/commands/swapmind-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/swapmind-command.ftl
@@ -1,0 +1,6 @@
+# Command: swapmind
+set-swapmind-command-description = Swaps the minds of the specified entities. Entities must have { $requiredComponent }.
+set-swapmind-command-help-text = Usage: { $command } <entityUid1> <entityUid2> [unvisit]
+set-swapmind-success-message = Minds successfully swapped.
+set-swapmind-command-minds-not-found = Error: Minds not found or entities are invalid.
+set-swapmind-command-target-has-no-mind-message = One of the specified entities does not have a MindContainerComponent.

--- a/Resources/Locale/en-US/administration/commands/swapmind-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/swapmind-command.ftl
@@ -1,6 +1,6 @@
 # Command: swapmind
 set-swapmind-command-description = Swaps the minds of the specified entities. Entities must have { $requiredComponent }.
-set-swapmind-command-help-text = Usage: { $command } <entityUid1> <entityUid2> [unvisit]
+set-swapmind-command-help-text = Usage: { $command } <Player1> <Player2> [unvisit]
 set-swapmind-success-message = Minds successfully swapped.
 set-swapmind-command-minds-not-found = Error: Minds not found or entities are invalid.
 set-swapmind-command-target-has-no-mind-message = One of the specified entities does not have a MindContainerComponent.


### PR DESCRIPTION
## About the PR
This PR introduces a new command `swapmind`, which allows administrators to swap the minds of two entities in-game. It is useful for debugging or managing gameplay situations where mind swapping is necessary.

## Why / Balance
This command adds an administrative tool for more flexible debugging and gameplay control. It doesn't significantly affect game balance

## Technical details
- The `SwapMindCommand` was implemented to allow administrators to swap the minds of two players or entities.
- The command validates the input to ensure the specified players or entities exist and have minds that can be swapped.
- A helper method `TryParseUid` was created to handle input parsing, either by username or entity UID.
- The command also provides autocompletion for player usernames.

## Media

https://github.com/user-attachments/assets/74c63c0a-c246-4211-a4bf-2b0ace706598

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


## Breaking changes
No breaking changes.

**Changelog**
**Changelog**
:cl: Schrodinger71
ADMIN:
- add: Added `swapmind` command for administrators to swap the minds of two players or entities.
