### PR TITLE
Fix shuttle arrival visualizer

### DIFF
--- a/Content.Server/Shuttles/DockingConfig.cs
+++ b/Content.Server/Shuttles/DockingConfig.cs
@@ -24,5 +24,9 @@ public sealed class DockingConfig
     public Box2 Area;
 
     public EntityCoordinates Coordinates;
+
+    /// <summary>
+    /// Local angle of the docking grid relative to the target grid.
+    /// </summary>
     public Angle Angle;
 }

--- a/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
@@ -79,7 +79,7 @@ public sealed partial class DockingSystem
             return false;
 
         shuttleDockedAABB = matty.TransformBox(shuttleAABB);
-        gridRotation = (targetGridRotation + offsetAngle).Reduced();
+        gridRotation = offsetAngle.Reduced();
         return true;
     }
 
@@ -125,7 +125,8 @@ public sealed partial class DockingSystem
     public DockingConfig? GetDockingConfigAt(EntityUid shuttleUid,
         EntityUid targetGrid,
         EntityCoordinates coordinates,
-        Angle angle)
+        Angle angle,
+        bool fallback = true)
     {
         var gridDocks = GetDocks(targetGrid);
         var shuttleDocks = GetDocks(shuttleUid);
@@ -138,6 +139,11 @@ public sealed partial class DockingSystem
             {
                 return config;
             }
+        }
+
+        if (fallback && configs.Count > 0)
+        {
+            return configs.First();
         }
 
         return null;

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -365,8 +365,6 @@ public sealed partial class ShuttleSystem
         _audio.SetGridAudio(audio);
         component.StartupStream = audio?.Entity;
 
-        // TODO: Play previs here for docking arrival.
-
         // Make sure the map is setup before we leave to avoid pop-in (e.g. parallax).
         EnsureFTLMap();
         return true;
@@ -450,7 +448,8 @@ public sealed partial class ShuttleSystem
 
         if (entity.Comp1.VisualizerProto != null)
         {
-            comp.VisualizerEntity = SpawnAtPosition(entity.Comp1.VisualizerProto, entity.Comp1.TargetCoordinates);
+            comp.VisualizerEntity = SpawnAttachedTo(entity.Comp1.VisualizerProto, entity.Comp1.TargetCoordinates);
+            DebugTools.Assert(Transform(comp.VisualizerEntity.Value).ParentUid == entity.Comp1.TargetCoordinates.EntityId);
             var visuals = Comp<FtlVisualizerComponent>(comp.VisualizerEntity.Value);
             visuals.Grid = entity.Owner;
             Dirty(comp.VisualizerEntity.Value, visuals);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -755,7 +755,7 @@ public sealed partial class ShuttleSystem
         // Set position
         var mapCoordinates = _transform.ToMapCoordinates(config.Coordinates);
         var mapUid = _mapSystem.GetMap(mapCoordinates.MapId);
-        _transform.SetCoordinates(shuttle.Owner, shuttle.Comp, new EntityCoordinates(mapUid, mapCoordinates.Position), rotation: config.Angle);
+        _transform.SetCoordinates(shuttle.Owner, shuttle.Comp, new EntityCoordinates(mapUid, mapCoordinates.Position), rotation: config.Angle + _transform.GetWorldRotation(config.Coordinates.EntityId));
 
         // Connect everything
         foreach (var (dockAUid, dockBUid, dockA, dockB) in config.Docks)

--- a/Resources/Prototypes/Entities/Effects/shuttle.yml
+++ b/Resources/Prototypes/Entities/Effects/shuttle.yml
@@ -3,6 +3,8 @@
   categories: [ HideSpawnMenu ]
   description: Visualizer for shuttles arriving. You shouldn't see this!
   components:
+  - type: Transform
+    noRot: true
   - type: FtlVisualizer
     sprite:
       sprite: /Textures/Effects/medi_holo.rsi

--- a/Resources/Prototypes/Entities/Effects/shuttle.yml
+++ b/Resources/Prototypes/Entities/Effects/shuttle.yml
@@ -5,6 +5,7 @@
   components:
   - type: Transform
     noRot: true
+    gridTraversal: false
   - type: FtlVisualizer
     sprite:
       sprite: /Textures/Effects/medi_holo.rsi


### PR DESCRIPTION
It was at a fixed spot but if the target is rotating it wasn't handled.

Also fixes https://github.com/space-wizards/space-station-14/issues/35779

Breaking change for dockingconfig angle being relative angle not world angle.

:cl:
- fix: Fix shuttle arrivals visualizer not updating with the target coordinates updating.