### PR TITLE
Add viewer parameter to Identity.Entity

### DIFF
--- a/Content.Shared/IdentityManagement/Identity.cs
+++ b/Content.Shared/IdentityManagement/Identity.cs
@@ -49,6 +49,9 @@ public static class Identity
     ///     This is an extension method because of its simplicity, and if it was any harder to call it might not
     ///     be used enough for loc.
     /// </summary>
+    /// <param name="viewer">
+    ///     If this entity can see through identities, this method will always return the actual target entity.
+    /// </param>
     public static EntityUid Entity(EntityUid uid, IEntityManager ent, EntityUid? viewer = null)
     {
         if (!ent.TryGetComponent<IdentityComponent>(uid, out var identity))

--- a/Content.Shared/IdentityManagement/Identity.cs
+++ b/Content.Shared/IdentityManagement/Identity.cs
@@ -49,9 +49,12 @@ public static class Identity
     ///     This is an extension method because of its simplicity, and if it was any harder to call it might not
     ///     be used enough for loc.
     /// </summary>
-    public static EntityUid Entity(EntityUid uid, IEntityManager ent)
+    public static EntityUid Entity(EntityUid uid, IEntityManager ent, EntityUid? viewer = null)
     {
         if (!ent.TryGetComponent<IdentityComponent>(uid, out var identity))
+            return uid;
+
+        if (viewer != null && CanSeeThroughIdentity(uid, viewer.Value, ent))
             return uid;
 
         return identity.IdentityEntitySlot.ContainedEntity ?? uid;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds an optional `viewer` parameter to the `Identity.Entity` method which uses `CanSeeThroughIdentity` to let ghosts see actual identities.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We already have this functionality in `Identity.Name`, but it's often useful to get an entity instead of just a string representation of the name. This is handy because many Fluent functions need an entity and not just a string - this makes it possible to use those functions while still working with the Identity system properly.

This makes it easy to do stuff like `{CAPITALIZE(THE($user))} does something` and have it able to resolve to `Urist McHands does something` or `The young man does something` as appropriate for the viewer's perspective.

## Technical details
<!-- Summary of code changes for easier review. -->
If a `viewer` entity is passed in, it gets passed through to `CanSeeThroughIdentity` (which just looks for a `GhostComponent`) - if true, the method returns the actual uid of the target; if false, it returns the identity entity (if one exists).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->