### PR TITLE
Remove redundant admin flag check in AdminVerbSystem.Tools

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -65,343 +65,340 @@ public sealed partial class AdminVerbSystem
         if (!_adminManager.HasAdminFlag(player, AdminFlags.Admin))
             return;
 
-        if (_adminManager.HasAdminFlag(player, AdminFlags.Admin))
+        if (TryComp<DoorBoltComponent>(args.Target, out var bolts))
         {
-            if (TryComp<DoorBoltComponent>(args.Target, out var bolts))
+            Verb bolt = new()
             {
-                Verb bolt = new()
-                {
-                    Text = bolts.BoltsDown ? "Unbolt" : "Bolt",
-                    Category = VerbCategory.Tricks,
-                    Icon = bolts.BoltsDown
-                        ? new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/unbolt.png"))
-                        : new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/bolt.png")),
-                    Act = () =>
-                    {
-                        _door.SetBoltsDown((args.Target, bolts), !bolts.BoltsDown);
-                    },
-                    Impact = LogImpact.Medium,
-                    Message = Loc.GetString(bolts.BoltsDown
-                        ? "admin-trick-unbolt-description"
-                        : "admin-trick-bolt-description"),
-                    Priority = (int) (bolts.BoltsDown ? TricksVerbPriorities.Unbolt : TricksVerbPriorities.Bolt),
-                };
-                args.Verbs.Add(bolt);
-            }
-
-            if (TryComp<AirlockComponent>(args.Target, out var airlockComp))
-            {
-                Verb emergencyAccess = new()
-                {
-                    Text = airlockComp.EmergencyAccess ? "Emergency Access Off" : "Emergency Access On",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/emergency_access.png")),
-                    Act = () =>
-                    {
-                        _airlockSystem.SetEmergencyAccess((args.Target, airlockComp), !airlockComp.EmergencyAccess);
-                    },
-                    Impact = LogImpact.Medium,
-                    Message = Loc.GetString(airlockComp.EmergencyAccess
-                        ? "admin-trick-emergency-access-off-description"
-                        : "admin-trick-emergency-access-on-description"),
-                    Priority = (int) (airlockComp.EmergencyAccess ? TricksVerbPriorities.EmergencyAccessOff : TricksVerbPriorities.EmergencyAccessOn),
-                };
-                args.Verbs.Add(emergencyAccess);
-            }
-
-            if (HasComp<DamageableComponent>(args.Target))
-            {
-                Verb rejuvenate = new()
-                {
-                    Text = "Rejuvenate",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/rejuvenate.png")),
-                    Act = () =>
-                    {
-                        _rejuvenate.PerformRejuvenate(args.Target);
-                    },
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-rejuvenate-description"),
-                    Priority = (int) TricksVerbPriorities.Rejuvenate,
-                };
-                args.Verbs.Add(rejuvenate);
-            }
-
-            if (!HasComp<GodmodeComponent>(args.Target))
-            {
-                Verb makeIndestructible = new()
-                {
-                    Text = "Make Indestructible",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/plus.svg.192dpi.png")),
-                    Act = () =>
-                    {
-                        _sharedGodmodeSystem.EnableGodmode(args.Target);
-                    },
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-make-indestructible-description"),
-                    Priority = (int) TricksVerbPriorities.MakeIndestructible,
-                };
-                args.Verbs.Add(makeIndestructible);
-            }
-            else
-            {
-                Verb makeVulnerable = new()
-                {
-                    Text = "Make Vulnerable",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/plus.svg.192dpi.png")),
-                    Act = () =>
-                    {
-                        _sharedGodmodeSystem.DisableGodmode(args.Target);
-                    },
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-make-vulnerable-description"),
-                    Priority = (int) TricksVerbPriorities.MakeVulnerable,
-                };
-                args.Verbs.Add(makeVulnerable);
-            }
-
-            if (TryComp<BatteryComponent>(args.Target, out var battery))
-            {
-                Verb refillBattery = new()
-                {
-                    Text = "Refill Battery",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/fill_battery.png")),
-                    Act = () =>
-                    {
-                        _batterySystem.SetCharge(args.Target, battery.MaxCharge, battery);
-                    },
-                    Impact = LogImpact.Medium,
-                    Message = Loc.GetString("admin-trick-refill-battery-description"),
-                    Priority = (int) TricksVerbPriorities.RefillBattery,
-                };
-                args.Verbs.Add(refillBattery);
-
-                Verb drainBattery = new()
-                {
-                    Text = "Drain Battery",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/drain_battery.png")),
-                    Act = () =>
-                    {
-                        _batterySystem.SetCharge(args.Target, 0, battery);
-                    },
-                    Impact = LogImpact.Medium,
-                    Message = Loc.GetString("admin-trick-drain-battery-description"),
-                    Priority = (int) TricksVerbPriorities.DrainBattery,
-                };
-                args.Verbs.Add(drainBattery);
-
-                Verb infiniteBattery = new()
-                {
-                    Text = "Infinite Battery",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/infinite_battery.png")),
-                    Act = () =>
-                    {
-                        var recharger = EnsureComp<BatterySelfRechargerComponent>(args.Target);
-                        recharger.AutoRecharge = true;
-                        recharger.AutoRechargeRate = battery.MaxCharge; // Instant refill.
-                        recharger.AutoRechargePause = false; // No delay.
-                    },
-                    Impact = LogImpact.Medium,
-                    Message = Loc.GetString("admin-trick-infinite-battery-object-description"),
-                    Priority = (int) TricksVerbPriorities.InfiniteBattery,
-                };
-                args.Verbs.Add(infiniteBattery);
-            }
-
-            if (TryComp<AnchorableComponent>(args.Target, out var anchor))
-            {
-                Verb blockUnanchor = new()
-                {
-                    Text = "Block Unanchoring",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/anchor.svg.192dpi.png")),
-                    Act = () =>
-                    {
-                        RemComp(args.Target, anchor);
-                    },
-                    Impact = LogImpact.Medium,
-                    Message = Loc.GetString("admin-trick-block-unanchoring-description"),
-                    Priority = (int) TricksVerbPriorities.BlockUnanchoring,
-                };
-                args.Verbs.Add(blockUnanchor);
-            }
-
-            if (TryComp<GasTankComponent>(args.Target, out var tank))
-            {
-                Verb refillInternalsO2 = new()
-                {
-                    Text = "Refill Internals Oxygen",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/oxygen.rsi"), "icon"),
-                    Act = () =>
-                    {
-                        RefillGasTank(args.Target, Gas.Oxygen, tank);
-                    },
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-internals-refill-oxygen-description"),
-                    Priority = (int) TricksVerbPriorities.RefillOxygen,
-                };
-                args.Verbs.Add(refillInternalsO2);
-
-                Verb refillInternalsN2 = new()
-                {
-                    Text = "Refill Internals Nitrogen",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/red.rsi"), "icon"),
-                    Act = () =>
-                    {
-                        RefillGasTank(args.Target, Gas.Nitrogen, tank);
-                    },
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-internals-refill-nitrogen-description"),
-                    Priority = (int) TricksVerbPriorities.RefillNitrogen,
-                };
-                args.Verbs.Add(refillInternalsN2);
-
-                Verb refillInternalsPlasma = new()
-                {
-                    Text = "Refill Internals Plasma",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/plasma.rsi"), "icon"),
-                    Act = () =>
-                    {
-                        RefillGasTank(args.Target, Gas.Plasma, tank);
-                    },
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-internals-refill-plasma-description"),
-                    Priority = (int) TricksVerbPriorities.RefillPlasma,
-                };
-                args.Verbs.Add(refillInternalsPlasma);
-            }
-
-            if (HasComp<InventoryComponent>(args.Target))
-            {
-                Verb refillInternalsO2 = new()
-                {
-                    Text = "Refill Internals Oxygen",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/oxygen.rsi"), "icon"),
-                    Act = () => RefillEquippedTanks(args.User, Gas.Oxygen),
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-internals-refill-oxygen-description"),
-                    Priority = (int) TricksVerbPriorities.RefillOxygen,
-                };
-                args.Verbs.Add(refillInternalsO2);
-
-                Verb refillInternalsN2 = new()
-                {
-                    Text = "Refill Internals Nitrogen",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/red.rsi"), "icon"),
-                    Act = () =>RefillEquippedTanks(args.User, Gas.Nitrogen),
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-internals-refill-nitrogen-description"),
-                    Priority = (int) TricksVerbPriorities.RefillNitrogen,
-                };
-                args.Verbs.Add(refillInternalsN2);
-
-                Verb refillInternalsPlasma = new()
-                {
-                    Text = "Refill Internals Plasma",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/plasma.rsi"), "icon"),
-                    Act = () => RefillEquippedTanks(args.User, Gas.Plasma),
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-internals-refill-plasma-description"),
-                    Priority = (int) TricksVerbPriorities.RefillPlasma,
-                };
-                args.Verbs.Add(refillInternalsPlasma);
-            }
-
-            Verb sendToTestArena = new()
-            {
-                Text = "Send to test arena",
+                Text = bolts.BoltsDown ? "Unbolt" : "Bolt",
                 Category = VerbCategory.Tricks,
-                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/eject.svg.192dpi.png")),
-
+                Icon = bolts.BoltsDown
+                    ? new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/unbolt.png"))
+                    : new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/bolt.png")),
                 Act = () =>
                 {
-                    var (mapUid, gridUid) = _adminTestArenaSystem.AssertArenaLoaded(player);
-                    _transformSystem.SetCoordinates(args.Target, new EntityCoordinates(gridUid ?? mapUid, Vector2.One));
+                    _door.SetBoltsDown((args.Target, bolts), !bolts.BoltsDown);
                 },
                 Impact = LogImpact.Medium,
-                Message = Loc.GetString("admin-trick-send-to-test-arena-description"),
-                Priority = (int) TricksVerbPriorities.SendToTestArena,
+                Message = Loc.GetString(bolts.BoltsDown
+                    ? "admin-trick-unbolt-description"
+                    : "admin-trick-bolt-description"),
+                Priority = (int) (bolts.BoltsDown ? TricksVerbPriorities.Unbolt : TricksVerbPriorities.Bolt),
             };
-            args.Verbs.Add(sendToTestArena);
+            args.Verbs.Add(bolt);
+        }
 
-            var activeId = FindActiveId(args.Target);
-
-            if (activeId is not null)
+        if (TryComp<AirlockComponent>(args.Target, out var airlockComp))
+        {
+            Verb emergencyAccess = new()
             {
-                Verb grantAllAccess = new()
+                Text = airlockComp.EmergencyAccess ? "Emergency Access Off" : "Emergency Access On",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/emergency_access.png")),
+                Act = () =>
                 {
-                    Text = "Grant All Access",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Misc/id_cards.rsi"), "centcom"),
-                    Act = () =>
-                    {
-                        GiveAllAccess(activeId.Value);
-                    },
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-grant-all-access-description"),
-                    Priority = (int) TricksVerbPriorities.GrantAllAccess,
-                };
-                args.Verbs.Add(grantAllAccess);
+                    _airlockSystem.SetEmergencyAccess((args.Target, airlockComp), !airlockComp.EmergencyAccess);
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString(airlockComp.EmergencyAccess
+                    ? "admin-trick-emergency-access-off-description"
+                    : "admin-trick-emergency-access-on-description"),
+                Priority = (int) (airlockComp.EmergencyAccess ? TricksVerbPriorities.EmergencyAccessOff : TricksVerbPriorities.EmergencyAccessOn),
+            };
+            args.Verbs.Add(emergencyAccess);
+        }
 
-                Verb revokeAllAccess = new()
-                {
-                    Text = "Revoke All Access",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Misc/id_cards.rsi"), "default"),
-                    Act = () =>
-                    {
-                        RevokeAllAccess(activeId.Value);
-                    },
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-revoke-all-access-description"),
-                    Priority = (int) TricksVerbPriorities.RevokeAllAccess,
-                };
-                args.Verbs.Add(revokeAllAccess);
-            }
-
-            if (HasComp<AccessComponent>(args.Target))
+        if (HasComp<DamageableComponent>(args.Target))
+        {
+            Verb rejuvenate = new()
             {
-                Verb grantAllAccess = new()
+                Text = "Rejuvenate",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/rejuvenate.png")),
+                Act = () =>
                 {
-                    Text = "Grant All Access",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Misc/id_cards.rsi"), "centcom"),
-                    Act = () =>
-                    {
-                        GiveAllAccess(args.Target);
-                    },
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-grant-all-access-description"),
-                    Priority = (int) TricksVerbPriorities.GrantAllAccess,
-                };
-                args.Verbs.Add(grantAllAccess);
+                    _rejuvenate.PerformRejuvenate(args.Target);
+                },
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-rejuvenate-description"),
+                Priority = (int) TricksVerbPriorities.Rejuvenate,
+            };
+            args.Verbs.Add(rejuvenate);
+        }
 
-                Verb revokeAllAccess = new()
+        if (!HasComp<GodmodeComponent>(args.Target))
+        {
+            Verb makeIndestructible = new()
+            {
+                Text = "Make Indestructible",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/plus.svg.192dpi.png")),
+                Act = () =>
                 {
-                    Text = "Revoke All Access",
-                    Category = VerbCategory.Tricks,
-                    Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Misc/id_cards.rsi"), "default"),
-                    Act = () =>
-                    {
-                        RevokeAllAccess(args.Target);
-                    },
-                    Impact = LogImpact.Extreme,
-                    Message = Loc.GetString("admin-trick-revoke-all-access-description"),
-                    Priority = (int) TricksVerbPriorities.RevokeAllAccess,
-                };
-                args.Verbs.Add(revokeAllAccess);
-            }
+                    _sharedGodmodeSystem.EnableGodmode(args.Target);
+                },
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-make-indestructible-description"),
+                Priority = (int) TricksVerbPriorities.MakeIndestructible,
+            };
+            args.Verbs.Add(makeIndestructible);
+        }
+        else
+        {
+            Verb makeVulnerable = new()
+            {
+                Text = "Make Vulnerable",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/plus.svg.192dpi.png")),
+                Act = () =>
+                {
+                    _sharedGodmodeSystem.DisableGodmode(args.Target);
+                },
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-make-vulnerable-description"),
+                Priority = (int) TricksVerbPriorities.MakeVulnerable,
+            };
+            args.Verbs.Add(makeVulnerable);
+        }
+
+        if (TryComp<BatteryComponent>(args.Target, out var battery))
+        {
+            Verb refillBattery = new()
+            {
+                Text = "Refill Battery",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/fill_battery.png")),
+                Act = () =>
+                {
+                    _batterySystem.SetCharge(args.Target, battery.MaxCharge, battery);
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString("admin-trick-refill-battery-description"),
+                Priority = (int) TricksVerbPriorities.RefillBattery,
+            };
+            args.Verbs.Add(refillBattery);
+
+            Verb drainBattery = new()
+            {
+                Text = "Drain Battery",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/drain_battery.png")),
+                Act = () =>
+                {
+                    _batterySystem.SetCharge(args.Target, 0, battery);
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString("admin-trick-drain-battery-description"),
+                Priority = (int) TricksVerbPriorities.DrainBattery,
+            };
+            args.Verbs.Add(drainBattery);
+
+            Verb infiniteBattery = new()
+            {
+                Text = "Infinite Battery",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/infinite_battery.png")),
+                Act = () =>
+                {
+                    var recharger = EnsureComp<BatterySelfRechargerComponent>(args.Target);
+                    recharger.AutoRecharge = true;
+                    recharger.AutoRechargeRate = battery.MaxCharge; // Instant refill.
+                    recharger.AutoRechargePause = false; // No delay.
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString("admin-trick-infinite-battery-object-description"),
+                Priority = (int) TricksVerbPriorities.InfiniteBattery,
+            };
+            args.Verbs.Add(infiniteBattery);
+        }
+
+        if (TryComp<AnchorableComponent>(args.Target, out var anchor))
+        {
+            Verb blockUnanchor = new()
+            {
+                Text = "Block Unanchoring",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/anchor.svg.192dpi.png")),
+                Act = () =>
+                {
+                    RemComp(args.Target, anchor);
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString("admin-trick-block-unanchoring-description"),
+                Priority = (int) TricksVerbPriorities.BlockUnanchoring,
+            };
+            args.Verbs.Add(blockUnanchor);
+        }
+
+        if (TryComp<GasTankComponent>(args.Target, out var tank))
+        {
+            Verb refillInternalsO2 = new()
+            {
+                Text = "Refill Internals Oxygen",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/oxygen.rsi"), "icon"),
+                Act = () =>
+                {
+                    RefillGasTank(args.Target, Gas.Oxygen, tank);
+                },
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-internals-refill-oxygen-description"),
+                Priority = (int) TricksVerbPriorities.RefillOxygen,
+            };
+            args.Verbs.Add(refillInternalsO2);
+
+            Verb refillInternalsN2 = new()
+            {
+                Text = "Refill Internals Nitrogen",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/red.rsi"), "icon"),
+                Act = () =>
+                {
+                    RefillGasTank(args.Target, Gas.Nitrogen, tank);
+                },
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-internals-refill-nitrogen-description"),
+                Priority = (int) TricksVerbPriorities.RefillNitrogen,
+            };
+            args.Verbs.Add(refillInternalsN2);
+
+            Verb refillInternalsPlasma = new()
+            {
+                Text = "Refill Internals Plasma",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/plasma.rsi"), "icon"),
+                Act = () =>
+                {
+                    RefillGasTank(args.Target, Gas.Plasma, tank);
+                },
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-internals-refill-plasma-description"),
+                Priority = (int) TricksVerbPriorities.RefillPlasma,
+            };
+            args.Verbs.Add(refillInternalsPlasma);
+        }
+
+        if (HasComp<InventoryComponent>(args.Target))
+        {
+            Verb refillInternalsO2 = new()
+            {
+                Text = "Refill Internals Oxygen",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/oxygen.rsi"), "icon"),
+                Act = () => RefillEquippedTanks(args.User, Gas.Oxygen),
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-internals-refill-oxygen-description"),
+                Priority = (int) TricksVerbPriorities.RefillOxygen,
+            };
+            args.Verbs.Add(refillInternalsO2);
+
+            Verb refillInternalsN2 = new()
+            {
+                Text = "Refill Internals Nitrogen",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/red.rsi"), "icon"),
+                Act = () =>RefillEquippedTanks(args.User, Gas.Nitrogen),
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-internals-refill-nitrogen-description"),
+                Priority = (int) TricksVerbPriorities.RefillNitrogen,
+            };
+            args.Verbs.Add(refillInternalsN2);
+
+            Verb refillInternalsPlasma = new()
+            {
+                Text = "Refill Internals Plasma",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/plasma.rsi"), "icon"),
+                Act = () => RefillEquippedTanks(args.User, Gas.Plasma),
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-internals-refill-plasma-description"),
+                Priority = (int) TricksVerbPriorities.RefillPlasma,
+            };
+            args.Verbs.Add(refillInternalsPlasma);
+        }
+
+        Verb sendToTestArena = new()
+        {
+            Text = "Send to test arena",
+            Category = VerbCategory.Tricks,
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/eject.svg.192dpi.png")),
+
+            Act = () =>
+            {
+                var (mapUid, gridUid) = _adminTestArenaSystem.AssertArenaLoaded(player);
+                _transformSystem.SetCoordinates(args.Target, new EntityCoordinates(gridUid ?? mapUid, Vector2.One));
+            },
+            Impact = LogImpact.Medium,
+            Message = Loc.GetString("admin-trick-send-to-test-arena-description"),
+            Priority = (int) TricksVerbPriorities.SendToTestArena,
+        };
+        args.Verbs.Add(sendToTestArena);
+
+        var activeId = FindActiveId(args.Target);
+
+        if (activeId is not null)
+        {
+            Verb grantAllAccess = new()
+            {
+                Text = "Grant All Access",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Misc/id_cards.rsi"), "centcom"),
+                Act = () =>
+                {
+                    GiveAllAccess(activeId.Value);
+                },
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-grant-all-access-description"),
+                Priority = (int) TricksVerbPriorities.GrantAllAccess,
+            };
+            args.Verbs.Add(grantAllAccess);
+
+            Verb revokeAllAccess = new()
+            {
+                Text = "Revoke All Access",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Misc/id_cards.rsi"), "default"),
+                Act = () =>
+                {
+                    RevokeAllAccess(activeId.Value);
+                },
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-revoke-all-access-description"),
+                Priority = (int) TricksVerbPriorities.RevokeAllAccess,
+            };
+            args.Verbs.Add(revokeAllAccess);
+        }
+
+        if (HasComp<AccessComponent>(args.Target))
+        {
+            Verb grantAllAccess = new()
+            {
+                Text = "Grant All Access",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Misc/id_cards.rsi"), "centcom"),
+                Act = () =>
+                {
+                    GiveAllAccess(args.Target);
+                },
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-grant-all-access-description"),
+                Priority = (int) TricksVerbPriorities.GrantAllAccess,
+            };
+            args.Verbs.Add(grantAllAccess);
+
+            Verb revokeAllAccess = new()
+            {
+                Text = "Revoke All Access",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Misc/id_cards.rsi"), "default"),
+                Act = () =>
+                {
+                    RevokeAllAccess(args.Target);
+                },
+                Impact = LogImpact.Extreme,
+                Message = Loc.GetString("admin-trick-revoke-all-access-description"),
+                Priority = (int) TricksVerbPriorities.RevokeAllAccess,
+            };
+            args.Verbs.Add(revokeAllAccess);
         }
 
         if (TryComp<StackComponent>(args.Target, out var stack))

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -82,7 +82,7 @@ public sealed partial class AdminVerbSystem
                 Message = Loc.GetString(bolts.BoltsDown
                     ? "admin-trick-unbolt-description"
                     : "admin-trick-bolt-description"),
-                Priority = (int) (bolts.BoltsDown ? TricksVerbPriorities.Unbolt : TricksVerbPriorities.Bolt),
+                Priority = (int)(bolts.BoltsDown ? TricksVerbPriorities.Unbolt : TricksVerbPriorities.Bolt),
             };
             args.Verbs.Add(bolt);
         }
@@ -102,7 +102,7 @@ public sealed partial class AdminVerbSystem
                 Message = Loc.GetString(airlockComp.EmergencyAccess
                     ? "admin-trick-emergency-access-off-description"
                     : "admin-trick-emergency-access-on-description"),
-                Priority = (int) (airlockComp.EmergencyAccess ? TricksVerbPriorities.EmergencyAccessOff : TricksVerbPriorities.EmergencyAccessOn),
+                Priority = (int)(airlockComp.EmergencyAccess ? TricksVerbPriorities.EmergencyAccessOff : TricksVerbPriorities.EmergencyAccessOn),
             };
             args.Verbs.Add(emergencyAccess);
         }
@@ -120,7 +120,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-rejuvenate-description"),
-                Priority = (int) TricksVerbPriorities.Rejuvenate,
+                Priority = (int)TricksVerbPriorities.Rejuvenate,
             };
             args.Verbs.Add(rejuvenate);
         }
@@ -138,7 +138,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-make-indestructible-description"),
-                Priority = (int) TricksVerbPriorities.MakeIndestructible,
+                Priority = (int)TricksVerbPriorities.MakeIndestructible,
             };
             args.Verbs.Add(makeIndestructible);
         }
@@ -155,7 +155,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-make-vulnerable-description"),
-                Priority = (int) TricksVerbPriorities.MakeVulnerable,
+                Priority = (int)TricksVerbPriorities.MakeVulnerable,
             };
             args.Verbs.Add(makeVulnerable);
         }
@@ -173,7 +173,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Medium,
                 Message = Loc.GetString("admin-trick-refill-battery-description"),
-                Priority = (int) TricksVerbPriorities.RefillBattery,
+                Priority = (int)TricksVerbPriorities.RefillBattery,
             };
             args.Verbs.Add(refillBattery);
 
@@ -188,7 +188,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Medium,
                 Message = Loc.GetString("admin-trick-drain-battery-description"),
-                Priority = (int) TricksVerbPriorities.DrainBattery,
+                Priority = (int)TricksVerbPriorities.DrainBattery,
             };
             args.Verbs.Add(drainBattery);
 
@@ -206,7 +206,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Medium,
                 Message = Loc.GetString("admin-trick-infinite-battery-object-description"),
-                Priority = (int) TricksVerbPriorities.InfiniteBattery,
+                Priority = (int)TricksVerbPriorities.InfiniteBattery,
             };
             args.Verbs.Add(infiniteBattery);
         }
@@ -224,7 +224,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Medium,
                 Message = Loc.GetString("admin-trick-block-unanchoring-description"),
-                Priority = (int) TricksVerbPriorities.BlockUnanchoring,
+                Priority = (int)TricksVerbPriorities.BlockUnanchoring,
             };
             args.Verbs.Add(blockUnanchor);
         }
@@ -242,7 +242,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-internals-refill-oxygen-description"),
-                Priority = (int) TricksVerbPriorities.RefillOxygen,
+                Priority = (int)TricksVerbPriorities.RefillOxygen,
             };
             args.Verbs.Add(refillInternalsO2);
 
@@ -257,7 +257,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-internals-refill-nitrogen-description"),
-                Priority = (int) TricksVerbPriorities.RefillNitrogen,
+                Priority = (int)TricksVerbPriorities.RefillNitrogen,
             };
             args.Verbs.Add(refillInternalsN2);
 
@@ -272,7 +272,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-internals-refill-plasma-description"),
-                Priority = (int) TricksVerbPriorities.RefillPlasma,
+                Priority = (int)TricksVerbPriorities.RefillPlasma,
             };
             args.Verbs.Add(refillInternalsPlasma);
         }
@@ -287,7 +287,7 @@ public sealed partial class AdminVerbSystem
                 Act = () => RefillEquippedTanks(args.User, Gas.Oxygen),
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-internals-refill-oxygen-description"),
-                Priority = (int) TricksVerbPriorities.RefillOxygen,
+                Priority = (int)TricksVerbPriorities.RefillOxygen,
             };
             args.Verbs.Add(refillInternalsO2);
 
@@ -296,10 +296,10 @@ public sealed partial class AdminVerbSystem
                 Text = "Refill Internals Nitrogen",
                 Category = VerbCategory.Tricks,
                 Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Tanks/red.rsi"), "icon"),
-                Act = () =>RefillEquippedTanks(args.User, Gas.Nitrogen),
+                Act = () => RefillEquippedTanks(args.User, Gas.Nitrogen),
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-internals-refill-nitrogen-description"),
-                Priority = (int) TricksVerbPriorities.RefillNitrogen,
+                Priority = (int)TricksVerbPriorities.RefillNitrogen,
             };
             args.Verbs.Add(refillInternalsN2);
 
@@ -311,7 +311,7 @@ public sealed partial class AdminVerbSystem
                 Act = () => RefillEquippedTanks(args.User, Gas.Plasma),
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-internals-refill-plasma-description"),
-                Priority = (int) TricksVerbPriorities.RefillPlasma,
+                Priority = (int)TricksVerbPriorities.RefillPlasma,
             };
             args.Verbs.Add(refillInternalsPlasma);
         }
@@ -329,7 +329,7 @@ public sealed partial class AdminVerbSystem
             },
             Impact = LogImpact.Medium,
             Message = Loc.GetString("admin-trick-send-to-test-arena-description"),
-            Priority = (int) TricksVerbPriorities.SendToTestArena,
+            Priority = (int)TricksVerbPriorities.SendToTestArena,
         };
         args.Verbs.Add(sendToTestArena);
 
@@ -348,7 +348,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-grant-all-access-description"),
-                Priority = (int) TricksVerbPriorities.GrantAllAccess,
+                Priority = (int)TricksVerbPriorities.GrantAllAccess,
             };
             args.Verbs.Add(grantAllAccess);
 
@@ -363,7 +363,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-revoke-all-access-description"),
-                Priority = (int) TricksVerbPriorities.RevokeAllAccess,
+                Priority = (int)TricksVerbPriorities.RevokeAllAccess,
             };
             args.Verbs.Add(revokeAllAccess);
         }
@@ -381,7 +381,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-grant-all-access-description"),
-                Priority = (int) TricksVerbPriorities.GrantAllAccess,
+                Priority = (int)TricksVerbPriorities.GrantAllAccess,
             };
             args.Verbs.Add(grantAllAccess);
 
@@ -396,7 +396,7 @@ public sealed partial class AdminVerbSystem
                 },
                 Impact = LogImpact.Extreme,
                 Message = Loc.GetString("admin-trick-revoke-all-access-description"),
-                Priority = (int) TricksVerbPriorities.RevokeAllAccess,
+                Priority = (int)TricksVerbPriorities.RevokeAllAccess,
             };
             args.Verbs.Add(revokeAllAccess);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes a bit of redundant logic in `AdminVerbSystem.Tools.cs`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's not really hurting anything by being there, but it's a bit silly. Removing it might save a couple CPU cycles or something, maybe.

## Technical details
<!-- Summary of code changes for easier review. -->
![Screenshot_20250327-184926](https://github.com/user-attachments/assets/a89658be-e15b-44c8-864a-281f57112c0a)

```c#
if (!condition)
    return;

if (condition)
{
    // stuff
}
```
It's silly to have a guard clause and then do a check for the same thing after it.
Now it's just:
```c#
if (!condition)
    return;

// stuff
```
Diff looks large because everything had to be unindented.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->