### PR TITLE
fix subwizard gamerule

### DIFF
--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -33,7 +33,6 @@
 
 # Needs testing
 - type: entity
-  abstract: true
   parent: BaseWizardRule
   id: SubWizard
   components:


### PR DESCRIPTION
Caused an Heisentest at 5% chance.
https://github.com/space-wizards/space-station-14/actions/runs/13572577451/job/37941034977#step:10:407
Should not be abstract so that it can actually be spawned.
No clue why the linter did not catch that.