### PR TITLE
Worldgen spring cleaning

### DIFF
--- a/Content.Server/Worldgen/Systems/Carvers/NoiseRangeCarverSystem.cs
+++ b/Content.Server/Worldgen/Systems/Carvers/NoiseRangeCarverSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Worldgen.Components.Carvers;
+using Content.Server.Worldgen.Components.Carvers;
 using Content.Server.Worldgen.Systems.Debris;
 
 namespace Content.Server.Worldgen.Systems.Carvers;
@@ -20,7 +20,7 @@ public sealed class NoiseRangeCarverSystem : EntitySystem
     private void OnPrePlaceDebris(EntityUid uid, NoiseRangeCarverComponent component,
         ref PrePlaceDebrisFeatureEvent args)
     {
-        var coords = WorldGen.WorldToChunkCoords(args.Coords.ToMapPos(EntityManager, _transform));
+        var coords = WorldGen.WorldToChunkCoords(_transform.ToMapCoordinates(args.Coords).Position);
         var val = _index.Evaluate(uid, component.NoiseChannel, coords);
 
         foreach (var (low, high) in component.Ranges)

--- a/Content.Server/Worldgen/Systems/Debris/DebrisFeaturePlacerSystem.cs
+++ b/Content.Server/Worldgen/Systems/Debris/DebrisFeaturePlacerSystem.cs
@@ -26,6 +26,8 @@ public sealed class DebrisFeaturePlacerSystem : BaseWorldSystem
 
     private ISawmill _sawmill = default!;
 
+    private List<Entity<MapGridComponent>> _mapGrids = new();
+
     /// <inheritdoc />
     public override void Initialize()
     {
@@ -139,7 +141,14 @@ public sealed class DebrisFeaturePlacerSystem : BaseWorldSystem
 
         component.DoSpawns = false; // Don't repeat yourself if this crashes.
 
-        var chunk = Comp<WorldChunkComponent>(args.Chunk);
+        if (!TryComp<WorldChunkComponent>(args.Chunk, out var chunk))
+            return;
+
+        var chunkMap = chunk.Map;
+
+        if (!TryComp<MapComponent>(chunkMap, out var map))
+            return;
+
         var densityChannel = component.DensityNoiseChannel;
         var density = _noiseIndex.Evaluate(uid, densityChannel, chunk.Coordinates + new Vector2(0.5f, 0.5f));
         if (density == 0)
@@ -157,7 +166,9 @@ public sealed class DebrisFeaturePlacerSystem : BaseWorldSystem
                 .ToList();
         }
 
-        points ??= GeneratePointsInChunk(args.Chunk, density, chunk.Coordinates, chunk.Map);
+        points ??= GeneratePointsInChunk(args.Chunk, density, chunk.Coordinates, chunkMap);
+
+        var mapId = map.MapId;
 
         var safetyBounds = Box2.UnitCentered.Enlarged(component.SafetyZoneRadius);
         var failures = 0; // Avoid severe log spam.
@@ -173,12 +184,10 @@ public sealed class DebrisFeaturePlacerSystem : BaseWorldSystem
             if (pointDensity == 0 && component.DensityClip || _random.Prob(component.RandomCancellationChance))
                 continue;
 
-            var coords = new EntityCoordinates(chunk.Map, point);
+            if (HasCollisions(mapId, safetyBounds.Translated(point)))
+                continue;
 
-            List<Entity<MapGridComponent>> mapGrids = new();
-            _mapManager.FindGridsIntersecting(Comp<MapComponent>(chunk.Map).MapId, safetyBounds.Translated(point), ref mapGrids);
-            if (mapGrids.Count > 0)
-                continue; // Oops, gonna collide.
+            var coords = new EntityCoordinates(chunkMap, point);
 
             var preEv = new PrePlaceDebrisFeatureEvent(coords, args.Chunk);
             RaiseLocalEvent(uid, ref preEv);
@@ -215,6 +224,19 @@ public sealed class DebrisFeaturePlacerSystem : BaseWorldSystem
 
         if (failures > 0)
             _sawmill.Error($"Failed to place {failures} debris at chunk {args.Chunk}");
+    }
+
+    /// <summary>
+    /// Checks to see if the potential spawn point is clear
+    /// </summary>
+    /// <param name="mapId"></param>
+    /// <param name="point"></param>
+    /// <returns></returns>
+    private bool HasCollisions(MapId mapId, Box2 point)
+    {
+        _mapGrids.Clear();
+        _mapManager.FindGridsIntersecting(mapId, point, ref _mapGrids);
+        return _mapGrids.Count > 0;
     }
 
     /// <summary>

--- a/Content.Server/Worldgen/Systems/Debris/DebrisFeaturePlacerSystem.cs
+++ b/Content.Server/Worldgen/Systems/Debris/DebrisFeaturePlacerSystem.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Numerics;
 using Content.Server.Worldgen.Components;
 using Content.Server.Worldgen.Components.Debris;
@@ -175,8 +175,9 @@ public sealed class DebrisFeaturePlacerSystem : BaseWorldSystem
 
             var coords = new EntityCoordinates(chunk.Map, point);
 
-            if (_mapManager
-                .FindGridsIntersecting(Comp<MapComponent>(chunk.Map).MapId, safetyBounds.Translated(point)).Any())
+            List<Entity<MapGridComponent>> mapGrids = new();
+            _mapManager.FindGridsIntersecting(Comp<MapComponent>(chunk.Map).MapId, safetyBounds.Translated(point), ref mapGrids);
+            if (mapGrids.Count > 0)
                 continue; // Oops, gonna collide.
 
             var preEv = new PrePlaceDebrisFeatureEvent(coords, args.Chunk);

--- a/Content.Server/Worldgen/Systems/Debris/NoiseDrivenDebrisSelectorSystem.cs
+++ b/Content.Server/Worldgen/Systems/Debris/NoiseDrivenDebrisSelectorSystem.cs
@@ -1,5 +1,6 @@
-﻿using Content.Server.Worldgen.Components.Debris;
+using Content.Server.Worldgen.Components.Debris;
 using Robust.Server.GameObjects;
+using Robust.Shared.Physics;
 using Robust.Shared.Random;
 
 namespace Content.Server.Worldgen.Systems.Debris;
@@ -28,7 +29,7 @@ public sealed class NoiseDrivenDebrisSelectorSystem : BaseWorldSystem
     private void OnSelectDebrisKind(EntityUid uid, NoiseDrivenDebrisSelectorComponent component,
         ref TryGetPlaceableDebrisFeatureEvent args)
     {
-        var coords = WorldGen.WorldToChunkCoords(args.Coords.ToMapPos(EntityManager, _xformSys));
+        var coords = WorldGen.WorldToChunkCoords(_xformSys.ToMapCoordinates(args.Coords).Position);
         var prob = _index.Evaluate(uid, component.NoiseChannel, coords);
 
         if (prob is < 0 or > 1)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Read #36156 

## Technical details
Use `SharedTransformSystem` map coords methods instead.
Also general improvements in `DebrisFeaturePlacerSystem`:

- `TryComp` guards instead of just `Comp` retrieval
- Using updated `FindGridsIntersecting` and caching the list to reuse
- Extracting the collision checking code into a separate function
- Rearranging some code for better performance and not running code that may be superfluous

Extracting `_mapGrids` to be a class variable might be overkill. Perhaps instantiating it once in the method before the loop will be enough?


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
