### PR TITLE
fix RangeNumberSelector to actually be inclusive

### DIFF
--- a/Content.Shared/EntityTable/EntitySelectors/EntSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/EntSelector.cs
@@ -20,7 +20,7 @@ public sealed partial class EntSelector : EntityTableSelector
         IEntityManager entMan,
         IPrototypeManager proto)
     {
-        var num = (int) Math.Round(Amount.Get(rand, entMan, proto));
+        var num = Amount.Get(rand);
         for (var i = 0; i < num; i++)
         {
             yield return Id;

--- a/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
@@ -30,7 +30,7 @@ public abstract partial class EntityTableSelector
         IEntityManager entMan,
         IPrototypeManager proto)
     {
-        var rolls = Rolls.Get(rand, entMan, proto);
+        var rolls = Rolls.Get(rand);
         for (var i = 0; i < rolls; i++)
         {
             if (!rand.Prob(Prob))

--- a/Content.Shared/EntityTable/ValueSelector/ConstantNumberSelector.cs
+++ b/Content.Shared/EntityTable/ValueSelector/ConstantNumberSelector.cs
@@ -1,5 +1,3 @@
-using Robust.Shared.Prototypes;
-
 namespace Content.Shared.EntityTable.ValueSelector;
 
 /// <summary>
@@ -8,14 +6,14 @@ namespace Content.Shared.EntityTable.ValueSelector;
 public sealed partial class ConstantNumberSelector : NumberSelector
 {
     [DataField]
-    public float Value = 1;
+    public int Value = 1;
 
-    public ConstantNumberSelector(float value)
+    public ConstantNumberSelector(int value)
     {
         Value = value;
     }
 
-    public override float Get(System.Random rand, IEntityManager entMan, IPrototypeManager proto)
+    public override int Get(System.Random rand)
     {
         return Value;
     }

--- a/Content.Shared/EntityTable/ValueSelector/NumberSelector.cs
+++ b/Content.Shared/EntityTable/ValueSelector/NumberSelector.cs
@@ -1,6 +1,5 @@
 using Content.Shared.EntityTable.EntitySelectors;
 using JetBrains.Annotations;
-using Robust.Shared.Prototypes;
 
 namespace Content.Shared.EntityTable.ValueSelector;
 
@@ -10,7 +9,5 @@ namespace Content.Shared.EntityTable.ValueSelector;
 [ImplicitDataDefinitionForInheritors, UsedImplicitly(ImplicitUseTargetFlags.WithInheritors)]
 public abstract partial class NumberSelector
 {
-    public abstract float Get(System.Random rand,
-        IEntityManager entMan,
-        IPrototypeManager proto);
+    public abstract int Get(System.Random rand);
 }

--- a/Content.Shared/EntityTable/ValueSelector/RangeNumberSelector.cs
+++ b/Content.Shared/EntityTable/ValueSelector/RangeNumberSelector.cs
@@ -1,7 +1,3 @@
-using System.Numerics;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
-
 namespace Content.Shared.EntityTable.ValueSelector;
 
 /// <summary>
@@ -10,10 +6,12 @@ namespace Content.Shared.EntityTable.ValueSelector;
 public sealed partial class RangeNumberSelector : NumberSelector
 {
     [DataField]
-    public Vector2 Range = new(1, 1);
+    public Vector2i Range = new(1, 1);
 
-    public override float Get(System.Random rand, IEntityManager entMan, IPrototypeManager proto)
+    public override int Get(System.Random rand)
     {
-        return rand.NextFloat(Range.X, Range.Y);
+        // rand.Next() is inclusive on the first number and exclusive on the second number,
+        // so we add 1 to the second number.
+        return rand.Next(Range.X, Range.Y + 1);
     }
 }

--- a/Content.Shared/EntityTable/ValueSelector/RangeNumberSelector.cs
+++ b/Content.Shared/EntityTable/ValueSelector/RangeNumberSelector.cs
@@ -14,6 +14,6 @@ public sealed partial class RangeNumberSelector : NumberSelector
 
     public override float Get(System.Random rand, IEntityManager entMan, IPrototypeManager proto)
     {
-        return rand.NextFloat(Range.X, Range.Y + 1);
+        return rand.NextFloat(Range.X, Range.Y);
     }
 }


### PR DESCRIPTION
## About the PR
Fixes RangeNumberSelector to be actually inclusive.

Required by https://github.com/space-wizards/space-station-14/pull/36146

## Why / Balance
I walk up to the store and ask for 4 apples. The storekeep says "SURE" and hands me 5 apples. I wonder why, I question why. I look him dead in the eye: why did this guy give me four apples? What could be the reason why?

And so I open Jetbrains Rider in search of why. I debug debug debug, but nothing catches my eye. Until I open the RangeNumberSelector, yes, something seems awry. This NextFloat! It's inclusive plus one! Yes, that must be why.

## Technical details
Removes a `+ 1`. It was already inclusive.

## Media
![rider64_lCP6XNuC8a](https://github.com/user-attachments/assets/6ba178b1-3e90-460a-9e1b-851ba866cc1c)
![Content Client_wJ7iV39GFo](https://github.com/user-attachments/assets/94c5a1a6-7184-4958-9a88-d0c18e5b5f18)
![rider64_6uXDnpkAGM](https://github.com/user-attachments/assets/647f8f54-17f4-4f14-9f15-277539e18acc)

## Breaking Changes
Generally, the random number system for determining what to select for the RangeNumberSelector logic has been changed to do random ints instead of floats. You should correct logic to deal with integers instead of floats.

Since the `RangeNumberSelector` range now is inclusive (instead of inclusive + 1), you will get one item less than you expected to get. You'll have to increase the range respectively.

- `Rolls.Get` in `ConstantNumberSelector.cs` signature changed from `Rolls.Get(rand, entMan, proto)` to `Rolls.Get(rand)`
- `Rolls.Get` in `EntityTableSelector.cs` signature changed from `Rolls.Get(rand, entMan, proto)` to `Rolls.Get(rand)`
- in `ConstantNumberSelector`, changed method signature: `public override float Get(System.Random rand, IEntityManager entMan, IPrototypeManager proto)` to public override int `Get(System.Random rand)`.
- in `NumberSelector`, changed `public abstract float Get(System.Random rand, IEntityManager entMan, IPrototypeManager proto)` to `public abstract int Get(System.Random rand)`
- `Vector2` in `RangeNumberSelector` converted to `Vector2i` (int).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Certain randomly filled bags will now have the correct number of contents inside of them.
