### PR TITLE
Reptilians Can Eat Chicken Nuggets

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -257,6 +257,7 @@
   - type: Tag
     tags:
       - Nugget
+      - Meat
   - type: Sprite
     sprite: Objects/Consumable/Food/Baked/nuggets.rsi
     layers:


### PR DESCRIPTION
## About the PR
I made it so Reptilians can eat chicken nuggets by adding a meat tag to the entity.

## Why / Balance
Reptilians can eat foods that are fruit or meat based, regardless of filler. For instance, they can eat cakes as long as they have fruit in them. Chicken nuggets are pretty decidedly meat, and even with EXCESSIVE breading, it feels like an oversight that they can't eat them.

## Technical details
Added a meat tag to the chicken nugget entity in misc.yml in the Food/Baked category.

## Media
[Here is a demonstration video of a Reptilian eating a whole box of chicken nuggets.](https://www.youtube.com/watch?v=CLnOSBH2XaM)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl: AgentSmithRadio
- tweak: Reptilians can now eat chicken nuggets.
