### PR TITLE
Artifact Origins

### DIFF
--- a/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactAnalyzerSystem.cs
@@ -306,6 +306,14 @@ public sealed class ArtifactAnalyzerSystem : EntitySystem
 
         var n = component.LastAnalyzedNode;
 
+        if (EntityManager.TryGetComponent(component.LastAnalyzedArtifact, out ArtifactComponent? arti))
+        {
+            var origin = Loc.GetString($"{arti.ArtiType}-artifact-type");
+
+            msg.AddMarkupOrThrow(Loc.GetString("analysis-console-info-origin", ("origin", origin)));
+            msg.PushNewline();
+        }
+
         msg.AddMarkupOrThrow(Loc.GetString("analysis-console-info-id", ("id", n.Id)));
         msg.PushNewline();
         msg.AddMarkupOrThrow(Loc.GetString("analysis-console-info-depth", ("depth", n.Depth)));

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
@@ -35,6 +35,12 @@ public sealed partial class ArtifactComponent : Component
     #endregion
 
     /// <summary>
+    /// The type of artifact this is, which determines what triggers and effects it can have
+    /// </summary>
+    [DataField("artiType")]
+    public ArtiOrigin ArtiType = ArtiOrigin.Undecided;
+
+    /// <summary>
     /// Cooldown time between artifact activations (in seconds).
     /// </summary>
     [DataField("timer"), ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.Nodes.cs
@@ -83,7 +83,8 @@ public sealed partial class ArtifactSystem
     {
         var allTriggers = _prototype.EnumeratePrototypes<ArtifactTriggerPrototype>()
             .Where(x => _whitelistSystem.IsWhitelistPassOrNull(x.Whitelist, artifact) &&
-            _whitelistSystem.IsBlacklistFailOrNull(x.Blacklist, artifact)).ToList();
+            _whitelistSystem.IsBlacklistFailOrNull(x.Blacklist, artifact) &&
+            IsTriggerValid(EntityManager.GetComponent<ArtifactComponent>(artifact), x)).ToList();
         var validDepth = allTriggers.Select(x => x.TargetDepth).Distinct().ToList();
 
         var weights = GetDepthWeights(validDepth, node.Depth);
@@ -98,7 +99,8 @@ public sealed partial class ArtifactSystem
     {
         var allEffects = _prototype.EnumeratePrototypes<ArtifactEffectPrototype>()
             .Where(x => _whitelistSystem.IsWhitelistPassOrNull(x.Whitelist, artifact) &&
-            _whitelistSystem.IsBlacklistFailOrNull(x.Blacklist, artifact)).ToList();
+            _whitelistSystem.IsBlacklistFailOrNull(x.Blacklist, artifact) &&
+            IsEffectValid(EntityManager.GetComponent<ArtifactComponent>(artifact), x)).ToList();
         var validDepth = allEffects.Select(x => x.TargetDepth).Distinct().ToList();
 
         var weights = GetDepthWeights(validDepth, node.Depth);
@@ -240,5 +242,19 @@ public sealed partial class ArtifactSystem
     public ArtifactNode GetNodeFromId(int id, IEnumerable<ArtifactNode> nodes)
     {
         return nodes.First(x => x.Id == id);
+    }
+
+    private bool IsTriggerValid(ArtifactComponent artifact, ArtifactTriggerPrototype artiTrigger)
+    {
+        if (artiTrigger.OriginWhitelist != null && !artiTrigger.OriginWhitelist.Contains(artifact.ArtiType.ToString()))
+            return false;
+        return true;
+    }
+
+    private bool IsEffectValid(ArtifactComponent artifact, ArtifactEffectPrototype artiEffect)
+    {
+        if (artiEffect.OriginWhitelist != null && !artiEffect.OriginWhitelist.Contains(artifact.ArtiType.ToString()))
+            return false;
+        return true;
     }
 }

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -129,6 +129,10 @@ public sealed partial class ArtifactSystem : EntitySystem
     {
         var nodeAmount = _random.Next(component.NodesMin, component.NodesMax);
 
+        if (component.ArtiType == ArtiOrigin.Undecided)
+            component.ArtiType = (ArtiOrigin)_random.Next(1, 6);
+
+
         GenerateArtifactNodeTree(uid, component.NodeTree, nodeAmount);
         var firstNode = GetRootNode(component.NodeTree);
         EnterNode(uid, ref firstNode, component);

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactSystem.cs
@@ -132,7 +132,6 @@ public sealed partial class ArtifactSystem : EntitySystem
         if (component.ArtiType == ArtiOrigin.Undecided)
             component.ArtiType = (ArtiOrigin)_random.Next(1, 6);
 
-
         GenerateArtifactNodeTree(uid, component.NodeTree, nodeAmount);
         var firstNode = GetRootNode(component.NodeTree);
         EnterNode(uid, ref firstNode, component);

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
@@ -42,8 +42,28 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, RandomArtifactSpriteComponent component, MapInitEvent args)
     {
-        var randomSprite = _random.Next(component.MinSprite, component.MaxSprite + 1);
-        _appearance.SetData(uid, SharedArtifactsVisuals.SpriteIndex, randomSprite);
+        var artiType = EntityManager.GetComponent<ArtifactComponent>(uid).ArtiType;
+        int[] randomSpriteChoices = [];
+        switch (artiType)
+        {
+            case ArtiOrigin.Eldritch:
+                randomSpriteChoices = component.EldritchSprites;
+                break;
+            case ArtiOrigin.Martian:
+                randomSpriteChoices = component.MartianSprites;
+                break;
+            case ArtiOrigin.Precursor:
+                randomSpriteChoices = component.PrecursorSprites;
+                break;
+            case ArtiOrigin.Silicon:
+                randomSpriteChoices = component.SilicionSprites;
+                break;
+            case ArtiOrigin.Wizard:
+                randomSpriteChoices = component.WizardSprites;
+                break;
+        }
+        var randomSprite = _random.Next(0, randomSpriteChoices.Length);
+        _appearance.SetData(uid, SharedArtifactsVisuals.SpriteIndex, randomSpriteChoices[randomSprite]);
         _item.SetHeldPrefix(uid, "ano" + randomSprite.ToString("D2")); //set item artifact inhands
     }
 

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
@@ -42,7 +42,7 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, RandomArtifactSpriteComponent component, MapInitEvent args)
     {
-        var artiType = EnsureComp<ArtifactComponent>(uid).ArtiType;
+        var artiType = EntityManager.GetComponent<ArtifactComponent>(uid).ArtiType;
         var randomSpriteChoices = Array.Empty<int>();
         switch (artiType)
         {
@@ -56,7 +56,7 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
                 randomSpriteChoices = component.PrecursorSprites;
                 break;
             case ArtiOrigin.Silicon:
-                randomSpriteChoices = component.SilicionSprites;
+                randomSpriteChoices = component.SiliconSprites;
                 break;
             case ArtiOrigin.Wizard:
                 randomSpriteChoices = component.WizardSprites;

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
@@ -42,7 +42,7 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, RandomArtifactSpriteComponent component, MapInitEvent args)
     {
-        var artiType = EntityManager.EnsureComponent<ArtifactComponent>(uid).ArtiType;
+        var artiType = EnsureComp<ArtifactComponent>(uid).ArtiType;
         int[] randomSpriteChoices = [];
         switch (artiType)
         {

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
@@ -42,7 +42,7 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, RandomArtifactSpriteComponent component, MapInitEvent args)
     {
-        var artiType = EntityManager.GetComponent<ArtifactComponent>(uid).ArtiType;
+        var artiType = EntityManager.EnsureComponent<ArtifactComponent>(uid).ArtiType;
         int[] randomSpriteChoices = [];
         switch (artiType)
         {

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
@@ -43,7 +43,7 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
     private void OnMapInit(EntityUid uid, RandomArtifactSpriteComponent component, MapInitEvent args)
     {
         var artiType = EnsureComp<ArtifactComponent>(uid).ArtiType;
-        int[] randomSpriteChoices = [];
+        var randomSpriteChoices = Array.Empty<int>();
         switch (artiType)
         {
             case ArtiOrigin.Eldritch:

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
@@ -42,9 +42,11 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, RandomArtifactSpriteComponent component, MapInitEvent args)
     {
-        var artiType = EntityManager.GetComponent<ArtifactComponent>(uid).ArtiType;
+        if (!EntityManager.TryGetComponent<ArtifactComponent>(uid, out var arti))
+            return;
+
         var randomSpriteChoices = Array.Empty<int>();
-        switch (artiType)
+        switch (arti.ArtiType)
         {
             case ArtiOrigin.Eldritch:
                 randomSpriteChoices = component.EldritchSprites;

--- a/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactEffectPrototype.cs
+++ b/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactEffectPrototype.cs
@@ -36,6 +36,12 @@ public sealed partial class ArtifactEffectPrototype : IPrototype
     [DataField("effectHint")]
     public string? EffectHint;
 
+    /// <summary>
+    /// Artifact types that can have this effect, leave blank for all
+    /// </summary>
+    [DataField("originWhitelist")]
+    public List<String>? OriginWhitelist;
+
     [DataField("whitelist")]
     public EntityWhitelist? Whitelist;
 

--- a/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactTriggerPrototype.cs
+++ b/Content.Shared/Xenoarchaeology/XenoArtifacts/ArtifactTriggerPrototype.cs
@@ -25,6 +25,12 @@ public sealed partial class ArtifactTriggerPrototype : IPrototype
     [DataField("triggerHint")]
     public string? TriggerHint;
 
+    /// <summary>
+    /// Artifact types that can have this trigger, leave blank for all
+    /// </summary>
+    [DataField("originWhitelist")]
+    public List<String>? OriginWhitelist;
+
     [DataField("whitelist")]
     public EntityWhitelist? Whitelist;
 

--- a/Content.Shared/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteComponent.cs
+++ b/Content.Shared/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class RandomArtifactSpriteComponent : Component
     public int[] PrecursorSprites = [];
 
     [DataField("siliconSprites")]
-    public int[] SilicionSprites = [];
+    public int[] SiliconSprites = [];
 
     [DataField("wizardSprites")]
     public int[] WizardSprites = [];

--- a/Content.Shared/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteComponent.cs
+++ b/Content.Shared/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteComponent.cs
@@ -3,11 +3,20 @@
 [RegisterComponent]
 public sealed partial class RandomArtifactSpriteComponent : Component
 {
-    [DataField("minSprite")]
-    public int MinSprite = 1;
+    [DataField("eldritchSprites")]
+    public int[] EldritchSprites = [];
 
-    [DataField("maxSprite")]
-    public int MaxSprite = 14;
+    [DataField("martianSprites")]
+    public int[] MartianSprites = [];
+
+    [DataField("precursorSprites")]
+    public int[] PrecursorSprites = [];
+
+    [DataField("siliconSprites")]
+    public int[] SilicionSprites = [];
+
+    [DataField("wizardSprites")]
+    public int[] WizardSprites = [];
 
     [DataField("activationTime")]
     public double ActivationTime = 2.0;

--- a/Content.Shared/Xenoarchaeology/XenoArtifacts/SharedArtifact.cs
+++ b/Content.Shared/Xenoarchaeology/XenoArtifacts/SharedArtifact.cs
@@ -10,6 +10,17 @@ public enum SharedArtifactsVisuals : byte
     IsActivated
 }
 
+[Serializable, NetSerializable]
+public enum ArtiOrigin : byte
+{
+    Undecided,
+    Eldritch,
+    Martian,
+    Precursor,
+    Silicon,
+    Wizard
+}
+
 /// <summary>
 ///     Raised as an instant action event when a sentient artifact activates itself using an action.
 /// </summary>

--- a/Resources/Locale/en-US/xenoarchaeology/artifact-analyzer.ftl
+++ b/Resources/Locale/en-US/xenoarchaeology/artifact-analyzer.ftl
@@ -15,6 +15,7 @@ analysis-console-info-no-scanner = No analyzer connected! Please connect one usi
 analysis-console-info-no-artifact = No artifact present! Place one on the pad then scan for information.
 analysis-console-info-ready = Systems operational. Ready to scan.
 
+analysis-console-info-origin = ORIGIN: {$origin}
 analysis-console-info-id = NODE_ID: {$id}
 analysis-console-info-depth = DEPTH: {$depth}
 analysis-console-info-triggered-true = ACTIVATED: TRUE

--- a/Resources/Locale/en-US/xenoarchaeology/artifact-hints.ftl
+++ b/Resources/Locale/en-US/xenoarchaeology/artifact-hints.ftl
@@ -41,4 +41,8 @@ artifact-trigger-hint-plasma = Gaseous plasma
 artifact-trigger-hint-land = Active deceleration
 artifact-trigger-hint-examine = Examination
 artifact-trigger-hint-medical = Therapeutic chemicals
+artifact-trigger-hint-pyrotechnic = Combustive chemicals
+artifact-trigger-hint-elemental = Elemental chemicals
+artifact-trigger-hint-acidic = Acidic chemicals
+artifact-trigger-hint-toxic = Noxious chemicals
 

--- a/Resources/Locale/en-US/xenoarchaeology/misc-artifact.ftl
+++ b/Resources/Locale/en-US/xenoarchaeology/misc-artifact.ftl
@@ -5,3 +5,9 @@ shuffle-artifact-popup = You feel yourself teleport instantly!
 charge-artifact-popup = You feel the air buzz with electricity.
 
 activate-artifact-popup-self = You activate node {$node}.
+
+Eldritch-artifact-type = ELDRITCH
+Wizard-artifact-type = WIZARD
+Silicon-artifact-type = SILICON
+Precursor-artifact-type = PRECURSOR
+Martian-artifact-type = MARTIAN

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
@@ -8,9 +8,9 @@
   - type: Sprite
     sprite: Objects/Specific/Xenoarchaeology/item_artifacts.rsi
     layers:
-    - state: ano01
+    - state: ano11
       map: [ "enum.ArtifactsVisualLayers.Base" ]
-    - state: ano01_on
+    - state: ano11_on
       map: [ "enum.ArtifactsVisualLayers.Effect" ]
       visible: false
   - type: Damageable
@@ -37,8 +37,12 @@
         friction: 0.2
   - type: Artifact
   - type: RandomArtifactSprite
-    maxSprite: 11
     activationTime: 2.4
+    eldritchSprites: [ 7, 8 ]
+    martianSprites: [ 3, 4 ]
+    precursorSprites: [ 9, 10, 11 ]
+    siliconSprites: [ 1, 2 ]
+    wizardSprites: [ 5, 6 ]
   - type: RandomSprite
     available:
     - enum.ArtifactsVisualLayers.Effect:
@@ -69,7 +73,7 @@
 - type: entity
   parent: BaseXenoArtifactItem
   id: SimpleXenoArtifactItem
-  suffix: Simple
+  suffix: Random Simple
   components:
   - type: Artifact
     nodesMin: 2
@@ -78,7 +82,7 @@
 - type: entity
   parent: BaseXenoArtifactItem
   id: MediumXenoArtifactItem
-  suffix: Medium
+  suffix: Random Medium
   components:
   - type: Artifact
     nodesMin: 5
@@ -87,7 +91,7 @@
 - type: entity
   parent: BaseXenoArtifactItem
   id: ComplexXenoArtifactItem
-  suffix: Complex
+  suffix: Random Complex
   components:
   - type: Artifact
     nodesMin: 9
@@ -97,11 +101,91 @@
 - type: entity
   parent: BaseXenoArtifactItem
   id: VariedXenoArtifactItem
-  suffix: Varied
+  suffix: Random Varied
   components:
   - type: Artifact
     nodesMin: 2
     nodesMax: 13
+
+- type: entity
+  parent: BaseXenoArtifactItem
+  id: EldritchXenoArtifactItem
+  suffix: Eldritch
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Xenoarchaeology/item_artifacts.rsi
+    layers:
+    - state: ano07
+      map: [ "enum.ArtifactsVisualLayers.Base" ]
+    - state: ano07_on
+      map: [ "enum.ArtifactsVisualLayers.Effect" ]
+      visible: false
+  - type: Artifact
+    artiType: Eldritch
+
+- type: entity
+  parent: BaseXenoArtifactItem
+  id: MartianXenoArtifactItem
+  suffix: Martian
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Xenoarchaeology/item_artifacts.rsi
+    layers:
+    - state: ano03
+      map: [ "enum.ArtifactsVisualLayers.Base" ]
+    - state: ano03_on
+      map: [ "enum.ArtifactsVisualLayers.Effect" ]
+      visible: false
+  - type: Artifact
+    artiType: Martian
+
+- type: entity
+  parent: BaseXenoArtifactItem
+  id: PrecursorXenoArtifactItem
+  suffix: Precursor
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Xenoarchaeology/item_artifacts.rsi
+    layers:
+    - state: ano09
+      map: [ "enum.ArtifactsVisualLayers.Base" ]
+    - state: ano09_on
+      map: [ "enum.ArtifactsVisualLayers.Effect" ]
+      visible: false
+  - type: Artifact
+    artiType: Precursor
+
+- type: entity
+  parent: BaseXenoArtifactItem
+  id: SiliconXenoArtifactItem
+  suffix: Silicon
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Xenoarchaeology/item_artifacts.rsi
+    layers:
+    - state: ano01
+      map: [ "enum.ArtifactsVisualLayers.Base" ]
+    - state: ano01_on
+      map: [ "enum.ArtifactsVisualLayers.Effect" ]
+      visible: false
+  - type: Artifact
+    artiType: Silicon
+
+- type: entity
+  parent: BaseXenoArtifactItem
+  id: WizardXenoArtifactItem
+  suffix: Wizard
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Xenoarchaeology/item_artifacts.rsi
+    layers:
+    - state: ano05
+      map: [ "enum.ArtifactsVisualLayers.Base" ]
+    - state: ano05_on
+      map: [ "enum.ArtifactsVisualLayers.Effect" ]
+      visible: false
+  - type: Artifact
+    artiType: Wizard
 
 - type: entity
   id: ArtifactFragment

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
@@ -10,9 +10,9 @@
     sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
     noRot: true
     layers:
-    - state: ano30
+    - state: ano29
       map: [ "enum.ArtifactsVisualLayers.Base" ]
-    - state: ano30_on
+    - state: ano29_on
       map: [ "enum.ArtifactsVisualLayers.Effect" ]
       visible: false
   - type: Damageable
@@ -47,7 +47,11 @@
   - type: InteractionOutline
   - type: Artifact
   - type: RandomArtifactSprite
-    maxSprite: 36
+    eldritchSprites: [ 8, 9, 10, 11, 12, 13, 14 ]
+    martianSprites: [ 15, 16, 17, 18, 19, 20, 21 ]
+    precursorSprites: [ 22, 23, 24, 25, 26, 27, 28, 29 ] #yes, there are 8 of these for some reason
+    siliconSprites: [ 1, 2, 3, 4, 5, 6, 7 ]
+    wizardSprites: [ 30, 31, 32, 33, 34, 35, 36 ]
   - type: RandomSprite
     available:
     - enum.ArtifactsVisualLayers.Effect:
@@ -68,7 +72,7 @@
 - type: entity
   parent: BaseXenoArtifact
   id: SimpleXenoArtifact
-  suffix: Simple
+  suffix: Random Simple
   components:
   - type: Artifact
     nodesMin: 2
@@ -77,7 +81,7 @@
 - type: entity
   parent: BaseXenoArtifact
   id: MediumXenoArtifact
-  suffix: Medium
+  suffix: Random Medium
   components:
   - type: Artifact
     nodesMin: 5
@@ -86,9 +90,98 @@
 - type: entity
   parent: BaseXenoArtifact
   id: ComplexXenoArtifact
-  suffix: Complex
+  suffix: Random Complex
   components:
   - type: Artifact
     nodesMin: 9
     nodesMax: 13
 
+- type: entity
+  parent: BaseXenoArtifact
+  id: EldritchXenoArtifact
+  suffix: Eldritch
+  components:
+  - type: Sprite
+    drawdepth: SmallObjects
+    sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
+    noRot: true
+    layers:
+    - state: ano08
+      map: [ "enum.ArtifactsVisualLayers.Base" ]
+    - state: ano08_on
+      map: [ "enum.ArtifactsVisualLayers.Effect" ]
+      visible: false
+  - type: Artifact
+    artiType: Eldritch
+
+- type: entity
+  parent: BaseXenoArtifact
+  id: MartianXenoArtifact
+  suffix: Martian
+  components:
+  - type: Sprite
+    drawdepth: SmallObjects
+    sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
+    noRot: true
+    layers:
+    - state: ano15
+      map: [ "enum.ArtifactsVisualLayers.Base" ]
+    - state: ano15_on
+      map: [ "enum.ArtifactsVisualLayers.Effect" ]
+      visible: false
+  - type: Artifact
+    artiType: Martian
+
+- type: entity
+  parent: BaseXenoArtifact
+  id: PrecursorXenoArtifact
+  suffix: Precursor
+  components:
+  - type: Sprite
+    drawdepth: SmallObjects
+    sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
+    noRot: true
+    layers:
+    - state: ano22
+      map: [ "enum.ArtifactsVisualLayers.Base" ]
+    - state: ano22_on
+      map: [ "enum.ArtifactsVisualLayers.Effect" ]
+      visible: false
+  - type: Artifact
+    artiType: Precursor
+
+- type: entity
+  parent: BaseXenoArtifact
+  id: SiliconXenoArtifact
+  suffix: Silicon
+  components:
+  - type: Sprite
+    drawdepth: SmallObjects
+    sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
+    noRot: true
+    layers:
+    - state: ano01
+      map: [ "enum.ArtifactsVisualLayers.Base" ]
+    - state: ano01_on
+      map: [ "enum.ArtifactsVisualLayers.Effect" ]
+      visible: false
+  - type: Artifact
+    artiType: Silicon
+
+- type: entity
+  parent: BaseXenoArtifact
+  id: WizardXenoArtifact
+  suffix: Wizard
+  components:
+  - type: Sprite
+    drawdepth: SmallObjects
+    sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
+    noRot: true
+    layers:
+    - state: ano30
+      map: [ "enum.ArtifactsVisualLayers.Base" ]
+    - state: ano30_on
+      map: [ "enum.ArtifactsVisualLayers.Effect" ]
+      visible: false
+  - type: Artifact
+    artiType: Wizard

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -140,8 +140,6 @@
   effectHint: artifact-effect-hint-release
   originWhitelist:
     - Silicon
-  triggerWhitelist:
-    - TriggerSiliconTouch
   components:
   - type: PointLight
     radius: 10

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -106,6 +106,7 @@
 - type: artifactEffect
   id: EffectWizardLight #nice and slow RGB that covers a room
   targetDepth: 0
+  effectHint: artifact-effect-hint-release
   originWhitelist:
     - Wizard
   components:
@@ -121,6 +122,7 @@
 - type: artifactEffect
   id: EffectMartianLight #basically blinding purple
   targetDepth: 0
+  effectHint: artifact-effect-hint-release
   originWhitelist:
     - Martian
   components:
@@ -135,6 +137,7 @@
 - type: artifactEffect
   id: EffectSiliconLight #normal room lighting
   targetDepth: 0
+  effectHint: artifact-effect-hint-release
   originWhitelist:
     - Silicon
   triggerWhitelist:

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -104,16 +104,49 @@
   - type: LightFlickerArtifact
 
 - type: artifactEffect
-  id: EffectPointLight
+  id: EffectWizardLight #nice and slow RGB that covers a room
   targetDepth: 0
+  originWhitelist:
+    - Wizard
+  components:
+  - type: RgbLightController
+    cycleRate: 0.04
+  - type: PointLight
+    radius: 8
+    energy: 8
+  - type: TriggerArtifact
+  - type: FlashOnTrigger
+    range: 4
+
+- type: artifactEffect
+  id: EffectMartianLight #basically blinding purple
+  targetDepth: 0
+  originWhitelist:
+    - Martian
   components:
   - type: PointLight
     radius: 8
     energy: 10
-    color: "#daa3fd"
+    color: "#cd80ff"
   - type: TriggerArtifact
   - type: FlashOnTrigger
-    range: 8
+    range: 10
+
+- type: artifactEffect
+  id: EffectSiliconLight #normal room lighting
+  targetDepth: 0
+  originWhitelist:
+    - Silicon
+  triggerWhitelist:
+    - TriggerSiliconTouch
+  components:
+  - type: PointLight
+    radius: 10
+    energy: 8
+    color: "#6c798c"
+  - type: TriggerArtifact
+  - type: FlashOnTrigger
+    range: 6
 
 - type: artifactEffect #bornana
   id: EffectBananaSpawn

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -105,7 +105,7 @@
 
 - type: artifactEffect
   id: EffectWizardLight #nice and slow RGB that covers a room
-  targetDepth: 0
+  targetDepth: 2
   effectHint: artifact-effect-hint-release
   originWhitelist:
     - Wizard
@@ -121,7 +121,7 @@
 
 - type: artifactEffect
   id: EffectMartianLight #basically blinding purple
-  targetDepth: 0
+  targetDepth: 2
   effectHint: artifact-effect-hint-release
   originWhitelist:
     - Martian
@@ -136,7 +136,7 @@
 
 - type: artifactEffect
   id: EffectSiliconLight #normal room lighting
-  targetDepth: 0
+  targetDepth: 2
   effectHint: artifact-effect-hint-release
   originWhitelist:
     - Silicon

--- a/Resources/Prototypes/XenoArch/artifact_triggers.yml
+++ b/Resources/Prototypes/XenoArch/artifact_triggers.yml
@@ -107,6 +107,8 @@
   id: TriggerBlood
   targetDepth: 1
   triggerHint: artifact-trigger-hint-blood
+  originWhitelist:
+    - Eldritch
   components:
   - type: Reactive
     groups:
@@ -126,7 +128,70 @@
     groups:
       Acidic: [ Touch ]
     reactions:
-    - reagents: [ Dylovene, Diphenhydramine, Arithrazine, Bicaridine, Dermaline, Dexalin, DexalinPlus, Tricordrazine, Leporazine, Bruizine, Lacerinol, Puncturase, Pyrazine, Insuzine, Kelotane, Hyronalin, Inaprovaline, Epinephrine ]
+    - reagents: [ Dylovene, Diphenhydramine, Arithrazine, Bicaridine, Dermaline, Dexalin, DexalinPlus, Tricordrazine, Leporazine, Bruizine, Lacerinol, Puncturase, Pyrazine, Insuzine, Kelotane, Hyronalin, Inaprovaline, Epinephrine, Omnizine, Barozine, Saline, Holywater ]
+      methods: [ Touch ]
+      effects:
+      - !type:ActivateArtifact
+
+- type: artifactTrigger
+  id: TriggerPyrotechnic
+  targetDepth: 4
+  triggerHint: artifact-trigger-hint-blood
+  originWhitelist:
+    - Wizard
+  components:
+  - type: Reactive
+    groups:
+      Acidic: [ Touch ]
+    reactions:
+    - reagents: [ Thermite, Napalm, Phlogiston, ChlorineTrifluoride, FoamingAgent, Fluorosurfactant ]
+      methods: [ Touch ]
+      effects:
+      - !type:ActivateArtifact
+
+- type: artifactTrigger
+  id: TriggerElemental
+  targetDepth: 2
+  triggerHint: artifact-trigger-hint-blood
+  originWhitelist:
+    - Precursor
+  components:
+  - type: Reactive
+    groups:
+      Acidic: [ Touch ]
+    reactions:
+    - reagents: [ Aluminium, Carbon, Chlorine, Copper, Fluorine, Gold, Hydrogen, Iodine, Iron, Lithium, Mercury, Potassium, Phosphorus, Radium, Silicon, Silver, Sulfur, Sodium, Uranium, Zinc, Lead ]
+      methods: [ Touch ]
+      effects:
+      - !type:ActivateArtifact
+
+- type: artifactTrigger
+  id: TriggerAcidic
+  triggerHint: artifact-trigger-hint-blood
+  originWhitelist:
+    - Martian
+  components:
+  - type: Reactive
+    groups:
+      Acidic: [ Touch ]
+    reactions:
+    - reagents: [ PolytrinicAcid, FerrochromicAcid, FluorosulfuricAcid, SulfuricAcid, NorepinephricAcid, AcidSpit, TranexamicAcid ]
+      methods: [ Touch ]
+      effects:
+      - !type:ActivateArtifact
+
+- type: artifactTrigger
+  id: TriggerToxin
+  targetDepth: 3
+  triggerHint: artifact-trigger-hint-blood
+  originWhitelist:
+    - Martian
+  components:
+  - type: Reactive
+    groups:
+      Acidic: [ Touch ]
+    reactions:
+    - reagents: [ Toxin, CarpoToxin, ChloralHydrate, GastroToxin, Mold, HeartbreakerToxin, Lexorin, Histamine, Amatoxin, VentCrud, Romerol, Bungotoxin, Vestine, Lipolicide, Mechanotoxin, Ipecac ]
       methods: [ Touch ]
       effects:
       - !type:ActivateArtifact

--- a/Resources/Prototypes/XenoArch/artifact_triggers.yml
+++ b/Resources/Prototypes/XenoArch/artifact_triggers.yml
@@ -136,7 +136,7 @@
 - type: artifactTrigger
   id: TriggerPyrotechnic
   targetDepth: 4
-  triggerHint: artifact-trigger-hint-blood
+  triggerHint: artifact-trigger-hint-pyrotechnic
   originWhitelist:
     - Wizard
   components:
@@ -152,7 +152,7 @@
 - type: artifactTrigger
   id: TriggerElemental
   targetDepth: 2
-  triggerHint: artifact-trigger-hint-blood
+  triggerHint: artifact-trigger-hint-elemental
   originWhitelist:
     - Precursor
   components:
@@ -167,7 +167,8 @@
 
 - type: artifactTrigger
   id: TriggerAcidic
-  triggerHint: artifact-trigger-hint-blood
+  targetDepth: 3
+  triggerHint: artifact-trigger-hint-acidic
   originWhitelist:
     - Martian
   components:
@@ -183,9 +184,7 @@
 - type: artifactTrigger
   id: TriggerToxin
   targetDepth: 3
-  triggerHint: artifact-trigger-hint-blood
-  originWhitelist:
-    - Martian
+  triggerHint: artifact-trigger-hint-toxic
   components:
   - type: Reactive
     groups:


### PR DESCRIPTION
## About the PR
Artifacts are split into 5 types, being: eldritch, wizard, precursor, silicon, and martian. The artifact types match the existing sprites and can also be discovered when scanning an artifact. Reactions and triggers can be specified to only occur on certain artifact origins, so each origin is made a bit unique in gameplay. 3 basic triggers and 3 effects were added to specific origins to show that its functional, with more wacky and interesting ones potentially added in future prs. 

## Why / Balance
No artifact gameplay has been added for over a year now, and I think this is a good start for more. There are also currently 47 artifact sprites that have no gameplay repercussions, which makes artifacts feel more like slightly differed point generators rather than alien artifacts that once had a purpose. The game's current sprites were all taken from goonstation, which had artifact origins of the same 5 names, so this is pretty much just a port.

## Technical details
Artifact sprites now come from the artifact type. Artifact effects and triggers check a whitelist to see if they are allowed to be on nodes in the current artifact. Made it so arti scanners show the type (localized). Splits the arti light effect into 3 possible light effects, adds a few new liquid reaction triggers. Artifacts that aren't spawned as specific types are automatically made into a random type. 

## Media
![image](https://github.com/user-attachments/assets/8e51315a-2583-47fa-8159-47247e7ec6d3)
![image](https://github.com/user-attachments/assets/92b0be0b-7d00-4c0f-9d38-b686f555fbfa)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: shibechef
- add: Artifacts are split into 5 origins, with a few new reactions and effects unique to each of them.