### PR TITLE
IconSmooth additional smoothing keys

### DIFF
--- a/Content.Client/IconSmoothing/IconSmoothComponent.cs
+++ b/Content.Client/IconSmoothing/IconSmoothComponent.cs
@@ -30,7 +30,7 @@ namespace Content.Client.IconSmoothing
         ///     Additional keys to smooth with.
         /// </summary>
         [DataField]
-        public List<string> AdditionalKeys { get; private set; } = new();
+        public List<string> AdditionalKeys = new();
 
         /// <summary>
         ///     Prepended to the RSI state.

--- a/Content.Client/IconSmoothing/IconSmoothComponent.cs
+++ b/Content.Client/IconSmoothing/IconSmoothComponent.cs
@@ -27,6 +27,12 @@ namespace Content.Client.IconSmoothing
         public string? SmoothKey { get; private set; }
 
         /// <summary>
+        ///     Additional keys to smooth with.
+        /// </summary>
+        [DataField]
+        public List<string> AdditionalKeys { get; private set; } = new();
+
+        /// <summary>
         ///     Prepended to the RSI state.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite), DataField("base")]

--- a/Content.Client/IconSmoothing/IconSmoothSystem.cs
+++ b/Content.Client/IconSmoothing/IconSmoothSystem.cs
@@ -376,7 +376,8 @@ namespace Content.Client.IconSmoothing
             while (candidates.MoveNext(out var entity))
             {
                 if (smoothQuery.TryGetComponent(entity, out var other) &&
-                    other.SmoothKey == smooth.SmoothKey &&
+                    other.SmoothKey != null &&
+                    (other.SmoothKey == smooth.SmoothKey || smooth.AdditionalKeys.Contains(other.SmoothKey)) &&
                     other.Enabled)
                 {
                     return true;

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -81,7 +81,7 @@
         acts: [ "Destruction" ]
 
   - type: IconSmooth
-    key: bricks
+    key: walls
     base: brick
 
 - type: entity

--- a/Resources/Prototypes/Entities/Tiles/chasm.yml
+++ b/Resources/Prototypes/Entities/Tiles/chasm.yml
@@ -27,6 +27,8 @@
     state: full
   - type: IconSmooth
     key: chasm
+    additionalKeys:
+    - walls
     base: chasm
   - type: Physics
     bodyType: Static

--- a/Resources/Prototypes/Entities/Tiles/lava.yml
+++ b/Resources/Prototypes/Entities/Tiles/lava.yml
@@ -36,6 +36,8 @@
     state: full
   - type: IconSmooth
     key: floor
+    additionalKeys:
+    - walls
     base: lava
   - type: Physics
     bodyType: Static


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
IconSmooth can now glue with entities that have a different smoothing key

For example used for some flooring entities that are now additionally glued to the walls, which looks quite nice.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/fc68374c-e605-4d76-b6f1-8f0295f99ec1)
![image](https://github.com/user-attachments/assets/18fbb163-c0de-419d-924d-294ca04154ee)
![image](https://github.com/user-attachments/assets/ef60100a-1154-4e9a-a11f-dfca05dd1d57)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
