### PR TITLE
Revert "[HOTFIX] - Players with unknown playtimes now are tagged as new players"

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -36,9 +36,6 @@ namespace Content.Client.Administration.UI.Bwoink
             RobustXamlLoader.Load(this);
             IoCManager.InjectDependencies(this);
 
-            var newPlayerThreshold = 0;
-            _cfg.OnValueChanged(CCVars.NewPlayerThreshold, (val) => { newPlayerThreshold = val; }, true);
-
             var uiController = _ui.GetUIController<AHelpUIController>();
             if (uiController.UIHelper is not AdminAHelpUIHandler helper)
                 return;
@@ -79,7 +76,7 @@ namespace Content.Client.Administration.UI.Bwoink
                 if (info.Antag && info.ActiveThisRound)
                     sb.Append(new Rune(0x1F5E1)); // 🗡
 
-                if (newPlayerThreshold != 0 && (info.OverallPlaytime == null || info.OverallPlaytime <= TimeSpan.FromMinutes(newPlayerThreshold)))
+                if (info.OverallPlaytime <= TimeSpan.FromMinutes(_cfg.GetCVar(CCVars.NewPlayerThreshold)))
                     sb.Append(new Rune(0x23F2)); // ⏲
 
                 sb.AppendFormat("\"{0}\"", text);

--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
@@ -22,9 +22,12 @@ namespace Content.Client.Administration.UI.Bwoink
                     return;
                 }
 
-                Title = $"{sel.CharacterName} / {sel.Username} | {Loc.GetString("generic-playtime-title")}: ";
+                Title = $"{sel.CharacterName} / {sel.Username}";
 
-                Title += sel.OverallPlaytime != null ? sel.PlaytimeString : Loc.GetString("generic-unknown-title");
+                if (sel.OverallPlaytime != null)
+                {
+                    Title += $" | {Loc.GetString("generic-playtime-title")}: {sel.PlaytimeString}";
+                }
             };
 
             OnOpen += () =>


### PR DESCRIPTION
Reverts space-wizards/space-station-14#35564

It turns out this has caused some usability concerns on the admin UI, that's impacting admin workflow.
https://discord.com/channels/310555209753690112/1281461283157184532/1345993716841709638

I have a fix in mind but just in case it turns out to take more time to fix and test, I propose reverting it for now