### PR TITLE
[April Fools] Fix a typo

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: [BaseStructure, StructureWheeled, BaseMajorContraband]
   id: NuclearBomb
-  name: nuclear fission explosive
+  name: unclear fission explosive
   description: You probably shouldn't stick around to see if this is armed.
   components:
   - type: Transform
@@ -125,7 +125,7 @@
 - type: entity
   parent: StorageTank
   id: NuclearBombKeg
-  name: nuclear fission explosive
+  name: unclear fission explosive
   suffix: keg
   description: You probably shouldn't stick around to see if this is armed. It has a tap on the side.
   components:


### PR DESCRIPTION
## About the PR
"Nuclear fission explosive" is now "unclear fission explosive"

## Why / Balance
Funny (it's not)

## Technical details
Yesn't

## Media
![изображение](https://github.com/user-attachments/assets/1b2ab33d-ff22-4d84-92e0-244b25d389a1)
That nuke is a bit unclear. You gotta clean it or something.

## Requirements
Non't

## Breaking changes
The only broken thing here is my sense of humor

**Changelog**
:cl:
- fix: Fixed a typo in the nuke's name
