### PR TITLE
Allow NukeOps test to function with multiple RuleGrids

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
@@ -152,14 +152,10 @@ public sealed class NukeOpsTest
             Assert.That(roleSys.MindGetAllRoleInfo(mindCrew).Any(x => nukeroles.Contains(x.Prototype)), Is.False);
         }
 
-        var ruleGridComps = entMan.AllComponents<RuleGridsComponent>();
-        Assert.That(ruleGridComps, Has.Length.EqualTo(1),
-            $"Unexpected RuleGrid(s) detected! {string.Join(',', ruleGridComps.Select(e => server.EntMan.ToPrettyString(e.Uid)))}");
-
         // The game rule exists, and all the stations/shuttles/maps are properly initialized
         var rule = entMan.AllComponents<NukeopsRuleComponent>().Single();
         var ruleComp = rule.Component;
-        var gridsRule = ruleGridComps.Single().Component;
+        var gridsRule = entMan.GetComponent<RuleGridsComponent>(rule.Uid);
         foreach (var grid in gridsRule.MapGrids)
         {
             Assert.That(entMan.EntityExists(grid));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`TryStopNukeOpsFromConstantlyFailing` no longer fails when it detects multiple `RuleGridsComponent`s.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #35868.

## Technical details
<!-- Summary of code changes for easier review. -->
Rather than getting all entities with `RuleGridsComponent`s and using `Single()` to get the one for the NukeOps rule, we now use `GetComponent` to grab the `RuleGridsComponent` from the entity that has the `NukeopsRuleComponent`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->