### PR TITLE
remove styleclass from playertab 'button' lines

### DIFF
--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
@@ -143,6 +143,7 @@ public sealed partial class PlayerTab : Control
         var entry = new PlayerTabEntry(player, new StyleBoxFlat(button.Index % 2 == 0 ? _altColor : _defaultColor));
         button.AddChild(entry);
         button.ToolTip = $"{player.Username}, {player.CharacterName}, {player.IdentityName}, {player.StartingJob}";
+        button.StyleClasses.Clear();
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Returns the old look of the admin playertab, which was changed unintentionally by #33412 


## Technical details
That PR added the button styleclass to ListContainerButton, which kinda makes sense, but on the admin playertab every line is mechanically a button, so they inherited the looks.  This messes up the column alignments with the header, and arguably looks weird for what is visually a  table. So I'm removing the styleclass from those instances of listcontainerbuttons

## Media

PR
![Screenshot_2025-03-29_132503](https://github.com/user-attachments/assets/d79c25c7-d889-4c91-b55c-08609154aa69)

Master
![Screenshot_2025-03-29_132532](https://github.com/user-attachments/assets/4913948e-84a6-4b36-b1b3-1f5077964f38)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Errant
- fix: The admin player tab is now cleansed of evil.