### PR TITLE
Fixed Wizard Thrust

### DIFF
--- a/Resources/Maps/Shuttles/wizard.yml
+++ b/Resources/Maps/Shuttles/wizard.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 247.1.0
+  engineVersion: 248.0.2
   forkId: ""
   forkVersion: ""
-  time: 02/23/2025 10:35:57
-  entityCount: 791
+  time: 03/20/2025 07:20:18
+  entityCount: 793
 maps: []
 grids:
 - 768
@@ -1369,6 +1369,11 @@ entities:
     components:
     - type: Transform
       pos: 7.5,1.5
+      parent: 768
+  - uid: 793
+    components:
+    - type: Transform
+      pos: 5.5,4.5
       parent: 768
 - proto: CableHV
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
fixes #35934
## About the PR
The wizard shuttle's thrusting ability was being hampered by one missing LV cable. With the addition of one small length of wire, the wizard's shuttle should now generate thrust with the best of 'em!

## Why / Balance
Power is critical for the thrusters thrusting.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/0b0113db-8522-4d5c-8a64-261514ff1c25)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

