### PR TITLE
Async doafter removal

### DIFF
--- a/Content.Shared/Engineering/EntitySystems/DisassembleOnAltVerbDoAfterEvent.cs
+++ b/Content.Shared/Engineering/EntitySystems/DisassembleOnAltVerbDoAfterEvent.cs
@@ -1,10 +1,7 @@
 using Content.Shared.DoAfter;
 using Robust.Shared.Serialization;
 
-namespace Content.Shared.Engineering.EntitySystems
-{
-    [Serializable, NetSerializable]
-    public sealed partial class DisassembleOnAltVerbDoAfterEvent : SimpleDoAfterEvent
-    {
-    }
-}
+namespace Content.Shared.Engineering.EntitySystems;
+
+[Serializable, NetSerializable]
+public sealed partial class DisassembleOnAltVerbDoAfterEvent : SimpleDoAfterEvent { }

--- a/Content.Shared/Engineering/EntitySystems/DisassembleOnAltVerbDoAfterEvent.cs
+++ b/Content.Shared/Engineering/EntitySystems/DisassembleOnAltVerbDoAfterEvent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Engineering.EntitySystems
+{
+    [Serializable, NetSerializable]
+    public sealed partial class DisassembleOnAltVerbDoAfterEvent : SimpleDoAfterEvent
+    {
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The doafter system looks fairly complex and I'm not 100% if I've understood everything correctly. The change is a bit more complex than a simple "use another API" like most of the rest of the warning cleanup.
Read #36156 

## Technical Details
Changed one of the simpler AwaitedDoAfterEvents to use the synchronous system instead. 
If I've understood correctly it will now use the newly created synchronous event and fire that on completion. Instead of awaiting for the time, it succeeds immediately and the code that would normally run after awaiting will instead run on event completion.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
