### PR TITLE
Changes ParallaxGenerator to use FastNoiseLite

### DIFF
--- a/Content.Client/Parallax/ParallaxGenerator.cs
+++ b/Content.Client/Parallax/ParallaxGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -131,7 +131,7 @@ namespace Content.Client.Parallax
         {
             private readonly Color InnerColor = Color.White;
             private readonly Color OuterColor = Color.Black;
-            private readonly NoiseGenerator.NoiseType NoiseType = NoiseGenerator.NoiseType.Fbm;
+            private readonly FastNoiseLite.FractalType NoiseType = FastNoiseLite.FractalType.FBm;
             private readonly uint Seed = 1234;
             private readonly float Persistence = 0.5f;
             private readonly float Lacunarity = (float) (Math.PI / 3);
@@ -204,10 +204,10 @@ namespace Content.Client.Parallax
                     switch (((TomlValue<string>) tomlObject).Value)
                     {
                         case "fbm":
-                            NoiseType = NoiseGenerator.NoiseType.Fbm;
+                            NoiseType = FastNoiseLite.FractalType.FBm;
                             break;
                         case "ridged":
-                            NoiseType = NoiseGenerator.NoiseType.Ridged;
+                            NoiseType = FastNoiseLite.FractalType.Ridged;
                             break;
                         default:
                             throw new InvalidOperationException();
@@ -217,14 +217,11 @@ namespace Content.Client.Parallax
 
             public override void Apply(Image<Rgba32> bitmap)
             {
-                var noise = new NoiseGenerator(NoiseType);
-                noise.SetSeed(Seed);
+                var noise = new FastNoiseLite((int)Seed);
+                noise.SetFractalType(NoiseType);
                 noise.SetFrequency(Frequency);
-                noise.SetPersistence(Persistence);
-                noise.SetLacunarity(Lacunarity);
-                noise.SetOctaves(Octaves);
-                noise.SetPeriodX(bitmap.Width);
-                noise.SetPeriodY(bitmap.Height);
+                noise.SetFractalLacunarity(Lacunarity);
+                noise.SetFractalOctaves((int)Octaves);
                 var threshVal = 1 / (1 - Threshold);
                 var powFactor = 1 / Power;
 
@@ -268,7 +265,7 @@ namespace Content.Client.Parallax
 
             // Noise mask stuff.
             private readonly bool Masked;
-            private readonly NoiseGenerator.NoiseType MaskNoiseType = NoiseGenerator.NoiseType.Fbm;
+            private readonly FastNoiseLite.FractalType MaskNoiseType = FastNoiseLite.FractalType.FBm;
             private readonly uint MaskSeed = 1234;
             private readonly float MaskPersistence = 0.5f;
             private readonly float MaskLacunarity = (float) (Math.PI * 2 / 3);
@@ -357,10 +354,10 @@ namespace Content.Client.Parallax
                     switch (((TomlValue<string>) tomlObject).Value)
                     {
                         case "fbm":
-                            MaskNoiseType = NoiseGenerator.NoiseType.Fbm;
+                            MaskNoiseType = FastNoiseLite.FractalType.FBm;
                             break;
                         case "ridged":
-                            MaskNoiseType = NoiseGenerator.NoiseType.Ridged;
+                            MaskNoiseType = FastNoiseLite.FractalType.Ridged;
                             break;
                         default:
                             throw new InvalidOperationException();
@@ -439,14 +436,10 @@ namespace Content.Client.Parallax
             {
                 var o = PointSize - 1;
                 var random = new Random(Seed);
-                var noise = new NoiseGenerator(MaskNoiseType);
-                noise.SetSeed(MaskSeed);
-                noise.SetFrequency(MaskFrequency);
-                noise.SetPersistence(MaskPersistence);
-                noise.SetLacunarity(MaskLacunarity);
-                noise.SetOctaves(MaskOctaves);
-                noise.SetPeriodX(buffer.Width);
-                noise.SetPeriodY(buffer.Height);
+                var noise = new FastNoiseLite((int)MaskSeed);
+                noise.SetFractalType(MaskNoiseType);
+                noise.SetFractalLacunarity(MaskLacunarity);
+                noise.SetFractalOctaves((int)MaskOctaves);
 
                 var threshVal = 1 / (1 - MaskThreshold);
                 var powFactor = 1 / MaskPower;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Instead of the `NoiseGenerator` we use `FastNoiseLite` If I'm correct, after this we'll be able to remove `NoiseGenerator` and `FastNoise` from the codebase entirely!

## Technical details
<!-- Summary of code changes for easier review. -->
Replaces `NoiseGenerator` construction in `ParallaxGenerator` with `FastNoiseLite`.
The `FastNoiseLite` API doesn't have Period or Persistence attributes exposed anywhere so we might lose some functionality in this case. 
Though the `GetNoise` function we're calling in `NoiseGenerator` didn't seem to make use of these really anyway, but I could be wrong on that. 
#33279 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
