### PR TITLE
Fix thrown item prediction weirdness

### DIFF
--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -145,6 +145,12 @@ namespace Content.Shared.Throwing
         {
             base.Update(frameTime);
 
+            // TODO predicted throwing - remove this check
+            // We don't want to predict landing or stopping, since throwing isn't actually predicted.
+            // If we do, the landing/stop will occur prematurely on the client.
+            if (_gameTiming.InPrediction)
+                return;
+
             var query = EntityQueryEnumerator<ThrownItemComponent, PhysicsComponent>();
             while (query.MoveNext(out var uid, out var thrown, out var physics))
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes issues with thrown items mispredicting their landing times.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #29859
Fixes #31350

## Technical details
<!-- Summary of code changes for easier review. -->
This was a fun one.
The misprediction was happening because the `ThrownItemComponent` on the thrown item was no longer present on the client at the time of the collision, which meant that the event that would normally cancel the slip wasn't being cancelled.
The `ThrownItemComponent` was missing because `ThrownItemSystem` acts as though throwing is predicted, but it isn't - throwing is started only on the server and the actual physics simulation of the throw only happens on the server. When the throw is started, the landing time is calculated and stored on the component (which is fine). But `ThrownItemSystem` is in Shared, so the client predicts the landing early, assuming the throw is predicted. This causes the `ThrownItemComponent` to get removed from the thrown item earlier than it should on the client, which means that it can cause mobs to slip while it should actually still be in flight.
To fix this, a check was added to `ThrownItemSystem`'s Update method that bails out during prediction.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->