### PR TITLE
Paradox Clones receive the implants the original has

### DIFF
--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -5,6 +5,8 @@ using Content.Shared.Cloning.Events;
 using Content.Shared.Database;
 using Content.Shared.Humanoid;
 using Content.Shared.Inventory;
+using Content.Shared.Implants;
+using Content.Shared.Implants.Components;
 using Content.Shared.NameModifier.Components;
 using Content.Shared.StatusEffect;
 using Content.Shared.Stacks;
@@ -35,6 +37,7 @@ public sealed class CloningSystem : EntitySystem
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly SharedStackSystem _stack = default!;
+    [Dependency] private readonly SharedSubdermalImplantSystem _subdermalImplant = default!;
 
     /// <summary>
     ///     Spawns a clone of the given humanoid mob at the specified location or in nullspace.
@@ -90,7 +93,12 @@ public sealed class CloningSystem : EntitySystem
 
         // Copy storage on the mob itself as well.
         // This is needed for slime storage.
-        CopyStorage(original, clone.Value, settings.Whitelist, settings.Blacklist);
+        if (settings.CopyInternalStorage)
+            CopyStorage(original, clone.Value, settings.Whitelist, settings.Blacklist);
+
+        // copy implants and their storage contents
+        if (settings.CopyImplants)
+            CopyImplants(original, clone.Value, settings.CopyInternalStorage, settings.Whitelist, settings.Blacklist);
 
         var originalName = Name(original);
         if (TryComp<NameModifierComponent>(original, out var nameModComp)) // if the originals name was modified, use the unmodified name
@@ -195,5 +203,33 @@ public sealed class CloningSystem : EntitySystem
             if (copy != null)
                 _storage.InsertAt(target, copy.Value, itemLocation, out _, playSound: false);
         }
+    }
+
+    /// <summary>
+    ///     Copies all implants from one mob to another.
+    ///     Might result in duplicates if the target already has them.
+    ///     Can copy the storage inside a storage implant according to a whitelist and blacklist.
+    /// </summary>
+    public void CopyImplants(Entity<ImplantedComponent?> original, EntityUid target, bool copyStorage = false, EntityWhitelist? whitelist = null, EntityWhitelist? blacklist = null)
+    {
+        if (!Resolve(original, ref original.Comp, false))
+            return; // they don't have any implants to copy!
+
+        foreach (var originalImplant in original.Comp.ImplantContainer.ContainedEntities)
+        {
+            if (!HasComp<SubdermalImplantComponent>(originalImplant))
+                continue; // not an implant (should only happen with admin shenanigans)
+
+            var implantId = MetaData(originalImplant).EntityPrototype?.ID;
+
+            if (implantId == null)
+                continue;
+
+            var targetImplant = _subdermalImplant.AddImplant(target, implantId);
+
+            if (copyStorage && targetImplant != null)
+                CopyStorage(originalImplant, targetImplant.Value, whitelist, blacklist); // only needed for storage implants
+        }
+
     }
 }

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -210,6 +210,11 @@ public sealed class CloningSystem : EntitySystem
     ///     Might result in duplicates if the target already has them.
     ///     Can copy the storage inside a storage implant according to a whitelist and blacklist.
     /// </summary>
+    /// <param name="original">Entity to copy implants from.</param>
+    /// <param name="target">Entity to copy implants to.</param>
+    /// <param name="copyStorage">If true will copy storage of the implants (E.g storage implant)</param>
+    /// <param name="whitelist">Whitelist for the storage copy (If copyStorage is true)</param>
+    /// <param name="blacklist">Blacklist for the storage copy (If copyStorage is true)</param>
     public void CopyImplants(Entity<ImplantedComponent?> original, EntityUid target, bool copyStorage = false, EntityWhitelist? whitelist = null, EntityWhitelist? blacklist = null)
     {
         if (!Resolve(original, ref original.Comp, false))

--- a/Content.Shared/Cloning/CloningSettingsPrototype.cs
+++ b/Content.Shared/Cloning/CloningSettingsPrototype.cs
@@ -48,7 +48,6 @@ public sealed partial class CloningSettingsPrototype : IPrototype, IInheritingPr
     [DataField]
     public bool CopyImplants = true;
 
-
     /// <summary>
     ///     Whitelist for the equipment allowed to be copied.
     /// </summary>

--- a/Content.Shared/Cloning/CloningSettingsPrototype.cs
+++ b/Content.Shared/Cloning/CloningSettingsPrototype.cs
@@ -37,6 +37,19 @@ public sealed partial class CloningSettingsPrototype : IPrototype, IInheritingPr
     public SlotFlags? CopyEquipment = SlotFlags.All;
 
     /// <summary>
+    ///     Whether or not to copy slime storage and storage implant contents.
+    /// </summary>
+    [DataField]
+    public bool CopyInternalStorage = true;
+
+    /// <summary>
+    ///     Whether or not to copy implants.
+    /// </summary>
+    [DataField]
+    public bool CopyImplants = true;
+
+
+    /// <summary>
     ///     Whitelist for the equipment allowed to be copied.
     /// </summary>
     [DataField]

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -73,6 +73,8 @@
   parent: Antag
   forceCloning: false
   copyEquipment: null
+  copyInternalStorage: false
+  copyImplants: false
 
 # spawner
 


### PR DESCRIPTION
## About the PR
cloning them now copies any implant and their contents in the case of a storage implant.

## Why / Balance
better copy

## Technical details
Check for any implants and implant a copy from their original protoype.
Add two new bools to the cloning settings.
I accidentally forgot to check for that in a previous PR, so currently cloning pods give you a copy of the items in your slime storage on master, which I now fixed.

## Media
![Screenshot (377)](https://github.com/user-attachments/assets/aa7b285e-b7a3-44ee-949e-ba3f1aa4c83f)
![Screenshot (378)](https://github.com/user-attachments/assets/e5d04767-2bf7-4c45-9b58-946ad90cde69)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- add: Paradox clones now receive any implants the original has.
- fix: Cloning pods no longer copy items in slime storage.

