### PR TITLE
Alternative fix for clientside solution resolves (Udder & Wooly debug asserts)

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -116,7 +116,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool ResolveSolution(Entity<SolutionContainerManagerComponent?> container, string? name, [NotNullWhen(true)] ref Entity<SolutionComponent>? entity)
     {
-        if (entity is not null)
+        if (entity is not null && (MetaData(entity.Value.Owner).Flags & MetaDataFlags.Detached) == 0)
         {
             DebugTools.Assert(TryGetSolution(container, name, out var debugEnt)
                               && debugEnt.Value.Owner == entity.Value.Owner);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This is an alternative approach to fixing #34282.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #34282

## Technical details
<!-- Summary of code changes for easier review. -->
In comparison to #35314, this approach applies to all uses of `ResolveSolution`, not just the specific cases of `UdderSystem` and `WoolySystem`. However, it does require looking up the MetaData component of the solution entity with each call, which could have some performance implications.

The way this works is by adding a check for the `Detached` metadata flag on the solution entity - entities outside of PVS are detached to nullspace on the client, so this detects when that happens. When it does, the conditional resolves to false, and execution will proceed to line 126: `return TryGetSolution(container, name, out entity);`. Because `entity` is passed to `ResolveSolution` as a ref parameter, passing it in to `TryGetSolution` causes the reference to get replaced with whatever `TryGetSolution` finds - which should be `null` in this case. This means that the cached reference on `UdderComponent` or wherever is properly set to null and `ResolveSolution` will return false for this call and any future calls until it can be resolved again (by reentering PVS).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->