### PR TITLE
Make ContainerFillSystem print contents on failure

### DIFF
--- a/Content.Shared/Containers/ContainerFillSystem.cs
+++ b/Content.Shared/Containers/ContainerFillSystem.cs
@@ -40,8 +40,8 @@ public sealed class ContainerFillSystem : EntitySystem
                 var ent = Spawn(proto, coords);
                 if (!_containerSystem.Insert(ent, container, containerXform: xform))
                 {
-                    var alreadyContained = string.Join(", ", container.ContainedEntities.Select(e => EntityManager.ToPrettyString(e)));
-                    Log.Error($"Entity {ToPrettyString(uid)} with a {nameof(ContainerFillComponent)} failed to insert an entity: {ToPrettyString(ent)}. Current contents: < {alreadyContained} >");
+                    var alreadyContained = container.ContainedEntities.Count > 0 ? string.Join("\n", container.ContainedEntities.Select(e => $"\t - {EntityManager.ToPrettyString(e)}")) : "< empty >";
+                    Log.Error($"Entity {ToPrettyString(uid)} with a {nameof(ContainerFillComponent)} failed to insert an entity: {ToPrettyString(ent)}.\nCurrent contents:\n{alreadyContained}");
                     _transform.AttachToGridOrMap(ent);
                     break;
                 }
@@ -74,8 +74,8 @@ public sealed class ContainerFillSystem : EntitySystem
                 var spawn = Spawn(proto, coords);
                 if (!_containerSystem.Insert(spawn, container, containerXform: xform))
                 {
-                    var alreadyContained = string.Join(", ", container.ContainedEntities.Select(e => EntityManager.ToPrettyString(e)));
-                    Log.Error($"Entity {ToPrettyString(ent)} with a {nameof(EntityTableContainerFillComponent)} failed to insert an entity: {ToPrettyString(spawn)}. Current contents: < {alreadyContained} >");
+                    var alreadyContained = container.ContainedEntities.Count > 0 ? string.Join("\n", container.ContainedEntities.Select(e => $"\t - {EntityManager.ToPrettyString(e)}")) : "< empty >";
+                    Log.Error($"Entity {ToPrettyString(ent)} with a {nameof(EntityTableContainerFillComponent)} failed to insert an entity: {ToPrettyString(spawn)}.\nCurrent contents:\n{alreadyContained}");
                     _transform.AttachToGridOrMap(spawn);
                     break;
                 }

--- a/Content.Shared/Containers/ContainerFillSystem.cs
+++ b/Content.Shared/Containers/ContainerFillSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Numerics;
 using Content.Shared.EntityTable;
 using Robust.Shared.Containers;
@@ -39,7 +40,8 @@ public sealed class ContainerFillSystem : EntitySystem
                 var ent = Spawn(proto, coords);
                 if (!_containerSystem.Insert(ent, container, containerXform: xform))
                 {
-                    Log.Error($"Entity {ToPrettyString(uid)} with a {nameof(ContainerFillComponent)} failed to insert an entity: {ToPrettyString(ent)}.");
+                    var alreadyContained = string.Join(", ", container.ContainedEntities.Select(e => EntityManager.ToPrettyString(e)));
+                    Log.Error($"Entity {ToPrettyString(uid)} with a {nameof(ContainerFillComponent)} failed to insert an entity: {ToPrettyString(ent)}. Current contents: < {alreadyContained} >");
                     _transform.AttachToGridOrMap(ent);
                     break;
                 }
@@ -72,7 +74,8 @@ public sealed class ContainerFillSystem : EntitySystem
                 var spawn = Spawn(proto, coords);
                 if (!_containerSystem.Insert(spawn, container, containerXform: xform))
                 {
-                    Log.Error($"Entity {ToPrettyString(ent)} with a {nameof(EntityTableContainerFillComponent)} failed to insert an entity: {ToPrettyString(spawn)}.");
+                    var alreadyContained = string.Join(", ", container.ContainedEntities.Select(e => EntityManager.ToPrettyString(e)));
+                    Log.Error($"Entity {ToPrettyString(ent)} with a {nameof(EntityTableContainerFillComponent)} failed to insert an entity: {ToPrettyString(spawn)}. Current contents: < {alreadyContained} >");
                     _transform.AttachToGridOrMap(spawn);
                     break;
                 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Improves the error message printed by `ContainerFillSystem` when it fails to spawn the contents of a `ContainerFillComponent` or `EntityTableContainerFillComponent`. The entities already contained are now listed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We currently have a heisenbug with smuggler's satchels sometimes overfilling on spawn. Having this information in the error message will help figure out which combinations are causing the failure.

## Technical details
<!-- Summary of code changes for easier review. -->
The new output looks like this:
```
[ERRO] system.container_fill: Entity smuggler's satchel (3037/n3037, ClothingBackpackSatchelSmugglerFilled) with a EntityTableContainerFillComponent failed to insert an entity: spesos (3056/n3056, SpaceCash100).
Current contents:
	 - spesos (3038/n3038, SpaceCash100)
	 - spesos (3039/n3039, SpaceCash100)
	 - outlaw's hat (3040/n3040, ClothingHeadHatOutlawHat)
	 - spesos (3042/n3042, SpaceCash100)
	 - spesos (3043/n3043, SpaceCash100)
	 - spesos (3044/n3044, SpaceCash100)
	 - spesos (3045/n3045, SpaceCash100)
	 - blue glowstick (3046/n3046, GlowstickBlue)
	 - blue glowstick (3047/n3047, GlowstickBlue)
	 - blue glowstick (3048/n3048, GlowstickBlue)
	 - blue glowstick (3049/n3049, GlowstickBlue)
	 - combat gloves (3050/n3050, ClothingHandsGlovesCombat)
	 - spesos (3052/n3052, SpaceCash100)
	 - spesos (3053/n3053, SpaceCash100)
	 - space dragon figure (3054/n3054, ToyFigurineSpaceDragon)
	 - spesos (3055/n3055, SpaceCash100)
```
(I modified the `EntityTable` YAML to force the error; these are not normal contents)

Yes, I used LINQ to build the entity list, but it's just a single `Select` and an error message is _hopefully_ not a very hot code path.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->