### PR TITLE
Update to borg ion storms

### DIFF
--- a/Content.Server/Silicons/Laws/IonStormSystem.cs
+++ b/Content.Server/Silicons/Laws/IonStormSystem.cs
@@ -228,7 +228,7 @@ public sealed class IonStormSystem : EntitySystem
         var subjects = _robustRandom.Prob(0.5f) ? objectsThreats : Loc.GetString("ion-storm-people");
 
         // message logic!!!
-        return _robustRandom.Next(0, 37) switch
+        return _robustRandom.Next(0, 35) switch
         {
             0  => Loc.GetString("ion-storm-law-on-station", ("joined", joined), ("subjects", triple)),
             1  => Loc.GetString("ion-storm-law-call-shuttle", ("joined", joined), ("subjects", triple)),
@@ -264,8 +264,6 @@ public sealed class IonStormSystem : EntitySystem
             31 => Loc.GetString("ion-storm-law-crew-must-eat", ("who", who), ("adjective", adjective), ("food", food), ("part", part)),
             32 => Loc.GetString("ion-storm-law-harm", ("who", harm)),
             33 => Loc.GetString("ion-storm-law-protect", ("who", harm)),
-            34 => Loc.GetString("ion-storm-law-exist-1", ("who", crew1)),
-            35 => Loc.GetString("ion-storm-law-exist-2", ("who", crew1), ("must", must)),
             _ => Loc.GetString("ion-storm-law-concept-verb", ("concept", concept), ("verb", verb), ("subjects", triple))
         };
     }

--- a/Content.Server/Silicons/Laws/IonStormSystem.cs
+++ b/Content.Server/Silicons/Laws/IonStormSystem.cs
@@ -228,10 +228,10 @@ public sealed class IonStormSystem : EntitySystem
         var subjects = _robustRandom.Prob(0.5f) ? objectsThreats : Loc.GetString("ion-storm-people");
 
         // message logic!!!
-        return _robustRandom.Next(0, 35) switch
+        return _robustRandom.Next(0, 37) switch
         {
             0  => Loc.GetString("ion-storm-law-on-station", ("joined", joined), ("subjects", triple)),
-            1  => Loc.GetString("ion-storm-law-no-shuttle", ("joined", joined), ("subjects", triple)),
+            1  => Loc.GetString("ion-storm-law-call-shuttle", ("joined", joined), ("subjects", triple)),
             2  => Loc.GetString("ion-storm-law-crew-are", ("who", crewAll), ("joined", joined), ("subjects", objectsThreats)),
             3  => Loc.GetString("ion-storm-law-subjects-harmful", ("adjective", adjective), ("subjects", triple)),
             4  => Loc.GetString("ion-storm-law-must-harmful", ("must", must)),
@@ -264,6 +264,8 @@ public sealed class IonStormSystem : EntitySystem
             31 => Loc.GetString("ion-storm-law-crew-must-eat", ("who", who), ("adjective", adjective), ("food", food), ("part", part)),
             32 => Loc.GetString("ion-storm-law-harm", ("who", harm)),
             33 => Loc.GetString("ion-storm-law-protect", ("who", harm)),
+            34 => Loc.GetString("ion-storm-law-exist-1", ("who", crew1)),
+            35 => Loc.GetString("ion-storm-law-exist-2", ("who", crew1), ("must", must)),
             _ => Loc.GetString("ion-storm-law-concept-verb", ("concept", concept), ("verb", verb), ("subjects", triple))
         };
     }

--- a/Resources/Locale/en-US/station-events/events/ion-storm.ftl
+++ b/Resources/Locale/en-US/station-events/events/ion-storm.ftl
@@ -18,7 +18,7 @@ ion-storm-x-and-y = {$x} AND {$y}
 # subjects can generally be threats or jobs or objects
 # thing is specified above it
 ion-storm-law-on-station = THERE ARE {$joined} {$subjects} ON THE STATION
-ion-storm-law-no-shuttle = THE SHUTTLE CANNOT BE CALLED BECAUSE OF {$joined} {$subjects} ON THE STATION
+ion-storm-law-call-shuttle = THE SHUTTLE MUST BE CALLED BECAUSE OF {$joined} {$subjects} ON THE STATION
 ion-storm-law-crew-are = THE {$who} ARE NOW {$joined} {$subjects}
 
 ion-storm-law-subjects-harmful = {$adjective} {$subjects} ARE HARMFUL TO THE CREW
@@ -84,6 +84,10 @@ ion-storm-law-crew-must-eat = ONLY THOSE WHO EAT {$adjective} {$food} ARE {$part
 
 ion-storm-law-harm = YOU MUST HARM {$who} AND NOT ALLOW THEM, THROUGH INACTION, TO ESCAPE HARM
 ion-storm-law-protect = YOU MUST NEVER HARM {$who} AND NOT ALLOW THEM, THROUGH INACTION, TO COME TO HARM
+
+# existence changing
+ion-storm-law-exist-1 = {$who} DO NOT EXIST AND THEREFORE SHOULD BE IGNORED
+ion-storm-law-exist-2 = ONLY {$who} WHO {$must} EXIST AND ALL OTHERS SHOULD BE IGNORED
 
 # implementing other variants is annoying so just have this one
 # COMMUNISM IS KILLING CLOWNS

--- a/Resources/Locale/en-US/station-events/events/ion-storm.ftl
+++ b/Resources/Locale/en-US/station-events/events/ion-storm.ftl
@@ -85,10 +85,6 @@ ion-storm-law-crew-must-eat = ONLY THOSE WHO EAT {$adjective} {$food} ARE {$part
 ion-storm-law-harm = YOU MUST HARM {$who} AND NOT ALLOW THEM, THROUGH INACTION, TO ESCAPE HARM
 ion-storm-law-protect = YOU MUST NEVER HARM {$who} AND NOT ALLOW THEM, THROUGH INACTION, TO COME TO HARM
 
-# existence changing
-ion-storm-law-exist-1 = {$who} DO NOT EXIST AND THEREFORE SHOULD BE IGNORED
-ion-storm-law-exist-2 = ONLY {$who} WHO {$must} EXIST AND ALL OTHERS SHOULD BE IGNORED
-
 # implementing other variants is annoying so just have this one
 # COMMUNISM IS KILLING CLOWNS
 ion-storm-law-concept-verb = {$concept} IS {$verb} {$subjects}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adjusts the Ion Storms so that borgs no longer roundstall if they randomly get the law to delay the shuttle. Also adds 2 new ion storms to keep things new.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It has been a common issue wherein borg players will get an ion storm law that says THE SHUTTLE CANNOT BE CALLED BECAUSE... and then they recall the shuttle, or prevent it from being called at all due to the law. This inverts the wording so that the borg will not stall the round.

From a gameplay perspective, removing the law makes less sense than rewording it. Removing the law is removing a piece of gameplay, regardless of size. Rewording it puts a sense of pressure onto the crew to locate the now clearly-faulty borg before evac arrives, and attempt to handle the situation (or allow the shuttle to arrive, and more onto the next round). This is a far better solution than a round going on far past when players have wanted it to end.

From a rules perspective, this still allows borg players to interpret the law as they see fit, as did the previous iteration of the law. Since borg players were not breaking a rule per-se, they should not be penalized by having the law removed from the game, but rather rebalanced to be more appropriate for how rounds progress.

As for the addition of the new type of ion storm law (2 new variants), this was added to bring in a bit of freshness to the laws.

## Technical details
<!-- Summary of code changes for easier review. -->
- Changed "CANNOT" to "MUST" in the wording for the ion storm law referring to the shuttle
- Added 2 new ion storm laws that refer to either specific roles or departments, and if they exist, in the yml file
- Added corresponding lines to the switch statement in the .cs file for the new ion storm laws
- Ensured the naming convention for the laws was maintained for ftl / language purposes
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/38ad20be-2178-43c1-9b87-4385c247abaa)
![image](https://github.com/user-attachments/assets/fd602f53-a636-4e73-bec6-40df6a47df31)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Reisama
- fix: Borgs will no longer get laws to prevent the shuttle from being called when Ion Stormed, and may get laws to call the shuttle instead.