### PR TITLE
Added headset options to salvage loadouts!

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -102,6 +102,7 @@ loadout-group-cargo-technician-shoes = Cargo Technician shoes
 loadout-group-salvage-specialist-backpack = Salvage Specialist backpack
 loadout-group-salvage-specialist-outerclothing = Salvage Specialist outer clothing
 loadout-group-salvage-specialist-shoes = Salvage Specialist shoes
+loadout-group-salvage-specialist-ears = Salvage Specialist ears
 
 # Engineering
 loadout-group-chief-engineer-head = Chief Engineer head

--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/salvage_specialist.yml
@@ -14,6 +14,17 @@
   equipment:
     back: ClothingBackpackDuffelSalvage
 
+# Ears
+- type: loadout
+  id: CargoHeadset
+  equipment:
+    headsets: ClothingHeadsetCargo
+
+- type: loadout
+  id: MiningHeadset
+  equipment:
+    headsets: ClothingHeadsetMining
+
 # OuterClothing
 - type: loadout
   id: SalvageSpecialistWintercoat

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -679,6 +679,14 @@
   - SalvageBoots
   - CargoWinterBoots
 
+- type: loadoutGroup
+  id: SalvageSpecialistEars
+  name: loadout-group-salvage-specialist-ears
+  minLimit: 0
+  loadouts:
+  - CargoHeadset
+  - MiningHeadset
+
 # Engineering
 - type: loadoutGroup
   id: ChiefEngineerHead

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -234,6 +234,7 @@
   - SalvageSpecialistBackpack
   - SalvageSpecialistOuterClothing
   - SalvageSpecialistShoes
+  - SalvageSpecialistEars
   - Glasses
   - Survival
   - Trinkets


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I added a new loadout group for the salvage specialist role, letting you choose between a normal cargo headset... or a mining headset!
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mining Headsets can sometimes spawn in the roundstart salvage room, so they might aswell be implemented in loadouts, this has no balance changes.
## Technical details
<!-- Summary of code changes for easier review. -->
Simply just added the Mining Headset and the Cargo Headset into the salvage specialist loadout files as a new group.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
**Changelog**
🆑 
- tweak: Salvage Specialists can now choose the type of headset they get to in their loadout