### PR TITLE
update emergency_meta

### DIFF
--- a/Resources/Maps/Shuttles/emergency_meta.yml
+++ b/Resources/Maps/Shuttles/emergency_meta.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Grid
+  engineVersion: 250.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 03/29/2025 03:10:03
+  entityCount: 927
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
 tilemap:
   0: Space
   29: FloorDark
@@ -69,10 +80,10 @@ entities:
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
     - type: DeviceNetwork
+      deviceNetId: Wireless
       configurators: []
       deviceLists: []
       transmitFrequencyId: ShuttleTimer
-      deviceNetId: Wireless
     - type: DecalGrid
       chunkCollection:
         version: 2
@@ -2321,6 +2332,22 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 16.5,-2.5
       parent: 1
+- proto: ChemistryBottleEpinephrine
+  entities:
+  - uid: 579
+    components:
+    - type: Transform
+      pos: 6.5416865,-8.488731
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 580
+    components:
+    - type: Transform
+      pos: 6.7847424,-8.481787
+      parent: 1
+    - type: Physics
+      canCollide: False
 - proto: CigaretteSpent
   entities:
   - uid: 483
@@ -2996,22 +3023,6 @@ entities:
     components:
     - type: Transform
       parent: 539
-    - type: Physics
-      canCollide: False
-- proto: EpinephrineChemistryBottle
-  entities:
-  - uid: 579
-    components:
-    - type: Transform
-      pos: 6.5416865,-8.488731
-      parent: 1
-    - type: Physics
-      canCollide: False
-  - uid: 580
-    components:
-    - type: Transform
-      pos: 6.7847424,-8.481787
-      parent: 1
     - type: Physics
       canCollide: False
 - proto: ExtinguisherCabinetFilled
@@ -5692,6 +5703,28 @@ entities:
       parent: 422
     - type: Physics
       canCollide: False
+- proto: Screen
+  entities:
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 5.5,-9.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 17.5,-3.5
+      parent: 1
 - proto: Screwdriver
   entities:
   - uid: 260


### PR DESCRIPTION
## About the PR
Updates emergency_meta to have screens

## Why / Balance
It didn't have screens before.
Fixes #31282 

## Media
![image](https://github.com/user-attachments/assets/e1c0db5c-53bc-4bbe-82f9-5e184f7699ae)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->