### PR TITLE
Wizard Staff Recharging

### DIFF
--- a/Content.Server/Actions/ActionOnInteractSystem.cs
+++ b/Content.Server/Actions/ActionOnInteractSystem.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 using Content.Shared.Actions;
+using Content.Shared.Charges.Components;
+using Content.Shared.Charges.Systems;
 using Content.Shared.Interaction;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -15,6 +17,7 @@ public sealed class ActionOnInteractSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
+    [Dependency] private readonly SharedChargesSystem _charges = default!;
 
     public override void Initialize()
     {
@@ -70,6 +73,15 @@ public sealed class ActionOnInteractSystem : EntitySystem
                 return;
 
             actionEnts = actionsContainerComponent.Container.ContainedEntities.ToList();
+        }
+
+        // Staves have limited charges, other items may not
+        if (TryComp<LimitedChargesComponent>(uid, out var charges))
+        {
+            if (_charges.IsEmpty(uid, charges))
+                return;
+
+            _charges.UseCharge(uid, charges);
         }
 
         // First, try entity target actions

--- a/Resources/Prototypes/Magic/animate_spell.yml
+++ b/Resources/Prototypes/Magic/animate_spell.yml
@@ -5,7 +5,6 @@
   components:
   - type: EntityTargetAction
     useDelay: 0
-    charges: 5
     itemIconStyle: BigAction
     whitelist:
       components:

--- a/Resources/Prototypes/Magic/animate_spell.yml
+++ b/Resources/Prototypes/Magic/animate_spell.yml
@@ -72,5 +72,6 @@
       - RequireProjectileTarget
       - BlockMovement
       - Item
+      - MeleeRequiresWield
       speech: action-speech-spell-animate
       doSpeech: false

--- a/Resources/Prototypes/Magic/staves.yml
+++ b/Resources/Prototypes/Magic/staves.yml
@@ -1,9 +1,27 @@
-# non-projectile / "gun" staves
+# staves will automatically recharge while wands require the recharge spell
 
-# wand that gives lights an RGB effect.
+- type: entity
+  id: BaseStaff
+  abstract: true
+  parent: [ BaseItem, BaseMagicalContraband ]
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Basic/staves.rsi
+  - type: Item
+    heldPrefix: staff
+    size: Normal
+  - type: LimitedCharges
+    maxCharges: 5
+    charges: 5
+  - type: AutoRecharge
+    rechargeDuration: 30
+  - type: Tag
+    tags:
+    - WizardStaff
+
 - type: entity
   id: RGBStaff
-  parent: BaseItem
+  parent: BaseStaff
   name: RGB staff
   description: Helps fix the underabundance of RGB gear on the station.
   components:
@@ -31,10 +49,13 @@
   - type: PointLight
     enabled: true
     radius: 2
+  - type: LimitedCharges
+    maxCharges: 25
+    charges: 25
 
 - type: entity
   id: AnimationStaff
-  parent: [ BaseItem, BaseMagicalContraband ]
+  parent: BaseStaff
   name: staff of animation
   description: Brings inanimate objects to life!
   components:
@@ -52,16 +73,12 @@
       - state: animation-inhand-left
       right:
       - state: animation-inhand-right
-  - type: Tag
-    tags:
-    - WizardWand
 
 - type: entity
   id: ActionRgbLight
   components:
   - type: EntityTargetAction
     whitelist: { components: [ PointLight ] }
-    charges: 25
     sound: /Audio/Magic/blink.ogg
     event: !type:ChangeComponentsSpellEvent
       toAdd:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
staves now have visible charges and automatically recharge
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
yes
## Technical details
<!-- Summary of code changes for easier review. -->
- Added private bool CheckForCharges method to ActionOnInteractSystem which handles the charges of the item
- Removed charges from ActionRgbLight and ActionAnimateSpell
- Created BaseStaff prototype which is an abstract item inherited currently by RGBStaff and AnimationStaff
- Changed Animate spell to remove MeleeRequiresWield component, fixes bug where animate items requiring wield couldn't attack
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
**Changelog**
:cl: ActiveMammoth
- add: Wizard staves now have visible charges and recharge automatically.
- fix: Animate weapons requiring wield now attack properly.
