### PR TITLE
[ADMIN] Automatically Add Minds.(setmind command)

### DIFF
--- a/Content.Server/Administration/Commands/SetMindCommand.cs
+++ b/Content.Server/Administration/Commands/SetMindCommand.cs
@@ -1,4 +1,4 @@
-using Content.Server.Players;
+using Content.Server.Mind.Commands;
 using Content.Shared.Administration;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
@@ -6,83 +6,82 @@ using Content.Shared.Players;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 
-namespace Content.Server.Administration.Commands
+namespace Content.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+sealed class SetMindCommand : IConsoleCommand
 {
-    [AdminCommand(AdminFlags.Admin)]
-    sealed class SetMindCommand : IConsoleCommand
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    public string Command => "setmind";
+
+    public string Description => Loc.GetString("set-mind-command-description", ("requiredComponent", nameof(MindContainerComponent)));
+
+    public string Help => Loc.GetString("set-mind-command-help-text", ("command", Command));
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        [Dependency] private readonly IEntityManager _entManager = default!;
-
-        public string Command => "setmind";
-
-        public string Description => Loc.GetString("set-mind-command-description", ("requiredComponent", nameof(MindContainerComponent)));
-
-        public string Help => Loc.GetString("set-mind-command-help-text", ("command", Command));
-
-        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        if (args.Length < 2)
         {
-            if (args.Length < 2)
-            {
-                shell.WriteLine(Loc.GetString("shell-wrong-arguments-number"));
-                return;
-            }
-
-            if (!int.TryParse(args[0], out var entInt))
-            {
-                shell.WriteLine(Loc.GetString("shell-entity-uid-must-be-number"));
-                return;
-            }
-
-            bool ghostOverride = true;
-            if (args.Length > 2)
-            {
-                ghostOverride = bool.Parse(args[2]);
-            }
-
-            var nent = new NetEntity(entInt);
-
-            if (!_entManager.TryGetEntity(nent, out var eUid))
-            {
-                shell.WriteLine(Loc.GetString("shell-invalid-entity-id"));
-                return;
-            }
-
-            if (!_entManager.HasComponent<MindContainerComponent>(eUid))
-            {
-                shell.WriteLine(Loc.GetString("set-mind-command-target-has-no-mind-message"));
-                return;
-            }
-
-            if (!IoCManager.Resolve<IPlayerManager>().TryGetSessionByUsername(args[1], out var session))
-            {
-                shell.WriteLine(Loc.GetString("shell-target-player-does-not-exist"));
-                return;
-            }
-
-            // hm, does player have a mind? if not we may need to give them one
-            var playerCData = session.ContentData();
-            if (playerCData == null)
-            {
-                shell.WriteLine(Loc.GetString("set-mind-command-target-has-no-content-data-message"));
-                return;
-            }
-
-            var mindSystem = _entManager.System<SharedMindSystem>();
-            var metadata = _entManager.GetComponent<MetaDataComponent>(eUid.Value);
-
-            var mind = playerCData.Mind ?? mindSystem.CreateMind(session.UserId, metadata.EntityName);
-
-            mindSystem.TransferTo(mind, eUid, ghostOverride);
+            shell.WriteLine(Loc.GetString("shell-wrong-arguments-number"));
+            return;
         }
 
-        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        if (!int.TryParse(args[0], out var entInt))
         {
-            if (args.Length == 2)
-            {
-                return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), Loc.GetString("cmd-mind-command-hint"));
-            }
-
-            return CompletionResult.Empty;
+            shell.WriteLine(Loc.GetString("shell-entity-uid-must-be-number"));
+            return;
         }
+
+        bool ghostOverride = true;
+        if (args.Length > 2)
+        {
+            ghostOverride = bool.Parse(args[2]);
+        }
+
+        var nent = new NetEntity(entInt);
+
+        if (!_entManager.TryGetEntity(nent, out var eUid))
+        {
+            shell.WriteLine(Loc.GetString("shell-invalid-entity-id"));
+            return;
+        }
+
+        if (!_entManager.HasComponent<MindContainerComponent>(eUid))
+        {
+            shell.WriteLine(Loc.GetString("set-mind-command-target-add-mind-message", ("uid", _entManager.ToPrettyString(eUid))));
+            MakeSentientCommand.MakeSentient(eUid.Value, _entManager);
+        }
+
+        if (!IoCManager.Resolve<IPlayerManager>().TryGetSessionByUsername(args[1], out var session))
+        {
+            shell.WriteLine(Loc.GetString("shell-target-player-does-not-exist"));
+            return;
+        }
+
+        // hm, does player have a mind? if not we may need to give them one
+        var playerCData = session.ContentData();
+        if (playerCData == null)
+        {
+            shell.WriteLine(Loc.GetString("set-mind-command-target-has-no-content-data-message"));
+            return;
+        }
+
+        var mindSystem = _entManager.System<SharedMindSystem>();
+        var metadata = _entManager.GetComponent<MetaDataComponent>(eUid.Value);
+
+        var mind = playerCData.Mind ?? mindSystem.CreateMind(session.UserId, metadata.EntityName);
+
+        mindSystem.TransferTo(mind, eUid, ghostOverride);
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 2)
+        {
+            return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), Loc.GetString("cmd-mind-command-hint"));
+        }
+
+        return CompletionResult.Empty;
     }
 }

--- a/Resources/Locale/en-US/administration/commands/set-mind-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/set-mind-command.ftl
@@ -1,5 +1,5 @@
 set-mind-command-description = Transfers a mind to the specified entity. The entity must have a {$requiredComponent}. By default this will force minds that are currently visiting other entities to return (i.e., return a ghost to their main body).
 set-mind-command-help-text = Usage: {$command} <entityUid> <username> [unvisit]
 set-mind-command-target-has-no-content-data-message = Target player does not have content data (wtf?)
-set-mind-command-target-has-no-mind-message = Target entity does not have a mind (did you forget to make sentient?)
+set-mind-command-target-add-mind-message = Target entity does not have a mind. For {$uid} adding mind.
 cmd-mind-command-hint = username

--- a/Resources/Locale/en-US/administration/commands/set-mind-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/set-mind-command.ftl
@@ -1,4 +1,4 @@
-set-mind-command-description = Transfers a mind to the specified entity. The entity must have a {$requiredComponent}. By default this will force minds that are currently visiting other entities to return (i.e., return a ghost to their main body).
+set-mind-command-description = Transfers a mind to the specified entity. If the entity does not have {$requiredComponent}, one will be added for it. By default this will force minds that are currently visiting other entities to return (i.e., return a ghost to their main body).
 set-mind-command-help-text = Usage: {$command} <entityUid> <username> [unvisit]
 set-mind-command-target-has-no-content-data-message = Target player does not have content data (wtf?)
 set-mind-command-target-add-mind-message = Target entity {$uid} did not have a mind previously, so one has been added.

--- a/Resources/Locale/en-US/administration/commands/set-mind-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/set-mind-command.ftl
@@ -1,5 +1,5 @@
 set-mind-command-description = Transfers a mind to the specified entity. The entity must have a {$requiredComponent}. By default this will force minds that are currently visiting other entities to return (i.e., return a ghost to their main body).
 set-mind-command-help-text = Usage: {$command} <entityUid> <username> [unvisit]
 set-mind-command-target-has-no-content-data-message = Target player does not have content data (wtf?)
-set-mind-command-target-add-mind-message = Target entity does not have a mind. For {$uid} adding mind.
+set-mind-command-target-add-mind-message = Target entity {$uid} did not have a mind previously, so one has been added.
 cmd-mind-command-hint = username


### PR DESCRIPTION
## About the PR
This PR modifies the `set-mind` command to automatically add a mind to an entity that doesn't have one. If the target entity lacks a `MindContainerComponent`, it now provides feedback to the user indicating that a mind is being added, and calls `MakeSentientCommand.MakeSentient` to make the entity sentient.

## Why / Balance
This change makes the `set-mind` command more flexible by allowing administrations to set minds in entities that aren't initially sentient. This enhances the functionality of the command, enabling it to be used on a broader range of entities, including non-sentient ones. It also improves user feedback by letting them know when the system is automatically making an entity sentient.
- This also solves the problem mentioned here (https://github.com/space-wizards/space-station-14/issues/35493)

## Technical details
- The check for the `MindContainerComponent` was modified so that if the target entity does not have one, it will add a mind to the entity.
- The message shown to the user was updated to indicate that the mind is being added, and it includes the entity's UID.
- The `MakeSentientCommand.MakeSentient` function is called to ensure the entity becomes sentient if it is not already.

## Media
![image](https://github.com/user-attachments/assets/afe787b2-7a8d-408d-acef-5643787bd0fb)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
:cl: Schrodinger71
ADMIN:
- tweak: `setmind` command now automatically adds a mind to entities that are not sentient and provides feedback when doing so.
