### PR TITLE
Fix revolutionary round start issue

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -348,6 +348,30 @@ namespace Content.Server.GameTicking
             return total;
         }
 
+        private bool HasEnoughAntagPlayers()
+        {
+            var antagPlayers = 0;
+            foreach (var (userId, status) in _playerGameStatuses)
+            {
+                if (LobbyEnabled && status == PlayerGameStatus.NotReadyToPlay)
+                    continue;
+
+                if (!_playerManager.TryGetSessionById(userId, out var session))
+                    continue;
+
+                if (_prefsManager.TryGetCachedPreferences(userId, out var preferences))
+                {
+                    var profile = (HumanoidCharacterProfile) preferences.SelectedCharacter;
+                    if (profile.AntagPreferences.Count > 0)
+                    {
+                        antagPlayers++;
+                    }
+                }
+            }
+
+            return antagPlayers >= CurrentPreset?.MinPlayersForAntag ?? 0;
+        }
+
         public void StartRound(bool force = false)
         {
 #if EXCEPTION_TOLERANCE
@@ -420,6 +444,15 @@ namespace Content.Server.GameTicking
             if (!StartPreset(origReadyPlayers, force))
             {
                 _startingRound = false;
+                return;
+            }
+
+            // Check if there are enough players with the antag role enabled
+            if (!HasEnoughAntagPlayers())
+            {
+                // Reroll the game mode and call StartRound again
+                SetGamePreset(_cfg.GetCVar(CCVars.GameLobbyDefaultPreset));
+                StartRound(force);
                 return;
             }
 

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -70,6 +70,15 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     {
         base.Started(uid, component, gameRule, args);
         component.CommandCheck = _timing.CurTime + component.TimerWait;
+
+        // Check if there are any head revs selected
+        var headRevs = EntityQuery<HeadRevolutionaryComponent>().ToList();
+        if (headRevs.Count == 0)
+        {
+            // Reroll the game mode and call StartRound again
+            GameTicker.SetGamePreset(GameTicker.DefaultPreset);
+            GameTicker.StartRound();
+        }
     }
 
     protected override void ActiveTick(EntityUid uid, RevolutionaryRuleComponent component, GameRuleComponent gameRule, float frameTime)


### PR DESCRIPTION
Add preround check for antag role players and ensure head revs are selected.

* Add `HasEnoughAntagPlayers` method in `Content.Server/GameTicking/GameTicker.RoundFlow.cs` to count players with the antag role enabled.
* Update `StartRound` method in `Content.Server/GameTicking/GameTicker.RoundFlow.cs` to call `HasEnoughAntagPlayers` before proceeding.
* Reroll the game mode and call `StartRound` again if `HasEnoughAntagPlayers` returns false.
* Add a check in the `Started` method of `Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs` to ensure there are always head revs selected.
* Reroll the game mode and call `StartRound` again if no head revs are selected.

