### PR TITLE
Fix name of cotton dough rope

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -489,7 +489,7 @@
           Quantity: 3.5
 
 - type: entity
-  name: dough rope
+  name: cotton dough rope
   parent: FoodBakingBase
   id: FoodDoughCottonRope
   description: A thin noodle of cotton dough. Can be cooked into a cotton bagel.


### PR DESCRIPTION
## About the PR
Changes the name of "cotton dough rope" which previously shared the same name as the regular dough rope.

## Why / Balance
I'm not sure why they had the same name. I assume it was an oversight. All other shapes of cotton dough have "cotton" in their name already.

## Technical details
Added a single word to a YML.

## Media
![cottonropefix-demo](https://github.com/user-attachments/assets/6c5256d7-237a-4b64-a820-9072c933142f)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->