### PR TITLE
Prevent crates, pet carriers and other things from going into disposals

### DIFF
--- a/Content.Server/Containers/ThrowInsertContainerSystem.cs
+++ b/Content.Server/Containers/ThrowInsertContainerSystem.cs
@@ -31,7 +31,7 @@ public sealed class ThrowInsertContainerSystem : EntitySystem
             return;
 
         var beforeThrowArgs = new BeforeThrowInsertEvent(args.Thrown);
-        RaiseLocalEvent(ent, beforeThrowArgs);
+        RaiseLocalEvent(ent, ref beforeThrowArgs);
 
         if (beforeThrowArgs.Cancelled)
         {
@@ -59,12 +59,5 @@ public sealed class ThrowInsertContainerSystem : EntitySystem
 /// Sent before the insertion is made.
 /// Allows preventing the insertion if any system on the entity should need to.
 /// </summary>
-public sealed class BeforeThrowInsertEvent : CancellableEntityEventArgs
-{
-    public readonly EntityUid ThrownEntity;
-
-    public BeforeThrowInsertEvent(EntityUid thrownEntity)
-    {
-        ThrownEntity = thrownEntity;
-    }
-}
+[ByRefEvent]
+public record struct BeforeThrowInsertEvent(EntityUid ThrownEntity, bool Cancelled = false);

--- a/Content.Server/Containers/ThrowInsertContainerSystem.cs
+++ b/Content.Server/Containers/ThrowInsertContainerSystem.cs
@@ -34,9 +34,7 @@ public sealed class ThrowInsertContainerSystem : EntitySystem
         RaiseLocalEvent(ent, ref beforeThrowArgs);
 
         if (beforeThrowArgs.Cancelled)
-        {
             return;
-        }
 
         if (_random.Prob(ent.Comp.Probability))
         {

--- a/Content.Server/Containers/ThrowInsertContainerSystem.cs
+++ b/Content.Server/Containers/ThrowInsertContainerSystem.cs
@@ -30,6 +30,14 @@ public sealed class ThrowInsertContainerSystem : EntitySystem
         if (!_containerSystem.CanInsert(args.Thrown, container))
             return;
 
+        var beforeThrowArgs = new BeforeThrowInsertEvent(args.Thrown);
+        RaiseLocalEvent(ent, beforeThrowArgs);
+
+        if (beforeThrowArgs.Cancelled)
+        {
+            return;
+        }
+
         if (_random.Prob(ent.Comp.Probability))
         {
             _audio.PlayPvs(ent.Comp.MissSound, ent);
@@ -44,5 +52,19 @@ public sealed class ThrowInsertContainerSystem : EntitySystem
 
         if (args.Component.Thrower != null)
             _adminLogger.Add(LogType.Landed, LogImpact.Low, $"{ToPrettyString(args.Thrown)} thrown by {ToPrettyString(args.Component.Thrower.Value):player} landed in {ToPrettyString(ent)}");
+    }
+}
+
+/// <summary>
+/// Sent before the insertion is made.
+/// Allows preventing the insertion if any system on the entity should need to.
+/// </summary>
+public sealed class BeforeThrowInsertEvent : CancellableEntityEventArgs
+{
+    public readonly EntityUid ThrownEntity;
+
+    public BeforeThrowInsertEvent(EntityUid thrownEntity)
+    {
+        ThrownEntity = thrownEntity;
     }
 }

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Atmos.EntitySystems;
+using Content.Server.Containers;
 using Content.Server.Disposal.Tube;
 using Content.Server.Disposal.Tube.Components;
 using Content.Server.Disposal.Unit.Components;
@@ -84,6 +85,8 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         SubscribeLocalEvent<DisposalUnitComponent, GetVerbsEvent<Verb>>(AddClimbInsideVerb);
 
         SubscribeLocalEvent<DisposalUnitComponent, DisposalDoAfterEvent>(OnDoAfter);
+
+        SubscribeLocalEvent<DisposalUnitComponent, BeforeThrowInsertEvent>(OnThrowInsert);
 
         SubscribeLocalEvent<DisposalUnitComponent, SharedDisposalUnitComponent.UiButtonPressedMessage>(OnUiButtonPressed);
     }
@@ -193,6 +196,12 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         AfterInsert(uid, component, args.Args.Target.Value, args.Args.User, doInsert: true);
 
         args.Handled = true;
+    }
+
+    private void OnThrowInsert(EntityUid uid, SharedDisposalUnitComponent component, BeforeThrowInsertEvent args)
+    {
+        if (!CanInsert(uid, component, args.ThrownEntity))
+            args.Cancel();
     }
 
     public override void DoInsertDisposalUnit(EntityUid uid, EntityUid toInsert, EntityUid user, SharedDisposalUnitComponent? disposal = null)

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposalUnitSystem.cs
@@ -198,10 +198,10 @@ public sealed class DisposalUnitSystem : SharedDisposalUnitSystem
         args.Handled = true;
     }
 
-    private void OnThrowInsert(EntityUid uid, SharedDisposalUnitComponent component, BeforeThrowInsertEvent args)
+    private void OnThrowInsert(Entity<DisposalUnitComponent> ent, ref BeforeThrowInsertEvent args)
     {
-        if (!CanInsert(uid, component, args.ThrownEntity))
-            args.Cancel();
+        if (!CanInsert(ent, ent, args.ThrownEntity))
+            args.Cancelled = true;
     }
 
     public override void DoInsertDisposalUnit(EntityUid uid, EntityUid toInsert, EntityUid user, SharedDisposalUnitComponent? disposal = null)

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -305,7 +305,7 @@ public abstract class SharedEntityStorageSystem : EntitySystem
 
         if (_container.IsEntityInContainer(container))
         {
-            if (_container.TryGetOuterContainer(container,Transform(container), out var outerContainer) &&
+            if (_container.TryGetOuterContainer(container, Transform(container), out var outerContainer) &&
                 !HasComp<HandsComponent>(outerContainer.Owner))
             {
                 _container.Insert(toRemove, outerContainer);

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -301,8 +301,20 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (!ResolveStorage(container, ref component))
             return false;
 
-        RemComp<InsideEntityStorageComponent>(toRemove);
         _container.Remove(toRemove, component.Contents);
+
+        if (_container.IsEntityInContainer(container))
+        {
+            if (_container.TryGetOuterContainer(container,Transform(container), out var outerContainer) &&
+                !HasComp<HandsComponent>(outerContainer.Owner))
+            {
+                _container.Insert(toRemove, outerContainer);
+                return true;
+            }
+        }
+
+        RemComp<InsideEntityStorageComponent>(toRemove);
+
         var pos = TransformSystem.GetWorldPosition(xform) + TransformSystem.GetWorldRotation(xform).RotateVec(component.EnteringOffset);
         TransformSystem.SetWorldPosition(toRemove, pos);
         return true;
@@ -364,17 +376,6 @@ public abstract class SharedEntityStorageSystem : EntitySystem
                 Popup.PopupClient(Loc.GetString("entity-storage-component-welded-shut-message"), target, user);
 
             return false;
-        }
-
-        if (_container.IsEntityInContainer(target))
-        {
-            if (_container.TryGetOuterContainer(target,Transform(target) ,out var container) &&
-                !HasComp<HandsComponent>(container.Owner))
-            {
-                Popup.PopupClient(Loc.GetString("entity-storage-component-already-contains-user-message"), user, user);
-
-                return false;
-            }
         }
 
         //Checks to see if the opening position, if offset, is inside of a wall.

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -39,6 +39,7 @@
       - HumanoidAppearance
       - Plunger
       - SolutionTransfer
+      - EntityStorage
     whitelist:
       components:
       - Item

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -77,9 +77,6 @@
     graph: DisposalMachine
     node: disposal_unit
   - type: DisposalUnit
-    blacklist:
-      components:
-      - EntityStorage
   - type: ThrowInsertContainer
     containerId: disposals
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -77,6 +77,9 @@
     graph: DisposalMachine
     node: disposal_unit
   - type: DisposalUnit
+    blacklist:
+      components:
+      - EntityStorage
   - type: ThrowInsertContainer
     containerId: disposals
   - type: UserInterface
@@ -120,6 +123,9 @@
     whitelist:
       components:
       - Item
+    blacklist:
+      components:
+      - EntityStorage
   - type: MailingUnit
   - type: DeviceNetwork
     deviceNetId: Wired


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

People found that you could put someone inside of a pet carrier and then put that pet carrier inside of a disposals bin, and then they can't escape. Extra points if you drop a minibomb and get a free gib.

Also the throwing system bypassed any insertion checks, which means that any object that could be considered thrown (which can be done by being launched at high velocity) could end up inside of a disposals bin. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Stuff was inside of disposals bin that shouldn't be in disposals bin. And also toilets.

## Technical details
<!-- Summary of code changes for easier review. -->

Blacklisted EntityStorage component from disposals/toilets; as far as I could tell that was only really seen on boxes, crates, lockers and pet carriers.

Also added a cancellable event to the ThrowInsertComponent that other systems can subscribe to for cancelling a throw insert.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/ea58ca3e-bf15-4f1a-90a6-eaa852b78454

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Pet carriers can no longer be put into toilets.
- fix: You can now escape containers (such as pet carriers) inserted into other containers.
- fix: Thrown items no longer bypasses insertion checks for toilets and disposal units.
