### PR TITLE
Jigger transfer amount

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
@@ -140,6 +140,10 @@
     solutions:
       drink:
         maxVol: 20
+  - type: SolutionTransfer
+    canChangeTransferAmount: true
+    minTransferAmount: 1
+    maxTransferAmount: 20
   - type: MixableSolution
     solution: drink
   - type: FitsInDispenser


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed jigger min transfer amount to 1 and max to 20, so it mathces maximum capacity.

## Why / Balance
Descripition of jugger says: "... Used to control the amount of ingredients.", so how does it works with the same amout of transfer as glass, shaker or bucket? Glass will be more usefull that jigger. By this PR, its wil be more balaced, so your can more precisely "control ammount of ingredients" but still have less solution container.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed max and minimum amount of jigger transfer amount
