### PR TITLE
Animated Containers Fix

### DIFF
--- a/Content.Shared/NPC/Systems/NpcFactionSystem.cs
+++ b/Content.Shared/NPC/Systems/NpcFactionSystem.cs
@@ -205,7 +205,7 @@ public sealed partial class NpcFactionSystem : EntitySystem
     private IEnumerable<EntityUid> GetNearbyFactions(EntityUid entity, float range, HashSet<ProtoId<NpcFactionPrototype>> factions)
     {
         var xform = Transform(entity);
-        foreach (var ent in _lookup.GetEntitiesInRange<NpcFactionMemberComponent>(_xform.GetMapCoordinates((entity, xform)), range))
+        foreach (var ent in _lookup.GetEntitiesInRange<NpcFactionMemberComponent>(_xform.GetMapCoordinates((entity, xform)), range, LookupFlags.Uncontained))
         {
             if (ent.Owner == entity)
                 continue;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
containers animated by the staff of animation no longer have their NPCs bug out
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
If a locker is animated, and has a person inside of it, the NPC bugs out and is useless, needs to be fixed

I asked Keron about it, they told me to just change it so that NPCs cannot target people in containers.
## Technical details
<!-- Summary of code changes for easier review. -->
- Changed GetNearbyFactions method in NpcFactionSystem to only look for uncontained targets instead of any target
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: ActiveMammoth
- fix: Hostile NPCs no longer target entities hidden inside of a container.