### PR TITLE
Increased blunt damage of parent GasTankBase

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -39,7 +39,14 @@
     attackRate: 0.8
     damage:
       types:
-        Blunt: 10
+        Blunt: 15
+  - type: StaminaDamageOnHit
+    damage: 5
+  - type: Wieldable
+  - type: IncreaseDamageOnWield
+    damage:
+      types:
+        Blunt: 3
   - type: PhysicalComposition
     materialComposition:
       Steel: 185


### PR DESCRIPTION
## About the PR
Increased blunt damage of gas tanks by tweaking parent GasTankRoundBase.

## Why / Balance
Issues #24984 states that previously was able to escape the room using air tanks to destroy the door after salvagers took all firearms. Player did not appear to have an escape route or any other weapon in a locked room.

## Technical details
Airlocks took on modifiers that had flat reductions against damage less than 10, which is why air tanks did not damage doors.
Increased blunt damage in parent GasTankRoundBase.
Also added Stamina Damage and increase damage on wield.
Only affects OxygenTank, NitrogenTank, AirTank and NitrousOxideTank. There appeared to be some inheritance issues that I did not want touch for this PR.

## Media
no media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No breaking changes

**Changelog**
:cl:
- tweak: Increased Damage for Gas Tanks
