### PR TITLE
Paradox clones get all storage items the original has.

### DIFF
--- a/Content.Shared/Cloning/CloningSettingsPrototype.cs
+++ b/Content.Shared/Cloning/CloningSettingsPrototype.cs
@@ -34,7 +34,7 @@ public sealed partial class CloningSettingsPrototype : IPrototype, IInheritingPr
     ///     Disabled when null.
     /// </summary>
     [DataField]
-    public SlotFlags? CopyEquipment = SlotFlags.WITHOUT_POCKET;
+    public SlotFlags? CopyEquipment = SlotFlags.All;
 
     /// <summary>
     ///     Whitelist for the equipment allowed to be copied.

--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -15,6 +15,7 @@ loadout-group-survival-syndicate = Github is forcing me to write text that is li
 loadout-group-breath-tool = Species-dependent breath tools
 loadout-group-tank-harness = Species-specific survival equipment
 loadout-group-EVA-tank = Species-specific gas tank
+loadout-group-vox-tank = Vox-specific gas tank
 loadout-group-pocket-tank-double = Species-specific double emergency tank in pocket
 loadout-group-survival-mime = Mime Survival Box
 

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -56,6 +56,7 @@
   blacklist:
     components:
     - AttachedClothing # helmets, which are part of the suit
+    - HumanoidAppearance # will cause problems for downstream felinids getting cloned as Urists
     - VirtualItem
 
 - type: cloningSettings

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -257,7 +257,7 @@
       pickPlayer: false
       startingGear: ParadoxCloneGear
       roleLoadout:
-      - RoleSurvivalStandard # give vox something to breath in case they don't get a copy
+      - RoleSurvivalVoxTank # give vox something to breath in case they don't get a copy
       briefing:
         text: paradox-clone-role-greeting
         color: lightblue

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -78,6 +78,7 @@
   - EmergencyOxygen
   - LoadoutSpeciesVoxNitrogen
 
+# nitrogen or oxygen tank, depending on what your species needs
 - type: loadoutGroup
   id: GroupEVATank
   name: loadout-group-EVA-tank
@@ -85,6 +86,14 @@
   loadouts:
   - LoadoutSpeciesEVANitrogen
   - LoadoutSpeciesEVAOxygen
+
+# vox get a nitrogen tank, other species get nothing
+- type: loadoutGroup
+  id: GroupEVATankVox
+  name: loadout-group-vox-tank
+  hidden: true
+  loadouts:
+  - LoadoutSpeciesVoxNitrogen
 
 - type: loadoutGroup
   id: GroupPocketTankDouble

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -527,11 +527,20 @@
 # These loadouts are used for non-crew spawns, like off-station antags and event mobs
 # They will be used without player configuration, thus they will only ever apply what is forced by MinLimit
 
+# gives vox a harness and breathing mask
+# nitrogen tank not included
 - type: roleLoadout
   id: RoleSurvivalVoxSupport
   groups:
   - GroupSpeciesBreathTool
   - GroupTankHarness
+
+# gives vox a nitrogen breathing tank
+# other species get nothing
+- type: roleLoadout
+  id: RoleSurvivalVoxTank
+  groups:
+  - GroupEVATankVox
 
 - type: roleLoadout
   id: RoleSurvivalStandard


### PR DESCRIPTION
## About the PR
The previous implementation only gave you an empty backpack. Now all storage items will spawn with the same contents on the clone. This also includes slime storage.

This PR will need extensive testing for items that should not be copied or may cause errors and should thus be blacklisted.

## Why / Balance
Command clones were easily identified by their missing unique items.

## Technical details
Added new functions to recursively copy an item and its storage.
This is not perfect, as it spawns a new item from the originals protoId, so all changes made to the item after spawning are lost. 
This only supports StorageComponent (meaning grid storage) and not arbitrary containers or itemslots, as we got too many duplicated components all adding their own spawning logic on map init. For example `StorgeFillComponent`, `ContainerFillComponent`, `EntityTableContainerFillComponent`, `ItemSlotsComponent` and so on.
But this is good enough for most cases.

How to test:
- Equip items, best in nested containers
- Use the `Random clone spawner` from the spawn menu to copy yourself
- compare inventories and check for errors
- Additionally test cloning a slime character being cloned with their internal storage.

## Media
![grafik](https://github.com/user-attachments/assets/1d7c3513-25d0-4bce-8f52-677f212e2ff9)
![grafik](https://github.com/user-attachments/assets/5d01d8f8-f7c9-47df-ae0a-8cd144bf127d)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- tweak: Paradox clones now recieve a copy of (almost) all the inventory items their original has.
