### PR TITLE
Improve sprite fading behaviour

### DIFF
--- a/Content.Client/Clickable/ClickableSystem.cs
+++ b/Content.Client/Clickable/ClickableSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Client.Sprite;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Utility;
@@ -17,12 +18,14 @@ public sealed class ClickableSystem : EntitySystem
 
     private EntityQuery<ClickableComponent> _clickableQuery;
     private EntityQuery<TransformComponent> _xformQuery;
+    private EntityQuery<FadingSpriteComponent> _fadingSpriteQuery;
 
     public override void Initialize()
     {
         base.Initialize();
         _clickableQuery = GetEntityQuery<ClickableComponent>();
         _xformQuery = GetEntityQuery<TransformComponent>();
+        _fadingSpriteQuery = GetEntityQuery<FadingSpriteComponent>();
     }
 
     /// <summary>
@@ -34,7 +37,7 @@ public sealed class ClickableSystem : EntitySystem
     /// The draw depth for the sprite that captured the click.
     /// </param>
     /// <returns>True if the click worked, false otherwise.</returns>
-    public bool CheckClick(Entity<ClickableComponent?, SpriteComponent, TransformComponent?> entity, Vector2 worldPos, IEye eye, out int drawDepth, out uint renderOrder, out float bottom)
+    public bool CheckClick(Entity<ClickableComponent?, SpriteComponent, TransformComponent?, FadingSpriteComponent?> entity, Vector2 worldPos, IEye eye, bool excludeFaded, out int drawDepth, out uint renderOrder, out float bottom)
     {
         if (!_clickableQuery.Resolve(entity.Owner, ref entity.Comp1, false))
         {
@@ -45,6 +48,14 @@ public sealed class ClickableSystem : EntitySystem
         }
 
         if (!_xformQuery.Resolve(entity.Owner, ref entity.Comp3))
+        {
+            drawDepth = default;
+            renderOrder = default;
+            bottom = default;
+            return false;
+        }
+
+        if (excludeFaded && _fadingSpriteQuery.Resolve(entity.Owner, ref entity.Comp4, false))
         {
             drawDepth = default;
             renderOrder = default;

--- a/Content.Client/Gameplay/GameplayStateBase.cs
+++ b/Content.Client/Gameplay/GameplayStateBase.cs
@@ -113,18 +113,18 @@ namespace Content.Client.Gameplay
             return first.IsValid() ? first : null;
         }
 
-        public IEnumerable<EntityUid> GetClickableEntities(EntityCoordinates coordinates)
+        public IEnumerable<EntityUid> GetClickableEntities(EntityCoordinates coordinates, bool excludeFaded = true)
         {
             var transformSystem = _entitySystemManager.GetEntitySystem<SharedTransformSystem>();
-            return GetClickableEntities(transformSystem.ToMapCoordinates(coordinates));
+            return GetClickableEntities(transformSystem.ToMapCoordinates(coordinates), excludeFaded);
         }
 
-        public IEnumerable<EntityUid> GetClickableEntities(MapCoordinates coordinates)
+        public IEnumerable<EntityUid> GetClickableEntities(MapCoordinates coordinates, bool excludeFaded = true)
         {
-            return GetClickableEntities(coordinates, _eyeManager.CurrentEye);
+            return GetClickableEntities(coordinates, _eyeManager.CurrentEye, excludeFaded);
         }
 
-        public IEnumerable<EntityUid> GetClickableEntities(MapCoordinates coordinates, IEye? eye)
+        public IEnumerable<EntityUid> GetClickableEntities(MapCoordinates coordinates, IEye? eye, bool excludeFaded = true)
         {
             /*
              * TODO:
@@ -147,7 +147,7 @@ namespace Content.Client.Gameplay
             foreach (var entity in entities)
             {
                 if (clickQuery.TryGetComponent(entity.Uid, out var component) &&
-                    clickables.CheckClick((entity.Uid, component, entity.Component, entity.Transform), coordinates.Position, eye,  out var drawDepthClicked, out var renderOrder, out var bottom))
+                    clickables.CheckClick((entity.Uid, component, entity.Component, entity.Transform), coordinates.Position, eye, excludeFaded, out var drawDepthClicked, out var renderOrder, out var bottom))
                 {
                     foundEntities.Add((entity.Uid, drawDepthClicked, renderOrder, bottom));
                 }

--- a/Content.Client/Sprite/SpriteFadeSystem.cs
+++ b/Content.Client/Sprite/SpriteFadeSystem.cs
@@ -1,8 +1,14 @@
+using System.Numerics;
 using Content.Client.Gameplay;
 using Content.Shared.Sprite;
 using Robust.Client.GameObjects;
+using Robust.Client.Input;
 using Robust.Client.Player;
 using Robust.Client.State;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Client.UserInterface;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Physics;
 
 namespace Content.Client.Sprite;
@@ -17,12 +23,20 @@ public sealed class SpriteFadeSystem : EntitySystem
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IStateManager _stateManager = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
     private readonly HashSet<FadingSpriteComponent> _comps = new();
 
     private EntityQuery<SpriteComponent> _spriteQuery;
     private EntityQuery<SpriteFadeComponent> _fadeQuery;
     private EntityQuery<FadingSpriteComponent> _fadingQuery;
+
+    /// <summary>
+    ///     Radius of the mouse point for the intersection test
+    /// </summary>
+    private static Vector2 MouseRadius = new Vector2(10f * float.Epsilon, 10f * float.Epsilon);
 
     private const float TargetAlpha = 0.4f;
     private const float ChangeRate = 1f;
@@ -46,46 +60,82 @@ public sealed class SpriteFadeSystem : EntitySystem
         sprite.Color = sprite.Color.WithAlpha(component.OriginalAlpha);
     }
 
-    public override void FrameUpdate(float frameTime)
+    /// <summary>
+    ///     Adds sprites to the fade set, and brings their alpha downwards
+    /// </summary>
+    private void FadeIn(float change)
     {
-        base.FrameUpdate(frameTime);
-
         var player = _playerManager.LocalEntity;
-        var change = ChangeRate * frameTime;
+        // ExcludeBoundingBox is set if we don't want to fade this sprite within the collision bounding boxes for the given POI
+        var pointsOfInterest = new List<(MapCoordinates Point, bool ExcludeBoundingBox)>();
 
-        if (TryComp(player, out TransformComponent? playerXform) &&
-            _stateManager.CurrentState is GameplayState state &&
-            _spriteQuery.TryGetComponent(player, out var playerSprite))
+        if (_uiManager.CurrentlyHovered is IViewportControl vp
+            && _inputManager.MouseScreenPosition.IsValid)
         {
-            var mapPos = _transform.GetMapCoordinates(_playerManager.LocalEntity!.Value, xform: playerXform);
+            pointsOfInterest.Add((vp.PixelToMap(_inputManager.MouseScreenPosition.Position), true));
+        }
 
-            // Also want to handle large entities even if they may not be clickable.
-            foreach (var ent in state.GetClickableEntities(mapPos, excludeFaded: false))
+        if (TryComp(player, out TransformComponent? playerXform))
+        {
+            pointsOfInterest.Add((_transform.GetMapCoordinates(_playerManager.LocalEntity!.Value, xform: playerXform), false));
+        }
+
+        if (_stateManager.CurrentState is GameplayState state && _spriteQuery.TryGetComponent(player, out var playerSprite))
+        {
+            foreach (var (mapPos, excludeBB) in pointsOfInterest)
             {
-                if (ent == player ||
-                    !_fadeQuery.HasComponent(ent) ||
-                    !_spriteQuery.TryGetComponent(ent, out var sprite) ||
-                    sprite.DrawDepth < playerSprite.DrawDepth)
+                // Also want to handle large entities even if they may not be clickable.
+                foreach (var ent in state.GetClickableEntities(mapPos, excludeFaded: false))
                 {
-                    continue;
-                }
+                    if (ent == player ||
+                        !_fadeQuery.HasComponent(ent) ||
+                        !_spriteQuery.TryGetComponent(ent, out var sprite) ||
+                        sprite.DrawDepth < playerSprite.DrawDepth)
+                    {
+                        continue;
+                    }
 
-                if (!_fadingQuery.TryComp(ent, out var fading))
-                {
-                    fading = AddComp<FadingSpriteComponent>(ent);
-                    fading.OriginalAlpha = sprite.Color.A;
-                }
+                    if (excludeBB)
+                    {
+                        var test = new Box2Rotated(mapPos.Position - MouseRadius, mapPos.Position + MouseRadius);
+                        var collided = false;
+                        foreach (var fixture in _physics.GetCollidingEntities(mapPos.MapId, test))
+                        {
+                            if (fixture.Owner == ent)
+                            {
+                                collided = true;
+                                break;
+                            }
+                        }
+                        if (collided)
+                        {
+                            break;
+                        }
+                    }
 
-                _comps.Add(fading);
-                var newColor = Math.Max(sprite.Color.A - change, TargetAlpha);
+                    if (!_fadingQuery.TryComp(ent, out var fading))
+                    {
+                        fading = AddComp<FadingSpriteComponent>(ent);
+                        fading.OriginalAlpha = sprite.Color.A;
+                    }
 
-                if (!sprite.Color.A.Equals(newColor))
-                {
-                    sprite.Color = sprite.Color.WithAlpha(newColor);
+                    _comps.Add(fading);
+                    var newColor = Math.Max(sprite.Color.A - change, TargetAlpha);
+
+                    if (!sprite.Color.A.Equals(newColor))
+                    {
+                        sprite.Color = sprite.Color.WithAlpha(newColor);
+                    }
                 }
             }
         }
+    }
 
+    /// <summary>
+    ///     Bring sprites back up to their original alpha if they aren't in the fade set, and removes their fade component when done
+    /// </summary>
+    private void FadeOut(float change)
+    {
         var query = AllEntityQuery<FadingSpriteComponent>();
         while (query.MoveNext(out var uid, out var comp))
         {
@@ -106,6 +156,16 @@ public sealed class SpriteFadeSystem : EntitySystem
                 RemCompDeferred<FadingSpriteComponent>(uid);
             }
         }
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        base.FrameUpdate(frameTime);
+
+        var change = ChangeRate * frameTime;
+
+        FadeIn(change);
+        FadeOut(change);
 
         _comps.Clear();
     }

--- a/Content.Client/Sprite/SpriteFadeSystem.cs
+++ b/Content.Client/Sprite/SpriteFadeSystem.cs
@@ -60,7 +60,7 @@ public sealed class SpriteFadeSystem : EntitySystem
             var mapPos = _transform.GetMapCoordinates(_playerManager.LocalEntity!.Value, xform: playerXform);
 
             // Also want to handle large entities even if they may not be clickable.
-            foreach (var ent in state.GetClickableEntities(mapPos))
+            foreach (var ent in state.GetClickableEntities(mapPos, excludeFaded: false))
             {
                 if (ent == player ||
                     !_fadeQuery.HasComponent(ent) ||

--- a/Content.IntegrationTests/Tests/ClickableTest.cs
+++ b/Content.IntegrationTests/Tests/ClickableTest.cs
@@ -80,7 +80,7 @@ namespace Content.IntegrationTests.Tests
 
                 var pos = clientEntManager.System<SharedTransformSystem>().GetWorldPosition(clientEnt);
 
-                hit = clientEntManager.System<ClickableSystem>().CheckClick((clientEnt, null, sprite, null), new Vector2(clickPosX, clickPosY) + pos, eye, out _, out _, out _);
+                hit = clientEntManager.System<ClickableSystem>().CheckClick((clientEnt, null, sprite, null), new Vector2(clickPosX, clickPosY) + pos, eye, false, out _, out _, out _);
             });
 
             await server.WaitPost(() =>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- faded sprites now get clicked through, allowing you to interact with objects behind faded objects w/o needing to use the disambiguation menu
- the mouse pointer is now used to unfade sprites

## Why / Balance
- deltav wants to raise walls up higher for a 3:4 perspective
- sprite fading needs to be more seamless and allow players to look behind walls in their character's FOV but not at their camera rotation more easily to ease friction
- we are NOT maintaining changes to clickable/gameplaystatebase/spritefadesystem downstream
- this would be nice for other forks probably

## Technical details
commit 1:
- have ClickableSystem ignore faded entities, unless it's being consulted by the system that determines which entities are faded
commit 2:
- have mouse position be used to fade sprites, but only if it's not colliding with their fixtures

## Media

https://github.com/user-attachments/assets/dffbaf21-d248-43d6-9eeb-e3ec264dcb21



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now more easily interact with objects behind faded ones, and you can look behind fadeable objects in your FOV by hovering them with your mouse pointer
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
