### PR TITLE
Roleban command error handling

### DIFF
--- a/Content.Server/Administration/Commands/RoleBanCommand.cs
+++ b/Content.Server/Administration/Commands/RoleBanCommand.cs
@@ -7,6 +7,8 @@ using Content.Shared.Database;
 using Content.Shared.Roles;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+
 namespace Content.Server.Administration.Commands;
 
 [AdminCommand(AdminFlags.Ban)]
@@ -15,6 +17,7 @@ public sealed class RoleBanCommand : IConsoleCommand
     [Dependency] private readonly IPlayerLocator _locator = default!;
     [Dependency] private readonly IBanManager _bans = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
 
     public string Command => "roleban";
     public string Description => Loc.GetString("cmd-roleban-desc");
@@ -74,6 +77,12 @@ public sealed class RoleBanCommand : IConsoleCommand
                 shell.WriteError(Loc.GetString("cmd-roleban-arg-count"));
                 shell.WriteLine(Help);
                 return;
+        }
+
+        if (!_proto.HasIndex<JobPrototype>(job))
+        {
+            shell.WriteError(Loc.GetString("cmd-roleban-job-parse",("job", job)));
+            return;
         }
 
         var located = await _locator.LookupIdByNameOrIdAsync(target);


### PR DESCRIPTION
## About the PR
Roleban command no longer crashes the debug client if a non-existant job is specified

## Why / Balance
 #35266 Most people agree that the client crashing is a bad thing

## Technical details
Now it tries to index the job before passing it to the next system.

## Media

![image](https://github.com/user-attachments/assets/7718f093-a571-417c-b01a-b13d7e5ab2ce)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes