### PR TITLE
Enable antag-before-job rolling for roundstart antags

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -189,6 +189,7 @@
       min: 240
       max: 420
   - type: AntagSelection
+    selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Traitor ]
       max: 8
@@ -222,6 +223,7 @@
     minPlayers: 15
   - type: RevolutionaryRule
   - type: AntagSelection
+    selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ HeadRev ]
       max: 3
@@ -310,6 +312,7 @@
       max: 900
   - type: ZombieRule
   - type: AntagSelection
+    selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ InitialInfected ]
       max: 6

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -16,6 +16,7 @@
     maxDifficulty: 2.5
   - type: AntagSelection
     agentName: thief-round-end-agent-name
+    selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Thief ]
       max: 3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR enables the option for roundstart antags roll before job selection. This means you can ready up as antag-immune jobs (Sec/Command/interns) and if a gamerule selects you for an antag, you will instead be given a non-antag-immune job. 

If you have only antag-immune jobs selected, it will default to your "If preferences unavailable" selection (i.e either Passenger or Remaining in lobby). If remaining in lobby, you lose your antag slot.

This system should be fine against antag-rolling, however there are some circumstances where a player will be able to deduce that they have spawned in as an antag (e.g. select Captain, spawn in as Passenger, no Captain on the station) but hopefully the increase in Sec/Command players will offset this.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

A fair amount of players choose to not play Sec/Command due to the inability for those jobs to roll antag. With this, readying up for those roles should hopefully become more attractive for a larger selection of the playerbase. 

## Technical details
<!-- Summary of code changes for easier review. -->

Just a yaml change, the code is already there.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

See https://github.com/space-wizards/space-station-14/pull/35789

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: All roundstart antags now roll before job selection. You are now able to ready up with antag-immune job preferences (Sec/Command/interns) set to High, and if selected for antag you will get an non-antag-immune job instead.
