### PR TITLE
Support separate displacement maps for left and right hand

### DIFF
--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -349,7 +349,12 @@ namespace Content.Client.Hands.Systems
                 sprite.LayerSetData(index, layerData);
 
                 //Add displacement maps
-                if (handComp.HandDisplacement is not null)
+                if (hand.Location == HandLocation.Left && handComp.LeftHandDisplacement is not null)
+                    _displacement.TryAddDisplacement(handComp.LeftHandDisplacement, sprite, index, key, revealedLayers);
+                else if (hand.Location == HandLocation.Right && handComp.RightHandDisplacement is not null)
+                    _displacement.TryAddDisplacement(handComp.RightHandDisplacement, sprite, index, key, revealedLayers);
+                //Fallback to default displacement map
+                else if (handComp.HandDisplacement is not null)
                     _displacement.TryAddDisplacement(handComp.HandDisplacement, sprite, index, key, revealedLayers);
             }
 

--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -78,8 +78,23 @@ public sealed partial class HandsComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan ThrowCooldown = TimeSpan.FromSeconds(0.5f);
 
+    /// <summary>
+    ///     Fallback displacement map applied to all sprites in the hand, unless otherwise specified
+    /// </summary>
     [DataField]
     public DisplacementData? HandDisplacement;
+
+    /// <summary>
+    ///     If defined, applies to all sprites in the left hand, ignoring <see cref="HandDisplacement"/>
+    /// </summary>
+    [DataField]
+    public DisplacementData? LeftHandDisplacement;
+
+    /// <summary>
+    ///     If defined, applies to all sprites in the right hand, ignoring <see cref="HandDisplacement"/>
+    /// </summary>
+    [DataField]
+    public DisplacementData? RightHandDisplacement;
 
     /// <summary>
     /// If false, hands cannot be stripped, and they do not show up in the stripping menu.


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

HandDisplacement is now used as Fallback unless special displacements for left and right hand are specified. So without Breaking Changes

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
useful for more complex species silhouettes when the arms are in completely different positions

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
For example: The items in the hands are more widely spaced than in a standard doll.
![image](https://github.com/user-attachments/assets/6ca37566-da93-4cf1-8698-801ab7bf3fce)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->