### PR TITLE
Players with unknown playtimes now are tagged as new players, take 2

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -108,31 +108,37 @@ namespace Content.Client.Administration.UI.Bwoink
                 if (a.IsPinned != b.IsPinned)
                     return a.IsPinned ? -1 : 1;
 
-                // First, sort by unread. Any chat with unread messages appears first.
+                // Then, any chat with unread messages.
                 var aUnread = ach.Unread > 0;
                 var bUnread = bch.Unread > 0;
                 if (aUnread != bUnread)
                     return aUnread ? -1 : 1;
 
-                // Sort by recent messages during the current round.
+                // Then, any chat with recent messages from the current round
                 var aRecent = a.ActiveThisRound && ach.LastMessage != DateTime.MinValue;
                 var bRecent = b.ActiveThisRound && bch.LastMessage != DateTime.MinValue;
                 if (aRecent != bRecent)
                     return aRecent ? -1 : 1;
 
-                // Next, sort by connection status. Any disconnected players are grouped towards the end.
+                // Sort by connection status. Disconnected players will be last.
                 if (a.Connected != b.Connected)
                     return a.Connected ? -1 : 1;
 
-                // Sort connected players by New Player status, then by Antag status
+                // Sort connected players by whether they have joined the round, then by New Player status, then by Antag status
                 if (a.Connected && b.Connected)
                 {
                     var aNewPlayer = IsNewPlayer(a);
                     var bNewPlayer = IsNewPlayer(b);
 
+                    //  Players who have joined the round will be listed before players in the lobby
+                    if (a.ActiveThisRound != b.ActiveThisRound)
+                        return a.ActiveThisRound ? -1 : 1;
+
+                    //  Within both the joined group and lobby group, new players will be grouped and listed first
                     if (aNewPlayer != bNewPlayer)
                         return aNewPlayer ? -1 : 1;
 
+                    //  Within all four previous groups, antagonists will be listed first.
                     if (a.Antag != b.Antag)
                         return a.Antag ? -1 : 1;
                 }

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -62,9 +62,9 @@ namespace Content.Client.Administration.UI.Bwoink
                 var sb = new StringBuilder();
 
                 if (info.Connected)
-                    sb.Append('●');
+                    sb.Append(info.ActiveThisRound ? '⚫' : '◐');
                 else
-                    sb.Append(info.ActiveThisRound ? '○' : '·');
+                    sb.Append(info.ActiveThisRound ? '⭘' : '·');
 
                 sb.Append(' ');
                 if (AHelpHelper.TryGetChannel(info.SessionId, out var panel) && panel.Unread > 0)

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -76,9 +76,11 @@ namespace Content.Client.Administration.UI.Bwoink
                     sb.Append(' ');
                 }
 
+                // Mark antagonists with symbol
                 if (info.Antag && info.ActiveThisRound)
                     sb.Append(new Rune(0x1F5E1)); // 🗡
 
+                // Mark new players with symbol
                 if (IsNewPlayer(info))
                     sb.Append(new Rune(0x23F2)); // ⏲
 
@@ -89,11 +91,12 @@ namespace Content.Client.Administration.UI.Bwoink
 
             bool IsNewPlayer(PlayerInfo info)
             {
-                if (newPlayerThreshold <= 0 || (info.OverallPlaytime == null && !info.Connected))
+                // Don't show every disconnected player as new, don't show 0-minute players as new if threshold is
+                if (newPlayerThreshold <= 0 || info.OverallPlaytime is null && !info.Connected)
                     return false;
 
-                return (info.OverallPlaytime == null
-                        || info.OverallPlaytime <= TimeSpan.FromMinutes(newPlayerThreshold));
+                return (info.OverallPlaytime is null
+                        || info.OverallPlaytime < TimeSpan.FromMinutes(newPlayerThreshold));
             }
 
             ChannelSelector.Comparison = (a, b) =>

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -89,6 +89,9 @@ namespace Content.Client.Administration.UI.Bwoink
                 return sb.ToString();
             };
 
+            // <summary>
+            // Returns true if the player's overall playtime is under the set threshold
+            // </summary>
             bool IsNewPlayer(PlayerInfo info)
             {
                 // Don't show every disconnected player as new, don't show 0-minute players as new if threshold is

--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml.cs
@@ -22,12 +22,9 @@ namespace Content.Client.Administration.UI.Bwoink
                     return;
                 }
 
-                Title = $"{sel.CharacterName} / {sel.Username}";
+                Title = $"{sel.CharacterName} / {sel.Username} | {Loc.GetString("generic-playtime-title")}: ";
 
-                if (sel.OverallPlaytime != null)
-                {
-                    Title += $" | {Loc.GetString("generic-playtime-title")}: {sel.PlaytimeString}";
-                }
+                Title += sel.OverallPlaytime != null ? sel.PlaytimeString : Loc.GetString("generic-unknown-title");
             };
 
             OnOpen += () =>

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -222,6 +222,7 @@ public sealed class AdminSystem : EntitySystem
         var entityName = string.Empty;
         var identityName = string.Empty;
 
+        // Visible (identity) name can be different from real name
         if (session?.AttachedEntity != null)
         {
             entityName = EntityManager.GetComponent<MetaDataComponent>(session.AttachedEntity.Value).EntityName;
@@ -230,6 +231,7 @@ public sealed class AdminSystem : EntitySystem
 
         var antag = false;
 
+        // Starting role, antagonist status and role type
         RoleTypePrototype roleType = new();
         var startingRole = string.Empty;
         if (_minds.TryGetMind(session, out var mindId, out var mindComp))
@@ -243,6 +245,7 @@ public sealed class AdminSystem : EntitySystem
             startingRole = _jobs.MindTryGetJobName(mindId);
         }
 
+        // Connection status and playtime
         var connected = session != null && session.Status is SessionStatus.Connected or SessionStatus.InGame;
         TimeSpan? overallPlaytime = null;
         if (session != null &&

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -247,7 +247,11 @@ public sealed class AdminSystem : EntitySystem
 
         // Connection status and playtime
         var connected = session != null && session.Status is SessionStatus.Connected or SessionStatus.InGame;
-        TimeSpan? overallPlaytime = null;
+
+        // Start with the last available playtime data
+        var cachedInfo = GetCachedPlayerInfo(data.UserId);
+        var overallPlaytime = cachedInfo?.OverallPlaytime;
+        // Overwrite with current playtime data, unless it's null (such as if the player just disconnected)
         if (session != null &&
             _playTime.TryGetTrackerTimes(session, out var playTimes) &&
             playTimes.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out var playTime))


### PR DESCRIPTION
## About the PR
Built on top of the reverted #35564
Connected players with NULL playtime are now (again) shown as New

Additionally, connected players who have entered the round are now listed above connected players who are still in the lobby. This, prevents brand new players still just looking at options/controls or setting up their character from being placed above antagonists in the round.
Disconnected players no longer show null playtime, so new players now show the clock icon even after they disconnect.

The full Ahelp window sorting is as follows:

Pinned users
Any users with unread messages
Users who are (or were) in the current round, and have sent recent messages
Connected users who...
...joined round, are new, and are antag
...joined round, are new
...joined round, are antag
...joined round
...are in lobby, are new
...are in lobby
Disconnected users who...
...joined round
...never left lobby

## Why / Balance
First version was made to improve the reliability of the New Player marker in the ahelp window
The first version did not sort any null playtime players as new, it just marked them as such. It would also mark any and every disconnected player as New. These two glitches together resulted in a confusing display

## Technical details
```The playtime of players is sometimes null (This sometimes can occur when the players are first joining the server but can also randomly happen to older players as well?). This doesn't fix the root issue, but when it does occur it will tag these players as having unknown playtime and the new player icon in the ahelp menu```

All "Is the player new" checks are now using a single codepath. Disconnected players with NULL playtime are no longer considered New

Previously, a disconnecting player sent a null session info as their last update, which wiped out their playtime ((as far as playerInfo was concerned)). Their playtime info would only update on their next reconnect. This means that, as far as the new system was concerned, every disconnected player would have been "new", since they had null playtime info.
PlayerInfo now uses the players last known playtime if an update sends null, so disconnected players will in most circumstances have some value for IsNewPlayer() to work with

## Media

![Screenshot_2025-03-05_103950](https://github.com/user-attachments/assets/d1646e8a-548a-4b64-94da-5dfaa4c80ac7)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: Beck Thompson, Errant
ADMIN:
- fix: Brand new players with NULL playtime data are no longer missing the clock icon in the Bwoink menu. Disconnected new players also no longer lose their clock icon.
- tweak: Connected players who have entered the round are now sorted above connected players who are still in the lobby. Players still in the lobby have a half-full symbol.

