### PR TITLE
Tweak Killer Tomato Size

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -80,7 +80,7 @@
   - MobBloodstream
   - MobFlammable
   - MobCombat
-  name: tomato killer
+  name: killer tomato
   description: Looks like it's not you eating tomatoes today, it's the tomatoes eating you.
   components:
   - type: GhostRole
@@ -129,6 +129,9 @@
   - type: ReplacementAccent
     accent: tomatoKiller
   - type: Item
+    size: Large
+    shape:
+    - 0,0,3,3
   - type: NpcFactionMember
     factions:
       - SimpleHostile


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

- "Tomato Killer" changed to "Killer Tomato".
- Size changed to large.
- Bag sized changed to 3x3.

## Why / Balance
Have you ever seen a Botanist drop 16 killer tomatoes on top of someone?

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Killer tomatoes are now of a correct size.
-->
