### PR TITLE
C4 helmet unequip delay

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -52,6 +52,8 @@
     slots:
     - HEAD
     quickEquip: false
+    equipDelay: 3
+    unequipDelay: 6
   - type: OnUseTimerTrigger
     delay: 10
     delayOptions: [10, 30, 60, 120, 300]


### PR DESCRIPTION
## About the PR
C4 head slot equip/unequip is now delayed similar to EVA helmet

## Why / Balance
I find the C4 helmet an amusing tool for hostage taking, but it's too easy to get rid of if the captive manages to break out of handcuffs.
Adding equip/unequip delays to put it in line with other "control" items like cuffs and blindfold.

## Technical details
Prototype change

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- add: C4 head slot equip/unequip is now delayed similar to EVA helmet
