### PR TITLE
Fix faction icons for paradox clones

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/ParadoxCloneRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/ParadoxCloneRuleComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class ParadoxCloneRuleComponent : Component
     ///     Cloning settings to be used.
     /// </summary>
     [DataField]
-    public ProtoId<CloningSettingsPrototype> Settings = "BaseClone";
+    public ProtoId<CloningSettingsPrototype> Settings = "Antag";
 
     /// <summary>
     ///     Visual effect spawned when gibbing at round end.

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -65,8 +65,10 @@
   id: Antag
   parent: BaseClone
   components:
-  - HeadRevolutionary
-  - Revolutionary
+  # disabled until mind roles are properly copied so they show up on the round end screen
+  # - HeadRevolutionary
+  # - Revolutionary
+  - NukeOperative
 
 - type: cloningSettings
   id: CloningPod

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -4,6 +4,8 @@
 # The datafields of the components are only shallow copied using CopyComp.
 # Subscribe to CloningEvent instead if that is not enough.
 
+# for basic traits etc.
+# used by the random clone spawner
 - type: cloningSettings
   id: BaseClone
   components:
@@ -61,15 +63,16 @@
     - HumanoidAppearance # will cause problems for downstream felinids getting cloned as Urists
     - VirtualItem
 
+# all antagonist roles
 - type: cloningSettings
   id: Antag
   parent: BaseClone
   components:
-  # disabled until mind roles are properly copied so they show up on the round end screen
-  # - HeadRevolutionary
-  # - Revolutionary
+  - HeadRevolutionary
+  - Revolutionary
   - NukeOperative
 
+# for cloning pods
 - type: cloningSettings
   id: CloningPod
   parent: Antag


### PR DESCRIPTION
## About the PR
Paradox clones of nukeops and revolutionaries now get the correct status icon.
This also has the side effect that the cloned nukie or head rev has to be killed for the crew win condition and shuttle auto-call, so this could use some discussion.

## Why / Balance
Make Liltenhead's new video out of date speedrun
https://www.youtube.com/watch?v=TkFqjAi5Ajk
Thanks for finding the bug!

## Technical details
Enabled the corresponding components in the cloning whitelist.
This was already working as part of normal cloning with cloning pods. Rev conversion works as intended. They currently don't show up as a nukie or rev on the round end screen until they get the correct mind role, but that should be fine for now since the original is already listed there and it would just mean a duplicate entry.

## Media
![Screenshot (380)](https://github.com/user-attachments/assets/646a7c24-1759-4dd9-879e-ea4c0e22696e)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Paradox clones of nuclear operatives and head revolutionaries now have the corresponding faction icon and need to be killed for a crew major victory.
