### PR TITLE
Cleanup SpecialRespawnSystem

### DIFF
--- a/Content.Server/Respawn/SpecialRespawnSystem.cs
+++ b/Content.Server/Respawn/SpecialRespawnSystem.cs
@@ -173,7 +173,7 @@ public sealed class SpecialRespawnSystem : SharedSpecialRespawnSystem
             var randomY = _random.Next((int) gridBounds.Bottom, (int) gridBounds.Top);
 
             tile = new Vector2i(randomX - (int) gridPos.X, randomY - (int) gridPos.Y);
-            var mapPos = grid.GridTileToWorldPos(tile);
+            var mapPos = _map.GridTileToWorldPos(targetGrid, grid, tile);
             var mapTarget = grid.WorldToTile(mapPos);
             var circle = new Circle(mapPos, 2);
 

--- a/Content.Server/Respawn/SpecialRespawnSystem.cs
+++ b/Content.Server/Respawn/SpecialRespawnSystem.cs
@@ -111,7 +111,7 @@ public sealed class SpecialRespawnSystem : SharedSpecialRespawnSystem
                 if (tile.IsSpace(_tileDefinitionManager)
                     || _turf.IsTileBlocked(tile, CollisionGroup.MobMask)
                     || !_atmosphere.IsTileMixtureProbablySafe(entityGridUid, entityMapUid.Value,
-                        grid.TileIndicesFor(mapPos)))
+                        _map.TileIndicesFor((entityGridUid.Value, grid), mapPos)))
                 {
                     continue;
                 }

--- a/Content.Server/Respawn/SpecialRespawnSystem.cs
+++ b/Content.Server/Respawn/SpecialRespawnSystem.cs
@@ -174,7 +174,7 @@ public sealed class SpecialRespawnSystem : SharedSpecialRespawnSystem
 
             tile = new Vector2i(randomX - (int) gridPos.X, randomY - (int) gridPos.Y);
             var mapPos = _map.GridTileToWorldPos(targetGrid, grid, tile);
-            var mapTarget = grid.WorldToTile(mapPos);
+            var mapTarget = _map.WorldToTile(targetGrid, grid, mapPos);
             var circle = new Circle(mapPos, 2);
 
             foreach (var newTileRef in _map.GetTilesIntersecting(targetGrid, grid, circle))

--- a/Content.Server/Respawn/SpecialRespawnSystem.cs
+++ b/Content.Server/Respawn/SpecialRespawnSystem.cs
@@ -136,7 +136,7 @@ public sealed class SpecialRespawnSystem : SharedSpecialRespawnSystem
     private void Respawn(EntityUid oldEntity, string prototype, EntityCoordinates coords)
     {
         var entity = Spawn(prototype, coords);
-        _adminLog.Add(LogType.Respawn, LogImpact.Extreme, $"{ToPrettyString(oldEntity)} was deleted and was respawned at {coords.ToMap(EntityManager, _transform)} as {ToPrettyString(entity)}");
+        _adminLog.Add(LogType.Respawn, LogImpact.Extreme, $"{ToPrettyString(oldEntity)} was deleted and was respawned at {_transform.ToMapCoordinates(coords)} as {ToPrettyString(entity)}");
         _chat.SendAdminAlert($"{MetaData(oldEntity).EntityName} was deleted and was respawned as {ToPrettyString(entity)}");
     }
 

--- a/Content.Server/Respawn/SpecialRespawnSystem.cs
+++ b/Content.Server/Respawn/SpecialRespawnSystem.cs
@@ -183,7 +183,7 @@ public sealed class SpecialRespawnSystem : SharedSpecialRespawnSystem
                     continue;
 
                 found = true;
-                targetCoords = grid.GridTileToLocal(tile);
+                targetCoords = _map.GridTileToLocal(targetGrid, grid, tile);
                 break;
             }
 

--- a/Content.Server/Respawn/SpecialRespawnSystem.cs
+++ b/Content.Server/Respawn/SpecialRespawnSystem.cs
@@ -157,7 +157,7 @@ public sealed class SpecialRespawnSystem : SharedSpecialRespawnSystem
 
         var xform = Transform(targetGrid);
 
-        if (!grid.TryGetTileRef(xform.Coordinates, out var tileRef))
+        if (!_map.TryGetTileRef(targetGrid, grid, xform.Coordinates, out var tileRef))
             return false;
 
         var tile = tileRef.GridIndices;

--- a/Content.Server/Respawn/SpecialRespawnSystem.cs
+++ b/Content.Server/Respawn/SpecialRespawnSystem.cs
@@ -169,10 +169,10 @@ public sealed class SpecialRespawnSystem : SharedSpecialRespawnSystem
         //Obviously don't put anything ridiculous in here
         for (var i = 0; i < maxAttempts; i++)
         {
-            var randomX = _random.Next((int) gridBounds.Left, (int) gridBounds.Right);
-            var randomY = _random.Next((int) gridBounds.Bottom, (int) gridBounds.Top);
+            var randomX = _random.Next((int)gridBounds.Left, (int)gridBounds.Right);
+            var randomY = _random.Next((int)gridBounds.Bottom, (int)gridBounds.Top);
 
-            tile = new Vector2i(randomX - (int) gridPos.X, randomY - (int) gridPos.Y);
+            tile = new Vector2i(randomX - (int)gridPos.X, randomY - (int)gridPos.Y);
             var mapPos = _map.GridTileToWorldPos(targetGrid, grid, tile);
             var mapTarget = _map.WorldToTile(targetGrid, grid, mapPos);
             var circle = new Circle(mapPos, 2);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 6 warnings in `SpecialRespawnSystem.cs`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
**1x 'MapGridComponent.TileIndicesFor(MapCoordinates)' is obsolete: 'Use the MapSystem method' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Swapped method. Had to pass in grid uid which was already in scope.

**1x 'EntityCoordinates.ToMap(IEntityManager, SharedTransformSystem)' is obsolete: 'Use SharedTransformSystem.ToMapCoordinates()' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Swapped method.

**1x 'MapGridComponent.TryGetTileRef(EntityCoordinates, out TileRef)' is obsolete: 'Use the MapSystem method' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Swapped method. Had to pass in grid uid which was already in scope.

**1x 'MapGridComponent.GridTileToWorldPos(Vector2i)' is obsolete: 'Use the MapSystem method' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Swapped method. Had to pass in grid uid which was already in scope.

**1x 'MapGridComponent.WorldToTile(Vector2)' is obsolete: 'Use the MapSystem method' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Swapped method. Had to pass in grid uid which was already in scope.

**1x 'MapGridComponent.GridTileToLocal(Vector2i)' is obsolete: 'Use the MapSystem method' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Swapped method. Had to pass in grid uid which was already in scope.

Also fixed formatting of cast expressions because why not?

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->