### PR TITLE
Require traitors to maroon their objective no matter what

### DIFF
--- a/Content.Server/Objectives/Components/KillPersonConditionComponent.cs
+++ b/Content.Server/Objectives/Components/KillPersonConditionComponent.cs
@@ -10,8 +10,14 @@ namespace Content.Server.Objectives.Components;
 public sealed partial class KillPersonConditionComponent : Component
 {
     /// <summary>
-    /// Whether the target must be truly dead, ignores missing evac.
+    /// Whether the target must be dead
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool RequireDead = false;
+
+    /// <summary>
+    /// Whether the target must not be on evac
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool RequireMaroon = true;
 }

--- a/Content.Server/Objectives/Components/KillPersonConditionComponent.cs
+++ b/Content.Server/Objectives/Components/KillPersonConditionComponent.cs
@@ -18,6 +18,6 @@ public sealed partial class KillPersonConditionComponent : Component
     /// <summary>
     /// Whether the target must not be on evac
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public bool RequireMaroon = true;
 }

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -39,9 +39,14 @@ public sealed class KillPersonConditionSystem : EntitySystem
             return 1f;
 
         var targetDead = _mind.IsCharacterDeadIc(mind);
-        var targetMarooned = !_config.GetCVar(CCVars.EmergencyShuttleEnabled) ||
-            (!_emergencyShuttle.IsTargetEscaping(target) &&
-             _emergencyShuttle.ShuttlesLeft) ;
+        var targetMarooned = (!_emergencyShuttle.IsTargetEscaping(target) &&
+                              _emergencyShuttle.ShuttlesLeft) ;
+        var shuttleDisabled = _config.GetCVar(CCVars.EmergencyShuttleEnabled);
+        if (shuttleDisabled && requireMaroon)
+        {
+            requireDead = true;
+            requireMaroon = false;
+        }
 
         if (requireMaroon)
         {

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -29,29 +29,23 @@ public sealed class KillPersonConditionSystem : EntitySystem
         if (!_target.GetTarget(uid, out var target))
             return;
 
-        args.Progress = GetProgress(target.Value, comp.RequireDead);
+        args.Progress = GetProgress(target.Value, comp.RequireDead, comp.RequireMaroon);
     }
 
-    private float GetProgress(EntityUid target, bool requireDead)
+    private float GetProgress(EntityUid target, bool requireDead, bool requireMaroon)
     {
         // deleted or gibbed or something, counts as dead
         if (!TryComp<MindComponent>(target, out var mind) || mind.OwnedEntity == null)
             return 1f;
 
-        // dead is success
-        if (_mind.IsCharacterDeadIc(mind))
-            return 1f;
-
-        // if the target has to be dead dead then don't check evac stuff
-        if (requireDead)
+        if (!_mind.IsCharacterDeadIc(mind) && requireDead)
             return 0f;
 
-        // if evac is disabled then they really do have to be dead
         if (!_config.GetCVar(CCVars.EmergencyShuttleEnabled))
-            return 0f;
+            return 1f; // good job budny you did it
 
         // target is escaping so you fail
-        if (_emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value))
+        if (_emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value) && requireMaroon)
             return 0f;
 
         // evac has left without the target, greentext since the target is afk in space with a full oxygen tank and coordinates off.

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -38,21 +38,22 @@ public sealed class KillPersonConditionSystem : EntitySystem
         if (!TryComp<MindComponent>(target, out var mind) || mind.OwnedEntity == null)
             return 1f;
 
-        if (!_mind.IsCharacterDeadIc(mind) && requireDead)
-            return 0f;
+        var targetDead = _mind.IsCharacterDeadIc(mind);
+        var targetMarooned = !_config.GetCVar(CCVars.EmergencyShuttleEnabled) ||
+            (!_emergencyShuttle.IsTargetEscaping(target) &&
+             _emergencyShuttle.ShuttlesLeft) ;
 
-        if (!_config.GetCVar(CCVars.EmergencyShuttleEnabled))
-            return 1f; // good job budny you did it
-
-        // target is escaping so you fail
-        if (_emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value) && requireMaroon)
-            return 0f;
-
-        // evac has left without the target, greentext since the target is afk in space with a full oxygen tank and coordinates off.
-        if (_emergencyShuttle.ShuttlesLeft)
-            return 1f;
-
-        // if evac is still here and target hasn't boarded, show 50% to give you an indicator that you are doing good
-        return _emergencyShuttle.EmergencyShuttleArrived ? 0.5f : 0f;
+        if (requireMaroon)
+        {
+            if (requireDead && !targetDead)
+                return 0f;
+            return targetMarooned ? 1f : _emergencyShuttle.EmergencyShuttleArrived ? 0.5f : 0f;
+        }
+        else
+        {
+            if (requireDead)
+                return targetDead ? 1f : 0f;
+            return 1f; // Good job you did it woohoo
+        }
     }
 }

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -47,17 +47,12 @@ public sealed class KillPersonConditionSystem : EntitySystem
             requireMaroon = false;
         }
 
+        if (requireDead && !targetDead)
+            return 0f;
+
         if (requireMaroon)
-        {
-            if (requireDead && !targetDead)
-                return 0f;
             return targetMarooned ? 1f : _emergencyShuttle.EmergencyShuttleArrived ? 0.5f : 0f;
-        }
-        else
-        {
-            if (requireDead)
-                return targetDead ? 1f : 0f;
-            return 1f; // Good job you did it woohoo
-        }
+
+        return 1f; // Good job you did it woohoo
     }
 }

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -41,8 +41,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
         var targetDead = _mind.IsCharacterDeadIc(mind);
         var targetMarooned = (!_emergencyShuttle.IsTargetEscaping(target) &&
                               _emergencyShuttle.ShuttlesLeft) ;
-        var shuttleDisabled = _config.GetCVar(CCVars.EmergencyShuttleEnabled);
-        if (shuttleDisabled && requireMaroon)
+        if (!_config.GetCVar(CCVars.EmergencyShuttleEnabled) && requireMaroon)
         {
             requireDead = true;
             requireMaroon = false;

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -39,8 +39,8 @@ public sealed class KillPersonConditionSystem : EntitySystem
             return 1f;
 
         var targetDead = _mind.IsCharacterDeadIc(mind);
-        var targetMarooned = (!_emergencyShuttle.IsTargetEscaping(target) &&
-                              _emergencyShuttle.ShuttlesLeft) ;
+        var targetMarooned = !_emergencyShuttle.IsTargetEscaping(target) &&
+                              _emergencyShuttle.ShuttlesLeft;
         if (!_config.GetCVar(CCVars.EmergencyShuttleEnabled) && requireMaroon)
         {
             requireDead = true;

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -50,7 +50,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
         if (requireDead && !targetDead)
             return 0f;
 
-        if (requireMaroon)
+        if (requireMaroon) // if evac is still here and target hasn't boarded, show 50% to give you an indicator that you are doing good
             return targetMarooned ? 1f : _emergencyShuttle.EmergencyShuttleArrived ? 0.5f : 0f;
 
         return 1f; // Good job you did it woohoo

--- a/Resources/Locale/en-US/objectives/conditions/kill-person.ftl
+++ b/Resources/Locale/en-US/objectives/conditions/kill-person.ftl
@@ -1,1 +1,3 @@
 objective-condition-kill-person-title = Kill or maroon {$targetName}, {CAPITALIZE($job)}
+objective-condition-kill-maroon-title = Kill and maroon {$targetName}, {CAPITALIZE($job)}
+objective-condition-maroon-person-title = Maroon {$targetName}, {CAPITALIZE($job)}

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -3,7 +3,7 @@
   id: TraitorObjectiveGroups
   weights:
     TraitorObjectiveGroupSteal: 1
-    TraitorObjectiveGroupKill: 1897459
+    TraitorObjectiveGroupKill: 1
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 1 #Involves helping/harming others without killing them or stealing their stuff
 

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -3,7 +3,7 @@
   id: TraitorObjectiveGroups
   weights:
     TraitorObjectiveGroupSteal: 1
-    TraitorObjectiveGroupKill: 1
+    TraitorObjectiveGroupKill: 1897459
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 1 #Involves helping/harming others without killing them or stealing their stuff
 

--- a/Resources/Prototypes/Objectives/paradoxClone.yml
+++ b/Resources/Prototypes/Objectives/paradoxClone.yml
@@ -32,7 +32,8 @@
   components:
   - type: PickSpecificPerson
   - type: KillPersonCondition
-    requireDead: true # don't count missing evac as killing
+    requireDead: true
+    requireMaroon: false # maintain original behavior
   - type: TargetObjective
     title: objective-condition-kill-head-title # kill <name>, <job>
 

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -96,7 +96,7 @@
 - type: entity
   parent: [BaseTraitorObjective, BaseKillObjective]
   id: KillRandomHeadObjective
-  description: We need this head gone and you probably know why. Good luck, agent.
+  description: We need this head gone and you probably know why. Make sure they don't make it to centcomm, even if they're dead. Good luck, agent.
   components:
   - type: Objective
     # technically its still possible for KillRandomPersonObjective to roll a head but this is guaranteed, so higher difficulty

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -90,7 +90,7 @@
     difficulty: 1.75
     unique: false
   - type: TargetObjective
-    title: objective-condition-kill-person-title
+    title: objective-condition-maroon-person-title
   - type: PickRandomPerson
 
 - type: entity
@@ -104,7 +104,7 @@
     # killing 1 head is enough
     unique: true
   - type: TargetObjective
-    title: objective-condition-kill-head-title
+    title: objective-condition-kill-maroon-title
   - type: PickRandomHead
   - type: KillPersonCondition
     # don't count missing evac as killing as heads are higher profile, so you really need to do the dirty work


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

The kill head objective now requires you to kill AND maroon the head, and the kill person objective only requires you to maroon them.

The paradox clone objective is unaffected (Mentioned because it uses `KillPersonCondition`)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Traitors will no longer be incentivized to kill their one kill objective just before they end up in CC, as doing this now doesn't actually complete the kill objective.

They will now be required to make sure they don't arrive at CC, even if they're dead. Being thrown out of the shuttle during transit counts as being marooned.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/0c649c2a-be62-4091-bc16-b8f6f6c97979)

(for context, dev has shuttle disabled)
![image](https://github.com/user-attachments/assets/14db48cd-9267-4a49-8f1b-0c155c52d928)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

No prototypes were renamed as they are not player-facing.

Do note that if your server lacks an evac shuttle for some reason (by way of CCvar `shuttle.emergency` being false), maroon-only objectives will instead require the target to be dead. Be aware, as this is not shown to players.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: Kill objectives will now always require you to maroon your target.