### PR TITLE
add: Dragon rift color changes based on charge

### DIFF
--- a/Content.Server/Dragon/DragonRiftSystem.cs
+++ b/Content.Server/Dragon/DragonRiftSystem.cs
@@ -40,11 +40,11 @@ public sealed class DragonRiftSystem : EntitySystem
         SubscribeLocalEvent<DragonRiftComponent, ComponentShutdown>(OnShutdown);
     }
 
-    private void OnGetState(EntityUid uid, DragonRiftComponent component, ref ComponentGetState args)
+    private void OnGetState(Entity<DragonRiftComponent> ent, ref ComponentGetState args)
     {
         args.State = new DragonRiftComponentState
         {
-            State = component.State,
+            State = ent.Comp.State,
         };
     }
 

--- a/Content.Server/Dragon/DragonRiftSystem.cs
+++ b/Content.Server/Dragon/DragonRiftSystem.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Serialization.Manager;
 using System.Numerics;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.GameStates;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Dragon;
@@ -33,9 +34,18 @@ public sealed class DragonRiftSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<DragonRiftComponent, ComponentGetState>(OnGetState);
         SubscribeLocalEvent<DragonRiftComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<DragonRiftComponent, AnchorStateChangedEvent>(OnAnchorChange);
         SubscribeLocalEvent<DragonRiftComponent, ComponentShutdown>(OnShutdown);
+    }
+
+    private void OnGetState(EntityUid uid, DragonRiftComponent component, ref ComponentGetState args)
+    {
+        args.State = new DragonRiftComponentState
+        {
+            State = component.State,
+        };
     }
 
     public override void Update(float frameTime)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
add: carp rifts shine different colors. violet above 50%, gold at 100%.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix. The code was in the game, it just wasn't working. Also good.

## Technical details
<!-- Summary of code changes for easier review. -->
[client-side system](https://github.com/space-wizards/space-station-14/blob/66e2b0ab64a33e3511ac415cadfcda43dd6ac6f0/Content.Client/Dragon/DragonSystem.cs#L17) was waiting for ComponentHandleState but server didn't have GetState

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/795aad5b-60de-4e29-9c5b-99e5de2fae11)


![image](https://github.com/user-attachments/assets/fc3c647c-1a49-4a0d-9a5f-2d9361eb9fdd)

![image](https://github.com/user-attachments/assets/a3107521-7fb7-4d17-8c7f-3024969b5670)


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Dragon rifts now shine a different color depending on charge progress.