### PR TITLE
[April Fools] Very Bad Day

### DIFF
--- a/Content.Server/GameTicking/Rules/VariationPass/Components/UnpowerAllVariationPassComponent.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/Components/UnpowerAllVariationPassComponent.cs
@@ -1,0 +1,9 @@
+using Content.Shared.Whitelist;
+
+namespace Content.Server.GameTicking.Rules.VariationPass.Components;
+
+/// <summary>
+/// Handles cutting a random wire on random devices around the station.
+/// </summary>
+[RegisterComponent]
+public sealed partial class UnpowerAllVariationPassComponent : Component;

--- a/Content.Server/GameTicking/Rules/VariationPass/UnpowerAllVariationPassSystem.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/UnpowerAllVariationPassSystem.cs
@@ -1,0 +1,28 @@
+using Content.Server.GameTicking.Rules.VariationPass.Components;
+using Content.Server.Power.Components;
+using Content.Server.Wires;
+using Content.Shared.Whitelist;
+using Robust.Shared.Random;
+
+namespace Content.Server.GameTicking.Rules.VariationPass;
+
+/// <summary>
+/// Handles unpowering stuff around the station.
+/// This system identifies target devices and adds <see cref="UnpowerOnMapInitComponent"/> to them.
+/// The actual wire cutting is handled by <see cref="CutWireOnMapInitSystem"/>.
+/// </summary>
+public sealed class UnpowerAllVariationPassSystem : VariationPassSystem<UnpowerAllVariationPassComponent>
+{
+    protected override void ApplyVariation(Entity<UnpowerAllVariationPassComponent> ent, ref StationVariationPassEvent args)
+    {
+        var query = AllEntityQuery<BatteryComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var transform))
+        {
+            // Ignore if not part of the station
+            if (!IsMemberOfStation((uid, transform), ref args))
+                continue;
+
+            EnsureComp<UnpowerOnMapInitComponent>(uid);
+        }
+    }
+}

--- a/Content.Server/Power/Components/UnpowerOnMapInitComponent.cs
+++ b/Content.Server/Power/Components/UnpowerOnMapInitComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Server.Power.Components;
+
+/// <summary>
+/// Fetches entity's <see cref="BatteryComponent"/> and unpowers it.
+/// Runs at MapInit and removes itself afterwards.
+/// </summary>
+[RegisterComponent]
+public sealed partial class UnpowerOnMapInitComponent : Component
+{
+}

--- a/Content.Server/Power/EntitySystems/UnpowerAllOnMapInitSystem.cs
+++ b/Content.Server/Power/EntitySystems/UnpowerAllOnMapInitSystem.cs
@@ -1,0 +1,31 @@
+using Content.Server.Power.Components;
+using Robust.Shared.Random;
+
+namespace Content.Server.Power.EntitySystems;
+
+/// <summary>
+/// Handles unpowering entities on map init>
+/// </summary>
+public sealed partial class UnpowerAllOnMapInitSystem : EntitySystem
+{
+    [Dependency] private readonly BatterySystem _battery = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<UnpowerOnMapInitComponent, MapInitEvent>(OnMapInit, after: [typeof(BatterySystem)]);
+    }
+
+    private void OnMapInit(Entity<UnpowerOnMapInitComponent> entity, ref MapInitEvent args)
+    {
+        if (TryComp<BatteryComponent>(entity, out var battery) && _random.Prob(0.9f)) // this is a piece of code for one day, i am hardcoding this
+        {
+            _battery.SetCharge(entity, 0f);
+        }
+
+        // Our work here is done
+        RemCompDeferred(entity, entity.Comp);
+    }
+}

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-verybadday.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-verybadday.ftl
@@ -1,0 +1,2 @@
+verybadday-title = Very Bad Day
+verybadday-description = This shift went downhill very fast.

--- a/Resources/Prototypes/GameRules/verybadday.yml
+++ b/Resources/Prototypes/GameRules/verybadday.yml
@@ -1,0 +1,36 @@
+- type: entity
+  id: TerribleRoundstartVariation
+  parent: BaseGameRule
+  components:
+  - type: RoundstartStationVariationRule
+    rules:
+    - id: TerriblePoweredLightVariationPass
+    - id: TerribleTrashVariationPass
+    - id: SolidWallRustingVariationPass
+    - id: ReinforcedWallRustingVariationPass
+    - id: BloodbathPuddleMessVariationPass
+    - id: UnpoweredStationVariationPass
+
+- type: entity
+  id: TerriblePoweredLightVariationPass
+  parent: BaseVariationPass
+  components:
+  - type: PoweredLightVariationPass
+    lightBreakChance: 0.5
+    lightAgingChance: 0.1
+
+- type: entity
+  id: TerribleTrashVariationPass
+  parent: BaseVariationPass
+  components:
+  - type: EntitySpawnVariationPass
+    tilesPerEntityAverage: 25
+    tilesPerEntityStdDev: 4
+    entities:
+    - id: RandomSpawner
+
+- type: entity
+  id: UnpoweredStationVariationPass
+  parent: BaseVariationPass
+  components:
+  - type: UnpowerAllVariationPass

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -234,3 +234,27 @@
   - KesslerSyndromeScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
+
+- type: gamePreset
+  id: VeryBadDay
+  alias:
+  - verybadday
+  - cdda #this is the game where the scenario comes from
+  name: verybadday-title
+  showInVote: true
+  description: verybadday-description
+  rules:
+  - Nukeops
+  - Traitor
+  - Revolutionary
+  - Zombie
+  - SubGamemodesRule
+  - KesslerSyndromeScheduler
+  - RampingStationEventScheduler
+  - TerribleRoundstartVariation
+  # no power
+  # force survivor antag
+  # forcecall shuttle
+  # forceset alert level
+  # everyone is drunk
+  # everyone is hurt


### PR DESCRIPTION
## About the PR
Added a new gamePreset - Very Bad Day. This is a reference to a name of a very hard scenario in a few zombie survival games.
This game preset is based on All At Once, but there are a few... Very fun additions:
- [X] The blood is everywhere.
- [X] The station is almost fully unpowered.
- [ ] Everyone is drunk and hurt.
- [ ] Everyone is a survivor. 
- [ ] The alert level is already at maximum.
- [ ] The shuttle is already called (although it's stuck in some space traffic).

## Why / Balance
Why balance?

## Technical details
UnpowerAllVariationPass has been added - it unpowers 90% of things with BatteryComponent.
A few TerribleSomethingVariationPass gamerules has also been added - those are just existing modified variation passes to show that the station is kinda fucked (guaranteed blood everywhere, tons of trash, etc)
something else idk it's not ready yet

## Media
later

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
:cl:
- add: Station can now have a very, VERY bad day. (psst check out preset vote menu)