### PR TITLE
Improvements to antag-before-job selection system

### DIFF
--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -44,10 +44,10 @@ public sealed partial class AntagSelectionComponent : Component
     public AntagSelectionTime SelectionTime = AntagSelectionTime.PostPlayerSpawn;
 
     /// <summary>
-    /// Cached sessions of players who are chosen yet not given the role yet.
+    /// Cached sessions of antag definitions and selected players. Players in this dict are not guaranteed to have been assigned the role yet.
     /// </summary>
     [DataField]
-    public HashSet<ICommonSession> PreSelectedSessions = new();
+    public Dictionary<AntagSelectionDefinition, HashSet<ICommonSession>>PreSelectedSessions = new();
 
     /// <summary>
     /// Cached sessions of players who are chosen. Used so we don't have to rebuild the pool multiple times in a tick.

--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -46,6 +46,7 @@ public sealed partial class AntagSelectionComponent : Component
     /// <summary>
     /// Cached sessions of players who are chosen yet not given the role yet.
     /// </summary>
+    [DataField]
     public HashSet<ICommonSession> PreSelectedSessions = new();
 
     /// <summary>

--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -449,9 +449,14 @@ public enum LogType
     /// An atmos networked device (such as a vent or pump) has had its settings changed, usually through an air alarm
     /// </summary>
     AtmosDeviceSetting = 97,
-    
+
     /// <summary>
     /// Commands related to admemes. Stuff like config changes, etc.
     /// </summary>
     AdminCommands = 98,
+
+    /// <summary>
+    /// A player was selected or assigned antag status
+    /// </summary>
+    AntagSelection = 99,
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR fixes some bugs with the antag-before-jobs selection system. Playtests on Vulture uncovered some things that didn't go as planned.

Also adds admin logs to when an antag is pre-selected/assigned, because for some reason that crucial information just wasn't being logged.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bug 1: Antag-latejoin-deficit. The preselection for a pending antag like Traitors happens upon roundstart, and as such the number of Traitors is based on the number of players readied up for the round. Latejoining was only applicable for *active* gamerules however, which meant anyone joining while the Traitor rule was pending to start wouldn't be considered (since the selection had already been made). This meant that once the rule kicked in the antag numbers would be at a deficit, which also caused latejoins *after* that to be more likely to get the role.

Bug 2: Multiple NukeOps Commanders. Due to the change in how antags are selected and assigned, there was a necessity to do a minor refactor of existing selection types. Unfortunately splitting up selection/assigning lost some functionality. This has now been remedied by tracking selections per selection defintion, rather than per gamerule.

## Technical details
<!-- Summary of code changes for easier review. -->

`PreSelectedSessions` has been changed from a `HashSet<ICommonSession>` into a `Dictionary<AntagSelectionDefinition, HashSet<ICommonSession>`, which means it tracks the sessions based on the *definition* in the gamerule. I.e. it doesn't track "This session is a NukeOps antag", but rather "This session is a NukeOps, Commander antag". 

Also added separate behavior for latejoining if it's an `IntraPlayerSpawn` gamerule that is delayed, so that you get added to the `PreSelectedSessions` list. Previously it didn't check delayed gamerules at all. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Not playerfacing.
