### PR TITLE
remove warden stamp mapped on meta

### DIFF
--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 250.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/29/2025 03:39:37
-  entityCount: 28696
+  time: 03/29/2025 04:10:56
+  entityCount: 28717
 maps:
 - 951
 grids:
@@ -12395,7 +12395,7 @@ entities:
       pos: 11.5,29.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -3917.2786
+      secondsUntilStateChange: -4233.237
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14230,6 +14230,11 @@ entities:
     - type: Transform
       pos: 39.5,24.5
       parent: 5350
+  - uid: 7224
+    components:
+    - type: Transform
+      pos: -48.5,-28.5
+      parent: 5350
   - uid: 8150
     components:
     - type: Transform
@@ -14689,12 +14694,6 @@ entities:
     - type: Transform
       pos: -29.5,15.5
       parent: 5350
-    - type: Door
-      secondsUntilStateChange: -257846.58
-      state: Opening
-    - type: DeviceLinkSource
-      lastSignals:
-        DoorStatus: True
 - proto: AirlockResearchDirectorGlassLocked
   entities:
   - uid: 20369
@@ -14954,7 +14953,7 @@ entities:
       pos: -4.5,53.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -112500.305
+      secondsUntilStateChange: -112816.266
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 2
@@ -17386,14 +17385,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 104.5,-14.5
       parent: 5350
-  - uid: 25968
-    components:
-    - type: MetaData
-      name: AI Sat West APC
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 98.5,-1.5
-      parent: 5350
   - uid: 27589
     components:
     - type: MetaData
@@ -17413,7 +17404,7 @@ entities:
   - uid: 28239
     components:
     - type: MetaData
-      name: AI Sat East APC
+      name: AI Sat West APC
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 101.5,1.5
@@ -21934,11 +21925,6 @@ entities:
       parent: 5350
 - proto: Barricade
   entities:
-  - uid: 17522
-    components:
-    - type: Transform
-      pos: -49.5,-28.5
-      parent: 5350
   - uid: 17523
     components:
     - type: Transform
@@ -21966,6 +21952,11 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,-41.5
+      parent: 5350
+  - uid: 7131
+    components:
+    - type: Transform
+      pos: -48.5,-28.5
       parent: 5350
   - uid: 15470
     components:
@@ -39531,11 +39522,6 @@ entities:
     - type: Transform
       pos: 104.5,-14.5
       parent: 5350
-  - uid: 25994
-    components:
-    - type: Transform
-      pos: 100.5,-1.5
-      parent: 5350
   - uid: 25997
     components:
     - type: Transform
@@ -43300,6 +43286,11 @@ entities:
     - type: Transform
       pos: 31.5,-38.5
       parent: 5350
+  - uid: 6286
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 5350
   - uid: 6338
     components:
     - type: Transform
@@ -43435,6 +43426,21 @@ entities:
     - type: Transform
       pos: -16.5,38.5
       parent: 5350
+  - uid: 7191
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 5350
+  - uid: 7209
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 5350
+  - uid: 7218
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 5350
   - uid: 7223
     components:
     - type: Transform
@@ -43455,10 +43461,25 @@ entities:
     - type: Transform
       pos: 10.5,-56.5
       parent: 5350
+  - uid: 7385
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 5350
+  - uid: 7435
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 5350
   - uid: 7448
     components:
     - type: Transform
       pos: 13.5,-56.5
+      parent: 5350
+  - uid: 7462
+    components:
+    - type: Transform
+      pos: 4.5,9.5
       parent: 5350
   - uid: 7479
     components:
@@ -43480,6 +43501,16 @@ entities:
     - type: Transform
       pos: -18.5,24.5
       parent: 5350
+  - uid: 7545
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 5350
+  - uid: 7757
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 5350
   - uid: 7908
     components:
     - type: Transform
@@ -43489,6 +43520,11 @@ entities:
     components:
     - type: Transform
       pos: 8.5,-56.5
+      parent: 5350
+  - uid: 7939
+    components:
+    - type: Transform
+      pos: 1.5,9.5
       parent: 5350
   - uid: 7945
     components:
@@ -46740,6 +46776,11 @@ entities:
     - type: Transform
       pos: -38.5,-46.5
       parent: 5350
+  - uid: 17522
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 5350
   - uid: 17648
     components:
     - type: Transform
@@ -49055,6 +49096,11 @@ entities:
     - type: Transform
       pos: 68.5,29.5
       parent: 5350
+  - uid: 23973
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 5350
   - uid: 24059
     components:
     - type: Transform
@@ -49089,6 +49135,11 @@ entities:
     components:
     - type: Transform
       pos: 16.5,7.5
+      parent: 5350
+  - uid: 24182
+    components:
+    - type: Transform
+      pos: -1.5,9.5
       parent: 5350
   - uid: 24209
     components:
@@ -49270,6 +49321,16 @@ entities:
     - type: Transform
       pos: 25.5,3.5
       parent: 5350
+  - uid: 25967
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 5350
+  - uid: 25968
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 5350
   - uid: 25988
     components:
     - type: Transform
@@ -49289,6 +49350,11 @@ entities:
     components:
     - type: Transform
       pos: 111.5,2.5
+      parent: 5350
+  - uid: 25994
+    components:
+    - type: Transform
+      pos: -4.5,9.5
       parent: 5350
   - uid: 26229
     components:
@@ -49809,6 +49875,46 @@ entities:
     components:
     - type: Transform
       pos: -6.5,26.5
+      parent: 5350
+  - uid: 28710
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 5350
+  - uid: 28711
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 5350
+  - uid: 28712
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 5350
+  - uid: 28713
+    components:
+    - type: Transform
+      pos: -8.5,9.5
+      parent: 5350
+  - uid: 28714
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 5350
+  - uid: 28715
+    components:
+    - type: Transform
+      pos: -10.5,9.5
+      parent: 5350
+  - uid: 28716
+    components:
+    - type: Transform
+      pos: -11.5,9.5
+      parent: 5350
+  - uid: 28717
+    components:
+    - type: Transform
+      pos: 6.5,9.5
       parent: 5350
 - proto: CableHVStack
   entities:
@@ -57843,11 +57949,6 @@ entities:
     components:
     - type: Transform
       pos: 104.5,0.5
-      parent: 5350
-  - uid: 25967
-    components:
-    - type: Transform
-      pos: 100.5,-1.5
       parent: 5350
   - uid: 25970
     components:
@@ -84486,7 +84587,7 @@ entities:
       pos: 31.5,-33.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -35339.355
+      secondsUntilStateChange: -35655.312
       state: Closing
   - uid: 9615
     components:
@@ -141732,6 +141833,11 @@ entities:
       parent: 5350
 - proto: RandomPosterAny
   entities:
+  - uid: 7384
+    components:
+    - type: Transform
+      pos: 27.5,34.5
+      parent: 5350
   - uid: 13743
     components:
     - type: Transform
@@ -141826,11 +141932,6 @@ entities:
     components:
     - type: Transform
       pos: 23.5,30.5
-      parent: 5350
-  - uid: 24182
-    components:
-    - type: Transform
-      pos: 26.5,34.5
       parent: 5350
   - uid: 24183
     components:
@@ -185124,18 +185225,13 @@ entities:
       parent: 5350
 - proto: WoodDoor
   entities:
-  - uid: 6286
-    components:
-    - type: Transform
-      pos: -48.5,-28.5
-      parent: 5350
   - uid: 17569
     components:
     - type: Transform
       pos: -28.5,-5.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -41051.266
+      secondsUntilStateChange: -41367.223
       state: Opening
   - uid: 17570
     components:

--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 247.2.0
+  engineVersion: 250.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/07/2025 19:53:37
-  entityCount: 28709
+  time: 03/29/2025 03:25:45
+  entityCount: 28697
 maps:
 - 951
 grids:
@@ -6885,9 +6885,11 @@ entities:
           0,10:
             0: 30503
           -1,10:
-            0: 65319
+            10: 1
+            0: 65318
           0,11:
-            0: 887
+            0: 631
+            6: 256
             1: 32768
           -1,11:
             0: 4095
@@ -6951,7 +6953,8 @@ entities:
           -2,9:
             0: 63351
           -2,10:
-            0: 30471
+            0: 29447
+            6: 1024
           -2,11:
             0: 1919
           -2,12:
@@ -7237,7 +7240,7 @@ entities:
             0: 65520
           11,6:
             0: 3903
-            10: 192
+            11: 192
           11,7:
             0: 30549
           11,8:
@@ -7565,7 +7568,7 @@ entities:
             1: 61440
           16,-4:
             1: 8738
-            11: 2184
+            12: 2184
           16,-3:
             1: 8738
             5: 2184
@@ -7576,7 +7579,7 @@ entities:
             1: 8738
             5: 2184
           17,-4:
-            11: 819
+            12: 819
             5: 2176
             1: 32768
           17,-3:
@@ -8834,6 +8837,21 @@ entities:
           - 0
           - 0
         - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 20.067156
+          - 75.49073
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
           temperature: 293.15
           moles:
           - 21.6852
@@ -9042,13 +9060,6 @@ entities:
       container: 18691
 - proto: ActionToggleLight
   entities:
-  - uid: 7435
-    components:
-    - type: Transform
-      parent: 7385
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 7385
   - uid: 9671
     components:
     - type: Transform
@@ -12384,7 +12395,7 @@ entities:
       pos: 11.5,29.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -3620.7197
+      secondsUntilStateChange: -3721.832
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14679,7 +14690,7 @@ entities:
       pos: -29.5,15.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -257550.02
+      secondsUntilStateChange: -257651.12
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14943,7 +14954,7 @@ entities:
       pos: -4.5,53.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -112203.75
+      secondsUntilStateChange: -112304.86
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 2
@@ -67457,31 +67468,6 @@ entities:
     - type: Transform
       pos: -49.479202,-34.51553
       parent: 5350
-- proto: ClothingBeltSecurityFilled
-  entities:
-  - uid: 7218
-    components:
-    - type: Transform
-      parent: 6696
-    - type: Physics
-      canCollide: False
-    - type: GroupExamine
-      group:
-      - hoverMessage: ""
-        contextText: verb-examine-group-other
-        icon: /Textures/Interface/examine-star.png
-        components:
-        - Armor
-        - ClothingSpeedModifier
-        entries:
-        - message: >-
-            It provides the following protection:
-
-            - [color=orange]Explosion[/color] damage [color=white]to contents[/color] reduced by [color=lightblue]10%[/color].
-          priority: 0
-          component: Armor
-        title: null
-    - type: InsideEntityStorage
 - proto: ClothingBeltUtility
   entities:
   - uid: 5395
@@ -67534,13 +67520,6 @@ entities:
       parent: 5350
 - proto: ClothingEyesGlassesSecurity
   entities:
-  - uid: 7209
-    components:
-    - type: Transform
-      parent: 6696
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
   - uid: 8206
     components:
     - type: Transform
@@ -67731,15 +67710,6 @@ entities:
     - type: Transform
       pos: -40.43663,-23.468378
       parent: 5350
-- proto: ClothingHandsGlovesCombat
-  entities:
-  - uid: 7191
-    components:
-    - type: Transform
-      parent: 6696
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: ClothingHandsGlovesLatex
   entities:
   - uid: 14975
@@ -68534,13 +68504,6 @@ entities:
     - type: Transform
       pos: 26.36865,-59.55566
       parent: 5350
-  - uid: 7545
-    components:
-    - type: Transform
-      parent: 6696
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: ClothingShoesBootsMagSci
   entities:
   - uid: 6381
@@ -70588,6 +70551,7 @@ entities:
     - type: Transform
       pos: -41.5,37.5
       parent: 5350
+    - type: Conveyed
   - uid: 19846
     components:
     - type: Transform
@@ -80910,15 +80874,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 76.5,-27.5
       parent: 5350
-- proto: DoorRemoteArmory
-  entities:
-  - uid: 7757
-    components:
-    - type: Transform
-      parent: 6696
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: Dresser
   entities:
   - uid: 3195
@@ -84542,7 +84497,7 @@ entities:
       pos: 31.5,-33.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -35042.797
+      secondsUntilStateChange: -35143.91
       state: Closing
   - uid: 9615
     components:
@@ -86156,13 +86111,6 @@ entities:
       parent: 5350
 - proto: Flash
   entities:
-  - uid: 7384
-    components:
-    - type: Transform
-      parent: 6696
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
   - uid: 12066
     components:
     - type: Transform
@@ -86255,27 +86203,6 @@ entities:
     - type: ActionsContainer
 - proto: FlashlightSeclite
   entities:
-  - uid: 7385
-    components:
-    - type: Transform
-      parent: 6696
-    - type: HandheldLight
-      toggleActionEntity: 7435
-    - type: ContainerContainer
-      containers:
-        cell_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 7462
-        actions: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 7435
-    - type: Physics
-      canCollide: False
-    - type: ActionsContainer
-    - type: InsideEntityStorage
   - uid: 9670
     components:
     - type: Transform
@@ -116589,8 +116516,6 @@ entities:
       parent: 5350
     - type: GasThermoMachine
       targetTemperature: 200.15
-    - type: ApcPowerReceiver
-      powerDisabled: False
   - uid: 22353
     components:
     - type: Transform
@@ -129631,15 +129556,6 @@ entities:
     - type: Transform
       pos: -50.5,-14.5
       parent: 5350
-- proto: HoloprojectorSecurity
-  entities:
-  - uid: 7939
-    components:
-    - type: Transform
-      parent: 6696
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: HospitalCurtainsOpen
   entities:
   - uid: 4105
@@ -131792,6 +131708,24 @@ entities:
       anchored: True
       pos: 0.5,46.5
       parent: 5350
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: Physics
       bodyType: Static
   - uid: 7688
@@ -131818,24 +131752,21 @@ entities:
       parent: 5350
     - type: Physics
       bodyType: Static
-- proto: LockerWarden
+- proto: LockerWardenFilled
   entities:
   - uid: 6696
     components:
     - type: Transform
-      anchored: True
       pos: -3.5,40.5
       parent: 5350
-    - type: Physics
-      bodyType: Static
     - type: EntityStorage
       air:
         volume: 200
         immutable: False
-        temperature: 293.14673
+        temperature: 293.14676
         moles:
-        - 1.8839531
-        - 7.0872526
+        - 1.7449701
+        - 6.5644107
         - 0
         - 0
         - 0
@@ -131846,26 +131777,6 @@ entities:
         - 0
         - 0
         - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 7939
-          - 7385
-          - 7384
-          - 7224
-          - 7218
-          - 7209
-          - 7191
-          - 7131
-          - 7545
-          - 7757
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: LockerWeldingSuppliesFilled
   entities:
   - uid: 6288
@@ -136565,12 +136476,6 @@ entities:
       parent: 5350
 - proto: PowerCellHigh
   entities:
-  - uid: 7462
-    components:
-    - type: Transform
-      parent: 7385
-    - type: Physics
-      canCollide: False
   - uid: 9672
     components:
     - type: Transform
@@ -146129,15 +146034,6 @@ entities:
     - type: Transform
       pos: -34.732925,-41.207012
       parent: 5350
-- proto: RubberStampWarden
-  entities:
-  - uid: 7131
-    components:
-    - type: Transform
-      parent: 6696
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: SalvageMagnet
   entities:
   - uid: 6114
@@ -154057,6 +153953,24 @@ entities:
     - type: Transform
       pos: -5.5,42.5
       parent: 5350
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
   - uid: 6512
     components:
     - type: Transform
@@ -160172,11 +160086,13 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -24.5,41.5
       parent: 5350
+    - type: Conveyed
   - uid: 28246
     components:
     - type: Transform
       pos: -23.5,46.5
       parent: 5350
+    - type: Conveyed
 - proto: TegCenter
   entities:
   - uid: 26997
@@ -179853,13 +179769,6 @@ entities:
     - type: Transform
       pos: 9.465627,24.685179
       parent: 5350
-  - uid: 7224
-    components:
-    - type: Transform
-      parent: 6696
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: WeaponDisablerPractice
   entities:
   - uid: 22293
@@ -185237,7 +185146,7 @@ entities:
       pos: -28.5,-5.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -40754.707
+      secondsUntilStateChange: -40855.82
       state: Opening
   - uid: 17570
     components:

--- a/Resources/Maps/meta.yml
+++ b/Resources/Maps/meta.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 250.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/29/2025 03:25:45
-  entityCount: 28697
+  time: 03/29/2025 03:39:37
+  entityCount: 28696
 maps:
 - 951
 grids:
@@ -12395,7 +12395,7 @@ entities:
       pos: 11.5,29.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -3721.832
+      secondsUntilStateChange: -3917.2786
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14690,7 +14690,7 @@ entities:
       pos: -29.5,15.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -257651.12
+      secondsUntilStateChange: -257846.58
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14954,7 +14954,7 @@ entities:
       pos: -4.5,53.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -112304.86
+      secondsUntilStateChange: -112500.305
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 2
@@ -81752,17 +81752,6 @@ entities:
       parent: 5350
     - type: PowerConsumer
       drawRate: 1
-  - uid: 23973
-    components:
-    - type: Transform
-      anchored: False
-      rot: 1.5707963267948966 rad
-      pos: 61.5,13.5
-      parent: 5350
-    - type: Physics
-      bodyType: Dynamic
-    - type: PowerConsumer
-      drawRate: 1
   - uid: 24048
     components:
     - type: Transform
@@ -84497,7 +84486,7 @@ entities:
       pos: 31.5,-33.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -35143.91
+      secondsUntilStateChange: -35339.355
       state: Closing
   - uid: 9615
     components:
@@ -185146,7 +185135,7 @@ entities:
       pos: -28.5,-5.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -40855.82
+      secondsUntilStateChange: -41051.266
       state: Opening
   - uid: 17570
     components:


### PR DESCRIPTION
## About the PR
Removes the mapped warden stamp on meta. I couldn't think of anything else to add to meta station.

## Why / Balance
It shouldn't be pre-mapped.

For some reason the locker was filled with warden gear in pre-init. I know who you are.

Fixes #34712

## Media
![Meta-0](https://github.com/user-attachments/assets/07ac21e6-0ad9-4d39-9037-e9abe4adf991)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->