### PR TITLE
Small revolvers cleanup

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/RevolverAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/RevolverAmmoProviderComponent.cs
@@ -16,36 +16,36 @@ public sealed partial class RevolverAmmoProviderComponent : AmmoProviderComponen
      * for example 7 entities when revolver spawns (1 for the revolver and 6 cylinders) we can instead defer it.
      */
 
-    [DataField("whitelist")]
+    [DataField]
     public EntityWhitelist? Whitelist;
 
     public Container AmmoContainer = default!;
 
-    [DataField("currentSlot")]
+    [DataField]
     public int CurrentIndex;
 
-    [DataField("capacity")]
+    [DataField]
     public int Capacity = 6;
 
     // Like BallisticAmmoProvider we defer spawning until necessary
     // AmmoSlots is the instantiated ammo and Chambers is the unspawned ammo (that may or may not have been shot).
 
     // TODO: Using an array would be better but this throws!
-    [DataField("ammoSlots")]
-    public List<EntityUid?> AmmoSlots = new();
+    [DataField]
+    public List<EntityUid?> AmmoSlots;
 
-    [DataField("chambers")]
-    public bool?[] Chambers = Array.Empty<bool?>();
+    [DataField]
+    public bool?[] Chambers = [];
 
     [DataField("proto", customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string? FillPrototype = "CartridgeMagnum";
 
-    [DataField("soundEject")]
+    [DataField]
     public SoundSpecifier? SoundEject = new SoundPathSpecifier("/Audio/Weapons/Guns/MagOut/revolver_magout.ogg");
 
-    [DataField("soundInsert")]
+    [DataField]
     public SoundSpecifier? SoundInsert = new SoundPathSpecifier("/Audio/Weapons/Guns/MagIn/revolver_magin.ogg");
 
-    [DataField("soundSpin")]
+    [DataField]
     public SoundSpecifier? SoundSpin = new SoundPathSpecifier("/Audio/Weapons/Guns/Misc/revolver_spin.ogg");
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -441,8 +441,8 @@ public partial class SharedGunSystem
             component.AmmoSlots.Add(null);
         }
 
-        // Set chambers to default if they are null or not equal to the capacity.
-        if (component.Chambers == null || component.Chambers.Length != component.Capacity && component.FillPrototype != null)
+        // Set chambers to default if they are not equal to the capacity.
+        if (component.Chambers.Length != component.Capacity && component.FillPrototype != null)
         {
             component.Chambers = new bool?[component.Capacity];
             for (var i = 0; i < component.Capacity; i++)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Interaction;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
@@ -6,11 +8,6 @@ using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
-using System;
-using System.Linq;
-using Content.Shared.Interaction.Events;
-using Content.Shared.Wieldable;
-using Content.Shared.Wieldable.Components;
 using JetBrains.Annotations;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
@@ -429,6 +426,10 @@ public partial class SharedGunSystem
         component.CurrentIndex = (component.CurrentIndex + count) % component.Capacity;
     }
 
+    /// <summary>
+    /// Raised on entity with <see cref="RevolverAmmoProviderComponent"/> during <see cref="ComponentInit"/>.
+    /// </summary>
+    /// <param name="uid">Entity that will be used for rising event. </param>
     private void OnRevolverInit(EntityUid uid, RevolverAmmoProviderComponent component, ComponentInit args)
     {
         component.AmmoContainer = Containers.EnsureContainer<Container>(uid, RevolverContainer);
@@ -440,10 +441,10 @@ public partial class SharedGunSystem
             component.AmmoSlots.Add(null);
         }
 
-        component.Chambers = new bool?[component.Capacity];
-
-        if (component.FillPrototype != null)
+        // Set chambers to default if they are null or not equal to the capacity.
+        if (component.Chambers == null || component.Chambers.Length != component.Capacity && component.FillPrototype != null)
         {
+            component.Chambers = new bool?[component.Capacity];
             for (var i = 0; i < component.Capacity; i++)
             {
                 if (component.AmmoSlots[i] != null)

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -88,10 +88,6 @@
     sprite: Objects/Weapons/Guns/Revolvers/inspector.rsi
   - type: Clothing
     sprite: Objects/Weapons/Guns/Revolvers/inspector.rsi
-  - type: RevolverAmmoProvider
-    capacity: 6
-    chambers: [ True, True, True, True, True, True ]
-    ammoSlots: [ null, null, null, null, null, null ]
 
 - type: entity
   name: Mateba
@@ -127,10 +123,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Revolvers/python.rsi
   - type: Gun
-    selectedMode: SemiAuto
     fireRate: 2
-    availableModes:
-    - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/revolver.ogg
       params:
@@ -148,7 +141,6 @@
         - SpeedLoaderMagnum
     proto: CartridgeMagnumAP
 
-
 - type: entity
   name: pirate revolver
   parent: [BaseWeaponRevolver, BaseMinorContraband]
@@ -161,9 +153,6 @@
     sprite: Objects/Weapons/Guns/Revolvers/pirate_revolver.rsi
   - type: Gun
     fireRate: 1
-  - type: ContainerContainer
-    containers:
-      revolver-ammo: !type:Container
   - type: RevolverAmmoProvider
     capacity: 5
     chambers: [ True, True, True, True, True ]


### PR DESCRIPTION
## About the PR
Now chambers in RevolverAmmoComponent can be modified, for example `chambers: [ True, False, False, null ]`.

## Why / Balance
Allows people create custom ammo for revolvers.

## Technical details
Cleared unused DataField names.
Now chambers will set to the default only if them now not equal to the capacity of gun.
Added some comments.
Cleaned unused lines in revolvers.yml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
