### PR TITLE
Power extensioncablesystem cleanups

### DIFF
--- a/Content.Server/Power/Components/ExtensionCableProviderComponent.cs
+++ b/Content.Server/Power/Components/ExtensionCableProviderComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Power.EntitySystems;
+using Content.Server.Power.EntitySystems;
 
 namespace Content.Server.Power.Components
 {
@@ -13,7 +13,7 @@ namespace Content.Server.Power.Components
         [DataField("transferRange")]
         public int TransferRange { get; set; } = 3;
 
-        [ViewVariables] public List<ExtensionCableReceiverComponent> LinkedReceivers { get; } = new();
+        [ViewVariables] public List<Entity<ExtensionCableReceiverComponent>> LinkedReceivers { get; } = new();
 
         /// <summary>
         ///     If <see cref="ExtensionCableReceiverComponent"/>s should consider connecting to this.

--- a/Content.Server/Power/Components/ExtensionCableReceiverComponent.cs
+++ b/Content.Server/Power/Components/ExtensionCableReceiverComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Power.EntitySystems;
+using Content.Server.Power.EntitySystems;
 
 namespace Content.Server.Power.Components
 {
@@ -7,7 +7,7 @@ namespace Content.Server.Power.Components
     public sealed partial class ExtensionCableReceiverComponent : Component
     {
         [ViewVariables]
-        public ExtensionCableProviderComponent? Provider { get; set; }
+        public Entity<ExtensionCableProviderComponent?> Provider { get; set; }
 
         [ViewVariables]
         public bool Connectable = false;

--- a/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
+++ b/Content.Server/Power/EntitySystems/ExtensionCableSystem.cs
@@ -237,7 +237,7 @@ namespace Content.Server.Power.EntitySystems
             if (!TryFindAvailableProvider(uid, receiver.ReceptionRange, out var provider, xform))
                 return;
 
-            receiver.Provider = (uid, provider);
+            receiver.Provider = provider;
             provider.Comp!.LinkedReceivers.Add((uid, receiver));
             RaiseLocalEvent(uid, new ProviderConnectedEvent(provider.Comp), broadcast: false);
             RaiseLocalEvent(provider.Owner, new ReceiverConnectedEvent((uid, receiver)), broadcast: false);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed warnings from the `ExtensionCableSystem`. 
Part of #33279 

## Technical details
<!-- Summary of code changes for easier review. -->
Removed 10 warnings from the system. Had to set the components to be `List<Entity<T>>` to track who owned the components.
2 things I'm not sure about:
- `MapSystem` caching, is it worth it? I'm not sure if it would be straightforward like the others but I could be wrong.
- The fact I'm now setting some components to be `(uid, null)` I don't like. Will they be GC'd? Don't want to cause memory issues if someone sets/unsets 1000000 of them.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Anything using `ExtensionCableReceiverComponent` or `ExtensionCableProviderComponent` now needs to be an `List<Entity<T>>`
