### PR TITLE
Remove unused PowerConsumer from grilles

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -34,8 +34,6 @@
     - type: Damageable
       damageContainer: StructuralInorganic
       damageModifierSet: PerforatedMetallic
-    - type: PowerConsumer
-      showInMonitor: false
     - type: Electrified
       requirePower: true
       noWindowInTile: true


### PR DESCRIPTION
This caused tons of completely wasted processing in the power system. Incredible.
