### PR TITLE
Cleanup BiomeSystem.Commands

### DIFF
--- a/Content.Server/Parallax/BiomeSystem.Commands.cs
+++ b/Content.Server/Parallax/BiomeSystem.Commands.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Administration;
 using Content.Shared.Administration;
 using Content.Shared.Parallax.Biomes;

--- a/Content.Server/Parallax/BiomeSystem.Commands.cs
+++ b/Content.Server/Parallax/BiomeSystem.Commands.cs
@@ -29,7 +29,7 @@ public sealed partial class BiomeSystem
 
         int.TryParse(args[0], out var mapInt);
         var mapId = new MapId(mapInt);
-        var mapUid = _mapManager.GetMapEntityId(mapId);
+        var mapUid = _mapSystem.GetMapOrInvalid(mapId);
 
         if (_mapManager.MapExists(mapId) ||
             !TryComp<BiomeComponent>(mapUid, out var biome))
@@ -64,7 +64,7 @@ public sealed partial class BiomeSystem
         }
 
         var mapId = new MapId(mapInt);
-        var mapUid = _mapManager.GetMapEntityId(mapId);
+        var mapUid = _mapSystem.GetMapOrInvalid(mapId);
 
         if (!_mapManager.MapExists(mapId) || !TryComp<BiomeComponent>(mapUid, out var biome))
         {
@@ -105,7 +105,7 @@ public sealed partial class BiomeSystem
             {
                 var mapId = new MapId(mapInt);
 
-                if (TryComp<BiomeComponent>(_mapManager.GetMapEntityId(mapId), out var biome))
+                if (TryComp<BiomeComponent>(_mapSystem.GetMapOrInvalid(mapId), out var biome))
                 {
                     var results = new List<string>();
 
@@ -145,7 +145,7 @@ public sealed partial class BiomeSystem
 
         var mapId = new MapId(mapInt);
 
-        if (!_mapManager.MapExists(mapId) || !TryComp<BiomeComponent>(_mapManager.GetMapEntityId(mapId), out var biome))
+        if (!_mapManager.MapExists(mapId) || !TryComp<BiomeComponent>(_mapSystem.GetMapOrInvalid(mapId), out var biome))
         {
             return;
         }

--- a/Content.Server/Parallax/BiomeSystem.Commands.cs
+++ b/Content.Server/Parallax/BiomeSystem.Commands.cs
@@ -31,7 +31,7 @@ public sealed partial class BiomeSystem
         var mapId = new MapId(mapInt);
         var mapUid = _mapSystem.GetMapOrInvalid(mapId);
 
-        if (_mapManager.MapExists(mapId) ||
+        if (_mapSystem.MapExists(mapId) ||
             !TryComp<BiomeComponent>(mapUid, out var biome))
         {
             return;
@@ -66,7 +66,7 @@ public sealed partial class BiomeSystem
         var mapId = new MapId(mapInt);
         var mapUid = _mapSystem.GetMapOrInvalid(mapId);
 
-        if (!_mapManager.MapExists(mapId) || !TryComp<BiomeComponent>(mapUid, out var biome))
+        if (!_mapSystem.MapExists(mapId) || !TryComp<BiomeComponent>(mapUid, out var biome))
         {
             return;
         }
@@ -145,7 +145,7 @@ public sealed partial class BiomeSystem
 
         var mapId = new MapId(mapInt);
 
-        if (!_mapManager.MapExists(mapId) || !TryComp<BiomeComponent>(_mapSystem.GetMapOrInvalid(mapId), out var biome))
+        if (!_mapSystem.MapExists(mapId) || !TryComp<BiomeComponent>(_mapSystem.GetMapOrInvalid(mapId), out var biome))
         {
             return;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 7 warnings in `BiomeSystem.Commands.cs`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
**4x 'IMapManager.GetMapEntityId(MapId)' is obsolete: 'Use MapSystem' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Replaced `_mapManager.GetMapEntityId` with `_mapSystem.GetMapOrInvalid`. Used `GetMapOrInvalid` rather than `GetMap` to replicate old functionality and avoid throwing an exception on commands with map mapIds.

**3x 'IMapManager.MapExists(MapId?)' is obsolete: 'Use MapSystem' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Simple substitution: `_mapManager.MapExists` -> `_mapSystem.MapExists`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->