### PR TITLE
Delete SolutionContainerVisualsComponent.InitialName

### DIFF
--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -28,7 +28,6 @@ public sealed class SolutionContainerVisualsSystem : VisualizerSystem<SolutionCo
     private void OnMapInit(EntityUid uid, SolutionContainerVisualsComponent component, MapInitEvent args)
     {
         var meta = MetaData(uid);
-        component.InitialName = meta.EntityName;
         component.InitialDescription = meta.EntityDescription;
     }
 

--- a/Content.Shared/Chemistry/Components/SolutionContainerVisualsComponent.cs
+++ b/Content.Shared/Chemistry/Components/SolutionContainerVisualsComponent.cs
@@ -37,9 +37,6 @@ namespace Content.Shared.Chemistry.Components
         public string? SolutionName;
 
         [DataField]
-        public string InitialName = string.Empty;
-
-        [DataField]
         public string InitialDescription = string.Empty;
 
         /// <summary>


### PR DESCRIPTION
It's a leftover from before `NameModifierSystem` and isn't used.

## Breaking Changes
`SolutionContainerVisualsComponent` no longer has an `InitialName` field. If you still need it, you can use `NameModifierSystem.GetBaseName`