### PR TITLE
allow bandanas to fit inside containers/lockers/crates without folding them first

### DIFF
--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -48,7 +48,7 @@ public sealed class FoldableSystem : EntitySystem
 
     public void OnStoreThisAttempt(EntityUid uid, FoldableComponent comp, ref InsertIntoEntityStorageAttemptEvent args)
     {
-        if (comp.IsFolded)
+        if (!comp.IsFolded && !comp.CanFoldInsideContainer)
             args.Cancelled = true;
     }
 

--- a/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/bandanas.yml
@@ -5,6 +5,7 @@
   components:
   - type: Foldable
     folded: true
+    canFoldInsideContainer: true
   - type: Mask
     isToggled: true
     enabled: false


### PR DESCRIPTION
…t. fixes #35953


## About the PR
change canFoldInsideContainer to true on bandanas

## Why / Balance
I scratched my head for like 15 minutes trying to figure out how to complete my bandana bounty... I thought I was cursed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Unfolded bandanas now fit in containers