### PR TITLE
Mark all hostile mind roles as antag

### DIFF
--- a/Resources/Locale/en-US/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/prototypes/roles/antags.ftl
@@ -1,4 +1,12 @@
-﻿roles-antag-syndicate-agent-name = Syndicate agent
+﻿roles-antag-generic-solo-antagonist-name = Solo Antagonist
+
+roles-antag-generic-free-agent-name = Free Agent
+
+roles-antag-generic-team-antagonist-name = Team Antagonist
+
+roles-antag-generic-silicon-antagonist-name = Silicon Antagonist
+
+roles-antag-syndicate-agent-name = Syndicate agent
 roles-antag-syndicate-agent-objective = Complete your objectives without being caught.
 
 roles-antag-syndicate-agent-sleeper-name = Syndicate sleeper agent

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -457,7 +457,7 @@
     description: ghost-role-information-mothroach-description
     rules: ghost-role-information-freeagent-rules
     mindRoles:
-    - MindRoleGhostRoleFreeAgent
+    - MindRoleGhostRoleFreeAgentHarmless
   - type: Fixtures
     fixtures:
       fix1:
@@ -1649,7 +1649,7 @@
     description: ghost-role-information-mouse-description
     rules: ghost-role-information-freeagent-rules
     mindRoles:
-    - MindRoleGhostRoleFreeAgent
+    - MindRoleGhostRoleFreeAgentHarmless
   - type: GhostTakeoverAvailable
   - type: Speech
     speechSounds: Squeak

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -171,7 +171,7 @@
       description: ghost-role-information-sentient-carp-description
       rules: ghost-role-information-space-dragon-summoned-carp-rules
       mindRoles:
-      - MindRoleGhostRoleTeamAntagonist
+      - MindRoleGhostRoleTeamAntagonistFlock
       raffle:
         settings: short
     - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -208,7 +208,7 @@
     description: ghost-role-information-honkbot-description
     rules: ghost-role-information-freeagent-rules
     mindRoles:
-    - MindRoleGhostRoleFreeAgent
+    - MindRoleGhostRoleFreeAgentHarmless
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
@@ -242,7 +242,7 @@
     description: ghost-role-information-jonkbot-description
     rules: ghost-role-information-freeagent-rules
     mindRoles:
-    - MindRoleGhostRoleFreeAgent
+    - MindRoleGhostRoleFreeAgentHarmless
     raffle:
       settings: default
   - type: InteractionPopup
@@ -379,7 +379,7 @@
     description: ghost-role-information-mimebot-description
     rules: ghost-role-information-freeagent-rules
     mindRoles:
-    - MindRoleGhostRoleFreeAgent
+    - MindRoleGhostRoleFreeAgentHarmless
     raffle:
       settings: default
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -390,7 +390,7 @@
     description: ghost-role-information-snail-description
     rules: ghost-role-information-freeagent-rules
     mindRoles:
-    - MindRoleGhostRoleFreeAgent
+    - MindRoleGhostRoleFreeAgentHarmless
   - type: GhostTakeoverAvailable
   - type: Emoting
   - type: Sprite
@@ -516,6 +516,9 @@
   id: MobSnailInstantDeath
   suffix: Smite
   components:
+  - type: GhostRole
+    mindRoles:
+    - MindRoleGhostRoleFreeAgent
   - type: MobStateActions
     actions:
       Alive:

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -161,6 +161,9 @@
   components:
   - type: Dragon
     spawnRiftAction: ActionSpawnRift
+  - type: GhostRole
+    mindRoles:
+    - MindRoleDragon
   - type: ActionGun
     action: ActionDragonsBreath
     gunProto: DragonsBreathGun

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -112,7 +112,7 @@
       description: ghost-role-information-syndicate-cyborg-description
       rules: ghost-role-information-silicon-rules
       mindRoles:
-      - MindRoleGhostRoleSilicon # Should this be Silicon or SiliconAntagonist ?
+      - MindRoleGhostRoleSilicon
       raffle:
         settings: default
     - type: GhostRoleMobSpawner

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -112,7 +112,7 @@
       description: ghost-role-information-syndicate-cyborg-description
       rules: ghost-role-information-silicon-rules
       mindRoles:
-      - MindRoleGhostRoleSilicon
+      - MindRoleGhostRoleSilicon # Should this be Silicon or SiliconAntagonist ?
       raffle:
         settings: default
     - type: GhostRoleMobSpawner

--- a/Resources/Prototypes/Roles/Antags/generic.yml
+++ b/Resources/Prototypes/Roles/Antags/generic.yml
@@ -1,0 +1,25 @@
+- type: antag
+  id: GenericAntagonist
+  name: roles-antag-generic-solo-antagonist-name
+  antagonist: true
+  objective: never-shown
+
+- type: antag
+  id: GenericTeamAntagonist
+  name: roles-antag-generic-team-antagonist-name
+  antagonist: true
+  objective: never-shown
+
+- type: antag
+  id: GenericFreeAgent
+  name: roles-antag-generic-free-agent-name
+  antagonist: true
+  objective: never-shown
+
+- type: antag
+  id: GenericSiliconAntagonist
+  name: roles-antag-generic-silicon-antagonist-name
+  antagonist: true
+  objective: never-shown
+
+

--- a/Resources/Prototypes/Roles/Antags/generic.yml
+++ b/Resources/Prototypes/Roles/Antags/generic.yml
@@ -21,5 +21,3 @@
   name: roles-antag-generic-silicon-antagonist-name
   antagonist: true
   objective: never-shown
-
-

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -243,7 +243,7 @@
   components:
   - type: MindRole
     roleType: TeamAntagonist
-    antagPrototype: SyndicateReinforcement
+    antagPrototype: GenericTeamAntagonist
 
 # Wizards
 - type: entity

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -14,6 +14,7 @@
   - type: MindRole
     antag: true
     antagPrototype: GenericAntagonist
+    roleType: SoloAntagonist
 
 #Observer
 - type: entity
@@ -77,9 +78,6 @@
   parent: [ BaseMindRoleAntag, MindRoleGhostRoleNeutral ]
   id: MindRoleGhostRoleSoloAntagonist
   name: Ghost Role (Solo Antagonist)
-  components:
-  - type: MindRole
-    roleType: SoloAntagonist
 
 - type: entity
   parent: [ BaseMindRoleAntag, MindRoleGhostRoleNeutral ]
@@ -147,7 +145,6 @@
   components:
   - type: MindRole
     antagPrototype: SpaceNinja
-    roleType: SoloAntagonist
     exclusiveAntag: true
   - type: NinjaRole
 
@@ -218,7 +215,6 @@
   components:
   - type: MindRole
     antagPrototype: Thief
-    roleType: SoloAntagonist
   - type: ThiefRole
 
 # Traitors
@@ -230,7 +226,6 @@
   - type: MindRole
     antagPrototype: Traitor
     exclusiveAntag: true
-    roleType: SoloAntagonist
   - type: TraitorRole
 
 - type: entity
@@ -259,7 +254,6 @@
   - type: MindRole
     antagPrototype: Wizard
     exclusiveAntag: true
-    roleType: SoloAntagonist
   - type: WizardRole
 
 # Zombie Squad

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -89,7 +89,7 @@
     antagPrototype: GenericTeamAntagonist
 
 # This should be used (or inherited) for team antags that are summoned or converted in large quantities, and are "secondary" to other antags
-# So they can be sorted later on the round end list
+# TODO: sort weight
 - type: entity
   parent: MindRoleGhostRoleTeamAntagonist
   id: MindRoleGhostRoleTeamAntagonistFlock

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -13,6 +13,7 @@
   components:
   - type: MindRole
     antag: true
+    antagPrototype: GenericAntagonist
 
 #Observer
 - type: entity
@@ -31,68 +32,77 @@
   - type: GhostRoleMarkerRole
 
 - type: entity
-  parent: BaseMindRole
+  parent: MindRoleGhostRoleNeutral
   id: MindRoleGhostRoleFamiliar
   name: Ghost Role (Familiar)
   components:
   - type: MindRole
     roleType: Familiar
-  - type: GhostRoleMarkerRole
 
 - type: entity
-  parent: BaseMindRole
+  parent: [ BaseMindRoleAntag, MindRoleGhostRoleNeutral ]
   id: MindRoleGhostRoleFreeAgent
   name: Ghost Role (Free Agent)
   components:
   - type: MindRole
     roleType: FreeAgent
-  - type: GhostRoleMarkerRole
+    antagPrototype: GenericFreeAgent
 
 - type: entity
-  parent: BaseMindRole
+  parent: MindRoleGhostRoleNeutral
+  id: MindRoleGhostRoleFreeAgentHarmless
+  name: Ghost Role (Free Agent)
+  components:
+  - type: MindRole
+    roleType: FreeAgent
+
+- type: entity
+  parent: MindRoleGhostRoleNeutral
   id: MindRoleGhostRoleSilicon
   name: Ghost Role (Silicon)
   components:
   - type: MindRole
     roleType: Silicon
-  - type: GhostRoleMarkerRole
 
 - type: entity
-  parent: BaseMindRole
+  parent: [ BaseMindRoleAntag, MindRoleGhostRoleNeutral ]
   id: MindRoleGhostRoleSiliconAntagonist
   name: Ghost Role (Silicon Antagonist)
   components:
   - type: MindRole
     roleType: SiliconAntagonist
-  - type: GhostRoleMarkerRole
+    antagPrototype: GenericSiliconAntagonist
 
 - type: entity
-  parent: BaseMindRole
+  parent: [ BaseMindRoleAntag, MindRoleGhostRoleNeutral ]
   id: MindRoleGhostRoleSoloAntagonist
   name: Ghost Role (Solo Antagonist)
   components:
   - type: MindRole
     roleType: SoloAntagonist
-  - type: GhostRoleMarkerRole
 
 - type: entity
-  parent: BaseMindRole
+  parent: [ BaseMindRoleAntag, MindRoleGhostRoleNeutral ]
   id: MindRoleGhostRoleTeamAntagonist
   name: Ghost Role (Team Antagonist)
   components:
   - type: MindRole
     roleType: TeamAntagonist
-  - type: GhostRoleMarkerRole
+    antagPrototype: GenericTeamAntagonist
 
-
+# This should be used (or inherited) for team antags that are summoned or converted in large quantities, and are "secondary" to other antags
+# So they can be sorted later on the round end list
+- type: entity
+  parent: MindRoleGhostRoleTeamAntagonist
+  id: MindRoleGhostRoleTeamAntagonistFlock
+  name: Ghost Role (Team Antagonist)
 
 # The Job MindRole holds the mob's Job prototype
 - type: entity
   parent: BaseMindRole
   id: MindRoleJob
   name: Job Role
-#  description:
-  # MindRoleComponent.JobPrototype is filled by SharedJobSystem
+  # JobPrototype is filled by SharedJobSystem
 
 # Silicon
 - type: entity
@@ -120,7 +130,6 @@
   parent: BaseMindRoleAntag
   id: MindRoleDragon
   name: Dragon Role
-#  description:
   components:
   - type: MindRole
     antagPrototype: Dragon
@@ -135,7 +144,6 @@
   parent: BaseMindRoleAntag
   id: MindRoleNinja
   name: Space Ninja Role
-#  description: mind-role-ninja-description
   components:
   - type: MindRole
     antagPrototype: SpaceNinja
@@ -148,7 +156,6 @@
   parent: BaseMindRoleAntag
   id: MindRoleNukeops
   name: Nukeops Operative Role
-#  description: mind-role-nukeops-description
   components:
   - type: MindRole
     roleType: TeamAntagonist
@@ -160,7 +167,6 @@
   parent: MindRoleNukeops
   id: MindRoleNukeopsMedic
   name: Nukeops Medic Role
-#  description: mind-role-nukeops-medic-description
   components:
   - type: MindRole
     antagPrototype: NukeopsMedic
@@ -169,7 +175,6 @@
   parent: MindRoleNukeops
   id: MindRoleNukeopsCommander
   name: Nukeops Commander Role
-#  description: mind-role-nukeops-commander-description
   components:
   - type: MindRole
     antagPrototype: NukeopsCommander
@@ -179,7 +184,6 @@
   parent: BaseMindRoleAntag
   id: MindRoleHeadRevolutionary
   name: Head Revolutionary Role
-#  description: mind-role-head-revolutionary-description
   components:
   - type: MindRole
     antagPrototype: HeadRev
@@ -191,7 +195,6 @@
   parent: MindRoleHeadRevolutionary
   id: MindRoleRevolutionary
   name: Revolutionary Role
-#  description: mind-role-revolutionary-description
   components:
   - type: MindRole
     antagPrototype: Rev
@@ -212,7 +215,6 @@
   parent: BaseMindRoleAntag
   id: MindRoleThief
   name: Thief Role
-#  description: mind-role-thief-description
   components:
   - type: MindRole
     antagPrototype: Thief
@@ -224,7 +226,6 @@
   parent: BaseMindRoleAntag
   id: MindRoleTraitor
   name: Traitor Role
-#  description: mind-role-traitor-description
   components:
   - type: MindRole
     antagPrototype: Traitor
@@ -236,7 +237,6 @@
   parent: MindRoleTraitor
   id: MindRoleTraitorSleeper
   name: Sleeper Agent Role
-#  description: mind-role-traitor-sleeper-description
   components:
   - type: MindRole
     antagPrototype: TraitorSleeper
@@ -245,17 +245,16 @@
   parent: MindRoleTraitor
   id: MindRoleTraitorReinforcement
   name: Syndicate Reinforcement Role
-  #  description: mind-role-syndicate-reinforcement-description
   components:
-    - type: MindRole
-      roleType: TeamAntagonist
+  - type: MindRole
+    roleType: TeamAntagonist
+    antagPrototype: SyndicateReinforcement
 
 # Wizards
 - type: entity
   parent: BaseMindRoleAntag
   id: MindRoleWizard
   name: Wizard Role
-  #  description: these are all commented out
   components:
   - type: MindRole
     antagPrototype: Wizard
@@ -268,7 +267,6 @@
   parent: BaseMindRoleAntag
   id: MindRoleInitialInfected
   name: Initial Infected Role
-#  description: mind-role-initial-infected-description
   components:
   - type: MindRole
     antagPrototype: InitialInfected
@@ -277,10 +275,9 @@
   - type: InitialInfectedRole
 
 - type: entity
-  parent: BaseMindRoleAntag
+  parent: MindRoleGhostRoleTeamAntagonistFlock
   id: MindRoleZombie
   name: Zombie Role
-#  description: mind-role-zombie-description
   components:
   - type: MindRole
     antagPrototype: Zombie


### PR DESCRIPTION
## About the PR

All (potentially) hostile ghostroles that were not already, are now marked as antag. They will show up on top of the round end character list in red, and they will show as ANTAG on the classic overlay. Mice, Mothroaches and Snails (except the Death Snail) are still not marked as antag, despite being free agents. Due to their effective harmlessness and potentially large numbers. (This can be easily changed, though, by editing a single mind role prototype)

## Why / Balance
Antags not being marked as antags is a clear bug. It has been ignored so far because the problem was "painted over" by the role types, but it is still causing some issues in places so time to fix it.
Fixes #26710

## Technical details
Mind roles have been given a more inheritance-based layout, with the prototype IDs staying as current.

All the "generic" ghostrole mind role prototypes are assigned a corresponding dummy antag prototype, that only serves to mark them as antag and write their role type on the round end screen, rather than being "Unknown".
Two new mind role prototypes were also created and assigned where appropriate:
`MindRoleGhostRoleFreeAgentHarmless `for unimpressive "nuissance" ghostroles like mice
`MindRoleGhostRoleTeamAntagonistFlock` for team antags that potentially spawn in large numbers and are conceptually "less important" than the antag that made/called them, or the other antags in that round. This role currently does not do anything on its own, but in the future it will allow the weighed ordering of antagonists on lists where they all appear.

## Media

Harmless Free Agent (mouse, snail, mothroach)
![Screenshot_2025-03-14_120441](https://github.com/user-attachments/assets/45b09391-d6e0-45ed-b6e7-d873f26e5d5d)

Dangerous Free Agent (death snail, closet skeleton, rat king)
![Screenshot_2025-03-14_120501](https://github.com/user-attachments/assets/b9e6fb67-7df2-43cb-b0c8-4be6b1199c7e)

Some ghostroles on the round end display. Old vs New
![round_end](https://github.com/user-attachments/assets/d2e62306-a666-4a9d-9053-0e491ee87570)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Mind Role Prototypes have been modified. All hostile or potentially hostile mind roles are now given a default antagonist prototype. For most current mind roles, no change should be required, except in one scenario:
Free Agents that are "harmless and unremarkable" such as mice and mothroaches, should use `MindRoleGhostRoleFreeAgentHarmless` instead of MindRoleGhostRoleFreeAgent. This will prevent them from showing as ANTAG on any interfaces that make this distinction (unless they get an actual antag role, such as by being zombified)

Many minor (and some not-so-minor) ghostrole antags will now start to appear on the top of the player list, and will no longer be listed as "Unknown". Instead their listed role will be their role type. 
At a later point, role subtypes (soonTM) will allow the proper naming of those antag roles, without requiring the creation of a new dummy antag prototype for every single ghostrole prototype that you want to rename.

**Changelog**
:cl: Errant
- fix: Some ghostrole antagonists were incorrectly not marked as such in the round end playerlist. Now all antagonists are sorted to the top and have red names.
ADMIN:
- fix: All Solo Antagonist, Team Antagonist, Altered Silicon and (non-harmless) Free Agent ghostroles are now marked as Antagonist on all interfaces where this distinction exists. (Classic admin overlay, admin playerlist, round end player list)