### PR TITLE
fix nukeops commander name

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -121,7 +121,7 @@
       - type: RandomMetadata
         nameSegments:
         - nukeops-role-commander
-        - SyndicateNamesElite
+        - NamesSyndicateElite
       - type: NpcFactionMember
         factions:
         - Syndicate


### PR DESCRIPTION
## About the PR
![Screenshot (373)](https://github.com/user-attachments/assets/3b9a3481-d82c-4247-88ad-2472d5050ecb)
Just noticed this on Vulture.
Missed this in https://github.com/space-wizards/space-station-14/pull/32893

## Why / Balance
bugfix

## Technical details
Correct the dataset name.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
nah
