### PR TITLE
Rename Laser Rifle to Laser Carbine

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -199,10 +199,10 @@
   - type: Appearance
 
 - type: entity
-  name: practice laser rifle
+  name: practice laser carbine
   parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponLaserCarbinePractice
-  description: This modified laser rifle fires nearly harmless beams in the 40-watt range, for target practice.
+  description: This modified laser carbine fires nearly harmless beams in the 40-watt range, for target practice.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
@@ -230,7 +230,7 @@
     price: 300
 
 - type: entity
-  name: laser rifle
+  name: laser carbine
   parent: [WeaponLaserCarbinePractice, BaseGunWieldable, BaseSecurityContraband]
   id: WeaponLaserCarbine
   description: Favoured by Nanotrasen Security for being cheap and easy to use.


### PR DESCRIPTION
## About the PR
Updated the name of the laser rifle to laser carbine. Also did this to the practice laser rifle.

## Why / Balance
Renaming it makes it match the pulse carbine vs pulse rifle difference more closely, and also its own internal name (which is laser carbine). In addition, the word rifle refers to barrel rifling which the laser rifle does not have as far as we know.

## Technical details
Just changed two visual names, nothing complex.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Nox38
- tweak: Renamed 'Laser Rifle' to 'Laser Carbine'
