### PR TITLE
Persist construction menu favorites client-side

### DIFF
--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -478,15 +478,19 @@ namespace Content.Client.Construction.UI
             PopulateCategories(_selectedCategory);
         }
 
+        // The favorites list is stored within a CVar and shared between multiple SS14 forks with potentially differing behaviors.
+        // To minimize fighting between clients, the following rules should be observed when updating the variable:
+        //  - Do not remove or modify unrecognized entries. Other forks may have different recipes.
+        //  - Do not rearrange the list unless the player intentionally performs some action to do so.
         public void SetFavorites(string favorites)
         {
             _favoritedRecipes.Clear();
             _favoritedRecipeIDs.Clear();
 
-            _favoritedRecipeIDs.AddRange(favorites.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
+            _favoritedRecipeIDs.AddRange(favorites.Split(','));
             foreach (var id in _favoritedRecipeIDs)
             {
-                if (_prototypeManager.TryIndex(id, out ConstructionPrototype? recipe))
+                if (_prototypeManager.TryIndex(id.Trim(), out ConstructionPrototype? recipe))
                     _favoritedRecipes.Add(recipe);
             }
 

--- a/Content.Shared/CCVar/CCVars.Interface.cs
+++ b/Content.Shared/CCVar/CCVars.Interface.cs
@@ -54,4 +54,10 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> AdminOverlayStartingJob =
         CVarDef.Create("ui.admin_overlay_starting_job", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// A comma-separated list of recipe prototype IDs that have been favorited in the construction menu.
+    /// </summary>
+    public static readonly CVarDef<string> ConstructionFavorites =
+        CVarDef.Create("ui.construction_favorites", "", CVar.CLIENTONLY | CVar.ARCHIVE);
 }


### PR DESCRIPTION
## About the PR
Persists the list of favorite items chosen in the construction menu client-side.

## Why / Balance
Addresses a common pain point of the construction menu for players that requires them to repopulate their favorites list after every round or reconnect.
Resolves #29592

## Technical details
- This adds a new client-only CVar `ui.construction_favorites` to store a comma-separated list of recipe prototype IDs.
- The order in which favorites are added is preserved. This provides no benefit today since the UI sorts items alphabetically regardless, however it leaves room for future changes that may allow players to reorder items.
- Unrecognized IDs are preserved in the list. This is important since the favorites list will be shared between all forks that adopt this PR, which will have their own IDs.

This solution is less ideal than one that saves the list server-side, but much simpler to implement and hopefully more convenient for players who regular multiple servers. If we or another fork decide to implement a server-side solution in the future, it would be a trivial matter to disregard the CVar.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it **does not require an ingame showcase**.

**Changelog**
:cl:
- tweak: Favorites selected in the construction menu will now persist between rounds.
