### PR TITLE
Another overlay stack sorting fix

### DIFF
--- a/Content.Client/Administration/OverlayOptions.cs
+++ b/Content.Client/Administration/OverlayOptions.cs
@@ -1,0 +1,8 @@
+namespace Content.Client.Administration;
+
+public enum AdminOverlayStackSortBy
+{
+    Character,
+    User,
+    Vertical
+}

--- a/Content.Shared/CCVar/CCVars.Interface.cs
+++ b/Content.Shared/CCVar/CCVars.Interface.cs
@@ -99,6 +99,12 @@ public sealed partial class CCVars
         CVarDef.Create("ui.admin_overlay_merge_distance", 0.33f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /// <summary>
+    /// Determines the order in which overlay entries are stacked
+    /// </summary>
+    public static readonly CVarDef<string> AdminOverlayStackSortBy =
+        CVarDef.Create("ui.admin_overlay_stack_sort_by", "Character", CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
     /// The maximum size that an overlay stack can reach. Additional overlays will be superimposed over the last one.
     /// </summary>
     public static readonly CVarDef<int> AdminOverlayStackMax =


### PR DESCRIPTION
## About the PR
Fix for overlay stacks (again). I am also looking into better fixes for smart sorting, but this is a simple quick fix that will make stacks usable, and supporting configurable sorting methods is generally useful anyway.

Overlay stack order can now be configured. Currently only available through console, via cvar `ui.admin_overlay_stack_sort_by`, to avoid conflicting with the admin options menu revamp on #35359. 
Options are "Character", "User" and "Vertical"(the current one)

If it works out on master, I would like to also cherrypick this for staging

## Why / Balance
The horrors persist

## Technical details
The list containing visible players that need their overlay drawn onscreen is passed to a switch to be ordered accoring to cvar setting. The sorted list is then passed along for iteration.

## Media

https://github.com/user-attachments/assets/12ee2f58-5999-4518-9690-f5eecdc0948b

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl: Errant
ADMIN:
- tweak: Admin overlay stacks are now sorted by character name, and should no longer jump around. Sorting can be configured via cvar ui.admin_overlay_stack_sort_by < Character | User | Vertical >