### PR TITLE
Show paradox clones in deadchat

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -24,6 +24,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
+using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
 using Content.Shared.Tag;
@@ -66,6 +67,7 @@ namespace Content.Server.Ghost
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly TagSystem _tag = default!;
+        [Dependency] private readonly NameModifierSystem _nameMod = default!;
 
         private EntityQuery<GhostComponent> _ghostQuery;
         private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -496,6 +498,10 @@ namespace Content.Server.Ghost
             else
                 _minds.TransferTo(mind.Owner, ghost, mind: mind.Comp);
             Log.Debug($"Spawned ghost \"{ToPrettyString(ghost)}\" for {mind.Comp.CharacterName}.");
+
+            // we changed the entity name above
+            // we have to call this after the mind has been transferred since some mind roles modify the ghost's name
+            _nameMod.RefreshNameModifiers(ghost);
             return ghost;
         }
 

--- a/Content.Server/Roles/ParadoxCloneRoleComponent.cs
+++ b/Content.Server/Roles/ParadoxCloneRoleComponent.cs
@@ -6,4 +6,12 @@ namespace Content.Server.Roles;
 ///     Added to mind role entities to tag that they are a paradox clone.
 /// </summary>
 [RegisterComponent]
-public sealed partial class ParadoxCloneRoleComponent : BaseMindRoleComponent;
+public sealed partial class ParadoxCloneRoleComponent : BaseMindRoleComponent
+{
+    /// <summary>
+    ///     Name modifer applied to the player when they turn into a ghost.
+    ///     Needed to be able to keep the original and the clone apart in dead chat.
+    /// </summary>
+    [DataField]
+    public LocId? NameModifier = "paradox-clone-ghost-name-modifier";
+}

--- a/Content.Server/Roles/ParadoxCloneRoleSystem.cs
+++ b/Content.Server/Roles/ParadoxCloneRoleSystem.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Ghost;
+using Content.Shared.Mind;
+using Content.Shared.NameModifier.EntitySystems;
+using Content.Shared.Roles;
+
+namespace Content.Server.Roles;
+
+/// <summary>
+///     System responsible for giving a ghost of a paradox clone a name modifier.
+/// </summary>
+public sealed class ParadoxCloneRoleSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ParadoxCloneRoleComponent, MindRelayedEvent<RefreshNameModifiersEvent>>(OnRefreshNameModifiers);
+    }
+
+    private void OnRefreshNameModifiers(Entity<ParadoxCloneRoleComponent> ent, ref MindRelayedEvent<RefreshNameModifiersEvent> args)
+    {
+        if (!TryComp<MindRoleComponent>(ent.Owner, out var roleComp))
+            return;
+
+        // only show for ghosts
+        if (!HasComp<GhostComponent>(roleComp.Mind.Comp.OwnedEntity))
+            return;
+
+        if (ent.Comp.NameModifier != null)
+            args.Args.AddModifier(ent.Comp.NameModifier.Value, 50);
+    }
+}

--- a/Content.Shared/Mind/SharedMindSystem.Relay.cs
+++ b/Content.Shared/Mind/SharedMindSystem.Relay.cs
@@ -1,0 +1,48 @@
+using Content.Shared.NameModifier.EntitySystems;
+using Content.Shared.Mind.Components;
+
+namespace Content.Shared.Mind;
+
+/// <summary>
+///     Relays events raised on a mobs body to its mind and mind role entities.
+///     Useful for events that should be raised both on the body and the mind.
+/// </summary>
+public abstract partial class SharedMindSystem : EntitySystem
+{
+    public void InitializeRelay()
+    {
+        // for name modifiers that depend on certain mind roles
+        SubscribeLocalEvent<MindContainerComponent, RefreshNameModifiersEvent>(RelayRefToMind);
+    }
+
+    protected void RelayToMind<T>(EntityUid uid, MindContainerComponent component, T args) where T : class
+    {
+        var ev = new MindRelayedEvent<T>(args);
+
+        if (TryGetMind(uid, out var mindId, out var mindComp, component))
+        {
+            RaiseLocalEvent(mindId, ref ev);
+
+            foreach (var role in mindComp.MindRoles)
+                RaiseLocalEvent(role, ref ev);
+        }
+    }
+
+    protected void RelayRefToMind<T>(EntityUid uid, MindContainerComponent component, ref T args) where T : class
+    {
+        var ev = new MindRelayedEvent<T>(args);
+
+        if (TryGetMind(uid, out var mindId, out var mindComp, component))
+        {
+            RaiseLocalEvent(mindId, ref ev);
+
+            foreach (var role in mindComp.MindRoles)
+                RaiseLocalEvent(role, ref ev);
+        }
+
+        args = ev.Args;
+    }
+}
+
+[ByRefEvent]
+public record struct MindRelayedEvent<TEvent>(TEvent Args);

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -19,7 +19,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Mind;
 
-public abstract class SharedMindSystem : EntitySystem
+public abstract partial class SharedMindSystem : EntitySystem
 {
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly INetManager _net = default!;
@@ -42,6 +42,8 @@ public abstract class SharedMindSystem : EntitySystem
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnReset);
         SubscribeLocalEvent<MindComponent, ComponentStartup>(OnMindStartup);
         SubscribeLocalEvent<MindComponent, EntityRenamedEvent>(OnRenamed);
+
+        InitializeRelay();
     }
 
     public override void Shutdown()

--- a/Resources/Locale/en-US/paradox-clone/role.ftl
+++ b/Resources/Locale/en-US/paradox-clone/role.ftl
@@ -3,3 +3,5 @@ paradox-clone-round-end-agent-name = paradox clone
 objective-issuer-paradox = [color=lightblue]Paradox[/color]
 
 paradox-clone-role-greeting = A freak space-time anomaly has teleported you into another reality! Now you have to find your counterpart and kill and replace them. Only one of you two can survive.
+
+paradox-clone-ghost-name-modifier = {$baseName} (clone)


### PR DESCRIPTION
## About the PR
If a paradox clone dies they now get a `Name (clone)` name modifier for their ghost and when talking in deadchat.

## Why / Balance
Deadchat became confusing when both the original and the clone were talking since they have the same name.
The drawback of this that this could be slightly metagameable by other ghosts in deadchat, but I guess they can already observe everything anyways, so it should be fine.

## Technical details
Added a mind event relay, which can be used to raise events on both the body and the mind.
They work identically to inventory relays and can be useful for other things in the future.
Add a name modifier for observers if they have the paradox clone mind role by subscribing to the `RefreshNameModifiersEvent`.

An alternative way to handle this would be to directly modify the `CharacterName` in the clone's `MindComponent` on spawning, which is used when ghosting to name the ghost. But this datafield is also used in a lot of other cases, for example for target objectives, which would need a major refactor.

## Media
![grafik](https://github.com/user-attachments/assets/fe874aa5-a480-436c-a550-b906fa911856)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Ghosts of paradox clones now have a name modifier so they can be distinguished by other ghosts.
