### PR TITLE
[APRIL FOOLS] I hate gasses

### DIFF
--- a/Resources/Locale/en-US/gases/gases.ftl
+++ b/Resources/Locale/en-US/gases/gases.ftl
@@ -1,5 +1,5 @@
-gases-oxygen = Oxygen
-gases-nitrogen = Nitrogen
+gases-oxygen = Nitrogen
+gases-nitrogen = Oxygen
 gases-co2 = Carbon Dioxide
 gases-plasma = Plasma
 gases-tritium = Tritium

--- a/Resources/Locale/en-US/reagents/meta/gases.ftl
+++ b/Resources/Locale/en-US/reagents/meta/gases.ftl
@@ -1,4 +1,4 @@
-reagent-name-oxygen = juice that makes you breathe
+reagent-name-oxygen = juice that is everywhere
 reagent-desc-oxygen = An oxidizing, colorless gas.
 
 reagent-name-plasma = juice that makes you burn
@@ -10,7 +10,7 @@ reagent-desc-tritium = Radioactive space-magic pixie dust.
 reagent-name-carbon-dioxide = juice that makes you suffocate
 reagent-desc-carbon-dioxide = You have genuinely no idea what this is.
 
-reagent-name-nitrogen = juice that is everywhere
+reagent-name-nitrogen = juice that makes you breathe
 reagent-desc-nitrogen = A colorless, odorless unreactive gas. Highly stable.
 
 reagent-name-nitrous-oxide = juice that makes you sleepy

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -53,18 +53,18 @@
   category: Breathing
   icons:
   - sprite: /Textures/Interface/Alerts/breathing.rsi
-    state: not_enough_oxy
-  name: alerts-low-oxygen-name
-  description: alerts-low-oxygen-desc
+    state: not_enough_nitro
+  name: alerts-low-nitrogen-name
+  description: alerts-low-nitrogen-desc
 
 - type: alert
   id: LowNitrogen
   category: Breathing
   icons:
-    - sprite: /Textures/Interface/Alerts/breathing.rsi
-      state: not_enough_nitro
-  name: alerts-low-nitrogen-name
-  description: alerts-low-nitrogen-desc
+  - sprite: /Textures/Interface/Alerts/breathing.rsi
+    state: not_enough_oxy
+    name: alerts-low-oxygen-name
+    description: alerts-low-oxygen-desc
 
 - type: alert
   id: Toxins

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -4,7 +4,7 @@
   specificHeat: 20
   heatCapacityRatio: 1.4
   molarMass: 32
-  color: 2887E8
+  color: DA1010
   reagent: Oxygen
   pricePerMole: 0
 
@@ -14,7 +14,7 @@
   specificHeat: 30
   heatCapacityRatio: 1.4
   molarMass: 28
-  color: DA1010
+  color: 2887E8
   reagent: Nitrogen
   pricePerMole: 0
 

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -16,7 +16,9 @@
   - type: Sprite
     layers:
     - state: internals
-    - state: emergencytank
+    - state: nitrogentank
+  - type: Label
+    currentLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxSurvival
@@ -34,9 +36,7 @@
   - type: Sprite
     layers:
     - state: internals
-    - state: nitrogentank
-  - type: Label
-    currentLabel: reagent-name-nitrogen
+    - state: emergencytank
 
 - type: entity
   parent: BoxCardboard
@@ -56,7 +56,9 @@
   - type: Sprite
     layers:
     - state: internals
-    - state: extendedtank
+    - state: nitrogentank
+  - type: Label
+    currentLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxSurvivalEngineering
@@ -74,9 +76,7 @@
   - type: Sprite
     layers:
     - state: internals
-    - state: nitrogentank
-  - type: Label
-    currentLabel: reagent-name-nitrogen
+    - state: extendedtank
 
 - type: entity
 
@@ -97,7 +97,9 @@
   - type: Sprite
     layers:
     - state: internals
-    - state: emergencytank
+    - state: nitrogentank
+  - type: Label
+    currentLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxSurvivalSecurity
@@ -115,9 +117,7 @@
   - type: Sprite
     layers:
     - state: internals
-    - state: nitrogentank
-  - type: Label
-    currentLabel: reagent-name-nitrogen
+    - state: emergencytank
 
 - type: entity
 
@@ -138,7 +138,9 @@
   - type: Sprite
     layers:
     - state: internals
-    - state: emergencytank
+    - state: nitrogentank
+  - type: Label
+    currentLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxSurvivalMedical
@@ -156,9 +158,7 @@
   - type: Sprite
     layers:
     - state: internals
-    - state: nitrogentank
-  - type: Label
-    currentLabel: reagent-name-nitrogen
+    - state: emergencytank
 
 - type: entity
   parent: BoxCardboard
@@ -184,6 +184,8 @@
   - type: Tag
     tags:
     - BoxHug
+  - type: Label
+    currentLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxHug
@@ -198,8 +200,6 @@
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
-  - type: Label
-    currentLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxSurvival
@@ -214,6 +214,12 @@
     - id: Flare
     - id: FoodBreadBaguette
     - id: DrinkWaterBottleFull
+  - type: Sprite
+    layers:
+    - state: internals
+    - state: nitrogentank
+  - type: Label
+    currentLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxSurvivalNitrogen
@@ -228,12 +234,6 @@
     - id: Flare
     - id: FoodBreadBaguette
     - id: DrinkWaterBottleFull
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: nitrogentank
-  - type: Label
-    currentLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxCardboard
@@ -252,7 +252,9 @@
   - type: Sprite
     layers:
     - state: internals
-    - state: extendedtank
+    - state: nitrogentank
+  - type: Label
+    currentLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxSurvivalSyndicate
@@ -269,6 +271,4 @@
   - type: Sprite
     layers:
     - state: internals
-    - state: nitrogentank
-  - type: Label
-    currentLabel: reagent-name-nitrogen
+    - state: extendedtank

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -59,19 +59,6 @@
 - type: entity
   parent: GasTankRoundBase
   id: OxygenTank
-  name: oxygen tank
-  description: A standard cylindrical gas tank for oxygen. It can hold 5 L of gas.
-  components:
-  - type: Sprite
-    sprite: Objects/Tanks/oxygen.rsi
-  - type: Item
-    sprite: Objects/Tanks/oxygen.rsi
-  - type: Clothing
-    sprite: Objects/Tanks/oxygen.rsi
-
-- type: entity
-  parent: GasTankRoundBase
-  id: NitrogenTank
   name: nitrogen tank
   description: A standard cylindrical gas tank for nitrogen. It can hold 5 L of gas.
   components:
@@ -84,21 +71,34 @@
 
 - type: entity
   parent: GasTankRoundBase
-  id: EmergencyOxygenTank
-  name: emergency oxygen tank
-  description: An easily portable tank for emergencies. Contains very little oxygen, rated for survival use only. It can hold 0.66 L of gas.
+  id: NitrogenTank
+  name: oxygen tank
+  description: A standard cylindrical gas tank for oxygen. It can hold 5 L of gas.
   components:
   - type: Sprite
-    sprite: Objects/Tanks/emergency.rsi
+    sprite: Objects/Tanks/oxygen.rsi
+  - type: Item
+    sprite: Objects/Tanks/oxygen.rsi
+  - type: Clothing
+    sprite: Objects/Tanks/oxygen.rsi
+
+- type: entity
+  parent: GasTankRoundBase
+  id: EmergencyOxygenTank
+  name: emergency nitrogen tank
+  description: An easily portable tank for emergencies. Contains very little nitrogen, rated for survival use only. It can hold 0.66 L of gas.
+  components:
+  - type: Sprite
+    sprite: Objects/Tanks/emergency_red.rsi
   - type: Item
     size: Small
-    sprite: Objects/Tanks/emergency.rsi
+    sprite: Objects/Tanks/emergency_red.rsi
   - type: GasTank
     air:
       volume: 0.66
       temperature: 293.15
   - type: Clothing
-    sprite: Objects/Tanks/emergency.rsi
+    sprite: Objects/Tanks/emergency_red.rsi
     slots:
     - Pocket
     - Belt
@@ -114,36 +114,19 @@
 - type: entity
   parent: EmergencyOxygenTank
   id: EmergencyNitrogenTank
-  name: emergency nitrogen tank
-  description: An easily portable tank for emergencies. Contains very little nitrogen, rated for survival use only. It can hold 0.66 L of gas.
+  name: emergency oxygen tank
+  description: An easily portable tank for emergencies. Contains very little oxygen, rated for survival use only. It can hold 0.66 L of gas.
   components:
   - type: Sprite
-    sprite: Objects/Tanks/emergency_red.rsi
+    sprite: Objects/Tanks/emergency.rsi
   - type: Item
-    sprite: Objects/Tanks/emergency_red.rsi
+    sprite: Objects/Tanks/emergency.rsi
   - type: Clothing
-    sprite: Objects/Tanks/emergency_red.rsi
+    sprite: Objects/Tanks/emergency.rsi
 
 - type: entity
   parent: EmergencyOxygenTank
   id: ExtendedEmergencyOxygenTank
-  name: extended-capacity emergency oxygen tank
-  description: An emergency tank with extended capacity. Technically rated for prolonged use. It can hold 1.5 L of gas.
-  components:
-  - type: Sprite
-    sprite: Objects/Tanks/emergency_extended.rsi
-  - type: Item
-    sprite: Objects/Tanks/emergency_extended.rsi
-  - type: GasTank
-    air:
-      volume: 1.5
-      temperature: 293.15
-  - type: Clothing
-    sprite: Objects/Tanks/emergency_extended.rsi
-
-- type: entity
-  parent: ExtendedEmergencyOxygenTank
-  id: ExtendedEmergencyNitrogenTank
   name: extended-capacity emergency nitrogen tank
   description: An emergency tank with extended capacity. Technically rated for prolonged use. It can hold 1.5 L of gas.
   components:
@@ -151,25 +134,42 @@
     sprite: Objects/Tanks/emergency_extended_red.rsi
   - type: Item
     sprite: Objects/Tanks/emergency_extended_red.rsi
+  - type: GasTank
+    air:
+      volume: 1.5
+      temperature: 293.15
   - type: Clothing
     sprite: Objects/Tanks/emergency_extended_red.rsi
 
 - type: entity
   parent: ExtendedEmergencyOxygenTank
-  id: DoubleEmergencyOxygenTank
-  name: double emergency oxygen tank
-  description: A high-grade dual-tank emergency life support container. It holds a decent amount of oxygen for its small size. It can hold 2.5 L of gas.
+  id: ExtendedEmergencyNitrogenTank
+  name: extended-capacity emergency oxygen tank
+  description: An emergency tank with extended capacity. Technically rated for prolonged use. It can hold 1.5 L of gas.
   components:
   - type: Sprite
-    sprite: Objects/Tanks/emergency_double.rsi
+    sprite: Objects/Tanks/emergency_extended.rsi
   - type: Item
-    sprite: Objects/Tanks/emergency_double.rsi
+    sprite: Objects/Tanks/emergency_extended.rsi
+  - type: Clothing
+    sprite: Objects/Tanks/emergency_extended.rsi
+
+- type: entity
+  parent: ExtendedEmergencyOxygenTank
+  id: DoubleEmergencyOxygenTank
+  name: double emergency nitrogen tank
+  description: A high-grade dual-tank emergency life support container. It holds a decent amount of nitrogen for its small size. It can hold 2.5 L of gas.
+  components:
+  - type: Sprite
+    sprite: Objects/Tanks/emergency_double_red.rsi
+  - type: Item
+    sprite: Objects/Tanks/emergency_double_red.rsi
   - type: GasTank
     air:
       volume: 2.5
       temperature: 293.15
   - type: Clothing
-    sprite: Objects/Tanks/emergency_double.rsi
+    sprite: Objects/Tanks/emergency_double_red.rsi
   - type: MeleeWeapon
     attackRate: 0.9
     damage:
@@ -179,21 +179,21 @@
 - type: entity
   parent: DoubleEmergencyOxygenTank
   id: DoubleEmergencyNitrogenTank
-  name: double emergency nitrogen tank
-  description: A high-grade dual-tank emergency life support container. It holds a decent amount of nitrogen for its small size. It can hold 2.5 L of gas.
+  name: double emergency oxygen tank
+  description: A high-grade dual-tank emergency life support container. It holds a decent amount of oxygen for its small size. It can hold 2.5 L of gas.
   components:
   - type: Sprite
-    sprite: Objects/Tanks/emergency_double_red.rsi
+    sprite: Objects/Tanks/emergency_double.rsi
   - type: Item
-    sprite: Objects/Tanks/emergency_double_red.rsi
+    sprite: Objects/Tanks/emergency_double.rsi
   - type: Clothing
-    sprite: Objects/Tanks/emergency_double_red.rsi
+    sprite: Objects/Tanks/emergency_double.rsi
 
 - type: entity
   parent: EmergencyOxygenTank
   id: EmergencyFunnyOxygenTank
   name: funny emergency oxygen tank
-  description: An easily portable tank for emergencies. Contains very little oxygen with an extra of funny gas, rated for survival use only. It can hold 0.66 L of gas.
+  description: An easily portable tank for emergencies. Contains very little nitrogen with an extra of funny gas, rated for survival use only. It can hold 0.66 L of gas.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency_clown.rsi

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -37,7 +37,7 @@
       - GasMiningAndStorage
 
 - type: entity
-  name: O2 gas miner
+  name: N2 gas miner
   parent: GasMinerBase
   id: GasMinerOxygen
   suffix: Shuttle, 300kPa
@@ -48,7 +48,7 @@
       spawnGas: Oxygen
 
 - type: entity
-  name: O2 gas miner
+  name: N2 gas miner
   parent: GasMinerOxygen
   id: GasMinerOxygenStation
   suffix: Station, 1000kPa
@@ -57,7 +57,7 @@
       maxExternalPressure: 1000
 
 - type: entity
-  name: O2 gas miner
+  name: N2 gas miner
   parent: GasMinerOxygen
   id: GasMinerOxygenStationLarge
   suffix: Large Station, 4500kPa
@@ -66,7 +66,7 @@
       maxExternalPressure: 4500
 
 - type: entity
-  name: N2 gas miner
+  name: O2 gas miner
   parent: GasMinerBase
   id: GasMinerNitrogen
   suffix: Shuttle, 300kPa
@@ -75,7 +75,7 @@
       spawnGas: Nitrogen
 
 - type: entity
-  name: N2 gas miner
+  name: O2 gas miner
   parent: GasMinerNitrogen
   id: GasMinerNitrogenStation
   suffix: Station, 1000kPa
@@ -84,7 +84,7 @@
       maxExternalPressure: 1000
 
 - type: entity
-  name: N2 gas miner
+  name: O2 gas miner
   parent: GasMinerNitrogen
   id: GasMinerNitrogenStationLarge
   suffix: Large Station, 4500kPa

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -200,12 +200,12 @@
 - type: entity
   parent: GasCanister
   id: OxygenCanister
-  name: oxygen canister
-  description: A canister that can contain any type of gas. This one is supposed to contain oxygen. It can be attached to connector ports using a wrench.
+  name: nitrogen canister
+  description: A canister that can contain any type of gas. This one is supposed to contain nitrogen. It can be attached to connector ports using a wrench.
   components:
   - type: Sprite
     layers:
-      - state: blue
+      - state: red
   - type: GasCanister
     gasMixture:
       volume: 1000
@@ -240,7 +240,7 @@
   id: LiquidOxygenCanister
   parent: OxygenCanister
   name: liquid oxygen canister
-  description: A canister that can contain any type of gas. This one is supposed to contain liquid oxygen. It can be attached to connector ports using a wrench.
+  description: A canister that can contain any type of gas. This one is supposed to contain liquid nitrogen. It can be attached to connector ports using a wrench.
   components:
   - type: GasCanister
     gasMixture:
@@ -254,12 +254,12 @@
 - type: entity
   parent: GasCanister
   id: NitrogenCanister
-  name: nitrogen canister
-  description: A canister that can contain any type of gas. This one is supposed to contain nitrogen. It can be attached to connector ports using a wrench.
+  name: oxygen canister
+  description: A canister that can contain any type of gas. This one is supposed to contain oxygen. It can be attached to connector ports using a wrench.
   components:
     - type: Sprite
       layers:
-        - state: red
+        - state: blue
     - type: GasCanister
       gasMixture:
         volume: 1000
@@ -294,8 +294,8 @@
 - type: entity
   id: LiquidNitrogenCanister
   parent: NitrogenCanister
-  name: liquid nitrogen canister
-  description: A canister that can contain any type of gas. This one is supposed to contain liquid nitrogen. It can be attached to connector ports using a wrench.
+  name: liquid oxygen canister
+  description: A canister that can contain any type of gas. This one is supposed to contain liquid oxygen. It can be attached to connector ports using a wrench.
   components:
   - type: GasCanister
     gasMixture:

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -4,7 +4,7 @@
   desc: reagent-desc-oxygen
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
-  color: "#c4f5ff"
+  color: "#a1e1ff"
   boilingPoint: -183.0
   meltingPoint: -218.4
   metabolisms:
@@ -190,7 +190,7 @@
   desc: reagent-desc-nitrogen
   physicalDesc: reagent-physical-desc-gaseous
   flavor: bitter
-  color: "#a1e1ff"
+  color: "#c4f5ff"
   boilingPoint: -195.8
   meltingPoint: -210.0
   metabolisms:


### PR DESCRIPTION
## About the PR
Inverses nitrogen and oxygen, cosmetically.

## Why / Balance
:trollface: 

## Technical details
All player-facing nitrogen and oxygen identifiers including color and description were swapped. Suffocating as a human even gives you a "N2" warning now.

## Media
![Content Client_xHEw38qGMk](https://github.com/user-attachments/assets/9a89a650-2904-49b3-9fc3-0b0a6dd15e7c)
![image](https://github.com/user-attachments/assets/26f92576-0493-490f-ac80-0b7e8f6fccc7)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Oh this'll break players alright

**Changelog**
:cl:
- tweak: I HATE OXYGEN AND NITROGEN