### PR TITLE
Clusterbangs and grenades now fit in sec belts

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -492,6 +492,7 @@
         - DoorRemote
         - Whistle
         - BalloonPopper
+        - ScatteringGrenade
   - type: ItemMapper
     mapLayers:
       flashbang:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
 Allows clusterbangs and clustergrenades to now be placed in the sec belts

## Why / Balance
Fixes issue brought up in #32891

## Technical details
Added the ScatteringGrenade component to the Security Belt whitelist

## Media
![image](https://github.com/user-attachments/assets/bbc55365-d1ac-4860-b7e6-2296a6984429)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Fixed Sec Belts not accepting Clusterbangs and Cluster grenades.
