### PR TITLE
Cleanup WarpCommand

### DIFF
--- a/Content.Server/Administration/Commands/WarpCommand.cs
+++ b/Content.Server/Administration/Commands/WarpCommand.cs
@@ -120,9 +120,8 @@ namespace Content.Server.Administration.Commands
                 }
 
                 var xform = _entManager.GetComponent<TransformComponent>(playerEntity);
-                var xformSystem = _entManager.System<SharedTransformSystem>();
-                xform.Coordinates = coords;
-                xformSystem.AttachToGridOrMap(playerEntity, xform);
+                _transform.SetCoordinates(playerEntity, coords);
+                _transform.AttachToGridOrMap(playerEntity, xform);
                 if (_entManager.TryGetComponent(playerEntity, out PhysicsComponent? physics))
                 {
                     _entManager.System<SharedPhysicsSystem>().SetLinearVelocity(playerEntity, Vector2.Zero, body: physics);

--- a/Content.Server/Administration/Commands/WarpCommand.cs
+++ b/Content.Server/Administration/Commands/WarpCommand.cs
@@ -83,8 +83,8 @@ namespace Content.Server.Administration.Commands
                             return 1;
                         }
 
-                        var mapA = a.GetMapId(_entManager);
-                        var mapB = a.GetMapId(_entManager);
+                        var mapA = _transform.GetMapId(a);
+                        var mapB = _transform.GetMapId(a);
 
                         if (mapA == mapB)
                         {

--- a/Content.Server/Administration/Commands/WarpCommand.cs
+++ b/Content.Server/Administration/Commands/WarpCommand.cs
@@ -48,7 +48,7 @@ namespace Content.Server.Administration.Commands
             }
             else
             {
-                if (player.Status != SessionStatus.InGame || player.AttachedEntity is not {Valid: true} playerEntity)
+                if (player.Status != SessionStatus.InGame || player.AttachedEntity is not { Valid: true } playerEntity)
                 {
                     shell.WriteLine("You are not in-game!");
                     return;

--- a/Content.Server/Administration/Commands/WarpCommand.cs
+++ b/Content.Server/Administration/Commands/WarpCommand.cs
@@ -17,8 +17,6 @@ namespace Content.Server.Administration.Commands
     {
         [Dependency] private readonly IEntityManager _entManager = default!;
 
-        [Dependency] private readonly SharedTransformSystem _transform = default!;
-
         public string Command => "warp";
         public string Description => "Teleports you to predefined areas on the map.";
 
@@ -59,14 +57,16 @@ namespace Content.Server.Administration.Commands
                 var currentMap = _entManager.GetComponent<TransformComponent>(playerEntity).MapID;
                 var currentGrid = _entManager.GetComponent<TransformComponent>(playerEntity).GridUid;
 
+                var xformSystem = _entManager.System<SharedTransformSystem>();
+
                 var found = GetWarpPointByName(location)
                     .OrderBy(p => p.Item1, Comparer<EntityCoordinates>.Create((a, b) =>
                     {
                         // Sort so that warp points on the same grid/map are first.
                         // So if you have two maps loaded with the same warp points,
                         // it will prefer the warp points on the map you're currently on.
-                        var aGrid = _transform.GetGrid(a);
-                        var bGrid = _transform.GetGrid(b);
+                        var aGrid = xformSystem.GetGrid(a);
+                        var bGrid = xformSystem.GetGrid(b);
 
                         if (aGrid == bGrid)
                         {
@@ -83,8 +83,8 @@ namespace Content.Server.Administration.Commands
                             return 1;
                         }
 
-                        var mapA = _transform.GetMapId(a);
-                        var mapB = _transform.GetMapId(b);
+                        var mapA = xformSystem.GetMapId(a);
+                        var mapB = xformSystem.GetMapId(b);
 
                         if (mapA == mapB)
                         {
@@ -120,8 +120,8 @@ namespace Content.Server.Administration.Commands
                 }
 
                 var xform = _entManager.GetComponent<TransformComponent>(playerEntity);
-                _transform.SetCoordinates(playerEntity, coords);
-                _transform.AttachToGridOrMap(playerEntity, xform);
+                xformSystem.SetCoordinates(playerEntity, coords);
+                xformSystem.AttachToGridOrMap(playerEntity, xform);
                 if (_entManager.TryGetComponent(playerEntity, out PhysicsComponent? physics))
                 {
                     _entManager.System<SharedPhysicsSystem>().SetLinearVelocity(playerEntity, Vector2.Zero, body: physics);

--- a/Content.Server/Administration/Commands/WarpCommand.cs
+++ b/Content.Server/Administration/Commands/WarpCommand.cs
@@ -17,6 +17,8 @@ namespace Content.Server.Administration.Commands
     {
         [Dependency] private readonly IEntityManager _entManager = default!;
 
+        [Dependency] private readonly SharedTransformSystem _transform = default!;
+
         public string Command => "warp";
         public string Description => "Teleports you to predefined areas on the map.";
 
@@ -63,8 +65,8 @@ namespace Content.Server.Administration.Commands
                         // Sort so that warp points on the same grid/map are first.
                         // So if you have two maps loaded with the same warp points,
                         // it will prefer the warp points on the map you're currently on.
-                        var aGrid = a.GetGridUid(_entManager);
-                        var bGrid = b.GetGridUid(_entManager);
+                        var aGrid = _transform.GetGrid(a);
+                        var bGrid = _transform.GetGrid(b);
 
                         if (aGrid == bGrid)
                         {

--- a/Content.Server/Administration/Commands/WarpCommand.cs
+++ b/Content.Server/Administration/Commands/WarpCommand.cs
@@ -119,9 +119,8 @@ namespace Content.Server.Administration.Commands
                     return;
                 }
 
-                var xform = _entManager.GetComponent<TransformComponent>(playerEntity);
                 xformSystem.SetCoordinates(playerEntity, coords);
-                xformSystem.AttachToGridOrMap(playerEntity, xform);
+                xformSystem.AttachToGridOrMap(playerEntity);
                 if (_entManager.TryGetComponent(playerEntity, out PhysicsComponent? physics))
                 {
                     _entManager.System<SharedPhysicsSystem>().SetLinearVelocity(playerEntity, Vector2.Zero, body: physics);

--- a/Content.Server/Administration/Commands/WarpCommand.cs
+++ b/Content.Server/Administration/Commands/WarpCommand.cs
@@ -84,7 +84,7 @@ namespace Content.Server.Administration.Commands
                         }
 
                         var mapA = _transform.GetMapId(a);
-                        var mapB = _transform.GetMapId(a);
+                        var mapB = _transform.GetMapId(b);
 
                         if (mapA == mapB)
                         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 5 warnings in `WarpCommand.cs`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
**2x 'EntityCoordinates.GetGridUid(IEntityManager)' is obsolete: 'Use SharedTransformSystem.GetGrid()' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Simple substitution.

**2x 'EntityCoordinates.GetMapId(IEntityManager)' is obsolete: 'Use SharedTransformSystem.GetMapId()' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Simple substitution.

**1x 'TransformComponent.Coordinates.set' is obsolete: 'Use the system's setter method instead.' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Simple substitution.

The `EntityManager.System` call to get `SharedMapSystem` was moved earlier in the method.

Also stumbled upon and fixed a bug where the `mapA` and `mapB` variables were being assigned the same value before comparison, leading to warp points on the current map not being prioritized correctly.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->