### PR TITLE
Add DamagedSiliconAccent to PBs and MMIs

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/DamageContainerContentsBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/DamageContainerContentsBehavior.cs
@@ -1,0 +1,57 @@
+using Content.Shared.Damage;
+using Robust.Server.Containers;
+using Robust.Shared.Containers;
+
+namespace Content.Server.Destructible.Thresholds.Behaviors
+{
+    /// <summary>
+    ///     Damage all items in specified containers
+    /// </summary>
+    [DataDefinition]
+    public sealed partial class DamageContainerContentsBehavior : IThresholdBehavior
+    {
+        /// <summary>
+        /// List of containers to apply damage to contents
+        /// </summary>
+        [DataField("containers")]
+        public List<string> Containers = new();
+
+        /// <summary>
+        /// Damage specifier to apply to container contents.
+        /// If null, apply the current damage of the owner entity to all the contents
+        /// </summary>
+        [DataField]
+        public DamageSpecifier? Damage = null;
+
+        [DataField]
+        public bool IgnoreResistances = false;
+
+        public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
+        {
+            if (!system.EntityManager.TryGetComponent<ContainerManagerComponent>(owner, out var containerManager))
+                return;
+
+            var containerSys = system.EntityManager.System<ContainerSystem>();
+            var damageSys = system.EntityManager.System<DamageableSystem>();
+
+            foreach (var containerId in Containers)
+            {
+                if (!containerSys.TryGetContainer(owner, containerId, out var container, containerManager))
+                    continue;
+
+                if (Damage == null)
+                {
+                    if (!system.EntityManager.TryGetComponent<DamageableComponent>(owner, out var damageable))
+                        return;
+                    Damage = damageable.Damage;
+                }
+                foreach (var ent in container.ContainedEntities)
+                {
+                    if(!system.EntityManager.TryGetComponent<DamageableComponent>(ent, out var damageable))
+                        continue;
+                    damageSys.TryChangeDamage(ent, Damage, IgnoreResistances, true, damageable);
+                }
+            }
+        }
+    }
+}

--- a/Content.Server/Destructible/Thresholds/Behaviors/DamageContainerContentsBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/DamageContainerContentsBehavior.cs
@@ -13,7 +13,7 @@ public sealed partial class DamageContainerContentsBehavior : IThresholdBehavior
     /// <summary>
     /// List of containers to apply damage to contents
     /// </summary>
-    [DataField("containers")]
+    [DataField]
     public List<string> Containers = new();
 
     /// <summary>

--- a/Content.Server/Destructible/Thresholds/Behaviors/DamageContainerContentsBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/DamageContainerContentsBehavior.cs
@@ -2,55 +2,54 @@ using Content.Shared.Damage;
 using Robust.Server.Containers;
 using Robust.Shared.Containers;
 
-namespace Content.Server.Destructible.Thresholds.Behaviors
+namespace Content.Server.Destructible.Thresholds.Behaviors;
+
+/// <summary>
+///     Damage all items in specified containers
+/// </summary>
+[DataDefinition]
+public sealed partial class DamageContainerContentsBehavior : IThresholdBehavior
 {
     /// <summary>
-    ///     Damage all items in specified containers
+    /// List of containers to apply damage to contents
     /// </summary>
-    [DataDefinition]
-    public sealed partial class DamageContainerContentsBehavior : IThresholdBehavior
+    [DataField("containers")]
+    public List<string> Containers = new();
+
+    /// <summary>
+    /// Damage specifier to apply to container contents.
+    /// If null, apply the current damage of the owner entity to all the contents
+    /// </summary>
+    [DataField]
+    public DamageSpecifier? Damage = null;
+
+    [DataField]
+    public bool IgnoreResistances = false;
+
+    public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
     {
-        /// <summary>
-        /// List of containers to apply damage to contents
-        /// </summary>
-        [DataField("containers")]
-        public List<string> Containers = new();
+        if (!system.EntityManager.TryGetComponent<ContainerManagerComponent>(owner, out var containerManager))
+            return;
 
-        /// <summary>
-        /// Damage specifier to apply to container contents.
-        /// If null, apply the current damage of the owner entity to all the contents
-        /// </summary>
-        [DataField]
-        public DamageSpecifier? Damage = null;
+        var containerSys = system.EntityManager.System<ContainerSystem>();
+        var damageSys = system.EntityManager.System<DamageableSystem>();
 
-        [DataField]
-        public bool IgnoreResistances = false;
-
-        public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
+        foreach (var containerId in Containers)
         {
-            if (!system.EntityManager.TryGetComponent<ContainerManagerComponent>(owner, out var containerManager))
-                return;
+            if (!containerSys.TryGetContainer(owner, containerId, out var container, containerManager))
+                continue;
 
-            var containerSys = system.EntityManager.System<ContainerSystem>();
-            var damageSys = system.EntityManager.System<DamageableSystem>();
-
-            foreach (var containerId in Containers)
+            if (Damage == null)
             {
-                if (!containerSys.TryGetContainer(owner, containerId, out var container, containerManager))
+                if (!system.EntityManager.TryGetComponent<DamageableComponent>(owner, out var damageable))
+                    return;
+                Damage = damageable.Damage;
+            }
+            foreach (var ent in container.ContainedEntities)
+            {
+                if(!system.EntityManager.TryGetComponent<DamageableComponent>(ent, out var damageable))
                     continue;
-
-                if (Damage == null)
-                {
-                    if (!system.EntityManager.TryGetComponent<DamageableComponent>(owner, out var damageable))
-                        return;
-                    Damage = damageable.Damage;
-                }
-                foreach (var ent in container.ContainedEntities)
-                {
-                    if(!system.EntityManager.TryGetComponent<DamageableComponent>(ent, out var damageable))
-                        continue;
-                    damageSys.TryChangeDamage(ent, Damage, IgnoreResistances, true, damageable);
-                }
+                damageSys.TryChangeDamage(ent, Damage, IgnoreResistances, true, damageable);
             }
         }
     }

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -192,6 +192,10 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
+      - !type:DamageContainerContentsBehavior
+        containers:
+        - borg_brain
+        ignoreResistances: true
       - !type:EmptyContainersBehaviour
         containers:
         - borg_brain

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -34,6 +34,9 @@
     proto: robot
   - type: Speech
     speechSounds: Pai
+  - type: MobState
+    allowedStates:
+    - Alive
   - type: ItemSlots
     slots:
       brain_slot:
@@ -53,6 +56,20 @@
     whitelist:
       components:
       - SecretStash
+  - type: DamagedSiliconAccent
+    damageAtMaxCorruption: 100
+    enableChargeCorruption: false
+  - type: Damageable
+    damageContainer: Silicon
+  - type: PassiveDamage
+    allowedStates:
+    - Alive
+    damage:
+      types:
+        Heat: -8
+        Shock: -8
+      groups:
+        Brute: -8
 
 - type: entity
   parent: MMI
@@ -137,3 +154,17 @@
       whitelist:
         components:
         - SecretStash
+    - type: DamagedSiliconAccent
+      damageAtMaxCorruption: 100
+      enableChargeCorruption: false
+    - type: Damageable
+      damageContainer: Silicon
+    - type: PassiveDamage
+      allowedStates:
+      - Alive
+      damage:
+        types:
+          Heat: -8
+          Shock: -8
+        groups:
+          Brute: -8


### PR DESCRIPTION
## About the PR

@drteaspoon420 reminded me that I should consider PBs and MMIs with my previous PR #35318.

I didn't see it as a problem before, but now I realize that they have access to binary chat and it could erase some of the interesting gameplay considerations with #35318.

## Why / Balance

This makes it so that PBs and MMIs (henceforth both referred to as PBs) can take damage. Their speech will be corrupted with maximum corruption at 100 total damage (in contrast to 300 damage for the chassis, the gib amount).

This makes it so that PBs cannot communicate clearly over binary chat if they are in danger.

PBs are also given a passive healing of 8 heat, shock, and blunt per second. This gives the effect of PBs acutely glitching out during damaging events, but recover over the course of about a minute (depending on how the damage types are spread out).

Additionally, the damage of the borg chassis is transferred to the brain on chassis destruction.

## Technical details

This is almost 100% done in yaml, but the behavior to transfer the damage to the brain had to be added. Hopefully the behavior is generic enough to be useful in other contexts.

It should be self explanatory

## Media

![image](https://github.com/user-attachments/assets/8fc1bf09-6a6e-4e44-b0e2-5dc83c08edcb)
![image](https://github.com/user-attachments/assets/dbd56f37-685b-4ec2-b563-32126643c28e)

_**A FEW MOMENTS LATER**_

![image](https://github.com/user-attachments/assets/a98ed7af-62a1-4bb8-9a7e-a8a72210e476)
![image](https://github.com/user-attachments/assets/a4c3bac5-79e1-4376-a626-8b58bca5482d)



## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes

None anticipated

**Changelog**

:cl:
- add: Add self-healing speech corruption to damaged PBs and MMIs
