### PR TITLE
Restore the order of admin overlay elements

### DIFF
--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -85,10 +85,10 @@ internal sealed class AdminNameOverlay : Overlay
 
             var currentOffset = Vector2.Zero;
 
-            args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, playerInfo.Username, uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
+            args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, playerInfo.CharacterName, uiScale, playerInfo.Connected ? Color.Aquamarine : Color.White);
             currentOffset += lineoffset;
 
-            args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, playerInfo.CharacterName, uiScale, playerInfo.Connected ? Color.Aquamarine : Color.White);
+            args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, playerInfo.Username, uiScale, playerInfo.Connected ? Color.Yellow : Color.White);
             currentOffset += lineoffset;
 
             if (!string.IsNullOrEmpty(playerInfo.PlaytimeString) && playTime)


### PR DESCRIPTION
## About the PR
Layout of the overlay is now once again Character, then Username

## Why / Balance
The order was changed by accident when the draw code was refactored

## Media

master branch
![Screenshot_2025-03-11_173006](https://github.com/user-attachments/assets/f3ace978-a935-4309-8a77-604f84b3b2b3)

PR (also the stable branch)
![image](https://github.com/user-attachments/assets/513cd549-61db-49c5-a10e-5e37c15478fb)




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl: Errant
ADMIN:
- fix: The admin overlay once again shows the character name in the top line.