### PR TITLE
Add "Reset to default" verb to `TriggerOnVoice`

### DIFF
--- a/Content.Server/Explosion/Components/TriggerOnVoiceComponent.cs
+++ b/Content.Server/Explosion/Components/TriggerOnVoiceComponent.cs
@@ -9,20 +9,21 @@ namespace Content.Server.Explosion.Components
         public bool IsListening => IsRecording || !string.IsNullOrWhiteSpace(KeyPhrase);
 
         [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("keyPhrase")]
         public string? KeyPhrase;
 
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField("listenRange")]
+        [DataField]
+        public LocId? DefaultKeyPhrase;
+
+        [DataField]
         public int ListenRange { get; private set; } = 4;
 
-        [DataField("isRecording")]
-        public bool IsRecording = false;
+        [DataField]
+        public bool IsRecording;
 
-        [DataField("minLength")]
+        [DataField]
         public int MinLength = 3;
 
-        [DataField("maxLength")]
+        [DataField]
         public int MaxLength = 50;
     }
 }

--- a/Resources/Locale/en-US/speech/speech-triggers.ftl
+++ b/Resources/Locale/en-US/speech/speech-triggers.ftl
@@ -1,0 +1,1 @@
+key-phrase-gadget = go go gadget

--- a/Resources/Locale/en-US/weapons/grenades/voice-trigger.ftl
+++ b/Resources/Locale/en-US/weapons/grenades/voice-trigger.ftl
@@ -4,9 +4,11 @@ trigger-voice-uninitialized = The display reads: Uninitialized...
 verb-trigger-voice-record = Record
 verb-trigger-voice-stop = Stop
 verb-trigger-voice-clear = Clear recording
+verb-trigger-voice-default = Reset to default
 
 popup-trigger-voice-start-recording = Started recording
 popup-trigger-voice-stop-recording = Stopped recording
 popup-trigger-voice-record-failed-too-long = Message too long, try again
 popup-trigger-voice-record-failed-too-short = Message too short, try again
 popup-trigger-voice-recorded = Recorded successfully
+popup-trigger-voice-set-default = Set to default keyphrase: "{$keyphrase}"

--- a/Resources/Prototypes/Entities/Clothing/Head/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/specific.yml
@@ -28,10 +28,8 @@
   - type: Tag
     tags: [] # ignore "WhitelistChameleon" tag
   - type: TriggerOnVoice
-    keyPhrase: "go go gadget"
+    defaultKeyPhrase: key-phrase-gadget
     listenRange: 0
-  - type: ActiveListener
-    range: 0
   - type: StorageVoiceControl
     allowedSlots:
     - HEAD


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds new verb that resets the keyphrase if we have change it.
This verb will be visible only if `DefaultKeyPhrase` is set in prototype and our current keyphrase differs from the default one.

Also localizes keyphrase for the "go go hat" prototype

## Why / Balance
This will allow to make keyphrases localizable for prototypes like "go go hat" in #35438
Also allows to reset keyphrase to default by verb which is a bit handy

## Technical details
Added new datafield `DefaultKeyPhrase` that stores the default keyphrase LocId value
`KeyPhrase` field was made only visible and editable in VV but not settable in yml (`DataField` attribute removed)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/5fb743ff-33b8-4421-a05e-c55a3ef47156



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Go go hat's activation phrase can be reset to the default without having to record it manually to reset the phrase.
