### PR TITLE
Add interaction tests for vending machines

### DIFF
--- a/Content.IntegrationTests/Tests/Vending/VendingInteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Vending/VendingInteractionTest.cs
@@ -13,6 +13,8 @@ public sealed class VendingInteractionTest : InteractionTest
 
     private const string RestockBoxProtoId = "InteractionTestRestockBox";
 
+    private const string RestockBoxOtherProtoId = "InteractionTestRestockBoxOther";
+
     [TestPrototypes]
     private const string TestPrototypes = $@"
 - type: entity
@@ -25,6 +27,11 @@ public sealed class VendingInteractionTest : InteractionTest
   startingInventory:
     {VendedItemProtoId}: 5
 
+- type: vendingMachineInventory
+  id: InteractionTestVendingInventoryOther
+  startingInventory:
+    {VendedItemProtoId}: 5
+
 - type: entity
   parent: BaseVendingMachineRestock
   id: {RestockBoxProtoId}
@@ -32,6 +39,14 @@ public sealed class VendingInteractionTest : InteractionTest
   - type: VendingMachineRestock
     canRestock:
     - InteractionTestVendingInventory
+
+- type: entity
+  parent: BaseVendingMachineRestock
+  id: {RestockBoxOtherProtoId}
+  components:
+  - type: VendingMachineRestock
+    canRestock:
+    - InteractionTestVendingInventoryOther
 
 - type: entity
   id: {VendingMachineProtoId}
@@ -134,6 +149,11 @@ public sealed class VendingInteractionTest : InteractionTest
 
         // Open the maintenance panel
         await InteractUsing(Screw);
+
+        // Try to restock using the wrong restock box (nothing happens)
+        await InteractUsing(RestockBoxOtherProtoId);
+
+        Assert.That(items.First().Amount, Is.EqualTo(5), "Restocked with wrong restock box.");
 
         // Restock the machine
         await InteractUsing(RestockBoxProtoId);

--- a/Content.IntegrationTests/Tests/Vending/VendingInteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Vending/VendingInteractionTest.cs
@@ -9,12 +9,17 @@ public sealed class VendingInteractionTest : InteractionTest
 {
     private const string VendingMachineProtoId = "InteractionTestVendingMachine";
 
-    private const string VendedItemProtoId = "PassengerPDA";
+    private const string VendedItemProtoId = "InteractionTestItem";
 
     private const string RestockBoxProtoId = "InteractionTestRestockBox";
 
     [TestPrototypes]
     private const string TestPrototypes = $@"
+- type: entity
+  parent: BaseItem
+  id: {VendedItemProtoId}
+  name: {VendedItemProtoId}
+
 - type: vendingMachineInventory
   id: InteractionTestVendingInventory
   startingInventory:
@@ -27,12 +32,6 @@ public sealed class VendingInteractionTest : InteractionTest
   - type: VendingMachineRestock
     canRestock:
     - InteractionTestVendingInventory
-  - type: Sprite
-    layers:
-    - state: base
-    - state: green_bit
-      shader: unshaded
-    - state: refill_ptech
 
 - type: entity
   id: {VendingMachineProtoId}
@@ -41,21 +40,8 @@ public sealed class VendingInteractionTest : InteractionTest
   - type: VendingMachine
     pack: InteractionTestVendingInventory
     ejectDelay: 0 # no delay to speed up tests
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: eject-unshaded
-    denyState: deny-unshaded
   - type: Sprite
-    sprite: Structures/Machines/VendingMachines/cart.rsi
-    layers:
-    - state: off
-      map: [ enum.VendingMachineVisualLayers.Base ]
-    - state: off
-      map: [ enum.VendingMachineVisualLayers.BaseUnshaded ]
-      shader: unshaded
-    - state: panel
-      map: [ enum.WiresVisualLayers.MaintenancePanel ]
+    sprite: error.rsi
 ";
 
     [Test]

--- a/Content.IntegrationTests/Tests/Vending/VendingInteractionTest.cs
+++ b/Content.IntegrationTests/Tests/Vending/VendingInteractionTest.cs
@@ -1,0 +1,83 @@
+using System.Linq;
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server.VendingMachines;
+
+namespace Content.IntegrationTests.Tests.Vending;
+
+public sealed class VendingInteractionTest : InteractionTest
+{
+    private const string VendingMachineProtoId = "InteractionTestVendingMachine";
+
+    private const string RestockBoxProtoId = "InteractionTestRestockBox";
+
+    [TestPrototypes]
+    private const string TestPrototypes = $@"
+- type: vendingMachineInventory
+  id: InteractionTestVendingInventory
+  startingInventory:
+    PassengerPDA: 5
+
+- type: entity
+  parent: BaseVendingMachineRestock
+  id: {RestockBoxProtoId}
+  components:
+  - type: VendingMachineRestock
+    canRestock:
+    - InteractionTestVendingInventory
+  - type: Sprite
+    layers:
+    - state: base
+    - state: green_bit
+      shader: unshaded
+    - state: refill_ptech
+
+- type: entity
+  id: {VendingMachineProtoId}
+  parent: VendingMachine
+  components:
+  - type: VendingMachine
+    pack: InteractionTestVendingInventory
+    offState: off
+    brokenState: broken
+    normalState: normal-unshaded
+    ejectState: eject-unshaded
+    denyState: deny-unshaded
+  - type: Sprite
+    sprite: Structures/Machines/VendingMachines/cart.rsi
+    layers:
+    - state: off
+      map: [ enum.VendingMachineVisualLayers.Base ]
+    - state: off
+      map: [ enum.VendingMachineVisualLayers.BaseUnshaded ]
+      shader: unshaded
+    - state: panel
+      map: [ enum.WiresVisualLayers.MaintenancePanel ]
+";
+
+    [Test]
+    public async Task RestockTest()
+    {
+        var vendingSystem = SEntMan.System<VendingMachineSystem>();
+
+        await SpawnTarget(VendingMachineProtoId);
+        var vendorEnt = SEntMan.GetEntity(Target.Value);
+
+        var items = vendingSystem.GetAllInventory(vendorEnt);
+
+        Assert.That(items, Is.Not.Empty, $"{VendingMachineProtoId} spawned with no items.");
+        Assert.That(items.First().Amount, Is.EqualTo(5), $"{VendingMachineProtoId} spawned with unexpected item count.");
+
+        // Try to restock with the maintenance panel closed (nothing happens)
+        await InteractUsing(RestockBoxProtoId);
+
+        Assert.That(items.First().Amount, Is.EqualTo(5), "Restocked without opening maintenance panel.");
+
+        // Open the maintenance panel
+        await InteractUsing(Screw);
+
+        // Restock the machine
+        await InteractUsing(RestockBoxProtoId);
+
+        Assert.That(items.First().Amount, Is.EqualTo(10), "Restocking resulted in unexpected item count.");
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a small suite of tests for various interactions with vending machines.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We really should have tests for all sorts of entity interactions, so that we can easily tell when something breaks. Here are some for vending machines.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds tests to check:
- Interacting with an unpowered vending machine does not open its BUI.
- Interacting with a powered vending machine does open its BUI.
- Interacting while the BUI is open closes it.
- Losing power automatically closes the BUI.
- Dispensing an item through the BUI lowers the stocked count and spawns the item.
- Using a screwdriver on a vending machine opens the maintenance panel.
- Restocking a vending machine with the maintenance panel closed does nothing.
- Restocking using the wrong restock box does nothing.
- Restocking using the correct restock box adds the initial item count.
- Vending machines can be broken with 100 blunt damage.
- Breaking automatically closes the BUI.
- Interacting with a broken vending machine does not open its BUI.
- Welding a broken vending machine repairs it.

You might notice that we already have some tests related to restocking vending machines [here](https://github.com/space-wizards/space-station-14/blob/1cc9e7516975a5af308832427eb1cdec3fa733bd/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs). However, those tests work by directly calling system methods. Testing interactions in addition should help catch more obscure failures.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->