### PR TITLE
Remove non-networked Dirty call in GuardianSystem

### DIFF
--- a/Content.Server/Guardian/GuardianSystem.cs
+++ b/Content.Server/Guardian/GuardianSystem.cs
@@ -70,7 +70,6 @@ namespace Content.Server.Guardian
 
             _container.Remove(uid, hostComponent.GuardianContainer);
             hostComponent.HostedGuardian = null;
-            Dirty(host.Value, hostComponent);
             QueueDel(hostComponent.ActionEntity);
             hostComponent.ActionEntity = null;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed a `Dirty` method invocation in `GuardianSystem` that should not be there.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
`GuardianSystem.OnGuardianShutdown` calls `Dirty`, despite being a server-only system and the `GuardianComponent` being dirtied being a server-only, non-networked component.

## Technical details
<!-- Summary of code changes for easier review. -->
Every time a holoparasite is deleted, an exception is raised:
```
[ERRO] entity: Caught exception while trying to call shutdown on component of entity 'Holoparasite (HOLO-294) (3016/n3016, MobHoloparasiteGuardian)'
Robust.Shared.Utility.DebugAssertException: Attempted to dirty a non-networked component: Content.Server.Guardian.GuardianHostComponent
```

You can test this by spawning a holoparasite injector, injecting yourself, activating the holoparasite, then using the debug action to delete it. The exception is caught and displayed in the server log.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->