### PR TITLE
Delete AccessReaderTest.TestTags

### DIFF
--- a/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
+++ b/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
@@ -13,35 +13,6 @@ namespace Content.IntegrationTests.Tests.Access
     public sealed class AccessReaderTest
     {
         [Test]
-        public async Task TestProtoTags()
-        {
-            await using var pair = await PoolManager.GetServerClient();
-            var server = pair.Server;
-
-            var protoManager = server.ResolveDependency<IPrototypeManager>();
-            var accessName = server.ResolveDependency<IComponentFactory>().GetComponentName(typeof(AccessReaderComponent));
-
-            await server.WaitAssertion(() =>
-            {
-                foreach (var ent in protoManager.EnumeratePrototypes<EntityPrototype>())
-                {
-                    if (!ent.Components.TryGetComponent(accessName, out var access))
-                        continue;
-
-                    var reader = (AccessReaderComponent) access;
-                    var allTags = reader.AccessLists.SelectMany(c => c).Union(reader.DenyTags);
-
-                    foreach (var level in allTags)
-                    {
-                        Assert.That(protoManager.HasIndex<AccessLevelPrototype>(level), $"Invalid access level: {level} found on {ent}");
-                    }
-                }
-            });
-
-            await pair.CleanReturnAsync();
-        }
-
-        [Test]
         public async Task TestTags()
         {
             await using var pair = await PoolManager.GetServerClient();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Deletes the obsolete `AccessReaderTest.TestTags` integration test.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This test is from back before `ProtoId<T>`, and all it does is check that the `AccessLevelPrototype`s used by entities with `AccessReaderComponent`s are valid. These days we have automatic validation of `ProtoId` fields in components by the YAML linter, so this test is redundant.

Unfortunately, it's a quick test to run, so this doesn't really do much to save on test run time.

## Technical details
<!-- Summary of code changes for easier review. -->
Deleted.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->