### PR TITLE
Use distinct action labels for toggling internals on and off.

### DIFF
--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -80,17 +80,18 @@ public sealed class InternalsSystem : EntitySystem
 
         InteractionVerb verb = new()
         {
-            Act = () => ToggleInternals(ent, user, force: false, ent),
             Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/dot.svg.192dpi.png")),
         };
 
         if (AreInternalsWorking(ent))
         {
+            verb.Act = () => ToggleInternals(ent, user, force: false, ent, ToggleMode.Off);
             verb.Message = Loc.GetString("action-description-internals-toggle-off");
             verb.Text = Loc.GetString("action-name-internals-toggle-off");
         }
         else
         {
+            verb.Act = () => ToggleInternals(ent, user, force: false, ent, ToggleMode.On);
             verb.Message = Loc.GetString("action-description-internals-toggle-on");
             verb.Text = Loc.GetString("action-name-internals-toggle-on");
         }
@@ -98,27 +99,32 @@ public sealed class InternalsSystem : EntitySystem
         args.Verbs.Add(verb);
     }
 
-    public void ToggleInternals(
+    private void ToggleInternals(
         EntityUid uid,
         EntityUid user,
         bool force,
-        InternalsComponent? internals = null)
+        InternalsComponent? internals = null,
+        ToggleMode mode = ToggleMode.Toggle)
     {
         if (!Resolve(uid, ref internals, logMissing: false))
             return;
 
-        // Toggle off if they're on
         if (AreInternalsWorking(internals))
         {
-            if (force)
-            {
-                DisconnectTank((uid, internals));
+            if (mode == ToggleMode.On)
                 return;
-            }
 
-            StartToggleInternalsDoAfter(user, (uid, internals));
+            if (force)
+                DisconnectTank((uid, internals));
+            else
+                StartToggleInternalsDoAfter(user, (uid, internals), mode);
+
             return;
         }
+
+        // If the intent was to disable internals there’s nothing left to do
+        if (mode == ToggleMode.Off)
+            return;
 
         // If they're not on then check if we have a mask to use
         if (internals.BreathTools.Count == 0)
@@ -137,20 +143,20 @@ public sealed class InternalsSystem : EntitySystem
 
         if (!force)
         {
-            StartToggleInternalsDoAfter(user, (uid, internals));
+            StartToggleInternalsDoAfter(user, (uid, internals), mode);
             return;
         }
 
         _gasTank.ConnectToInternals(tank.Value);
     }
 
-    private void StartToggleInternalsDoAfter(EntityUid user, Entity<InternalsComponent> targetEnt)
+    private void StartToggleInternalsDoAfter(EntityUid user, Entity<InternalsComponent> targetEnt, ToggleMode mode)
     {
         // Is the target not you? If yes, use a do-after to give them time to respond.
         var isUser = user == targetEnt.Owner;
         var delay = !isUser ? targetEnt.Comp.Delay : TimeSpan.Zero;
 
-        _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, delay, new InternalsDoAfterEvent(), targetEnt, target: targetEnt)
+        _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, delay, new InternalsDoAfterEvent(mode), targetEnt, target: targetEnt)
         {
             BreakOnDamage = true,
             BreakOnMove =  true,
@@ -163,7 +169,7 @@ public sealed class InternalsSystem : EntitySystem
         if (args.Cancelled || args.Handled)
             return;
 
-        ToggleInternals(ent, args.User, force: true, ent);
+        ToggleInternals(ent, args.User, force: true, ent, args.ToggleMode);
 
         args.Handled = true;
     }

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -80,14 +80,20 @@ public sealed class InternalsSystem : EntitySystem
 
         InteractionVerb verb = new()
         {
-            Act = () =>
-            {
-                ToggleInternals(ent, user, force: false, ent);
-            },
-            Message = Loc.GetString("action-description-internals-toggle"),
+            Act = () => ToggleInternals(ent, user, force: false, ent),
             Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/dot.svg.192dpi.png")),
-            Text = Loc.GetString("action-name-internals-toggle"),
         };
+
+        if (AreInternalsWorking(ent))
+        {
+            verb.Message = Loc.GetString("action-description-internals-toggle-off");
+            verb.Text = Loc.GetString("action-name-internals-toggle-off");
+        }
+        else
+        {
+            verb.Message = Loc.GetString("action-description-internals-toggle-on");
+            verb.Text = Loc.GetString("action-name-internals-toggle-on");
+        }
 
         args.Verbs.Add(verb);
     }

--- a/Content.Shared/Internals/InternalsDoAfterEvent.cs
+++ b/Content.Shared/Internals/InternalsDoAfterEvent.cs
@@ -4,9 +4,24 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Internals;
 
-[Serializable, NetSerializable]
-public sealed partial class InternalsDoAfterEvent : SimpleDoAfterEvent
+public enum ToggleMode
 {
+    Toggle,
+    On,
+    Off
+}
+
+[Serializable, NetSerializable]
+public sealed partial class InternalsDoAfterEvent : DoAfterEvent
+{
+    public ToggleMode ToggleMode = ToggleMode.Toggle;
+
+    public InternalsDoAfterEvent(ToggleMode mode)
+    {
+        ToggleMode = mode;
+    }
+
+    public override DoAfterEvent Clone() => this;
 }
 
 public sealed partial class ToggleInternalsAlertEvent : BaseAlertEvent;

--- a/Resources/Locale/en-US/actions/actions/internals.ftl
+++ b/Resources/Locale/en-US/actions/actions/internals.ftl
@@ -1,5 +1,7 @@
-action-name-internals-toggle = Toggle Internals
-action-description-internals-toggle = Breathe from the equipped gas tank. Also requires equipped breath mask.
+action-name-internals-toggle-on = Toggle Internals On
+action-description-internals-toggle-on = Breathe from the equipped gas tank. Also requires equipped breath mask.
+action-name-internals-toggle-off = Toggle Internals Off
+action-description-internals-toggle-off = Breathe from the environment.
 
 internals-no-breath-tool = You are not wearing a breathing tool
 internals-no-tank = You are not wearing a gas tank


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes the verb menu item from "Toggle Internals" to "Toggle Internals On/Off".

## Why / Balance
Right now if you are trying to help someone who is critical there’s no way to tell if their internals are currently on or off, only trial and error with toggling.

## Technical details
To avoid potentially confusing situations where two people could "Toggle Internals On" on the same entity (thus turning it on and then off), this also changes the logic to implement specific action modes.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
add: Clearer labels for toggle internals actions