### PR TITLE
Add microwave-nukedisk interaction

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -544,6 +544,10 @@ namespace Content.Server.Kitchen.EntitySystems
                 var ev = new BeingMicrowavedEvent(uid, user);
                 RaiseLocalEvent(item, ev);
 
+                // TODO MICROWAVE SPARKS & EFFECTS
+                // Various microwaveable entities should probably spawn a spark, play a sound, and generate a pop=up.
+                // This should probably be handled by the microwave system, with fields in BeingMicrowavedEvent.
+
                 if (ev.Handled)
                 {
                     UpdateUserInterfaceState(uid, component);

--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -21,8 +21,7 @@ namespace Content.Server.Nuke
         /// <summary>
         ///     Default bomb timer value in seconds.
         /// </summary>
-        [DataField("timer")]
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public int Timer = 300;
 
         /// <summary>
@@ -36,7 +35,7 @@ namespace Content.Server.Nuke
         ///     How long until the bomb can arm again after deactivation.
         ///     Used to prevent announcements spam.
         /// </summary>
-        [DataField("cooldown")]
+        [DataField]
         public int Cooldown = 30;
 
         /// <summary>
@@ -143,32 +142,32 @@ namespace Content.Server.Nuke
         /// </summary>
         public (MapId, EntityUid?)? OriginMapGrid;
 
-        [DataField("codeLength")] public int CodeLength = 6;
-        [ViewVariables] public string Code = string.Empty;
+        [DataField] public int CodeLength = 6;
+        [DataField] public string Code = string.Empty;
 
         /// <summary>
         ///     Time until explosion in seconds.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public float RemainingTime;
 
         /// <summary>
         ///     Time until bomb cooldown will expire in seconds.
         /// </summary>
-        [ViewVariables]
+        [DataField]
         public float CooldownTime;
 
         /// <summary>
         ///     Current nuclear code buffer. Entered manually by players.
         ///     If valid it will allow arm/disarm bomb.
         /// </summary>
-        [ViewVariables]
+        [DataField]
         public string EnteredCode = "";
 
         /// <summary>
         ///     Current status of a nuclear bomb.
         /// </summary>
-        [ViewVariables]
+        [DataField]
         public NukeStatus Status = NukeStatus.AWAIT_DISK;
 
         /// <summary>

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -86,7 +86,6 @@ public sealed class NukeSystem : EntitySystem
 
     private void OnInit(EntityUid uid, NukeComponent component, ComponentInit args)
     {
-        component.RemainingTime = component.Timer;
         _itemSlots.AddItemSlot(uid, SharedNukeComponent.NukeDiskSlotId, component.DiskSlot);
 
         UpdateStatus(uid, component);
@@ -114,11 +113,13 @@ public sealed class NukeSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, NukeComponent nuke, MapInitEvent args)
     {
+        nuke.RemainingTime = nuke.Timer;
         var originStation = _station.GetOwningStation(uid);
 
         if (originStation != null)
+        {
             nuke.OriginStation = originStation;
-
+        }
         else
         {
             var transform = Transform(uid);

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.AlertLevel;
 using Content.Server.Audio;
 using Content.Server.Chat.Systems;
 using Content.Server.Explosion.EntitySystems;
+using Content.Server.Kitchen.Components;
 using Content.Server.Pinpointer;
 using Content.Server.Popups;
 using Content.Server.Station.Systems;
@@ -79,6 +80,8 @@ public sealed class NukeSystem : EntitySystem
 
         // Doafter events
         SubscribeLocalEvent<NukeComponent, NukeDisarmDoAfterEvent>(OnDoAfter);
+
+        SubscribeLocalEvent<NukeDiskComponent, BeingMicrowavedEvent>(OnMicrowaved);
     }
 
     private void OnInit(EntityUid uid, NukeComponent component, ComponentInit args)
@@ -123,6 +126,18 @@ public sealed class NukeSystem : EntitySystem
         }
 
         nuke.Code = GenerateRandomNumberString(nuke.CodeLength);
+    }
+
+    /// <summary>
+    /// Slightly randomize nuke countdown timer
+    /// </summary>
+    private void OnMicrowaved(Entity<NukeDiskComponent> ent, ref BeingMicrowavedEvent args)
+    {
+        if (ent.Comp.TimeModifier != null)
+            return;
+
+        var seconds = _random.NextGaussian(ent.Comp.MicrowaveMean.TotalSeconds, ent.Comp.MicrowaveStd.TotalSeconds);
+        ent.Comp.TimeModifier = TimeSpan.FromSeconds(seconds);
     }
 
     private void OnRemove(EntityUid uid, NukeComponent component, ComponentRemove args)
@@ -346,11 +361,11 @@ public sealed class NukeSystem : EntitySystem
                     break;
                 }
 
-                // var isValid = _codes.IsCodeValid(uid, component.EnteredCode);
                 if (component.EnteredCode == component.Code)
                 {
                     component.Status = NukeStatus.AWAIT_ARM;
-                    component.RemainingTime = component.Timer;
+                    var modifier = CompOrNull<NukeDiskComponent>(component.DiskSlot.Item)?.TimeModifier ?? TimeSpan.Zero;
+                    component.RemainingTime = MathF.Max(component.Timer + (float)modifier.TotalSeconds, component.MinimumTime);
                     _audio.PlayPvs(component.AccessGrantedSound, uid);
                 }
                 else

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -138,6 +138,7 @@ public sealed class NukeSystem : EntitySystem
 
         var seconds = _random.NextGaussian(ent.Comp.MicrowaveMean.TotalSeconds, ent.Comp.MicrowaveStd.TotalSeconds);
         ent.Comp.TimeModifier = TimeSpan.FromSeconds(seconds);
+        _popups.PopupEntity(Loc.GetString("nuke-disk-component-microwave"), ent.Owner, PopupType.Medium);
     }
 
     private void OnRemove(EntityUid uid, NukeComponent component, ComponentRemove args)

--- a/Content.Shared/Nuke/NukeDiskComponent.cs
+++ b/Content.Shared/Nuke/NukeDiskComponent.cs
@@ -8,5 +8,16 @@ namespace Content.Shared.Nuke;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class NukeDiskComponent : Component
 {
+    /// <summary>
+    /// Used to modify the nuke's countdown timer.
+    /// </summary>
+    [DataField]
+    public TimeSpan? TimeModifier;
 
+    [DataField]
+    public TimeSpan MicrowaveMean = TimeSpan.Zero;
+
+    [DataField]
+    public TimeSpan MicrowaveStd = TimeSpan.FromSeconds(27.35);
+    // STD of 27.36s means theres an 90% chance the time is between +-45s, and a ~99% chance its between +-70s
 }

--- a/Resources/Locale/en-US/nuke/nuke-component.ftl
+++ b/Resources/Locale/en-US/nuke/nuke-component.ftl
@@ -6,6 +6,8 @@ nuke-component-announcement-unarmed = The station's self-destruct was deactivate
 nuke-component-announcement-send-codes = Attention! Self-destruction codes have been sent to designated fax machines.
 nuke-component-doafter-warning = You start fiddling with wires and knobs in order to disarm the nuke.. This may take a while.
 
+nuke-disk-component-microwave = The disk sparks and fizzles a bit, but seems mostly unharmed?
+
 # Nuke UI
 nuke-user-interface-title = Nuclear Fission Explosive
 nuke-user-interface-arm-button = ARM


### PR DESCRIPTION
## About the PR
Makes microwaving a nuke disk change the nuke countdown timer by a random amount.

## Why / Balance
Why? I was told to add the feature by a friend and we don't have enough funny microwave interactions. 

Balance wise, it currently randomly changes the default 300s cooldown using a gaussian distribution. 90% of the time the modifier is smaller than 45s, and 99% of the it's smaller than 70s. The resulting nuke timer will still always be greater than `NukeComponent.MinimumTime`. Using a flat distribution instead of gaussian might be better for balance as it prevent extreme events, but I'd rather it just usually have a small impact, while still allowing it to sometimes change the timer by an appreciable amount. I don't really feel strongly about the specific numbers, I chose them pretty arbitrarily.

## Technical details
Adds a new `NukeDiskComponent.TimeModifier` datafield that is combined with the NukeComponent's `Timer` datafield to set the remaining time when the nuke is ready to be armed. Unless it already has a value, the disks time modifier will be randomly assigned whenever the disk is first microwaved, and there is no way to know what the modifier is until the disk is in the nuke & the code has been entered.

## Media

I've added a pop-up message, but cant be bothered re-recording the video:

https://github.com/user-attachments/assets/922612df-f5b2-4eec-b301-dc3eca7ca1cc

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

:cl:
- add: Microwaving the nuke disk will now slightly randomize the nuke countdown timer.
