### PR TITLE
Atmos alarms autolink

### DIFF
--- a/Content.Server/DeviceLinking/Components/AlarmAutoLinkComponent.cs
+++ b/Content.Server/DeviceLinking/Components/AlarmAutoLinkComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Server.DeviceLinking.Components;
 
 /// <summary>
-/// Entity with this component will be automatically linked to devices that have the specified components.
+/// Entities with this component will be automatically linked to devices that have the specified prototypes.
 /// </summary>
 [RegisterComponent]
 public sealed partial class AlarmAutoLinkComponent : Component

--- a/Content.Server/DeviceLinking/Components/AlarmAutoLinkComponent.cs
+++ b/Content.Server/DeviceLinking/Components/AlarmAutoLinkComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.DeviceLinking.Components;
+
+/// <summary>
+/// Entity with this component will be automatically linked to devices that have the specified components.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AlarmAutoLinkComponent : Component
+{
+    /// <summary>
+    /// Prototypes that will automatically link to the entity if they are in the same room.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<EntityPrototype>> AutoLinkPrototypes = new ();
+}

--- a/Content.Server/DeviceLinking/Systems/AlarmAutoLinkSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/AlarmAutoLinkSystem.cs
@@ -1,0 +1,98 @@
+using Content.Server.Atmos.Components;
+using Content.Server.DeviceLinking.Components;
+using Content.Server.DeviceNetwork.Systems;
+using Content.Shared.Atmos;
+using Content.Shared.DeviceNetwork.Components;
+using Content.Shared.Doors.Components;
+using Content.Shared.Maps;
+using Robust.Server.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server.DeviceLinking.Systems;
+
+public sealed class AlarmAutoLinkSystem : EntitySystem
+{
+    [Dependency] private readonly DeviceListSystem _deviceListSystem = default!;
+    [Dependency] private readonly MapSystem _mapSystem = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookupSystem = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<AlarmAutoLinkComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(Entity<AlarmAutoLinkComponent> ent, ref MapInitEvent args)
+    {
+        if (!TryComp<DeviceListComponent>(ent, out var list))
+            return;
+
+        var xform = Transform(ent);
+        if (xform.GridUid is not { } gridUid || !TryComp(gridUid, out MapGridComponent? gridComp))
+            return;
+
+        var grid = new Entity<MapGridComponent>(gridUid, gridComp);
+        var indices = _mapSystem.TileIndicesFor(grid, xform.Coordinates);
+        // We indent one tile in the direction of rotation of the entity
+        var seed = (indices + xform.LocalRotation.ToWorldVec()).Floored();
+
+        var queue = new Queue<TileRef>();
+        var visited = new HashSet<Vector2i>();
+
+        queue.Enqueue(_mapSystem.GetTileRef(grid, seed));
+
+        var directions = new Vector2i[]
+        {
+            new(0, 1), new(0, -1),
+            new (1, 0), new(-1, 0),
+        };
+
+        // Using flood-fill to iterate room tiles
+        while (queue.TryDequeue(out var node))
+        {
+            if (!visited.Add(node.GridIndices))
+                continue;
+
+            var isBorder = false;
+            var worldCoord = _mapSystem.LocalToWorld(grid.Owner, grid.Comp, node.GridIndices);
+            var worldAABB = new Box2(worldCoord, worldCoord + grid.Comp.TileSizeVector).Enlarged(-0.1f);
+            var entities = _entityLookupSystem.GetEntitiesIntersecting(gridUid, worldAABB);
+
+            foreach (var entity in entities)
+            {
+                if (MetaData(entity).EntityPrototype is not { } proto)
+                    continue;
+
+                // Using AirtightComponent to detect room borders
+                if (!isBorder && TryComp(entity, out AirtightComponent? airtight))
+                {
+                    if (airtight.AirBlocked)
+                    {
+                        if (((AtmosDirection) airtight.CurrentAirBlockedDirection).HasFlag(AtmosDirection.All))
+                            isBorder = true;
+                    }
+                    // Firelocks are always considered as room borders
+                    else if (TryComp(entity, out FirelockComponent? _))
+                    {
+                        isBorder = true;
+                    }
+                }
+
+                if (ent.Comp.AutoLinkPrototypes.Contains(proto))
+                    _deviceListSystem.UpdateDeviceList(ent, new List<EntityUid> { entity }, true, list);
+            }
+
+            if (isBorder)
+                continue;
+
+            foreach (var offset in directions)
+            {
+                var nextTile = _mapSystem.GetTileRef(grid, node.GridIndices + offset);
+                if (!nextTile.IsSpace())
+                    queue.Enqueue(nextTile);
+            }
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/freezer.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/freezer.yml
@@ -27,3 +27,17 @@
   components:
   - type: AirAlarm
     autoMode: false
+
+- type: entity
+  id: AirAlarmFreezerAutoLink
+  parent: AirAlarmFreezer
+  suffix: Autolink, Freezer Atmosphere, auto mode disabled
+  components:
+    - type: AlarmAutoLink
+      autoLinkPrototypes:
+        - GasVentScrubberFreezer
+        - GasVentPumpFreezer
+        - AirSensorFreezer
+        - Firelock
+        - FirelockGlass
+

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
@@ -48,3 +48,17 @@
   components:
   - type: AirAlarm
     autoMode: false
+
+- type: entity
+  id: AirAlarmVoxAutoLink
+  parent: AirAlarmVox
+  suffix: Autolink, Vox Atmosphere, auto mode disabled
+  components:
+    - type: AlarmAutoLink
+      autoLinkPrototypes:
+        - GasVentScrubberVox
+        - GasVentPumpVox
+        - AirSensorVox
+        - Firelock
+        - FirelockGlass
+

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -118,6 +118,20 @@
     - DeviceMonitoringAndControl
 
 - type: entity
+  id: AirAlarmAutoLink
+  parent: AirAlarm
+  suffix: Autolink
+  components:
+    - type: AlarmAutoLink
+      autoLinkPrototypes:
+        - GasVentScrubber
+        - GasVentPump
+        - GasDualPortVentPump
+        - AirSensor
+        - Firelock
+        - FirelockGlass
+
+- type: entity
   id: AirAlarmAssembly
   name: air alarm assembly
   description: An air alarm. Doesn't look like it'll be alarming air any time soon.
@@ -146,3 +160,4 @@
     node: assembly
   - type: Transform
     anchored: true
+

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
@@ -114,6 +114,17 @@
     - Wallmount
 
 - type: entity
+  id: FireAlarmAutoLink
+  parent: FireAlarm
+  suffix: Autolink
+  components:
+    - type: AlarmAutoLink
+      autoLinkPrototypes:
+        - AirSensor
+        - Firelock
+        - FirelockGlass
+
+- type: entity
   id: FireAlarmAssembly
   name: fire alarm assembly
   description: A fire alarm assembly. Very mild.
@@ -142,3 +153,4 @@
     mode: SnapgridCenter
     snap:
     - Wallmount
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added air and fire alarms that have an automatic linking function. Linking takes place with all atmospheric objects in the room. Room borders are defined using walls and firelocks.

## Why
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This will greatly simplify the work of mappers, connecting alarms is the most annoying thing in mapping

## Technical details
<!-- Summary of code changes for easier review. -->
The flood-fill is used to iterate the tiles in the room when the entity is initialized and searches for the prototypes specified in the AlarmAutoLinkComponent, which are then linked to the alarm. Room borders are defined using the AirtightComponent of the entities in the room.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/dc6e37dd-02c0-4844-bdc6-b2396775b97b


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun