### PR TITLE
Remove salt ore from salvage ore asteroids

### DIFF
--- a/Resources/Prototypes/Procedural/Magnet/asteroid_ore_gens.yml
+++ b/Resources/Prototypes/Procedural/Magnet/asteroid_ore_gens.yml
@@ -4,7 +4,6 @@
     OreIron: 1.0
     OreQuartz: 1.0
     OreCoal: 0.33
-    OreSalt: 0.25
     OreGold: 0.25
     OreSilver: 0.25
     OrePlasma: 0.20


### PR DESCRIPTION
## About the PR
Removed salt ore from salvage asteroids

## Why / Balance
Salt ore is probably one of the most useless item after salami lid. Its have two reagents - salt and iodine. Wow cool! Its so much a lot interact with chemists and chiefs! But, actually, iodine is the most unused reagent in chemistry and can be easy ordered in cargo. We also have many others reagents that salvage specialists can bring to the station (like omnisine or carptoxin). Same situation for the chef, salt can be ordered from chemists or can be purchased in cargo and salvage specialists can bring to the chef other more interesting things (like meat of the fauna). Also this PR doesn't remove salt ore fully, it still can be found on vgroid and expeditions.

## Technical details
One line change literally.

## Media
No.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Ore asteroids from salvage magnet no longer can contain salt.
