### PR TITLE
remove mind roles from EntityWhitelist

### DIFF
--- a/Content.Server/Objectives/Components/RoleRequirementComponent.cs
+++ b/Content.Server/Objectives/Components/RoleRequirementComponent.cs
@@ -1,5 +1,6 @@
 using Content.Server.Objectives.Systems;
-using Content.Shared.Whitelist;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
 
 namespace Content.Server.Objectives.Components;
 
@@ -10,6 +11,9 @@ namespace Content.Server.Objectives.Components;
 [RegisterComponent, Access(typeof(RoleRequirementSystem))]
 public sealed partial class RoleRequirementComponent : Component
 {
-    [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
-    public EntityWhitelist Roles = new();
+    /// <summary>
+    /// Mind role component whitelist.
+    /// </summary>
+    [DataField(required: true, customTypeSerializer: typeof(CustomHashSetSerializer<string, ComponentNameSerializer>))]
+    public HashSet<string> Roles = new();
 }

--- a/Content.Server/Objectives/Systems/RoleRequirementSystem.cs
+++ b/Content.Server/Objectives/Systems/RoleRequirementSystem.cs
@@ -1,6 +1,6 @@
 using Content.Server.Objectives.Components;
 using Content.Shared.Objectives.Components;
-using Content.Shared.Whitelist;
+using Content.Shared.Roles;
 
 namespace Content.Server.Objectives.Systems;
 
@@ -9,7 +9,8 @@ namespace Content.Server.Objectives.Systems;
 /// </summary>
 public sealed class RoleRequirementSystem : EntitySystem
 {
-    [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly IComponentFactory _componentFactory = default!;
+    [Dependency] private readonly SharedRoleSystem _roles = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -22,7 +23,19 @@ public sealed class RoleRequirementSystem : EntitySystem
         if (args.Cancelled)
             return;
 
-        if (_whitelistSystem.IsWhitelistFail(comp.Roles, args.MindId))
-            args.Cancelled = true;
+        foreach (var role in comp.Roles)
+        {
+            if (!_componentFactory.TryGetRegistration(role, out var roleReg))
+            {
+                Log.Error($"Role component not found for RoleRequirementComponent: {role}");
+                continue;
+            }
+
+            if (_roles.MindHasRole(args.MindId, roleReg.Type, out _))
+                return; // whitelist pass
+        }
+
+        // whitelist fail
+        args.Cancelled = true;
     }
 }

--- a/Content.Server/Objectives/Systems/RoleRequirementSystem.cs
+++ b/Content.Server/Objectives/Systems/RoleRequirementSystem.cs
@@ -9,7 +9,6 @@ namespace Content.Server.Objectives.Systems;
 /// </summary>
 public sealed class RoleRequirementSystem : EntitySystem
 {
-    [Dependency] private readonly IComponentFactory _componentFactory = default!;
     [Dependency] private readonly SharedRoleSystem _roles = default!;
     public override void Initialize()
     {
@@ -25,7 +24,7 @@ public sealed class RoleRequirementSystem : EntitySystem
 
         foreach (var role in comp.Roles)
         {
-            if (!_componentFactory.TryGetRegistration(role, out var roleReg))
+            if (!EntityManager.ComponentFactory.TryGetRegistration(role, out var roleReg))
             {
                 Log.Error($"Role component not found for RoleRequirementComponent: {role}");
                 continue;

--- a/Content.Shared/Whitelist/EntityWhitelist.cs
+++ b/Content.Shared/Whitelist/EntityWhitelist.cs
@@ -10,6 +10,9 @@ namespace Content.Shared.Whitelist;
 ///     Does not whitelist by prototypes, since that is undesirable; you're better off just adding a tag to all
 ///     entity prototypes that need to be whitelisted, and checking for that.
 /// </summary>
+/// <remarks>
+///     Do not add more conditions like itemsize to the whitelist, this should stay as lightweight as possible!
+/// </remarks>
 /// <code>
 /// whitelist:
 ///   tags:
@@ -30,12 +33,6 @@ public sealed partial class EntityWhitelist
     ///     Component names that are allowed in the whitelist.
     /// </summary>
     [DataField] public string[]? Components;
-    // TODO yaml validation
-
-    /// <summary>
-    ///     Mind Role Prototype names that are allowed in the whitelist.
-    /// </summary>
-    [DataField] public string[]? MindRoles;
     // TODO yaml validation
 
     /// <summary>

--- a/Content.Shared/Whitelist/EntityWhitelistSystem.cs
+++ b/Content.Shared/Whitelist/EntityWhitelistSystem.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Item;
-using Content.Shared.Roles;
 using Content.Shared.Tag;
 
 namespace Content.Shared.Whitelist;
@@ -8,7 +7,6 @@ namespace Content.Shared.Whitelist;
 public sealed class EntityWhitelistSystem : EntitySystem
 {
     [Dependency] private readonly IComponentFactory _factory = default!;
-    [Dependency] private readonly SharedRoleSystem _roles = default!;
     [Dependency] private readonly TagSystem _tag = default!;
 
     private EntityQuery<ItemComponent> _itemQuery;
@@ -54,22 +52,6 @@ public sealed class EntityWhitelistSystem : EntitySystem
                 var regs = StringsToRegs(list.Components);
                 list.Registrations = new List<ComponentRegistration>();
                 list.Registrations.AddRange(regs);
-            }
-        }
-
-        if (list.MindRoles != null)
-        {
-            var regs = StringsToRegs(list.MindRoles);
-
-            foreach (var role in regs)
-            {
-                if ( _roles.MindHasRole(uid, role.Type, out _))
-                {
-                    if (!list.RequireAll)
-                        return true;
-                }
-                else if (list.RequireAll)
-                    return false;
             }
         }
 

--- a/Resources/Prototypes/Objectives/dragon.yml
+++ b/Resources/Prototypes/Objectives/dragon.yml
@@ -9,8 +9,7 @@
     issuer: objective-issuer-dragon
   - type: RoleRequirement
     roles:
-      mindRoles:
-      - DragonRole
+    - DragonRole
 
 - type: entity
   parent: BaseDragonObjective

--- a/Resources/Prototypes/Objectives/ninja.yml
+++ b/Resources/Prototypes/Objectives/ninja.yml
@@ -9,8 +9,7 @@
     issuer: objective-issuer-spiderclan
   - type: RoleRequirement
     roles:
-      mindRoles:
-      - NinjaRole
+    - NinjaRole
 
 - type: entity
   parent: BaseNinjaObjective

--- a/Resources/Prototypes/Objectives/paradoxClone.yml
+++ b/Resources/Prototypes/Objectives/paradoxClone.yml
@@ -9,8 +9,7 @@
     issuer: objective-issuer-paradox
   - type: RoleRequirement
     roles:
-      mindRoles:
-      - ParadoxCloneRole
+    - ParadoxCloneRole
   - type: Tag
     tags:
     - ParadoxCloneObjectiveBlacklist # don't copy the objectives from other clones

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -7,8 +7,7 @@
     issuer: objective-issuer-thief
   - type: RoleRequirement
     roles:
-      mindRoles:
-      - ThiefRole
+    - ThiefRole
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -7,8 +7,7 @@
     issuer: objective-issuer-syndicate
   - type: RoleRequirement
     roles:
-      mindRoles:
-      - TraitorRole
+    - TraitorRole
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Objectives/wizard.yml
+++ b/Resources/Prototypes/Objectives/wizard.yml
@@ -9,8 +9,7 @@
     issuer: objective-issuer-swf
   - type: RoleRequirement
     roles:
-      mindRoles:
-      - WizardRole
+    - WizardRole
 
 - type: entity
   parent: [BaseWizardObjective, BaseSurviveObjective]


### PR DESCRIPTION
## About the PR
They should not be in there, whitelists should stay as lightweight as possible.
Itemsize should probably be removed as well.

## Why / Balance
![grafik](https://github.com/user-attachments/assets/2edae959-21b3-496c-be88-be7bab5ea9c2)

## Technical details
Removed the roles datafield from `EntityWhitelist` and the corresponding logic from the system.
The only thing using it was `RoleRequirementComponent`, so I have rewritten that to directly check if the target has the given role components.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Removed the `Roles` datafield from `EntityWhitelist`.
`RoleRequirementComponent` now needs a hashset of component names instead of an `EntityWhitelist`.
This needs a minor change to the yaml formatting:
```
  - type: RoleRequirement
    roles:
      mindRoles:
      - NinjaRole
``` 
becomes
```
  - type: RoleRequirement
    roles:
    - NinjaRole
```

**Changelog**
not player facing
