### PR TITLE
Centcomm death rattle implant

### DIFF
--- a/Content.Shared/Implants/Components/RattleComponent.cs
+++ b/Content.Shared/Implants/Components/RattleComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Implants.Components;
 public sealed partial class RattleComponent : Component
 {
     // The radio channel the message will be sent to
-    [DataField]
+    [DataField("radioChannel")]
     public ProtoId<RadioChannelPrototype> RadioChannel = "Syndicate";
 
     // The message that the implant will send when crit

--- a/Content.Shared/Implants/Components/RattleComponent.cs
+++ b/Content.Shared/Implants/Components/RattleComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Implants.Components;
 public sealed partial class RattleComponent : Component
 {
     // The radio channel the message will be sent to
-    [DataField("radioChannel")]
+    [DataField]
     public ProtoId<RadioChannelPrototype> RadioChannel = "Syndicate";
 
     // The message that the implant will send when crit
@@ -16,6 +16,6 @@ public sealed partial class RattleComponent : Component
     public LocId CritMessage = "deathrattle-implant-critical-message";
 
     // The message that the implant will send when dead
-    [DataField("deathMessage")]
+    [DataField]
     public LocId DeathMessage = "deathrattle-implant-dead-message";
 }

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -18,9 +18,9 @@
   id: EventHumanoidCentcomm
   parent: EventHumanoidMindShielded
   components:
-    - type: AutoImplant
-      implants:
-      - DeathRattleImplantCentcomm
+  - type: AutoImplant
+    implants:
+    - DeathRattleImplantCentcomm
 
 ## Death Squad
 

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -14,6 +14,14 @@
     - type: MindShield
     - type: AntagImmune
 
+- type: randomHumanoidSettings
+  id: EventHumanoidCentcomm
+  parent: EventHumanoidMindShielded
+  components:
+    - type: AutoImplant
+      implants:
+      - DeathRattleImplantCentcomm
+
 ## Death Squad
 
 - type: entity
@@ -33,7 +41,7 @@
 
 - type: randomHumanoidSettings
   id: DeathSquad
-  parent: EventHumanoidMindShielded
+  parent: EventHumanoidCentcomm
   randomizeName: false
   components:
     - type: GhostRole
@@ -72,7 +80,7 @@
 
 - type: randomHumanoidSettings
   id: ERTLeader
-  parent: EventHumanoidMindShielded
+  parent: EventHumanoidCentcomm
   randomizeName: false
   components:
     - type: GhostRole
@@ -500,7 +508,7 @@
 
 - type: randomHumanoidSettings
   id: CBURNAgent
-  parent: EventHumanoidMindShielded
+  parent: EventHumanoidCentcomm
   components:
     - type: Loadout
       prototypes: [CBURNGear]
@@ -530,7 +538,7 @@
 
 - type: randomHumanoidSettings
   id: CentcomOfficial
-  parent: EventHumanoidMindShielded
+  parent: EventHumanoidCentcomm
   components:
     - type: GhostRole
       name: ghost-role-information-centcom-official-name

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -311,7 +311,7 @@
 
 - type: entity
   id: DeathRattleImplanterCentcomm
-  suffix: deathrattle centcomm
+  suffix: centcomm death rattle
   parent: BaseImplantOnlyImplanter
   components:
   - type: Implanter

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -308,3 +308,11 @@
   components:
   - type: Implanter
     implant: RadioImplantCentcomm
+
+- type: entity
+  id: DeathRattleImplanterCentcomm
+  suffix: deathrattle centcomm
+  parent: BaseImplantOnlyImplanter
+  components:
+  - type: Implanter
+    implant: DeathRattleImplantCentcomm

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -364,20 +364,11 @@
     - CentCom
 
 - type: entity
-  parent: BaseSubdermalImplant
+  parent: DeathRattleImplant
   id: DeathRattleImplantCentcomm
   name: centcomm death rattle implant
   description: This implant will inform the Centcomm radio channel should the user fall into critical condition or die.
   categories: [ HideSpawnMenu ]
   components:
-  - type: SubdermalImplant
-    permanent: true
-    whitelist:
-      components:
-      - MobState # admeme implanting a chair with rattle implant needs to give the chair mobstate so it can die first
-  - type: TriggerOnMobstateChange
-    mobState:
-    - Critical
-    - Dead
   - type: Rattle
     radioChannel: CentCom

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -362,3 +362,22 @@
   - type: RadioImplant
     radioChannels:
     - CentCom
+
+- type: entity
+  parent: BaseSubdermalImplant
+  id: DeathRattleImplantCentcomm
+  name: centcomm death rattle implant
+  description: This implant will inform the Centcomm radio channel should the user fall into critical condition or die.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubdermalImplant
+    permanent: true
+    whitelist:
+      components:
+      - MobState # admeme implanting a chair with rattle implant needs to give the chair mobstate so it can die first
+  - type: TriggerOnMobstateChange
+    mobState:
+    - Critical
+    - Dead
+  - type: Rattle
+    radioChannel: CentCom

--- a/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
@@ -12,6 +12,9 @@
   - AllAccess
   access:
   - CentralCommand
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
 
 - type: startingGear
   id: CBURNGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
@@ -12,6 +12,9 @@
   - AllAccess
   access:
   - CentralCommand
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
 
 - type: startingGear
   id: DeathSquadGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -13,6 +13,9 @@
   - AllAccess
   access:
   - CentralCommand
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
 
 - type: startingGear
   id: ERTLeaderGear
@@ -107,6 +110,8 @@
   - !type:AddComponentSpecial
     components:
     - type: BibleUser #Lets them heal with bibles
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
 
 - type: startingGear
   id: ERTChaplainGear
@@ -185,6 +190,9 @@
   - AllAccess
   access:
   - CentralCommand
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
 
 - type: startingGear
   id: ERTEngineerGear
@@ -257,6 +265,9 @@
   - AllAccess
   access:
   - CentralCommand
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
 
 - type: startingGear
   id: ERTSecurityGear
@@ -347,6 +358,9 @@
   - AllAccess
   access:
   - CentralCommand
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
 
 - type: startingGear
   id: ERTMedicalGear
@@ -411,6 +425,9 @@
   - AllAccess
   access:
   - CentralCommand
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
 
 - type: startingGear
   id: ERTJanitorGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
@@ -12,6 +12,9 @@
   - AllAccess
   access:
   - CentralCommand
+  special:
+  - !type:AddImplantSpecial
+    implants: [ MindShieldImplant, DeathRattleImplantCentcomm ]
 
 - type: startingGear
   id: CentcomGear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds an implant + implanter for a death-rattle for the centcomm radio channel, and adds them natively to CC ghost roles.

## Why / Balance
Because it seems fitting, and useful for potential admeme roleplay with CC.

## Technical details
Adds `DeathRattleImplantCentcomm` and `DeathRattleImplanterCentcomm` that has a death rattle effect on crit and death to the CentCom channel. Also adds a tag to the RadioChannel field, because why not.

## Media
(other rattling implants added to compare)
![image](https://github.com/user-attachments/assets/793b516a-9008-4a8d-bbc7-5a8524631922)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None?

**Changelog**
No cl as players won't experience this outside admemes.
