### PR TITLE
AI and Engi-Borg Diagnostics Hud

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -75,6 +75,10 @@
     - sprite: Mobs/Silicon/station_ai.rsi
       state: default
   - type: ShowJobIcons
+  - type: ShowHealthBars
+    damageContainers:
+    - Inorganic
+    - Silicon
 
 - type: entity
   id: AiHeldIntellicard

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -45,13 +45,19 @@
 
   defaultModules:
   - BorgModuleTool
-  - BorgModuleConstruction
-  - BorgModuleRCD
   - BorgModuleCable
+  - BorgModuleRCD
+  - BorgModuleConstruction
 
   radioChannels:
   - Engineering
   - Science
+
+  addComponents:
+  - type: ShowHealthBars
+    damageContainers:
+    - Inorganic
+    - Silicon
 
   # Visual
   inventoryTemplateId: borgShort


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I gave AI and Engi-Borg Diagnostics Hud
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In 13 AI has diagnostics hud.
## Technical details
<!-- Summary of code changes for easier review. -->
.yml edit
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
AI Perspective
![image](https://github.com/user-attachments/assets/67696e18-3ac4-4e6f-8478-d75eb5bf9443)

Borg Perspective
![image](https://github.com/user-attachments/assets/c4ae8301-046e-4723-8542-a21a73df5c64)
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: AI and Engi-Borgs now have inbuilt Diagnostic HUDs