### PR TITLE
Make NukeOpsTest only use Nukeops gamerule

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
@@ -29,6 +29,18 @@ namespace Content.IntegrationTests.Tests.GameRules;
 [TestFixture]
 public sealed class NukeOpsTest
 {
+    private const string NukeOpsGamePreset = "TestNukeops";
+
+    [TestPrototypes]
+    private const string Prototypes = $@"
+- type: gamePreset
+  id: {NukeOpsGamePreset}
+  name: nukeops-title
+  showInVote: false
+  rules:
+  - Nukeops
+";
+
     /// <summary>
     /// Check that a nuke ops game mode can start without issue. I.e., that the nuke station and such all get loaded.
     /// </summary>
@@ -90,7 +102,7 @@ public sealed class NukeOpsTest
         // Ready up and start nukeops
         ticker.ToggleReadyAll(true);
         Assert.That(ticker.PlayerGameStatuses.Values.All(x => x == PlayerGameStatus.ReadyToPlay));
-        await pair.WaitCommand("forcepreset Nukeops");
+        await pair.WaitCommand($"forcepreset {NukeOpsGamePreset}");
         await pair.RunTicksSync(10);
 
         // Game should have started


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Modifies `TryStopNukeOpsFromConstantlyFailing` so that it uses a custom `GamePresetPrototype` set up to only include the actual `Nukeops` gamerule and no others.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #35868.

## Technical details
<!-- Summary of code changes for easier review. -->
The test currently uses the Nukeops `GamePresetPrototype`, which is defined as:
```
- type: gamePreset
  id: Nukeops
  alias:
    - nukeops
  name: nukeops-title
  description: nukeops-description
  showInVote: false
  rules:
    - Nukeops
    - SubGamemodesRule
    - BasicStationEventScheduler
    - MeteorSwarmScheduler
    - SpaceTrafficControlEventScheduler
    - BasicRoundstartVariation
```
We don't want those other gamerules getting added - especially `SubGamemodesRule`, which is what occasionally adds the wizard subgamemode which causes the test to fail.
So the test now loads its own preset which just includes the `Nukeops` rule.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->