### PR TITLE
[HOTFIX] - Players with unknown playtimes now are tagged as new players

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -74,7 +74,7 @@ namespace Content.Client.Administration.UI.Bwoink
                 if (info.Antag && info.ActiveThisRound)
                     sb.Append(new Rune(0x1F5E1)); // 🗡
 
-                if (info.OverallPlaytime <= TimeSpan.FromMinutes(_cfg.GetCVar(CCVars.NewPlayerThreshold)))
+                if (info.OverallPlaytime == null || info.OverallPlaytime <= TimeSpan.FromMinutes(_cfg.GetCVar(CCVars.NewPlayerThreshold)))
                     sb.Append(new Rune(0x23F2)); // ⏲
 
                 sb.AppendFormat("\"{0}\"", text);

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -36,6 +36,9 @@ namespace Content.Client.Administration.UI.Bwoink
             RobustXamlLoader.Load(this);
             IoCManager.InjectDependencies(this);
 
+            var newPlayerThreshold = 0;
+            _cfg.OnValueChanged(CCVars.NewPlayerThreshold, (val) => { newPlayerThreshold = val; }, true);
+
             var uiController = _ui.GetUIController<AHelpUIController>();
             if (uiController.UIHelper is not AdminAHelpUIHandler helper)
                 return;
@@ -74,7 +77,6 @@ namespace Content.Client.Administration.UI.Bwoink
                 if (info.Antag && info.ActiveThisRound)
                     sb.Append(new Rune(0x1F5E1)); // 🗡
 
-                var newPlayerThreshold = _cfg.GetCVar(CCVars.NewPlayerThreshold);
                 if (newPlayerThreshold != 0 && (info.OverallPlaytime == null || info.OverallPlaytime <= TimeSpan.FromMinutes(newPlayerThreshold)))
                     sb.Append(new Rune(0x23F2)); // ⏲
 

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -74,7 +74,8 @@ namespace Content.Client.Administration.UI.Bwoink
                 if (info.Antag && info.ActiveThisRound)
                     sb.Append(new Rune(0x1F5E1)); // 🗡
 
-                if (info.OverallPlaytime == null || info.OverallPlaytime <= TimeSpan.FromMinutes(_cfg.GetCVar(CCVars.NewPlayerThreshold)))
+                var newPlayerThreshold = _cfg.GetCVar(CCVars.NewPlayerThreshold);
+                if (newPlayerThreshold != 0 && (info.OverallPlaytime == null || info.OverallPlaytime <= TimeSpan.FromMinutes(newPlayerThreshold)))
                     sb.Append(new Rune(0x23F2)); // ⏲
 
                 sb.AppendFormat("\"{0}\"", text);

--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace Content.Client.Administration.UI.Bwoink
 
                 Title = $"{sel.CharacterName} / {sel.Username} | {Loc.GetString("generic-playtime-title")}: ";
 
-                Title += sel.OverallPlaytime != null ? sel.PlaytimeString : Loc.GetString("unknown-playtime");
+                Title += sel.OverallPlaytime != null ? sel.PlaytimeString : Loc.GetString("generic-unknown-title");
             };
 
             OnOpen += () =>

--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
@@ -22,12 +22,9 @@ namespace Content.Client.Administration.UI.Bwoink
                     return;
                 }
 
-                Title = $"{sel.CharacterName} / {sel.Username}";
+                Title = $"{sel.CharacterName} / {sel.Username} | {Loc.GetString("generic-playtime-title")}: ";
 
-                if (sel.OverallPlaytime != null)
-                {
-                    Title += $" | {Loc.GetString("generic-playtime-title")}: {sel.PlaytimeString}";
-                }
+                Title += sel.OverallPlaytime != null ? sel.PlaytimeString : Loc.GetString("unknown-playtime");
             };
 
             OnOpen += () =>

--- a/Resources/Locale/en-US/generic.ftl
+++ b/Resources/Locale/en-US/generic.ftl
@@ -13,5 +13,6 @@ generic-hours = hours
 generic-minutes = minutes
 
 generic-playtime-title = Playtime
+unknown-playtime = UNKNOWN
 
 generic-confirm = Confirm

--- a/Resources/Locale/en-US/generic.ftl
+++ b/Resources/Locale/en-US/generic.ftl
@@ -13,6 +13,5 @@ generic-hours = hours
 generic-minutes = minutes
 
 generic-playtime-title = Playtime
-unknown-playtime = UNKNOWN
 
 generic-confirm = Confirm


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title! The admins wanted it.

## Technical details
<!-- Summary of code changes for easier review. -->
The playtime of players is sometimes null (This sometimes can occur when the players are first joining the server but can also randomly happen to older players as well). This doesn't fix the root issue, but when it does occur it will tag these players as having unknown playtime and the new player icon in the ahelp menu

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![Screenshot from 2025-02-27 11-23-58](https://github.com/user-attachments/assets/09f11c3e-4a38-4b4d-b8d8-3f21f87d4ed6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->