### PR TITLE
Cleanup: Replace obsolete method uses from `SharedContainerSystem`

### DIFF
--- a/Content.Client/UserInterface/Systems/Storage/Controls/StorageWindow.cs
+++ b/Content.Client/UserInterface/Systems/Storage/Controls/StorageWindow.cs
@@ -199,7 +199,7 @@ public sealed class StorageWindow : BaseWindow
         var containerSystem = _entity.System<SharedContainerSystem>();
         var uiSystem = _entity.System<UserInterfaceSystem>();
 
-        if (containerSystem.TryGetContainingContainer(StorageEntity.Value, out var container) &&
+        if (containerSystem.TryGetContainingContainer((StorageEntity.Value, null), out var container) &&
             _entity.TryGetComponent(container.Owner, out StorageComponent? storage) &&
             storage.Container.Contains(StorageEntity.Value) &&
             uiSystem
@@ -281,7 +281,7 @@ public sealed class StorageWindow : BaseWindow
             {
                 var containerSystem = _entity.System<SharedContainerSystem>();
 
-                if (containerSystem.TryGetContainingContainer(StorageEntity.Value, out var container) &&
+                if (containerSystem.TryGetContainingContainer((StorageEntity.Value, null), out var container) &&
                     _entity.TryGetComponent(container.Owner, out StorageComponent? storage) &&
                     storage.Container.Contains(StorageEntity.Value))
                 {
@@ -519,7 +519,7 @@ public sealed class StorageWindow : BaseWindow
             if (StorageEntity != null && _entity.System<StorageSystem>().NestedStorage)
             {
                 // If parent container nests us then show back button
-                if (containerSystem.TryGetContainingContainer(StorageEntity.Value, out var container) &&
+                if (containerSystem.TryGetContainingContainer((StorageEntity.Value, null), out var container) &&
                     _entity.TryGetComponent(container.Owner, out StorageComponent? storageComp) && storageComp.Container.Contains(StorageEntity.Value))
                 {
                     _backButton.Visible = true;

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -88,7 +88,7 @@ namespace Content.Server.Construction
             {
                 if (near == user)
                     continue;
-                if (_interactionSystem.InRangeUnobstructed(pos, near, 2f) && _container.IsInSameOrParentContainer(user, near))
+                if (_interactionSystem.InRangeUnobstructed(pos, near, 2f) && _container.IsInSameOrParentContainer((user, null), (near, null)))
                     yield return near;
             }
         }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -140,7 +140,7 @@ namespace Content.Server.Explosion.EntitySystems
 
         private void HandleShockTrigger(Entity<ShockOnTriggerComponent> shockOnTrigger, ref TriggerEvent args)
         {
-            if (!_container.TryGetContainingContainer(shockOnTrigger.Owner, out var container))
+            if (!_container.TryGetContainingContainer((shockOnTrigger.Owner, null), out var container))
                 return;
 
             var containerEnt = container.Owner;

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -229,7 +229,7 @@ public sealed class NPCUtilitySystem : EntitySystem
             }
             case TargetAccessibleCon:
             {
-                if (_container.TryGetContainingContainer(targetUid, out var container))
+                if (_container.TryGetContainingContainer((targetUid, null), out var container))
                 {
                     if (TryComp<EntityStorageComponent>(container.Owner, out var storageComponent))
                     {

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -72,7 +72,7 @@ namespace Content.Shared.Examine
             // Is the target hidden in a opaque locker or something? Currently this check allows players to examine
             // their organs, if they can somehow target them. Really this should be with userSeeInsideSelf: false, and a
             // separate check for if the item is in their inventory or hands.
-            if (_containerSystem.IsInSameOrTransparentContainer(examiner, entity, userSeeInsideSelf: true))
+            if (_containerSystem.IsInSameOrTransparentContainer((examiner, null), (entity, null), userSeeInsideSelf: true))
                 return true;
 
             // is it inside of an open storage (e.g., an open backpack)?

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -1326,7 +1326,7 @@ namespace Content.Shared.Interaction
             if (_strippable.IsStripHidden(slotDef, user))
                 return false;
 
-            return InRangeUnobstructed(user, wearer) && _containerSystem.IsInSameOrParentContainer(user, wearer);
+            return InRangeUnobstructed(user, wearer) && _containerSystem.IsInSameOrParentContainer((user, null), (wearer, null));
         }
 
         protected bool ValidateClientInput(

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -205,7 +205,7 @@ public abstract partial class InventorySystem
             itemUid = attachedComp.AttachedUid;
 
         // Can the actor reach the target?
-        if (actor != target && !(_interactionSystem.InRangeUnobstructed(actor, target) && _containerSystem.IsInSameOrParentContainer(actor, target)))
+        if (actor != target && !(_interactionSystem.InRangeUnobstructed(actor, target) && _containerSystem.IsInSameOrParentContainer((actor, null), (target, null))))
             return false;
 
         // Can the actor reach the item?

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -391,7 +391,7 @@ public sealed class PullingSystem : EntitySystem
             return false;
         }
 
-        if (!_containerSystem.IsInSameOrNoContainer(puller, pullableUid))
+        if (!_containerSystem.IsInSameOrNoContainer((puller, null), (pullableUid, null)))
         {
             return false;
         }

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -133,12 +133,12 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         args.Handled = true;
 
         // Hopefully AI never needs storage
-        if (_containers.TryGetContainingContainer(args.Target, out var targetContainer))
+        if (_containers.TryGetContainingContainer((args.Target, null), out var targetContainer))
         {
             return;
         }
 
-        if (!_containers.IsInSameOrTransparentContainer(args.User, args.Target, otherContainer: targetContainer))
+        if (!_containers.IsInSameOrTransparentContainer((args.User, null), (args.Target, null), otherContainer: targetContainer))
         {
             return;
         }

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -321,7 +321,7 @@ public abstract class SharedStorageSystem : EntitySystem
     public void OpenStorageUI(EntityUid uid, EntityUid actor, StorageComponent? storageComp = null, bool silent = true)
     {
         // Handle recursively opening nested storages.
-        if (ContainerSystem.TryGetContainingContainer(uid, out var container) &&
+        if (ContainerSystem.TryGetContainingContainer((uid, null), out var container) &&
             UI.IsUiOpen(container.Owner, StorageComponent.StorageUiKey.Key, actor))
         {
             _nestedCheck = true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Just as the title says.

## Why / Balance
Obsolete since space-wizards/RobustToolbox#5136

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
N/A
