### PR TITLE
Uncuffing yourself will now deal minor stamina damage

### DIFF
--- a/Content.Shared/Cuffs/Components/HandcuffComponent.cs
+++ b/Content.Shared/Cuffs/Components/HandcuffComponent.cs
@@ -34,6 +34,12 @@ public sealed partial class HandcuffComponent : Component
     public float StunBonus = 2f;
 
     /// <summary>
+    /// Amount of Stamina Damage dealt on a self-uncuff attempt.
+    /// </summary>
+    [DataField]
+    public float SelfUncuffStamDamage = 15f;
+
+    /// <summary>
     ///     Will the cuffs break when removed?
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
@@ -99,10 +105,11 @@ public sealed partial class HandcuffComponent : Component
 /// Should generate popups on the User.
 /// </summary>
 [ByRefEvent]
-public record struct UncuffAttemptEvent(EntityUid User, EntityUid Target)
+public record struct UncuffAttemptEvent(EntityUid User, EntityUid Target, EntityUid Cuffs)
 {
     public readonly EntityUid User = User;
     public readonly EntityUid Target = Target;
+    public readonly EntityUid Cuffs = Cuffs;
     public bool Cancelled = false;
 }
 

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -53,7 +53,7 @@ namespace Content.Shared.Cuffs
         [Dependency] private readonly SharedInteractionSystem _interaction = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
-        [Dependency] private   readonly StaminaSystem           _stamina         = default!;
+        [Dependency] private readonly StaminaSystem _stamina = default!;
         [Dependency] private readonly UseDelaySystem _delay = default!;
 
         public override void Initialize()

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -132,7 +132,10 @@ namespace Content.Shared.Cuffs
                 Dirty(args.User, cuffable);
 
                 // User will take self-inflicted stamina damage if attempting to uncuff themselves. This should happen even if the uncuff attempt fails.
-                _stamina.TakeStaminaDamage(args.Target, 15f, visual: true, source: args.User);
+                if (TryComp<HandcuffComponent>(args.Cuffs, out var handcuffComp))
+                {
+                    _stamina.TakeStaminaDamage(args.Target, handcuffComp.SelfUncuffStamDamage, visual: true, source: args.User);
+                }
             }
             else
             {
@@ -609,7 +612,7 @@ namespace Content.Shared.Cuffs
             if (!Resolve(cuffsToRemove.Value, ref cuff))
                 return;
 
-            var attempt = new UncuffAttemptEvent(user, target);
+            var attempt = new UncuffAttemptEvent(user, target, cuffsToRemove.Value);
             RaiseLocalEvent(user, ref attempt, true);
 
             if (attempt.Cancelled)
@@ -695,7 +698,7 @@ namespace Content.Shared.Cuffs
 
             if (user != null)
             {
-                var attempt = new UncuffAttemptEvent(user.Value, target);
+                var attempt = new UncuffAttemptEvent(user.Value, target, cuffsToRemove);
                 RaiseLocalEvent(user.Value, ref attempt);
                 if (attempt.Cancelled)
                     return;

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Cuffs.Components;
+using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands;
@@ -52,6 +53,7 @@ namespace Content.Shared.Cuffs
         [Dependency] private readonly SharedInteractionSystem _interaction = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
+        [Dependency] private   readonly StaminaSystem           _stamina         = default!;
         [Dependency] private readonly UseDelaySystem _delay = default!;
 
         public override void Initialize()
@@ -128,6 +130,9 @@ namespace Content.Shared.Cuffs
 
                 cuffable.CanStillInteract = false;
                 Dirty(args.User, cuffable);
+
+                // User will take self-inflicted stamina damage if attempting to uncuff themselves. This should happen even if the uncuff attempt fails.
+                _stamina.TakeStaminaDamage(args.Target, 15f, visual: true, source: args.User);
             }
             else
             {


### PR DESCRIPTION
## About the PR
Performing an uncuff attempt on yourself will cause you to take a minor amount of stamina damage. 
Intended to be a simple first PR!

## Why / Balance
Toxic Players have a tendency to spam their uncuff ad nauseam while discussion happens around them or if they are feeling particularly ornery about their situation. This is usually not fun to deal with as the person holding them that needs to micromanage their do-after timer. This simple change is intended to act as a deterrent for spamming uncuff attempts, while not affecting those who are patient with their break out attempts. 

It is important to note that the do-after window is currently *greater* than the window for stamina recovery, meaning all stamina damage gained from a single attempt will be recovered before the do-after completes. It additionally provides a nice bit of visual feedback of the user needing to **painfully** break out of their own cuffs with a flash of synchronized stam damage.

At its current damage value, it would take at least 7 back to back uncuff attempts before you can stam crit yourself. 
However, in practice it will usually take around 9 to 10, accounting for small delays between attempts and the natrual stamina regeneration working in the players favor.

## Technical details
This is my first PR to this repo so the implementation is intended to be exceedingly simple.


It is currently tied into the  `if (args.User == args.Target)` comparison, so it will never trigger unless the user is the one uncuffing themselves. It is not tied into the do-after event so continuous spamming of uncuff will cause you to take damage multiple times within the same do-after period, though since the entire point of this change is to deter uncuff spam this may be an ignorable issue.

## Media

https://github.com/user-attachments/assets/cdf0e1f2-dd7b-4eff-a1e0-bca96c007a19



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Constructor of `UncuffAttemptEvent` now passes the uid of the cuffs to determine how much damage to apply.
New Variable of `SelfUncuffStamDamage` can be added to cuffs to give a custom damage value, by default this is 15.

**Changelog**
:cl:
- tweak: Attempting to uncuff yourself will now deal a minor amount of self-inflicted stamina damage.
