### PR TITLE
[Draft] Replacing mole to unit conversions with mass to unit conversions.

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/Components/GasCondenserComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasCondenserComponent.cs
@@ -27,13 +27,4 @@ public sealed partial class GasCondenserComponent : Component
     /// </summary>
     [ViewVariables]
     public Entity<SolutionComponent>? Solution = null;
-
-    /// <summary>
-    /// For a condenser, how many U of reagents are given for a molar mass of 1
-    /// </summary>
-    /// <remarks>
-    /// Taken based on the idea that one mole of Carbon-12 should equal 1u, because chemistry
-    /// </remarks>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float MolarMassToReagentMultiplier = 0.0833f;
 }

--- a/Content.Server/Atmos/Piping/Unary/Components/GasCondenserComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasCondenserComponent.cs
@@ -29,12 +29,11 @@ public sealed partial class GasCondenserComponent : Component
     public Entity<SolutionComponent>? Solution = null;
 
     /// <summary>
-    /// For a condenser, how many U of reagents are given per each mole of gas.
+    /// For a condenser, how many U of reagents are given for a molar mass of 1
     /// </summary>
     /// <remarks>
-    /// Derived from a standard of 500u per canister:
-    /// 400u / 1871.71051 moles per canister
+    /// Taken based on the idea that one mole of Carbon-12 should equal 1u, because chemistry
     /// </remarks>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float MolesToReagentMultiplier = 0.2137f;
+    public float MolarMassToReagentMultiplier = 0.0833f;
 }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCondenserSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCondenserSystem.cs
@@ -51,16 +51,15 @@ public sealed class GasCondenserSystem : EntitySystem
             if (_atmosphereSystem.GetGas(i).Reagent is not { } gasReagent)
                 continue;
 
-            var molarMassToReagentMultiplier = entity.Comp.MolarMassToReagentMultiplier;
             var molarMass = _atmosphereSystem.GetGas(i).MolarMass;
-            var amount = FixedPoint2.Min(FixedPoint2.New(moles * molarMassToReagentMultiplier * molarMass), solution.AvailableVolume);
+            var amount = FixedPoint2.Min(FixedPoint2.New(moles * Atmospherics.MolarMassToReagentMultiplier * molarMass), solution.AvailableVolume);
             if (amount <= 0)
                 continue;
 
             solution.AddReagent(gasReagent, amount);
 
             // if we have leftover reagent, then convert it back to moles and put it back in the mixture.
-            inlet.Air.AdjustMoles(i, moles - (amount.Float() / (molarMassToReagentMultiplier * molarMass)));
+            inlet.Air.AdjustMoles(i, moles - (amount.Float() / (Atmospherics.MolarMassToReagentMultiplier * molarMass)));
         }
 
         _solution.UpdateChemicals(entity.Comp.Solution.Value);

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCondenserSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCondenserSystem.cs
@@ -51,15 +51,16 @@ public sealed class GasCondenserSystem : EntitySystem
             if (_atmosphereSystem.GetGas(i).Reagent is not { } gasReagent)
                 continue;
 
-            var moleToReagentMultiplier = entity.Comp.MolesToReagentMultiplier;
-            var amount = FixedPoint2.Min(FixedPoint2.New(moles * moleToReagentMultiplier), solution.AvailableVolume);
+            var molarMassToReagentMultiplier = entity.Comp.MolarMassToReagentMultiplier;
+            var molarMass = _atmosphereSystem.GetGas(i).MolarMass;
+            var amount = FixedPoint2.Min(FixedPoint2.New(moles * molarMassToReagentMultiplier * molarMass), solution.AvailableVolume);
             if (amount <= 0)
                 continue;
 
             solution.AddReagent(gasReagent, amount);
 
             // if we have leftover reagent, then convert it back to moles and put it back in the mixture.
-            inlet.Air.AdjustMoles(i, moles - (amount.Float() / moleToReagentMultiplier));
+            inlet.Air.AdjustMoles(i, moles - (amount.Float() / (molarMassToReagentMultiplier * molarMass)));
         }
 
         _solution.UpdateChemicals(entity.Comp.Solution.Value);

--- a/Content.Server/Atmos/Reactions/WaterVaporReaction.cs
+++ b/Content.Server/Atmos/Reactions/WaterVaporReaction.cs
@@ -17,7 +17,7 @@ namespace Content.Server.Atmos.Reactions
 
         [DataField("gas")] public int GasId { get; private set; } = 0;
 
-        [DataField("molesPerUnit")] public float MolesPerUnit { get; private set; } = 1;
+        [DataField("molesPerUnit")] public float MolesPerTick { get; private set; } = 1;
 
         public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
         {
@@ -30,14 +30,14 @@ namespace Content.Server.Atmos.Reactions
                 return ReactionResult.NoReaction;
 
             // If we don't have enough moles of the specified gas, do nothing.
-            if (mixture.GetMoles(GasId) < MolesPerUnit)
+            if (mixture.GetMoles(GasId) < MolesPerTick)
                 return ReactionResult.NoReaction;
 
             // Remove the moles from the mixture...
-            mixture.AdjustMoles(GasId, -MolesPerUnit);
+            mixture.AdjustMoles(GasId, -MolesPerTick);
 
             var tileRef = atmosphereSystem.GetTileRef(tile);
-            atmosphereSystem.Puddle.TrySpillAt(tileRef, new Solution(Reagent, FixedPoint2.New(MolesPerUnit)), out _, sound: false);
+            atmosphereSystem.Puddle.TrySpillAt(tileRef, new Solution(Reagent, FixedPoint2.New(MolesPerTick * Atmospherics.MolarMassToReagentMultiplier * atmosphereSystem.GetGas(GasId).MolarMass)), out _, sound: false);
 
             return ReactionResult.Reacting;
         }

--- a/Content.Server/Body/Systems/LungSystem.cs
+++ b/Content.Server/Body/Systems/LungSystem.cs
@@ -89,6 +89,7 @@ public sealed class LungSystem : EntitySystem
         {
             var i = (int) gasId;
             var moles = gas[i];
+            var molarMass = _atmos.GetGas(i).MolarMass;
             if (moles <= 0)
                 continue;
 
@@ -96,7 +97,7 @@ public sealed class LungSystem : EntitySystem
             if (reagent is null)
                 continue;
 
-            var amount = moles * Atmospherics.BreathMolesToReagentMultiplier;
+            var amount = moles * Atmospherics.MolarMassToReagentMultiplier * molarMass;
             solution.AddReagent(reagent, amount);
         }
     }

--- a/Content.Server/EntityEffects/Effects/ModifyLungGas.cs
+++ b/Content.Server/EntityEffects/Effects/ModifyLungGas.cs
@@ -38,7 +38,7 @@ public sealed partial class ModifyLungGas : EntityEffect
         {
             foreach (var (gas, ratio) in _ratios)
             {
-                var quantity = ratio * amount / Atmospherics.BreathMolesToReagentMultiplier;
+                var quantity = ratio * amount ;
                 if (quantity < 0)
                     quantity = Math.Max(quantity, -lung.Air[(int) gas]);
                 lung.Air.AdjustMoles(gas, quantity);

--- a/Content.Server/EntityEffects/Effects/Oxygenate.cs
+++ b/Content.Server/EntityEffects/Effects/Oxygenate.cs
@@ -8,7 +8,7 @@ namespace Content.Server.EntityEffects.Effects;
 public sealed partial class Oxygenate : EntityEffect
 {
     [DataField]
-    public float Factor = 1f;
+    public float Factor = 12000f;
 
     // JUSTIFICATION: This is internal magic that players never directly interact with.
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)

--- a/Content.Server/EntityEffects/Effects/Oxygenate.cs
+++ b/Content.Server/EntityEffects/Effects/Oxygenate.cs
@@ -8,7 +8,7 @@ namespace Content.Server.EntityEffects.Effects;
 public sealed partial class Oxygenate : EntityEffect
 {
     [DataField]
-    public float Factor = 12000f;
+    public float Factor = 500f;
 
     // JUSTIFICATION: This is internal magic that players never directly interact with.
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -336,7 +336,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     I hereby decree. This is Arbitrary Suck my Dick
         /// </summary>
-        public const float BreathMolesToReagentMultiplier = 1144;
+        public const float MolarMassToReagentMultiplier = 0.08333f;
 
         #region Pipes
 

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -86,7 +86,7 @@
         damage:
           types:
             Poison:
-              1
+              0.5
       # We need a metabolism effect on reagent removal
       - !type:AdjustAlert
         alertType: Toxins
@@ -132,7 +132,7 @@
         damage:
           types:
             Radiation:
-              1
+              2
       # We need a metabolism effect on reagent removal
       - !type:AdjustAlert
         alertType: Toxins


### PR DESCRIPTION
This is my first C# PR, but I may have bitten off a bit more than I can chew (feel free to close if you don't like it)

## About the PR
In four places, direct conversions between moles and units have been replaced with conversions between mass and units (mass being equal to moles * relative molecular mass). The current method is tuned such that one mole of carbon-12 would be equal to 1u (because chemistry).

Tritium and Plasma have also been given slight buffs and nerfs to their damage, as they have a very low and high molecular mass respectively. These aren't final, however (see Merge Requirements)

## Why / Balance
Why? Because mass -> units is more ✨ realistic ✨.
Balance? Nope, see Merge Requirements.

## Technical details
- Adds a constant (Atmospherics.MolarMassToReagentMultiplier) that is just ~1/12
- Slightly reworks various areas of the code to include molar mass and the constant to the calculations
- Yeets the CreateGas Multiplier constant and the GasCondenser MolesToReagentMultiplier constant, in favour of the above method.
- Plasma + Trit YAML balance change

## Merge Requirements
The main issue with this PR, and the reason it is still a draft, is that the breathing system is fucked and I can't understand it. With the modifications made to the breathing system, saturation decreases at ~18.25kPa (as opposed to ~18.0kPa). Additionally, the "Factor" constant required raising to ~500 for _some_ reason to prevent everyone from suffocation, but doesn't affect the survivable pressure??

Atmos code is cursed. The issue isn't that major, but if the maintainers want it reverted, I'm not going to be the one figuring out how the breathing system works.

Also, the tritium and plasma buffs/nerfs should be playtested, I'll do that myself, but only if the above issue is fixed/accepted as a reasonable change.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Since this is still a draft, the changes aren't final but here's the current breaking changes:
Atmospherics.cs: Atmospherics.BreathMolesToReagentMultiplier has been renamed to Atmospherics.MolarMassToReagentMultiplier, and has been expanded in scope.
GasCondenserComponent.cs: The MolesToReagentMultiplier field (previously VV ReadWrite) has been removed

**Changelog**
IDK if it needs a changelog, but I'll amend it with one if the PR gets approval/conceptual approval and it is needed.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
