### PR TITLE
Increase line spacing of the admin overlay

### DIFF
--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -76,7 +76,7 @@ internal sealed class AdminNameOverlay : Overlay
             }
 
             var uiScale = _userInterfaceManager.RootControl.UIScale;
-            var lineoffset = new Vector2(0f, 11f) * uiScale;
+            var lineoffset = new Vector2(0f, 14f) * uiScale;
             var screenCoordinates = _eyeManager.WorldToScreen(aabb.Center +
                                                               new Angle(-_eyeManager.CurrentEye.Rotation).RotateVec(
                                                                   aabb.TopRight - aabb.Center)) + new Vector2(1f, 7f);


### PR DESCRIPTION
## Why / Balance
Letters overlap

## Media
live: 11
![Screenshot_2025-02-28_204716](https://github.com/user-attachments/assets/2ab5ee3d-c5d5-4b00-9ed1-1189bf0f0f79)

proposed: 14
![Screenshot_2025-02-28_204151__14](https://github.com/user-attachments/assets/e98c3df5-6864-4741-841c-570d0e34cf0f)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->