### PR TITLE
Tweak sun shadow rotations

### DIFF
--- a/Content.Client/Light/SunShadowOverlay.cs
+++ b/Content.Client/Light/SunShadowOverlay.cs
@@ -114,7 +114,9 @@ public sealed class SunShadowOverlay : Overlay
                     foreach (var ent in _shadows)
                     {
                         var xform = _entManager.GetComponent<TransformComponent>(ent.Owner);
-                        var worldMatrix = _xformSys.GetWorldMatrix(xform);
+                        var (worldPos, worldRot) = _xformSys.GetWorldPositionRotation(xform);
+                        // Need no rotation on matrix as sun shadow direction doesn't care.
+                        var worldMatrix = Matrix3x2.CreateTranslation(worldPos);
                         var renderMatrix = Matrix3x2.Multiply(worldMatrix, invMatrix);
                         var pointCount = ent.Comp.Points.Length;
 
@@ -122,6 +124,10 @@ public sealed class SunShadowOverlay : Overlay
 
                         for (var i = 0; i < pointCount; i++)
                         {
+                            // Update point based on entity rotation.
+                            indices[i] = worldRot.RotateVec(indices[i]);
+
+                            // Add the offset point by the sun shadow direction.
                             indices[pointCount + i] = indices[i] + direction;
                         }
 


### PR DESCRIPTION
Won't use the entity's rotation for the matrix, I just forgot to do this. Means shadows will always point in the same direction and the points will correctly adjust as the entity rotates.

:cl:
- fix: Fix sun shadow rotations not always being accurate.