### PR TITLE
Mob solution based virus 

### DIFF
--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -101,6 +101,7 @@ guide-entry-chemicals = Chemicals
 guide-entry-drinks = Drinks
 guide-entry-foodrecipes = Food Recipes
 
+guide-entry-virology = Virology
 guide-entry-elements = Elements
 guide-entry-medicine = Medicine
 guide-entry-narcotics = Narcotics

--- a/Resources/Locale/en-US/metabolism/metabolism-groups.ftl
+++ b/Resources/Locale/en-US/metabolism/metabolism-groups.ftl
@@ -1,4 +1,5 @@
 metabolism-group-poison = Poison
+metabolism-group-virology = Virology
 metabolism-group-medicine = Medicine
 metabolism-group-narcotic = Narcotic
 metabolism-group-alcohol = Alcohol

--- a/Resources/Locale/en-US/reagents/AIDncer.ftl
+++ b/Resources/Locale/en-US/reagents/AIDncer.ftl
@@ -1,0 +1,2 @@
+reagent-name-aidncer = AIDncer
+reagent-desc-aidncer = Cosmic AIDS, which mutated to also be cancer. Don't tell anyone that you have it, otherwise everyone will know that you like to drink mopwata.

--- a/Resources/Locale/en-US/reagents/AIDncerAntibody.ftl
+++ b/Resources/Locale/en-US/reagents/AIDncerAntibody.ftl
@@ -1,0 +1,2 @@
+reagent-name-aidncerantibody = AIDncer antibodies
+reagent-desc-aidncerantibody = Antibodies capable of fighting AIDncer.

--- a/Resources/Prototypes/Chemistry/metabolism_groups.yml
+++ b/Resources/Prototypes/Chemistry/metabolism_groups.yml
@@ -18,6 +18,10 @@
 - type: metabolismGroup
   id: Food
   name: metabolism-group-food
+  
+- type: metabolismGroup
+  id: Virology
+  name: Virology #CHANGE
 
 - type: metabolismGroup
   id: Drink

--- a/Resources/Prototypes/Chemistry/metabolism_groups.yml
+++ b/Resources/Prototypes/Chemistry/metabolism_groups.yml
@@ -21,7 +21,7 @@
   
 - type: metabolismGroup
   id: Virology
-  name: Virology #CHANGE
+  name: metabolism-group-virology
 
 - type: metabolismGroup
   id: Drink

--- a/Resources/Prototypes/Chemistry/mixing_types.yml
+++ b/Resources/Prototypes/Chemistry/mixing_types.yml
@@ -31,6 +31,7 @@
 
 # Alternative Mixing Methods
 
+
 - type: mixingCategory
   id: Centrifuge
   verbText: mixing-verb-centrifuge

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
@@ -143,7 +143,9 @@
         maxVol: 50
         reagents:
         - ReagentId: Mopwata
-          Quantity: 40
+          Quantity: 38
+        - ReagentId: AIDncer
+          Quantity: 2
   - type: RandomFillSolution
     solution: drink
     weightedRandomId: RandomFillMopwata

--- a/Resources/Prototypes/Guidebook/chemicals.yml
+++ b/Resources/Prototypes/Guidebook/chemicals.yml
@@ -13,7 +13,13 @@
   - Biological
   - Special
   - Others
+  - VirologyGuide
   filterEnabled: True
+
+- type: guideEntry
+  id: VirologyGuide
+  name: guide-entry-virology
+  text: "/ServerInfo/Guidebook/ChemicalTabs/Virology.xml"
 
 - type: guideEntry
   id: Elements

--- a/Resources/Prototypes/Reagents/virology.yml
+++ b/Resources/Prototypes/Reagents/virology.yml
@@ -39,7 +39,7 @@
   group: Virology
   desc: reagent-desc-aidncerantibody 
   physicalDesc: reagent-physical-desc-opaque
-  flavor: AIDS
+  flavor: bitter
   color: "#ffffff"
   metabolisms:
     Medicine:
@@ -68,7 +68,7 @@
   group: Virology
   desc: reagent-desc-aidncer
   physicalDesc: reagent-physical-desc-opaque
-  flavor: AIDS
+  flavor: bitter
   color: "#ffffff"
   metabolisms:
     Poison:

--- a/Resources/Prototypes/Reagents/virology.yml
+++ b/Resources/Prototypes/Reagents/virology.yml
@@ -1,0 +1,100 @@
+#- type: reagent
+#  id: Bicaridine
+#  name: reagent-name-bicaridine
+#  group: Medicine
+#  desc: reagent-desc-bicaridine
+#  physicalDesc: reagent-physical-desc-opaque
+#  flavor: medicine
+#  color: "#ffaa00"
+#  metabolisms:
+#    Medicine:
+#      effects:
+#      - !type:HealthChange
+#        damage:
+#          groups:
+#            Brute: -2
+#      - !type:HealthChange
+#        conditions:
+#        - !type:ReagentThreshold
+#          min: 15
+#        damage:
+#          types:
+#            Asphyxiation: 0.5
+#            Poison: 1.5
+#      - !type:ChemVomit
+#        conditions:
+#        - !type:ReagentThreshold
+#          min: 30
+#        probability: 0.02
+#      - !type:Jitter
+#        conditions:
+#        - !type:ReagentThreshold
+#          min: 15
+#      - !type:Drunk
+
+        
+- type: reagent
+  id: AIDncerAntibody
+  name: AIDncer antibodies #CHANGE
+  group: Virology
+  desc: AIDncer antibodies #CHANGE
+  physicalDesc: reagent-physical-desc-opaque #CHANGE
+  flavor: AIDS
+  color: "#ffffff"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.1
+      effects:
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          min: 5
+        reagent: AIDncer
+        amount: -0.3
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          min: 4.5
+          max: 10
+        reagent: AIDncerAntibody
+        amount: 0.4
+      - !type:AdjustReagent
+        reagent: AIDncerAntibody
+        amount: 0.1
+
+- type: reagent
+  id: AIDncer
+  name: AIDncer virus #CHANGE
+  group: Virology
+  desc: AIDncer virus #CHANGE
+  physicalDesc: reagent-physical-desc-opaque #CHANGE
+  flavor: AIDS
+  color: "#ffffff"
+  metabolisms:
+    Poison:
+      metabolismRate: 0.1
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Cellular: 0.5
+      - !type:AdjustReagent
+        reagent: AIDncer
+        amount: 0.2
+      - !type:AdjustReagent
+        reagent: AIDncerAntibody
+        amount: 0.03
+              
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          

--- a/Resources/Prototypes/Reagents/virology.yml
+++ b/Resources/Prototypes/Reagents/virology.yml
@@ -35,10 +35,10 @@
         
 - type: reagent
   id: AIDncerAntibody
-  name: AIDncer antibodies #CHANGE
+  name: reagent-name-aidncerantibody 
   group: Virology
-  desc: AIDncer antibodies #CHANGE
-  physicalDesc: reagent-physical-desc-opaque #CHANGE
+  desc: reagent-desc-aidncerantibody 
+  physicalDesc: reagent-physical-desc-opaque
   flavor: AIDS
   color: "#ffffff"
   metabolisms:
@@ -64,10 +64,10 @@
 
 - type: reagent
   id: AIDncer
-  name: AIDncer virus #CHANGE
+  name: reagent-name-aidncer
   group: Virology
-  desc: AIDncer virus #CHANGE
-  physicalDesc: reagent-physical-desc-opaque #CHANGE
+  desc: reagent-desc-aidncer
+  physicalDesc: reagent-physical-desc-opaque
   flavor: AIDS
   color: "#ffffff"
   metabolisms:

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Virology.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Virology.xml
@@ -1,0 +1,5 @@
+<Document>
+# Virology
+This list contain viruses that can kill you, also includes antibodies which cure diseases.
+<GuideReagentGroupEmbed Group="Virology"/>
+</Document>


### PR DESCRIPTION
## About the PR
Added AIDncer, a virus. It works using the mob solution system. Metabolising it deals cellular damage and adds antibodies. Virus isn't instant deadly, but if you have it, without treatment you will die. antibodies will start to remove virus from solution when at least 5u is present. Having at least 5 units of antibodies will make them regenerate to 10 fast, allowing doctors to farm them on animals for cures. Right now it only spreads through direct injestion of the AIDncer, which can be only but always found in mopwata.

## Why / Balance
First of all, it will give traitors a new option of killing people - imagine poking someone with AIDncer syringe. AIDncer is deadly if not treated. Second is medical can finally have some form of gameplay other than clicking LMB on patients for the entire shift.
Also imagine AIDncer foam bomb...

## Technical details
added Resources\Prototypes\Reagents\Virology.yml for future updates. Updates will be coming out regulary.
Added AIDncer reagent in Resources\Prototypes\Reagents\Virology.yml
Added AIDncer antibodies in Resources\Prototypes\Reagents\Virology.yml
Added localisations and guidebook entry for both above.
Modified mopwata prototype to always have a bit of AIDncer


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: VunderFaffle
- add: added AIDncer virus.
- add: added AIDncer antibodies wich are produced when the AIDncer is in the body.
- add: guidebook entry for AIDncer and Virology tab.
- tweak: Mopwata now always has AIDncer in it.
