### PR TITLE
toggleable tinted windows

### DIFF
--- a/Content.Server/DeviceLinking/Components/OccluderSignalControlComponent.cs
+++ b/Content.Server/DeviceLinking/Components/OccluderSignalControlComponent.cs
@@ -1,0 +1,32 @@
+using Content.Server.DeviceLinking.Systems;
+using Content.Shared.DeviceLinking;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.DeviceLinking.Components;
+
+/// <summary>
+/// Component for controlling an occluder via device linking signals.
+/// Allows enabling, disabling, or toggling the occluder state.
+/// <seealso cref="OccluderSignalControlSystem"/>
+/// </summary>
+[RegisterComponent, Access(typeof(OccluderSignalControlSystem))]
+public sealed partial class OccluderSignalControlComponent : Component
+{
+    /// <summary>
+    /// Name of the port used to enable the occluder.
+    /// </summary>
+    [DataField]
+    public ProtoId<SinkPortPrototype> EnablePort = "On";
+
+    /// <summary>
+    /// Name of the port used to disable the occluder.
+    /// </summary>
+    [DataField]
+    public ProtoId<SinkPortPrototype> DisablePort = "Off";
+
+    /// <summary>
+    /// Name of the port used to toggle the occluder state.
+    /// </summary>
+    [DataField]
+    public ProtoId<SinkPortPrototype> TogglePort = "Toggle";
+}

--- a/Content.Server/DeviceLinking/Systems/OccluderSignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/OccluderSignalControlSystem.cs
@@ -1,0 +1,57 @@
+using Content.Server.DeviceLinking.Components;
+using Content.Server.DeviceLinking.Events;
+using Content.Server.DeviceNetwork;
+using Robust.Server.GameObjects;
+
+namespace Content.Server.DeviceLinking.Systems;
+
+/// <summary>
+/// Controls an <see cref="OccluderComponent"/> through device signals.
+/// <seealso cref="OccluderSignalControlComponent"/>
+/// </summary>
+public sealed class OccluderSignalControlSystem : EntitySystem
+{
+    [Dependency] private readonly DeviceLinkSystem _deviceLink = default!;
+    [Dependency] private readonly ServerOccluderSystem _occluder = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<OccluderSignalControlComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<OccluderSignalControlComponent, SignalReceivedEvent>(OnSignalReceived);
+    }
+
+    private void OnInit(Entity<OccluderSignalControlComponent> ent, ref ComponentInit args)
+    {
+        _deviceLink.EnsureSinkPorts(ent.Owner, ent.Comp.EnablePort, ent.Comp.DisablePort, ent.Comp.TogglePort);
+    }
+
+    private void OnSignalReceived(Entity<OccluderSignalControlComponent> ent, ref SignalReceivedEvent args)
+    {
+        // Early return if there's nothing to toggle.
+        if (!TryComp<OccluderComponent>(ent, out var occluder))
+            return;
+
+        var state = SignalState.Momentary;
+        args.Data?.TryGetValue(DeviceNetworkConstants.LogicState, out state);
+
+        // Only process signals that are High or Momentary
+        if (state != SignalState.High && state != SignalState.Momentary)
+            return;
+
+        if (args.Port == ent.Comp.EnablePort)
+        {
+            _occluder.SetEnabled(ent, true, occluder);
+        }
+        else if (args.Port == ent.Comp.DisablePort)
+        {
+            _occluder.SetEnabled(ent, false, occluder);
+        }
+        else if (args.Port == ent.Comp.TogglePort)
+        {
+            _occluder.SetEnabled(ent, !occluder.Enabled, occluder);
+        }
+    }
+}

--- a/Content.Server/DeviceLinking/Systems/OccluderSignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/OccluderSignalControlSystem.cs
@@ -1,17 +1,17 @@
 using Content.Server.DeviceLinking.Components;
 using Content.Server.DeviceLinking.Events;
 using Content.Server.DeviceNetwork;
+using Content.Shared.DeviceLinking.Components;
+using Content.Shared.DeviceLinking.Systems;
 using Robust.Server.GameObjects;
 
 namespace Content.Server.DeviceLinking.Systems;
 
 /// <summary>
-/// Controls an <see cref="OccluderComponent"/> through device signals.
-/// <seealso cref="OccluderSignalControlComponent"/>
+/// Server-side logic for <see cref="SharedOccluderSignalControlSystem"/>.
 /// </summary>
-public sealed class OccluderSignalControlSystem : EntitySystem
+public sealed class OccluderSignalControlSystem : SharedOccluderSignalControlSystem
 {
-    [Dependency] private readonly DeviceLinkSystem _deviceLink = default!;
     [Dependency] private readonly ServerOccluderSystem _occluder = default!;
 
     /// <inheritdoc/>
@@ -19,13 +19,7 @@ public sealed class OccluderSignalControlSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<OccluderSignalControlComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<OccluderSignalControlComponent, SignalReceivedEvent>(OnSignalReceived);
-    }
-
-    private void OnInit(Entity<OccluderSignalControlComponent> ent, ref ComponentInit args)
-    {
-        _deviceLink.EnsureSinkPorts(ent.Owner, ent.Comp.EnablePort, ent.Comp.DisablePort, ent.Comp.TogglePort);
     }
 
     private void OnSignalReceived(Entity<OccluderSignalControlComponent> ent, ref SignalReceivedEvent args)

--- a/Content.Shared/DeviceLinking/Components/OccluderSignalControlComponent.cs
+++ b/Content.Shared/DeviceLinking/Components/OccluderSignalControlComponent.cs
@@ -1,15 +1,14 @@
-using Content.Server.DeviceLinking.Systems;
-using Content.Shared.DeviceLinking;
+using Content.Shared.DeviceLinking.Systems;
 using Robust.Shared.Prototypes;
 
-namespace Content.Server.DeviceLinking.Components;
+namespace Content.Shared.DeviceLinking.Components;
 
 /// <summary>
 /// Component for controlling an occluder via device linking signals.
 /// Allows enabling, disabling, or toggling the occluder state.
-/// <seealso cref="OccluderSignalControlSystem"/>
+/// <seealso cref="SharedOccluderSignalControlSystem"/>
 /// </summary>
-[RegisterComponent, Access(typeof(OccluderSignalControlSystem))]
+[RegisterComponent, Access(typeof(SharedOccluderSignalControlSystem))]
 public sealed partial class OccluderSignalControlComponent : Component
 {
     /// <summary>

--- a/Content.Shared/DeviceLinking/Systems/SharedOccluderSignalControlSystem.cs
+++ b/Content.Shared/DeviceLinking/Systems/SharedOccluderSignalControlSystem.cs
@@ -1,0 +1,25 @@
+using Content.Shared.DeviceLinking.Components;
+
+namespace Content.Shared.DeviceLinking.Systems;
+
+/// <summary>
+/// Controls an <see cref="OccluderComponent"/> through device signals.
+/// <seealso cref="OccluderSignalControlComponent"/>
+/// </summary>
+public abstract class SharedOccluderSignalControlSystem : EntitySystem
+{
+    [Dependency] private readonly SharedDeviceLinkSystem _deviceLink = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<OccluderSignalControlComponent, ComponentInit>(OnInit);
+    }
+
+    private void OnInit(Entity<OccluderSignalControlComponent> ent, ref ComponentInit args)
+    {
+        _deviceLink.EnsureSinkPorts(ent.Owner, ent.Comp.EnablePort, ent.Comp.DisablePort, ent.Comp.TogglePort);
+    }
+}

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -113,6 +113,28 @@
     price: 70
 
 - type: entity
+  parent: TintedWindow
+  id: TintedWindowToggleable
+  suffix: Toggleable
+  components:
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSink
+    ports:
+    - On
+    - Off
+    - Toggle
+  - type: OccluderSignalControl
+  - type: Construction
+    graph: Window
+    node: tintedWindowToggleable
+    containers:
+    - board
+
+- type: entity
   id: WindowRCDResistant
   parent: Window
   abstract: true

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/window.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/window.yml
@@ -53,7 +53,7 @@
             - material: ReinforcedGlass
               amount: 2
               doAfter: 4
-        
+
         - to: clockworkWindow
           steps:
             - material: ClockworkGlass
@@ -116,6 +116,25 @@
               doAfter: 1
             - tool: Anchoring
               doAfter: 2
+        - to: tintedWindowToggleable
+          steps:
+          - tag: DoorElectronics
+            store: board
+            name: door electronics circuit board
+            icon:
+              sprite: Objects/Misc/module.rsi
+              state: door_electronics
+            doAfter: 1
+
+    - node: tintedWindowToggleable
+      entity: TintedWindowToggleable
+      edges:
+      - to: tintedWindow
+        completed:
+        - !type:EmptyAllContainers { }
+        steps:
+        - tool: Screwing
+          doAfter: 1
 
     - node: plasmaWindow
       entity: PlasmaWindow
@@ -223,7 +242,7 @@
               doAfter: 2
             - tool: Anchoring
               doAfter: 3
-    
+
     - node: shuttleWindow
       entity: ShuttleWindow
       edges:

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -468,6 +468,25 @@
   canRotate: false
 
 - type: construction
+  name: toggleable tinted window
+  id: TintedWindowToggleable
+  graph: Window
+  startNode: start
+  targetNode: tintedWindowToggleable
+  category: construction-category-structures
+  description: Not clear, but lasers still pass through. Can be toggled with a signal.
+  canBuildInImpassable: true
+  conditions:
+  - !type:EmptyOrWindowValidInTile
+  - !type:NoWindowsInTile
+  icon:
+    sprite: Structures/Windows/tinted_window.rsi
+    state: full
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: false
+
+- type: construction
   name: clockwork window
   id: ClockworkWindow
   graph: Window


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

adds toggleable tinted windows! they can be toggled on or off using signal buttons or switches
created by adding door electronics to a regular tinted window (i didn't have a better idea)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

it's really cool! 

## Technical details
<!-- Summary of code changes for easier review. -->

added OccluderSignalControlComponent and the relevant EntitySystem, pretty self explanatory

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added toggleable tinted windows, which can be switched on or off with signal logic.
