### PR TITLE
Cleanup: Remove redundant prototype name specifications

### DIFF
--- a/Content.Client/Parallax/Data/ParallaxPrototype.cs
+++ b/Content.Client/Parallax/Data/ParallaxPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Client.Parallax.Data;
 /// <summary>
 /// Prototype data for a parallax.
 /// </summary>
-[Prototype("parallax")]
+[Prototype]
 public sealed partial class ParallaxPrototype : IPrototype
 {
     /// <inheritdoc/>

--- a/Content.Server/Announcements/RoundAnnouncementPrototype.cs
+++ b/Content.Server/Announcements/RoundAnnouncementPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Server.Announcements;
 /// <summary>
 /// Used for any announcements on the start of a round.
 /// </summary>
-[Prototype("roundAnnouncement")]
+[Prototype]
 public sealed partial class RoundAnnouncementPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
+++ b/Content.Server/Atmos/Reactions/GasReactionPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Atmos.Reactions
 {
-    [Prototype("gasReaction")]
+    [Prototype]
     public sealed partial class GasReactionPrototype : IPrototype
     {
         [ViewVariables]

--- a/Content.Server/Botany/SeedPrototype.cs
+++ b/Content.Server/Botany/SeedPrototype.cs
@@ -11,7 +11,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Server.Botany;
 
-[Prototype("seed")]
+[Prototype]
 public sealed partial class SeedPrototype : SeedData, IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Server/Connection/Whitelist/WhitelistPrototype.cs
+++ b/Content.Server/Connection/Whitelist/WhitelistPrototype.cs
@@ -17,7 +17,7 @@ namespace Content.Server.Connection.Whitelist;
 /// Next means the next condition in the list is checked.
 /// If the condition doesn't match, the next condition is checked.
 /// </summary>
-[Prototype("playerConnectionWhitelist")]
+[Prototype]
 public sealed partial class PlayerConnectionWhitelistPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
+++ b/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Server.GameTicking.Presets
     /// <summary>
     ///     A round-start setup preset, such as which antagonists to spawn.
     /// </summary>
-    [Prototype("gamePreset")]
+    [Prototype]
     public sealed partial class GamePresetPrototype : IPrototype
     {
         [IdDataField]

--- a/Content.Server/GameTicking/Prototypes/LobbyBackgroundPrototype.cs
+++ b/Content.Server/GameTicking/Prototypes/LobbyBackgroundPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Server.GameTicking.Prototypes;
 /// <summary>
 /// Prototype for a lobby background the game can choose.
 /// </summary>
-[Prototype("lobbyBackground")]
+[Prototype]
 public sealed partial class LobbyBackgroundPrototype : IPrototype
 {
     /// <inheritdoc/>

--- a/Content.Server/Ghost/Roles/Raffles/GhostRoleRaffleDeciderPrototype.cs
+++ b/Content.Server/Ghost/Roles/Raffles/GhostRoleRaffleDeciderPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Server.Ghost.Roles.Raffles;
 /// <summary>
 /// Allows getting a <see cref="IGhostRoleRaffleDecider"/> as prototype.
 /// </summary>
-[Prototype("ghostRoleRaffleDecider")]
+[Prototype]
 public sealed partial class GhostRoleRaffleDeciderPrototype : IPrototype
 {
     /// <inheritdoc />

--- a/Content.Server/Holiday/HolidayPrototype.cs
+++ b/Content.Server/Holiday/HolidayPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Holiday
 {
-    [Prototype("holiday")]
+    [Prototype]
     public sealed partial class HolidayPrototype : IPrototype
     {
         [DataField("name")] public string Name { get; private set; } = string.Empty;

--- a/Content.Server/Maps/GameMapPoolPrototype.cs
+++ b/Content.Server/Maps/GameMapPoolPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Server.Maps;
 /// <summary>
 /// Prototype that holds a pool of maps that can be indexed based on the map pool CCVar.
 /// </summary>
-[Prototype("gameMapPool"), PublicAPI]
+[Prototype, PublicAPI]
 public sealed partial class GameMapPoolPrototype : IPrototype
 {
     /// <inheritdoc/>

--- a/Content.Server/Maps/GameMapPrototype.cs
+++ b/Content.Server/Maps/GameMapPrototype.cs
@@ -14,7 +14,7 @@ namespace Content.Server.Maps;
 /// Forks should not directly edit existing parts of this class.
 /// Make a new partial for your fancy new feature, it'll save you time later.
 /// </remarks>
-[Prototype("gameMap"), PublicAPI]
+[Prototype, PublicAPI]
 [DebuggerDisplay("GameMapPrototype [{ID} - {MapName}]")]
 public sealed partial class GameMapPrototype : IPrototype
 {

--- a/Content.Server/NPC/Queries/Curves/UtilityCurvePresetPrototype.cs
+++ b/Content.Server/NPC/Queries/Curves/UtilityCurvePresetPrototype.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.NPC.Queries.Curves;
 
-[Prototype("utilityCurvePreset")]
+[Prototype]
 public sealed partial class UtilityCurvePresetPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = string.Empty;

--- a/Content.Server/NPC/Queries/UtilityQueryPrototype.cs
+++ b/Content.Server/NPC/Queries/UtilityQueryPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Server.NPC.Queries;
 /// Each query is run in turn to get the final available results.
 /// These results are then run through the considerations.
 /// </summary>
-[Prototype("utilityQuery")]
+[Prototype]
 public sealed partial class UtilityQueryPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Server/Wires/WireLayout.cs
+++ b/Content.Server/Wires/WireLayout.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Wires;
 ///     wires. Once one of these is initialized, it should be stored in the
 ///     WiresSystem as a functional wire set.
 /// </summary>
-[Prototype("wireLayout")]
+[Prototype]
 public sealed partial class WireLayoutPrototype : IPrototype, IInheritingPrototype
 {
     [IdDataField]

--- a/Content.Server/Worldgen/Prototypes/NoiseChannelPrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/NoiseChannelPrototype.cs
@@ -79,7 +79,7 @@ public class NoiseChannelConfig
     public float Minimum { get; private set; }
 }
 
-[Prototype("noiseChannel")]
+[Prototype]
 public sealed partial class NoiseChannelPrototype : NoiseChannelConfig, IPrototype, IInheritingPrototype
 {
     /// <inheritdoc />

--- a/Content.Server/Worldgen/Prototypes/WorldgenConfigPrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/WorldgenConfigPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Server.Worldgen.Prototypes;
 ///     This is a prototype for controlling overall world generation.
 ///     The components included are applied to the map that world generation is configured on.
 /// </summary>
-[Prototype("worldgenConfig")]
+[Prototype]
 public sealed partial class WorldgenConfigPrototype : IPrototype
 {
     /// <inheritdoc />

--- a/Content.Shared/Access/AccessGroupPrototype.cs
+++ b/Content.Shared/Access/AccessGroupPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Access;
 ///     Contains a list of access tags that are part of this group.
 ///     Used by <see cref="AccessComponent"/> to avoid boilerplate.
 /// </summary>
-[Prototype("accessGroup")]
+[Prototype]
 public sealed partial class AccessGroupPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Access/AccessLevelPrototype.cs
+++ b/Content.Shared/Access/AccessLevelPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Access
     /// <summary>
     ///     Defines a single access level that can be stored on ID cards and checked for.
     /// </summary>
-    [Prototype("accessLevel")]
+    [Prototype]
     public sealed partial class AccessLevelPrototype : IPrototype
     {
         [ViewVariables]

--- a/Content.Shared/Atmos/Prototypes/GasPrototype.cs
+++ b/Content.Shared/Atmos/Prototypes/GasPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Atmos.Prototypes
 {
-    [Prototype("gas")]
+    [Prototype]
     public sealed partial class GasPrototype : IPrototype
     {
         [DataField("name")] public string Name { get; set; } = "";

--- a/Content.Shared/Audio/AmbientMusicPrototype.cs
+++ b/Content.Shared/Audio/AmbientMusicPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Audio;
 /// <summary>
 /// Attaches a rules prototype to sound files to play ambience.
 /// </summary>
-[Prototype("ambientMusic")]
+[Prototype]
 public sealed partial class AmbientMusicPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = string.Empty;

--- a/Content.Shared/Body/Prototypes/BodyPrototype.cs
+++ b/Content.Shared/Body/Prototypes/BodyPrototype.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Body.Prototypes;
 
-[Prototype("body")]
+[Prototype]
 public sealed partial class BodyPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Body/Prototypes/MetabolismGroupPrototype.cs
+++ b/Content.Shared/Body/Prototypes/MetabolismGroupPrototype.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Body.Prototypes
 {
-    [Prototype("metabolismGroup")]
+    [Prototype]
     public sealed partial class MetabolismGroupPrototype : IPrototype
     {
         [IdDataField]

--- a/Content.Shared/Body/Prototypes/MetabolizerTypePrototype.cs
+++ b/Content.Shared/Body/Prototypes/MetabolizerTypePrototype.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Body.Prototypes
 {
-    [Prototype("metabolizerType")]
+    [Prototype]
     public sealed partial class MetabolizerTypePrototype : IPrototype
     {
         [IdDataField]

--- a/Content.Shared/Chat/Prototypes/AutoEmotePrototype.cs
+++ b/Content.Shared/Chat/Prototypes/AutoEmotePrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Chat.Prototypes;
 
-[Prototype("autoEmote")]
+[Prototype]
 public sealed partial class AutoEmotePrototype : IPrototype
 {
     /// <inheritdoc/>

--- a/Content.Shared/Chat/Prototypes/EmotePrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmotePrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Chat.Prototypes;
 ///     IC emotes (scream, smile, clapping, etc).
 ///     Entities can activate emotes by chat input, radial or code.
 /// </summary>
-[Prototype("emote")]
+[Prototype]
 public sealed partial class EmotePrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
+++ b/Content.Shared/Chat/Prototypes/EmoteSoundsPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Chat.Prototypes;
 ///     Sounds collection for each <see cref="EmotePrototype"/>.
 ///     Different entities may use different sounds collections.
 /// </summary>
-[Prototype("emoteSounds"), Serializable, NetSerializable]
+[Prototype, Serializable, NetSerializable]
 public sealed partial class EmoteSoundsPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Chat/TypingIndicator/TypingIndicatorPrototype.cs
+++ b/Content.Shared/Chat/TypingIndicator/TypingIndicatorPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Chat.TypingIndicator;
 /// <summary>
 ///     Prototype to store chat typing indicator visuals.
 /// </summary>
-[Prototype("typingIndicator")]
+[Prototype]
 public sealed partial class TypingIndicatorPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Chemistry/Dispenser/ReagentDispenserInventoryPrototype.cs
+++ b/Content.Shared/Chemistry/Dispenser/ReagentDispenserInventoryPrototype.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Chemistry.Dispenser
     /// to define which reagents it's able to dispense. Based off of how vending
     /// machines define their inventory.
     /// </summary>
-    [Serializable, NetSerializable, Prototype("reagentDispenserInventory")]
+    [Serializable, NetSerializable, Prototype]
     public sealed partial class ReagentDispenserInventoryPrototype : IPrototype
     {
         [DataField("inventory", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]

--- a/Content.Shared/Chemistry/Reaction/MixingCategoryPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/MixingCategoryPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Chemistry.Reaction;
 /// <summary>
 /// This is a prototype for a method of chemical mixing, to be used by <see cref="ReactionMixerComponent"/>
 /// </summary>
-[Prototype("mixingCategory")]
+[Prototype]
 public sealed partial class MixingCategoryPrototype : IPrototype
 {
     /// <inheritdoc/>

--- a/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Chemistry.Reaction
     /// <summary>
     /// Prototype for chemical reaction definitions
     /// </summary>
-    [Prototype("reaction")]
+    [Prototype]
     public sealed partial class ReactionPrototype : IPrototype, IComparable<ReactionPrototype>
     {
         [ViewVariables]

--- a/Content.Shared/Chemistry/Reaction/ReactiveGroupPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactiveGroupPrototype.cs
@@ -2,7 +2,7 @@
 
 namespace Content.Shared.Chemistry.Reaction;
 
-[Prototype("reactiveGroup")]
+[Prototype]
 public sealed partial class ReactiveGroupPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -20,7 +20,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Chemistry.Reagent
 {
-    [Prototype("reagent")]
+    [Prototype]
     [DataDefinition]
     public sealed partial class ReagentPrototype : IPrototype, IInheritingPrototype
     {

--- a/Content.Shared/Communications/CommsHackerComponent.cs
+++ b/Content.Shared/Communications/CommsHackerComponent.cs
@@ -29,7 +29,7 @@ public sealed partial class CommsHackerComponent : Component
 /// Generally some kind of mid-round minor antag, though you could make it call in scrubber backflow if you wanted to.
 /// You wouldn't do that, right?
 /// </summary>
-[Prototype("ninjaHackingThreat")]
+[Prototype]
 public sealed partial class NinjaHackingThreatPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Construction/Prototypes/ConstructionGraphPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionGraphPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Construction.Prototypes
 {
-    [Prototype("constructionGraph")]
+    [Prototype]
     public sealed partial class ConstructionGraphPrototype : IPrototype, ISerializationHooks
     {
         private readonly Dictionary<string, ConstructionGraphNode> _nodes = new();

--- a/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Construction.Prototypes;
 
-[Prototype("construction")]
+[Prototype]
 public sealed partial class ConstructionPrototype : IPrototype
 {
     [DataField("conditions")] private List<IConstructionCondition> _conditions = new();

--- a/Content.Shared/Damage/Prototypes/DamageContainerPrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageContainerPrototype.cs
@@ -12,7 +12,7 @@ namespace Content.Shared.Damage.Prototypes
     ///     and damage groups. Currently this is only used to specify what damage types a <see
     ///     cref="DamageableComponent"/> should support.
     /// </remarks>
-    [Prototype("damageContainer")]
+    [Prototype]
     [Serializable, NetSerializable]
     public sealed partial class DamageContainerPrototype : IPrototype
     {

--- a/Content.Shared/Damage/Prototypes/DamageGroupPrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageGroupPrototype.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Damage.Prototypes
     ///     These groups can be used to specify supported damage types of a <see cref="DamageContainerPrototype"/>, or
     ///     to change/get/set damage in a <see cref="DamageableComponent"/>.
     /// </remarks>
-    [Prototype("damageGroup", 2)]
+    [Prototype(2)]
     [Serializable, NetSerializable]
     public sealed partial class DamageGroupPrototype : IPrototype
     {

--- a/Content.Shared/Damage/Prototypes/DamageModifierSetPrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageModifierSetPrototype.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Damage.Prototypes
     ///     Done to avoid removing the 'required' tag on the ID and passing around a 'prototype' when we really
     ///     just want normal data to be deserialized.
     /// </remarks>
-    [Prototype("damageModifierSet")]
+    [Prototype]
     public sealed partial class DamageModifierSetPrototype : DamageModifierSet, IPrototype
     {
         [ViewVariables]

--- a/Content.Shared/Damage/Prototypes/DamageTypePrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageTypePrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Damage.Prototypes
     /// <summary>
     ///     A single damage type. These types are grouped together in <see cref="DamageGroupPrototype"/>s.
     /// </summary>
-    [Prototype("damageType")]
+    [Prototype]
     public sealed partial class DamageTypePrototype : IPrototype
     {
         [IdDataField]

--- a/Content.Shared/Damage/Prototypes/ExaminableDamagePrototype.cs
+++ b/Content.Shared/Damage/Prototypes/ExaminableDamagePrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Damage.Prototypes;
 /// <summary>
 ///     Prototype for examinable damage messages.
 /// </summary>
-[Prototype("examinableDamage")]
+[Prototype]
 public sealed partial class ExaminableDamagePrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Dataset/DatasetPrototype.cs
+++ b/Content.Shared/Dataset/DatasetPrototype.cs
@@ -2,7 +2,7 @@
 
 namespace Content.Shared.Dataset
 {
-    [Prototype("dataset")]
+    [Prototype]
     public sealed partial class DatasetPrototype : IPrototype
     {
         [ViewVariables]

--- a/Content.Shared/Decals/DecalPrototype.cs
+++ b/Content.Shared/Decals/DecalPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Decals
 {
-    [Prototype("decal")]
+    [Prototype]
     public sealed partial class DecalPrototype : IPrototype, IInheritingPrototype
     {
         [IdDataField] public string ID { get; private set; } = null!;

--- a/Content.Shared/DeviceLinking/DevicePortPrototype.cs
+++ b/Content.Shared/DeviceLinking/DevicePortPrototype.cs
@@ -27,13 +27,13 @@ public abstract class DevicePortPrototype
     public string Description = default!;
 }
 
-[Prototype("sinkPort")]
+[Prototype]
 [Serializable, NetSerializable]
 public sealed partial class SinkPortPrototype : DevicePortPrototype, IPrototype
 {
 }
 
-[Prototype("sourcePort")]
+[Prototype]
 [Serializable, NetSerializable]
 public sealed partial class SourcePortPrototype : DevicePortPrototype, IPrototype
 {

--- a/Content.Shared/DeviceNetwork/DeviceFrequencyPrototype.cs
+++ b/Content.Shared/DeviceNetwork/DeviceFrequencyPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.DeviceNetwork;
 /// <summary>
 ///     A named device network frequency. Useful for ensuring entity prototypes can communicate with each other.
 /// </summary>
-[Prototype("deviceFrequency")]
+[Prototype]
 [Serializable, NetSerializable]
 public sealed partial class DeviceFrequencyPrototype : IPrototype
 {

--- a/Content.Shared/EntityList/EntityListPrototype.cs
+++ b/Content.Shared/EntityList/EntityListPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.EntityList
 {
-    [Prototype("entityList")]
+    [Prototype]
     public sealed partial class EntityListPrototype : IPrototype
     {
         [ViewVariables]

--- a/Content.Shared/EntityList/EntityLootTablePrototype.cs
+++ b/Content.Shared/EntityList/EntityLootTablePrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Random;
 
 namespace Content.Shared.EntityList;
 
-[Prototype("entityLootTable")]
+[Prototype]
 public sealed partial class EntityLootTablePrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Explosion/ExplosionPrototype.cs
+++ b/Content.Shared/Explosion/ExplosionPrototype.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Explosion;
 ///     entities is evaluated and stored by the explosion system. Adding or removing a prototype would require updating
 ///     that map of airtight entities. This could be done, but is just not yet implemented.
 /// </remarks>
-[Prototype("explosion")]
+[Prototype]
 public sealed partial class ExplosionPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Ghost/Roles/Raffles/GhostRoleRaffleSettingsPrototype.cs
+++ b/Content.Shared/Ghost/Roles/Raffles/GhostRoleRaffleSettingsPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Ghost.Roles.Raffles;
 /// <summary>
 /// Allows specifying the settings for a ghost role raffle as a prototype.
 /// </summary>
-[Prototype("ghostRoleRaffleSettings")]
+[Prototype]
 public sealed partial class GhostRoleRaffleSettingsPrototype : IPrototype
 {
     /// <inheritdoc />

--- a/Content.Shared/GridPreloader/Prototypes/PreloadedGridPrototype.cs
+++ b/Content.Shared/GridPreloader/Prototypes/PreloadedGridPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.GridPreloader.Prototypes;
 /// and allow the GridPreloader system to load them in the middle of the round. This is needed for optimization,
 /// because loading grids in the middle of a round causes the server to lag.
 /// </summary>
-[Prototype("preloadedGrid")]
+[Prototype]
 public sealed partial class PreloadedGridPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = string.Empty;

--- a/Content.Shared/Guidebook/GuideEntry.cs
+++ b/Content.Shared/Guidebook/GuideEntry.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Guidebook;
 
-[Prototype("guideEntry")]
+[Prototype]
 public sealed partial class GuideEntryPrototype : GuideEntry, IPrototype
 {
     public string ID => Id;

--- a/Content.Shared/HUD/HudThemePrototype.cs
+++ b/Content.Shared/HUD/HudThemePrototype.cs
@@ -2,7 +2,7 @@
 
 namespace Content.Shared.HUD
 {
-    [Prototype("hudTheme")]
+    [Prototype]
     public sealed partial class HudThemePrototype : IPrototype, IComparable<HudThemePrototype>
     {
         [DataField("name", required: true)]

--- a/Content.Shared/Humanoid/Markings/MarkingPoints.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPoints.cs
@@ -34,7 +34,7 @@ public sealed partial class MarkingPoints
     }
 }
 
-[Prototype("markingPoints")]
+[Prototype]
 public sealed partial class MarkingPointsPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Humanoid.Markings
 {
-    [Prototype("marking")]
+    [Prototype]
     public sealed partial class MarkingPrototype : IPrototype
     {
         [IdDataField]

--- a/Content.Shared/Humanoid/Prototypes/HumanoidProfilePrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/HumanoidProfilePrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Humanoid.Prototypes;
 
-[Prototype("humanoidProfile")]
+[Prototype]
 public sealed partial class HumanoidProfilePrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Humanoid/Prototypes/RandomHumanoidSettingsPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/RandomHumanoidSettingsPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Humanoid.Prototypes;
 /// <summary>
 ///     This is what is used to change a humanoid spawned by RandomHumanoidSystem in Content.Server.
 /// </summary>
-[Prototype("randomHumanoidSettings")]
+[Prototype]
 public sealed partial class RandomHumanoidSettingsPrototype : IPrototype, IInheritingPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Humanoid.Prototypes;
 
-[Prototype("species")]
+[Prototype]
 public sealed partial class SpeciesPrototype : IPrototype
 {
     /// <summary>

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Inventory;
 
-[Prototype("inventoryTemplate")]
+[Prototype]
 public sealed partial class InventoryTemplatePrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = string.Empty;

--- a/Content.Shared/Item/ItemSizePrototype.cs
+++ b/Content.Shared/Item/ItemSizePrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Item;
 /// <summary>
 /// This is a prototype for a category of an item's size.
 /// </summary>
-[Prototype("itemSize")]
+[Prototype]
 public sealed partial class ItemSizePrototype : IPrototype, IComparable<ItemSizePrototype>
 {
     /// <inheritdoc/>

--- a/Content.Shared/Materials/MaterialPrototype.cs
+++ b/Content.Shared/Materials/MaterialPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Materials
     ///     Materials are read-only storage for the properties of specific materials.
     ///     Properties should be intrinsic (or at least as much is necessary for game purposes).
     /// </summary>
-    [Prototype("material")]
+    [Prototype]
     public sealed partial class MaterialPrototype : IPrototype, IInheritingPrototype
     {
         [ViewVariables]

--- a/Content.Shared/NPC/Prototypes/NpcFactionPrototype.cs
+++ b/Content.Shared/NPC/Prototypes/NpcFactionPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.NPC.Prototypes;
 /// <summary>
 /// Contains data about this faction's relations with other factions.
 /// </summary>
-[Prototype("npcFaction")]
+[Prototype]
 public sealed partial class NpcFactionPrototype : IPrototype
 {
     [ViewVariables]

--- a/Content.Shared/NameIdentifier/NameIdentifierGroupPrototype.cs
+++ b/Content.Shared/NameIdentifier/NameIdentifierGroupPrototype.cs
@@ -2,7 +2,7 @@
 
 namespace Content.Shared.NameIdentifier;
 
-[Prototype("nameIdentifierGroup")]
+[Prototype]
 public sealed partial class NameIdentifierGroupPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Nutrition/Flavor.cs
+++ b/Content.Shared/Nutrition/Flavor.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Nutrition;
 
-[Prototype("flavor")]
+[Prototype]
 public sealed partial class FlavorPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Nutrition/Prototypes/FoodSequenceElementPrototype.cs
+++ b/Content.Shared/Nutrition/Prototypes/FoodSequenceElementPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Nutrition.Prototypes;
 /// <summary>
 /// Unique data storage block for different FoodSequence layers
 /// </summary>
-[Prototype("foodSequenceElement")]
+[Prototype]
 public sealed partial class FoodSequenceElementPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Objectives/Prototypes/StealTargetGroupPrototype.cs
+++ b/Content.Shared/Objectives/Prototypes/StealTargetGroupPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Objectives;
 /// <summary>
 /// General data about a group of items, such as icon, description, name. Used for Steal objective
 /// </summary>
-[Prototype("stealTargetGroup")]
+[Prototype]
 public sealed partial class StealTargetGroupPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Parallax/Biomes/BiomeTemplatePrototype.cs
+++ b/Content.Shared/Parallax/Biomes/BiomeTemplatePrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Parallax.Biomes;
 /// <summary>
 /// A preset group of biome layers to be used for a <see cref="BiomeComponent"/>
 /// </summary>
-[Prototype("biomeTemplate")]
+[Prototype]
 public sealed partial class BiomeTemplatePrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Parallax/Biomes/Markers/BiomeMarkerLayerPrototype.cs
+++ b/Content.Shared/Parallax/Biomes/Markers/BiomeMarkerLayerPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Parallax.Biomes.Markers;
 /// <summary>
 /// Spawns entities inside of the specified area with the minimum specified radius.
 /// </summary>
-[Prototype("biomeMarkerLayer")]
+[Prototype]
 public sealed partial class BiomeMarkerLayerPrototype : IBiomeMarkerLayer
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Players/PlayTimeTracking/PlayTimeTrackerPrototype.cs
+++ b/Content.Shared/Players/PlayTimeTracking/PlayTimeTrackerPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Players.PlayTimeTracking;
 /// <summary>
 /// Given to a role to specify its ID for role-timer tracking purposes. That's it.
 /// </summary>
-[Prototype("playTimeTracker")]
+[Prototype]
 public sealed partial class PlayTimeTrackerPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutGroupPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Preferences.Loadouts;
 /// <summary>
 /// Corresponds to a set of loadouts for a particular slot.
 /// </summary>
-[Prototype("loadoutGroup")]
+[Prototype]
 public sealed partial class LoadoutGroupPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Procedural/DungeonPresetPrototype.cs
+++ b/Content.Shared/Procedural/DungeonPresetPrototype.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Procedural;
 
-[Prototype("dungeonPreset")]
+[Prototype]
 public sealed partial class DungeonPresetPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Procedural/DungeonRoomPackPrototype.cs
+++ b/Content.Shared/Procedural/DungeonRoomPackPrototype.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Procedural;
 
-[Prototype("dungeonRoomPack")]
+[Prototype]
 public sealed partial class DungeonRoomPackPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Procedural/DungeonRoomPrototype.cs
+++ b/Content.Shared/Procedural/DungeonRoomPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Procedural;
 
-[Prototype("dungeonRoom")]
+[Prototype]
 public sealed partial class DungeonRoomPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = string.Empty;

--- a/Content.Shared/Procedural/Loot/SalvageLootPrototype.cs
+++ b/Content.Shared/Procedural/Loot/SalvageLootPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Procedural.Loot;
 /// <summary>
 /// Spawned inside of a salvage mission.
 /// </summary>
-[Prototype("salvageLoot")]
+[Prototype]
 public sealed partial class SalvageLootPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Procedural/SalvageDifficultyPrototype.cs
+++ b/Content.Shared/Procedural/SalvageDifficultyPrototype.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Procedural;
 
-[Prototype("salvageDifficulty")]
+[Prototype]
 public sealed partial class SalvageDifficultyPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = string.Empty;

--- a/Content.Shared/Prototypes/NavMapBlipPrototype.cs
+++ b/Content.Shared/Prototypes/NavMapBlipPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Prototypes;
 
-[Prototype("navMapBlip")]
+[Prototype]
 public sealed partial class NavMapBlipPrototype : IPrototype
 {
     [ViewVariables]

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Radio;
 
-[Prototype("radioChannel")]
+[Prototype]
 public sealed partial class RadioChannelPrototype : IPrototype
 {
     /// <summary>

--- a/Content.Shared/Random/Rules/RulesSystem.cs
+++ b/Content.Shared/Random/Rules/RulesSystem.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Random.Rules;
 /// Every single condition needs to be true for this to be selected.
 /// e.g. "choose maintenance audio if 90% of tiles nearby are maintenance tiles"
 /// </summary>
-[Prototype("rules")]
+[Prototype]
 public sealed partial class RulesPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = string.Empty;

--- a/Content.Shared/Random/WeightedRandomEntityPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomEntityPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Random;
 /// <summary>
 /// Linter-friendly version of weightedRandom for Entity prototypes.
 /// </summary>
-[Prototype("weightedRandomEntity")]
+[Prototype]
 public sealed partial class WeightedRandomEntityPrototype : IWeightedRandomPrototype
 {
     [IdDataField]

--- a/Content.Shared/Random/WeightedRandomFillSolutionPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomFillSolutionPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Random;
 /// <summary>
 ///     Random weighting dataset for solutions, able to specify reagents quantity.
 /// </summary>
-[Prototype("weightedRandomFillSolution")]
+[Prototype]
 public sealed partial class WeightedRandomFillSolutionPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Random/WeightedRandomOrePrototype.cs
+++ b/Content.Shared/Random/WeightedRandomOrePrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Random;
 /// <summary>
 /// Linter-friendly version of weightedRandom for Ore prototypes.
 /// </summary>
-[Prototype("weightedRandomOre")]
+[Prototype]
 public sealed partial class WeightedRandomOrePrototype : IWeightedRandomPrototype
 {
     [IdDataField]

--- a/Content.Shared/Random/WeightedRandomPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Random;
 /// <summary>
 /// Generic random weighting dataset to use.
 /// </summary>
-[Prototype("weightedRandom")]
+[Prototype]
 public sealed partial class WeightedRandomPrototype : IWeightedRandomPrototype
 {
     [IdDataField]

--- a/Content.Shared/Random/WeightedRandomSpeciesPrototype.cs
+++ b/Content.Shared/Random/WeightedRandomSpeciesPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Random;
 /// <summary>
 /// Linter-friendly version of weightedRandom for Species prototypes.
 /// </summary>
-[Prototype("weightedRandomSpecies")]
+[Prototype]
 public sealed partial class WeightedRandomSpeciesPrototype : IWeightedRandomPrototype
 {
     [IdDataField]

--- a/Content.Shared/Research/Prototypes/TechDisciplinePrototype.cs
+++ b/Content.Shared/Research/Prototypes/TechDisciplinePrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Research.Prototypes;
 /// This is a prototype for a research discipline, a category
 /// that governs how <see cref="TechnologyPrototype"/>s are unlocked.
 /// </summary>
-[Prototype("techDiscipline")]
+[Prototype]
 public sealed partial class TechDisciplinePrototype : IPrototype
 {
     /// <inheritdoc/>

--- a/Content.Shared/Research/Prototypes/TechnologyPrototype.cs
+++ b/Content.Shared/Research/Prototypes/TechnologyPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Research.Prototypes;
 /// <summary>
 /// This is a prototype for a technology that can be unlocked.
 /// </summary>
-[Prototype("technology")]
+[Prototype]
 public sealed partial class TechnologyPrototype : IPrototype
 {
     /// <inheritdoc/>

--- a/Content.Shared/Roles/AntagPrototype.cs
+++ b/Content.Shared/Roles/AntagPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Roles;
 /// <summary>
 ///     Describes information for a single antag.
 /// </summary>
-[Prototype("antag")]
+[Prototype]
 [Serializable, NetSerializable]
 public sealed partial class AntagPrototype : IPrototype
 {

--- a/Content.Shared/Roles/DepartmentPrototype.cs
+++ b/Content.Shared/Roles/DepartmentPrototype.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Roles;
 
-[Prototype("department")]
+[Prototype]
 public sealed partial class DepartmentPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Roles
     /// <summary>
     ///     Describes information for a single job on the station.
     /// </summary>
-    [Prototype("job")]
+    [Prototype]
     public sealed partial class JobPrototype : IPrototype
     {
         [ViewVariables]

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageAirMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageAirMod.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 /// Used when creating the planet for a salvage expedition.
 /// Which one is selected depends on the mission difficulty, different weightedRandoms are picked from.
 /// </summary>
-[Prototype("salvageAirMod")]
+[Prototype]
 public sealed partial class SalvageAirMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField]

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageAirMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageAirMod.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 /// Used when creating the planet for a salvage expedition.
 /// Which one is selected depends on the mission difficulty, different weightedRandoms are picked from.
 /// </summary>
-[Prototype]
+[Prototype("salvageAirMod")]
 public sealed partial class SalvageAirMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField]

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageBiomeModPrototype.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageBiomeModPrototype.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 /// <summary>
 /// Affects the biome to be used for salvage.
 /// </summary>
-[Prototype("salvageBiomeMod")]
+[Prototype]
 public sealed partial class SalvageBiomeModPrototype : IPrototype, ISalvageMod
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageDungeonModPrototype.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageDungeonModPrototype.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Salvage.Expeditions.Modifiers;
 
-[Prototype("salvageDungeonMod")]
+[Prototype]
 public sealed partial class SalvageDungeonModPrototype : IPrototype, IBiomeSpecificMod
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageLightMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageLightMod.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Salvage.Expeditions.Modifiers;
 
-[Prototype]
+[Prototype("salvageLightMod")]
 public sealed partial class SalvageLightMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageLightMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageLightMod.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Salvage.Expeditions.Modifiers;
 
-[Prototype("salvageLightMod")]
+[Prototype]
 public sealed partial class SalvageLightMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageMod.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 /// <summary>
 /// Generic modifiers with no additional data
 /// </summary>
-[Prototype]
+[Prototype("salvageMod")]
 public sealed partial class SalvageMod : IPrototype, ISalvageMod
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageMod.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Salvage.Expeditions.Modifiers;
 /// <summary>
 /// Generic modifiers with no additional data
 /// </summary>
-[Prototype("salvageMod")]
+[Prototype]
 public sealed partial class SalvageMod : IPrototype, ISalvageMod
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTemperatureMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTemperatureMod.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Salvage.Expeditions.Modifiers;
 
-[Prototype]
+[Prototype("salvageTemperatureMod")]
 public sealed partial class SalvageTemperatureMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTemperatureMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageTemperatureMod.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Salvage.Expeditions.Modifiers;
 
-[Prototype("salvageTemperatureMod")]
+[Prototype]
 public sealed partial class SalvageTemperatureMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageWeatherMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageWeatherMod.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Salvage.Expeditions.Modifiers;
 
-[Prototype("salvageWeatherMod")]
+[Prototype]
 public sealed partial class SalvageWeatherMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Salvage/Expeditions/Modifiers/SalvageWeatherMod.cs
+++ b/Content.Shared/Salvage/Expeditions/Modifiers/SalvageWeatherMod.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Salvage.Expeditions.Modifiers;
 
-[Prototype]
+[Prototype("salvageWeatherMod")]
 public sealed partial class SalvageWeatherMod : IPrototype, IBiomeSpecificMod
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Salvage/Expeditions/SalvageFactionPrototype.cs
+++ b/Content.Shared/Salvage/Expeditions/SalvageFactionPrototype.cs
@@ -2,7 +2,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Salvage.Expeditions;
 
-[Prototype("salvageFaction")]
+[Prototype]
 public sealed partial class SalvageFactionPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Silicons/Laws/SiliconLawPrototype.cs
+++ b/Content.Shared/Silicons/Laws/SiliconLawPrototype.cs
@@ -77,7 +77,7 @@ public partial class SiliconLaw : IComparable<SiliconLaw>, IEquatable<SiliconLaw
 /// <summary>
 /// This is a prototype for a law governing the behavior of silicons.
 /// </summary>
-[Prototype("siliconLaw")]
+[Prototype]
 [Serializable, NetSerializable]
 public sealed partial class SiliconLawPrototype : SiliconLaw, IPrototype
 {

--- a/Content.Shared/Silicons/Laws/SiliconLawsetPrototype.cs
+++ b/Content.Shared/Silicons/Laws/SiliconLawsetPrototype.cs
@@ -61,7 +61,7 @@ public sealed partial class SiliconLawset
 /// This is a prototype for a <see cref="SiliconLawPrototype"/> list.
 /// Cannot be used directly since it is a list of prototype ids rather than List<Siliconlaw>.
 /// </summary>
-[Prototype("siliconLawset"), Serializable, NetSerializable]
+[Prototype, Serializable, NetSerializable]
 public sealed partial class SiliconLawsetPrototype : IPrototype
 {
     /// <inheritdoc/>

--- a/Content.Shared/Speech/SpeechSoundsPrototype.cs
+++ b/Content.Shared/Speech/SpeechSoundsPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Speech
 {
-    [Prototype("speechSounds")]
+    [Prototype]
     public sealed partial class SpeechSoundsPrototype : IPrototype
     {
         [ViewVariables]

--- a/Content.Shared/Speech/SpeechVerbPrototype.cs
+++ b/Content.Shared/Speech/SpeechVerbPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Speech;
 ///     Handles replacing speech verbs and other conditional chat modifications like bolding or font type depending
 ///     on punctuation or by directly overriding the prototype.
 /// </summary>
-[Prototype("speechVerb")]
+[Prototype]
 public sealed partial class SpeechVerbPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/SprayPainter/Prototypes/AirlockDepartmentsPrototype.cs
+++ b/Content.Shared/SprayPainter/Prototypes/AirlockDepartmentsPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.SprayPainter.Prototypes;
 /// <summary>
 /// Maps airlock style names to department ids.
 /// </summary>
-[Prototype("airlockDepartments")]
+[Prototype]
 public sealed partial class AirlockDepartmentsPrototype : IPrototype
 {
     [IdDataField]

--- a/Content.Shared/Spreader/EdgeSpreaderPrototype.cs
+++ b/Content.Shared/Spreader/EdgeSpreaderPrototype.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Spreader;
 /// <summary>
 /// Adds this node group to <see cref="Content.Server.Spreader.SpreaderSystem"/> for tick updates.
 /// </summary>
-[Prototype("edgeSpreader")]
+[Prototype]
 public sealed partial class EdgeSpreaderPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = string.Empty;

--- a/Content.Shared/StatusEffect/StatusEffectPrototype.cs
+++ b/Content.Shared/StatusEffect/StatusEffectPrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.StatusEffect
 {
-    [Prototype("statusEffect")]
+    [Prototype]
     public sealed partial class StatusEffectPrototype : IPrototype
     {
         [IdDataField]

--- a/Content.Shared/Store/CurrencyPrototype.cs
+++ b/Content.Shared/Store/CurrencyPrototype.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Store;
 ///     Mainly used for antags, such as traitors, nukies, and revenants
 ///     This is separate to the cargo ordering system.
 /// </summary>
-[Prototype("currency")]
+[Prototype]
 [DataDefinition, Serializable, NetSerializable]
 public sealed partial class CurrencyPrototype : IPrototype
 {

--- a/Content.Shared/Store/ListingPrototype.cs
+++ b/Content.Shared/Store/ListingPrototype.cs
@@ -241,7 +241,7 @@ public partial class ListingData : IEquatable<ListingData>
 /// <summary>
 ///     Defines a set item listing that is available in a store
 /// </summary>
-[Prototype("listing")]
+[Prototype]
 [Serializable, NetSerializable]
 [DataDefinition]
 public sealed partial class ListingPrototype : ListingData, IPrototype
@@ -422,7 +422,7 @@ public sealed partial class ListingDataWithCostModifiers : ListingData
 ///     Defines set of rules for category of discounts -
 ///     how <see cref="StoreDiscountComponent"/> will be filled by respective system.
 /// </summary>
-[Prototype("discountCategory")]
+[Prototype]
 [DataDefinition, Serializable, NetSerializable]
 public sealed partial class DiscountCategoryPrototype : IPrototype
 {

--- a/Content.Shared/Store/StoreCategoryPrototype.cs
+++ b/Content.Shared/Store/StoreCategoryPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Store;
 /// <summary>
 ///     Used to define different categories for a store.
 /// </summary>
-[Prototype("storeCategory")]
+[Prototype]
 [Serializable, NetSerializable, DataDefinition]
 public sealed partial class StoreCategoryPrototype : IPrototype
 {

--- a/Content.Shared/Store/StorePresetPrototype.cs
+++ b/Content.Shared/Store/StorePresetPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Store;
 /// <summary>
 ///     Specifies generic info for initializing a store.
 /// </summary>
-[Prototype("storePreset")]
+[Prototype]
 [DataDefinition]
 public sealed partial class StorePresetPrototype : IPrototype
 {

--- a/Content.Shared/StoryGen/Prototypes/StoryTemplatePrototype.cs
+++ b/Content.Shared/StoryGen/Prototypes/StoryTemplatePrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.StoryGen;
 /// <summary>
 /// Prototype for a story template that can be filled in with words chosen from <see cref="DatasetPrototype"/>s.
 /// </summary>
-[Serializable, Prototype("storyTemplate")]
+[Serializable, Prototype]
 public sealed partial class StoryTemplatePrototype : IPrototype
 {
     /// <summary>

--- a/Content.Shared/Thief/Prototypes/ThiefBackpackSetPrototype.cs
+++ b/Content.Shared/Thief/Prototypes/ThiefBackpackSetPrototype.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Thief;
 /// <summary>
 /// A prototype that defines a set of items and visuals in a specific starter set for the antagonist thief
 /// </summary>
-[Prototype("thiefBackpackSet")]
+[Prototype]
 public sealed partial class ThiefBackpackSetPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/VendingMachines/VendingMachineInventoryPrototype.cs
+++ b/Content.Shared/VendingMachines/VendingMachineInventoryPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.VendingMachines
 {
-    [Serializable, NetSerializable, Prototype("vendingMachineInventory")]
+    [Serializable, NetSerializable, Prototype]
     public sealed partial class VendingMachineInventoryPrototype : IPrototype
     {
         [ViewVariables]

--- a/Content.Shared/Weapons/Ranged/HitscanPrototype.cs
+++ b/Content.Shared/Weapons/Ranged/HitscanPrototype.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Weapons.Ranged;
 
-[Prototype("hitscan")]
+[Prototype]
 public sealed partial class HitscanPrototype : IPrototype, IShootable
 {
     [ViewVariables]

--- a/Content.Shared/Weather/WeatherPrototype.cs
+++ b/Content.Shared/Weather/WeatherPrototype.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Weather;
 
-[Prototype("weather")]
+[Prototype]
 public sealed partial class WeatherPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;

--- a/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactEffectPrototype.cs
+++ b/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactEffectPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Xenoarchaeology.XenoArtifacts;
 /// <summary>
 /// This is a prototype for...
 /// </summary>
-[Prototype("artifactEffect")]
+[Prototype]
 [DataDefinition]
 public sealed partial class ArtifactEffectPrototype : IPrototype
 {

--- a/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactTriggerPrototype.cs
+++ b/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactTriggerPrototype.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Xenoarchaeology.XenoArtifacts;
 /// <summary>
 /// This is a prototype for...
 /// </summary>
-[Prototype("artifactTrigger")]
+[Prototype]
 [DataDefinition]
 public sealed partial class ArtifactTriggerPrototype : IPrototype
 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Cleans up all `Prototype` attributes that specify a type name which matches the name that would automatically be generated for them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Clean code is happy code.
This will keep the warning count down if https://github.com/space-wizards/RobustToolbox/pull/5718 is merged.

## Technical details
<!-- Summary of code changes for easier review. -->
Literally just used the code fixer from https://github.com/space-wizards/RobustToolbox/pull/5718 on Content.Client, Content.Server, and Content.Shared.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->