### PR TITLE
Reorganize speech traits into accents and traits

### DIFF
--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -61,5 +61,5 @@ humanoid-profile-editor-trait-count-hint = Points available: [{$current}/{$max}]
 
 trait-category-disabilities = Disabilities
 trait-category-speech-accents = Speech Accents
-trait-category-speech-traits = Speech traits
+trait-category-speech-traits = Speech Traits
 trait-category-quirks = Quirks

--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -60,5 +60,6 @@ humanoid-profile-editor-no-traits = No traits available
 humanoid-profile-editor-trait-count-hint = Points available: [{$current}/{$max}]
 
 trait-category-disabilities = Disabilities
-trait-category-speech = Speech traits
+trait-category-speech-accents = Speech Accents
+trait-category-speech-traits = Speech traits
 trait-category-quirks = Quirks

--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -3,8 +3,13 @@
   name: trait-category-disabilities
 
 - type: traitCategory
-  id: SpeechTraits
-  name: trait-category-speech
+  id: SpeechAccent # Accents from a language or dialect
+  name: trait-category-speech-accents
+  maxTraitPoints: 2
+
+- type: traitCategory
+  id: SpeechTraits # Modifies your speech, like a stutter or lisp
+  name: trait-category-speech-traits
   maxTraitPoints: 2
 
 - type: traitCategory

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -69,16 +69,6 @@
   components:
   - type: SpanishAccent
 
-- type: trait
-  id: Liar
-  name: trait-liar-name
-  description: trait-liar-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: ReplacementAccent
-    accent: liar
-
 
 
 ##Traits
@@ -104,5 +94,15 @@
   cost: 1
   components:
   - type: FrontalLisp
+
+- type: trait
+  id: Liar
+  name: trait-liar-name
+  description: trait-liar-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: ReplacementAccent
+    accent: liar
 
 

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -1,11 +1,11 @@
-# Free
+##Accents
 
 - type: trait
   id: Accentless
   name: trait-accentless-name
   description: trait-accentless-desc
-  category: SpeechTraits
-  cost: 2
+  category: SpeechAccent
+  cost: 1
   components:
   - type: Accentless
     removes:
@@ -14,13 +14,11 @@
     - type: ReplacementAccent
       accent: dwarf
 
-# 1 Cost
-
 - type: trait
   id: SouthernAccent
   name: trait-southern-name
   description: trait-southern-desc
-  category: SpeechTraits
+  category: SpeechAccent
   cost: 1
   components:
   - type: SouthernAccent
@@ -29,26 +27,16 @@
   id: PirateAccent
   name: trait-pirate-accent-name
   description: trait-pirate-accent-desc
-  category: SpeechTraits
+  category: SpeechAccent
   cost: 1
   components:
   - type: PirateAccent
 
 - type: trait
-  id: CowboyAccent
-  name: trait-cowboy-name
-  description: trait-cowboy-desc
-  category: SpeechTraits
-  cost: 1
-  components:
-  - type: ReplacementAccent
-    accent: cowboy
-
-- type: trait
   id: GermanAccent
   name: trait-german-name
   description: trait-german-desc
-  category: SpeechTraits
+  category: SpeechAccent
   cost: 1
   components:
   - type: GermanAccent
@@ -57,7 +45,7 @@
   id: ItalianAccent
   name: trait-italian-name
   description: trait-italian-desc
-  category: SpeechTraits
+  category: SpeechAccent
   cost: 1
   components:
   - type: ReplacementAccent
@@ -67,7 +55,7 @@
   id: FrenchAccent
   name: trait-french-name
   description: trait-french-desc
-  category: SpeechTraits
+  category: SpeechAccent
   cost: 1
   components:
   - type: FrenchAccent
@@ -76,7 +64,7 @@
   id: SpanishAccent
   name: trait-spanish-name
   description: trait-spanish-desc
-  category: SpeechTraits
+  category: SpeechAccent
   cost: 1
   components:
   - type: SpanishAccent
@@ -91,14 +79,16 @@
   - type: ReplacementAccent
     accent: liar
 
-# 2 Cost
+
+
+##Traits
 
 - type: trait
   id: SocialAnxiety
   name: trait-socialanxiety-name
   description: trait-socialanxiety-desc
   category: SpeechTraits
-  cost: 2
+  cost: 1
   components:
   - type: StutteringAccent
     matchRandomProb: 0.1
@@ -111,6 +101,8 @@
   name: trait-frontal-lisp-name
   description: trait-frontal-lisp-desc
   category: SpeechTraits
-  cost: 2
+  cost: 1
   components:
   - type: FrontalLisp
+
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Accents are now split into Speech Accents and Speech Traits
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Allows for better point distribution balancing between language accents and allows for more flexibility with future accents or traits
## Technical details
<!-- Summary of code changes for easier review. -->
Added a new trait category
Reorganized speech.yml
Added and modified localization
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/b62424bc-9d2a-4adb-ab8d-eece2c3f706f)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
SpeechTraits was split into SpeechTraits and SpeechAccents, including localization changes.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Minemoder
- tweak: Accents have been split into Accents and Traits.
