### PR TITLE
Allow dump out bags into lathes

### DIFF
--- a/Content.Shared/Storage/Components/DumpableComponent.cs
+++ b/Content.Shared/Storage/Components/DumpableComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class DumpableDoAfterEvent : SimpleDoAfterEvent
 
 /// <summary>
 /// Lets you dump this container on the ground using a verb,
-/// or when interacting with it on a disposal unit or placeable surface.
+/// or when interacting with it on a disposal unit, placeable surface or lathes.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class DumpableComponent : Component

--- a/Content.Shared/Storage/EntitySystems/DumpableSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/DumpableSystem.cs
@@ -116,7 +116,7 @@ public sealed class DumpableSystem : EntitySystem
         {
             if (comp.Whitelist == null || comp.Whitelist.Tags == null)
                 return;
-            List<ProtoId<TagPrototype>> tags = comp.Whitelist.Tags;
+            var tags = comp.Whitelist.Tags;
             foreach (var entity in storage.Container.ContainedEntities)
             {
                 if (!_tag.HasAnyTag(entity, tags))

--- a/Resources/Locale/en-US/storage/components/dumpable-component.ftl
+++ b/Resources/Locale/en-US/storage/components/dumpable-component.ftl
@@ -1,3 +1,4 @@
 dump-verb-name = Dump out on ground
 dump-disposal-verb-name = Dump out into {$unit}
+dump-lathe-verb-name = Dump out into {$lathe}
 dump-placeable-verb-name = Dump out onto {$surface}


### PR DESCRIPTION
## About the PR
Now dumpable items can be dumped out into structures with material storage component.

## Why / Balance
Right now inserting ore into processor is really feels bad, you need to dump it on the floor, them take it in hands, them insert into processor. This pull request allows dump it directly into lathe.

## Technical details
Added some checks into DumpableSystem.cs

## Media
https://github.com/user-attachments/assets/786d8d05-0150-458b-948a-761cc7530302

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Ore bags now can be dumped out directly into ore processor.
