### PR TITLE
Fix thermal regulation

### DIFF
--- a/Content.Server/Body/Systems/ThermalRegulatorSystem.cs
+++ b/Content.Server/Body/Systems/ThermalRegulatorSystem.cs
@@ -51,6 +51,7 @@ public sealed class ThermalRegulatorSystem : EntitySystem
         if (!Resolve(ent, ref ent.Comp2, logMissing: false))
             return;
 
+        // TODO: Why do we have two datafields for this if they are only ever used once here?
         var totalMetabolismTempChange = ent.Comp1.MetabolismHeat - ent.Comp1.RadiatedHeat;
 
         // implicit heat regulation
@@ -74,7 +75,7 @@ public sealed class ThermalRegulatorSystem : EntitySystem
 
         // if body temperature is not within comfortable, thermal regulation
         // processes starts
-        if (tempDiff > ent.Comp1.ThermalRegulationTemperatureThreshold)
+        if (tempDiff < ent.Comp1.ThermalRegulationTemperatureThreshold)
             return;
 
         if (ent.Comp2.CurrentTemperature > ent.Comp1.NormalBodyTemperature)


### PR DESCRIPTION
## About the PR
Taken from https://github.com/space-wizards/space-station-14/pull/35020, the credit goes to shibechef.
That PR included other changes and the author closed it themselves.
Turns out sweating and shivering never worked before, this PR fixes it.

## Why / Balance
you don't turn into ash as easily anymore

## Technical details
The guard statement condition was inversed, meaning you were only sweating or shivering when the temperature difference was below the threshold, not above it. This means you can now easier recover from extreme temperatures.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**

:cl: shibechef
- fix: Bodies can now thermally regulate themselves again.

