### PR TITLE
Unclean implanters have cleanable information about what was contained in them

### DIFF
--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -263,6 +263,9 @@ namespace Content.Server.Forensics
 
             if (TryComp<ResidueComponent>(args.Used, out var residue))
                 targetComp.Residues.Add(string.IsNullOrEmpty(residue.ResidueColor) ? Loc.GetString("forensic-residue", ("adjective", residue.ResidueAdjective)) : Loc.GetString("forensic-residue-colored", ("color", residue.ResidueColor), ("adjective", residue.ResidueAdjective)));
+;
+            var foresnicsCleanedEvent = new ForensicsCleanedEvent();
+            RaiseLocalEvent(args.Target!.Value, ref foresnicsCleanedEvent);
         }
 
         public string GenerateFingerprint()

--- a/Content.Shared/Forensics/Events.cs
+++ b/Content.Shared/Forensics/Events.cs
@@ -31,6 +31,14 @@ public sealed partial class CleanForensicsDoAfterEvent : SimpleDoAfterEvent
 }
 
 /// <summary>
+/// Raised when a Successful clean doafter has occured.
+/// </summary>
+[ByRefEvent]
+public record struct ForensicsCleanedEvent()
+{
+};
+
+/// <summary>
 /// An event to apply DNA evidence from a donor onto some recipient.
 /// </summary>
 [ByRefEvent]

--- a/Content.Shared/Implants/Components/ImplanterComponent.cs
+++ b/Content.Shared/Implants/Components/ImplanterComponent.cs
@@ -107,6 +107,12 @@ public sealed partial class ImplanterComponent : Component
     [AutoNetworkedField]
     public EntProtoId? DeimplantChosen = null;
 
+    /// <summary>
+    /// Stores the current stored implant name, to be cleared if someone cleans the evidence off of the implanter.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public LocId? CurrentImplanterLoc;
+
     public bool UiUpdateNeeded;
 }
 

--- a/Content.Shared/Implants/Components/SubdermalImplantComponent.cs
+++ b/Content.Shared/Implants/Components/SubdermalImplantComponent.cs
@@ -56,6 +56,12 @@ public sealed partial class SubdermalImplantComponent : Component
     /// </summary>
     [DataField]
     public EntProtoId? DrawableProtoIdOverride;
+
+    /// <summary>
+    /// The Name of localization id of the implant for naming the Implanter
+    /// </summary>
+    [DataField]
+    public LocId ImplantLoc;
 }
 
 /// <summary>

--- a/Resources/Locale/en-US/implant/implant.ftl
+++ b/Resources/Locale/en-US/implant/implant.ftl
@@ -34,3 +34,22 @@ scramble-implant-activated-popup = Your appearance shifts and changes!
 
 deathrattle-implant-dead-message = {$user} has died {$position}.
 deathrattle-implant-critical-message = {$user} life signs critical, immediate assistance required {$position}.
+
+## Implants
+sad-trombone-implant = sad trombone {$baseName}
+light-implant = light {$baseName}
+bike-horn-implant = bike horn {$baseName}
+tracking-implant = tracking {$baseName}
+storage-implant = storage {$baseName}
+freedom-implant = freedom {$baseName}
+radio-implant = radio {$baseName}
+uplink-implant = uplink {$baseName}
+emp-implant = EMP {$baseName}
+scram-implant = scram {$baseName}
+micro-bomb-implant = micro-bomb {$baseName}
+macro-bomb-implant = macro-bomb {$baseName}
+death-acidifier-implant = death-acidifer {$baseName}
+death-rattle-implant = death rattle {$baseName}
+fake-mindshield-implant = fake mindshield {$baseName}
+mindshield-implant = mindshield {$baseName}
+radio-centcomm-implant = radio centcomm {$baseName}

--- a/Resources/Locale/en-US/implant/implant.ftl
+++ b/Resources/Locale/en-US/implant/implant.ftl
@@ -46,6 +46,7 @@ radio-implant = radio {$baseName}
 uplink-implant = uplink {$baseName}
 emp-implant = EMP {$baseName}
 scram-implant = scram {$baseName}
+dna-scrambler-implant = DNA scrambler {$baseName}
 micro-bomb-implant = micro-bomb {$baseName}
 macro-bomb-implant = macro-bomb {$baseName}
 death-acidifier-implant = death-acidifer {$baseName}

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -1,7 +1,7 @@
 # Implanters
 
 - type: entity
-  name: implanter
+  name: implanter item
   description: A syringe exclusively designed for the injection and extraction of subdermal implants. Use care when extracting implants, as incorrect draw settings may injure the user.
   id: BaseImplanter
   parent: BaseItem
@@ -12,7 +12,7 @@
       containers:
         implanter_slot: !type:ContainerSlot { }
     - type: NameModifier
-      baseName: Implanter
+      baseName: implanter
     - type: Implanter
       whitelist:
         components:
@@ -131,7 +131,7 @@
   abstract: true
   components:
     - type: NameModifier
-      baseName: Syndicate Implanter
+      baseName: syndicate implanter
     - type: Item
       sprite: Objects/Specific/Medical/syndi_implanter.rsi
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -11,6 +11,8 @@
     - type: ContainerContainer
       containers:
         implanter_slot: !type:ContainerSlot { }
+    - type: NameModifier
+      baseName: Implanter
     - type: Implanter
       whitelist:
         components:
@@ -108,6 +110,7 @@
   description: A disposable syringe exclusively designed for the injection of subdermal implants.
   abstract: true
   components:
+
     - type: Sprite
       sprite: Objects/Specific/Medical/implanter.rsi
       state: implanter0
@@ -124,10 +127,11 @@
 - type: entity
   id: BaseImplantOnlyImplanterSyndi
   parent: [BaseImplantOnlyImplanter, BaseSyndicateContraband]
-  name: syndicate implanter
-  description: A compact disposable syringe exclusively designed for the injection of subdermal implants.
+  description: A compact disposable syringe exclusively designed for the injection of subdermal implants. Remember to use soap to clean the evidence!
   abstract: true
   components:
+    - type: NameModifier
+      baseName: Syndicate Implanter
     - type: Item
       sprite: Objects/Specific/Medical/syndi_implanter.rsi
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -20,6 +20,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: sad-trombone-implant
       whitelist:
         components:
         - MobState # admeme implanting a chair with trombone implant needs to give the chair mobstate so it can die first
@@ -40,6 +41,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: light-implant
       implantAction: ActionToggleLight
     - type: PointLight
       enabled: false
@@ -62,6 +64,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: bike-horn-implant
       implantAction: ActionActivateHonkImplant
     - type: TriggerImplantAction
     - type: EmitSoundOnTrigger
@@ -83,6 +86,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: tracking-implant
       whitelist:
         components:
         - MobState # admeme implanting a chair with tracking implant needs to give the chair mobstate so it can die first
@@ -113,6 +117,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: storage-implant
       implantAction: ActionOpenStorageImplant
       whitelist:
         components:
@@ -137,6 +142,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: freedom-implant
       implantAction: ActionActivateFreedomImplant
       whitelist:
         components:
@@ -150,6 +156,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SubdermalImplant
+    implantLoc: radio-implant
   - type: RadioImplant
     radioChannels:
     - Syndicate
@@ -162,6 +169,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SubdermalImplant
+    implantLoc: uplink-implant
     implantAction: ActionOpenUplinkImplant
     whitelist:
       components:
@@ -182,6 +190,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: emp-implant
       implantAction: ActionActivateEmpImplant
     - type: TriggerImplantAction
     - type: EmpOnTrigger
@@ -197,6 +206,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: scram-implant
       implantAction: ActionActivateScramImplant
     - type: TriggerImplantAction
     - type: ScramImplant
@@ -209,6 +219,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: dna-scrambler-implant
       implantAction: ActionActivateDnaScramblerImplant
       whitelist:
         components:
@@ -224,6 +235,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: micro-bomb-implant
       permanent: true
       implantAction: ActionActivateMicroBomb
     - type: TriggerOnMobstateChange
@@ -254,6 +266,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: macro-bomb-implant
       permanent: true
     - type: TriggerOnMobstateChange #Chains with OnUseTimerTrigger
       mobState:
@@ -289,6 +302,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SubdermalImplant
+    implantLoc: death-acidifier-implant
     permanent: true
     implantAction: ActionActivateDeathAcidifier
   - type: TriggerOnMobstateChange
@@ -313,6 +327,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      implantLoc: death-rattle-implant
       permanent: true
       whitelist:
         components:
@@ -331,6 +346,7 @@
   categories: [ HideSpawnMenu ]
   components:
       - type: SubdermalImplant
+        implantLoc: fake-mindshield-implant
         implantAction: FakeMindShieldToggleAction
       - type: FakeMindShieldImplant
 
@@ -344,6 +360,7 @@
   categories: [ HideSpawnMenu ]
   components:
    - type: SubdermalImplant
+     implantLoc: mindshield-implant
      permanent: true
    - type: Tag
      tags:
@@ -359,6 +376,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SubdermalImplant
+    implantLoc: radio-centcomm-implant
   - type: RadioImplant
     radioChannels:
     - CentCom


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
added back the Meta information to Implanters to better support unclean implanter interactions for #32136 and added extra system work to support removing that meta information should a syndicate clean up after themselves.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prior to the Implanter Draw Rework, Metashield generally had 2 methods of defeating an implant:
Witness someone using the implant
Find an unclean implanter with DNA on it.

Now with mechanical enforcement, an unclean implanter is a frustrating endeavor as you must let someone who you know has an implant run around with the syndicate contraband without being able to directly remove it, or Actually attempt to remove that implant due to not knowing what it is.

With this if a Syndicate fails to clean up their evidence, Secoffs will be able to both attempt the draw and have a direct knowledge of which one to draw (Something that a syndicate can counterplay by drawing it themselves, so potentially dangerous regardless) rather than needing to "Rainbow" every implant or do a 2x50 genetic damage testing popular implants.

It however doesn't reveal "what" implants are in play if a syndicate cleans up after themselves, which keeps and ensures detective work must be done if even a trivial amount of diligence is taken.

Additionally: Added a Small reminder to clean your evidence with soap to the implanter, to hopefully inform New syndicates they can clean it.

## Technical details
<!-- Summary of code changes for easier review. -->
Added code to inform the implanter what implant is inside when created and rename itself, additionally adds cleaning code and raises events from forensics system when the DoAfter completes.

Needed to change the Implanter name `implanter` due to how `metadataSystem` blocks renaming an entity to it's entity name when done via NameModifierSystem

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/e98d9b3f-b108-469e-9eda-e13b056b20c9


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Kickguy223
- tweak: re-added information about what implant was in an implanter
- add: cleaning a implanter also removes what was in the implanter