### PR TITLE
Fix KeyNotFoundException that sometimes happens on server shutdown

### DIFF
--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -85,11 +85,11 @@ public sealed class MindSystem : SharedMindSystem
     {
         if (base.TryGetMind(user, out mindId, out mind))
         {
-            DebugTools.Assert(_players.GetPlayerData(user).ContentData() is not { } data || data.Mind == mindId);
+            DebugTools.Assert(!_players.TryGetPlayerData(user, out var playerData) || playerData.ContentData() is not { } data || data.Mind == mindId);
             return true;
         }
 
-        DebugTools.Assert(_players.GetPlayerData(user).ContentData()?.Mind == null);
+        DebugTools.Assert(!_players.TryGetPlayerData(user, out var pData) || pData.ContentData()?.Mind == null);
         return false;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed a bug that could throw an exception when shutting down a development server.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Honestly not a very important bug, since it only affects servers running in debug mode and only happens when they're shutting down anyway. But it's been bothering me for a while and I wanted to fix it.

## Technical details
<!-- Summary of code changes for easier review. -->
Shutting down the development server with a client connected sometimes causes a debug assert on the way out. I have not found a way to reliably reproduce this issue, but it seems to happen fairly frequently for me - I suspect that hardware specifics may play a part in it.

In any case, the stack trace pointed to `SharedPlayerManager.GetPlayerData` throwing a `KeyNotFoundException` when trying to index the player data, because the player session has already been removed. This PR swaps `SharedPlayerManager.GetPlayerData` for `SharedPlayerManager.TryGetPlayerData`, which won't throw an exception when the key isn't found.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->