### PR TITLE
Evil Syndie Implants: OF DOOM!!

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -72,6 +72,15 @@ uplink-exploding-syndicate-bomb-desc = A big, anchored bomb that can create a hu
 uplink-exploding-syndicate-bomb-fake-name = Decoy Syndicate Bomb
 uplink-exploding-syndicate-bomb-fake-desc = A training bomb carefully made to look just like the real thing. In all ways similar to a syndicate bomb, but only creates a tiny explosion.
 
+uplink-evil-sad-trombone-implant-name = Evil Sad Trombone Implant
+uplink-evil-sad-trombone-implant-desc = Cybersun's most junior clown says this is essential to all successful infiltration ops. That seems doubtful, but maybe it'll confuse the Security team (or at least make your failure a little funnier).
+
+uplink-evil-light-implant-name = Evil Light Implant
+uplink-evil-light-implant-desc = An experimental implant that creates a blinding flash, toned down after it was discovered that it tended to microwave the implantee's brain. This version is of limited use, but, hey, it might confuse a Security officer or two.
+
+uplink-evil-bike-horn-implant-name = Evil... Bike Horn Implant? Seriously?
+uplink-evil-bike-horn-implant-desc = Look, we've got nothing here. It was Craig's first day at the office and it seemed like a good idea at the time. Honour Craig's memory with a little clowning, and maybe confuse the Security team while you're at it.
+
 uplink-cluster-grenade-name = Cluster Grenade
 uplink-cluster-grenade-desc = Three explosive grenades bundled together. The cluster splits after 3.5 seconds.
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1867,6 +1867,36 @@
   - !type:ListingLimitedStockCondition
     stock: 3
 
+- type: listing
+  id: UplinkEvilSadTromboneImplant
+  name: uplink-evil-sad-trombone-implant-name
+  description: uplink-evil-sad-trombone-implant-desc
+  productEntity: EvilSadTromboneImplanter
+  cost:
+    Telecrystal: 1
+  categories:
+  - UplinkPointless
+
+- type: listing
+  id: UplinkEvilLightImplant
+  name: uplink-evil-light-implant-name
+  description: uplink-evil-light-implant-desc
+  productEntity: EvilLightImplanter
+  cost:
+    Telecrystal: 1
+  categories:
+  - UplinkPointless
+
+- type: listing
+  id: UplinkEvilBikeHornImplant
+  name: uplink-evil-bike-horn-implant-name
+  description: uplink-evil-bike-horn-implant-desc
+  productEntity: EvilBikeHornImplanter
+  cost:
+    Telecrystal: 1
+  categories:
+  - UplinkPointless
+
 # Job Specific
 
 - type: listing

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -307,3 +307,29 @@
   components:
   - type: Implanter
     implant: RadioImplantCentcomm
+
+# Evil fun implanters OF DOOM!! Used as decoys to throw Sec off the scent.
+
+- type: entity
+  id: EvilSadTromboneImplanter
+  suffix: sad trombone (evil!)
+  parent: BaseImplantOnlyImplanterSyndi
+  components:
+    - type: Implanter
+      implant: SadTromboneImplant
+
+- type: entity
+  id: EvilLightImplanter
+  suffix: light (monstrous!)
+  parent: BaseImplantOnlyImplanterSyndi
+  components:
+    - type: Implanter
+      implant: LightImplant
+
+- type: entity
+  id: EvilBikeHornImplanter
+  suffix: bike horn (dastardly!)
+  parent: BaseImplantOnlyImplanterSyndi
+  components:
+    - type: Implanter
+      implant: BikeHornImplant


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added three useless implants to the Uplink - "evil" equivalents of the three fun implants in the game (bike horn, sad trombone and light)

## Why / Balance
There's nothing wrong with more fun uplink items, but this also fills an important gap in the Tot arsenal. Currently, a syndicate implanter _must_ have contained a contraband implant. By adding alternatives, this doesn't itself add this fakeout gameplay (you can always extract an implant after adding it), but it does make such fakeouts only 1 TC and, hey, you can make youself use the sad trombone sound effect if you die. That's funny.

## Technical details
YAML edit, total snoozefest.

## Media
![image](https://github.com/user-attachments/assets/f292f4e9-0a9b-4e47-9cd3-b63b67e400cb)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nah

**Changelog**
:cl:
- add: Three "useless" syndicate implanters have been added to the uplink. Good for clowning or faking out security teams.
