### PR TITLE
Overlay stack sorting fix

### DIFF
--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -95,7 +95,7 @@ internal sealed class AdminNameOverlay : Overlay
                 continue;
 
             // Get on-screen coordinates of player
-            var screenCoordinates = _eyeManager.WorldToScreen(aabb.Center);
+            var screenCoordinates = _eyeManager.WorldToScreen(aabb.Center).Rounded();
 
             sortable.Add((info, aabb, entity.Value, screenCoordinates));
         }
@@ -109,7 +109,7 @@ internal sealed class AdminNameOverlay : Overlay
             var screenCoordinatesCenter = info.Item4;
             //the center position is kept separately, for simpler position comparison later
             var centerOffset = new Vector2(28f, -18f) * uiScale;
-            var screenCoordinates = screenCoordinatesCenter + centerOffset;
+            var screenCoordinates = screenCoordinatesCenter + centerOffset.Rounded();
             var alpha = 1f;
 
             //TODO make a smarter system where the starting offset can be modified by the predicted position and size of already-drawn overlays/stacks?

--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -109,7 +109,7 @@ internal sealed class AdminNameOverlay : Overlay
             var screenCoordinatesCenter = info.Item4;
             //the center position is kept separately, for simpler position comparison later
             var centerOffset = new Vector2(28f, -18f) * uiScale;
-            var screenCoordinates = screenCoordinatesCenter + centerOffset.Rounded();
+            var screenCoordinates = screenCoordinatesCenter + centerOffset;
             var alpha = 1f;
 
             //TODO make a smarter system where the starting offset can be modified by the predicted position and size of already-drawn overlays/stacks?


### PR DESCRIPTION
## About the PR
Stacked overlays should no longer sometimes inexplicably flicker/rapidly switch the order

## Why / Balance
Bug

## Technical details
The stack flicker is probably caused by the imprecision of the numbers used for sorting, though the problem is rare and exceedingly difficult to reproduced or observein dev... So I could not actually confirm what exactly happens when this issue manifests or if this indeed fixes it, but it probably will

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
