### PR TITLE
Cleanup Objective files, add PickSpecificPersonComponent

### DIFF
--- a/Content.Server/Objectives/Components/PickRandomHeadComponent.cs
+++ b/Content.Server/Objectives/Components/PickRandomHeadComponent.cs
@@ -1,12 +1,8 @@
-using Content.Server.Objectives.Systems;
-
 namespace Content.Server.Objectives.Components;
 
 /// <summary>
 /// Sets the target for <see cref="TargetObjectiveComponent"/> to a random head.
 /// If there are no heads it will fallback to any person.
 /// </summary>
-[RegisterComponent, Access(typeof(KillPersonConditionSystem))]
-public sealed partial class PickRandomHeadComponent : Component
-{
-}
+[RegisterComponent]
+public sealed partial class PickRandomHeadComponent : Component;

--- a/Content.Server/Objectives/Components/PickRandomPersonComponent.cs
+++ b/Content.Server/Objectives/Components/PickRandomPersonComponent.cs
@@ -1,11 +1,7 @@
-using Content.Server.Objectives.Systems;
-
 namespace Content.Server.Objectives.Components;
 
 /// <summary>
 /// Sets the target for <see cref="TargetObjectiveComponent"/> to a random person.
 /// </summary>
-[RegisterComponent, Access(typeof(KillPersonConditionSystem))]
-public sealed partial class PickRandomPersonComponent : Component
-{
-}
+[RegisterComponent]
+public sealed partial class PickRandomPersonComponent : Component;

--- a/Content.Server/Objectives/Components/PickSpecificPersonComponent.cs
+++ b/Content.Server/Objectives/Components/PickSpecificPersonComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Server.Objectives.Components;
+
+/// <summary>
+/// Sets this objective's target to the one given in <see cref="TargetOverrideComponent"/>, if the entity has it.
+/// This component needs to be added to objective entity itself.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PickSpecificPersonComponent : Component;

--- a/Content.Server/Objectives/Components/RandomTraitorAliveComponent.cs
+++ b/Content.Server/Objectives/Components/RandomTraitorAliveComponent.cs
@@ -1,11 +1,7 @@
-using Content.Server.Objectives.Systems;
-
 namespace Content.Server.Objectives.Components;
 
 /// <summary>
 /// Sets the target for <see cref="KeepAliveConditionComponent"/> to a random traitor.
 /// </summary>
-[RegisterComponent, Access(typeof(KeepAliveConditionSystem))]
-public sealed partial class RandomTraitorAliveComponent : Component
-{
-}
+[RegisterComponent]
+public sealed partial class RandomTraitorAliveComponent : Component;

--- a/Content.Server/Objectives/Components/RandomTraitorProgressComponent.cs
+++ b/Content.Server/Objectives/Components/RandomTraitorProgressComponent.cs
@@ -1,11 +1,7 @@
-using Content.Server.Objectives.Systems;
-
 namespace Content.Server.Objectives.Components;
 
 /// <summary>
 /// Sets the target for <see cref="HelpProgressConditionComponent"/> to a random traitor.
 /// </summary>
-[RegisterComponent, Access(typeof(HelpProgressConditionSystem))]
-public sealed partial class RandomTraitorProgressComponent : Component
-{
-}
+[RegisterComponent]
+public sealed partial class RandomTraitorProgressComponent : Component;

--- a/Content.Server/Objectives/Components/TargetOverrideComponent.cs
+++ b/Content.Server/Objectives/Components/TargetOverrideComponent.cs
@@ -1,0 +1,16 @@
+namespace Content.Server.Objectives.Components;
+
+/// <summary>
+/// Sets a target objective to a specific target when receiving it.
+/// The objective entity needs to have <see cref="PickSpecificPersonComponent"/>.
+/// This component needs to be added to entity receiving the objective.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TargetOverrideComponent : Component
+{
+    /// <summary>
+    /// The entity that should be targeted.
+    /// </summary>
+    [DataField]
+    public EntityUid? Target;
+}

--- a/Content.Server/Objectives/Systems/HelpProgressConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/HelpProgressConditionSystem.cs
@@ -18,7 +18,6 @@ public sealed class HelpProgressConditionSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<HelpProgressConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
-
     }
 
     private void OnGetProgress(EntityUid uid, HelpProgressConditionComponent comp, ref ObjectiveGetProgressEvent args)

--- a/Content.Server/Objectives/Systems/HelpProgressConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/HelpProgressConditionSystem.cs
@@ -1,23 +1,17 @@
-using Content.Server.GameTicking.Rules;
 using Content.Server.Objectives.Components;
 using Content.Shared.Mind;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Objectives.Systems;
-using Content.Shared.Roles.Jobs;
-using Robust.Shared.Random;
-using System.Linq;
 
 namespace Content.Server.Objectives.Systems;
 
 /// <summary>
-/// Handles help progress condition logic and picking random help targets.
+/// Handles help progress condition logic.
 /// </summary>
 public sealed class HelpProgressConditionSystem : EntitySystem
 {
-    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
     [Dependency] private readonly TargetObjectiveSystem _target = default!;
-    [Dependency] private readonly TraitorRuleSystem _traitorRule = default!;
 
     public override void Initialize()
     {
@@ -25,7 +19,6 @@ public sealed class HelpProgressConditionSystem : EntitySystem
 
         SubscribeLocalEvent<HelpProgressConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
 
-        SubscribeLocalEvent<RandomTraitorProgressComponent, ObjectiveAssignedEvent>(OnTraitorAssigned);
     }
 
     private void OnGetProgress(EntityUid uid, HelpProgressConditionComponent comp, ref ObjectiveGetProgressEvent args)
@@ -34,55 +27,6 @@ public sealed class HelpProgressConditionSystem : EntitySystem
             return;
 
         args.Progress = GetProgress(target.Value);
-    }
-
-    private void OnTraitorAssigned(EntityUid uid, RandomTraitorProgressComponent comp, ref ObjectiveAssignedEvent args)
-    {
-        // invalid prototype
-        if (!TryComp<TargetObjectiveComponent>(uid, out var target))
-        {
-            args.Cancelled = true;
-            return;
-        }
-
-        var traitors = _traitorRule.GetOtherTraitorMindsAliveAndConnected(args.Mind).ToHashSet();
-
-        // cant help anyone who is tasked with helping:
-        // 1. thats boring
-        // 2. no cyclic progress dependencies!!!
-        foreach (var traitor in traitors)
-        {
-            // TODO: replace this with TryComp<ObjectivesComponent>(traitor) or something when objectives are moved out of mind
-            if (!TryComp<MindComponent>(traitor.Id, out var mind))
-                continue;
-
-            foreach (var objective in mind.Objectives)
-            {
-                if (HasComp<HelpProgressConditionComponent>(objective))
-                    traitors.RemoveWhere(x => x.Mind == mind);
-            }
-        }
-
-        // Can't have multiple objectives to help/save the same person
-        foreach (var objective in args.Mind.Objectives)
-        {
-            if (HasComp<RandomTraitorAliveComponent>(objective) || HasComp<RandomTraitorProgressComponent>(objective))
-            {
-                if (TryComp<TargetObjectiveComponent>(objective, out var help))
-                {
-                    traitors.RemoveWhere(x => x.Id == help.Target);
-                }
-            }
-        }
-
-        // no more helpable traitors
-        if (traitors.Count == 0)
-        {
-            args.Cancelled = true;
-            return;
-        }
-
-        _target.SetTarget(uid, _random.Pick(traitors).Id, target);
     }
 
     private float GetProgress(EntityUid target)

--- a/Content.Server/Objectives/Systems/KeepAliveCondition.cs
+++ b/Content.Server/Objectives/Systems/KeepAliveCondition.cs
@@ -1,30 +1,22 @@
 using Content.Server.Objectives.Components;
-using Content.Server.GameTicking.Rules;
 using Content.Shared.Mind;
 using Content.Shared.Objectives.Components;
-using Content.Shared.Roles.Jobs;
-using Robust.Shared.Random;
-using System.Linq;
 
 namespace Content.Server.Objectives.Systems;
 
 /// <summary>
-/// Handles keep alive condition logic and picking random traitors to keep alive.
+/// Handles keep alive condition logic.
 /// </summary>
 public sealed class KeepAliveConditionSystem : EntitySystem
 {
-    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly TargetObjectiveSystem _target = default!;
-    [Dependency] private readonly TraitorRuleSystem _traitorRule = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<KeepAliveConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
-
-        SubscribeLocalEvent<RandomTraitorAliveComponent, ObjectiveAssignedEvent>(OnAssigned);
     }
 
     private void OnGetProgress(EntityUid uid, KeepAliveConditionComponent comp, ref ObjectiveGetProgressEvent args)
@@ -33,39 +25,6 @@ public sealed class KeepAliveConditionSystem : EntitySystem
             return;
 
         args.Progress = GetProgress(target.Value);
-    }
-
-    private void OnAssigned(EntityUid uid, RandomTraitorAliveComponent comp, ref ObjectiveAssignedEvent args)
-    {
-        // invalid prototype
-        if (!TryComp<TargetObjectiveComponent>(uid, out var target))
-        {
-            args.Cancelled = true;
-            return;
-        }
-
-        var traitors = _traitorRule.GetOtherTraitorMindsAliveAndConnected(args.Mind).ToHashSet();
-
-        // Can't have multiple objectives to help/save the same person
-        foreach (var objective in args.Mind.Objectives)
-        {
-            if (HasComp<RandomTraitorAliveComponent>(objective) || HasComp<RandomTraitorProgressComponent>(objective))
-            {
-                if (TryComp<TargetObjectiveComponent>(objective, out var help))
-                {
-                    traitors.RemoveWhere(x => x.Id == help.Target);
-                }
-            }
-        }
-
-        // You are the first/only traitor.
-        if (traitors.Count == 0)
-        {
-            args.Cancelled = true;
-            return;
-        }
-
-        _target.SetTarget(uid, _random.Pick(traitors).Id, target);
     }
 
     private float GetProgress(EntityUid target)

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -1,12 +1,9 @@
 using Content.Server.Objectives.Components;
-using Content.Server.Revolutionary.Components;
 using Content.Server.Shuttles.Systems;
 using Content.Shared.CCVar;
 using Content.Shared.Mind;
 using Content.Shared.Objectives.Components;
 using Robust.Shared.Configuration;
-using Robust.Shared.Random;
-using System.Linq;
 
 namespace Content.Server.Objectives.Systems;
 
@@ -17,7 +14,6 @@ public sealed class KillPersonConditionSystem : EntitySystem
 {
     [Dependency] private readonly EmergencyShuttleSystem _emergencyShuttle = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
-    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly TargetObjectiveSystem _target = default!;
 
@@ -26,10 +22,6 @@ public sealed class KillPersonConditionSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<KillPersonConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
-
-        SubscribeLocalEvent<PickRandomPersonComponent, ObjectiveAssignedEvent>(OnPersonAssigned);
-
-        SubscribeLocalEvent<PickRandomHeadComponent, ObjectiveAssignedEvent>(OnHeadAssigned);
     }
 
     private void OnGetProgress(EntityUid uid, KillPersonConditionComponent comp, ref ObjectiveGetProgressEvent args)
@@ -38,74 +30,6 @@ public sealed class KillPersonConditionSystem : EntitySystem
             return;
 
         args.Progress = GetProgress(target.Value, comp.RequireDead);
-    }
-
-    private void OnPersonAssigned(EntityUid uid, PickRandomPersonComponent comp, ref ObjectiveAssignedEvent args)
-    {
-        // invalid objective prototype
-        if (!TryComp<TargetObjectiveComponent>(uid, out var target))
-        {
-            args.Cancelled = true;
-            return;
-        }
-
-        // target already assigned
-        if (target.Target != null)
-            return;
-
-        var allHumans = _mind.GetAliveHumans(args.MindId);
-
-        // Can't have multiple objectives to kill the same person
-        foreach (var objective in args.Mind.Objectives)
-        {
-            if (HasComp<KillPersonConditionComponent>(objective) && TryComp<TargetObjectiveComponent>(objective, out var kill))
-            {
-                allHumans.RemoveWhere(x => x.Owner == kill.Target);
-            }
-        }
-
-        // no other humans to kill
-        if (allHumans.Count == 0)
-        {
-            args.Cancelled = true;
-            return;
-        }
-
-        _target.SetTarget(uid, _random.Pick(allHumans), target);
-    }
-
-    private void OnHeadAssigned(EntityUid uid, PickRandomHeadComponent comp, ref ObjectiveAssignedEvent args)
-    {
-        // invalid prototype
-        if (!TryComp<TargetObjectiveComponent>(uid, out var target))
-        {
-            args.Cancelled = true;
-            return;
-        }
-
-        // target already assigned
-        if (target.Target != null)
-            return;
-
-        // no other humans to kill
-        var allHumans = _mind.GetAliveHumans(args.MindId);
-        if (allHumans.Count == 0)
-        {
-            args.Cancelled = true;
-            return;
-        }
-
-        var allHeads = new HashSet<Entity<MindComponent>>();
-        foreach (var person in allHumans)
-        {
-            if (TryComp<MindComponent>(person, out var mind) && mind.OwnedEntity is { } ent && HasComp<CommandStaffComponent>(ent))
-                allHeads.Add(person);
-        }
-
-        if (allHeads.Count == 0)
-            allHeads = allHumans; // fallback to non-head target
-
-        _target.SetTarget(uid, _random.Pick(allHeads), target);
     }
 
     private float GetProgress(EntityUid target, bool requireDead)

--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -1,0 +1,208 @@
+using Content.Server.Objectives.Components;
+using Content.Shared.Mind;
+using Content.Shared.Objectives.Components;
+using Content.Server.GameTicking.Rules;
+using Content.Server.Revolutionary.Components;
+using Robust.Shared.Random;
+using System.Linq;
+
+namespace Content.Server.Objectives.Systems;
+
+public sealed class PickObjectiveTargetSystem : EntitySystem
+{
+    [Dependency] private readonly TargetObjectiveSystem _target = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly TraitorRuleSystem _traitorRule = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PickSpecificPersonComponent, ObjectiveAssignedEvent>(OnSpecificPersonAssigned);
+        SubscribeLocalEvent<PickRandomPersonComponent, ObjectiveAssignedEvent>(OnRandomPersonAssigned);
+        SubscribeLocalEvent<PickRandomHeadComponent, ObjectiveAssignedEvent>(OnRandomHeadAssigned);
+
+        SubscribeLocalEvent<RandomTraitorProgressComponent, ObjectiveAssignedEvent>(OnRandomTraitorProgressAssigned);
+        SubscribeLocalEvent<RandomTraitorAliveComponent, ObjectiveAssignedEvent>(OnRandomTraitorAliveAssigned);
+    }
+
+    private void OnSpecificPersonAssigned(Entity<PickSpecificPersonComponent> ent, ref ObjectiveAssignedEvent args)
+    {
+        // invalid objective prototype
+        if (!TryComp<TargetObjectiveComponent>(ent.Owner, out var target))
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        // target already assigned
+        if (target.Target != null)
+            return;
+
+        if (args.Mind.OwnedEntity == null)
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        var user = args.Mind.OwnedEntity.Value;
+        if (!TryComp<TargetOverrideComponent>(user, out var targetComp) || targetComp.Target == null)
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        _target.SetTarget(ent.Owner, targetComp.Target.Value);
+    }
+
+    private void OnRandomPersonAssigned(Entity<PickRandomPersonComponent> ent, ref ObjectiveAssignedEvent args)
+    {
+        // invalid objective prototype
+        if (!TryComp<TargetObjectiveComponent>(ent.Owner, out var target))
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        // target already assigned
+        if (target.Target != null)
+            return;
+
+        var allHumans = _mind.GetAliveHumans(args.MindId);
+
+        // Can't have multiple objectives to kill the same person
+        foreach (var objective in args.Mind.Objectives)
+        {
+            if (HasComp<KillPersonConditionComponent>(objective) && TryComp<TargetObjectiveComponent>(objective, out var kill))
+            {
+                allHumans.RemoveWhere(x => x.Owner == kill.Target);
+            }
+        }
+
+        // no other humans to kill
+        if (allHumans.Count == 0)
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        _target.SetTarget(ent.Owner, _random.Pick(allHumans), target);
+    }
+
+    private void OnRandomHeadAssigned(Entity<PickRandomHeadComponent> ent, ref ObjectiveAssignedEvent args)
+    {
+        // invalid prototype
+        if (!TryComp<TargetObjectiveComponent>(ent.Owner, out var target))
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        // target already assigned
+        if (target.Target != null)
+            return;
+
+        // no other humans to kill
+        var allHumans = _mind.GetAliveHumans(args.MindId);
+        if (allHumans.Count == 0)
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        var allHeads = new HashSet<Entity<MindComponent>>();
+        foreach (var person in allHumans)
+        {
+            if (TryComp<MindComponent>(person, out var mind) && mind.OwnedEntity is { } owned && HasComp<CommandStaffComponent>(owned))
+                allHeads.Add(person);
+        }
+
+        if (allHeads.Count == 0)
+            allHeads = allHumans; // fallback to non-head target
+
+        _target.SetTarget(ent.Owner, _random.Pick(allHeads), target);
+    }
+
+    private void OnRandomTraitorProgressAssigned(Entity<RandomTraitorProgressComponent> ent, ref ObjectiveAssignedEvent args)
+    {
+        // invalid prototype
+        if (!TryComp<TargetObjectiveComponent>(ent.Owner, out var target))
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        var traitors = _traitorRule.GetOtherTraitorMindsAliveAndConnected(args.Mind).ToHashSet();
+
+        // cant help anyone who is tasked with helping:
+        // 1. thats boring
+        // 2. no cyclic progress dependencies!!!
+        foreach (var traitor in traitors)
+        {
+            // TODO: replace this with TryComp<ObjectivesComponent>(traitor) or something when objectives are moved out of mind
+            if (!TryComp<MindComponent>(traitor.Id, out var mind))
+                continue;
+
+            foreach (var objective in mind.Objectives)
+            {
+                if (HasComp<HelpProgressConditionComponent>(objective))
+                    traitors.RemoveWhere(x => x.Mind == mind);
+            }
+        }
+
+        // Can't have multiple objectives to help/save the same person
+        foreach (var objective in args.Mind.Objectives)
+        {
+            if (HasComp<RandomTraitorAliveComponent>(objective) || HasComp<RandomTraitorProgressComponent>(objective))
+            {
+                if (TryComp<TargetObjectiveComponent>(objective, out var help))
+                {
+                    traitors.RemoveWhere(x => x.Id == help.Target);
+                }
+            }
+        }
+
+        // no more helpable traitors
+        if (traitors.Count == 0)
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        _target.SetTarget(ent.Owner, _random.Pick(traitors).Id, target);
+    }
+
+    private void OnRandomTraitorAliveAssigned(Entity<RandomTraitorAliveComponent> ent, ref ObjectiveAssignedEvent args)
+    {
+        // invalid prototype
+        if (!TryComp<TargetObjectiveComponent>(ent.Owner, out var target))
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        var traitors = _traitorRule.GetOtherTraitorMindsAliveAndConnected(args.Mind).ToHashSet();
+
+        // Can't have multiple objectives to help/save the same person
+        foreach (var objective in args.Mind.Objectives)
+        {
+            if (HasComp<RandomTraitorAliveComponent>(objective) || HasComp<RandomTraitorProgressComponent>(objective))
+            {
+                if (TryComp<TargetObjectiveComponent>(objective, out var help))
+                {
+                    traitors.RemoveWhere(x => x.Id == help.Target);
+                }
+            }
+        }
+
+        // You are the first/only traitor.
+        if (traitors.Count == 0)
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        _target.SetTarget(ent.Owner, _random.Pick(traitors).Id, target);
+    }
+}

--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -8,6 +8,10 @@ using System.Linq;
 
 namespace Content.Server.Objectives.Systems;
 
+/// <summary>
+/// Handles assinging a target to an objective entity with <see cref="TargetObjectiveComponent"/> using different components.
+/// These can be combined with condition components for objective completions in order to create a variety of objectives.
+/// </summary>
 public sealed class PickObjectiveTargetSystem : EntitySystem
 {
     [Dependency] private readonly TargetObjectiveSystem _target = default!;


### PR DESCRIPTION
## About the PR
Atomized from https://github.com/space-wizards/space-station-14/pull/35794

## Technical details
Cleans up objective systems and components.
Previously the objective target assignment subscriptions were all in the same files as the conditions that they were used with in the case of traitors. However, this file structure made no sense, as they can be arbitrarily combined (for example a "protect a random head objective" can be made by combining two components). I moved all these subscriptions into the same file to make this more comprehensible.

Re-added a target picking component based on https://github.com/space-wizards/space-station-14/pull/26978, but made it more reusable and non-terminator specific.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
only moved some code, no public API functions though

**Changelog**
no player facing changes
