### PR TITLE
Adds 10% slowdown to syndicate commander hardsuit 

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -637,8 +637,8 @@
         Radiation: 0.25
         Caustic: 0.4
   - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Adds 10% slowdown (both sprint and walk) to syndicate commander hardsuit

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The syndicate commander hardsuit having no slowdown at all seems at odds with encouraging nuclear operatives to not space the station, as well as being less reliant on teammates by virtue of outrunning them in a group. Commanders will also swap hardsuits with more robust teammates for move speed alone.

Reduces the effectiveness of giving commander suit users speed-boost chems and a L6 or energy sword, which would otherwise make them extremely difficult to kill and wipe half the crew without needing their team. (This can occur with normal blood-red hardsuits but the commander suit has higher survivability and thus chance to solo.)

Lore isn't as important as balance but the description and sprite alludes to commander hardsuit being 'bulked up,' implying extra weight and thus slowdown without other modifications. In addition, the only other combat hardsuit in the game that has no slowdown would be a Deathsquad hardsuit.

## Technical details
<!-- Summary of code changes for easier review. -->
yml changes only

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/8328efc4-26db-4f5e-a2c9-8a05363fd43c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Syndicate commander hardsuit now slows movement by 10%.