### PR TITLE
add sprite index offset to stackcomponent

### DIFF
--- a/Content.Client/Stack/StackSystem.cs
+++ b/Content.Client/Stack/StackSystem.cs
@@ -67,9 +67,9 @@ namespace Content.Client.Stack
                 hidden = false;
 
             if (comp.IsComposite)
-                _counterSystem.ProcessCompositeSprite(uid, actual, maxCount, comp.LayerStates, hidden, sprite: args.Sprite);
+                _counterSystem.ProcessCompositeSprite(uid, actual, maxCount, comp.LayerStates, hidden, comp.SpriteIndexOffset, sprite: args.Sprite);
             else
-                _counterSystem.ProcessOpaqueSprite(uid, comp.BaseLayer, actual, maxCount, comp.LayerStates, hidden, sprite: args.Sprite);
+                _counterSystem.ProcessOpaqueSprite(uid, comp.BaseLayer, actual, maxCount, comp.LayerStates, hidden, comp.SpriteIndexOffset, sprite: args.Sprite);
         }
     }
 }

--- a/Content.Client/Storage/Systems/ItemCounterSystem.cs
+++ b/Content.Client/Storage/Systems/ItemCounterSystem.cs
@@ -38,23 +38,30 @@ public sealed class ItemCounterSystem : SharedItemCounterSystem
             ProcessOpaqueSprite(uid, comp.BaseLayer, actual, maxCount, comp.LayerStates, hidden, sprite: args.Sprite);
     }
 
-    public void ProcessOpaqueSprite(EntityUid uid, string layer, int count, int maxCount, List<string> states, bool hide = false, SpriteComponent? sprite = null)
+    public void ProcessOpaqueSprite(EntityUid uid, string layer, int count, int maxCount, List<string> states, bool hide = false, int spriteIndexOffset = 0, SpriteComponent? sprite = null)
     {
         if (!Resolve(uid, ref sprite)
         ||  !sprite.LayerMapTryGet(layer, out var layerKey, logError: true))
             return;
-        
+
         var activeState = ContentHelpers.RoundToEqualLevels(count, maxCount, states.Count);
+
+        // Apply the offset
+        activeState = Math.Clamp(activeState + spriteIndexOffset, 0, states.Count - 1);
+
         sprite.LayerSetState(layerKey, states[activeState]);
         sprite.LayerSetVisible(layerKey, !hide);
     }
 
-    public void ProcessCompositeSprite(EntityUid uid, int count, int maxCount, List<string> layers, bool hide = false, SpriteComponent? sprite = null)
+    public void ProcessCompositeSprite(EntityUid uid, int count, int maxCount, List<string> layers, bool hide = false, int spriteIndexOffset = 0, SpriteComponent? sprite = null)
     {
         if(!Resolve(uid, ref sprite))
             return;
-        
+
         var activeTill = ContentHelpers.RoundToNearestLevels(count, maxCount, layers.Count);
+
+        activeTill = Math.Clamp(activeTill + spriteIndexOffset, 0, layers.Count);
+
         for(var i = 0; i < layers.Count; ++i)
         {
             sprite.LayerSetVisible(layers[i], !hide && i < activeTill);

--- a/Content.Shared/Stacks/StackComponent.cs
+++ b/Content.Shared/Stacks/StackComponent.cs
@@ -78,6 +78,13 @@ namespace Content.Shared.Stacks
         [DataField("layerStates")]
         [ViewVariables(VVAccess.ReadWrite)]
         public List<string> LayerStates = new();
+
+        /// <summary>
+        /// Offset applied to the sprite index when selecting which sprite to display from LayerStates.
+        /// Useful for correcting sprite selection in cases where there's a 1:1 mapping between count and sprite states.
+        /// </summary>
+        [DataField]
+        public int SpriteIndexOffset;
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

apparently the StackSystem doesn't support 1:1 sprite to count mapping
So if you have a stack with a max count of 5, and 5 different states representing each item in the stack (`layerStates: [ icon, cone_2, cone_3, cone_4, cone_5 ]`), the `RoundToEqualLevels(1, 5, 5)` helper will return `1`, which will result in us using the *second* sprite from the list (because of zero indexing). This means we won't ever use the actual first sprite in the list.

![image](https://github.com/user-attachments/assets/5ab8d176-a7e0-4a85-9bf0-eeeffc06f5f6)

Looks like `RoundToEqualLevels` is designed for cases where you have fewer sprite states than possible count values (like with other stacks in the game, like bananium, where you have 2 states for 10 possible values). This might not be the best solution, but this seems to be the somewhat intended behavior(?), so adding an offset is better than duping states.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no fun