### PR TITLE
make paradox clone receive the original's objectives

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/ParadoxCloneRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/ParadoxCloneRuleComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Cloning;
+using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.GameTicking.Rules.Components;
@@ -20,4 +21,23 @@ public sealed partial class ParadoxCloneRuleComponent : Component
     /// </summary>
     [DataField]
     public EntProtoId GibProto = "MobParadoxTimed";
+
+    /// <summary>
+    ///     Mind entity of the original player.
+    ///     Gets assigned when cloning.
+    /// </summary>
+    [DataField]
+    public EntityUid? Original;
+
+    /// <summary>
+    ///     Whitelist for Objectives to be copied to the clone.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? ObjectiveWhitelist;
+
+    /// <summary>
+    ///     Blacklist for Objectives to be copied to the clone.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? ObjectiveBlacklist;
 }

--- a/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
@@ -2,11 +2,9 @@ using Content.Server.Antag;
 using Content.Server.Cloning;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Objectives.Components;
-using Content.Server.Objectives.Systems;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Gibbing.Components;
 using Content.Shared.Mind;
-using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -15,7 +13,6 @@ namespace Content.Server.GameTicking.Rules;
 public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComponent>
 {
     [Dependency] private readonly SharedTransformSystem _transform = default!;
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly CloningSystem _cloning = default!;
@@ -48,12 +45,6 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
         if (args.Session?.AttachedEntity is not { } spawner)
             return;
 
-        if (!_prototypeManager.TryIndex(ent.Comp.Settings, out var settings))
-        {
-            Log.Error($"Used invalid cloning settings {ent.Comp.Settings} for ParadoxCloneRule");
-            return;
-        }
-
         // get possible targets
         var allHumans = _mind.GetAliveHumans();
 
@@ -68,7 +59,7 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
         var playerToClone = _random.Pick(allHumans);
         var bodyToClone = playerToClone.Comp.OwnedEntity;
 
-        if (bodyToClone == null || !_cloning.TryCloning(bodyToClone.Value, _transform.GetMapCoordinates(spawner), settings, out var clone))
+        if (bodyToClone == null || !_cloning.TryCloning(bodyToClone.Value, _transform.GetMapCoordinates(spawner), ent.Comp.Settings, out var clone))
         {
             Log.Error($"Unable to make a paradox clone of entity {ToPrettyString(bodyToClone)}");
             return;

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Objectives.Systems;
 using Content.Shared.Players;
+using Content.Shared.Whitelist;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
@@ -26,6 +27,7 @@ public abstract class SharedMindSystem : EntitySystem
     [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
     [Dependency] private readonly SharedPlayerSystem _player = default!;
     [Dependency] private readonly MetaDataSystem _metadata = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
 
     [ViewVariables]
     protected readonly Dictionary<NetUserId, EntityUid> UserMinds = new();
@@ -364,6 +366,16 @@ public abstract class SharedMindSystem : EntitySystem
         var title = Name(objective);
         _adminLogger.Add(LogType.Mind, LogImpact.Low, $"Objective {objective} ({title}) removed from the mind of {MindOwnerLoggingString(mind)}");
         mind.Objectives.Remove(objective);
+
+        // garbage collection
+        // only delete the objective entity if no mind uses it anymore
+        var mindQuery = new AllEntityQueryEnumerator<MindComponent>();
+        while (mindQuery.MoveNext(out _, out var queryComp))
+        {
+            if (queryComp.Objectives.Contains(objective))
+                return true;
+        }
+
         Del(objective);
         return true;
     }
@@ -393,6 +405,33 @@ public abstract class SharedMindSystem : EntitySystem
         }
         objective = default;
         return false;
+    }
+
+    /// <summary>
+    /// Copies objectives from one mind to another, so that they are shared between two players.
+    /// </summary>
+    /// <remarks>
+    /// Only copies the reference to the objective entity, not the entity itself.
+    /// This relies on the fact that objectives are never changed after spawning them.
+    /// If someone ever changes that, they will have to address this.
+    /// </remarks>
+    /// <param name="source"> mind entity of the player to copy from </param>
+    /// <param name="target"> mind entity of the player to copy to </param>
+    /// <param name="except"> whitelist for objectives that should be copied </param>
+    /// <param name="except"> blacklist for objectives that should not be copied </param>
+    public void CopyObjectives(Entity<MindComponent?> source, Entity<MindComponent?> target, EntityWhitelist? whitelist = null, EntityWhitelist? blacklist = null)
+    {
+        if (!Resolve(source, ref source.Comp) || !Resolve(target, ref target.Comp))
+            return;
+
+        foreach (var objective in source.Comp.Objectives)
+        {
+            if (target.Comp.Objectives.Contains(objective))
+                continue; // target already has this objective
+
+            if (_whitelist.CheckBoth(objective, blacklist, whitelist))
+                AddObjective(target, target.Comp, objective);
+        }
     }
 
     /// <summary>

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -367,8 +367,8 @@ public abstract class SharedMindSystem : EntitySystem
         _adminLogger.Add(LogType.Mind, LogImpact.Low, $"Objective {objective} ({title}) removed from the mind of {MindOwnerLoggingString(mind)}");
         mind.Objectives.Remove(objective);
 
-        // garbage collection
-        // only delete the objective entity if no mind uses it anymore
+        // garbage collection - only delete the objective entity if no mind uses it anymore
+        // This comes up for stuff like paradox clones where the objectives share the same entity
         var mindQuery = new AllEntityQueryEnumerator<MindComponent>();
         while (mindQuery.MoveNext(out _, out var queryComp))
         {

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -27,6 +27,7 @@
   - Clumsy
   - MindShield
   - MimePowers
+  - SpaceNinja
   # accents
   - Accentless
   - BackwardsAccent

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -243,6 +243,9 @@
     reoccurrenceDelay: 20
     minimumPlayers: 15
   - type: ParadoxCloneRule
+    objectiveBlacklist:
+      tags:
+      - ParadoxCloneObjectiveBlacklist
   - type: AntagObjectives
     objectives:
     - ParadoxCloneKillObjective

--- a/Resources/Prototypes/Objectives/paradoxClone.yml
+++ b/Resources/Prototypes/Objectives/paradoxClone.yml
@@ -11,6 +11,9 @@
     roles:
       mindRoles:
       - ParadoxCloneRole
+  - type: Tag
+    tags:
+    - ParadoxCloneObjectiveBlacklist # don't copy the objectives from other clones
 
 - type: entity
   parent: [BaseParadoxCloneObjective, BaseLivingObjective]

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -955,6 +955,9 @@
   id: Packet
 
 - type: Tag
+  id: ParadoxCloneObjectiveBlacklist # objective entities with this tag don't get copied to paradox clones
+
+- type: Tag
   id: Paper
 
 - type: Tag


### PR DESCRIPTION
## About the PR
Paradox clones now receive all the objectives the original had in their character menu.
This PR will need a lot of testing with all different objective types.

## Why / Balance
This should make things less confusing for players and admins regarding server rules.
For example a clone of a nukie is now allowed to start the nuke.
Also a fun extra challenge in the rare case this happens.

## Technical details
Adds a function that copies objectives from one mind to another.
This only copies the EntityUid of that objective entity and does not create a full copy of the entity itself (which would be very hard to do with our ECS). This works without any problems because objective entities are never modfied or deleted.

At the moment the corresponding mind roles for the objectives are not copied. This should be fine for now though since paradox clones already are a Solo Antagonist, so it should be unproblematic rule-wise.

In the case of being a clone of a clone you don't get a copy of their paradox objectives as these have been blacklisted.
In a future PR I will change the paradox clone kill objective so you have to kill *all* your copies rather than only the specific one you were spawned from.

I also removed a redundant TryIndex in the game rule as that prototype was just being cast back to a ProtoId anyways, which was then checked a second time.

Adds the missing SpaceNinjaComponent to the cloning whitelist so that the ninja can use their equipment.

## Media
![grafik](https://github.com/user-attachments/assets/b74253dd-9e7e-4201-ad7c-bb08c7d060f8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- add: Paradox clones now receive any objective the original had.

