### PR TITLE
Fix ninjas remaining invisible to other clients if they remove their suit while invisible

### DIFF
--- a/Content.Shared/Item/ItemToggle/ComponentTogglerSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ComponentTogglerSystem.cs
@@ -28,5 +28,7 @@ public sealed class ComponentTogglerSystem : EntitySystem
             EntityManager.RemoveComponents(target.Value, ent.Comp.RemoveComponents ?? ent.Comp.Components);
             ent.Comp.Target = null;
         }
+
+        Dirty(ent);
     }
 }

--- a/Content.Shared/Item/ItemToggle/ComponentTogglerSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ComponentTogglerSystem.cs
@@ -16,11 +16,17 @@ public sealed class ComponentTogglerSystem : EntitySystem
 
     private void OnToggled(Entity<ComponentTogglerComponent> ent, ref ItemToggledEvent args)
     {
-        var target = ent.Comp.Parent ? Transform(ent).ParentUid : ent.Owner;
-
         if (args.Activated)
+        {
+            var target = ent.Comp.Parent ? Transform(ent).ParentUid : ent.Owner;
+            ent.Comp.Target = target;
             EntityManager.AddComponents(target, ent.Comp.Components);
+        }
         else
-            EntityManager.RemoveComponents(target, ent.Comp.RemoveComponents ?? ent.Comp.Components);
+        {
+            var target = ent.Comp.Target != null ? ent.Comp.Target : (ent.Comp.Parent ? Transform(ent).ParentUid : ent.Owner);
+            EntityManager.RemoveComponents(target.Value, ent.Comp.RemoveComponents ?? ent.Comp.Components);
+            ent.Comp.Target = null;
+        }
     }
 }

--- a/Content.Shared/Item/ItemToggle/Components/ComponentTogglerComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ComponentTogglerComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Item.ItemToggle.Components;
 /// Adds or removes components when toggled.
 /// Requires <see cref="ItemToggleComponent"/>.
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(ComponentTogglerSystem))]
+[RegisterComponent, NetworkedComponent, Access(typeof(ComponentTogglerSystem)), AutoGenerateComponentState]
 public sealed partial class ComponentTogglerComponent : Component
 {
     /// <summary>
@@ -33,6 +33,6 @@ public sealed partial class ComponentTogglerComponent : Component
     /// <summary>
     /// Tracks the target of the component toggle.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public EntityUid? Target;
 }

--- a/Content.Shared/Item/ItemToggle/Components/ComponentTogglerComponent.cs
+++ b/Content.Shared/Item/ItemToggle/Components/ComponentTogglerComponent.cs
@@ -29,4 +29,10 @@ public sealed partial class ComponentTogglerComponent : Component
     /// </summary>
     [DataField]
     public bool Parent;
+
+    /// <summary>
+    /// Tracks the target of the component toggle.
+    /// </summary>
+    [DataField]
+    public EntityUid? Target;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Bugfix. When unequipping the ninja suit while the cloaking is active, you become visible to your client but other clients still see you as invisible. This can be seen via examine, as you'll still have the "Shimmer" examine text that indicates invisible items.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This is a mald bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->

The reason why is because unequipping an item is meant to trigger `ComponentTogglerSystem`, which it does, but the event only fires *after* the unequip (and before the item is technically in your hands). This means that when it tries to remove the `StealthComponent` from the parent (i.e. the player), it instead targets the world entity as it sees it as its parent. 

Due to prediction, the client "incorrectly" assumes the player is still the parent, and thus removes the `StealthComponent` as one would expect.

This PR changes it so that `ComponentTogglerComponent` remembers its target after being set, and makes sure to remove components from that when toggled off.

## Steps to test

1. Boot up two clients.
2. `addgamerule NinjaSpawn` and make one client choose it.
3. Go invisible as ninja (make sure you are outside PVS range).
4. Spawn in a hardsuit and put it on *without turning off your invisibility*. You will become visible on your client.
5. Jetpack over to the station.
6. Turn on the ninja's invisibility power, and remove the suit.

On master you should still remain invisible on the non-ninja client, while with the PR that should be fixed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Space ninjas now correctly lose invisibility for all players when removing their ninja suits.
