### PR TITLE
Fix migrations not being applied to PostMapInitTest

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -293,8 +293,7 @@ namespace Content.IntegrationTests.Tests
                 data,
                 DeserializationOptions.Default,
                 ev.RenamedPrototypes,
-                ev.DeletedPrototypes
-                );
+                ev.DeletedPrototypes);
 
             if (!reader.TryProcessData())
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes the issue causing `PostMapInitTest` to fail on maps that contain migrated entities.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #35932.

## Technical details
<!-- Summary of code changes for easier review. -->
The error shows up in `PostMapInitTest` when it calls `IsPreInit` (notably, this is called only for maps saved in version 7 format, which is why some maps seem to be immune). It creates an `EntityDeserializer` and uses it to read the map data without actually spawning it. The normal way of loading a map via `MapLoaderSystem` raises a `BeforeEntityReadEvent` which `MapMigrationSystem` subscribes to and supplies data about migrations, which are then passed into the `EntityDeserializer` in `MapLoaderSystem`. However, `PostMapInitTest` does not raise the event and creates its `EntityDeserializer` without any migration data.

To fix this, `PostMapInitTest` now raises a `BeforeEntityReadEvent` and passes the results into its `EntityDeserializer`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->