### PR TITLE
Webhook for Admin Logs

### DIFF
--- a/Content.Server/Administration/Logs/AdminLogManager.Webhook.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.Webhook.cs
@@ -1,0 +1,381 @@
+﻿using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Content.Server.Discord;
+using Content.Server.GameTicking;
+using Content.Shared.CCVar;
+using Content.Shared.Database;
+using Robust.Shared;
+
+namespace Content.Server.Administration.Logs;
+
+public sealed partial class AdminLogManager
+{
+
+    [Dependency] private readonly IEntitySystemManager _entSys = default!;
+
+    [GeneratedRegex(@"^https://discord\.com/api/webhooks/(\d+)/((?!.*/).*)$")]
+    private static partial Regex DiscordRegex();
+
+    private readonly HttpClient _httpClient = new();
+
+    private bool _lockProcessing;
+    private DiscordRelayInteraction? _relayMessage = null;
+
+    private string _footerIconUrl = string.Empty;
+    private string _avatarUrl = string.Empty;
+    private string _serverName = string.Empty;
+    private string _webhookUrl = string.Empty;
+
+    private readonly Queue<string> _messageQueue = new();
+    private WebhookData? _webhookData;
+    private int _maxAdditionalChars;
+
+    // Max embed description length is 4096, according to https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
+    // Keep small margin, just to be safe
+    private const ushort DescriptionMax = 4000;
+
+    // Maximum length a message can be before it is cut off
+    // Should be shorter than DescriptionMax
+    private const ushort MessageLengthCap = 3000;
+
+    // Text to be used to cut off messages that are too long. Should be shorter than MessageLengthCap
+    private const string TooLongText = "... **(too long)**";
+
+    public void InitializeWebhook()
+    {
+        _configuration.OnValueChanged(CCVars.DiscordAdminLogWebhook, OnWebhookChanged, true);
+        _configuration.OnValueChanged(CCVars.DiscordAHelpFooterIcon, OnFooterIconChanged, true);
+        _configuration.OnValueChanged(CCVars.DiscordAHelpAvatar, OnAvatarChanged, true);
+        _configuration.OnValueChanged(CVars.GameHostName, OnServerNameChanged, true);
+
+        var defaultParams = new AdminLogMessageParams(
+            string.Empty,
+            TimeSpan.Zero.ToString("hh\\:mm\\:ss"),
+            _runLevel,
+            null
+        );
+        _maxAdditionalChars = GenerateAdminLogMessage(defaultParams).Length;
+    }
+
+    public void UpdateWebhook()
+    {
+        if (_lockProcessing)
+            return;
+
+        var queue = _messageQueue;
+        if (queue.Count == 0)
+            return;
+
+        _lockProcessing = true;
+
+        ProcessQueue(queue);
+    }
+
+    #region OnChanged
+
+    private async void OnWebhookChanged(string url)
+    {
+        _webhookUrl = url;
+
+        if (url == string.Empty)
+            return;
+
+        // Basic sanity check and capturing webhook ID and token
+        var match = DiscordRegex().Match(url);
+
+        if (!match.Success)
+        {
+            // TODO: Ideally, CVar validation during setting should be better integrated
+            _sawmill.Log(LogLevel.Warning, "Webhook URL does not appear to be valid. Using anyways...");
+            return;
+        }
+
+        if (match.Groups.Count <= 2)
+        {
+            _sawmill.Log(LogLevel.Error, "Could not get webhook ID or token.");
+            return;
+        }
+
+        var webhookId = match.Groups[1].Value;
+        var webhookToken = match.Groups[2].Value;
+
+        // Fire and forget
+        _webhookData = await GetWebhookData(webhookId, webhookToken);
+    }
+
+    private async Task<WebhookData?> GetWebhookData(string id, string token)
+    {
+        var response = await _httpClient.GetAsync($"https://discord.com/api/v10/webhooks/{id}/{token}");
+
+        var content = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+        {
+            _sawmill.Log(LogLevel.Error,
+                $"Discord returned bad status code when trying to get webhook data (perhaps the webhook URL is invalid?): {response.StatusCode}\nResponse: {content}");
+            return null;
+        }
+
+        return JsonSerializer.Deserialize<WebhookData>(content);
+    }
+
+    private void OnFooterIconChanged(string url)
+    {
+        _footerIconUrl = url;
+    }
+
+    private void OnAvatarChanged(string url)
+    {
+        _avatarUrl = url;
+    }
+
+    private void OnServerNameChanged(string obj)
+    {
+        _serverName = obj;
+    }
+
+    public void WebhookOnGameRunLevelChanged()
+    {
+        _relayMessage = null;
+    }
+
+    #endregion
+
+    private void SendAdminLogWebhook(string message, LogImpact? logImpact = null)
+    {
+        // Enqueue the message for Discord relay
+        if (_webhookUrl != string.Empty)
+        {
+            // Get the current timestamp
+            var timestamp = DateTime.Now.ToString("HH:mm:ss");
+            var roundTime = System.TimeSpan.Zero.ToString("hh\\:mm\\:ss");
+            if (_entSys.TryGetEntitySystem<GameTicker>(out var gameTicker))
+                roundTime = gameTicker.RoundDuration().ToString("hh\\:mm\\:ss");
+
+            var str = message;
+            if (str.Length + _maxAdditionalChars > DescriptionMax)
+            {
+                str = str[..(DescriptionMax - _maxAdditionalChars)];
+            }
+
+            // Create the message parameters for Discord
+            var messageParams = new AdminLogMessageParams(
+                str,
+                roundTime,
+                _runLevel,
+                logImpact
+            );
+
+            var discordMessage = GenerateAdminLogMessage(messageParams);
+            _messageQueue.Enqueue(discordMessage);
+        }
+    }
+
+    private async void ProcessQueue(Queue<string> messages)
+    {
+        // Whether an embed already exists for this player
+        var exists = _relayMessage != null;
+
+        // Whether the message will become too long after adding these new messages
+        var tooLong = exists && messages.Sum(msg => Math.Min(msg.Length, MessageLengthCap) + "\n".Length)
+            + _relayMessage?.Description.Length > DescriptionMax;
+
+        // If there is no existing embed, or it is getting too long, we create a new embed
+        if (!exists || tooLong)
+        {
+            var linkToPrevious = string.Empty;
+
+            // If we have all the data required, we can link to the embed of the previous round or embed that was too long
+            if (_webhookData is { GuildId: { } guildId, ChannelId: { } channelId })
+            {
+                if (tooLong && _relayMessage?.Id != null)
+                {
+                    linkToPrevious =
+                        $"**[Go to previous embed of this round](https://discord.com/channels/{guildId}/{channelId}/{_relayMessage.Id})**\n";
+                }
+            }
+
+            _relayMessage = new DiscordRelayInteraction()
+            {
+                Id = null,
+                Description = linkToPrevious,
+                LastRunLevel = _runLevel,
+            };
+        }
+
+        // Previous message was in another RunLevel, so show that in the embed
+        if (_relayMessage!.LastRunLevel != _runLevel)
+        {
+            _relayMessage.Description += _runLevel switch
+            {
+                GameRunLevel.PreRoundLobby => "\n\n:arrow_forward: _**Pre-round lobby started**_\n",
+                GameRunLevel.InRound => "\n\n:arrow_forward: _**Round started**_\n",
+                GameRunLevel.PostRound => "\n\n:stop_button: _**Post-round started**_\n",
+                _ => throw new ArgumentOutOfRangeException(nameof(_runLevel),
+                    $"{_runLevel} was not matched."),
+            };
+
+            _relayMessage.LastRunLevel = _runLevel;
+        }
+
+        // Add available messages to the embed description
+        while (messages.TryDequeue(out var message))
+        {
+            string text;
+
+            // In case someone thinks they're funny
+            if (message.Length > MessageLengthCap)
+                text = message[..(MessageLengthCap - TooLongText.Length)] + TooLongText;
+            else
+                text = message;
+
+            _relayMessage.Description += $"\n{text}";
+        }
+
+        var payload = GeneratePayload(_relayMessage.Description);
+
+        // If there is no existing embed, create a new one
+        // Otherwise patch (edit) it
+        if (_relayMessage.Id == null)
+        {
+            var request = await _httpClient.PostAsync($"{_webhookUrl}?wait=true",
+                new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
+
+            var content = await request.Content.ReadAsStringAsync();
+            if (!request.IsSuccessStatusCode)
+            {
+                _sawmill.Log(LogLevel.Error,
+                    $"Discord returned bad status code when posting message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
+                _relayMessage = null;
+                return;
+            }
+
+            var id = JsonNode.Parse(content)?["id"];
+            if (id == null)
+            {
+                _sawmill.Log(LogLevel.Error,
+                    $"Could not find id in json-content returned from discord webhook: {content}");
+                _relayMessage = null;
+                return;
+            }
+
+            _relayMessage.Id = id.ToString();
+        }
+        else
+        {
+            var request = await _httpClient.PatchAsync($"{_webhookUrl}/messages/{_relayMessage.Id}",
+                new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
+
+            if (!request.IsSuccessStatusCode)
+            {
+                var content = await request.Content.ReadAsStringAsync();
+                _sawmill.Log(LogLevel.Error,
+                    $"Discord returned bad status code when patching message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
+                _relayMessage = null;
+                return;
+            }
+        }
+
+        _lockProcessing = false;
+    }
+
+    private string GenerateAdminLogMessage(AdminLogMessageParams parameters)
+    {
+        var stringbuilder = new StringBuilder();
+
+        if (parameters.Impact == LogImpact.Extreme)
+            stringbuilder.Append(":red_square: ");
+        else if (parameters.Impact == LogImpact.High)
+            stringbuilder.Append(":orange_square: ");
+        else if (parameters.Impact == LogImpact.Medium)
+            stringbuilder.Append(":blue_square: ");
+        else if (parameters.Impact == LogImpact.Low)
+            stringbuilder.Append(":green_square: ");
+
+        if (parameters.RoundTime != string.Empty && parameters.RoundState == GameRunLevel.InRound)
+            stringbuilder.Append($" **{parameters.RoundTime}** ");
+
+        stringbuilder.Append(parameters.Message);
+
+        return stringbuilder.ToString();
+    }
+
+    private WebhookPayload GeneratePayload(string messages)
+    {
+        // Limit server name to 1500 characters, in case someone tries to be a little funny
+        var serverName = _serverName[..Math.Min(_serverName.Length, 1500)];
+
+        int roundId = 0;
+        if (_entSys.TryGetEntitySystem<GameTicker>(out var gameTicker))
+            roundId = gameTicker.RoundId;
+
+        var round = _runLevel switch
+        {
+            GameRunLevel.PreRoundLobby => roundId == 0
+                ? "pre-round lobby after server restart" // first round after server restart has ID == 0
+                : $"pre-round lobby for round {roundId + 1}",
+            GameRunLevel.InRound => $"round {roundId}",
+            GameRunLevel.PostRound => $"post-round {roundId}",
+            _ => throw new ArgumentOutOfRangeException(nameof(_runLevel),
+                $"{_runLevel} was not matched."),
+        };
+
+        return new WebhookPayload
+        {
+            AvatarUrl = string.IsNullOrWhiteSpace(_avatarUrl) ? null : _avatarUrl,
+            Embeds = new List<WebhookEmbed>
+            {
+                new()
+                {
+                    Description = messages,
+                    Color = 0xadadad,
+                    Footer = new WebhookEmbedFooter
+                    {
+                        Text = $"{serverName} ({round})",
+                        IconUrl = string.IsNullOrWhiteSpace(_footerIconUrl) ? null : _footerIconUrl
+                    },
+                },
+            },
+        };
+    }
+}
+
+public sealed class AdminLogMessageParams
+{
+    public string Message { get; set; }
+    public string RoundTime { get; set; }
+    public GameRunLevel RoundState { get; set; }
+
+    public LogImpact? Impact { get; set; }
+
+    public AdminLogMessageParams(
+        string message,
+        string roundTime,
+        GameRunLevel roundState,
+        LogImpact? impact)
+    {
+        Message = message;
+        RoundTime = roundTime;
+        RoundState = roundState;
+        Impact = impact;
+    }
+}
+
+internal sealed class DiscordRelayInteraction
+{
+    public string? Id;
+
+    /// <summary>
+    /// Contents for the discord message.
+    /// </summary>
+    public string Description = string.Empty;
+
+    /// <summary>
+    /// Run level of the last interaction. If different we'll link to the last Id.
+    /// </summary>
+    public GameRunLevel LastRunLevel;
+}

--- a/Content.Server/Administration/Logs/AdminLogManager.Webhook.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.Webhook.cs
@@ -20,6 +20,8 @@ public sealed partial class AdminLogManager
 
     private readonly HttpClient _httpClient = new();
 
+    private TimeSpan _nextWebhookUpdateTime = new();
+
     private bool _lockProcessing;
     private AdminLogDiscordRelayInteraction? _relayMessage = null;
 
@@ -50,6 +52,13 @@ public sealed partial class AdminLogManager
 
     public void UpdateWebhook()
     {
+        // Only try to update the webhook every x seconds.
+        if (_timing.RealTime < _nextWebhookUpdateTime)
+            return;
+
+        // We use the queue send delay, same as for the delay for when logs are stored in database.
+        _nextWebhookUpdateTime = _timing.RealTime.Add(_queueSendDelay);
+
         if (_lockProcessing)
             return;
 

--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -118,6 +118,8 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
             QueueCapReached.Set(0);
             LogsSent.Set(0);
         }
+
+        InitializeWebhook();
     }
 
     public async Task Shutdown()
@@ -130,6 +132,8 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
 
     public async void Update()
     {
+        UpdateWebhook();
+
         if (_runLevel == GameRunLevel.PreRoundLobby)
         {
             await PreRoundUpdate();
@@ -287,6 +291,8 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
                 LogsSent.Set(0);
             }
         }
+
+        WebhookOnGameRunLevelChanged();
     }
 
     private void Add(LogType type, LogImpact impact, string message, JsonDocument json, HashSet<Guid> players)
@@ -355,7 +361,10 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
         }
 
         if (adminLog)
+        {
             _chat.SendAdminAlert(logMessage);
+            SendAdminLogWebhook(logMessage, impact);
+        }
 
         if (preRound)
         {

--- a/Content.Server/Discord/DiscordWebhook.cs
+++ b/Content.Server/Discord/DiscordWebhook.cs
@@ -1,21 +1,41 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Content.Server.Discord;
 
-public sealed class DiscordWebhook : IPostInjectInit
+public sealed partial class DiscordWebhook : IPostInjectInit
 {
     private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
         { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+
+
+    [GeneratedRegex(@"^https://discord\.com/api/webhooks/(\d+)/((?!.*/).*)$")]
+    private static partial Regex DiscordRegex();
 
     [Dependency] private readonly ILogManager _log = default!;
 
     private const string BaseUrl = "https://discord.com/api/v10/webhooks";
     private readonly HttpClient _http = new();
     private ISawmill _sawmill = default!;
+
+    // Max embed description length is 4096, according to https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
+    // Keep small margin, just to be safe
+    public const ushort DescriptionMax = 4000;
+
+    // Maximum length a message can be before it is cut off
+    // Should be shorter than DescriptionMax
+    public const ushort MessageLengthCap = 3000;
+
+    // Text to be used to cut off messages that are too long. Should be shorter than MessageLengthCap
+    public const string TooLongText = "... **(too long)**";
+
 
     private string GetUrl(WebhookIdentifier identifier)
     {
@@ -60,6 +80,21 @@ public sealed class DiscordWebhook : IPostInjectInit
     {
         if (await GetWebhook(url) is { } data)
             onComplete(data);
+    }
+
+    public async Task<WebhookData?> GetWebhookData(string id, string token)
+    {
+        var response = await _http.GetAsync($"https://discord.com/api/v10/webhooks/{id}/{token}");
+
+        var content = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+        {
+            _sawmill.Log(LogLevel.Error,
+                $"Discord returned bad status code when trying to get webhook data (perhaps the webhook URL is invalid?): {response.StatusCode}\nResponse: {content}");
+            return null;
+        }
+
+        return JsonSerializer.Deserialize<WebhookData>(content);
     }
 
     /// <summary>
@@ -139,5 +174,116 @@ public sealed class DiscordWebhook : IPostInjectInit
         }
     }
 
+    /// <summary>
+    /// Retrieve the token and ID for the webhook at the given URL, and also sanity-check the URL.
+    /// </summary>
+    /// <param name="url">URL to get ID and token for.</param>
+    /// <param name="webhookId">URL's webhook ID string.</param>
+    /// <param name="webhookToken">URL's webhook token string.</param>
+    /// <returns>Returns false if the URL does not appear to be valid, or if the webhook ID/token could not be retrieved.</returns>
+    public bool TryGetWebhookIdToken(string url,
+        [NotNullWhen(true)] out string? webhookId,
+        [NotNullWhen(true)] out string? webhookToken)
+    {
+        webhookId = null;
+        webhookToken = null;
 
+        var match = DiscordRegex().Match(url);
+
+        if (!match.Success)
+        {
+            // TODO: Ideally, CVar validation during setting should be better integrated
+            _sawmill.Log(LogLevel.Warning, "Webhook URL does not appear to be valid.");
+            return false;
+        }
+
+        if (match.Groups.Count <= 2)
+        {
+            _sawmill.Log(LogLevel.Error, "Could not get webhook ID or token.");
+            return false;
+        }
+
+        webhookId = match.Groups[1].Value;
+        webhookToken = match.Groups[2].Value;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to post the payload to an existing message ID, and if none exists, creates a new one.
+    /// If an error happens, the method returns false so that the relay interaction can be wiped.
+    /// </summary>
+    /// <param name="relayMessage">The DiscordRelayInteraction to check the ID of.</param>
+    /// <param name="webhookUrl">The webhook's URL.</param>
+    /// <param name="payload">The payload to be posted.</param>
+    /// <returns>True if successfully posted/patched, false if an error occurred.</returns>
+    public async Task<bool> PostPayload(DiscordRelayInteraction relayMessage, string webhookUrl, WebhookPayload payload)
+    {
+        // If no existing post exists, create a new one
+        if (relayMessage.Id == null)
+        {
+            var request = await _http.PostAsync($"{webhookUrl}?wait=true",
+                new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
+
+            var content = await request.Content.ReadAsStringAsync();
+            if (!request.IsSuccessStatusCode)
+            {
+                _sawmill.Log(LogLevel.Error,
+                    $"Discord returned bad status code when posting message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
+                return false;
+            }
+
+            var id = JsonNode.Parse(content)?["id"];
+            if (id == null)
+            {
+                _sawmill.Log(LogLevel.Error,
+                    $"Could not find id in json-content returned from discord webhook: {content}");
+                return false;
+            }
+
+            relayMessage.Id = id.ToString();
+        }
+        // Otherwise, look for an existing one and patch it.
+        else
+        {
+            var request = await _http.PatchAsync($"{webhookUrl}/messages/{relayMessage.Id}",
+                new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
+
+            if (!request.IsSuccessStatusCode)
+            {
+                var content = await request.Content.ReadAsStringAsync();
+                _sawmill.Log(LogLevel.Error,
+                    $"Discord returned bad status code when patching message (perhaps the message is too long?): {request.StatusCode}\nResponse: {content}");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Trim a message to be compliant with Discord message length cap.
+    /// If too long, cut it off and add notice to the end.
+    /// </summary>
+    public string TrimMessage(string message)
+    {
+        if (message.Length > MessageLengthCap)
+            return message[..(MessageLengthCap - TooLongText.Length)] + TooLongText;
+
+        return message;
+    }
+}
+
+/// <summary>
+/// Base Discord relay interaction class, containing the ID and description of a webhook message.
+/// Can be inherited to extend functionality and keep track of additional data.
+/// </summary>
+public abstract class DiscordRelayInteraction
+{
+    public string? Id;
+
+    /// <summary>
+    /// Contents for the discord message.
+    /// </summary>
+    public string Description = string.Empty;
 }

--- a/Content.Shared/CCVar/CCVars.Discord.cs
+++ b/Content.Shared/CCVar/CCVars.Discord.cs
@@ -72,4 +72,10 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<float> DiscordWatchlistConnectionBufferTime =
         CVarDef.Create("discord.watchlist_connection_buffer_time", 5f, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     URL of the Discord webhook which will relay relevant admin log messages.
+    /// </summary>
+    public static readonly CVarDef<string> DiscordAdminLogWebhook =
+        CVarDef.Create("discord.admin_log_webhook", string.Empty, CVar.SERVERONLY | CVar.CONFIDENTIAL);
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds the functionality to forward admin logs to a Discord webhook. 

It also splits out some of the webhook functionality in `BwoinkSystem.cs` to `DiscordWebhook.cs` so it can be reused. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Any admin log that gets sent to the ingame chatbox as an admin alert (note, this does NOT include all admin alerts, such as player join and gamerule messages, only admin logs) also gets forwarded to a Discord webhook. This is High alerts for new players as defined in https://github.com/space-wizards/space-station-14/pull/35961, and all Extreme alerts. 

The logs are sorted by round ID and provide support to jump to previous rounds (or previous messages if the Discord limit is reached). Messages update every 5 seconds.

## Technical details
<!-- Summary of code changes for easier review. -->

`AdminLogManager.Webhook` uses a system similar to `BwoinkSystem` to create the payloads. Where possible the functionality has been separated out in `DiscordWebhook`. 

Since bwoinks sort messages based on the user sending and adminlogs sort based on the server, there's enough similar-yet-different functionality in either system to keep them separate.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/c182f039-3eae-48e7-b952-29c1288d8b34)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: `CCVars.DiscordAdminLogWebhook` has been added, which when set to a Discord webhook url forwards admin log alerts.
