### PR TITLE
World target EMP implants

### DIFF
--- a/Content.Server/Implants/SubdermalImplantSystem.cs
+++ b/Content.Server/Implants/SubdermalImplantSystem.cs
@@ -4,13 +4,15 @@ using Content.Server.Cuffs;
 using Content.Server.Emp;
 using Content.Server.Forensics;
 using Content.Server.Humanoid;
+using Content.Server.IdentityManagement;
 using Content.Server.Implants.Components;
 using Content.Server.Store.Components;
 using Content.Server.Store.Systems;
 
 using Content.Shared.Cuffs.Components;
-using Content.Shared.Forensics;
+using Content.Shared.DetailExaminable;
 using Content.Shared.Forensics.Components;
+using Content.Shared.Forensics;
 using Content.Shared.Humanoid;
 using Content.Shared.Implants.Components;
 using Content.Shared.Implants;
@@ -29,14 +31,6 @@ using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Random;
-using System.Numerics;
-using Content.Shared.Movement.Pulling.Components;
-using Content.Shared.Movement.Pulling.Systems;
-using Content.Server.IdentityManagement;
-using Content.Shared.DetailExaminable;
-using Content.Shared.Store.Components;
-using Robust.Shared.Collections;
-using Robust.Shared.Map.Components;
 
 namespace Content.Server.Implants;
 
@@ -48,6 +42,7 @@ public sealed class SubdermalImplantSystem : SharedSubdermalImplantSystem
     [Dependency] private readonly ForensicsSystem _forensicsSystem = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoidAppearance = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IdentitySystem _identity = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly PullingSystem _pullingSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -55,7 +50,6 @@ public sealed class SubdermalImplantSystem : SharedSubdermalImplantSystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedTransformSystem _xform = default!;
     [Dependency] private readonly StoreSystem _store = default!;
-    [Dependency] private readonly IdentitySystem _identity = default!;
 
     private EntityQuery<PhysicsComponent> _physicsQuery;
     private HashSet<Entity<MapGridComponent>> _targetGrids = [];

--- a/Content.Shared/Implants/Components/SubdermalImplantComponent.cs
+++ b/Content.Shared/Implants/Components/SubdermalImplantComponent.cs
@@ -96,3 +96,8 @@ public sealed partial class UseDnaScramblerImplantEvent : InstantActionEvent
 {
 
 }
+
+public sealed partial class UseEmpImplantEvent : WorldTargetActionEvent
+{
+
+}

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -119,18 +119,20 @@
 - type: entity
   id: ActionActivateEmpImplant
   name: Activate EMP
-  description: Triggers a small EMP pulse around you
+  description: Triggers a small EMP pulse around chosen place.
   components:
-  - type: InstantAction
-    checkCanInteract: false
-    charges: 3
-    useDelay: 5
-    itemIconStyle: BigAction
-    priority: -20
+  - type: WorldTargetAction
     icon:
       sprite: Objects/Weapons/Grenades/empgrenade.rsi
       state: icon
-    event: !type:ActivateImplantEvent
+    itemIconStyle: BigAction
+    charges: 3
+    useDelay: 5
+    priority: -20
+    event: !type:UseEmpImplantEvent
+    checkCanAccess: false
+    checkCanInteract: false
+    range: 0
 
 - type: entity
   id: ActionActivateScramImplant

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -183,7 +183,6 @@
   components:
     - type: SubdermalImplant
       implantAction: ActionActivateEmpImplant
-    - type: TriggerImplantAction
     - type: EmpOnTrigger
       range: 2.75
       energyConsumption: 50000


### PR DESCRIPTION
## About the PR
EMP implant action is now world-target.

## Why / Balance
Right now only thing that can be used against stan-meta is a EMP stuff. And we have EMP implanters that fully useless against any kind of disablers. This PR allows use EMP implanters on a long range.

## Media
https://github.com/user-attachments/assets/6a6ea32a-7fd5-49e2-bfc3-656eb6813300

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: EMP implant action is now require target and can be used on distant range.