### PR TITLE
Fix nuke disk getting lost when polymorphed holder is deleted

### DIFF
--- a/Content.Server/Polymorph/Components/PolymorphedEntityComponent.cs
+++ b/Content.Server/Polymorph/Components/PolymorphedEntityComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class PolymorphedEntityComponent : Component
     /// The original entity that the player will revert back into
     /// </summary>
     [DataField(required: true)]
-    public EntityUid Parent;
+    public EntityUid? Parent;
 
     /// <summary>
     /// The amount of time that has passed since the entity was created

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -314,6 +314,10 @@ public sealed partial class PolymorphSystem : EntitySystem
         var uidXform = Transform(uid);
         var parentXform = Transform(parent.Value);
 
+        // Don't swap back onto a terminating grid
+        if (TerminatingOrDeleted(uidXform.ParentUid))
+            return null;
+
         if (component.Configuration.ExitPolymorphSound != null)
             _audio.PlayPvs(component.Configuration.ExitPolymorphSound, uidXform.Coordinates);
 

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -59,7 +59,7 @@ public sealed partial class PolymorphSystem : EntitySystem
         SubscribeLocalEvent<PolymorphedEntityComponent, BeforeFullyEatenEvent>(OnBeforeFullyEaten);
         SubscribeLocalEvent<PolymorphedEntityComponent, BeforeFullySlicedEvent>(OnBeforeFullySliced);
         SubscribeLocalEvent<PolymorphedEntityComponent, DestructionEventArgs>(OnDestruction);
-        SubscribeLocalEvent<PolymorphedEntityComponent, ComponentRemove>(OnPolymorphedRemoved);
+        SubscribeLocalEvent<PolymorphedEntityComponent, EntityTerminatingEvent>(OnPolymorphedTerminating);
 
         InitializeMap();
         InitializeTrigger();
@@ -165,9 +165,10 @@ public sealed partial class PolymorphSystem : EntitySystem
         }
     }
 
-    private void OnPolymorphedRemoved(Entity<PolymorphedEntityComponent> ent, ref ComponentRemove args)
+    private void OnPolymorphedTerminating(Entity<PolymorphedEntityComponent> ent, ref EntityTerminatingEvent args)
     {
         // Remove our original entity too
+        // Note that Revert will set Parent to null, so reverted entities will not be deleted
         QueueDel(ent.Comp.Parent);
     }
 

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -167,6 +167,9 @@ public sealed partial class PolymorphSystem : EntitySystem
 
     private void OnPolymorphedTerminating(Entity<PolymorphedEntityComponent> ent, ref EntityTerminatingEvent args)
     {
+        if (ent.Comp.Configuration.RevertOnDelete)
+            Revert((ent, ent));
+
         // Remove our original entity too
         // Note that Revert will set Parent to null, so reverted entities will not be deleted
         QueueDel(ent.Comp.Parent);

--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -98,6 +98,12 @@ public sealed partial record PolymorphConfiguration
     public bool RevertOnDeath = true;
 
     /// <summary>
+    /// Whether or not the polymorph reverts when the entity is deleted.
+    /// </summary>
+    [DataField(serverOnly: true)]
+    public bool RevertOnDelete = true;
+
+    /// <summary>
     /// Whether or not the polymorph reverts when the entity is eaten or fully sliced.
     /// </summary>
     [DataField(serverOnly: true)]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
If someone holding the nuke disk is polymorphed and their polymorphed self is deleted (by falling into a recycler, by admin command, and possibly by other means), the nuke disk will respawn like normal.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes https://github.com/space-wizards/space-station-14/issues/35877.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a handler for `EntityTerminatingEvent` to `PolymorphSystem`. The original entity is now queued for deletion when the polymorph substitute is deleted, so the nuke disk in the original's inventory will be deleted.
`PolymorphSystem.Revert` now sets `PolymorphedEntityComponent.Parent` to null, so that successfully reverted polymorphs aren't deleted.

This may also have some performance benefits, overall, since the original entities of deleted polymorphs are now deleted, instead of being left to hang around on a paused map for eternity.

A `RevertOnDelete` property has been added to `PolymorphPrototype` which can be used to make the polymorphed entity revert in situations where it is about to be deleted. This is set to false by default, because it has balance implications (throwing bread-polymorphed players into the recycler is no longer deadly, admins deleting polymorphed players just reverts them).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/48872c3f-1a4a-4ff7-bb62-8788cc5b068b

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`PolymorphedEntityComponent.Parent` is now nullable.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->