### PR TITLE
DetGadget hat fixes

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.Voice.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.Voice.cs
@@ -48,13 +48,15 @@ namespace Content.Server.Explosion.EntitySystems
                 return;
             }
 
-            if (!string.IsNullOrWhiteSpace(component.KeyPhrase) && message.Contains(component.KeyPhrase, StringComparison.InvariantCultureIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(component.KeyPhrase) && message.IndexOf(component.KeyPhrase, StringComparison.InvariantCultureIgnoreCase) is var index and >= 0 )
             {
                 _adminLogger.Add(LogType.Trigger, LogImpact.High,
                         $"A voice-trigger on {ToPrettyString(ent):entity} was triggered by {ToPrettyString(args.Source):speaker} speaking the key-phrase {component.KeyPhrase}.");
                 Trigger(ent, args.Source);
 
-                var voice = new VoiceTriggeredEvent(args.Source, message);
+                var messageWithoutPhrase = message.Remove(index, component.KeyPhrase.Length).Trim();
+
+                var voice = new VoiceTriggeredEvent(args.Source, message, messageWithoutPhrase);
                 RaiseLocalEvent(ent, ref voice);
             }
         }
@@ -147,5 +149,6 @@ namespace Content.Server.Explosion.EntitySystems
 /// </summary>
 /// <param name="Source"> The EntityUid of the entity sending the message</param>
 /// <param name="Message"> The contents of the message</param>
+/// <param name="MessageWithoutPhrase"> The message without the phrase that triggered it.</param>
 [ByRefEvent]
-public readonly record struct VoiceTriggeredEvent(EntityUid Source, string? Message);
+public readonly record struct VoiceTriggeredEvent(EntityUid Source, string Message, string MessageWithoutPhrase);

--- a/Content.Shared/Labels/EntitySystems/SharedLabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedLabelSystem.cs
@@ -48,4 +48,18 @@ public abstract partial class SharedLabelSystem : EntitySystem
         if (!string.IsNullOrEmpty(entity.Comp.CurrentLabel))
             args.AddModifier("comp-label-format", extraArgs: ("label", entity.Comp.CurrentLabel));
     }
+
+    /// <summary>
+    /// Retrieves the current label of the specified entity.
+    /// </summary>
+    /// <param name="entity">The entity with the <see cref="LabelComponent"/>.</param>
+    /// <returns>The current label of the entity, or null if no label exists.</returns>
+    public string? LabelOrNull(Entity<LabelComponent?> entity)
+    {
+        if (!Resolve(entity, ref entity.Comp))
+        {
+            return null;
+        }
+        return entity.Comp.CurrentLabel;
+    }
 }

--- a/Content.Shared/Labels/EntitySystems/SharedLabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedLabelSystem.cs
@@ -48,18 +48,4 @@ public abstract partial class SharedLabelSystem : EntitySystem
         if (!string.IsNullOrEmpty(entity.Comp.CurrentLabel))
             args.AddModifier("comp-label-format", extraArgs: ("label", entity.Comp.CurrentLabel));
     }
-
-    /// <summary>
-    /// Retrieves the current label of the specified entity.
-    /// </summary>
-    /// <param name="entity">The entity with the <see cref="LabelComponent"/>.</param>
-    /// <returns>The current label of the entity, or null if no label exists.</returns>
-    public string? LabelOrNull(Entity<LabelComponent?> entity)
-    {
-        if (!Resolve(entity, ref entity.Comp))
-        {
-            return null;
-        }
-        return entity.Comp.CurrentLabel;
-    }
 }


### PR DESCRIPTION
## About the PR
"""Refactors""" the DetGadget hat extraction logic to be 12% less horrible to look at.

The hat will now explicitly check the requested items' label, if it exists, and compare against that when serving requests. This means that you can now label your items before you put them in, to expedite retrieving items.

For example, you can rename your explosive grenade just "grenade" and the hat will pull it out when you say "go go gadget grenade". Similarly, you can name a .30 ammo box just "ammo" and it will extract that as well.

## Why / Balance
It's really annoying to say the longhand of every single name. In addition, putting a label on a hat can make the item very hard to retrieve as you'd have to say the full name of the item, with label.

This also makes the hat easier to use for species with accents. For example, a forensic scanner might be worded as "Ssscanner" if spoken by a reptilian, which would be completely dodged by the string comparison. Now, you can name your scanner "Ssscanner" and it'll pick up on it just fine. This issue is a larger core issue behind TriggerSystem.Voice, which can be easily fixed by Slamchat when that hits the repo.

## Technical details
Extracting items has been moved into a method that gets called when we want to extract an item.

The logic for extracting an item has changed. When the system iterates over all of the items currently in the attached storage:
- It checks to see if an item has a `NameModifierComponent`. If true, it'll run a comparison on the original name of the item. If it finds the item it wants, it'll call the extraction method.
- The above check repeats exactly the same for `LabelComponent` if applicable.
- If it doesn't have a `LabelComponent` or a `NameModifierComponent`, a simple check of the name will be done against the message and it will call the extraction method if true.

## Media
https://github.com/user-attachments/assets/7db7e1c0-718e-40c1-8df3-075541854813

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: The Go Go Hat now checks if your message matches either the name of the item or the label of the item. This allows people with accents to name their items according to how their character would say the item, or for a faster retrieval without having to type out the full name.