### PR TITLE
[April Fools] Minor Scurret YAML fixes, wawa

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
@@ -90,26 +90,6 @@
           32:
             sprite: Mobs/Animals/scurret/displacement.rsi
             state: jumpsuit
-      head:
-        sizeMaps:
-          32:
-            sprite: Mobs/Animals/scurret/displacement.rsi
-            state: head
-      ears:
-        sizeMaps:
-          32:
-            sprite: Mobs/Animals/scurret/displacement.rsi
-            state: ears
-      eyes:
-        sizeMaps:
-          32:
-            sprite: Mobs/Animals/scurret/displacement.rsi
-            state: eyes
-      mask:
-        sizeMaps:
-          32:
-            sprite: Mobs/Animals/scurret/displacement.rsi
-            state: mask
       id:
         sizeMaps:
           32:
@@ -120,16 +100,10 @@
           32:
             sprite: Mobs/Animals/scurret/displacement.rsi
             state: gloves
-  - type: Hands
-    handDisplacement:
-      sizeMaps:
-        32:
-          sprite: Mobs/Animals/scurret/displacement.rsi
-          state: hand
   - type: InventorySlots
   - type: Food
   - type: Hunger
-    baseDecayRate: 0.25 # They get a lil' hungy
+    baseDecayRate: 0.05 # They get a lil' hungy
   - type: BodyEmotes # Grants them clapping and so on.
     soundsId: GeneralBodyEmotes
   - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
1. Scurret hunger is now at normal rates, not 5x higher than intended
2. Displacement maps that are causing issues have been discarded for now, wawa.

## Why / Balance
Displacement mapping is currently causing some melted sprite problems so best to discard, and microplastics are a bit deadly.

## Technical details
YAML 

## Media
Nah

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
