### PR TITLE
Fix spray nozzle not cleaning reagents properly

### DIFF
--- a/Content.Server/Chemistry/Components/VaporComponent.cs
+++ b/Content.Server/Chemistry/Components/VaporComponent.cs
@@ -1,36 +1,37 @@
 ﻿using Robust.Shared.Map;
 
-namespace Content.Server.Chemistry.Components;
-
-[RegisterComponent]
-public sealed partial class VaporComponent : Component
+namespace Content.Server.Chemistry.Components
 {
-    public const string SolutionName = "vapor";
+    [RegisterComponent]
+    public sealed partial class VaporComponent : Component
+    {
+        public const string SolutionName = "vapor";
 
-    /// <summary>
-    /// Stores data on the previously reacted tile. We only want to do reaction checks once per tile.
-    /// </summary>
-    [DataField]
-    public TileRef? PreviousTileRef;
+        /// <summary>
+        /// Stores data on the previously reacted tile. We only want to do reaction checks once per tile.
+        /// </summary>
+        [DataField]
+        public TileRef? PreviousTileRef;
 
-    /// <summary>
-    /// Percentage of the reagent that is reacted with the TileReaction.
-    /// <example>
-    /// 0.5 = 50% of the reagent is reacted.
-    /// </example>
-    /// </summary>
-    [DataField]
-    public float TransferAmountPercentage;
+        /// <summary>
+        /// Percentage of the reagent that is reacted with the TileReaction.
+        /// <example>
+        /// 0.5 = 50% of the reagent is reacted.
+        /// </example>
+        /// </summary>
+        [DataField]
+        public float TransferAmountPercentage;
 
-    /// <summary>
-    /// The minimum amount of the reagent that will be reacted with the TileReaction.
-    /// We do this to prevent floating point issues. A reagent with a low percentage transfer amount will
-    /// transfer 0.01~ forever and never get deleted.
-    /// <remarks>Defaults to 0.05 if not defined, a good general value.</remarks>
-    /// </summary>
-    [DataField]
-    public float MinimumTransferAmount = 0.05f;
+        /// <summary>
+        /// The minimum amount of the reagent that will be reacted with the TileReaction.
+        /// We do this to prevent floating point issues. A reagent with a low percentage transfer amount will
+        /// transfer 0.01~ forever and never get deleted.
+        /// <remarks>Defaults to 0.05 if not defined, a good general value.</remarks>
+        /// </summary>
+        [DataField]
+        public float MinimumTransferAmount = 0.05f;
 
-    [DataField]
-    public bool Active;
+        [DataField]
+        public bool Active;
+    }
 }

--- a/Content.Server/Chemistry/Components/VaporComponent.cs
+++ b/Content.Server/Chemistry/Components/VaporComponent.cs
@@ -11,7 +11,6 @@ namespace Content.Server.Chemistry.Components
         /// <summary>
         /// Stores data on the previously reacted tile. We only want to do reaction checks once per tile.
         /// </summary>
-        [DataField]
         public TileRef PreviousTileRef;
 
         /// <summary>

--- a/Content.Server/Chemistry/Components/VaporComponent.cs
+++ b/Content.Server/Chemistry/Components/VaporComponent.cs
@@ -1,5 +1,4 @@
-﻿using Content.Shared.FixedPoint;
-using Robust.Shared.Map;
+﻿using Robust.Shared.Map;
 
 namespace Content.Server.Chemistry.Components
 {
@@ -11,7 +10,8 @@ namespace Content.Server.Chemistry.Components
         /// <summary>
         /// Stores data on the previously reacted tile. We only want to do reaction checks once per tile.
         /// </summary>
-        public TileRef PreviousTileRef;
+        [DataField]
+        public TileRef? PreviousTileRef;
 
         /// <summary>
         /// Percentage of the solution that is reacted with the TileReaction.

--- a/Content.Server/Chemistry/Components/VaporComponent.cs
+++ b/Content.Server/Chemistry/Components/VaporComponent.cs
@@ -7,11 +7,10 @@ namespace Content.Server.Chemistry.Components
     {
         public const string SolutionName = "vapor";
 
-        [DataField("transferAmount")]
-        public FixedPoint2 TransferAmount = FixedPoint2.New(0.5);
+        [DataField]
+        public FixedPoint2 TransferAmount = FixedPoint2.New(0.15);
 
-        public float ReactTimer;
-        [DataField("active")]
+        [DataField]
         public bool Active;
     }
 }

--- a/Content.Server/Chemistry/Components/VaporComponent.cs
+++ b/Content.Server/Chemistry/Components/VaporComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.FixedPoint;
+using Robust.Shared.Map;
 
 namespace Content.Server.Chemistry.Components
 {
@@ -7,8 +8,17 @@ namespace Content.Server.Chemistry.Components
     {
         public const string SolutionName = "vapor";
 
+        /// <summary>
+        /// Stores data on the previously reacted tile. We only want to do reaction checks once per tile.
+        /// </summary>
+        public TileRef PreviousTileRef;
+
+        /// <summary>
+        /// Percentage of the solution that is reacted with the TileReaction.
+        /// Ex: 0.5 = 50% reacts.
+        /// </summary>
         [DataField]
-        public FixedPoint2 TransferAmount = FixedPoint2.New(0.15);
+        public FixedPoint2 TransferAmount;
 
         [DataField]
         public bool Active;

--- a/Content.Server/Chemistry/Components/VaporComponent.cs
+++ b/Content.Server/Chemistry/Components/VaporComponent.cs
@@ -11,6 +11,7 @@ namespace Content.Server.Chemistry.Components
         /// <summary>
         /// Stores data on the previously reacted tile. We only want to do reaction checks once per tile.
         /// </summary>
+        [DataField]
         public TileRef PreviousTileRef;
 
         /// <summary>

--- a/Content.Server/Chemistry/Components/VaporComponent.cs
+++ b/Content.Server/Chemistry/Components/VaporComponent.cs
@@ -14,11 +14,22 @@ public sealed partial class VaporComponent : Component
     public TileRef? PreviousTileRef;
 
     /// <summary>
-    /// Percentage of the solution that is reacted with the TileReaction.
-    /// Ex: 0.5 = 50% reacts.
+    /// Percentage of the reagent that is reacted with the TileReaction.
+    /// <example>
+    /// 0.5 = 50% of the reagent is reacted.
+    /// </example>
     /// </summary>
     [DataField]
     public float TransferAmountPercentage;
+
+    /// <summary>
+    /// The minimum amount of the reagent that will be reacted with the TileReaction.
+    /// We do this to prevent floating point issues. A reagent with a low percentage transfer amount will
+    /// transfer 0.01~ forever and never get deleted.
+    /// <remarks>Defaults to 0.05 if not defined, a good general value.</remarks>
+    /// </summary>
+    [DataField]
+    public float MinimumTransferAmount = 0.05f;
 
     [DataField]
     public bool Active;

--- a/Content.Server/Chemistry/Components/VaporComponent.cs
+++ b/Content.Server/Chemistry/Components/VaporComponent.cs
@@ -18,7 +18,7 @@ namespace Content.Server.Chemistry.Components
         /// Ex: 0.5 = 50% reacts.
         /// </summary>
         [DataField]
-        public FixedPoint2 TransferAmount;
+        public float TransferAmountPercentage;
 
         [DataField]
         public bool Active;

--- a/Content.Server/Chemistry/Components/VaporComponent.cs
+++ b/Content.Server/Chemistry/Components/VaporComponent.cs
@@ -1,26 +1,25 @@
 ﻿using Robust.Shared.Map;
 
-namespace Content.Server.Chemistry.Components
+namespace Content.Server.Chemistry.Components;
+
+[RegisterComponent]
+public sealed partial class VaporComponent : Component
 {
-    [RegisterComponent]
-    public sealed partial class VaporComponent : Component
-    {
-        public const string SolutionName = "vapor";
+    public const string SolutionName = "vapor";
 
-        /// <summary>
-        /// Stores data on the previously reacted tile. We only want to do reaction checks once per tile.
-        /// </summary>
-        [DataField]
-        public TileRef? PreviousTileRef;
+    /// <summary>
+    /// Stores data on the previously reacted tile. We only want to do reaction checks once per tile.
+    /// </summary>
+    [DataField]
+    public TileRef? PreviousTileRef;
 
-        /// <summary>
-        /// Percentage of the solution that is reacted with the TileReaction.
-        /// Ex: 0.5 = 50% reacts.
-        /// </summary>
-        [DataField]
-        public float TransferAmountPercentage;
+    /// <summary>
+    /// Percentage of the solution that is reacted with the TileReaction.
+    /// Ex: 0.5 = 50% reacts.
+    /// </summary>
+    [DataField]
+    public float TransferAmountPercentage;
 
-        [DataField]
-        public bool Active;
-    }
+    [DataField]
+    public bool Active;
 }

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -41,7 +41,8 @@ namespace Content.Server.Chemistry.EntitySystems
 
         private void HandleCollide(Entity<VaporComponent> entity, ref StartCollideEvent args)
         {
-            if (!EntityManager.TryGetComponent(entity.Owner, out SolutionContainerManagerComponent? contents)) return;
+            if (!EntityManager.TryGetComponent(entity.Owner, out SolutionContainerManagerComponent? contents))
+                return;
 
             foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((entity.Owner, contents)))
             {
@@ -98,18 +99,17 @@ namespace Content.Server.Chemistry.EntitySystems
             {
                 foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((uid, container)))
                 {
-                    Update(frameTime, (uid, vaporComp), soln, xform);
+                    Update((uid, vaporComp), soln, xform);
                 }
             }
         }
 
-        private void Update(float frameTime, Entity<VaporComponent> ent, Entity<SolutionComponent> soln, TransformComponent xform)
+        private void Update(Entity<VaporComponent> ent, Entity<SolutionComponent> soln, TransformComponent xform)
         {
             var (entity, vapor) = ent;
             if (!vapor.Active)
                 return;
 
-            vapor.ReactTimer += frameTime;
 
             var contents = soln.Comp.Solution;
             if (vapor.ReactTimer >= ReactTime && TryComp(xform.GridUid, out MapGridComponent? gridComp))
@@ -119,7 +119,8 @@ namespace Content.Server.Chemistry.EntitySystems
                 var tile = _map.GetTileRef(xform.GridUid.Value, gridComp, xform.Coordinates);
                 foreach (var reagentQuantity in contents.Contents.ToArray())
                 {
-                    if (reagentQuantity.Quantity == FixedPoint2.Zero) continue;
+                    if (reagentQuantity.Quantity == FixedPoint2.Zero)
+                        continue;
                     var reagent = _protoManager.Index<ReagentPrototype>(reagentQuantity.Reagent.Prototype);
 
                     var reaction =

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -17,141 +17,153 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Spawners;
 using System.Numerics;
 
-namespace Content.Server.Chemistry.EntitySystems;
-
-[UsedImplicitly]
-internal sealed class VaporSystem : EntitySystem
+namespace Content.Server.Chemistry.EntitySystems
 {
-    [Dependency] private readonly IPrototypeManager _protoManager = default!;
-    [Dependency] private readonly SharedMapSystem _map = default!;
-    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
-    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
-    [Dependency] private readonly ThrowingSystem _throwing = default!;
-    [Dependency] private readonly ReactiveSystem _reactive = default!;
-    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
-
-    public override void Initialize()
+    [UsedImplicitly]
+    internal sealed class VaporSystem : EntitySystem
     {
-        base.Initialize();
+        [Dependency] private readonly IPrototypeManager _protoManager = default!;
+        [Dependency] private readonly SharedMapSystem _map = default!;
+        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+        [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
+        [Dependency] private readonly ThrowingSystem _throwing = default!;
+        [Dependency] private readonly ReactiveSystem _reactive = default!;
+        [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
 
-        SubscribeLocalEvent<VaporComponent, StartCollideEvent>(HandleCollide);
-    }
-
-    private void HandleCollide(Entity<VaporComponent> entity, ref StartCollideEvent args)
-    {
-        if (!EntityManager.TryGetComponent(entity.Owner, out SolutionContainerManagerComponent? contents)) return;
-
-        foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((entity.Owner, contents)))
+        public override void Initialize()
         {
-            var solution = soln.Comp.Solution;
-            _reactive.DoEntityReaction(args.OtherEntity, solution, ReactionMethod.Touch);
+            base.Initialize();
+
+            SubscribeLocalEvent<VaporComponent, StartCollideEvent>(HandleCollide);
         }
 
-        // Check for collision with a impassable object (e.g. wall) and stop
-        if ((args.OtherFixture.CollisionLayer & (int) CollisionGroup.Impassable) != 0 && args.OtherFixture.Hard)
+        private void HandleCollide(Entity<VaporComponent> entity, ref StartCollideEvent args)
         {
-            EntityManager.QueueDeleteEntity(entity);
-        }
-    }
+            if (!EntityManager.TryGetComponent(entity.Owner, out SolutionContainerManagerComponent? contents))
+                return;
 
-    public void Start(Entity<VaporComponent> vapor, TransformComponent vaporXform, Vector2 dir, float speed, MapCoordinates target, float aliveTime, EntityUid? user = null)
-    {
-        vapor.Comp.Active = true;
-        var despawn = EnsureComp<TimedDespawnComponent>(vapor);
-        despawn.Lifetime = aliveTime;
-
-        // Set Move
-        if (EntityManager.TryGetComponent(vapor, out PhysicsComponent? physics))
-        {
-            _physics.SetLinearDamping(vapor, physics, 0f);
-            _physics.SetAngularDamping(vapor, physics, 0f);
-
-            _throwing.TryThrow(vapor, dir, speed, user: user);
-
-            var distance = (target.Position - _transformSystem.GetWorldPosition(vaporXform)).Length();
-            var time = (distance / physics.LinearVelocity.Length());
-            despawn.Lifetime = MathF.Min(aliveTime, time);
-        }
-    }
-
-    internal bool TryAddSolution(Entity<VaporComponent> vapor, Solution solution)
-    {
-        if (solution.Volume == 0)
-        {
-            return false;
-        }
-        if (!_solutionContainerSystem.TryGetSolution(vapor.Owner, VaporComponent.SolutionName, out var vaporSolution))
-        {
-            return false;
-        }
-
-        return _solutionContainerSystem.TryAddSolution(vaporSolution.Value, solution);
-    }
-
-    public override void Update(float frameTime)
-    {
-        base.Update(frameTime);
-
-        // Enumerate over all VaporComponents
-        var query = EntityQueryEnumerator<VaporComponent, SolutionContainerManagerComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out var vaporComp, out var container, out var xform))
-        {
-            // Return early if we're not active
-            if (!vaporComp.Active)
-                continue;
-
-            // Get the current location of the vapor entity first
-            if (TryComp(xform.GridUid, out MapGridComponent? gridComp))
+            foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((entity.Owner, contents)))
             {
-                var tile = _map.GetTileRef(xform.GridUid.Value, gridComp, xform.Coordinates);
+                var solution = soln.Comp.Solution;
+                _reactive.DoEntityReaction(args.OtherEntity, solution, ReactionMethod.Touch);
+            }
 
-                // Check if the tile is a tile we've reacted with previously. If so, skip it.
-                // If we have no previous tile reference, we don't return so we can save one.
-                if (vaporComp.PreviousTileRef != null && tile == vaporComp.PreviousTileRef)
+            // Check for collision with a impassable object (e.g. wall) and stop
+            if ((args.OtherFixture.CollisionLayer & (int)CollisionGroup.Impassable) != 0 && args.OtherFixture.Hard)
+            {
+                EntityManager.QueueDeleteEntity(entity);
+            }
+        }
+
+        public void Start(Entity<VaporComponent> vapor,
+            TransformComponent vaporXform,
+            Vector2 dir,
+            float speed,
+            MapCoordinates target,
+            float aliveTime,
+            EntityUid? user = null)
+        {
+            vapor.Comp.Active = true;
+            var despawn = EnsureComp<TimedDespawnComponent>(vapor);
+            despawn.Lifetime = aliveTime;
+
+            // Set Move
+            if (EntityManager.TryGetComponent(vapor, out PhysicsComponent? physics))
+            {
+                _physics.SetLinearDamping(vapor, physics, 0f);
+                _physics.SetAngularDamping(vapor, physics, 0f);
+
+                _throwing.TryThrow(vapor, dir, speed, user: user);
+
+                var distance = (target.Position - _transformSystem.GetWorldPosition(vaporXform)).Length();
+                var time = (distance / physics.LinearVelocity.Length());
+                despawn.Lifetime = MathF.Min(aliveTime, time);
+            }
+        }
+
+        internal bool TryAddSolution(Entity<VaporComponent> vapor, Solution solution)
+        {
+            if (solution.Volume == 0)
+            {
+                return false;
+            }
+
+            if (!_solutionContainerSystem.TryGetSolution(vapor.Owner,
+                    VaporComponent.SolutionName,
+                    out var vaporSolution))
+            {
+                return false;
+            }
+
+            return _solutionContainerSystem.TryAddSolution(vaporSolution.Value, solution);
+        }
+
+        public override void Update(float frameTime)
+        {
+            base.Update(frameTime);
+
+            // Enumerate over all VaporComponents
+            var query = EntityQueryEnumerator<VaporComponent, SolutionContainerManagerComponent, TransformComponent>();
+            while (query.MoveNext(out var uid, out var vaporComp, out var container, out var xform))
+            {
+                // Return early if we're not active
+                if (!vaporComp.Active)
                     continue;
 
-                // Enumerate over all the reagents in the vapor entity solution
-                foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((uid, container)))
+                // Get the current location of the vapor entity first
+                if (TryComp(xform.GridUid, out MapGridComponent? gridComp))
                 {
-                    // Iterate over the reagents in the solution
-                    // Reason: Each reagent in our solution may have a unique TileReaction
-                    // In this instance, we check individually for each reagent's TileReaction
-                    // This is not doing chemical reactions!
-                    var contents = soln.Comp.Solution;
-                    foreach (var reagentQuantity in contents.Contents.ToArray())
+                    var tile = _map.GetTileRef(xform.GridUid.Value, gridComp, xform.Coordinates);
+
+                    // Check if the tile is a tile we've reacted with previously. If so, skip it.
+                    // If we have no previous tile reference, we don't return so we can save one.
+                    if (vaporComp.PreviousTileRef != null && tile == vaporComp.PreviousTileRef)
+                        continue;
+
+                    // Enumerate over all the reagents in the vapor entity solution
+                    foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((uid, container)))
                     {
-                        // Check if the reagent is empty
-                        if (reagentQuantity.Quantity == FixedPoint2.Zero)
-                            continue;
+                        // Iterate over the reagents in the solution
+                        // Reason: Each reagent in our solution may have a unique TileReaction
+                        // In this instance, we check individually for each reagent's TileReaction
+                        // This is not doing chemical reactions!
+                        var contents = soln.Comp.Solution;
+                        foreach (var reagentQuantity in contents.Contents.ToArray())
+                        {
+                            // Check if the reagent is empty
+                            if (reagentQuantity.Quantity == FixedPoint2.Zero)
+                                continue;
 
-                        var reagent = _protoManager.Index<ReagentPrototype>(reagentQuantity.Reagent.Prototype);
+                            var reagent = _protoManager.Index<ReagentPrototype>(reagentQuantity.Reagent.Prototype);
 
-                        // Limit the reaction amount to a minimum value to ensure no floating point funnies.
-                        // Ex: A solution with a low percentage transfer amount will slowly approach 0.01... and never get deleted
-                        var clampedAmount = Math.Max(
-                            (float)reagentQuantity.Quantity * vaporComp.TransferAmountPercentage,
-                            vaporComp.MinimumTransferAmount);
+                            // Limit the reaction amount to a minimum value to ensure no floating point funnies.
+                            // Ex: A solution with a low percentage transfer amount will slowly approach 0.01... and never get deleted
+                            var clampedAmount = Math.Max(
+                                (float)reagentQuantity.Quantity * vaporComp.TransferAmountPercentage,
+                                vaporComp.MinimumTransferAmount);
 
-                        // Preform the reagent's TileReaction
-                        var reaction =
-                            reagent.ReactionTile(tile,
-                                clampedAmount,
-                                EntityManager,
-                                reagentQuantity.Reagent.Data);
+                            // Preform the reagent's TileReaction
+                            var reaction =
+                                reagent.ReactionTile(tile,
+                                    clampedAmount,
+                                    EntityManager,
+                                    reagentQuantity.Reagent.Data);
 
-                        if (reaction > reagentQuantity.Quantity)
-                            reaction = reagentQuantity.Quantity;
+                            if (reaction > reagentQuantity.Quantity)
+                                reaction = reagentQuantity.Quantity;
 
-                        _solutionContainerSystem.RemoveReagent(soln, reagentQuantity.Reagent, reaction);
+                            _solutionContainerSystem.RemoveReagent(soln, reagentQuantity.Reagent, reaction);
+                        }
+
+                        // Delete the vapor entity if it has no contents
+                        if (contents.Volume == 0)
+                            EntityManager.QueueDeleteEntity(uid);
+
                     }
 
-                    // Delete the vapor entity if it has no contents
-                    if (contents.Volume == 0)
-                        EntityManager.QueueDeleteEntity(uid);
-
+                    // Set the previous tile reference to the current tile
+                    vaporComp.PreviousTileRef = tile;
                 }
-                // Set the previous tile reference to the current tile
-                vaporComp.PreviousTileRef = tile;
             }
         }
     }

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -39,8 +39,7 @@ namespace Content.Server.Chemistry.EntitySystems
 
         private void HandleCollide(Entity<VaporComponent> entity, ref StartCollideEvent args)
         {
-            if (!EntityManager.TryGetComponent(entity.Owner, out SolutionContainerManagerComponent? contents))
-                return;
+            if (!EntityManager.TryGetComponent(entity.Owner, out SolutionContainerManagerComponent? contents)) return;
 
             foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((entity.Owner, contents)))
             {

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -107,6 +107,10 @@ namespace Content.Server.Chemistry.EntitySystems
                 {
                     var tile = _map.GetTileRef(xform.GridUid.Value, gridComp, xform.Coordinates);
 
+                    // Check if the tile is a tile we've reacted with previously. If so, skip it.
+                    if (tile == vaporComp.PreviousTileRef)
+                        return;
+
                     // Enumerate over all the reagents in the vapor entity solution
                     foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((uid, container)))
                     {
@@ -126,16 +130,14 @@ namespace Content.Server.Chemistry.EntitySystems
                             // Preform the reagent's TileReaction
                             var reaction =
                                 reagent.ReactionTile(tile,
-                                    reagentQuantity.Quantity / vaporComp.TransferAmount,
+                                    reagentQuantity.Quantity * vaporComp.TransferAmount,
                                     EntityManager,
                                     reagentQuantity.Reagent.Data);
 
-                            if (reaction > reagentQuantity.Quantity)
-                            {
-                                Log.Error(
-                                    $"Tried to tile react more than we have for reagent {reagentQuantity}. Found {reaction} and we only have {reagentQuantity.Quantity}");
-                                reaction = reagentQuantity.Quantity;
-                            }
+                            // if (reaction > reagentQuantity.Quantity)
+                            // {
+                            //     reaction = reagentQuantity.Quantity;
+                            // }
 
                             _solutionContainerSystem.RemoveReagent(soln, reagentQuantity.Reagent, reaction);
                         }
@@ -146,6 +148,8 @@ namespace Content.Server.Chemistry.EntitySystems
                             EntityManager.QueueDeleteEntity(uid);
                         }
                     }
+                    // Set the previous tile reference to the current tile
+                    vaporComp.PreviousTileRef = tile;
                 }
             }
         }

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -104,7 +104,8 @@ internal sealed class VaporSystem : EntitySystem
                 var tile = _map.GetTileRef(xform.GridUid.Value, gridComp, xform.Coordinates);
 
                 // Check if the tile is a tile we've reacted with previously. If so, skip it.
-                if (tile == vaporComp.PreviousTileRef)
+                // If we have no previous tile reference, we don't return so we can save one.
+                if (vaporComp.PreviousTileRef != null && tile == vaporComp.PreviousTileRef)
                     return;
 
                 // Enumerate over all the reagents in the vapor entity solution

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -134,10 +134,10 @@ namespace Content.Server.Chemistry.EntitySystems
                                     EntityManager,
                                     reagentQuantity.Reagent.Data);
 
-                            // if (reaction > reagentQuantity.Quantity)
-                            // {
-                            //     reaction = reagentQuantity.Quantity;
-                            // }
+                            if (reaction > reagentQuantity.Quantity)
+                            {
+                                reaction = reagentQuantity.Quantity;
+                            }
 
                             _solutionContainerSystem.RemoveReagent(soln, reagentQuantity.Reagent, reaction);
                         }

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -124,10 +124,16 @@ internal sealed class VaporSystem : EntitySystem
 
                         var reagent = _protoManager.Index<ReagentPrototype>(reagentQuantity.Reagent.Prototype);
 
+                        // Limit the reaction amount to a minimum value to ensure no floating point funnies.
+                        // Ex: A solution with a low percentage transfer amount will slowly approach 0.01... and never get deleted
+                        var clampedAmount = Math.Max(
+                            (float)reagentQuantity.Quantity * vaporComp.TransferAmountPercentage,
+                            vaporComp.MinimumTransferAmount);
+
                         // Preform the reagent's TileReaction
                         var reaction =
                             reagent.ReactionTile(tile,
-                                reagentQuantity.Quantity * vaporComp.TransferAmountPercentage,
+                                clampedAmount,
                                 EntityManager,
                                 reagentQuantity.Reagent.Data);
 

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -78,14 +78,10 @@ internal sealed class VaporSystem : EntitySystem
     internal bool TryAddSolution(Entity<VaporComponent> vapor, Solution solution)
     {
         if (solution.Volume == 0)
-        {
             return false;
-        }
 
         if (!_solutionContainerSystem.TryGetSolution(vapor.Owner, VaporComponent.SolutionName, out var vaporSolution))
-        {
             return false;
-        }
 
         return _solutionContainerSystem.TryAddSolution(vaporSolution.Value, solution);
     }
@@ -130,23 +126,20 @@ internal sealed class VaporSystem : EntitySystem
                         // Preform the reagent's TileReaction
                         var reaction =
                             reagent.ReactionTile(tile,
-                                reagentQuantity.Quantity * vaporComp.TransferAmount,
+                                reagentQuantity.Quantity * vaporComp.TransferAmountPercentage,
                                 EntityManager,
                                 reagentQuantity.Reagent.Data);
 
                         if (reaction > reagentQuantity.Quantity)
-                        {
                             reaction = reagentQuantity.Quantity;
-                        }
 
                         _solutionContainerSystem.RemoveReagent(soln, reagentQuantity.Reagent, reaction);
                     }
 
+                    // Delete the vapor entity if it has no contents
                     if (contents.Volume == 0)
-                    {
-                        // Delete the vapor entity if it has no contents
                         EntityManager.QueueDeleteEntity(uid);
-                    }
+
                 }
                 // Set the previous tile reference to the current tile
                 vaporComp.PreviousTileRef = tile;

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -39,8 +39,7 @@ internal sealed class VaporSystem : EntitySystem
 
     private void HandleCollide(Entity<VaporComponent> entity, ref StartCollideEvent args)
     {
-        if (!EntityManager.TryGetComponent(entity.Owner, out SolutionContainerManagerComponent? contents))
-            return;
+        if (!EntityManager.TryGetComponent(entity.Owner, out SolutionContainerManagerComponent? contents)) return;
 
         foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((entity.Owner, contents)))
         {
@@ -78,10 +77,13 @@ internal sealed class VaporSystem : EntitySystem
     internal bool TryAddSolution(Entity<VaporComponent> vapor, Solution solution)
     {
         if (solution.Volume == 0)
+        {
             return false;
-
+        }
         if (!_solutionContainerSystem.TryGetSolution(vapor.Owner, VaporComponent.SolutionName, out var vaporSolution))
+        {
             return false;
+        }
 
         return _solutionContainerSystem.TryAddSolution(vaporSolution.Value, solution);
     }
@@ -96,7 +98,7 @@ internal sealed class VaporSystem : EntitySystem
         {
             // Return early if we're not active
             if (!vaporComp.Active)
-                return;
+                continue;
 
             // Get the current location of the vapor entity first
             if (TryComp(xform.GridUid, out MapGridComponent? gridComp))
@@ -106,7 +108,7 @@ internal sealed class VaporSystem : EntitySystem
                 // Check if the tile is a tile we've reacted with previously. If so, skip it.
                 // If we have no previous tile reference, we don't return so we can save one.
                 if (vaporComp.PreviousTileRef != null && tile == vaporComp.PreviousTileRef)
-                    return;
+                    continue;
 
                 // Enumerate over all the reagents in the vapor entity solution
                 foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((uid, container)))

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -28,7 +28,7 @@
     transferAmount: 100
   - type: UseDelay
   - type: Spray
-    transferAmount: 10
+    TransferAmountPercentage: 10
     pushbackAmount: 60
     spraySound:
       path: /Audio/Effects/extinguish.ogg

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -28,7 +28,7 @@
     transferAmount: 100
   - type: UseDelay
   - type: Spray
-    TransferAmountPercentage: 10
+    TransferAmountPercentage: 1
     pushbackAmount: 60
     spraySound:
       path: /Audio/Effects/extinguish.ogg

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -28,7 +28,7 @@
     transferAmount: 100
   - type: UseDelay
   - type: Spray
-    TransferAmountPercentage: 1
+    transferAmount: 10
     pushbackAmount: 60
     spraySound:
       path: /Audio/Effects/extinguish.ogg

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -99,8 +99,8 @@
   - type: Tag
     tags:
       - Spray
-# Vapor
 
+# Vapor
 - type: entity
   id: Vapor
   name: "vapor"
@@ -111,6 +111,7 @@
       vapor:
         maxVol: 50
   - type: Vapor
+    transferAmount: 0.5
   - type: AnimationPlayer
   - type: Sprite
     sprite: Effects/chempuff.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -111,7 +111,7 @@
       vapor:
         maxVol: 50
   - type: Vapor
-    transferAmount: 0.5
+    TransferAmountPercentage: 0.5
   - type: AnimationPlayer
   - type: Sprite
     sprite: Effects/chempuff.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -111,7 +111,8 @@
       vapor:
         maxVol: 50
   - type: Vapor
-    TransferAmountPercentage: 0.5
+    active: true
+    transferAmountPercentage: 0.5
   - type: AnimationPlayer
   - type: Sprite
     sprite: Effects/chempuff.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -874,6 +874,7 @@
         - BulletImpassable
   - type: Vapor
     active: true
+    transferAmount: 0.5
   - type: Appearance
   - type: VaporVisuals
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -874,7 +874,7 @@
         - BulletImpassable
   - type: Vapor
     active: true
-    transferAmount: 0.5
+    TransferAmountPercentage: 0.5
   - type: Appearance
   - type: VaporVisuals
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -874,7 +874,7 @@
         - BulletImpassable
   - type: Vapor
     active: true
-    TransferAmountPercentage: 0.5
+    transferAmountPercentage: 0.5
   - type: Appearance
   - type: VaporVisuals
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -874,7 +874,7 @@
         - BulletImpassable
   - type: Vapor
     active: true
-    transferAmountPercentage: 0.5
+    transferAmountPercentage: 1
   - type: Appearance
   - type: VaporVisuals
 


### PR DESCRIPTION
## About the PR
Fixes the spray nozzle / backpack water tank not properly cleaning puddles.

Fixes #35246.

## Why / Balance
It was broken! This makes the spray work a lot better and makes this tech finally appetizing for janitor players.

## Technical details
Old code was very weird, but it was made by Sloth so it was probably made like that for a good reason. In summary:
- Wraps everything into one Update loop.
- Removes the previous fixed timer for only calling for collision checks every 0.125 seconds. This is what caused the previous bug.
- Moved checks around so that cheap checks happen first before expensive ones.
- Added a check so that we only preform solution cleaning logic on one tile only. This can be changed if necessary but I found it helpful to avoid buggy behavior.

At a high level:
- Code iterates over all entities that have a `VaporComponent`
- We pull info about the entity including its current position, solution component, etc.
- For every reagent contained in the solution, we do a tile reaction with the tile we're currently on, by a certain defined percentage. This is customizable by `vaporComp.TransferAmount`.
- If we don't have enough reagent left to complete the next reaction, then we only react with how much we have.
- Remove what we reacted from the solution.
- If there's no more reagents in the shot, delete it.
- Save the previously ran tile for a future comparison (we only want to run our logic for one tile).

## Media
![Content Client_k6ojXp8Svh](https://github.com/user-attachments/assets/0f16046d-c2de-4531-8774-a8c5be1d9297)

(Newer addition)
![Content Client_ABKoakvr8e](https://github.com/user-attachments/assets/dbed8203-8d6d-4459-a2b7-0b19c79b9add)

That was a whole welding tank worth of mess cleaned in like 15 seconds!

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Fixed backpack water tanks (spray nozzle) projectiles not properly cleaning up puddles.