### PR TITLE
fix thermal regulation, this time for real, I promise

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -259,7 +259,7 @@
       280: 0.6
       260: 0.4
   - type: ThermalRegulator
-    metabolismHeat: 800
+    metabolismHeat: 500
     radiatedHeat: 100
     implicitHeatRegulation: 800
     sweatHeatRegulation: 2000

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -259,9 +259,9 @@
       280: 0.6
       260: 0.4
   - type: ThermalRegulator
-    metabolismHeat: 500
+    metabolismHeat: 800
     radiatedHeat: 100
-    implicitHeatRegulation: 800
+    implicitHeatRegulation: 500
     sweatHeatRegulation: 2000
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 310.15

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -261,11 +261,11 @@
   - type: ThermalRegulator
     metabolismHeat: 800
     radiatedHeat: 100
-    implicitHeatRegulation: 500
+    implicitHeatRegulation: 800
     sweatHeatRegulation: 2000
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 310.15
-    thermalRegulationTemperatureThreshold: 10
+    thermalRegulationTemperatureThreshold: 2
   - type: Perishable
   - type: Butcherable
     butcheringType: Spike # TODO human.

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -157,7 +157,7 @@
     sweatHeatRegulation: 2000
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 310.15
-    thermalRegulationTemperatureThreshold: 10
+    thermalRegulationTemperatureThreshold: 2
   - type: MovedByPressure
 
 # Used for mobs that require regular atmospheric conditions.
@@ -173,7 +173,7 @@
     sweatHeatRegulation: 500
     shiveringHeatRegulation: 500
     normalBodyTemperature: 310.15
-    thermalRegulationTemperatureThreshold: 10
+    thermalRegulationTemperatureThreshold: 2
   - type: Temperature
     heatDamageThreshold: 325
     coldDamageThreshold: 260


### PR DESCRIPTION
## About the PR
BEHOLD, GRAPHS:
![thermal_1](https://github.com/user-attachments/assets/320ebf2d-0abe-4d15-8c9f-e5debde5ccac)
This one was before my bugfix in https://github.com/space-wizards/space-station-14/pull/35971
You can see how the condition for sweating and shivering was inverted, causing you to ash or freeze at extreme temperatures because they shut down.

![thermal_2](https://github.com/user-attachments/assets/a52948b0-16ac-4cea-a997-7411b3277a84)
This one was after my bugfix. sweating and shivering now kicks in as proper second stage of thermal regulation when hitting the threshold of 25° difference to normal temperature. The problem is that some hardsuits like the atmos suit got near perfect heat isolation and without sweating you increase in temperature by default, meaning you would keep heating up until you hit the 25° difference threshold and sweating kicks in. At this point you already get the temperature alert.

https://github.com/space-wizards/space-station-14/pull/35981 already fixed this by reducing the sweating/shivering threshold, but I originally objected reducing it too much because we don't have such realistic temperatures in this game (you can easily survive having 200°C body temperature) and sweating/shivering should serve as a second stage of regulation rather than being active at all time.

But it turns out that the 10° difference still gives you the heat warning once you reach that temperature inside an atmos suit, so we now reduce it to the originally proposed, more realistic value, giving this result.

![thermal_3](https://github.com/user-attachments/assets/d00c5314-a896-4ca0-9e04-d50adb53477c)

The downside is that makes it now basically the same as implicit heat regulation, which is active at all times. But we can address that by actually implementing the currently unused `CanShiver` and `CanSweat` action blockers, which are currently always true. An interesting mechanic for this could be requiring requiring hunger and thirst to do so.

## Why / Balance
Fixes https://github.com/space-wizards/space-station-14/issues/33596
Supercedes https://github.com/space-wizards/space-station-14/pull/34972

## Technical details
change numbers

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Adjusted thermal regulation again so you no longer overheat in hardsuits.
