### PR TITLE
Adjust small light hitbox

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -273,7 +273,7 @@
         fix1:
           shape:
             !type:PhysShapeAabb
-            bounds: "-0.2,0.5,0.2,0.35"
+            bounds: "-0.1,0.5,0.1,0.255"
           density: 190
           mask:
           - TabletopMachineMask


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adjusted vectors of small light hitbox to conform with the sprite
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->Shooting small lights is more difficult than it needs to be, as the sprite doesn't match the current hitbox.

## Technical details
<!-- Summary of code changes for easier review. -->
Adjusted the vector code of the fixtures component to better fit the sprite. 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No major breaking changes, however, the hitbox for _SmallLightEmpty_ now matches the hitbox of the light with a bulb in it. This is a problem with the inheritance heirarchy of Small Lights. Fix could be to remove collision from _SmallLightAlwaysPowered_ and _SmallLightEmpty_ and give collision individually to child entities. 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed an issue where small lights are too hard to shoot.

