### PR TITLE
Fix SpeakOnTrigger not working for messages starting with '.'

### DIFF
--- a/Content.Server/Chat/Systems/SpeakOnTriggerSystem.cs
+++ b/Content.Server/Chat/Systems/SpeakOnTriggerSystem.cs
@@ -34,6 +34,10 @@ public sealed class SpeakOnTriggerSystem : EntitySystem
             return;
 
         var message = Loc.GetString(_random.Pick(messagePack.Values));
+        // Chatcode moment: messages starting with "." are considered radio messages.
+        // Prepending ">" forces the message to be spoken instead.
+        // TODO chat refactor: remove this
+        message = '>' + message;
         _chat.TrySendInGameICMessage(ent.Owner, message, InGameICChatType.Speak, true);
 
         if (useDelay != null)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`SpeakOnTrigger` can now properly say messages that start with a period. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Needed to fix the mime figurine's messages from not displaying. See #36039.

## Technical details
<!-- Summary of code changes for easier review. -->
Chatcode is weird. Messages starting with "." are forced to be spoken as radio messages, whether the speaker can use a radio or not.
Adding ">" before the message forces it to be spoken normally.

Chatcode refactor plz.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->