### PR TITLE
[APRIL FOOLS] Fix map population values to comply with new art direction

### DIFF
--- a/Resources/Prototypes/Maps/Relic.yml
+++ b/Resources/Prototypes/Maps/Relic.yml
@@ -2,8 +2,8 @@
   id: Relic
   mapName: 'Relic'
   mapPath: /Maps/Relic.yml
-  minPlayers: 20
-  maxPlayers: 55
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Relic:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -2,8 +2,8 @@
   id: Amber
   mapName: 'Amber'
   mapPath: /Maps/amber.yml
-  minPlayers: 15
-  maxPlayers: 60
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Amber:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -2,7 +2,7 @@
   id: Bagel
   mapName: 'Bagel Station'
   mapPath: /Maps/bagel.yml
-  minPlayers: 35
+  minPlayers: 0
   maxPlayers: 80
   stations:
     Bagel:

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -2,7 +2,8 @@
   id: Box
   mapName: 'Box Station'
   mapPath: /Maps/box.yml
-  minPlayers: 50
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Boxstation:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -2,7 +2,8 @@
   id: Convex
   mapName: 'Convex'
   mapPath: /Maps/convex.yml
-  minPlayers: 75
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Convex:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -2,8 +2,8 @@
   id: Core
   mapName: 'Core'
   mapPath: /Maps/core.yml
-  minPlayers: 35
-  maxPlayers: 70
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Core:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/debug.yml
+++ b/Resources/Prototypes/Maps/debug.yml
@@ -3,6 +3,7 @@
   mapName: Empty
   mapPath: /Maps/Test/empty.yml
   minPlayers: 0
+  maxPlayers: 80
   stations:
     Empty:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -2,8 +2,8 @@
   id: Elkridge
   mapName: 'Elkridge Depot'
   mapPath: /Maps/elkridge.yml
-  minPlayers: 15
-  maxPlayers: 45
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Elkridge:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -2,7 +2,8 @@
   id: Fland
   mapName: 'Fland Installation'
   mapPath: /Maps/fland.yml
-  minPlayers: 70
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Fland:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/gate.yml
+++ b/Resources/Prototypes/Maps/gate.yml
@@ -2,7 +2,8 @@
   id: Gate
   mapName: 'Gate Station'
   mapPath: /Maps/gate.yml
-  minPlayers: 55
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Gate:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/loop.yml
+++ b/Resources/Prototypes/Maps/loop.yml
@@ -2,8 +2,8 @@
   id: Loop
   mapName: 'Loop Station'
   mapPath: /Maps/loop.yml
-  minPlayers: 35
-  maxPlayers: 70
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Loop:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -2,8 +2,8 @@
   id: Marathon
   mapName: 'Marathon Station'
   mapPath: /Maps/marathon.yml
-  minPlayers: 35
-  maxPlayers: 70
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Marathon:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -2,7 +2,7 @@
   id: Meta
   mapName: 'Meta Station'
   mapPath: /Maps/meta.yml
-  minPlayers: 50
+  minPlayers: 0
   maxPlayers: 80
   stations:
     Meta:

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -2,7 +2,8 @@
   id: Oasis
   mapName: 'Oasis'
   mapPath: /Maps/oasis.yml
-  minPlayers: 70
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Oasis:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -2,8 +2,8 @@
   id: Omega
   mapName: 'Omega'
   mapPath: /Maps/omega.yml
-  minPlayers: 7
-  maxPlayers: 35
+  minPlayers: 0
+  maxPlayers: 80 
   stations:
     Omega:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -2,8 +2,8 @@
   id: Packed
   mapName: 'Packed'
   mapPath: /Maps/packed.yml
-  minPlayers: 7
-  maxPlayers: 35
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Packed:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -2,7 +2,7 @@
   id: Plasma
   mapName: 'Plasma'
   mapPath: /Maps/plasma.yml
-  minPlayers: 30
+  minPlayers: 0
   maxPlayers: 80
   stations:
     Plasma:

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -3,7 +3,7 @@
   mapName: 'Reach'
   mapPath: /Maps/reach.yml
   minPlayers: 0
-  maxPlayers: 7
+  maxPlayers: 80
   stations:
     Reach:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -3,7 +3,7 @@
   mapName: 'Saltern'
   mapPath: /Maps/saltern.yml
   minPlayers: 0
-  maxPlayers: 35
+  maxPlayers: 80
   fallback: true
   stations:
     Saltern:

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -4,8 +4,8 @@
   mapPath: /Maps/train.yml
   maxRandomOffset: 0
   randomRotation: false
-  minPlayers: 35
-  maxPlayers: 70
+  minPlayers: 0
+  maxPlayers: 80
   stations:
     Train:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Every map's population now ranges from 0-80 players.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More maps = more fun! Some servers never get to experience the smaller maps.
## Technical details
<!-- Summary of code changes for easier review. -->
I changed the population value for ever map to   minPlayers: 0
  maxPlayers: 80. This includes the debug map
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
I'm not doing that
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Everything broke
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Every map can now be selected whenever! Woohoo!

