### PR TITLE
[April Fools] Genetic damage is more accurately named

### DIFF
--- a/Resources/Locale/en-US/damage/damage-groups.ftl
+++ b/Resources/Locale/en-US/damage/damage-groups.ftl
@@ -3,4 +3,4 @@ damage-group-burn = Burn
 damage-group-airloss = Airloss
 damage-group-toxin = Toxin
 damage-group-genetic = Cringe
-damage-group-metaphysical = Metaphysical
+damage-group-metaphysical = Ligma

--- a/Resources/Locale/en-US/damage/damage-groups.ftl
+++ b/Resources/Locale/en-US/damage/damage-groups.ftl
@@ -2,5 +2,5 @@ damage-group-brute = Brute
 damage-group-burn = Burn
 damage-group-airloss = Airloss
 damage-group-toxin = Toxin
-damage-group-genetic = Genetic
+damage-group-genetic = Fuck You
 damage-group-metaphysical = Metaphysical

--- a/Resources/Locale/en-US/damage/damage-groups.ftl
+++ b/Resources/Locale/en-US/damage/damage-groups.ftl
@@ -2,5 +2,5 @@ damage-group-brute = Brute
 damage-group-burn = Burn
 damage-group-airloss = Airloss
 damage-group-toxin = Toxin
-damage-group-genetic = Fuck You
+damage-group-genetic = Cringe
 damage-group-metaphysical = Metaphysical

--- a/Resources/Locale/en-US/implant/implant.ftl
+++ b/Resources/Locale/en-US/implant/implant.ftl
@@ -4,7 +4,7 @@ implanter-component-implanting-target = {$user} is trying to implant you with so
 implanter-component-implant-failed = The {$implant} cannot be given to {$target}!
 implanter-draw-failed-permanent = The {$implant} in {$target} is fused with { OBJECT($target) } and cannot be removed!
 implanter-draw-failed = You tried to remove an implant but found nothing.
-implanter-draw-failed-catastrophically = The implanter finds nothing and catastrophically fails, shunting genetic material into {$user}'s hand!
+implanter-draw-failed-catastrophically = The implanter finds nothing and catastrophically fails, shunting genetic material into {$user}'s hand! Fuck you!!
 implanter-component-implant-already = {$target} already has the {$implant}!
 
 ## UI


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
FUCK YOU

## Why / Balance
Genetics damage isn't real and it's just used to really know that the game designer hates you. The name is inaccurate and should be changed to make the role of genetics damage easier for new doctors in medical to understand.

## Technical details
FUCK YOU

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] FUCK YOU
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
FUCK YOU

**Changelog**

:cl:
- tweak: Fuck you, and your little dog too!!