### PR TITLE
Whitehole/Singularity grenade price adjustments + whitehole grenade fix

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -269,11 +269,11 @@
   productEntity: SingularityGrenade
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 1
   cost:
-    Telecrystal: 6
+    Telecrystal: 2
   categories:
-    - UplinkExplosives
+    - UplinkDisruption
 
 - type: listing
   id: UplinkWhiteholeGrenade
@@ -284,9 +284,9 @@
   discountDownTo:
     Telecrystal: 1
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
-    - UplinkExplosives
+    - UplinkDisruption
 
 - type: listing
   id: UplinkGrenadePenguin

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -248,10 +248,10 @@
         sound:
           path: /Audio/Effects/Grenades/Supermatter/whitehole_loop.ogg
       - type: GravityWell
-        maxRange: 10
-        baseRadialAcceleration: -180
-        baseTangentialAcceleration: -5
-        gravPulsePeriod: 0.01
+        maxRange: 8
+        baseRadialAcceleration: -10
+        baseTangentialAcceleration: -1
+        gravPulsePeriod: 0.03
       - type: SingularityDistortion
         intensity: -200
         falloffPower: 1.5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -201,7 +201,7 @@
         sound:
           path: /Audio/Effects/Grenades/Supermatter/supermatter_loop.ogg
       - type: GravityWell
-        maxRange: 10
+        maxRange: 7
         baseRadialAcceleration: 5
         baseTangentialAcceleration: .5
         gravPulsePeriod: 0.03
@@ -248,7 +248,7 @@
         sound:
           path: /Audio/Effects/Grenades/Supermatter/whitehole_loop.ogg
       - type: GravityWell
-        maxRange: 8
+        maxRange: 7
         baseRadialAcceleration: -10
         baseTangentialAcceleration: -1
         gravPulsePeriod: 0.03


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Moved both the singularity and whitehole grenades from Explosive to Disruption in the uplink.
Lowered the price of both to 2.
Fixed the power of whitehole grenades, as it was broken alongside singularity but never fixed.
Slightly tweaked ranges so they arent as destructive

### Keep in mind, the videos showcase usage against stationary objects. It will be nowhere near as effective on people.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
For simply pushing and pulling items around both the grenades are not worth 6 and 3 tc. Especially after the fix where they no longer make things collapse through reality and noclip into the 4th wall.
They're also very rarely bought. Especially whitehole.
And whitehole has an increased purchase rate cause its currently bugged.
(store purchases by syndies in the past 7 days)
![image](https://github.com/user-attachments/assets/12cf74fc-ae4b-4446-a703-4a37af570128)
![image](https://github.com/user-attachments/assets/6c17f097-5fc2-4604-8284-1a43e48b3a00)


## Technical details
<!-- Summary of code changes for easier review. -->
Price adjustments, some value changes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/ed9161ff-2ef0-474b-ba5c-554be16dab9f)

Singularity

https://github.com/user-attachments/assets/680f034f-8efa-4af9-9ffe-202576f5696c

Whitehole

https://github.com/user-attachments/assets/ba24d08b-4673-4715-a2b4-72a2aff71a40


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Singularity and Whitehole grenades are now in the Disruption category of uplinks.
- tweak: Singularity and Whitehole grenades have had their prices reduced to 2TC each.
- fix: Whitehole grenade no longer has extremely overtuned strength.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
