### PR TITLE
Give PAIs binary again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -44,9 +44,13 @@
     stopSearchVerbPopup: pai-system-stopped-searching
   - type: Examiner
   - type: IntrinsicRadioReceiver
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Binary
   - type: ActiveRadio
     channels:
     - Common
+    - Binary
   - type: DoAfter
   - type: Actions
   - type: TypingIndicator


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? --> PAIs have been given back their access to the binary channel (normal PAIs, not syndicate ones.)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> As it stands, PAIs are, to put it bluntly, useless. The only thing a PAI can do it open the map and play music. In the event a PAI's owner is in danger, they're useless when it comes to calling for help; especially if their owner is a mime, mute, or dead.

## Technical details
<!-- Summary of code changes for easier review. --> reverted changes to Resources/Prototypes/Entities/Objects/Fun/pai.yml in space-wizards:master pr #32385

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Lucidueye
- add: PAIs have binary radio again

