### PR TITLE
Make MappingDataNode use string keys

### DIFF
--- a/Content.Server/Atmos/Serialization/TileAtmosCollectionSerializer.cs
+++ b/Content.Server/Atmos/Serialization/TileAtmosCollectionSerializer.cs
@@ -25,7 +25,7 @@ public sealed partial class TileAtmosCollectionSerializer : ITypeSerializer<Dict
         SerializationHookContext hookCtx, ISerializationContext? context = null,
         ISerializationManager.InstantiationDelegate<Dictionary<Vector2i, TileAtmosphere>>? instanceProvider = null)
     {
-        node.TryGetValue(new ValueDataNode("version"), out var versionNode);
+        node.TryGetValue("version", out var versionNode);
         var version = ((ValueDataNode?) versionNode)?.AsInt() ?? 1;
         Dictionary<Vector2i, TileAtmosphere> tiles = new();
 
@@ -59,7 +59,7 @@ public sealed partial class TileAtmosCollectionSerializer : ITypeSerializer<Dict
             var dataNode = (MappingDataNode) node["data"];
             var chunkSize = serializationManager.Read<int>(dataNode["chunkSize"], hookCtx, context);
 
-            dataNode.TryGetValue(new ValueDataNode("uniqueMixes"), out var mixNode);
+            dataNode.TryGet("uniqueMixes", out var mixNode);
             var unique = mixNode == null ? null : serializationManager.Read<List<GasMixture>?>(mixNode, hookCtx, context);
 
             if (unique != null)
@@ -67,7 +67,7 @@ public sealed partial class TileAtmosCollectionSerializer : ITypeSerializer<Dict
                 var tileNode = (MappingDataNode) dataNode["tiles"];
                 foreach (var (chunkNode, valueNode) in tileNode)
                 {
-                    var chunkOrigin = serializationManager.Read<Vector2i>(chunkNode, hookCtx, context);
+                    var chunkOrigin = serializationManager.Read<Vector2i>(tileNode.GetKeyNode(chunkNode), hookCtx, context);
                     var chunk = serializationManager.Read<TileAtmosChunk>(valueNode, hookCtx, context);
 
                     foreach (var (mix, data) in chunk.Data)

--- a/Content.Server/Maps/MapMigrationSystem.cs
+++ b/Content.Server/Maps/MapMigrationSystem.cs
@@ -66,13 +66,13 @@ public sealed class MapMigrationSystem : EntitySystem
 
         foreach (var (key, value) in mappings)
         {
-            if (key is not ValueDataNode keyNode || value is not ValueDataNode valueNode)
+            if (value is not ValueDataNode valueNode)
                 continue;
 
             if (string.IsNullOrWhiteSpace(valueNode.Value) || valueNode.Value == "null")
-                ev.DeletedPrototypes.Add(keyNode.Value);
+                ev.DeletedPrototypes.Add(key);
             else
-                ev.RenamedPrototypes.Add(keyNode.Value, valueNode.Value);
+                ev.RenamedPrototypes.Add(key, valueNode.Value);
         }
     }
 }

--- a/Content.Server/Maps/MapMigrationSystem.cs
+++ b/Content.Server/Maps/MapMigrationSystem.cs
@@ -33,7 +33,7 @@ public sealed class MapMigrationSystem : EntitySystem
             return;
 
         // Verify that all of the entries map to valid entity prototypes.
-        foreach (var node in mappings.Values)
+        foreach (var node in mappings.Children.Values)
         {
             var newId = ((ValueDataNode) node).Value;
             if (!string.IsNullOrEmpty(newId) && newId != "null")

--- a/Content.Server/NPC/NPCBlackboardSerializer.cs
+++ b/Content.Server/NPC/NPCBlackboardSerializer.cs
@@ -23,11 +23,11 @@ public sealed class NPCBlackboardSerializer : ITypeReader<NPCBlackboard, Mapping
 
         foreach (var data in node)
         {
-            var key = data.Key.ToYamlNode().AsString();
+            var key = data.Key;
 
             if (data.Value.Tag == null)
             {
-                validated.Add(new ErrorNode(data.Key, $"Unable to validate {key}'s type"));
+                validated.Add(new ErrorNode(node.GetKeyNode(key), $"Unable to validate {key}'s type"));
                 continue;
             }
 
@@ -35,7 +35,7 @@ public sealed class NPCBlackboardSerializer : ITypeReader<NPCBlackboard, Mapping
 
             if (!reflection.TryLooseGetType(typeString, out var type))
             {
-                validated.Add(new ErrorNode(data.Key, $"Unable to find type for {typeString}"));
+                validated.Add(new ErrorNode(node.GetKeyNode(key), $"Unable to find type for {typeString}"));
                 continue;
             }
 
@@ -60,7 +60,7 @@ public sealed class NPCBlackboardSerializer : ITypeReader<NPCBlackboard, Mapping
 
         foreach (var data in node)
         {
-            var key = data.Key.ToYamlNode().AsString();
+            var key = data.Key;
 
             if (data.Value.Tag == null)
                 throw new NullReferenceException($"Found null tag for {key}");

--- a/Content.Shared/Body/Prototypes/BodyPrototypeSerializer.cs
+++ b/Content.Shared/Body/Prototypes/BodyPrototypeSerializer.cs
@@ -40,12 +40,6 @@ public sealed class BodyPrototypeSerializer : ITypeReader<BodyPrototype, Mapping
         {
             foreach (var (key, value) in organsNode)
             {
-                if (key is not ValueDataNode)
-                {
-                    nodes.Add(new ErrorNode(key, $"Key is not a value data node"));
-                    continue;
-                }
-
                 if (value is not ValueDataNode organ)
                 {
                     nodes.Add(new ErrorNode(value, $"Value is not a value data node"));
@@ -91,12 +85,6 @@ public sealed class BodyPrototypeSerializer : ITypeReader<BodyPrototype, Mapping
 
             foreach (var (key, value) in slots)
             {
-                if (key is not ValueDataNode)
-                {
-                    nodes.Add(new ErrorNode(key, $"Key is not a value data node"));
-                    continue;
-                }
-
                 if (value is not MappingDataNode slot)
                 {
                     nodes.Add(new ErrorNode(value, $"Slot is not a mapping data node"));
@@ -128,10 +116,9 @@ public sealed class BodyPrototypeSerializer : ITypeReader<BodyPrototype, Mapping
         var slotNodes = node.Get<MappingDataNode>("slots");
         var allConnections = new Dictionary<string, (string? Part, HashSet<string>? Connections, Dictionary<string, string>? Organs)>();
 
-        foreach (var (keyNode, valueNode) in slotNodes)
+        foreach (var (slotId, valueNode) in slotNodes)
         {
-            var slotId = ((ValueDataNode) keyNode).Value;
-            var slot = ((MappingDataNode) valueNode);
+            var slot = (MappingDataNode) valueNode;
 
             string? part = null;
             if (slot.TryGet<ValueDataNode>("part", out var value))
@@ -155,9 +142,9 @@ public sealed class BodyPrototypeSerializer : ITypeReader<BodyPrototype, Mapping
             {
                 organs = new Dictionary<string, string>();
 
-                foreach (var (organKeyNode, organValueNode) in slotOrgansNode)
+                foreach (var (organKey, organValueNode) in slotOrgansNode)
                 {
-                    organs.Add(((ValueDataNode) organKeyNode).Value, ((ValueDataNode) organValueNode).Value);
+                    organs.Add(organKey, ((ValueDataNode) organValueNode).Value);
                 }
             }
 

--- a/Content.Shared/Containers/ContainerFillComponent.cs
+++ b/Content.Shared/Containers/ContainerFillComponent.cs
@@ -49,13 +49,11 @@ public sealed class ContainerFillSerializer : ITypeValidator<Dictionary<string, 
 
         foreach (var (key, val) in node.Children)
         {
-            var keyVal = serializationManager.ValidateNode<string>(key, context);
-
             var listVal = (val is SequenceDataNode seq)
                 ? ListSerializer.Validate(serializationManager, seq, dependencies, context)
                 : new ErrorNode(val, "ContainerFillComponent prototypes must be a sequence/list");
 
-            mapping.Add(keyVal, listVal);
+            mapping.Add(new ValidatedValueNode(node.GetKeyNode(key)), listVal);
         }
 
         return new ValidatedMappingNode(mapping);

--- a/Content.Shared/Decals/DecalGridChunkCollectionTypeSerializer.cs
+++ b/Content.Shared/Decals/DecalGridChunkCollectionTypeSerializer.cs
@@ -29,7 +29,7 @@ namespace Content.Shared.Decals
             IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null,
             ISerializationManager.InstantiationDelegate<DecalGridChunkCollection>? _ = default)
         {
-            node.TryGetValue(new ValueDataNode("version"), out var versionNode);
+            node.TryGetValue("version", out var versionNode);
             var version = ((ValueDataNode?) versionNode)?.AsInt() ?? 1;
             Dictionary<Vector2i, DecalChunk> dictionary;
             uint nextIndex = 0;
@@ -49,7 +49,7 @@ namespace Content.Shared.Decals
 
                     foreach (var (decalUidNode, decalData) in deckNodes)
                     {
-                        var dUid = serializationManager.Read<uint>(decalUidNode, hookCtx, context);
+                        var dUid = uint.Parse(decalUidNode, CultureInfo.InvariantCulture);
                         var coords = serializationManager.Read<Vector2>(decalData, hookCtx, context);
 
                         var chunkOrigin = SharedMapSystem.GetChunkIndices(coords, SharedDecalSystem.ChunkSize);
@@ -132,7 +132,7 @@ namespace Content.Shared.Decals
                 {
                     var decal = decalLookup[uid];
                     // Inline coordinates
-                    decks.Add(serializationManager.WriteValue(uid, alwaysWrite, context), serializationManager.WriteValue(decal.Coordinates, alwaysWrite, context));
+                    decks.Add(uid.ToString(), serializationManager.WriteValue(decal.Coordinates, alwaysWrite, context));
                 }
 
                 lookupNode.Add("decals", decks);


### PR DESCRIPTION
Changes required for an engine PR, see engine PR for details.
Requires space-wizards/RobustToolbox/pull/5783
