### PR TITLE
[April Fools] Live mop bucket: Actually change name in all places

### DIFF
--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -59,7 +59,7 @@ ghost-role-information-hamster-description = A grumpy little ball of fluff.
 ghost-role-information-hamlet-name = Hamlet the Hamster
 ghost-role-information-hamlet-description = Lives in the station bridge, has a bit of a temper and is always hungry.
 
-ghost-role-information-bucket-name = Alive Mop Bucket
+ghost-role-information-bucket-name = Living Mop Bucket
 ghost-role-information-bucket-description = You can be a marvel of science!
 
 ghost-role-information-slimes-name = Slime


### PR DESCRIPTION
## About the PR
Since my live mop bucket was silently renamed to a living mop bucket in half of all occurrences, I have come to finish that job.

## Why / Balance
So that the name is consistent.

## Technical details
It has a different name now.

## Media
No.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
Nothing