### PR TITLE
Killer tomatos take damage from weedkiller and plantbgone

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -126,8 +126,8 @@
           groups:
             Brute: -2
             Burn: -2
-    - reagents: [WeedKiller, PlantBGone]
-      methods: [Touch]
+    - reagents: [ WeedKiller, PlantBGone ]
+      methods: [ Touch ]
       effects:
       - !type:HealthChange
         scaleByQuantity: true

--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -126,6 +126,14 @@
           groups:
             Brute: -2
             Burn: -2
+    - reagents: [WeedKiller, PlantBGone]
+      methods: [Touch]
+      effects:
+      - !type:HealthChange
+        scaleByQuantity: true
+        damage:
+          types:
+            Heat: 2
   - type: ReplacementAccent
     accent: tomatoKiller
   - type: Item


### PR DESCRIPTION
## About the PR
title

## Why / Balance
You would expect it to work this way.
Also makes it possible to counter giant hordes of them (without making them too weak, aiming with a spray is not that easy, but good against swarms)

## Technical details
yaml

## Media

https://github.com/user-attachments/assets/284560cc-54b6-4cee-93f3-77e849dd5d7b

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**

:cl:
- tweak: Tomato Killers now take damage from weedkiller and plant b gone.
