### PR TITLE
EmoteSounds Cleanup and Prototype now can use Parents

### DIFF
--- a/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
@@ -2,6 +2,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
 
 namespace Content.Shared.Chat.Prototypes;
 
@@ -10,16 +11,27 @@ namespace Content.Shared.Chat.Prototypes;
 ///     Different entities may use different sounds collections.
 /// </summary>
 [Prototype("emoteSounds"), Serializable, NetSerializable]
-public sealed partial class EmoteSoundsPrototype : IPrototype
+public sealed class EmoteSoundsPrototype : IPrototype, IInheritingPrototype
 {
+    /// <inheritdoc/>
     [IdDataField]
     public string ID { get; private set; } = default!;
+
+    /// <inheritdoc/>
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<EmoteSoundsPrototype>))]
+    public string[]? Parents { get; private set; }
+
+    /// <inheritdoc/>
+    [AbstractDataField]
+    [NeverPushInheritance]
+    public bool Abstract { get; }
 
     /// <summary>
     ///     Optional fallback sound that will play if collection
     ///     doesn't have specific sound for this emote id.
     /// </summary>
     [DataField("sound")]
+    [AlwaysPushInheritance]
     public SoundSpecifier? FallbackSound;
 
     /// <summary>
@@ -27,11 +39,13 @@ public sealed partial class EmoteSoundsPrototype : IPrototype
     ///     This will overwrite any params that may be set in sound specifiers.
     /// </summary>
     [DataField("params")]
+    [AlwaysPushInheritance]
     public AudioParams? GeneralParams;
 
     /// <summary>
     ///     Collection of emote prototypes and their sounds.
     /// </summary>
-    [DataField("sounds", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<SoundSpecifier, EmotePrototype>))]
+    [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<SoundSpecifier, EmotePrototype>))]
+    [AlwaysPushInheritance]
     public Dictionary<string, SoundSpecifier> Sounds = new();
 }


### PR DESCRIPTION
## About the PR
Made it so EmoteSoundsPrototype.cs allows for parenting other emote sounds, allowing smaller and more defined yaml changes as currently all emote sounds must be fully defined. This means even if a character would have lets say, the same sounds as MaleHuman, all their sounds must be manually added leading to bloat.

This comes from an update from RMC: https://github.com/RMC-14/RMC-14/pull/4139

[TODO - Finish cleanup]

## Why / Balance
Make it so we are able to make generic sounds, male/female generic sounds, and then classify only specific new sounds to races for example. Meaning no more missing sound effects when cleaned up.

## Technical details
_[TODO - Find naming scheme for generic sounds and finish cleanup]_
Word for word from the PR:
adds abstract and parent field to `EmoteSoundsPrototype`


## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- fix: All species no longer have missing sound effects.

