### PR TITLE
polymorph popup fixes

### DIFF
--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -204,6 +204,12 @@ public sealed partial class PolymorphSystem : EntitySystem
 
         var child = Spawn(configuration.Entity, _transform.GetMapCoordinates(uid, targetTransformComp), rotation: _transform.GetWorldRotation(uid));
 
+        if (configuration.PolymorphPopup != null)
+            _popup.PopupEntity(Loc.GetString(configuration.PolymorphPopup,
+                ("parent", Identity.Entity(uid, EntityManager)),
+                ("child", Identity.Entity(child, EntityManager))),
+                child);
+
         MakeSentientCommand.MakeSentient(child, EntityManager);
 
         var polymorphedComp = _compFact.GetComponent<PolymorphedEntityComponent>();
@@ -347,10 +353,11 @@ public sealed partial class PolymorphSystem : EntitySystem
         var ev = new PolymorphedEvent(uid, parent, true);
         RaiseLocalEvent(uid, ref ev);
 
-        _popup.PopupEntity(Loc.GetString("polymorph-revert-popup-generic",
+        if (component.Configuration.ExitPolymorphPopup != null)
+            _popup.PopupEntity(Loc.GetString(component.Configuration.ExitPolymorphPopup,
                 ("parent", Identity.Entity(uid, EntityManager)),
                 ("child", Identity.Entity(parent, EntityManager))),
-            parent);
+                parent);
         QueueDel(uid);
 
         return parent;

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -416,7 +416,7 @@ public abstract partial class SharedBuckleSystem
 
     public bool TryUnbuckle(Entity<BuckleComponent?> buckle, EntityUid? user, bool popup)
     {
-        if (!Resolve(buckle.Owner, ref buckle.Comp))
+        if (!Resolve(buckle.Owner, ref buckle.Comp, false))
             return false;
 
         if (!CanUnbuckle(buckle, user, popup, out var strap))

--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -128,6 +128,18 @@ public sealed partial record PolymorphConfiguration
     /// </summary>
     [DataField]
     public SoundSpecifier? ExitPolymorphSound;
+
+    /// <summary>
+    ///     If not null, this popup will be displayed when being polymorphed into something.
+    /// </summary>
+    [DataField]
+    public LocId? PolymorphPopup = "polymorph-popup-generic";
+
+    /// <summary>
+    ///     If not null, this popup will be displayed when when being reverted from a polymorph.
+    /// </summary>
+    [DataField]
+    public LocId? ExitPolymorphPopup = "polymorph-revert-popup-generic";
 }
 
 public enum PolymorphInventoryChange : byte

--- a/Resources/Locale/en-US/polymorph/polymorph.ftl
+++ b/Resources/Locale/en-US/polymorph/polymorph.ftl
@@ -1,5 +1,5 @@
 polymorph-self-action-name = Polymorph ({CAPITALIZE($target)})
 polymorph-self-action-description = Instantly polymorph yourself into {$target}.
 
-polymorph-popup-generic = {CAPITALIZE($parent)} turned into {$child}.
-polymorph-revert-popup-generic = {CAPITALIZE($parent)} reverted back into {$child}.
+polymorph-popup-generic = {CAPITALIZE(THE($parent))} turned into {$child}.
+polymorph-revert-popup-generic = {CAPITALIZE(THE($parent))} reverted back into {$child}.


### PR DESCRIPTION
Polymorph has received some bugfixes:
PolymorphSystem tries to unbuckle the target before polymorphing, but this can lead to a failed resolve in the case of the wand of entrance, since walls don't have BuckleComponent. We set logging to false for that resolve to fix it.
Also added a missing popup, which had a ftl string that was never used. The popup LocIds were moved into the prototype so we can set custom ones.

Required for https://github.com/space-wizards/space-station-14/pull/35794