### PR TITLE
Extended oxygen and nitrogen tanks for sec survival boxes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -89,7 +89,7 @@
   - type: StorageFill
     contents:
     - id: ClothingMaskGasSecurity
-    - id: EmergencyOxygenTankFilled
+    - id: ExtendedEmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick
@@ -97,7 +97,7 @@
   - type: Sprite
     layers:
     - state: internals
-    - state: emergencytank
+    - state: extendedtank
 
 - type: entity
   parent: BoxSurvivalSecurity
@@ -107,7 +107,7 @@
   - type: StorageFill
     contents:
     - id: ClothingMaskGasSecurity
-    - id: EmergencyNitrogenTankFilled
+    - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -79,7 +79,6 @@
     currentLabel: reagent-name-nitrogen
 
 - type: entity
-
   parent: BoxCardboard
   id: BoxSurvivalSecurity
   name: survival box
@@ -120,7 +119,6 @@
     currentLabel: reagent-name-nitrogen
 
 - type: entity
-
   parent: BoxCardboard
   id: BoxSurvivalMedical
   name: survival box


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Reopening of #26825, related to #35373.

- Replaces emergency oxygen and nitrogen tanks inside security survival boxes with extended counterparts

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

PR #26825 was closed too quickly without discussion under the reasoning security doesn't need extended tanks roundstart.

However, any player with a gun or jetpack will tell you that losing the exosuit back slot is problematic. Even in low pressure environments there is a risk of losing your weapon when stunned or paralyzed because you couldn't holster your weapon.

Due to how easy it is to damage the station and lose pressure, the spacing strategy favours antags like nuclear operatives as they have free exosuit slot to work with in combat. Security's emergency tanks are too small and only last 4 minutes, far less than the 15+ minutes that other space-borne antags get.

While security could just hoard and carry extra emergency tanks, this empties out emergency closets and harms the crew. Extended emergency tanks are currently only available for engineering roundstart. Double emergency tanks meanwhile are either only found as maints loot, mapped in, or from salvage if and when they find the rare lathe recipe.

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![dotnet_oIKc8V7f5a](https://github.com/user-attachments/assets/e48b6f60-b3a5-48c1-9fea-49c81329821d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: Security survival boxes now come with extended emergency tanks.