### PR TITLE
Add stamina and mob damage playtest modifiers

### DIFF
--- a/Content.Shared/CCVar/CCVars.Playtest.cs
+++ b/Content.Shared/CCVar/CCVars.Playtest.cs
@@ -78,7 +78,7 @@ public sealed partial class CCVars
             CVarDef.Create("playtest.explosion_damage_modifier", 1f, CVar.SERVER | CVar.REPLICATED);
 
         /// <summary>
-        ///     Scales the damage dealt to mobs in the game (i.e. entities with MobComponent).
+        ///     Scales the damage dealt to mobs in the game (i.e. entities with MobStateComponent).
         /// </summary>
         [CVarControl(AdminFlags.VarEdit)]
         public static readonly CVarDef<float> PlaytestMobDamageModifier =

--- a/Content.Shared/CCVar/CCVars.Playtest.cs
+++ b/Content.Shared/CCVar/CCVars.Playtest.cs
@@ -77,4 +77,18 @@ public sealed partial class CCVars
         public static readonly CVarDef<float> PlaytestExplosionDamageModifier =
             CVarDef.Create("playtest.explosion_damage_modifier", 1f, CVar.SERVER | CVar.REPLICATED);
 
+        /// <summary>
+        ///     Scales the damage dealt to mobs in the game (i.e. entities with MobComponent).
+        /// </summary>
+        [CVarControl(AdminFlags.VarEdit)]
+        public static readonly CVarDef<float> PlaytestMobDamageModifier =
+            CVarDef.Create("playtest.mob_damage_modifier", 1f, CVar.SERVER | CVar.REPLICATED);
+
+        /// <summary>
+        ///     Scales the stamina damage dealt the game.
+        /// </summary>
+        [CVarControl(AdminFlags.VarEdit)]
+        public static readonly CVarDef<float> PlaytestStaminaDamageModifier =
+            CVarDef.Create("playtest.stamina_damage_modifier", 1f, CVar.SERVER | CVar.REPLICATED);
+
 }

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -214,9 +214,6 @@ namespace Content.Shared.Damage
 
             damage = ApplyUniversalAllModifiers(damage);
 
-            if (UniversalMobDamageModifier != 1f && HasComp<MobStateComponent>(uid))
-                damage *= UniversalMobDamageModifier;
-
             // TODO DAMAGE PERFORMANCE
             // Consider using a local private field instead of creating a new dictionary here.
             // Would need to check that nothing ever tries to cache the delta.

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -40,6 +40,7 @@ namespace Content.Shared.Damage
         public float UniversalExplosionDamageModifier { get; private set; } = 1f;
         public float UniversalThrownDamageModifier { get; private set; } = 1f;
         public float UniversalTopicalsHealModifier { get; private set; } = 1f;
+        public float UniversalMobDamageModifier { get; private set; } = 1f;
 
         public override void Initialize()
         {
@@ -82,6 +83,7 @@ namespace Content.Shared.Damage
             Subs.CVar(_config, CCVars.PlaytestExplosionDamageModifier, value => UniversalExplosionDamageModifier = value, true);
             Subs.CVar(_config, CCVars.PlaytestThrownDamageModifier, value => UniversalThrownDamageModifier = value, true);
             Subs.CVar(_config, CCVars.PlaytestTopicalsHealModifier, value => UniversalTopicalsHealModifier = value, true);
+            Subs.CVar(_config, CCVars.PlaytestMobDamageModifier, value => UniversalMobDamageModifier = value, true);
         }
 
         /// <summary>
@@ -211,6 +213,9 @@ namespace Content.Shared.Damage
             }
 
             damage = ApplyUniversalAllModifiers(damage);
+
+            if (UniversalMobDamageModifier != 1f && HasComp<MobStateComponent>(uid))
+                damage *= UniversalMobDamageModifier;
 
             // TODO DAMAGE PERFORMANCE
             // Consider using a local private field instead of creating a new dictionary here.

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -190,10 +190,7 @@ public partial class MobStateSystem
 
     private void OnDamageModify(Entity<MobStateComponent> ent, ref DamageModifyEvent args)
     {
-        if (_damageable.UniversalMobDamageModifier != 1)
-        {
-            args.Damage *= _damageable.UniversalMobDamageModifier;
-        }
+        args.Damage *= _damageable.UniversalMobDamageModifier;
     }
 
     #endregion

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Shared.Bed.Sleep;
 using Content.Shared.Buckle.Components;
 using Content.Shared.CombatMode.Pacification;
+using Content.Shared.Damage;
 using Content.Shared.Damage.ForceSay;
 using Content.Shared.Emoting;
 using Content.Shared.Hands;
@@ -44,6 +45,7 @@ public partial class MobStateSystem
         SubscribeLocalEvent<MobStateComponent, TryingToSleepEvent>(OnSleepAttempt);
         SubscribeLocalEvent<MobStateComponent, CombatModeShouldHandInteractEvent>(OnCombatModeShouldHandInteract);
         SubscribeLocalEvent<MobStateComponent, AttemptPacifiedAttackEvent>(OnAttemptPacifiedAttack);
+        SubscribeLocalEvent<MobStateComponent, DamageModifyEvent>(OnDamageModify);
 
         SubscribeLocalEvent<MobStateComponent, UnbuckleAttemptEvent>(OnUnbuckleAttempt);
     }
@@ -184,6 +186,14 @@ public partial class MobStateSystem
     private void OnAttemptPacifiedAttack(Entity<MobStateComponent> ent, ref AttemptPacifiedAttackEvent args)
     {
         args.Cancelled = true;
+    }
+
+    private void OnDamageModify(Entity<MobStateComponent> ent, ref DamageModifyEvent args)
+    {
+        if (_damageable.UniversalMobDamageModifier != 1)
+        {
+            args.Damage *= _damageable.UniversalMobDamageModifier;
+        }
     }
 
     #endregion

--- a/Content.Shared/Mobs/Systems/MobStateSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
+using Content.Shared.Damage;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Standing;
 using Robust.Shared.Physics.Systems;
@@ -16,6 +17,7 @@ public partial class MobStateSystem : EntitySystem
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
     private ISawmill _sawmill = default!;
 
     private EntityQuery<MobStateComponent> _mobStateQuery;

--- a/Resources/Locale/en-US/cvar/cvar-help.ftl
+++ b/Resources/Locale/en-US/cvar/cvar-help.ftl
@@ -27,3 +27,7 @@ changecvar-simple-playtest_reagent_heal_modifier = Multiplier affecting reagent 
 changecvar-full-playtest_reagent_heal_modifier = Multiplier affecting all healing done by reagents.
 changecvar-simple-playtest_explosion_damage_modifier = Multiplier affecting explosion damage.
 changecvar-full-playtest_explosion_damage_modifier = Multiplier affecting all damage dealt by explosives.
+changecvar-simple-playtest_stamina_damage_modifier = Multiplier affecting stamina damage.
+changecvar-full-playtest_stamina_damage_modifier = Multiplier affecting all stamina damage dealt.
+changecvar-simple-playtest_mob_damage_modifier = Multiplier affecting all damage dealt to mobs.
+changecvar-full-playtest_mob_damage_modifier = Multiplier affecting all damage dealt to entities with MobStateComponent.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds two playtest cvars for mob damage and stamina damage.

Mob damage is for all damage dealt to mobs (specifically those with the MobStateComponent).
Stamina damage is all stamina damage dealt.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Changing the modifier for damage dealt via damage source means it also impacts damaging structures and objects. This ended up being fairly impactful, so hopefully only affecting mobs will make for more interesting balance tests.

Also stamina damage needed a modifier.

## Technical details
<!-- Summary of code changes for easier review. -->

Cvar subscription => update a system value => modify the correct damage.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

ADMIN: 
:cl:
- add: Added playtest cvars for mob and stamina damage. Can be changed via changecvar with VVEDIT perms.
