### PR TITLE
Make NukeOpsTest list RuleGrids on failure

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
@@ -152,10 +152,14 @@ public sealed class NukeOpsTest
             Assert.That(roleSys.MindGetAllRoleInfo(mindCrew).Any(x => nukeroles.Contains(x.Prototype)), Is.False);
         }
 
+        var ruleGridComps = entMan.AllComponents<RuleGridsComponent>();
+        Assert.That(ruleGridComps, Has.Length.EqualTo(1),
+            $"Unexpected RuleGrid(s) detected! {string.Join(',', ruleGridComps.Select(e => server.EntMan.ToPrettyString(e.Uid)))}");
+
         // The game rule exists, and all the stations/shuttles/maps are properly initialized
         var rule = entMan.AllComponents<NukeopsRuleComponent>().Single();
         var ruleComp = rule.Component;
-        var gridsRule = entMan.AllComponents<RuleGridsComponent>().Single().Component;
+        var gridsRule = ruleGridComps.Single().Component;
         foreach (var grid in gridsRule.MapGrids)
         {
             Assert.That(entMan.EntityExists(grid));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Modifies `TryStopNukeOpsFromConstantlyFailing` so that instead of just throwing an exception when `entMan.AllComponents<RuleGridsComponent>().Single()` detects more than one `RuleGridsComponent`, it now prints out a list of the entities.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Clearer assertion messages make debugging easier. 

## Technical details
<!-- Summary of code changes for easier review. -->
This failure can be forced to happen by adding `await pair.WaitCommand("addgamerule WizardSpawn");` earlier in the test.
With that added, the following message is printed:
```
TryStopNukeOpsFromConstantlyFailing (25s 331ms): Error Message:   Unexpected RuleGrid(s) detected! Southern Mace (1/n1, Nukeops
      ), (9485/n9485, WizardSpawn)
```
Which helpfully identifies the `WizardSpawn` entity that caused the failure.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
