### PR TITLE
Added the ability to refuel torches (and other expendable lights)

### DIFF
--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -63,7 +63,7 @@ namespace Content.Server.Light.EntitySystems
                 {
                     case ExpendableLightState.Lit:
                         component.CurrentState = ExpendableLightState.Fading;
-                        component.StateExpiryTime = component.FadeOutDuration;
+                        component.StateExpiryTime = (float)component.FadeOutDuration.TotalSeconds;
 
                         UpdateVisualizer(ent);
 
@@ -124,13 +124,13 @@ namespace Content.Server.Light.EntitySystems
             if (stack.StackTypeId != component.RefuelMaterialID)
                 return;
 
-            if (component.StateExpiryTime + component.RefuelMaterialTime >= component.RefuelMaximumDuration)
+            if (component.StateExpiryTime + component.RefuelMaterialTime.TotalSeconds >= component.RefuelMaximumDuration.TotalSeconds)
                 return;
 
             if (component.CurrentState is ExpendableLightState.Dead)
             {
                 component.CurrentState = ExpendableLightState.BrandNew;
-                component.StateExpiryTime = component.RefuelMaterialTime;
+                component.StateExpiryTime = (float)component.RefuelMaterialTime.TotalSeconds;
 
                 _nameModifier.RefreshNameModifiers(uid);
                 _stackSystem.SetCount(args.Used, stack.Count - 1, stack);
@@ -138,15 +138,15 @@ namespace Content.Server.Light.EntitySystems
                 return;
             }
 
-            component.StateExpiryTime += component.RefuelMaterialTime;
+            component.StateExpiryTime += (float)component.RefuelMaterialTime.TotalSeconds;
             _stackSystem.SetCount(args.Used, stack.Count - 1, stack);
             args.Handled = true;
         }
 
-        private void OnRefreshNameModifiers(EntityUid uid, ExpendableLightComponent component, RefreshNameModifiersEvent args)
+        private void OnRefreshNameModifiers(Entity<ExpendableLightComponent> entity, ref RefreshNameModifiersEvent args)
         {
-            if (component.CurrentState is ExpendableLightState.Dead)
-                args.AddModifier(component.SpentName);
+            if (entity.Comp.CurrentState is ExpendableLightState.Dead)
+                args.AddModifier("expendable-light-spent-prefix");
         }
 
         private void UpdateVisualizer(Entity<ExpendableLightComponent> ent, AppearanceComponent? appearance = null)
@@ -205,7 +205,7 @@ namespace Content.Server.Light.EntitySystems
             }
 
             component.CurrentState = ExpendableLightState.BrandNew;
-            component.StateExpiryTime = component.GlowDuration;
+            component.StateExpiryTime = (float)component.GlowDuration.TotalSeconds;
             EntityManager.EnsureComponent<PointLightComponent>(uid);
         }
 

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -76,8 +76,6 @@ namespace Content.Server.Light.EntitySystems
 
                         _tagSystem.AddTag(ent, "Trash");
 
-                        _tagSystem.AddTag(ent, "Trash");
-
                         UpdateSounds(ent);
                         UpdateVisualizer(ent);
 

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -118,13 +118,13 @@ namespace Content.Server.Light.EntitySystems
             if (args.Handled)
                 return;
 
-            if (!EntityManager.TryGetComponent(args.Used, out StackComponent? stack))
+            if (!TryComp(args.Used, out StackComponent? stack))
                 return;
 
             if (stack.StackTypeId != component.RefuelMaterialID)
                 return;
 
-            if (component.StateExpiryTime + component.RefuelMaterialTime >= component.RefuelMaximum)
+            if (component.StateExpiryTime + component.RefuelMaterialTime >= component.RefuelMaximumDuration)
                 return;
 
             if (component.CurrentState is ExpendableLightState.Dead)

--- a/Content.Shared/Light/Components/SharedExpendableLightComponent.cs
+++ b/Content.Shared/Light/Components/SharedExpendableLightComponent.cs
@@ -32,8 +32,8 @@ public abstract partial class SharedExpendableLightComponent : Component
     [DataField("refuelMaterialTime")]
     public float RefuelMaterialTime { get; set; } = 15f;
 
-    [DataField("refuelMaximum")]
-    public float RefuelMaximum { get; set; } = 60 * 15f * 2;
+    [DataField("refuelMaximumDuration")]
+    public float RefuelMaximumDuration { get; set; } = 60 * 15f * 2;
 
     [DataField("litSound")]
     public SoundSpecifier? LitSound { get; set; }

--- a/Content.Shared/Light/Components/SharedExpendableLightComponent.cs
+++ b/Content.Shared/Light/Components/SharedExpendableLightComponent.cs
@@ -23,11 +23,17 @@ public abstract partial class SharedExpendableLightComponent : Component
     [DataField("fadeOutDuration")]
     public float FadeOutDuration { get; set; } = 60 * 5f;
 
-    [DataField("spentDesc")]
-    public string SpentDesc { get; set; } = string.Empty;
-
     [DataField("spentName")]
     public string SpentName { get; set; } = string.Empty;
+
+    [DataField("refuelMaterialID")]
+    public string? RefuelMaterialID { get; set; } = null;
+
+    [DataField("refuelMaterialTime")]
+    public float RefuelMaterialTime { get; set; } = 15f;
+
+    [DataField("refuelMaximum")]
+    public float RefuelMaximum { get; set; } = 60 * 15f * 2;
 
     [DataField("litSound")]
     public SoundSpecifier? LitSound { get; set; }

--- a/Content.Shared/Light/Components/SharedExpendableLightComponent.cs
+++ b/Content.Shared/Light/Components/SharedExpendableLightComponent.cs
@@ -1,5 +1,7 @@
+using Content.Shared.Stacks;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Light.Components;
@@ -9,40 +11,37 @@ public abstract partial class SharedExpendableLightComponent : Component
 {
 
     [ViewVariables(VVAccess.ReadOnly)]
-    public ExpendableLightState CurrentState { get; set; }
+    public ExpendableLightState CurrentState;
 
-    [DataField("turnOnBehaviourID")]
-    public string TurnOnBehaviourID { get; set; } = string.Empty;
+    [DataField]
+    public string TurnOnBehaviourID = string.Empty;
 
-    [DataField("fadeOutBehaviourID")]
-    public string FadeOutBehaviourID { get; set; } = string.Empty;
+    [DataField]
+    public string FadeOutBehaviourID = string.Empty;
 
-    [DataField("glowDuration")]
-    public float GlowDuration { get; set; } = 60 * 15f;
+    [DataField]
+    public TimeSpan GlowDuration = TimeSpan.FromSeconds(60 * 15f);
 
-    [DataField("fadeOutDuration")]
-    public float FadeOutDuration { get; set; } = 60 * 5f;
+    [DataField]
+    public TimeSpan FadeOutDuration = TimeSpan.FromSeconds(60 * 5f);
 
-    [DataField("spentName")]
-    public string SpentName { get; set; } = string.Empty;
+    [DataField]
+    public ProtoId<StackPrototype>? RefuelMaterialID;
 
-    [DataField("refuelMaterialID")]
-    public string? RefuelMaterialID { get; set; } = null;
+    [DataField]
+    public TimeSpan RefuelMaterialTime = TimeSpan.FromSeconds(15f);
 
-    [DataField("refuelMaterialTime")]
-    public float RefuelMaterialTime { get; set; } = 15f;
+    [DataField]
+    public TimeSpan RefuelMaximumDuration = TimeSpan.FromSeconds(60 * 15f * 2);
 
-    [DataField("refuelMaximumDuration")]
-    public float RefuelMaximumDuration { get; set; } = 60 * 15f * 2;
+    [DataField]
+    public SoundSpecifier? LitSound;
 
-    [DataField("litSound")]
-    public SoundSpecifier? LitSound { get; set; }
+    [DataField]
+    public SoundSpecifier? LoopedSound;
 
-    [DataField("loopedSound")]
-    public SoundSpecifier? LoopedSound { get; set; }
-
-    [DataField("dieSound")]
-    public SoundSpecifier? DieSound { get; set; } = null;
+    [DataField]
+    public SoundSpecifier? DieSound;
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/light/components/expendable-light-component.ftl
+++ b/Resources/Locale/en-US/light/components/expendable-light-component.ftl
@@ -1,14 +1,2 @@
 expendable-light-start-verb = Start Light
-
-expendable-light-spent-flare-name = spent flare
-expendable-light-spent-flare-desc = It looks like this flare has burnt out. What a bummer.
-
-expendable-light-burnt-torch-name = burnt torch
-expendable-light-burnt-torch-desc = It looks like this torch has burnt out. What a bummer.
-
-expendable-light-spent-green-glowstick-name = spent green glowstick
-expendable-light-spent-red-glowstick-name = spent red glowstick
-expendable-light-spent-purple-glowstick-name = spent purple glowstick
-expendable-light-spent-yellow-glowstick-name = spent purple glowstick
-expendable-light-spent-blue-glowstick-name = spent blue glowstick
-expendable-light-spent-glowstick-desc = It looks like this glowstick has stopped glowing. How tragic.
+expendable-light-spent-prefix = spent

--- a/Resources/Locale/en-US/light/components/expendable-light-component.ftl
+++ b/Resources/Locale/en-US/light/components/expendable-light-component.ftl
@@ -1,2 +1,2 @@
 expendable-light-start-verb = Start Light
-expendable-light-spent-prefix = spent
+expendable-light-spent-prefix = spent {$baseName}

--- a/Resources/Prototypes/Entities/Objects/Misc/torch.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/torch.yml
@@ -7,8 +7,8 @@
     - type: ExpendableLight
       spentName: expendable-light-burnt-torch-name
       refuelMaterialID: WoodPlank
-      refuelMaximum: 205
       glowDuration: 100
+      refuelMaximumDuration: 205
       fadeOutDuration: 4
       iconStateSpent: torch_spent
       turnOnBehaviourID: turn_on

--- a/Resources/Prototypes/Entities/Objects/Misc/torch.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/torch.yml
@@ -5,7 +5,6 @@
   description: A torch fashioned from some wood.
   components:
     - type: ExpendableLight
-      spentName: expendable-light-burnt-torch-name
       refuelMaterialID: WoodPlank
       glowDuration: 100
       refuelMaximumDuration: 205
@@ -80,5 +79,3 @@
     - type: Tag
       tags:
       - Torch
-    - type: NameModifier
-      baseName: torch

--- a/Resources/Prototypes/Entities/Objects/Misc/torch.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/torch.yml
@@ -6,7 +6,8 @@
   components:
     - type: ExpendableLight
       spentName: expendable-light-burnt-torch-name
-      spentDesc: expendable-light-burnt-torch-desc
+      refuelMaterialID: WoodPlank
+      refuelMaximum: 205
       glowDuration: 100
       fadeOutDuration: 4
       iconStateSpent: torch_spent
@@ -79,3 +80,5 @@
     - type: Tag
       tags:
       - Torch
+    - type: NameModifier
+      baseName: torch

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -10,7 +10,6 @@
     - Trash
   - type: SpaceGarbage
   - type: ExpendableLight
-    spentName: expendable-light-spent-flare-name
     glowDuration: 225
     fadeOutDuration: 15
     iconStateOn: flare_unlit

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -11,7 +11,6 @@
   - type: SpaceGarbage
   - type: ExpendableLight
     spentName: expendable-light-spent-flare-name
-    spentDesc: expendable-light-spent-flare-desc
     glowDuration: 225
     fadeOutDuration: 15
     iconStateOn: flare_unlit

--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -6,7 +6,6 @@
   components:
     - type: SpaceGarbage
     - type: ExpendableLight
-      spentName: expendable-light-spent-green-glowstick-name
       glowDuration: 900 # time in seconds
       glowColorLit: "#00FF00"
       fadeOutDuration: 300

--- a/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/glowstick.yml
@@ -7,7 +7,6 @@
     - type: SpaceGarbage
     - type: ExpendableLight
       spentName: expendable-light-spent-green-glowstick-name
-      spentDesc: expendable-light-spent-glowstick-desc
       glowDuration: 900 # time in seconds
       glowColorLit: "#00FF00"
       fadeOutDuration: 300


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR adds the ability to refuel entities with the ExpendableLights component.

## Why / Balance
Previously, torches could not be refueled and left wasted items, making a survival experience terrible. This patch fixes the issue by adding the ability to refuel expendable lights. (toggle-able in the component definition, disabled by default)

## Technical details
This patch makes two revamps, namely:
* Adds extra parameters to allow refueling 
* Changes the ExpendableLightSystem to change names using the NameModifierSystem

## Media
https://files.catbox.moe/oatj4r.mov

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
This PR removes the spentDesc datafield, as there is no non-hacky ways that i know of to restore the item's description to its default value. ~~Whatever parses the prototypes doesn't complain about it for now, so it's fine as is. If you're going to touch up any entities with the ExpendableLight component, make sure to remove the spentDesc field.~~ All prototypes with the deprecated field have been removed

**Changelog**
:cl: mjarduk
- tweak: Torches can now be refueled.
- fix: Burnt torches/glowsticks names' can now display if they're glued, cluwnified, etc.