### PR TITLE
Fix error when disconnecting the client while a projectile is embedded

### DIFF
--- a/Content.IntegrationTests/Tests/Embedding/EmbedTest.cs
+++ b/Content.IntegrationTests/Tests/Embedding/EmbedTest.cs
@@ -22,7 +22,6 @@ public sealed class EmbedTest : InteractionTest
     /// occur due to reparenting during cleanup.
     /// </summary>
     [Test]
-    [Explicit]
     public async Task TestDisconnectWhileEmbedded()
     {
         // Spawn the target we're going to throw at

--- a/Content.IntegrationTests/Tests/Embedding/EmbedTest.cs
+++ b/Content.IntegrationTests/Tests/Embedding/EmbedTest.cs
@@ -1,0 +1,54 @@
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Shared.Projectiles;
+using Robust.Shared.Network;
+
+namespace Content.IntegrationTests.Tests.Embedding;
+
+public sealed class EmbedTest : InteractionTest
+{
+    /// <summary>
+    /// Embeddable entity that will be thrown at the target.
+    /// </summary>
+    private const string EmbeddableProtoId = "SurvivalKnife";
+
+    /// <summary>
+    /// Target entity that the thrown item will embed into.
+    /// </summary>
+    private const string TargetProtoId = "AirlockGlass";
+
+    /// <summary>
+    /// Embeds an entity with a <see cref="EmbeddableProjectileComponent"/> into a target,
+    /// then disconnects the client. Intended to reveal any clientside issues that might
+    /// occur due to reparenting during cleanup.
+    /// </summary>
+    [Test]
+    [Explicit]
+    public async Task TestDisconnectWhileEmbedded()
+    {
+        // Spawn the target we're going to throw at
+        await SpawnTarget(TargetProtoId);
+
+        // Give the player the embeddable to throw
+        var projectile = await PlaceInHands(EmbeddableProtoId);
+        Assert.That(TryComp<EmbeddableProjectileComponent>(projectile, out var embedComp),
+            $"{EmbeddableProtoId} does not have EmbeddableProjectileComponent");
+        // Make sure the projectile isn't already embedded into anything
+        Assert.That(embedComp.EmbeddedIntoUid, Is.Null,
+            $"Projectile already embedded into {SEntMan.ToPrettyString(embedComp.EmbeddedIntoUid)}");
+
+        // Have the player throw the embeddable at the target
+        await ThrowItem();
+
+        // Wait a moment for the item to hit and embed
+        await RunSeconds(0.5f);
+
+        // Make sure the projectile is embedded into the target
+        Assert.That(embedComp.EmbeddedIntoUid, Is.EqualTo(ToServer(Target)),
+            "Projectile not embedded into target");
+
+        // Disconnect the client
+        var cNetMgr = Client.ResolveDependency<IClientNetManager>();
+        await Client.WaitPost(Client.EntMan.FlushEntities);
+        await Pair.RunTicksSync(1);
+    }
+}

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -143,6 +143,8 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         }
 
         var xform = Transform(uid);
+        if (TerminatingOrDeleted(xform.GridUid) && TerminatingOrDeleted(xform.MapUid))
+            return;
         TryComp<PhysicsComponent>(uid, out var physics);
         _physics.SetBodyType(uid, BodyType.Dynamic, body: physics, xform: xform);
         _transform.AttachToGridOrMap(uid, xform);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a bug where shutting down the client or server while an embeddable projectile is embedded into another entity caused an error.

Adds a test that throws an embeddable projectile (a survival knife) into a target (a glass airlock), then disconnects the client from the server, and a test that just deleting the target causes the projectile to detach and not be deleted.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/36020.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a check that the projectile's grid and map aren't terminating before trying to reparent.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
