### PR TITLE
[april fools] nuke timer calibration station event

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -243,7 +243,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
 
     private void OnNukeDisarm(NukeDisarmSuccessEvent ev)
     {
-        CheckRoundShouldEnd();
+        // Do not end the round if the bomb was armed (and disarmed) as part of the nuke calibration event
+        if(ev.CheckRoundShouldEnd)
+            CheckRoundShouldEnd();
     }
 
     private void OnComponentRemove(EntityUid uid, NukeOperativeComponent component, ComponentRemove args)
@@ -419,9 +421,6 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         foreach (var nuke in EntityQuery<NukeComponent>())
         {
             if (nuke.Status == NukeStatus.ARMED)
-                return;
-            // If we're bypassing the requirement for a nuke disk in order to arm/disarm the nuke, don't end the round. This makes sure that disarming the nuke doesn't end the round after a nuke calibration.
-            else if (nuke.DiskBypassEnabled)
                 return;
         }
 

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -420,8 +420,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         {
             if (nuke.Status == NukeStatus.ARMED)
                 return;
-            // So if the nuke isn't armed, and the disk isn't inside, don't end the round. This is so that nuke calibration event doesn't end the round upon the nuke being disarmed.
-            else if (!nuke.DiskSlot.HasItem)
+            // If we're bypassing the requirement for a nuke disk in order to arm/disarm the nuke, don't end the round. This makes sure that disarming the nuke doesn't end the round after a nuke calibration.
+            else if (nuke.DiskBypassEnabled)
                 return;
         }
 

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -420,6 +420,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         {
             if (nuke.Status == NukeStatus.ARMED)
                 return;
+            // So if the nuke isn't armed, and the disk isn't inside, don't end the round. This is so that nuke calibration event doesn't end the round upon the nuke being disarmed.
+            else if (!nuke.DiskSlot.HasItem)
+                return;
         }
 
         var shuttle = GetShuttle((ent, ent));

--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -1,5 +1,7 @@
 using System.Threading;
 using Content.Server.Explosion.EntitySystems;
+using Content.Server.StationEvents.Components;
+using Content.Server.StationEvents.Events;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Explosion;
 using Content.Shared.Nuke;
@@ -170,6 +172,20 @@ namespace Content.Server.Nuke
         /// </summary>
         [ViewVariables]
         public NukeStatus Status = NukeStatus.AWAIT_DISK;
+
+        /// <summary>
+        ///     Should we allow disarming/arming, even if there's no disk?
+        ///     Does not allow anchoring/unanchoring without the disk.
+        ///     Arming nuke still requires code to be entered.
+        /// </summary>
+        [ViewVariables]
+        public bool DiskBypassEnabled = false;
+
+        /// <summary>
+        ///     Should we reset the disk bypass value to false when the nuke is disarmed?
+        /// </summary>
+        [ViewVariables]
+        public bool ShouldResetDiskBypass = false;
 
         /// <summary>
         ///     Check if nuke has already played the nuke song so we don't do it again

--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -182,10 +182,10 @@ namespace Content.Server.Nuke
         public bool DiskBypassEnabled = false;
 
         /// <summary>
-        ///     Should we reset the disk bypass value to false when the nuke is disarmed?
+        ///     Should we reset the disk bypass value, and the nuke timer, to their defaults when the nuke is disarmed?
         /// </summary>
         [ViewVariables]
-        public bool ShouldResetDiskBypass = false;
+        public bool ShouldResetAfterDiskBypass = false;
 
         /// <summary>
         ///     Check if nuke has already played the nuke song so we don't do it again

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -540,10 +540,13 @@ public sealed class NukeSystem : EntitySystem
         component.Status = NukeStatus.COOLDOWN;
         component.CooldownTime = component.Cooldown;
 
-        if (component.ShouldResetDiskBypass == true)
+        if (component.ShouldResetAfterDiskBypass == true)
+        {
             component.DiskBypassEnabled = false;
+            component.RemainingTime = component.Timer;
+        }
 
-        component.ShouldResetDiskBypass = false;
+        component.ShouldResetAfterDiskBypass = false;
 
         UpdateUserInterface(uid, component);
         UpdateAppearance(uid, component);
@@ -607,14 +610,14 @@ public sealed class NukeSystem : EntitySystem
     /// <summary>
     ///     Sets whether we can bypass the disk when arming/disarming, and if it should be reset later.
     /// </summary>
-    /// <param name="shouldResetDiskBypassLater">Whether DiskBypassEnabled should be reset to false after nuke is disarmed.</param>
-    public void SetDiskBypassEnabled(EntityUid uid, bool diskBypass, bool shouldResetDiskBypassLater = true, NukeComponent? component = null)
+    /// <param name="shouldResetLater">Whether DiskBypassEnabled, and the nuke timer, should be reset to default after nuke is disarmed.</param>
+    public void SetDiskBypassEnabled(EntityUid uid, bool diskBypass, bool shouldResetLater = true, NukeComponent? component = null)
     {
         if (!Resolve(uid, ref component))
             return;
 
         component.DiskBypassEnabled = diskBypass;
-        component.ShouldResetDiskBypass = shouldResetDiskBypassLater;
+        component.ShouldResetAfterDiskBypass = shouldResetLater;
         UpdateUserInterface(uid, component);
     }
 

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -267,9 +267,10 @@ public sealed class NukeSystem : EntitySystem
         if (args.Handled || args.Cancelled)
             return;
 
+        var bypass = component.DiskBypassEnabled;
         DisarmBomb(uid, component);
 
-        var ev = new NukeDisarmSuccessEvent();
+        var ev = new NukeDisarmSuccessEvent(!bypass);
         RaiseLocalEvent(ev);
 
         args.Handled = true;
@@ -580,11 +581,11 @@ public sealed class NukeSystem : EntitySystem
 
         component.Exploded = true;
 
-        _explosions.QueueExplosion(uid,
-            component.ExplosionType,
-            component.TotalIntensity,
-            component.IntensitySlope,
-            component.MaxIntensity);
+        // _explosions.QueueExplosion(uid,
+        //     component.ExplosionType,
+        //     component.TotalIntensity,
+        //     component.IntensitySlope,
+        //     component.MaxIntensity);
 
         RaiseLocalEvent(new NukeExplodedEvent()
         {
@@ -681,6 +682,13 @@ public sealed class NukeExplodedEvent : EntityEventArgs
 /// </summary>
 public sealed class NukeDisarmSuccessEvent : EntityEventArgs
 {
+    /// <summary>
+    ///     Check for NukeOps round end conditions
+    /// </summary>
+    public bool CheckRoundShouldEnd;
 
+    public NukeDisarmSuccessEvent(bool checkRoundShouldEnd)
+    {
+        CheckRoundShouldEnd = checkRoundShouldEnd;
+    }
 }
-

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -581,11 +581,11 @@ public sealed class NukeSystem : EntitySystem
 
         component.Exploded = true;
 
-        // _explosions.QueueExplosion(uid,
-        //     component.ExplosionType,
-        //     component.TotalIntensity,
-        //     component.IntensitySlope,
-        //     component.MaxIntensity);
+        _explosions.QueueExplosion(uid,
+            component.ExplosionType,
+            component.TotalIntensity,
+            component.IntensitySlope,
+            component.MaxIntensity);
 
         RaiseLocalEvent(new NukeExplodedEvent()
         {

--- a/Content.Server/StationEvents/Components/NukeCalibrationRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/NukeCalibrationRuleComponent.cs
@@ -25,7 +25,6 @@ public sealed partial class NukeCalibrationRuleComponent : Component
     /// </summary>
     [DataField]
     public EntityUid AffectedNuke;
-    public NukeComponent? ;
     [DataField]
     public float NukeTimer = 170f;
     [DataField]

--- a/Content.Server/StationEvents/Components/NukeCalibrationRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/NukeCalibrationRuleComponent.cs
@@ -1,0 +1,31 @@
+using Content.Server.Nuke;
+using Content.Server.StationEvents.Events;
+using Robust.Shared.Audio;
+
+namespace Content.Server.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(NukeCalibrationRule))]
+public sealed partial class NukeCalibrationRuleComponent : Component
+{
+    /// <summary>
+    /// Sound of the announcement to play if automatic disarm of the nuke was unsuccessful.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier AutoDisarmFailedSound = new SoundPathSpecifier("/Audio/Misc/notice1.ogg");
+    /// <summary>
+    /// Sound of the announcement to play if automatic disarm of the nuke was successful.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier AutoDisarmSuccessSound = new SoundPathSpecifier("/Audio/Misc/notice2.ogg");
+
+    public EntityUid AffectedStation;
+    /// <summary>
+    /// The nuke that was '''calibrated'''.
+    /// </summary>
+    public EntityUid AffectedNuke;
+    public NukeComponent? AffectedNukeComponent;
+    public float NukeTimer = 170f;
+    public float AutoDisarmChance = 0.5f;
+    public float TimeUntilFirstAnnouncement = 15f;
+    public bool FirstAnnouncementMade = false;
+}

--- a/Content.Server/StationEvents/Components/NukeCalibrationRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/NukeCalibrationRuleComponent.cs
@@ -18,14 +18,20 @@ public sealed partial class NukeCalibrationRuleComponent : Component
     [DataField]
     public SoundSpecifier AutoDisarmSuccessSound = new SoundPathSpecifier("/Audio/Misc/notice2.ogg");
 
+    [DataField]
     public EntityUid AffectedStation;
     /// <summary>
     /// The nuke that was '''calibrated'''.
     /// </summary>
+    [DataField]
     public EntityUid AffectedNuke;
-    public NukeComponent? AffectedNukeComponent;
+    public NukeComponent? ;
+    [DataField]
     public float NukeTimer = 170f;
+    [DataField]
     public float AutoDisarmChance = 0.5f;
+    [DataField]
     public float TimeUntilFirstAnnouncement = 15f;
+    [DataField]
     public bool FirstAnnouncementMade = false;
 }

--- a/Content.Server/StationEvents/Events/NukeCalibrationRule.cs
+++ b/Content.Server/StationEvents/Events/NukeCalibrationRule.cs
@@ -1,0 +1,109 @@
+using Content.Server.StationEvents.Components;
+using Content.Server.Nuke;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Station.Components;
+using Content.Shared.Nuke;
+using Robust.Shared.Utility;
+using Timer = Robust.Shared.Timing.Timer;
+using Content.Shared.Construction.Components;
+using Content.Server.Chat.Systems;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
+using Content.Server.Popups;
+using Content.Shared.Popups;
+
+namespace Content.Server.StationEvents.Events
+{
+    public sealed class NukeCalibrationRule : StationEventSystem<NukeCalibrationRuleComponent>
+    {
+        [Dependency] private readonly NukeSystem _nuke = default!;
+        [Dependency] private IEntityManager _entityManager = default!;
+        [Dependency] private readonly ChatSystem _chat = default!;
+        [Dependency] private readonly SharedAudioSystem _audio = default!;
+        [Dependency] private readonly PopupSystem _popups = default!;
+
+        protected override void Started(EntityUid uid, NukeCalibrationRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+        {
+            base.Started(uid, component, gameRule, args);
+
+            if (!TryGetRandomStation(out var affectedStation))
+                return;
+
+            component.AffectedStation = affectedStation.Value;
+
+            var nukeQuery = _entityManager.AllEntityQueryEnumerator<NukeComponent, TransformComponent>();
+            while (nukeQuery.MoveNext(out var nuke, out var nukeComponent, out var nukeTransform))
+            {
+                // let's not arm the nuke if it isn't on station
+                if (CompOrNull<StationMemberComponent>(nukeTransform.GridUid)?.Station != affectedStation)
+                    continue;
+
+                if (!nukeTransform.Anchored)
+                    continue;
+
+                if (nukeComponent.Status == NukeStatus.ARMED)
+                    continue;
+
+                _nuke.SetRemainingTime(nuke, component.NukeTimer);
+                _nuke.ArmBomb(nuke, nukeComponent);
+                component.AffectedNuke = nuke;
+                component.AffectedNukeComponent = nukeComponent;
+                _popups.PopupEntity(Loc.GetString("station-event-nuke-calibration-arm-popup"), nuke, PopupType.LargeCaution);
+
+                break;
+            }
+        }
+
+        protected override void Ended(EntityUid uid, NukeCalibrationRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
+        {
+            base.Ended(uid, component, gameRule, args);
+
+            if (component.AffectedNukeComponent == null)
+                return;
+
+            // Lucky enough, so nuke gets disarmed for you :D
+            if (RobustRandom.NextFloat() <= component.AutoDisarmChance)
+            {
+                // 220
+                _nuke.SetRemainingTime(component.AffectedNuke, component.AffectedNukeComponent.Timer);
+                if (component.AffectedNukeComponent.Status != NukeStatus.ARMED)
+                    return;
+
+                _nuke.DisarmBomb(component.AffectedNuke, component.AffectedNukeComponent);
+                _chat.DispatchGlobalAnnouncement(Loc.GetString("station-event-nuke-calibration-disarm-success-announcement"), playSound: false, colorOverride: Color.Green);
+                _audio.PlayGlobal(component.AutoDisarmSuccessSound, Filter.Broadcast(), true);
+
+                return;
+            }
+
+            if (component.AffectedNukeComponent.Status != NukeStatus.ARMED)
+                return;
+
+            // Ooops.....
+            _nuke.SetDiskBypassEnabled(component.AffectedNuke, true, true, component.AffectedNukeComponent);
+            _chat.DispatchGlobalAnnouncement(Loc.GetString("station-event-nuke-calibration-disarm-fail-announcement"), playSound: false, colorOverride: Color.Crimson);
+            _audio.PlayGlobal(component.AutoDisarmFailedSound, Filter.Broadcast(), true);
+        }
+
+        protected override void ActiveTick(EntityUid uid, NukeCalibrationRuleComponent component, GameRuleComponent gameRule, float frameTime)
+        {
+            base.ActiveTick(uid, component, gameRule, frameTime);
+
+            if (component.AffectedNukeComponent == null)
+            {
+                ForceEndSelf(uid, gameRule);
+                return;
+            }
+
+            if (component.FirstAnnouncementMade == true)
+                return;
+
+            component.TimeUntilFirstAnnouncement -= frameTime;
+            if (component.TimeUntilFirstAnnouncement > 0f)
+                return;
+
+            component.FirstAnnouncementMade = true;
+            _chat.DispatchGlobalAnnouncement(Loc.GetString("station-event-nuke-calibration-midway-announcement"), colorOverride: Color.Yellow);
+        }
+    }
+}

--- a/Content.Server/StationEvents/Events/NukeCalibrationRule.cs
+++ b/Content.Server/StationEvents/Events/NukeCalibrationRule.cs
@@ -17,7 +17,6 @@ namespace Content.Server.StationEvents.Events
     public sealed class NukeCalibrationRule : StationEventSystem<NukeCalibrationRuleComponent>
     {
         [Dependency] private readonly NukeSystem _nuke = default!;
-        [Dependency] private IEntityManager _entityManager = default!;
         [Dependency] private readonly ChatSystem _chat = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly PopupSystem _popups = default!;
@@ -31,7 +30,7 @@ namespace Content.Server.StationEvents.Events
 
             component.AffectedStation = affectedStation.Value;
 
-            var nukeQuery = _entityManager.AllEntityQueryEnumerator<NukeComponent, TransformComponent>();
+            var nukeQuery = AllEntityQuery<NukeComponent, TransformComponent>();
             while (nukeQuery.MoveNext(out var nuke, out var nukeComponent, out var nukeTransform))
             {
                 // let's not arm the nuke if it isn't on station

--- a/Resources/Locale/en-US/station-events/events/nuke-calibration.ftl
+++ b/Resources/Locale/en-US/station-events/events/nuke-calibration.ftl
@@ -1,0 +1,7 @@
+## NukeCalibration
+
+station-event-nuke-calibration-midway-announcement = Attention! The station nuclear fission explosive has been armed for routine nuke timer recalibration. Nuke might be remotely disarmed shortly. Do not panic.
+station-event-nuke-calibration-disarm-fail-announcement = Attention! We are unable to remotely disarm the station nuke at this moment. Manual disarm has been authorised, disarm the warhead immediately!
+station-event-nuke-calibration-disarm-success-announcement = Station nuke calibration procedure has concluded; the nuke has been disarmed. Thank you for your patience.
+
+station-event-nuke-calibration-arm-popup = The timing mechanism on the nuke suddenly flashes red!

--- a/Resources/Locale/en-US/station-events/events/nuke-calibration.ftl
+++ b/Resources/Locale/en-US/station-events/events/nuke-calibration.ftl
@@ -5,3 +5,4 @@ station-event-nuke-calibration-disarm-fail-announcement = Attention! We are unab
 station-event-nuke-calibration-disarm-success-announcement = Station nuke calibration procedure has concluded; the nuke has been disarmed. Thank you for your patience.
 
 station-event-nuke-calibration-arm-popup = The timing mechanism on the nuke suddenly flashes red!
+station-event-nuke-calibration-arm-and-disk-ejected-popup = The timing mechanism on the nuke suddenly flashes red, and the disk ejects out of the nuke!

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -158,8 +158,8 @@
   # Nukes are very faulty nowadays
   - type: GameRule
     delay:
-      min:  1
-      max:  2
+      min:  5
+      max:  20
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -2,6 +2,7 @@
   id: BasicCalmEventsTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
+    - id: NukeCalibration
     - id: AnomalySpawn
     - id: BluespaceArtifact
     - id: BluespaceLocker
@@ -142,6 +143,23 @@
     weight: 5
     duration: 1
   - type: ClericalErrorRule
+
+- type: entity
+  parent: BaseGameRule
+  id: NukeCalibration
+  endAnnouncement: station-event-power-grid-check-end-announcement
+  components:
+  - type: StationEvent
+    weight: 9
+    duration: 40
+    reoccurrenceDelay: 2
+    minimumPlayers: 20
+  - type: NukeCalibrationRule
+  # Nukes are very faulty nowadays
+  - type: GameRule
+    delay:
+      min:  1
+      max:  2
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -145,9 +145,8 @@
   - type: ClericalErrorRule
 
 - type: entity
-  parent: BaseGameRule
   id: NukeCalibration
-  endAnnouncement: station-event-power-grid-check-end-announcement
+  parent: BaseGameRule
   components:
   - type: StationEvent
     weight: 9
@@ -155,11 +154,6 @@
     reoccurrenceDelay: 2
     minimumPlayers: 20
   - type: NukeCalibrationRule
-  # Nukes are very faulty nowadays
-  - type: GameRule
-    delay:
-      min:  5
-      max:  20
 
 - type: entity
   parent: BaseGameRule


### PR DESCRIPTION
## About the PR
Added a new common station event: nuke calibration
When this event happens (provided that there's a nuke on station, and it's not armed yet):
0. Try to anchor the nuke, proceed with the event if successful in doing so.
1. Nuke is armed. Nuke cannot be disarmed at this moment, unless the disk was already in it
2. An announcement is made 15 seconds later, notifying crew of 'routine nuke timer calibration'
3. 25 seconds later, there is a 50% chance for either:
- The nuke to be disarmed
- The nuke stays armed, but the requirement for the disk to be inside to be disarmed is removed (so it can be disarmed)

The nuke timer is reset back to its default (300 seconds) after the event ends.

_**The rarity of this event is intentionally set low.**_

## Why / Balance
It's funny :trollface: 

## Technical details
Added NukeCalibrationRule.cs, NukeCalibrationRuleComponent.cs, and nuke-calibration.ftl
Added 2 new vars to NukeComponent:
- DiskBypassEnabled
- ShouldResetDiskBypass

Added new method SetDiskBypassEnabled on NukeSystem, which sets DiskBypassEnabled and ShouldResetDiskBypass

If the event rolls to automatically defuse the nuke, remaining time is set _before_ checking if the nuke is armed and then disarming it. This is so that the nuke timer is reset, if it was somehow disarmed manually.

The 50% chance for disarm/arm is rolled when the event ends, with the first announcement being set 15 seconds into the event. The event is, internally, 40 seconds long.

## Media
https://www.youtube.com/watch?v=UGst4wj0E30

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Due to shortage of nuke inspectors, centcom will now perform routine calibrations of the station nuke timer.