### PR TITLE
Made the Captain Hardsuit more durable.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -320,7 +320,7 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
   id: ClothingOuterHardsuitCap
-  name: captain's armored spacesuit
+  name: Captain's Armored Spacesuit
   description: A formal armored spacesuit, made for the station's captain.
   components:
   - type: Sprite
@@ -335,15 +335,15 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.6
+        Blunt: 0.5
+        Slash: 0.6
+        Piercing: 0.2
         Heat: 0.5
-        Radiation: 0.5
-        Caustic: 0.6
+        Radiation: 0.01
+        Caustic: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCap


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I changed the damage resistance on the captain's armored spacesuit to make the captain more durable to damage

## Why / Balance
Right now, Nukies can FULLY KILL a captain in his ARMORED spacesuit with a SINGULAR mag of the C-20, and crit them in a half of a mag, considering the spacesuit is labeled as armored, I think it's best to make it durable to bullets and other types of damage.

## Technical details
Changed the .X values of the different damage multipliers of the ClothingOuterHardsuitCap prototype.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://www.youtube.com/watch?v=txej5mjGQBQ

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Changed the .X values of the different damage multipliers of the ClothingOuterHardsuitCap prototype.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Buffed the Captain's Armored Spacesuit to make it more durable.
-->
