### PR TITLE
Add libicu to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,7 @@ in import (builtins.fetchTarball {
 let
   dependencies = with pkgs; [
     dotnetCorePackages.sdk_9_0
+    icu
     glfw
     SDL2
     libGL


### PR DESCRIPTION
## About the PR
I'm not sure if it's just me but without this, the C# debugger in VSCode simply does not work

## Why / Balance
n/A

## Technical details
icu is a set of libraries used by .NET and its tooling for i18n stuff.
cf. https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu

## Media
n/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
n/A