### PR TITLE
CVar - Toggle display of round-end greentext

### DIFF
--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -33,7 +33,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
 
     private IEnumerable<string>? _objectives;
 
-    public bool ShowGreentext { get; set; }
+    private bool _showGreentext;
 
     public override void Initialize()
     {
@@ -41,7 +41,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
 
         SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndText);
 
-        Subs.CVar(_cfg, CCVars.GameShowGreentext, value => ShowGreentext = value, true);
+        Subs.CVar(_cfg, CCVars.GameShowGreentext, value => _showGreentext = value, true);
 
         _prototypeManager.PrototypesReloaded += CreateCompletions;
     }
@@ -169,11 +169,11 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                     totalObjectives++;
 
                     agentSummary.Append("- ");
-                    if (!ShowGreentext)
+                    if (!_showGreentext)
                     {
                         agentSummary.AppendLine(objectiveTitle);
                     }
-                    if (ShowGreentext && progress > 0.99f)
+                    else if (progress > 0.99f)
                     {
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-success",
@@ -182,7 +182,7 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                         ));
                         completedObjectives++;
                     }
-                    if (ShowGreentext && progress < 1f)
+                    else
                     {
                         agentSummary.AppendLine(Loc.GetString(
                             "objectives-objective-fail",

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -169,30 +169,27 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                     totalObjectives++;
 
                     agentSummary.Append("- ");
-                    if (ShowGreentext)
-                    {
-                        if (progress > 0.99f)
-                        {
-                            agentSummary.AppendLine(Loc.GetString(
-                                "objectives-objective-success",
-                                ("objective", objectiveTitle),
-                                ("markupColor", "green")
-                            ));
-                            completedObjectives++;
-                        }
-                        else
-                        {
-                            agentSummary.AppendLine(Loc.GetString(
-                                "objectives-objective-fail",
-                                ("objective", objectiveTitle),
-                                ("progress", (int) (progress * 100)),
-                                ("markupColor", "red")
-                            ));
-                        }
-                    }
-                    else
+                    if (!ShowGreentext)
                     {
                         agentSummary.AppendLine(objectiveTitle);
+                    }
+                    if (ShowGreentext && progress > 0.99f)
+                    {
+                        agentSummary.AppendLine(Loc.GetString(
+                            "objectives-objective-success",
+                            ("objective", objectiveTitle),
+                            ("markupColor", "green")
+                        ));
+                        completedObjectives++;
+                    }
+                    if (ShowGreentext && progress < 1f)
+                    {
+                        agentSummary.AppendLine(Loc.GetString(
+                            "objectives-objective-fail",
+                            ("objective", objectiveTitle),
+                            ("progress", (int) (progress * 100)),
+                            ("markupColor", "red")
+                        ));
                     }
                 }
             }

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -12,9 +12,11 @@ using Robust.Shared.Random;
 using System.Linq;
 using System.Text;
 using Content.Server.Objectives.Commands;
+using Content.Shared.CCVar;
 using Content.Shared.Prototypes;
 using Content.Shared.Roles.Jobs;
 using Robust.Server.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Objectives;
@@ -27,14 +29,19 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly EmergencyShuttleSystem _emergencyShuttle = default!;
     [Dependency] private readonly SharedJobSystem _job = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     private IEnumerable<string>? _objectives;
+
+    public bool ShowGreentext { get; set; }
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndText);
+
+        Subs.CVar(_cfg, CCVars.GameShowGreentext, value => ShowGreentext = value, true);
 
         _prototypeManager.PrototypesReloaded += CreateCompletions;
     }
@@ -162,23 +169,30 @@ public sealed class ObjectivesSystem : SharedObjectivesSystem
                     totalObjectives++;
 
                     agentSummary.Append("- ");
-                    if (progress > 0.99f)
+                    if (ShowGreentext)
                     {
-                        agentSummary.AppendLine(Loc.GetString(
-                            "objectives-objective-success",
-                            ("objective", objectiveTitle),
-                            ("markupColor", "green")
-                        ));
-                        completedObjectives++;
+                        if (progress > 0.99f)
+                        {
+                            agentSummary.AppendLine(Loc.GetString(
+                                "objectives-objective-success",
+                                ("objective", objectiveTitle),
+                                ("markupColor", "green")
+                            ));
+                            completedObjectives++;
+                        }
+                        else
+                        {
+                            agentSummary.AppendLine(Loc.GetString(
+                                "objectives-objective-fail",
+                                ("objective", objectiveTitle),
+                                ("progress", (int) (progress * 100)),
+                                ("markupColor", "red")
+                            ));
+                        }
                     }
                     else
                     {
-                        agentSummary.AppendLine(Loc.GetString(
-                            "objectives-objective-fail",
-                            ("objective", objectiveTitle),
-                            ("progress", (int) (progress * 100)),
-                            ("markupColor", "red")
-                        ));
+                        agentSummary.AppendLine(objectiveTitle);
                     }
                 }
             }

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -54,6 +54,12 @@ public sealed partial class CCVars
         GameLobbyEnableWin = CVarDef.Create("game.enablewin", true, CVar.ARCHIVE);
 
     /// <summary>
+    ///     Controls if round-end window shows whether the objective was completed or not.
+    /// </summary>
+    public static readonly CVarDef<bool>
+        GameShowGreentext = CVarDef.Create("game.showgreentext", true, CVar.ARCHIVE | CVar.SERVERONLY);
+
+    /// <summary>
     ///     Controls the maximum number of character slots a player is allowed to have.
     /// </summary>
     public static readonly CVarDef<int>


### PR DESCRIPTION
## About the PR
game.showgreentext (default true) now controls whether the round-end objective progress is shown.

## Why / Balance
While this PR is not changing anything for the upstream, this is something that forks might want.
The greentext/redtext obsession is something that ruins roleplay quite a lot in the game; instead of trying to spice up the round, antagonists do objectives in the same boring ways just to be considered "robust". Removal of greentext is supposed to mitigate that by highlighting that objectives are somewhat optional.

## Technical details


## Media
https://youtu.be/nPrUoX8f23c

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
