### PR TITLE
[April fools] Better stamps

### DIFF
--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -140,8 +140,9 @@ public sealed class PaperSystem : EntitySystem
         }
 
         // If a stamp, attempt to stamp paper
-        if (TryComp<StampComponent>(args.Used, out var stampComp) && TryStamp(entity, GetStampInfo(stampComp), stampComp.StampState))
+        if (TryComp<StampComponent>(args.Used, out var stampComp))
         {
+            SetContent(entity, Loc.GetString("paper-component-action-stamp-paper-paperwork-is-bad"));
             // successfully stamped, play popup
             var stampPaperOtherMessage = Loc.GetString("paper-component-action-stamp-paper-other",
                     ("user", args.User),

--- a/Resources/Locale/en-US/paper/paper-component.ftl
+++ b/Resources/Locale/en-US/paper/paper-component.ftl
@@ -10,8 +10,9 @@ paper-component-examine-detail-stamped-by = {CAPITALIZE(THE($paper))} {CONJUGATE
 paper-component-illiterate = You are unable to write.
 paper-component-illiterate-mime = Your vow forbids you from writing.
 
-paper-component-action-stamp-paper-other = {CAPITALIZE(THE($user))} stamps {THE($target)} with {THE($stamp)}.
-paper-component-action-stamp-paper-self = You stamp {THE($target)} with {THE($stamp)}.
+paper-component-action-stamp-paper-other = {CAPITALIZE(THE($user))} stamps {THE($target)} with {THE($stamp)}... But something wrong...
+paper-component-action-stamp-paper-self = You stamp {THE($target)} with {THE($stamp)}... But something wrong...
+paper-component-action-stamp-paper-paperwork-is-bad = Paperwork sucks.
 
 # Indicator to show how full a paper is
 paper-ui-fill-level = {$currentLength}/{$maxLength}


### PR DESCRIPTION
## About the PR
Stamps now make documents better

## Why / Balance
Paperwork is probably greatest part of space station. And its PR make it better.

## Media
https://github.com/user-attachments/assets/f3299954-368c-400e-b6b9-245c46adb008

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
Hidden gem mechanic, no player facing