### PR TITLE
Make the captain and CentCom's mindshield implants unremoveable+

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/roles.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/roles.yml
@@ -13,9 +13,6 @@
       state: captain
     - type: RandomHumanoidSpawner
       settings: VisitorCaptain
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 - type: entity
   id: RandomHumanoidVisitorCE
@@ -26,9 +23,6 @@
       state: ce
     - type: RandomHumanoidSpawner
       settings: VisitorCE
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 - type: entity
   id: RandomHumanoidVisitorCMO
@@ -39,9 +33,6 @@
       state: cmo
     - type: RandomHumanoidSpawner
       settings: VisitorCMO
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 - type: entity
   id: RandomHumanoidVisitorHOP
@@ -52,9 +43,6 @@
       state: hop
     - type: RandomHumanoidSpawner
       settings: VisitorHOP
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 - type: entity
   id: RandomHumanoidVisitorHOS
@@ -65,9 +53,6 @@
       state: hos
     - type: RandomHumanoidSpawner
       settings: VisitorHOS
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 - type: entity
   id: RandomHumanoidVisitorRD
@@ -78,9 +63,6 @@
       state: rd
     - type: RandomHumanoidSpawner
       settings: VisitorResearchDirector
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 - type: entity
   id: RandomHumanoidVisitorQM
@@ -91,9 +73,6 @@
       state: qm
     - type: RandomHumanoidSpawner
       settings: VisitorQM
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 # Security
 
@@ -106,9 +85,6 @@
       state: security_cadet
     - type: RandomHumanoidSpawner
       settings: VisitorSecurityCadet
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 - type: entity
   id: RandomHumanoidVisitorSecurityOfficer
@@ -119,9 +95,6 @@
       state: security_officer
     - type: RandomHumanoidSpawner
       settings: VisitorSecurityOfficer
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 - type: entity
   id: RandomHumanoidVisitorDetective
@@ -132,9 +105,6 @@
       state: detective
     - type: RandomHumanoidSpawner
       settings: VisitorDetective
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 - type: entity
   id: RandomHumanoidVisitorWarden
@@ -145,9 +115,6 @@
       state: warden
     - type: RandomHumanoidSpawner
       settings: VisitorWarden
-    - type: AutoImplant
-      implants:
-      - MindShieldImplant
 
 # Cargo
 

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -18,11 +18,14 @@
 
 - type: randomHumanoidSettings
   id: VisitorCaptain
-  parent: VisitorHead
+  parent: EventHumanoidPermaMindShielded
   components:
     - type: GhostRole
       name: job-name-captain
       description: ghost-role-information-command-description
+      rules: ghost-role-information-nonantagonist-rules
+      raffle:
+        settings: default
     - type: Loadout
       prototypes: [ VisitorCaptain, VisitorCaptainAlt ]
       roleLoadout: [ RoleSurvivalStandard ]

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -11,7 +11,9 @@
   id: EventHumanoidMindShielded
   parent: EventHumanoid
   components:
-    - type: MindShield
+    - type: AutoImplant
+      implants:
+      - UnremoveableMindshieldImplant
     - type: AntagImmune
 
 ## Death Squad

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -13,8 +13,17 @@
   components:
     - type: AutoImplant
       implants:
-      - UnremoveableMindshieldImplant
+      - MindShieldImplant
     - type: AntagImmune
+
+- type: randomHumanoidSettings
+  id: EventHumanoidPermaMindShielded
+  parent: EventHumanoid
+  components:
+  - type: AutoImplant
+    implants:
+    - UnremoveableMindShieldImplant
+  - type: AntagImmune
 
 ## Death Squad
 
@@ -35,7 +44,7 @@
 
 - type: randomHumanoidSettings
   id: DeathSquad
-  parent: EventHumanoidMindShielded
+  parent: EventHumanoidPermaMindShielded
   randomizeName: false
   components:
     - type: GhostRole
@@ -74,7 +83,7 @@
 
 - type: randomHumanoidSettings
   id: ERTLeader
-  parent: EventHumanoidMindShielded
+  parent: EventHumanoidPermaMindShielded
   randomizeName: false
   components:
     - type: GhostRole
@@ -502,7 +511,7 @@
 
 - type: randomHumanoidSettings
   id: CBURNAgent
-  parent: EventHumanoidMindShielded
+  parent: EventHumanoidPermaMindShielded
   components:
     - type: Loadout
       prototypes: [CBURNGear]
@@ -532,7 +541,7 @@
 
 - type: randomHumanoidSettings
   id: CentcomOfficial
-  parent: EventHumanoidMindShielded
+  parent: EventHumanoidPermaMindShielded
   components:
     - type: GhostRole
       name: ghost-role-information-centcom-official-name

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -307,3 +307,11 @@
   components:
   - type: Implanter
     implant: RadioImplantCentcomm
+
+- type: entity
+  id: UnremovableMindShieldImplanter
+  suffix: cranial mindshield
+  parent: BaseImplantOnlyImplanter
+  components:
+  - type: Implanter
+    implant: UnremoveableMindshieldImplant

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -314,4 +314,4 @@
   parent: BaseImplantOnlyImplanter
   components:
   - type: Implanter
-    implant: UnremoveableMindshieldImplant
+    implant: UnremoveableMindShieldImplant

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -365,7 +365,7 @@
 
 - type: entity
   parent: BaseSubdermalImplant
-  id: UnremoveableMindshieldImplant
+  id: UnremoveableMindShieldImplant
   name: cranial mindshield implant
   description: This implant will ensure loyalty to Nanotrasen and prevent mind control devices, and can be implanted beneath the cranium to prevent removal.
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -362,3 +362,17 @@
   - type: RadioImplant
     radioChannels:
     - CentCom
+
+- type: entity
+  parent: BaseSubdermalImplant
+  id: UnremoveableMindshieldImplant
+  name: cranial mindshield implant
+  description: This implant will ensure loyalty to Nanotrasen and prevent mind control devices, and can be implanted beneath the cranium to prevent removal.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubdermalImplant
+    permanent: true
+  - type: MindShieldImplant
+  - type: Tag
+    tags:
+      - MindShield

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -26,7 +26,7 @@
   - AllAccess
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+    implants: [ UnremoveableMindshieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -26,7 +26,7 @@
   - AllAccess
   special:
   - !type:AddImplantSpecial
-    implants: [ UnremoveableMindshieldImplant ]
+    implants: [ UnremoveableMindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff

--- a/Resources/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml
@@ -40,7 +40,7 @@
   - [bold]Visibly be destroyed upon being implanted into a [color=#5e9cff]Head Revolutionary[/color][/bold], giving you away
   - NOT protect against flash disorientation
 
-  Assume all of [color=#cb0000]Security[/color] and [color=#1b67a5]Command[/color] are implanted with mindshields already, [bold]however they can be removed using an empty implanter, obtainable from the Medical department's MedFab.[/bold]
+  Assume all of [color=#cb0000]Security[/color] and [color=#1b67a5]Command[/color] are implanted with mindshields already, [bold]however - with the exception of the captains - they can be removed using an empty implanter, obtainable from the Medical department's MedFab.[/bold]
 
   <Box>
     <GuideEntityEmbed Entity="MindShieldImplanter"/>


### PR DESCRIPTION

## About the PR
Made an unremoveable variant of the mindshield implant, and gave it to the captain and CentCom ghost roles. Also changed the visitor ghost roles with mindshields to actually use implants, so that they can be removed.

## Why / Balance
The [Revs rework doc](https://docs.spacestation14.com/en/space-station-14/round-flow/proposals/revolutionaries-codeword-rework.html#mindshields) specifies that the captain, and CentCom should be unconvertabe, and that their mindshields should be unremoveable.

## Technical details
Added UnremoveableMindShieldImplant and a corresponding implanter
Changed Captain to use UnremoveableMindShieldImplant 
Changed EventHumanoidMindShielded to use AutoImplant instead of the MindShield component (making the mindshield removeable)
Removed AutoImplant from EventHumanoidMindShielded's children
Added EventHumanoidPermaMindShielded
Changed CentCom ghost roles, and the visiting captain ghost role, to use EventHumanoidPermaMindShielded

## Media


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

:cl:
- tweak: The Captains mindshield can no longer be removed.
- fix: Visitors can have their mindshields removed.
