### PR TITLE
Fix embedded projectile deletion not being tracked by container

### DIFF
--- a/Content.IntegrationTests/Tests/Embedding/EmbedTest.cs
+++ b/Content.IntegrationTests/Tests/Embedding/EmbedTest.cs
@@ -1,5 +1,6 @@
 using Content.IntegrationTests.Tests.Interaction;
 using Content.Shared.Projectiles;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Network;
 
 namespace Content.IntegrationTests.Tests.Embedding;
@@ -87,5 +88,85 @@ public sealed class EmbedTest : InteractionTest
         // Make sure the embeddable wasn't deleted with the target
         AssertExists(projectile);
         await AssertEntityLookup(EmbeddableProtoId);
+    }
+
+    /// <summary>
+    /// Throws two embeddable projectiles at a target, then deletes them
+    /// one at a time, making sure that they are tracked correctly and that
+    /// the <see cref="EmbeddedContainerComponent"/> is removed once all
+    /// projectiles are gone.
+    /// </summary>
+    [Test]
+    public async Task TestDeleteWhileEmbedded()
+    {
+        // Spawn the target we're going to throw at
+        await SpawnTarget(TargetProtoId);
+
+        // Give the player the embeddable to throw
+        var projectile1 = await PlaceInHands(EmbeddableProtoId);
+        Assert.That(TryComp<EmbeddableProjectileComponent>(projectile1, out var embedComp),
+            $"{EmbeddableProtoId} does not have EmbeddableProjectileComponent.");
+        // Make sure the projectile isn't already embedded into anything
+        Assert.That(embedComp.EmbeddedIntoUid, Is.Null,
+            $"Projectile already embedded into {SEntMan.ToPrettyString(embedComp.EmbeddedIntoUid)}.");
+
+        // Have the player throw the embeddable at the target
+        await ThrowItem();
+
+        // Give the player a second embeddable to throw
+        var projectile2 = await PlaceInHands(EmbeddableProtoId);
+        Assert.That(TryComp<EmbeddableProjectileComponent>(projectile1, out var embedComp2),
+            $"{EmbeddableProtoId} does not have EmbeddableProjectileComponent.");
+
+        // Wait a moment for the projectile to hit and embed
+        await RunSeconds(0.5f);
+
+        // Make sure the projectile is embedded into the target
+        Assert.That(embedComp.EmbeddedIntoUid, Is.EqualTo(ToServer(Target)),
+            "First projectile not embedded into target.");
+        Assert.That(TryComp<EmbeddedContainerComponent>(out var containerComp),
+            "Target was not given EmbeddedContainerComponent.");
+        Assert.That(containerComp.EmbeddedObjects, Does.Contain(ToServer(projectile1)),
+            "Target is not tracking the first projectile as embedded.");
+        Assert.That(containerComp.EmbeddedObjects, Has.Count.EqualTo(1),
+            "Target has unexpected EmbeddedObjects count.");
+
+        // Wait for the cooldown between throws
+        await RunSeconds(Hands.ThrowCooldown.Seconds);
+
+        // Throw the second projectile
+        await ThrowItem();
+
+        // Wait a moment for the second projectile to hit and embed
+        await RunSeconds(0.5f);
+
+        Assert.That(embedComp2.EmbeddedIntoUid, Is.EqualTo(ToServer(Target)),
+            "Second projectile not embedded into target");
+        AssertComp<EmbeddedContainerComponent>();
+        Assert.That(containerComp.EmbeddedObjects, Does.Contain(ToServer(projectile1)),
+            "Target is not tracking the second projectile as embedded.");
+        Assert.That(containerComp.EmbeddedObjects, Has.Count.EqualTo(2),
+            "Target EmbeddedObjects count did not increase with second projectile.");
+
+        // Delete the first projectile
+        await Delete(projectile1);
+
+        Assert.That(containerComp.EmbeddedObjects, Does.Not.Contain(ToServer(projectile1)),
+            "Target did not stop tracking first projectile after it was deleted.");
+        Assert.That(containerComp.EmbeddedObjects, Does.Not.Contain(EntityUid.Invalid),
+            "Target EmbeddedObjects contains an invalid entity.");
+        foreach (var embedded in containerComp.EmbeddedObjects)
+        {
+            Assert.That(!SEntMan.Deleted(embedded),
+                "Target EmbeddedObjects contains a deleted entity.");
+        }
+        Assert.That(containerComp.EmbeddedObjects, Has.Count.EqualTo(1),
+            "Target EmbeddedObjects count did not decrease after deleting first projectile.");
+
+        // Delete the second projectile
+        await Delete(projectile2);
+
+        Assert.That(!SEntMan.HasComponent<EmbeddedContainerComponent>(ToServer(Target)),
+            "Target did not remove EmbeddedContainerComponent after both projectiles were deleted.");
     }
 }

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -148,6 +148,8 @@ public abstract partial class SharedProjectileSystem : EntitySystem
             {
                 embeddedContainer.EmbeddedObjects.Remove(uid);
                 Dirty(component.EmbeddedIntoUid.Value, embeddedContainer);
+                if (embeddedContainer.EmbeddedObjects.Count == 0)
+                    RemCompDeferred<EmbeddedContainerComponent>(component.EmbeddedIntoUid.Value);
             }
         }
 

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -136,12 +136,6 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
-        if (component.DeleteOnRemove && _net.IsServer)
-        {
-            QueueDel(uid);
-            return;
-        }
-
         if (component.EmbeddedIntoUid is not null)
         {
             if (TryComp<EmbeddedContainerComponent>(component.EmbeddedIntoUid.Value, out var embeddedContainer))
@@ -151,6 +145,12 @@ public abstract partial class SharedProjectileSystem : EntitySystem
                 if (embeddedContainer.EmbeddedObjects.Count == 0)
                     RemCompDeferred<EmbeddedContainerComponent>(component.EmbeddedIntoUid.Value);
             }
+        }
+
+        if (component.DeleteOnRemove && _net.IsServer)
+        {
+            QueueDel(uid);
+            return;
         }
 
         var xform = Transform(uid);

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -39,6 +39,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         SubscribeLocalEvent<EmbeddableProjectileComponent, ThrowDoHitEvent>(OnEmbedThrowDoHit);
         SubscribeLocalEvent<EmbeddableProjectileComponent, ActivateInWorldEvent>(OnEmbedActivate);
         SubscribeLocalEvent<EmbeddableProjectileComponent, RemoveEmbeddedProjectileEvent>(OnEmbedRemove);
+        SubscribeLocalEvent<EmbeddableProjectileComponent, ComponentShutdown>(OnEmbeddableCompShutdown);
 
         SubscribeLocalEvent<EmbeddedContainerComponent, EntityTerminatingEvent>(OnEmbeddableTermination);
     }
@@ -73,6 +74,11 @@ public abstract partial class SharedProjectileSystem : EntitySystem
 
         // try place it in the user's hand
         _hands.TryPickupAnyHand(args.User, embeddable);
+    }
+
+    private void OnEmbeddableCompShutdown(Entity<EmbeddableProjectileComponent> embeddable, ref ComponentShutdown arg)
+    {
+        EmbedDetach(embeddable, embeddable.Comp);
     }
 
     private void OnEmbedThrowDoHit(Entity<EmbeddableProjectileComponent> embeddable, ref ThrowDoHitEvent args)
@@ -139,7 +145,9 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         if (component.EmbeddedIntoUid is not null)
         {
             if (TryComp<EmbeddedContainerComponent>(component.EmbeddedIntoUid.Value, out var embeddedContainer))
+            {
                 embeddedContainer.EmbeddedObjects.Remove(uid);
+            }
         }
 
         var xform = Transform(uid);

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -147,6 +147,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
             if (TryComp<EmbeddedContainerComponent>(component.EmbeddedIntoUid.Value, out var embeddedContainer))
             {
                 embeddedContainer.EmbeddedObjects.Remove(uid);
+                Dirty(component.EmbeddedIntoUid.Value, embeddedContainer);
             }
         }
 

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -136,7 +136,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
-        if (component.DeleteOnRemove)
+        if (component.DeleteOnRemove && _net.IsServer)
         {
             QueueDel(uid);
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`EmbeddedContainerComponent` now properly tracks when embedded projectiles are deleted in any way, instead of only tracking when they are removed by hand.
Additionally, the `EmbeddedContainerComponent` is now removed from an entity when there are no more projectiles embedded into it.
Also added a missing Dirty call on `EmbeddedContainerComponent` when an entity is removed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes a [bug that was showing up in server logs](https://discord.com/channels/310555209753690112/900426319433728030/1354969365426213017).
For the second part, it's good to clean up components that aren't doing anything anymore.

## Technical details
<!-- Summary of code changes for easier review. -->
- `EmbeddableProjectileComponent` now subscribes to `ComponentShutdown` and calls `EmbedDetach`.
- `EmbeddedContainerComponent` now removes itself when its `EmbeddedObjects` HashSet is empty.
- Added a test that throws two projectiles at a target and deletes them one at a time, making sure they are removed from the target's `EmbeddedObjects` HashSet correctly and that the `EmbeddedContainerComponent` is removed when both are gone.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->