### PR TITLE
Teslaloose nerf

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
@@ -25,11 +25,11 @@
     color: "#4080FF"
   - type: Appearance
   - type: LightningArcShooter
-    arcDepth: 2
+    arcDepth: 1
     maxLightningArc: 1
-    shootMinInterval: 4
+    shootMinInterval: 7.5
     shootMaxInterval: 10
-    shootRange: 3
+    shootRange: 2
     lightningPrototype: Lightning
 
 - type: entity
@@ -77,18 +77,19 @@
       params:
         variation: 0.3
   - type: LightningArcShooter
-    arcDepth: 3
+    arcDepth: 2
     maxLightningArc: 4
-    shootMinInterval: 3
-    shootMaxInterval: 5
-    shootRange: 7
+    shootMinInterval: 5
+    shootMaxInterval: 7
+    shootRange: 5
     lightningPrototype: Lightning #To do: change to HyperchargedLightning, after fix beam system
   - type: ChasingWalk
     minSpeed: 1
-    maxSpeed: 3
+    maxSpeed: 2
   - type: ChaoticJump
-    jumpMinInterval: 8
-    jumpMaxInterval: 15
+    jumpMinInterval: 10
+    rangeMin: 2.5
+    rangeMax: 4
   - type: WarpPoint
     follow: true
     location: tesla ball


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Makes teslas less likely to destroy the entire station

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Compared to singulooses, teslalooses are unusually destructive and tend to wipe the entire station. This is likely down to the chasing behaviour, which I have opted to keep in favour of lowering destructive values. This includes lowering its speed, increasing the time between shocks, making teleportation less erratic, etc.

When testing a teslaloose on Bagel (including adding Urists around the map), the teslaloose seemed less destructive overall; half the station was still standing by five minutes, and some departments still had functioning electronics after the tesla passed through.

I have not done enough tests to check if power generation is significantly affected by these changes.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Teslas are now less destructive after escaping containment. This includes an increased time between lightning bolts and slower teleportation rate.