### PR TITLE
Reagent guidebook reactions UI dividers

### DIFF
--- a/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml
+++ b/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml
@@ -1,5 +1,4 @@
 ﻿<BoxContainer xmlns="https://spacestation14.io"
-              xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
               Orientation="Vertical"
               HorizontalAlignment="Stretch"
               HorizontalExpand="True"

--- a/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml
+++ b/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml
@@ -1,30 +1,36 @@
 ﻿<BoxContainer xmlns="https://spacestation14.io"
-              Orientation="Horizontal"
+              xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
+              Orientation="Vertical"
               HorizontalAlignment="Stretch"
               HorizontalExpand="True"
               Margin="0 0 0 5">
-    <BoxContainer Name="ReactantsContainer" Orientation="Vertical" HorizontalExpand="True" VerticalAlignment="Center">
-        <RichTextLabel Name="ReactantsLabel"
-                       HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       Access="Public"
-                       Visible="False"/>
+    <BoxContainer
+        Orientation="Horizontal">
+        <BoxContainer Name="ReactantsContainer" Orientation="Vertical" HorizontalExpand="True"
+                      VerticalAlignment="Center">
+            <RichTextLabel Name="ReactantsLabel"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           Access="Public"
+                           Visible="False" />
+        </BoxContainer>
+        <BoxContainer Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <TextureRect TexturePath="/Textures/Interface/Misc/beakerlarge.png"
+                         HorizontalAlignment="Center"
+                         Name="MixTexture"
+                         Access="Public" />
+            <RichTextLabel Name="MixLabel"
+                           HorizontalAlignment="Center"
+                           Access="Public"
+                           Margin="2 0 0 0" />
+        </BoxContainer>
+        <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalAlignment="Center">
+            <RichTextLabel Name="ProductsLabel"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           Access="Public"
+                           Visible="False" />
+        </BoxContainer>
     </BoxContainer>
-    <BoxContainer Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextureRect TexturePath="/Textures/Interface/Misc/beakerlarge.png"
-                     HorizontalAlignment="Center"
-                     Name="MixTexture"
-                     Access="Public"/>
-        <RichTextLabel Name="MixLabel"
-                       HorizontalAlignment="Center"
-                       Access="Public"
-                       Margin="2 0 0 0"/>
-    </BoxContainer>
-    <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalAlignment="Center">
-        <RichTextLabel Name="ProductsLabel"
-                       HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       Access="Public"
-                       Visible="False"/>
-    </BoxContainer>
+    <PanelContainer StyleClasses="LowDivider" Margin="0 5 0 5" />
 </BoxContainer>

--- a/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml
+++ b/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml
@@ -3,8 +3,7 @@
               HorizontalAlignment="Stretch"
               HorizontalExpand="True"
               Margin="0 0 0 5">
-    <BoxContainer
-        Orientation="Horizontal">
+    <BoxContainer Orientation="Horizontal">
         <BoxContainer Name="ReactantsContainer" Orientation="Vertical" HorizontalExpand="True"
                       VerticalAlignment="Center">
             <RichTextLabel Name="ReactantsLabel"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a divider line between recipe positions in the Guidebook. When many reagents are involved in one recipe, without the divider, you get confused about which reagents belong to which recipe. Now there is no such problem.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/400ebe5b-c84a-4695-acbd-fed3d833eaf4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

