### PR TITLE
Fixed some unintended salvage changes.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -5,7 +5,6 @@
   description: A hand-held mass scanner.
   components:
   - type: Item
-    size: Small
     sprite: Objects/Tools/handheld_mass_scanner.rsi
   - type: Sprite
     sprite: Objects/Tools/handheld_mass_scanner.rsi

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -5,7 +5,7 @@
   description: A hand-held mass scanner.
   components:
   - type: Item
-    size: Normal
+    size: Small
     sprite: Objects/Tools/handheld_mass_scanner.rsi
   - type: Sprite
     sprite: Objects/Tools/handheld_mass_scanner.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -114,7 +114,7 @@
 
 - type: entity
   name: survival knife
-  parent: [CombatKnife, BaseSecurityCargoContraband]
+  parent: [BaseSecurityCargoContraband, CombatKnife]
   id: SurvivalKnife
   description: Weapon of first and last resort for combatting space carp.
   components:
@@ -129,7 +129,7 @@
 
 - type: entity
   name: kukri knife
-  parent: [CombatKnife, BaseSecurityCargoContraband]
+  parent: [BaseSecurityCargoContraband, CombatKnife]
   id: KukriKnife
   description: Professionals have standards. Be polite. Be efficient. Have a plan to kill everyone you meet.
   components:


### PR DESCRIPTION
## About the PR

Noticed that 2 recent PR's made some unintended item changes, specifically for salvage.

- A PR adding inhand sprites to various items unintentionally made the Handheld Mass Scanner a 2x2 instead of a 1x2. #33689 
- A PR editing Security contraband tags swapped around the parents on the Survival Knife and Kukri, meaning the Combat Knife parent made them appear as Security contraband instead of Cargo/Security Contraband. #35281 

## Why / Balance
No balance issues, just bugfixing.

## Technical details
A few lines of YAML to make the Handheld Mass Scanner a small item and swapping around the parents on the Survival Knife and Kukri

## Media
N/A

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
N/A

**Changelog**
:cl:
- fix: Fixed some unintended changes to Salvage gear.