### PR TITLE
Give the Luxury Hardsuit back to the QM, Part 1.

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
@@ -9,11 +9,21 @@
   group: market
 
 - type: cargoProduct
-  id: CargoLuxuryHardsuit
+  id: CargoMiningHardsuit
   icon:
-    sprite: Clothing/Head/Hardsuits/luxury.rsi
+    sprite: Clothing/Head/Hardsuits/salvage.rsi
     state: icon
-  product: CrateCargoLuxuryHardsuit
+  product: CrateCargoMiningHardsuit
   cost: 15000
   category: cargoproduct-category-name-cargo
   group: market
+
+#- type: cargoProduct #Disabled until discussions finish of it being QM exclusive
+# id: CargoLuxuryHardsuit
+# icon:
+#   sprite: Clothing/Head/Hardsuits/Luxury.rsi
+#  state: icon
+# product: CrateCargoLuxuryHardsuit
+#  cost: 15000
+#  category: cargoproduct-category-name-cargo
+#  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
@@ -1,12 +1,22 @@
 - type: entity
-  id: CrateCargoLuxuryHardsuit
+  id: CrateCargoMiningHardsuit
   parent: CratePirate
-  name: luxury mining hardsuit crate
-  description: Finally, a hardsuit Quartermasters could call their own. Centcomm has heard you, now stop asking.
+  name: mining hardsuit crate
+  description: A hardsuit that can be used for both basic and advanced mining trips.
   components:
   - type: StorageFill
     contents:
-    - id: ClothingOuterHardsuitLuxury
+    - id: ClothingOuterHardsuitSalvage
+
+#- type: entity #Disabled until discussions finish of it being QM exclusive
+#  id: CrateCargoLuxuryHardsuit
+#  parent: CratePirate
+#  name: luxury mining hardsuit crate
+#  description: Finally, a hardsuit Quartermasters could call their own. Centcomm has heard you, now stop asking.
+#  components:
+#  - type: StorageFill
+#    contents:
+#    - id: ClothingOuterHardsuitLuxury
 
 - type: entity
   id: CrateCargoGambling

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -144,6 +144,21 @@
   - type: AccessReader
     access: [["Security"]]
 
+#QM's hardsuit
+- type: entity
+  id: SuitStorageQM
+  parent: SuitStorageBase
+  suffix: Quartermaster
+  components:
+  - type: StorageFill
+    contents:
+    - id: OxygenTankFilled
+    - id: ClothingOuterHardsuitLuxury
+    - id: ClothingMaskBreath
+  - type: AccessReader
+    access: [["Quartermaster"]]
+
+
 #CE's hardsuit
 - type: entity
   id: SuitStorageCE

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -484,11 +484,10 @@
 
 #Luxury Mining Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase
-  id: ClothingOuterHardsuitLuxury #DO NOT MAP - https://github.com/space-wizards/space-station-14/pull/19738#issuecomment-1703486738
+  parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
+  id: ClothingOuterHardsuitLuxury
   name: luxury mining hardsuit
   description: A refurbished mining hardsuit, fashioned after the Quartermaster's colors. Graphene lining provides less protection, but is much easier to move.
-  categories: [ DoNotMap ]
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/luxury.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I added the locker fill for the Luxury Hardsuit, to map in the QM's office on stations, gave it a command only contraband status, and replace the crate for the luxury hardsuit with a normal mining hardsuit. (I didn't want to map it in to the game with this PR, as iirc those are meant to be in seperate PRs. (Which is why this PR has Part 1 in the title)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I did this for a multitude of reasons, for the longest time the Quartermaster was the only command member (Besides HoP) without a specific hardsuit for them, even though there could be situations where they need a Hardsuit, such as if the cargo shuttle gets hit by meteors, or if the ATS has any vent critters in it, I answer more problems that would conflict with the original PR below
- Its an item meant to represent status. - Though that is true, there are better alternate options that could be used to represent wealth in cargo, such as grand lottery crates and maybe... a future crate containing gold items?
- The QM doesn't need a hardsuit, its a desk job. - Its much more than a desk job, especially if you are the only member of cargo on a low-pop shift, also.. the CMO has a hardsuit, and they don't need it because they stay in one room all shift.
- Its a joke item that's meant to show that the quartermaster barely counts as a command member.  - This joke is old and overused, the quartermaster is much more than a flashy cargo tech, they should be considered a member of command and have an easily accessible hardsuit like the rest of command. 

## Technical details
<!-- Summary of code changes for easier review. -->
Just a few simple changes, added a fill for it in suit storage, gave the original item contraband status, changed the original Luxury Suit crate to just a normal Mining Suit Crate.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Screenshot 2025-03-19 222632](https://github.com/user-attachments/assets/2df681d2-60b3-4505-8877-965fa97c40fc)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
🆑 
- tweak: The Luxury Hardsuit now spawns roundstart in the Quartermaster's room, along with it no longer being able to be bought from cargo.