### PR TITLE
Hotfix: Fix AntagRandomSpawn location preview

### DIFF
--- a/Content.Server/Antag/AntagRandomSpawnRule.cs
+++ b/Content.Server/Antag/AntagRandomSpawnRule.cs
@@ -1,4 +1,5 @@
 using Content.Server.Antag.Components;
+using Content.Shared.GameTicking.Components;
 using Content.Server.GameTicking.Rules;
 
 namespace Content.Server.Antag;
@@ -14,9 +15,20 @@ public sealed class AntagRandomSpawnSystem : GameRuleSystem<AntagRandomSpawnComp
         SubscribeLocalEvent<AntagRandomSpawnComponent, AntagSelectLocationEvent>(OnSelectLocation);
     }
 
+    protected override void Added(EntityUid uid, AntagRandomSpawnComponent comp, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    {
+        base.Added(uid, comp, gameRule, args);
+
+        // we have to select this here because AntagSelectLocationEvent is raised twice because MakeAntag is called twice
+        // once when a ghost role spawner is created and once when someone takes the ghost role
+
+        if (TryFindRandomTile(out _, out _, out _, out var coords))
+            comp.Coords = coords;
+    }
+
     private void OnSelectLocation(Entity<AntagRandomSpawnComponent> ent, ref AntagSelectLocationEvent args)
     {
-        if (TryFindRandomTile(out _, out _, out _, out var coords))
-            args.Coordinates.Add(_transform.ToMapCoordinates(coords));
+        if (ent.Comp.Coords != null)
+            args.Coordinates.Add(_transform.ToMapCoordinates(ent.Comp.Coords.Value));
     }
 }

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -393,6 +393,11 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             return;
         }
 
+        // TODO: This is really messy because this part runs twice for midround events.
+        // Once when the ghostrole spawner is created and once when a player takes it.
+        // Therefore any component subscribing to this has to make sure both subscriptions return the same value
+        // or the ghost role raffle location preview will be wrong.
+
         var getPosEv = new AntagSelectLocationEvent(session, ent);
         RaiseLocalEvent(ent, ref getPosEv, true);
         if (getPosEv.Handled)

--- a/Content.Server/Antag/Components/AntagRandomSpawnComponent.cs
+++ b/Content.Server/Antag/Components/AntagRandomSpawnComponent.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Map;
+
 namespace Content.Server.Antag.Components;
 
 /// <summary>
@@ -5,4 +7,11 @@ namespace Content.Server.Antag.Components;
 /// Requires <see cref="AntagSelectionComponent"/>.
 /// </summary>
 [RegisterComponent]
-public sealed partial class AntagRandomSpawnComponent : Component;
+public sealed partial class AntagRandomSpawnComponent : Component
+{
+    /// <summary>
+    /// Location that was picked.
+    /// </summary>
+    [DataField]
+    public EntityCoordinates? Coords;
+}


### PR DESCRIPTION
## About the PR
Fixes events with `AntagRandomSpawnComponent` spawning somewhere completely different than the preview you see when you click on "follow" in the ghost role raffle menu.
This bug currently happens for the paradox clone, but it used to happen to dragons as well before they were changed to spawn in space.

## Why / Balance
bugfix
Players taking ghost roles should know where they will spawn (and it works this way for roles with different spawn logic).

## Technical details
`MakeAntag` is called twice, once when a spawner is generated by the game rule (in that case it cancels the function early), and once when a player takes the ghost role. Therefore `AntagSelectLocationEvent` is raised twice as well, giving you a different location for the spawner entity and the spawned entity. This code is really spaghettified and should either be split up into multiple functions or events, but that will likely get soaped into a refactor.
For now we fix it the same way `SpaceSpawnRuleComponent` does, by only randomizing once when the game rule is added, ensuring both subscriptions return the same location.

## How to test

- edit `DerelictCyborgSpawn` by removing 
```
  - type: SpaceSpawnRule
    spawnDistance: 0
```
and replacing it with
```
  - type: AntagRandomSpawn
```

- `addgamerule DerelictCyborgSpawn`

- open the ghost role raffle window and click on "follow", you will teleport to a random station tile
- take the ghost role
- on master you will spawn somewhere completely different than shown in the preview
- with this bugfix you will correctly spawn at the preview location, similar to how it works for `SpaceSpawnRule`

(you can also test this with the paradox clone event, but you need two clients in that case because it needs someone to clone)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed the paradox clone ghost role raffle showing a wrong spawn location.
