### PR TITLE
Save Space Station 14 from the Toilet Gibber Forever

### DIFF
--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Body.Components;
 using Content.Shared.Buckle;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Storage.Components;
@@ -23,7 +24,7 @@ public sealed class FoldableSystem : EntitySystem
 
         SubscribeLocalEvent<FoldableComponent, ComponentInit>(OnFoldableInit);
         SubscribeLocalEvent<FoldableComponent, ContainerGettingInsertedAttemptEvent>(OnInsertEvent);
-        SubscribeLocalEvent<FoldableComponent, StoreMobInItemContainerAttemptEvent>(OnStoreThisAttempt);
+        SubscribeLocalEvent<FoldableComponent, InsertIntoEntityStorageAttemptEvent>(OnStoreThisAttempt);
         SubscribeLocalEvent<FoldableComponent, StorageOpenAttemptEvent>(OnFoldableOpenAttempt);
 
         SubscribeLocalEvent<FoldableComponent, StrapAttemptEvent>(OnStrapAttempt);
@@ -45,10 +46,8 @@ public sealed class FoldableSystem : EntitySystem
             args.Cancelled = true;
     }
 
-    public void OnStoreThisAttempt(EntityUid uid, FoldableComponent comp, ref StoreMobInItemContainerAttemptEvent args)
+    public void OnStoreThisAttempt(EntityUid uid, FoldableComponent comp, ref InsertIntoEntityStorageAttemptEvent args)
     {
-        args.Handled = true;
-
         if (comp.IsFolded)
             args.Cancelled = true;
     }

--- a/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/SharedEntityStorageComponent.cs
@@ -65,12 +65,6 @@ public abstract partial class SharedEntityStorageComponent : Component
     public float EnteringRange = 0.18f;
 
     /// <summary>
-    /// If true, there may be mobs inside the container, even if the container is an Item
-    /// </summary>
-    [DataField]
-    public bool ItemCanStoreMobs = false;
-
-    /// <summary>
     /// Whether or not to show the contents when the storage is closed
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
@@ -153,10 +147,7 @@ public sealed class EntityStorageComponentState : ComponentState
 }
 
 [ByRefEvent]
-public record struct InsertIntoEntityStorageAttemptEvent(bool Cancelled = false);
-
-[ByRefEvent]
-public record struct StoreMobInItemContainerAttemptEvent(bool Handled, bool Cancelled = false);
+public record struct InsertIntoEntityStorageAttemptEvent(EntityUid ItemToInsert, bool Cancelled = false);
 
 [ByRefEvent]
 public record struct StorageOpenAttemptEvent(EntityUid User, bool Silent, bool Cancelled = false);

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -250,6 +250,11 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         var count = 0;
         foreach (var entity in ev.Contents)
         {
+            // TODO: Write a better lookup query that does not cause entity storages to attempt to insert themselves
+            // into themselves.
+            if (entity == uid)
+                continue;
+
             if (!ev.BypassChecks.Contains(entity))
             {
                 if (!CanInsert(entity, uid, component))
@@ -342,9 +347,8 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         if (component.Whitelist != null)
             return _whitelistSystem.IsValid(component.Whitelist, toInsert);
 
-        // Mobs can be inserted into entity storage if the container isn't an item. All other entities must be an item.
-        // Being a mob has a higher priority than being an tem.
-        return HasComp<BodyComponent>(toInsert) ? !HasComp<ItemComponent>(container) : HasComp<ItemComponent>(toInsert);
+        // The inserted entity must be a mob or an item.
+        return HasComp<BodyComponent>(toInsert) || HasComp<ItemComponent>(toInsert);
     }
 
     public bool TryOpenStorage(EntityUid user, EntityUid target, bool silent = false)

--- a/Resources/Prototypes/Entities/Objects/Misc/arabianlamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/arabianlamp.yml
@@ -13,7 +13,6 @@
     breakOnAccessBreaker: false
   - type: EntityStorage
     capacity: 1 # Its smol.
-    itemCanStoreMobs: false #  just leaving this here explicitly since I know at some point someone will want to use this to hold a mob. This also prevents it from becoming His Grace.
   # - type: StorageFill
     # contents:
       # - id: PuddleSparkle # Ha! Cute. Unfortunately it despawns before the container is likely to open.

--- a/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: PetCarrier
   name: big pet carrier
-  description: Allows large animals to be carried comfortably.
+  description: Allows large animals to be carried comfortably. It smells vaguely of toilet water and explosives.
   parent: BaseStructureDynamic
   components:
   - type: Sprite
@@ -36,7 +36,9 @@
   - type: EntityStorage
     capacity: 1
     airtight: false
-    itemCanStoreMobs: true
+    whitelist:
+      tags:
+        - VimPilot # If it can fit in a Vim it can fit in a pet carrier.
   - type: Weldable
   - type: ResistLocker
   - type: PlaceableSurface

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -44,6 +44,10 @@
   - type: EntityStorage
     capacity: 1
     isCollidableWhenOpen: true
+    whitelist: # Use a tag whitelist rather than filtering for PerishableComponent to avoid chefs using body bags for food preservation
+      tags:
+        - VimPilot # Pets
+        - CanPilot # People
     closeSound:
       path: /Audio/Misc/zip.ogg
     openSound:

--- a/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
@@ -128,6 +128,9 @@
     whitelist:
       components:
       - Artifact
+      tags:
+      - CanPilot # People
+      - VimPilot # Pets
   - type: Appearance
   - type: GenericVisualizer
     visuals:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Pet carriers are an obvious vector for abuse that requires reworking how EntityStorage actually works to fix, a wonderful change that has a high risk of unintended consequences in other code! The description of the pet carrier has been updated to reference the infamous Toilet Gibber of 2545.

## Why / Balance
Currently an obvious vector for kidnapping and insta-gibbing people thanks to a wonderful combination of toilets and minibombs. Only rarely used for their intended purpose, and without crew objectives to protect pets their "intended unintended" purpose to facilitate dognapping Ian ends up feeling a bit of a weak reason to cope with their abuse.

## Technical details
EntityStorage now actually uses its whitelist properly.
A redundant event has been removed.

## Media

https://github.com/user-attachments/assets/b8890468-7178-41c6-b086-68af2b3fc95d



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The event ```StoreMobInItemContainerAttemptEvent``` has been removed. Use ```InsertIntoEntityStorageAttemptEvent``` instead, checking if the item being inserted is a mob via ```HasComp<BodyComponent>``` or another solution of your preference.

**Changelog**
:cl:
- fix: Pet carriers now only carry pets. preventing various unintended, albeit hilarious, activities. 