### PR TITLE
Fix salvage sites ejecting borg brains when they despawn

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -147,12 +147,28 @@ public sealed partial class SalvageSystem
             var mobQuery = AllEntityQuery<MobStateComponent, TransformComponent>();
             _detachEnts.Clear();
 
+            var mobStateQuery = GetEntityQuery<MobStateComponent>();
             while (mobQuery.MoveNext(out var mobUid, out _, out var xform))
             {
                 if (xform.GridUid == null || !data.Comp.ActiveEntities.Contains(xform.GridUid.Value) || xform.MapUid == null)
                     continue;
 
                 if (_salvMobQuery.HasComp(mobUid))
+                    continue;
+
+                bool CheckParents(EntityUid uid)
+                {
+                    do
+                    {
+                        uid = _transform.GetParentUid(uid);
+                        if (mobStateQuery.HasComp(uid))
+                            return true;
+                    }
+                    while (uid != xform.GridUid);
+                    return false;
+                }
+
+                if (CheckParents(mobUid))
                     continue;
 
                 // Can't parent directly to map as it runs grid traversal.

--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -164,7 +164,7 @@ public sealed partial class SalvageSystem
                         if (mobStateQuery.HasComp(uid))
                             return true;
                     }
-                    while (uid != xform.GridUid);
+                    while (uid != xform.GridUid && uid != EntityUid.Invalid);
                     return false;
                 }
 

--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -19,12 +19,14 @@ public sealed partial class SalvageSystem
     private const string MagnetChannel = "Supply";
 
     private EntityQuery<SalvageMobRestrictionsComponent> _salvMobQuery;
+    private EntityQuery<MobStateComponent> _mobStateQuery;
 
     private List<(Entity<TransformComponent> Entity, EntityUid MapUid, Vector2 LocalPosition)> _detachEnts = new();
 
     private void InitializeMagnet()
     {
         _salvMobQuery = GetEntityQuery<SalvageMobRestrictionsComponent>();
+        _mobStateQuery = GetEntityQuery<MobStateComponent>();
 
         SubscribeLocalEvent<SalvageMagnetDataComponent, MapInitEvent>(OnMagnetDataMapInit);
 
@@ -147,7 +149,6 @@ public sealed partial class SalvageSystem
             var mobQuery = AllEntityQuery<MobStateComponent, TransformComponent>();
             _detachEnts.Clear();
 
-            var mobStateQuery = GetEntityQuery<MobStateComponent>();
             while (mobQuery.MoveNext(out var mobUid, out _, out var xform))
             {
                 if (xform.GridUid == null || !data.Comp.ActiveEntities.Contains(xform.GridUid.Value) || xform.MapUid == null)
@@ -161,7 +162,7 @@ public sealed partial class SalvageSystem
                     do
                     {
                         uid = _transform.GetParentUid(uid);
-                        if (mobStateQuery.HasComp(uid))
+                        if (_mobStateQuery.HasComp(uid))
                             return true;
                     }
                     while (uid != xform.GridUid && uid != EntityUid.Invalid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Cyborgs can now safely work at salvage magnet sites (wrecks, asteroids, etc.) without fear of having their brains removed when the site despawns.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #35116

## Technical details
<!-- Summary of code changes for easier review. -->
The issue occurs because `SalvageSystem.EndMagnet` takes each entity on the grid that has a `MobStateComponent` and reparents it to the map. Notably, both the borg body entity and the positronic brain have a `MobStateComponent`, so they are both _separately_ reparented to the map. This doesn't seem to happen all the time, which I think is due to update order - if the body gets moved first, then the brain is taken with it and is no longer in the entity query so it doesn't get moved separately.

In experimenting with this, I noticed that it affects any mobs that are contained within other mobs - for example, a mouse in a player's backpack will get removed and placed beside the player too.

To fix both of these cases, the logic in `EndMagnet` was expanded so that before reparenting a mob, its parents and their parents (and all the way up the hierarchy) are checked for their own `MobStateComponent`s - if one is found, mob isn't reparented (since the parent will be).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Cyborgs no longer have their brains removed if the salvage site they are on despawns.