### PR TITLE
Switch replay file extension to .rtreplay

### DIFF
--- a/Content.Shared/CCVar/CCVars.Replays.cs
+++ b/Content.Shared/CCVar/CCVars.Replays.cs
@@ -30,7 +30,7 @@ public sealed partial class CCVars
     /// </remarks>
     public static readonly CVarDef<string> ReplayAutoRecordName =
         CVarDef.Create("replay.auto_record_name",
-            "{year}_{month}_{day}-{hour}_{minute}-round_{round}.zip",
+            "{year}_{month}_{day}-{hour}_{minute}-round_{round}.rtreplay",
             CVar.SERVERONLY);
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Switched the default replay file extension

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

In preparation to https://github.com/space-wizards/SS14.Launcher/pull/136

## Technical details
<!-- Summary of code changes for easier review. -->

Needs #robust-pr-here

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Any parsers should expect .rtreplay files, which are just a zip with another name