### PR TITLE
Fix development and debug configurations for tests

### DIFF
--- a/Content.IntegrationTests/PoolManager.Cvars.cs
+++ b/Content.IntegrationTests/PoolManager.Cvars.cs
@@ -33,7 +33,6 @@ public static partial class PoolManager
         (CVars.ReplayServerRecordingEnabled.Name, "false"),
         (CCVars.GameDummyTicker.Name, "true"),
         (CCVars.GameLobbyEnabled.Name, "false"),
-        (CCVars.ConfigPresetDevelopment.Name, "false"),
         (CCVars.AdminLogsEnabled.Name, "false"),
         (CCVars.AutosaveEnabled.Name, "false"),
         (CVars.NetBufferSize.Name, "0"),

--- a/Content.IntegrationTests/PoolManager.Cvars.cs
+++ b/Content.IntegrationTests/PoolManager.Cvars.cs
@@ -33,7 +33,7 @@ public static partial class PoolManager
         (CVars.ReplayServerRecordingEnabled.Name, "false"),
         (CCVars.GameDummyTicker.Name, "true"),
         (CCVars.GameLobbyEnabled.Name, "false"),
-        (CCVars.ConfigPresetDevelopment.Name, "true"),
+        (CCVars.ConfigPresetDevelopment.Name, "false"),
         (CCVars.AdminLogsEnabled.Name, "false"),
         (CCVars.AutosaveEnabled.Name, "false"),
         (CVars.NetBufferSize.Name, "0"),

--- a/Content.IntegrationTests/PoolManager.Cvars.cs
+++ b/Content.IntegrationTests/PoolManager.Cvars.cs
@@ -33,6 +33,7 @@ public static partial class PoolManager
         (CVars.ReplayServerRecordingEnabled.Name, "false"),
         (CCVars.GameDummyTicker.Name, "true"),
         (CCVars.GameLobbyEnabled.Name, "false"),
+        (CCVars.ConfigPresetDevelopment.Name, "true"),
         (CCVars.AdminLogsEnabled.Name, "false"),
         (CCVars.AutosaveEnabled.Name, "false"),
         (CVars.NetBufferSize.Name, "0"),

--- a/Resources/ConfigPresets/Build/debug.toml
+++ b/Resources/ConfigPresets/Build/debug.toml
@@ -1,6 +1,1 @@
-﻿[events]
-# Annoying
-enabled = false
-
-[shuttle]
-auto_call_time = 0
+﻿

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -5,6 +5,9 @@ lobbyenabled = false
 map = "Dev"
 role_timers = false
 
+[events]
+enabled = false
+
 [ghost]
 role_time = 0.5
 quick_lottery = true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Moved the config options to disable events and shuttle auto-recall from debug.toml to development.toml.
Also, PoolManager for tests was disabling the settings from the development config. Changed it so it enables them instead.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
See Discord discussion: https://discord.com/channels/310555209753690112/900426319433728030/1345826218599125114