### PR TITLE
Rework the way held items scatter when holder is knocked down

### DIFF
--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -268,8 +268,8 @@ namespace Content.Server.Hands.Systems
                 // Decrease the distance of the throw by a random amount
                 itemVelocity *= _random.NextFloat(1f);
                 // Heavier objects don't get thrown as far
-                if (TryComp<PhysicsComponent>(held, out var heldPhysics))
-                    itemVelocity *= heldPhysics.InvMass;
+                // If the item doesn't have a physics component, it isn't going to get thrown anyway, but we'll assume infinite mass
+                itemVelocity *= TryComp<PhysicsComponent>(held, out var heldPhysics) ? heldPhysics.InvMass : 0;
                 // Throw at half the holder's intentional throw speed and
                 // vary the speed a little to make it look more interesting
                 var throwSpeed = entity.Comp.BaseThrowspeed * 0.5f * _random.NextFloat(0.9f, 1.1f);

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -247,6 +247,7 @@ namespace Content.Server.Hands.Systems
         {
             // If the holder doesn't have a physics component, they ain't moving
             var holderVelocity = _physicsQuery.TryComp(entity, out var physics) ? physics.LinearVelocity : Vector2.Zero;
+            var spreadMaxAngle = Angle.FromDegrees(DropHeldItemsSpread);
 
             var fellEvent = new FellDownEvent(entity);
             RaiseLocalEvent(entity, fellEvent, false);
@@ -266,7 +267,6 @@ namespace Content.Server.Hands.Systems
                     continue;
 
                 // Rotate the item's throw vector a bit for each item
-                var spreadMaxAngle = Angle.FromDegrees(DropHeldItemsSpread);
                 var angleOffset = _random.NextAngle(-spreadMaxAngle, spreadMaxAngle);
                 // Rotate the holder's velocity vector by the angle offset to get the item's velocity vector
                 var itemVelocity = angleOffset.RotateVec(holderVelocity);

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -266,7 +266,8 @@ namespace Content.Server.Hands.Systems
                     continue;
 
                 // Rotate the item's throw vector a bit for each item
-                var angleOffset = Angle.FromDegrees(_random.NextFloat(-1, 1) * DropHeldItemsSpread);
+                var spreadMaxAngle = Angle.FromDegrees(DropHeldItemsSpread);
+                var angleOffset = _random.NextAngle(-spreadMaxAngle, spreadMaxAngle);
                 // Rotate the holder's velocity vector by the angle offset to get the item's velocity vector
                 var itemVelocity = angleOffset.RotateVec(holderVelocity);
                 // Decrease the distance of the throw by a random amount

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -276,7 +276,7 @@ namespace Content.Server.Hands.Systems
                 itemVelocity *= _physicsQuery.TryComp(held, out var heldPhysics) ? heldPhysics.InvMass : 0;
                 // Throw at half the holder's intentional throw speed and
                 // vary the speed a little to make it look more interesting
-                var throwSpeed = entity.Comp.BaseThrowspeed * 0.5f * _random.NextFloat(0.9f, 1.1f);
+                var throwSpeed = entity.Comp.BaseThrowspeed * _random.NextFloat(0.45f, 0.55f);
 
                 _throwingSystem.TryThrow(held,
                     itemVelocity,

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -241,7 +241,8 @@ namespace Content.Server.Hands.Systems
 
         private void OnDropHandItems(Entity<HandsComponent> entity, ref DropHandItemsEvent args)
         {
-            var holderVelocity = Comp<PhysicsComponent>(entity).LinearVelocity;
+            // If the holder doesn't have a physics component, they ain't moving
+            var holderVelocity = TryComp<PhysicsComponent>(entity, out var physics) ? physics.LinearVelocity : Vector2.Zero;
 
             var fellEvent = new FellDownEvent(entity);
             RaiseLocalEvent(entity, fellEvent, false);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Rewrites the logic/math behind the how held items are thrown when someone slips or otherwise gets knocked down.

Notably:
- Items are now thrown in the direction the holder is moving, +/- 45 degrees. Previously they could be thrown in any direction.
- There is no longer a 45% chance for the item to just get dropped at the holder's feet instead of being thrown. This was almost certainly a bug caused by a stray minus sign in the code. Items can still get thrown very short distances (even zero), but it's now just as likely as any other distance.
- Item mass is now taken into account: lighter items fly farther than heavier ones. This is based on the item's mass, which is in turn based on the size and density of its fixtures. A lot of items don't have these values customized, so expect there to be some oddities (ex: a piece of paper weighs as much as a crowbar), but these YAML values can be corrected over time and are outside the scope of this PR.

As with the previous implementation, the lack of prediction for throwing is a bit unpleasant. The items scatter a moment after the player slips on the local client. This was the case before, but the accidental 45% chance of dropping the item in place covered it up a bit.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's pretty funny now to see a player's held items go flying out in front of them as they slip, and it makes more sense than having them sometimes go backward or often just appear on the ground at their feet.

There are some slight balance implications, because this could theoretically make it a little bit easier to pick up your dropped items when you slip. As before, you do still need to wait until you stand up to do so though, so the change is very minimal.

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced some 4 year old code which did some funky things, some of which didn't seem to work.
- The holder's velocity is taken from their physics component.
- Each item's velocity is based on the holder's velocity, then rotated by a random amount up to a const value (`DropHeldItemsSpread`) degrees, in the positive or negative direction.
- The item's velocity is then scaled by a random value from 0 to 1, varying the distance it will travel.
- It is then divided by the item's physical mass, giving lighter items a higher velocity and vice versa.
- The `baseThrowSpeed` of the throw is set to half of the holder's `BaseThrowSpeed` (since it's not a deliberate throw), then given a +/-10% variation.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/aec08bd7-5a86-4d1a-be1a-f40ac0ac6dfe

Butter weighs less than a crowbar.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Items thrown when someone slips now tend to scatter in the direction they are moving, and respect the item's mass.