### PR TITLE
Fix admeme hand teleproter.

### DIFF
--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -95,6 +95,10 @@ public sealed class HandTeleporterSystem : EntitySystem
             var timeout = EnsureComp<PortalTimeoutComponent>(user);
             timeout.EnteredPortal = null;
             component.FirstPortal = Spawn(component.FirstPortalPrototype, Transform(user).Coordinates);
+
+            if (TryComp<PortalComponent>(component.FirstPortal, out var portal) && component.AllowPortalsOnDifferentMaps)
+                portal.CanTeleportToOtherMaps = true;
+
             _adminLogger.Add(LogType.EntitySpawn, LogImpact.High, $"{ToPrettyString(user):player} opened {ToPrettyString(component.FirstPortal.Value)} at {Transform(component.FirstPortal.Value).Coordinates} using {ToPrettyString(uid)}");
             _audio.PlayPvs(component.NewPortalSound, uid);
         }
@@ -113,6 +117,10 @@ public sealed class HandTeleporterSystem : EntitySystem
             var timeout = EnsureComp<PortalTimeoutComponent>(user);
             timeout.EnteredPortal = null;
             component.SecondPortal = Spawn(component.SecondPortalPrototype, Transform(user).Coordinates);
+
+            if (TryComp<PortalComponent>(component.SecondPortal, out var portal) && component.AllowPortalsOnDifferentMaps)
+                portal.CanTeleportToOtherMaps = true;
+
             _adminLogger.Add(LogType.EntitySpawn, LogImpact.High, $"{ToPrettyString(user):player} opened {ToPrettyString(component.SecondPortal.Value)} at {Transform(component.SecondPortal.Value).Coordinates} linked to {ToPrettyString(component.FirstPortal!.Value)} using {ToPrettyString(uid)}");
             _link.TryLink(component.FirstPortal!.Value, component.SecondPortal.Value, true);
             _audio.PlayPvs(component.NewPortalSound, uid);

--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -96,7 +96,7 @@ public sealed class HandTeleporterSystem : EntitySystem
             timeout.EnteredPortal = null;
             component.FirstPortal = Spawn(component.FirstPortalPrototype, Transform(user).Coordinates);
 
-            if (TryComp<PortalComponent>(component.FirstPortal, out var portal) && component.AllowPortalsOnDifferentMaps)
+            if (component.AllowPortalsOnDifferentMaps && TryComp<PortalComponent>(component.FirstPortal, out var portal))
                 portal.CanTeleportToOtherMaps = true;
 
             _adminLogger.Add(LogType.EntitySpawn, LogImpact.High, $"{ToPrettyString(user):player} opened {ToPrettyString(component.FirstPortal.Value)} at {Transform(component.FirstPortal.Value).Coordinates} using {ToPrettyString(uid)}");
@@ -118,7 +118,7 @@ public sealed class HandTeleporterSystem : EntitySystem
             timeout.EnteredPortal = null;
             component.SecondPortal = Spawn(component.SecondPortalPrototype, Transform(user).Coordinates);
 
-            if (TryComp<PortalComponent>(component.SecondPortal, out var portal) && component.AllowPortalsOnDifferentMaps)
+            if (component.AllowPortalsOnDifferentMaps && TryComp<PortalComponent>(component.SecondPortal, out var portal))
                 portal.CanTeleportToOtherMaps = true;
 
             _adminLogger.Add(LogType.EntitySpawn, LogImpact.High, $"{ToPrettyString(user):player} opened {ToPrettyString(component.SecondPortal.Value)} at {Transform(component.SecondPortal.Value).Coordinates} linked to {ToPrettyString(component.FirstPortal!.Value)} using {ToPrettyString(uid)}");

--- a/Content.Shared/Teleportation/Components/HandTeleporterComponent.cs
+++ b/Content.Shared/Teleportation/Components/HandTeleporterComponent.cs
@@ -21,10 +21,16 @@ public sealed partial class HandTeleporterComponent : Component
     public EntityUid? SecondPortal = null;
 
     /// <summary>
-    ///     Portals can't be placed on different grids?
+    ///     Should the portals be able to be placed across grids?
     /// </summary>
     [DataField]
     public bool AllowPortalsOnDifferentGrids;
+
+    /// <summary>
+    ///     Should the portals work across maps?
+    /// </summary>
+    [DataField]
+    public bool AllowPortalsOnDifferentMaps;
 
     [DataField("firstPortalPrototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string FirstPortalPrototype = "PortalRed";

--- a/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
@@ -28,5 +28,7 @@
     - state: icon
       color: green
   - type: HandTeleporter
+    allowPortalsOnDifferentGrids: true
+    allowPortalsOnDifferentMaps: true
     firstPortalPrototype: PortalGatewayBlue
     secondPortalPrototype: PortalGatewayOrange


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made the admeme hand teleporter work across maps and grids.
Rimworld enjoyers rejoice, it is now 10x easier to set up.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I believe this was the intended behaviour to begin with. Up until now you had to manually VV both the teleporter and the portals to allow this to happen.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a datafield, added a check to allow handmade teleporters to make portals that work across maps.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
ADMIN:
- fix: Admeme hand teleproter now correctly works across grids and maps.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
