### PR TITLE
Improve Do Not Map test to whitelist specific prototypes per map and whitelist entire directories

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -67,6 +67,10 @@ namespace Content.IntegrationTests.Tests
         /// <summary>
         /// Maps listed here are given blanket freedom to contain "DoNotMap" entities. Use sparingly.
         /// </summary>
+        /// <remarks>
+        /// It is also possible to whitelist entire directories here. For example, adding
+        /// "/Maps/Shuttles/" will whitelist all shuttle maps.
+        /// </remarks>
         private static readonly string[] DoNotMapWhitelistAll =
         {
             "/Maps/centcomm.yml",
@@ -280,8 +284,11 @@ namespace Content.IntegrationTests.Tests
         /// </summary>
         private void CheckDoNotMap(ResPath map, YamlNode node, IPrototypeManager protoManager)
         {
-            if (DoNotMapWhitelistAll.Contains(map.ToString()))
-                return;
+            foreach (var mapFilter in DoNotMapWhitelistAll)
+            {
+                if (map.ToString().StartsWith(mapFilter))
+                    return;
+            }
 
             var yamlEntities = node["entities"];
             if (!protoManager.TryIndex<EntityCategoryPrototype>("DoNotMap", out var dnmCategory))

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -52,7 +52,7 @@ namespace Content.IntegrationTests.Tests
         /// despite being categorized as "DoNotMap", while any unlisted prototypes will still
         /// cause the test to fail.
         /// </remarks>
-        private static readonly Dictionary<string, EntProtoId[]> DoNotMapWhiteList = new()
+        private static readonly Dictionary<string, EntProtoId[]> DoNotMapWhitelistSpecific = new()
         {
             {"/Maps/bagel.yml", ["RubberStampMime"]},
             {"/Maps/meta.yml", ["RubberStampWarden"]},
@@ -71,7 +71,7 @@ namespace Content.IntegrationTests.Tests
         /// It is also possible to whitelist entire directories here. For example, adding
         /// "/Maps/Shuttles/" will whitelist all shuttle maps.
         /// </remarks>
-        private static readonly string[] DoNotMapWhitelistAll =
+        private static readonly string[] DoNotMapWhitelist =
         {
             "/Maps/centcomm.yml",
         };
@@ -273,7 +273,7 @@ namespace Content.IntegrationTests.Tests
 
         private bool IsWhitelistedForMap(EntProtoId protoId, ResPath map)
         {
-            if (!DoNotMapWhiteList.TryGetValue(map.ToString(), out var allowedProtos))
+            if (!DoNotMapWhitelistSpecific.TryGetValue(map.ToString(), out var allowedProtos))
                 return false;
 
             return allowedProtos.Contains(protoId);
@@ -284,7 +284,7 @@ namespace Content.IntegrationTests.Tests
         /// </summary>
         private void CheckDoNotMap(ResPath map, YamlNode node, IPrototypeManager protoManager)
         {
-            foreach (var mapFilter in DoNotMapWhitelistAll)
+            foreach (var mapFilter in DoNotMapWhitelist)
             {
                 if (map.ToString().StartsWith(mapFilter))
                     return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds two new features to the integration test that checks for "Do Not Map" entities on maps (https://github.com/space-wizards/space-station-14/pull/34711)
- It is now possible to whitelist specific entity prototypes on a map, instead of having to whitelist an entire map to permit a single prototype:
```c#
{"/Maps/meta.yml", ["RubberStampWarden"]},
{"/Maps/reach.yml", ["HandheldCrewMonitor"]},
{"/Maps/gate.yml", ["ShuttleGunPerforator", "StationAiBrain"]},
```
- It is now possible to whitelist entire directories of maps, including subdirectories. This can be used, for example, to whitelist all shuttle maps:
```c#
"/Maps/Shuttles/"
```

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Inspired by the last two bullet points of https://github.com/space-wizards/space-station-14/issues/35208.

## Technical details
<!-- Summary of code changes for easier review. -->
- Added a new static field `DoNotMapWhitelistSpecific` above the existing `DoNotMapWhitelist`. `DoNotMapWhitelistSpecific` is a dictionary of map paths to arrays of EntProtoIds that are whitelisted.
- Added a method that looks up a given EntProtoId string and a map path and uses `DoNotMapWhitelistSpecific` to return whether the given combo is permitted or not.
- Changed the logic used to check for matches in `DoNotMapWhitelist` from requiring an exact match with any whitelist entry to checking if the map path string starts with any whitelist entry.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
