### PR TITLE
Cleanup: ExtensionCableSystem

### DIFF
--- a/Content.Server/Power/Components/ExtensionCableProviderComponent.cs
+++ b/Content.Server/Power/Components/ExtensionCableProviderComponent.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Power.Components
         [DataField("transferRange")]
         public int TransferRange { get; set; } = 3;
 
-        [ViewVariables] public List<ExtensionCableReceiverComponent> LinkedReceivers { get; } = new();
+        [ViewVariables] public List<Entity<ExtensionCableReceiverComponent>> LinkedReceivers { get; } = new();
 
         /// <summary>
         ///     If <see cref="ExtensionCableReceiverComponent"/>s should consider connecting to this.

--- a/Content.Server/Power/Components/ExtensionCableReceiverComponent.cs
+++ b/Content.Server/Power/Components/ExtensionCableReceiverComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Server.Power.Components
     public sealed partial class ExtensionCableReceiverComponent : Component
     {
         [ViewVariables]
-        public ExtensionCableProviderComponent? Provider { get; set; }
+        public Entity<ExtensionCableProviderComponent>? Provider { get; set; }
 
         [ViewVariables]
         public bool Connectable = false;

--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -8,6 +8,8 @@ namespace Content.Server.Power.EntitySystems
 {
     public sealed class ExtensionCableSystem : EntitySystem
     {
+        [Dependency] private readonly SharedMapSystem _map = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -126,7 +128,7 @@ namespace Content.Server.Power.EntitySystems
             if (!TryComp(xform.GridUid, out MapGridComponent? grid))
                 yield break;
 
-            var nearbyEntities = grid.GetCellsInSquareArea(coordinates, (int) Math.Ceiling(range / grid.TileSize));
+            var nearbyEntities = _map.GetCellsInSquareArea(xform.GridUid.Value, grid, coordinates, (int)Math.Ceiling(range / grid.TileSize));
 
             foreach (var entity in nearbyEntities)
             {
@@ -252,7 +254,7 @@ namespace Content.Server.Power.EntitySystems
             }
 
             var coordinates = xform.Coordinates;
-            var nearbyEntities = grid.GetCellsInSquareArea(coordinates, (int) Math.Ceiling(range / grid.TileSize));
+            var nearbyEntities = _map.GetCellsInSquareArea(xform.GridUid.Value, grid, coordinates, (int)Math.Ceiling(range / grid.TileSize));
             var cableQuery = GetEntityQuery<ExtensionCableProviderComponent>();
             var metaQuery = GetEntityQuery<MetaDataComponent>();
             var xformQuery = GetEntityQuery<TransformComponent>();

--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -34,17 +34,17 @@ namespace Content.Server.Power.EntitySystems
                 return;
 
             provider.TransferRange = range;
-            ResetReceivers(provider);
+            ResetReceivers((uid, provider));
         }
 
-        private void OnProviderStarted(EntityUid uid, ExtensionCableProviderComponent provider, ComponentStartup args)
+        private void OnProviderStarted(Entity<ExtensionCableProviderComponent> provider, ref ComponentStartup args)
         {
-            Connect(uid, provider);
+            Connect(provider);
         }
 
-        private void OnProviderShutdown(EntityUid uid, ExtensionCableProviderComponent provider, ComponentShutdown args)
+        private void OnProviderShutdown(Entity<ExtensionCableProviderComponent> provider, ref ComponentShutdown args)
         {
-            var xform = Transform(uid);
+            var xform = Transform(provider);
 
             // If grid deleting no need to update power.
             if (HasComp<MapGridComponent>(xform.GridUid) &&
@@ -53,54 +53,54 @@ namespace Content.Server.Power.EntitySystems
                 return;
             }
 
-            Disconnect(uid, provider);
+            Disconnect(provider);
         }
 
-        private void OnProviderAnchorStateChanged(EntityUid uid, ExtensionCableProviderComponent provider, ref AnchorStateChangedEvent args)
+        private void OnProviderAnchorStateChanged(Entity<ExtensionCableProviderComponent> provider, ref AnchorStateChangedEvent args)
         {
             if (args.Anchored)
-                Connect(uid, provider);
+                Connect(provider);
             else
-                Disconnect(uid, provider);
+                Disconnect(provider);
         }
 
-        private void Connect(EntityUid uid, ExtensionCableProviderComponent provider)
+        private void Connect(Entity<ExtensionCableProviderComponent> provider)
         {
-            provider.Connectable = true;
+            provider.Comp.Connectable = true;
 
-            foreach (var receiver in FindAvailableReceivers(uid, provider.TransferRange))
+            foreach (var receiver in FindAvailableReceivers(provider.Owner, provider.Comp.TransferRange))
             {
-                receiver.Comp.Provider?.LinkedReceivers.Remove(receiver);
+                receiver.Comp.Provider?.Comp.LinkedReceivers.Remove(receiver);
                 receiver.Comp.Provider = provider;
-                provider.LinkedReceivers.Add(receiver);
+                provider.Comp.LinkedReceivers.Add(receiver);
                 RaiseLocalEvent(receiver, new ProviderConnectedEvent(provider), broadcast: false);
-                RaiseLocalEvent(uid, new ReceiverConnectedEvent(receiver), broadcast: false);
+                RaiseLocalEvent(provider, new ReceiverConnectedEvent(receiver), broadcast: false);
             }
         }
 
-        private void Disconnect(EntityUid uid, ExtensionCableProviderComponent provider)
+        private void Disconnect(Entity<ExtensionCableProviderComponent> provider)
         {
             // same as OnProviderShutdown
-            provider.Connectable = false;
+            provider.Comp.Connectable = false;
             ResetReceivers(provider);
         }
 
-        private void OnProviderReAnchor(EntityUid uid, ExtensionCableProviderComponent component, ref ReAnchorEvent args)
+        private void OnProviderReAnchor(Entity<ExtensionCableProviderComponent> provider, ref ReAnchorEvent args)
         {
-            Disconnect(uid, component);
-            Connect(uid, component);
+            Disconnect(provider);
+            Connect(provider);
         }
 
-        private void ResetReceivers(ExtensionCableProviderComponent provider)
+        private void ResetReceivers(Entity<ExtensionCableProviderComponent> provider)
         {
             var providerId = provider.Owner;
-            var receivers = provider.LinkedReceivers.ToArray();
-            provider.LinkedReceivers.Clear();
+            var receivers = provider.Comp.LinkedReceivers.ToArray();
+            provider.Comp.LinkedReceivers.Clear();
 
             foreach (var receiver in receivers)
             {
                 var receiverId = receiver.Owner;
-                receiver.Provider = null;
+                receiver.Comp.Provider = null;
                 RaiseLocalEvent(receiverId, new ProviderDisconnectedEvent(provider), broadcast: false);
                 RaiseLocalEvent(providerId, new ReceiverDisconnectedEvent((receiverId, receiver)), broadcast: false);
             }
@@ -162,88 +162,88 @@ namespace Content.Server.Power.EntitySystems
 
             if (provider != null)
             {
-                RaiseLocalEvent(provider.Owner, new ReceiverDisconnectedEvent((uid, receiver)), broadcast: false);
-                provider.LinkedReceivers.Remove(receiver);
+                RaiseLocalEvent(provider.Value, new ReceiverDisconnectedEvent((uid, receiver)), broadcast: false);
+                provider.Value.Comp.LinkedReceivers.Remove((uid, receiver));
             }
 
             receiver.ReceptionRange = range;
-            TryFindAndSetProvider(receiver);
+            TryFindAndSetProvider((uid, receiver));
         }
 
-        private void OnReceiverStarted(EntityUid uid, ExtensionCableReceiverComponent receiver, ComponentStartup args)
+        private void OnReceiverStarted(Entity<ExtensionCableReceiverComponent> receiver, ref ComponentStartup args)
         {
             if (EntityManager.TryGetComponent(receiver.Owner, out PhysicsComponent? physicsComponent))
             {
-                receiver.Connectable = physicsComponent.BodyType == BodyType.Static;
+                receiver.Comp.Connectable = physicsComponent.BodyType == BodyType.Static;
             }
 
-            if (receiver.Provider == null)
+            if (receiver.Comp.Provider == null)
             {
                 TryFindAndSetProvider(receiver);
             }
         }
 
-        private void OnReceiverShutdown(EntityUid uid, ExtensionCableReceiverComponent receiver, ComponentShutdown args)
+        private void OnReceiverShutdown(Entity<ExtensionCableReceiverComponent> receiver, ref ComponentShutdown args)
         {
-            Disconnect(uid, receiver);
+            Disconnect(receiver);
         }
 
-        private void OnReceiverAnchorStateChanged(EntityUid uid, ExtensionCableReceiverComponent receiver, ref AnchorStateChangedEvent args)
+        private void OnReceiverAnchorStateChanged(Entity<ExtensionCableReceiverComponent> receiver, ref AnchorStateChangedEvent args)
         {
             if (args.Anchored)
             {
-                Connect(uid, receiver);
+                Connect(receiver);
             }
             else
             {
-                Disconnect(uid, receiver);
+                Disconnect(receiver);
             }
         }
 
-        private void OnReceiverReAnchor(EntityUid uid, ExtensionCableReceiverComponent receiver, ref ReAnchorEvent args)
+        private void OnReceiverReAnchor(Entity<ExtensionCableReceiverComponent> receiver, ref ReAnchorEvent args)
         {
-            Disconnect(uid, receiver);
-            Connect(uid, receiver);
+            Disconnect(receiver);
+            Connect(receiver);
         }
 
-        private void Connect(EntityUid uid, ExtensionCableReceiverComponent receiver)
+        private void Connect(Entity<ExtensionCableReceiverComponent> receiver)
         {
-            receiver.Connectable = true;
-            if (receiver.Provider == null)
+            receiver.Comp.Connectable = true;
+            if (receiver.Comp.Provider == null)
             {
                 TryFindAndSetProvider(receiver);
             }
         }
 
-        private void Disconnect(EntityUid uid, ExtensionCableReceiverComponent receiver)
+        private void Disconnect(Entity<ExtensionCableReceiverComponent> receiver)
         {
-            receiver.Connectable = false;
-            RaiseLocalEvent(uid, new ProviderDisconnectedEvent(receiver.Provider), broadcast: false);
-            if (receiver.Provider != null)
+            receiver.Comp.Connectable = false;
+            RaiseLocalEvent(receiver, new ProviderDisconnectedEvent(receiver.Comp.Provider), broadcast: false);
+            if (receiver.Comp.Provider != null)
             {
-                RaiseLocalEvent(receiver.Provider.Owner, new ReceiverDisconnectedEvent((uid, receiver)), broadcast: false);
-                receiver.Provider.LinkedReceivers.Remove(receiver);
+                RaiseLocalEvent(receiver.Comp.Provider.Value, new ReceiverDisconnectedEvent(receiver), broadcast: false);
+                receiver.Comp.Provider.Value.Comp.LinkedReceivers.Remove(receiver);
             }
 
-            receiver.Provider = null;
+            receiver.Comp.Provider = null;
         }
 
-        private void TryFindAndSetProvider(ExtensionCableReceiverComponent receiver, TransformComponent? xform = null)
+        private void TryFindAndSetProvider(Entity<ExtensionCableReceiverComponent> receiver, TransformComponent? xform = null)
         {
             var uid = receiver.Owner;
-            if (!receiver.Connectable)
+            if (!receiver.Comp.Connectable)
                 return;
 
-            if (!TryFindAvailableProvider(uid, receiver.ReceptionRange, out var provider, xform))
+            if (!TryFindAvailableProvider(uid, receiver.Comp.ReceptionRange, out var provider, xform))
                 return;
 
-            receiver.Provider = provider;
-            provider.LinkedReceivers.Add(receiver);
+            receiver.Comp.Provider = provider;
+            provider.Value.Comp.LinkedReceivers.Add(receiver);
             RaiseLocalEvent(uid, new ProviderConnectedEvent(provider), broadcast: false);
-            RaiseLocalEvent(provider.Owner, new ReceiverConnectedEvent((uid, receiver)), broadcast: false);
+            RaiseLocalEvent(provider.Value, new ReceiverConnectedEvent((uid, receiver)), broadcast: false);
         }
 
-        private bool TryFindAvailableProvider(EntityUid owner, float range, [NotNullWhen(true)] out ExtensionCableProviderComponent? foundProvider, TransformComponent? xform = null)
+        private bool TryFindAvailableProvider(EntityUid owner, float range, [NotNullWhen(true)] out Entity<ExtensionCableProviderComponent>? foundProvider, TransformComponent? xform = null)
         {
             if (!Resolve(owner, ref xform) || !TryComp(xform.GridUid, out MapGridComponent? grid))
             {
@@ -257,7 +257,7 @@ namespace Content.Server.Power.EntitySystems
             var metaQuery = GetEntityQuery<MetaDataComponent>();
             var xformQuery = GetEntityQuery<TransformComponent>();
 
-            ExtensionCableProviderComponent? closestCandidate = null;
+            Entity<ExtensionCableProviderComponent>? closestCandidate = null;
             var closestDistanceFound = float.MaxValue;
             foreach (var entity in nearbyEntities)
             {
@@ -277,12 +277,12 @@ namespace Content.Server.Power.EntitySystems
                 if (distance >= closestDistanceFound)
                     continue;
 
-                closestCandidate = provider;
+                closestCandidate = (entity, provider);
                 closestDistanceFound = distance;
             }
 
             // Make sure the provider is in range before claiming success
-            if (closestCandidate != null && closestDistanceFound <= Math.Min(range, closestCandidate.TransferRange))
+            if (closestCandidate != null && closestDistanceFound <= Math.Min(range, closestCandidate.Value.Comp.TransferRange))
             {
                 foundProvider = closestCandidate;
                 return true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes all warnings in `ExtensionCableSystem` (10 warnings, by my count).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
- Changes a bunch of private methods of the system to take `Entity<T>`s as parameters rather than just components.
- Makes `ExtensionCableReceiverComponent.Provider` an `Entity<ExtensionCableProviderComponent>?` instead of an `ExtensionCableProviderComponent?`
- Makes `ExtensionCableProviderComponent.LinkedReceivers` a `List<Entity<ExtensionCableReceiverComponent>>` instead of a `List<ExtensionCableReceiverComponent>`
- Replaces calls to `MapGridComponent.GetCellsInSquareArea` with their `SharedMapSystem` equivalents.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- `ExtensionCableReceiverComponent.Provider` is now an `Entity<ExtensionCableProviderComponent>?` instead of an `ExtensionCableProviderComponent?`
- `ExtensionCableProviderComponent.LinkedReceivers` is now a `List<Entity<ExtensionCableReceiverComponent>>` instead of a `List<ExtensionCableReceiverComponent>`
