### PR TITLE
Let LocalizedDatasetPrototypeTest report multiple failures

### DIFF
--- a/Content.IntegrationTests/Tests/Localization/LocalizedDatasetPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Localization/LocalizedDatasetPrototypeTest.cs
@@ -19,16 +19,19 @@ public sealed class LocalizedDatasetPrototypeTest
 
         var protos = protoMan.EnumeratePrototypes<LocalizedDatasetPrototype>().OrderBy(p => p.ID);
 
-        // Check each prototype
-        foreach (var proto in protos)
+        Assert.Multiple(() =>
         {
-            // Check each value in the prototype
-            foreach (var locId in proto.Values)
+            // Check each prototype
+            foreach (var proto in protos)
             {
-                // Make sure the localization manager has a string for the LocId
-                Assert.That(localizationMan.HasString(locId), $"LocalizedDataset {proto.ID} with prefix \"{proto.Values.Prefix}\" specifies {proto.Values.Count} entries, but no localized string was found matching {locId}!");
+                // Check each value in the prototype
+                foreach (var locId in proto.Values)
+                {
+                    // Make sure the localization manager has a string for the LocId
+                    Assert.That(localizationMan.HasString(locId), $"LocalizedDataset {proto.ID} with prefix \"{proto.Values.Prefix}\" specifies {proto.Values.Count} entries, but no localized string was found matching {locId}!");
+                }
             }
-        }
+        });
 
         await pair.CleanReturnAsync();
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`LocalizedDatasetPrototypeTest` now reports all missing loc strings instead of just the first one.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More useful test results.

## Technical details
<!-- Summary of code changes for easier review. -->
Just wraps the main loop of the test in `Assert.Multiple`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->