### PR TITLE
Paradox Clones spawn with their suit sensors off

### DIFF
--- a/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
@@ -1,11 +1,12 @@
 using Content.Server.Antag;
 using Content.Server.Cloning;
 using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Medical.SuitSensors;
 using Content.Server.Objectives.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Gibbing.Components;
+using Content.Shared.Medical.SuitSensor;
 using Content.Shared.Mind;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.GameTicking.Rules;
@@ -16,6 +17,7 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly CloningSystem _cloning = default!;
+    [Dependency] private readonly SuitSensorSystem _sensor = default!;
 
     public override void Initialize()
     {
@@ -71,6 +73,9 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
         var gibComp = EnsureComp<GibOnRoundEndComponent>(clone.Value);
         gibComp.SpawnProto = ent.Comp.GibProto;
         gibComp.PreventGibbingObjectives = new() { "ParadoxCloneKillObjective" }; // don't gib them if they killed the original.
+
+        // turn their suit sensors off so they don't immediately get noticed
+        _sensor.SetAllSensors(clone.Value, SuitSensorMode.SensorOff);
 
         args.Entity = clone;
         ent.Comp.Original = playerToClone.Owner;

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using System.Threading.Tasks.Sources;
 using Content.Server.Access.Systems;
 using Content.Server.DeviceNetwork;
 using Content.Server.DeviceNetwork.Components;
@@ -15,6 +16,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Interaction;
+using Content.Shared.Inventory;
 using Content.Shared.Medical.SuitSensor;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -44,6 +46,7 @@ public sealed class SuitSensorSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
 
     public override void Initialize()
     {
@@ -344,6 +347,20 @@ public sealed class SuitSensorSystem : EntitySystem
         {
             var msg = Loc.GetString("suit-sensor-mode-state", ("mode", GetModeName(mode)));
             _popupSystem.PopupEntity(msg, sensors, userUid.Value);
+        }
+    }
+
+    /// <summary>
+    ///     Set all suit sensors on the equipment someone is wearing.
+    /// </summary>
+    public void SetAllSensors(EntityUid target, SuitSensorMode mode, SlotFlags slots = SlotFlags.All )
+    {
+        // iterate over all inventory slots
+        var slotEnumerator = _inventory.GetSlotEnumerator(target, slots);
+        while (slotEnumerator.NextItem(out var item, out _))
+        {
+            if (TryComp<SuitSensorComponent>(item, out var sensorComp))
+                SetSensor((item, sensorComp), mode);
         }
     }
 

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-using System.Threading.Tasks.Sources;
 using Content.Server.Access.Systems;
 using Content.Server.DeviceNetwork;
 using Content.Server.DeviceNetwork.Components;

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -350,7 +350,7 @@ public sealed class SuitSensorSystem : EntitySystem
     }
 
     /// <summary>
-    ///     Set all suit sensors on the equipment someone is wearing.
+    ///     Set all suit sensors on the equipment someone is wearing to the specified mode.
     /// </summary>
     public void SetAllSensors(EntityUid target, SuitSensorMode mode, SlotFlags slots = SlotFlags.All )
     {


### PR DESCRIPTION
## About the PR
title

## Why / Balance
They sometimes got caught immediately if the AI or paramed was watching the console.
This gives them the chance to decide themselves if and when to enable the suit sensors.

## Technical details
added a function to set all suit sensors in someone's inventory

## Media
![Screenshot (379)](https://github.com/user-attachments/assets/eb80df7e-f8fe-4200-99ff-1324dba9261d)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- tweak: Paradox Clones now start with their suit sensors turned off.
