### PR TITLE
Cleanup TabletopSystem.Map

### DIFF
--- a/Content.Server/Tabletop/TabletopSystem.Map.cs
+++ b/Content.Server/Tabletop/TabletopSystem.Map.cs
@@ -45,7 +45,7 @@ namespace Content.Server.Tabletop
         /// </summary>
         private void EnsureTabletopMap()
         {
-            if (TabletopMap != MapId.Nullspace && _mapManager.MapExists(TabletopMap))
+            if (TabletopMap != MapId.Nullspace && _map.MapExists(TabletopMap))
                 return;
 
             TabletopMap = _mapManager.CreateMap();
@@ -89,7 +89,7 @@ namespace Content.Server.Tabletop
 
         private void OnRoundRestart(RoundRestartCleanupEvent _)
         {
-            if (TabletopMap == MapId.Nullspace || !_mapManager.MapExists(TabletopMap))
+            if (TabletopMap == MapId.Nullspace || !_map.MapExists(TabletopMap))
                 return;
 
             // This will usually *not* be the case, but better make sure.

--- a/Content.Server/Tabletop/TabletopSystem.Map.cs
+++ b/Content.Server/Tabletop/TabletopSystem.Map.cs
@@ -93,7 +93,7 @@ namespace Content.Server.Tabletop
                 return;
 
             // This will usually *not* be the case, but better make sure.
-            _mapManager.DeleteMap(TabletopMap);
+            _map.DeleteMap(TabletopMap);
 
             // Reset tabletop count.
             _tabletops = 0;

--- a/Content.Server/Tabletop/TabletopSystem.Map.cs
+++ b/Content.Server/Tabletop/TabletopSystem.Map.cs
@@ -48,9 +48,9 @@ namespace Content.Server.Tabletop
             if (TabletopMap != MapId.Nullspace && _map.MapExists(TabletopMap))
                 return;
 
-            TabletopMap = _mapManager.CreateMap();
+            var mapUid = _map.CreateMap(out var mapId);
+            TabletopMap = mapId;
             _tabletops = 0;
-            var mapUid = _mapManager.GetMapEntityId(TabletopMap);
 
             var mapComp = EntityManager.GetComponent<MapComponent>(mapUid);
 

--- a/Content.Server/Tabletop/TabletopSystem.cs
+++ b/Content.Server/Tabletop/TabletopSystem.cs
@@ -22,6 +22,7 @@ namespace Content.Server.Tabletop
     public sealed partial class TabletopSystem : SharedTabletopSystem
     {
         [Dependency] private readonly IMapManager _mapManager = default!;
+        [Dependency] private readonly SharedMapSystem _map = default!;
         [Dependency] private readonly EyeSystem _eye = default!;
         [Dependency] private readonly ViewSubscriberSystem _viewSubscriberSystem = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;

--- a/Content.Server/Tabletop/TabletopSystem.cs
+++ b/Content.Server/Tabletop/TabletopSystem.cs
@@ -12,7 +12,6 @@ using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
-using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 
@@ -21,7 +20,6 @@ namespace Content.Server.Tabletop
     [UsedImplicitly]
     public sealed partial class TabletopSystem : SharedTabletopSystem
     {
-        [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly SharedMapSystem _map = default!;
         [Dependency] private readonly EyeSystem _eye = default!;
         [Dependency] private readonly ViewSubscriberSystem _viewSubscriberSystem = default!;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes 5 warnings in `TabletopSystem.Map.cs`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/issues/33279

## Technical details
<!-- Summary of code changes for easier review. -->
**2x 'IMapManager.MapExists(MapId?)' is obsolete: 'Use MapSystem' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Simple substitution.

**1x 'IMapManager.DeleteMap(MapId)' is obsolete: 'Use MapSystem' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
Simple substitution.

**1x 'IMapManager.CreateMap(MapId?)' is obsolete: 'Use MapSystem' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
**1x 'IMapManager.GetMapEntityId(MapId)' is obsolete: 'Use MapSystem' [CS0618](https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618))**
These two were able to be combined by using `SharedMapSystem.CreateMap`, which returns the map uid (removing the need for `IMapManager.GetMapEntityId`) and has the assigned `MapId` as an out parameter (which `IMapManager.CreateMap` used to return).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->