### PR TITLE
lock bwoinkwindow bottom bar height

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
@@ -2,14 +2,14 @@
     xmlns="https://spacestation14.io"
     xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls">
     <PanelContainer StyleClasses="BackgroundDark">
-        <SplitContainer Orientation="Vertical">
+        <SplitContainer Orientation="Vertical" ResizeMode="NotResizable">
             <SplitContainer Orientation="Horizontal" VerticalExpand="True">
                 <cc:PlayerListControl Access="Public" Name="ChannelSelector" HorizontalExpand="True" SizeFlagsStretchRatio="2" />
                 <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="2">
                     <BoxContainer Access="Public" Name="BwoinkArea" VerticalExpand="True" />
                 </BoxContainer>
             </SplitContainer>
-            <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
+            <BoxContainer Orientation="Horizontal" SetHeight="30" >
                 <CheckBox Name="AdminOnly" Access="Public" Text="{Loc 'admin-ahelp-admin-only'}" ToolTip="{Loc 'admin-ahelp-admin-only-tooltip'}" />
                 <Control HorizontalExpand="True" MinWidth="5" />
                 <CheckBox Name="PlaySound" Access="Public" Text="{Loc 'admin-bwoink-play-sound'}" Pressed="True" />


### PR DESCRIPTION
## About the PR
Bwoink window control bar is now fixed in size.

## Why / Balance
Control bar could be unintentionally resized along with the bwoinkwindow, and consume space needlessly. There is no need for it to ever cover more height than it's starting size.

## Media
Before:

![image](https://github.com/user-attachments/assets/9f1a26aa-b5d0-4552-935c-1c3c45ee17f8)

After:

https://github.com/user-attachments/assets/1309d91b-85b6-4ee5-852e-100a51b69a49

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Errant
ADMIN:
- fix: Bwoink window control bar now has a fixed height.
