### PR TITLE
Improve paradox clone item copying

### DIFF
--- a/Content.Server/Cloning/CloningSystem.Subscriptions.cs
+++ b/Content.Server/Cloning/CloningSystem.Subscriptions.cs
@@ -1,0 +1,69 @@
+using Content.Server.Forensics;
+using Content.Shared.Cloning.Events;
+using Content.Shared.FixedPoint;
+using Content.Shared.Labels.Components;
+using Content.Shared.Labels.EntitySystems;
+using Content.Shared.Stacks;
+using Content.Shared.Store;
+using Content.Shared.Store.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Cloning;
+
+/// <summary>
+///     The part of item cloning responsible for copying over important components.
+///     This is used for <see cref="CopyItem"/>.
+///     Anything not copied over here gets reverted to the values the item had in its prototype.
+/// </summary>
+/// <remarks>
+///     This method of copying items is of course not perfect as we cannot clone every single component, which would be pretty much impossible with our ECS.
+///     We only consider the most important components so the paradox clone gets similar equipment.
+///     This method of using subscriptions was chosen to make it easy for forks to add their own custom components that need to be copied.
+/// </remarks>
+public sealed partial class CloningSystem : EntitySystem
+{
+    [Dependency] private readonly SharedStackSystem _stack = default!;
+    [Dependency] private readonly SharedLabelSystem _label = default!;
+    [Dependency] private readonly ForensicsSystem _forensics = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StackComponent, CloningItemEvent>(OnCloneStack);
+        SubscribeLocalEvent<LabelComponent, CloningItemEvent>(OnCloneLabel);
+        SubscribeLocalEvent<ForensicsComponent, CloningItemEvent>(OnCloneForensics);
+        SubscribeLocalEvent<StoreComponent, CloningItemEvent>(OnCloneStore);
+    }
+
+    private void OnCloneStack(Entity<StackComponent> ent, ref CloningItemEvent args)
+    {
+        // if the clone is a stack as well, adjust the count of the copy
+        if (TryComp<StackComponent>(args.CloneUid, out var cloneStackComp))
+            _stack.SetCount(args.CloneUid, ent.Comp.Count, cloneStackComp);
+    }
+
+    private void OnCloneLabel(Entity<LabelComponent> ent, ref CloningItemEvent args)
+    {
+        // copy the label
+        _label.Label(args.CloneUid, ent.Comp.CurrentLabel);
+    }
+
+    private void OnCloneForensics(Entity<ForensicsComponent> ent, ref CloningItemEvent args)
+    {
+        // copy any forensics to the cloned item
+        _forensics.CopyForensicsFrom(ent.Comp, args.CloneUid);
+    }
+
+    private void OnCloneStore(Entity<StoreComponent> ent, ref CloningItemEvent args)
+    {
+        // copy the current amount of currency in the store
+        // at the moment this takes care of uplink implants and the portable nukie uplinks
+        // turning a copied pda into an uplink will need some refactoring first
+        if (TryComp<StoreComponent>(args.CloneUid, out var cloneStoreComp))
+        {
+            cloneStoreComp.Balance = new Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2>(ent.Comp.Balance);
+        }
+    }
+
+}

--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -138,6 +138,11 @@ namespace Content.Server.Forensics
             {
                 dest.Fingerprints.Add(print);
             }
+
+            foreach (var residue in src.Residues)
+            {
+                dest.Residues.Add(residue);
+            }
         }
 
         public List<string> GetSolutionsDNA(EntityUid uid)

--- a/Content.Shared/Cloning/CloningEvents.cs
+++ b/Content.Shared/Cloning/CloningEvents.cs
@@ -2,12 +2,21 @@ namespace Content.Shared.Cloning.Events;
 
 /// <summary>
 ///    Raised before a mob is cloned. Cancel to prevent cloning.
+///    This is raised on the original mob.
 /// </summary>
 [ByRefEvent]
 public record struct CloningAttemptEvent(CloningSettingsPrototype Settings, bool Cancelled = false);
 
 /// <summary>
-///    Raised after a new mob got spawned when cloning a humanoid.
+///    Raised after a new mob was spawned when cloning a humanoid.
+///    This is raised on the original mob.
 /// </summary>
 [ByRefEvent]
 public record struct CloningEvent(CloningSettingsPrototype Settings, EntityUid CloneUid);
+
+/// <summary>
+///    Raised after a new item was spawned when cloning an item.
+///    This is raised on the original item.
+/// </summary>
+[ByRefEvent]
+public record struct CloningItemEvent(EntityUid CloneUid);


### PR DESCRIPTION
## About the PR
Now copies currency in stores like the uplink, labels, forensics, and paper data.

## Why / Balance
No more full TC uplink for clones, since they also get the items the original has.
The others cases were picked because they are the most common ways to identify an item.

## Technical details
Moved copying data to the cloned item into a subscription.
This should allow forks to easily add their own components if needed.
The chosen components are some of the most importanat ones. Of course this could be extended with more and more edge cases, but I think with this item copying is good enough for any gameplay purposes regarding the paradox clone (with the exception of pda uplinks, which needs a refactor first).
In the future a more general approach to copying existing items, like an `IClonable` interface for components could be used to make a larger selection of components copyable with a better syntax.

## Media
![1](https://github.com/user-attachments/assets/6b1df9df-e24d-47fd-8c50-dcbb607cde0f)
![2](https://github.com/user-attachments/assets/b041d5d2-4107-451a-9493-691d7c4f37fb)
![3](https://github.com/user-attachments/assets/5c83b0ca-1d97-47ad-99bc-3dbef788f335)
![4](https://github.com/user-attachments/assets/e4c366d5-1c08-4fb3-8ec4-7dbf2d4f26ad)

## How to test
- Put some items into your inventory.
- Spawn a "Random Clone Spawner" from the spawn menu
- Compare

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- tweak: Further improved item copying for paradox clones.
