### PR TITLE
Moths can eat pills

### DIFF
--- a/Resources/Prototypes/Body/Organs/moth.yml
+++ b/Resources/Prototypes/Body/Organs/moth.yml
@@ -8,6 +8,7 @@
       tags:
       - ClothMade
       - Paper
+      - Pill
   - type: SolutionContainerManager
     solutions:
       stomach:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Moths can now eat pills
<!-- What did you change? -->

## Why / Balance
Requested on Discord. Frankly, the reasoning behind moths not being able to eat pills doesn't make sense either. Moths in SS14 eat fibers, specifically plan protein fibers like cotton and paper. Pills can be made of a variety of different things including plant fibers, so why doesn't Nanotrasen just change how their pills are made? 

This also has no balance implications as the jug meta currently reigns supreme, and is just a mild annoyance and noobtrap for moth players.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
One single line of YAML, moths can now eat pills

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
No media necessary unless you want to see a moth overdosing on bicar pills

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Moths can now eat pills
