### PR TITLE
Add prediction to electric grills

### DIFF
--- a/Content.Client/Temperature/Systems/EntityHeaterSystem.cs
+++ b/Content.Client/Temperature/Systems/EntityHeaterSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.Temperature.Systems;
+
+namespace Content.Client.Temperature.Systems;
+
+public sealed partial class EntityHeaterSystem : SharedEntityHeaterSystem;

--- a/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
+++ b/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
@@ -30,7 +30,7 @@ public sealed class EntityHeaterSystem : SharedEntityHeaterSystem
     public override void Update(float deltaTime)
     {
         var query = EntityQueryEnumerator<EntityHeaterComponent, ItemPlacerComponent, ApcPowerReceiverComponent>();
-        while (query.MoveNext(out var _, out var _, out var placer, out var power))
+        while (query.MoveNext(out _, out _, out var placer, out var power))
         {
             if (!power.Powered)
                 continue;

--- a/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
+++ b/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
@@ -1,40 +1,23 @@
 using Content.Server.Power.Components;
-using Content.Server.Temperature.Components;
-using Content.Shared.Examine;
 using Content.Shared.Placeable;
-using Content.Shared.Popups;
-using Content.Shared.Power;
+using Content.Shared.Power.Components;
 using Content.Shared.Temperature;
-using Content.Shared.Verbs;
-using Robust.Server.Audio;
+using Content.Shared.Temperature.Components;
+using Content.Shared.Temperature.Systems;
 
 namespace Content.Server.Temperature.Systems;
 
 /// <summary>
-/// Handles <see cref="EntityHeaterComponent"/> updating and events.
+/// Handles the server-only parts of <see cref="SharedEntityHeaterSystem"/>
 /// </summary>
-public sealed class EntityHeaterSystem : EntitySystem
+public sealed class EntityHeaterSystem : SharedEntityHeaterSystem
 {
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly TemperatureSystem _temperature = default!;
-    [Dependency] private readonly AudioSystem _audio = default!;
-
-    private readonly int SettingCount = Enum.GetValues(typeof(EntityHeaterSetting)).Length;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<EntityHeaterComponent, ExaminedEvent>(OnExamined);
-        SubscribeLocalEvent<EntityHeaterComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
-        SubscribeLocalEvent<EntityHeaterComponent, PowerChangedEvent>(OnPowerChanged);
-    }
 
     public override void Update(float deltaTime)
     {
         var query = EntityQueryEnumerator<EntityHeaterComponent, ItemPlacerComponent, ApcPowerReceiverComponent>();
-        while (query.MoveNext(out var uid, out var comp, out var placer, out var power))
+        while (query.MoveNext(out var _, out var _, out var placer, out var power))
         {
             if (!power.Powered)
                 continue;
@@ -50,66 +33,17 @@ public sealed class EntityHeaterSystem : EntitySystem
         }
     }
 
-    private void OnExamined(EntityUid uid, EntityHeaterComponent comp, ExaminedEvent args)
+    /// <remarks>
+    /// <see cref="SharedApcPowerReceiverComponent"/> doesn't have a Load property, so we need
+    /// this server-only override to handle setting it.
+    /// </remarks>
+    protected override void ChangeSetting(Entity<EntityHeaterComponent> ent, EntityHeaterSetting setting, EntityUid? user = null)
     {
-        if (!args.IsInDetailsRange)
+        base.ChangeSetting(ent, setting, user);
+
+        if (!TryComp<ApcPowerReceiverComponent>(ent, out var power))
             return;
 
-        args.PushMarkup(Loc.GetString("entity-heater-examined", ("setting", comp.Setting)));
-    }
-
-    private void OnGetVerbs(EntityUid uid, EntityHeaterComponent comp, GetVerbsEvent<AlternativeVerb> args)
-    {
-        if (!args.CanAccess || !args.CanInteract)
-            return;
-
-        var setting = (int) comp.Setting;
-        setting++;
-        setting %= SettingCount;
-        var nextSetting = (EntityHeaterSetting) setting;
-
-        args.Verbs.Add(new AlternativeVerb()
-        {
-            Text = Loc.GetString("entity-heater-switch-setting", ("setting", nextSetting)),
-            Act = () =>
-            {
-                ChangeSetting(uid, nextSetting, comp);
-                _popup.PopupEntity(Loc.GetString("entity-heater-switched-setting", ("setting", nextSetting)), uid, args.User);
-            }
-        });
-    }
-
-    private void OnPowerChanged(EntityUid uid, EntityHeaterComponent comp, ref PowerChangedEvent args)
-    {
-        // disable heating element glowing layer if theres no power
-        // doesn't actually turn it off since that would be annoying
-        var setting = args.Powered ? comp.Setting : EntityHeaterSetting.Off;
-        _appearance.SetData(uid, EntityHeaterVisuals.Setting, setting);
-    }
-
-    private void ChangeSetting(EntityUid uid, EntityHeaterSetting setting, EntityHeaterComponent? comp = null, ApcPowerReceiverComponent? power = null)
-    {
-        if (!Resolve(uid, ref comp, ref power))
-            return;
-
-        comp.Setting = setting;
-        power.Load = SettingPower(setting, comp.Power);
-        _appearance.SetData(uid, EntityHeaterVisuals.Setting, setting);
-        _audio.PlayPvs(comp.SettingSound, uid);
-    }
-
-    private float SettingPower(EntityHeaterSetting setting, float max)
-    {
-        switch (setting)
-        {
-            case EntityHeaterSetting.Low:
-                return max / 3f;
-            case EntityHeaterSetting.Medium:
-                return max * 2f / 3f;
-            case EntityHeaterSetting.High:
-                return max;
-            default:
-                return 0f;
-        }
+        power.Load = SettingPower(setting, ent.Comp.Power);
     }
 }

--- a/Content.Shared/Temperature/Components/EntityHeaterComponent.cs
+++ b/Content.Shared/Temperature/Components/EntityHeaterComponent.cs
@@ -1,26 +1,27 @@
-using Content.Server.Temperature.Systems;
-using Content.Shared.Temperature;
+using Content.Shared.Temperature.Systems;
 using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
 
-namespace Content.Server.Temperature.Components;
+namespace Content.Shared.Temperature.Components;
 
 /// <summary>
 /// Adds thermal energy to entities with <see cref="TemperatureComponent"/> placed on it.
 /// </summary>
-[RegisterComponent, Access(typeof(EntityHeaterSystem))]
+[RegisterComponent, Access(typeof(SharedEntityHeaterSystem))]
+[NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class EntityHeaterComponent : Component
 {
     /// <summary>
     /// Power used when heating at the high setting.
     /// Low and medium are 33% and 66% respectively.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float Power = 2400f;
 
     /// <summary>
     /// Current setting of the heater. If it is off or unpowered it won't heat anything.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public EntityHeaterSetting Setting = EntityHeaterSetting.Off;
 
     /// <summary>

--- a/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
@@ -50,7 +50,6 @@ public abstract partial class SharedEntityHeaterSystem : EntitySystem
             Act = () =>
             {
                 ChangeSetting(ent, nextSetting, user);
-                _popup.PopupClient(Loc.GetString("entity-heater-switched-setting", ("setting", nextSetting)), ent, user);
             }
         });
     }
@@ -69,6 +68,7 @@ public abstract partial class SharedEntityHeaterSystem : EntitySystem
         Dirty(ent, ent.Comp);
         _appearance.SetData(ent, EntityHeaterVisuals.Setting, setting);
         _audio.PlayPredicted(ent.Comp.SettingSound, ent, user);
+        _popup.PopupClient(Loc.GetString("entity-heater-switched-setting", ("setting", setting)), ent, user);
     }
 
     protected float SettingPower(EntityHeaterSetting setting, float max)

--- a/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
@@ -79,13 +79,6 @@ public abstract partial class SharedEntityHeaterSystem : EntitySystem
 
     protected float SettingPower(EntityHeaterSetting setting, float max)
     {
-        return setting switch
-        {
-            EntityHeaterSetting.Low => max / 3f,
-            EntityHeaterSetting.Medium => max * 2f / 3f,
-            EntityHeaterSetting.High => max,
-            _ => 0.01f,
-        };
         // Power use while off needs to be non-zero so powernet doesn't consider the device powered
         // by an unpowered network while in the off state. Otherwise, when we increase the load,
         // the clientside APC receiver will think the device is powered until it gets the next
@@ -93,5 +86,12 @@ public abstract partial class SharedEntityHeaterSystem : EntitySystem
         // I spent several hours trying to figure out a better way to do this using PowerDisabled
         // or something, but nothing worked as well as this.
         // Just think of the load as a little LED, or bad wiring, or something.
+        return setting switch
+        {
+            EntityHeaterSetting.Low => max / 3f,
+            EntityHeaterSetting.Medium => max * 2f / 3f,
+            EntityHeaterSetting.High => max,
+            _ => 0.01f,
+        };
     }
 }

--- a/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
@@ -1,0 +1,84 @@
+using Content.Shared.Examine;
+using Content.Shared.Popups;
+using Content.Shared.Power;
+using Content.Shared.Temperature.Components;
+using Content.Shared.Verbs;
+using Robust.Shared.Audio.Systems;
+
+namespace Content.Shared.Temperature.Systems;
+
+/// <summary>
+/// Handles <see cref="EntityHeaterComponent"/> events.
+/// </summary>
+public abstract partial class SharedEntityHeaterSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+
+    private readonly int _settingCount = Enum.GetValues<EntityHeaterSetting>().Length;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EntityHeaterComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<EntityHeaterComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+        SubscribeLocalEvent<EntityHeaterComponent, PowerChangedEvent>(OnPowerChanged);
+    }
+
+    private void OnExamined(EntityUid uid, EntityHeaterComponent comp, ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        args.PushMarkup(Loc.GetString("entity-heater-examined", ("setting", comp.Setting)));
+    }
+
+    private void OnGetVerbs(EntityUid uid, EntityHeaterComponent comp, GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        var setting = (int)comp.Setting + 1;
+        setting %= _settingCount;
+        var nextSetting = (EntityHeaterSetting)setting;
+
+        args.Verbs.Add(new AlternativeVerb()
+        {
+            Text = Loc.GetString("entity-heater-switch-setting", ("setting", nextSetting)),
+            Act = () =>
+            {
+                ChangeSetting((uid, comp), nextSetting, args.User);
+                _popup.PopupClient(Loc.GetString("entity-heater-switched-setting", ("setting", nextSetting)), uid, args.User);
+            }
+        });
+    }
+
+    private void OnPowerChanged(EntityUid uid, EntityHeaterComponent comp, ref PowerChangedEvent args)
+    {
+        // disable heating element glowing layer if theres no power
+        // doesn't actually turn it off since that would be annoying
+        var setting = args.Powered ? comp.Setting : EntityHeaterSetting.Off;
+        _appearance.SetData(uid, EntityHeaterVisuals.Setting, setting);
+    }
+
+    protected virtual void ChangeSetting(Entity<EntityHeaterComponent> ent, EntityHeaterSetting setting, EntityUid? user = null)
+    {
+        ent.Comp.Setting = setting;
+        Dirty(ent, ent.Comp);
+        _appearance.SetData(ent, EntityHeaterVisuals.Setting, setting);
+        _audio.PlayPredicted(ent.Comp.SettingSound, ent, user);
+    }
+
+    protected float SettingPower(EntityHeaterSetting setting, float max)
+    {
+        return setting switch
+        {
+            EntityHeaterSetting.Low => max / 3f,
+            EntityHeaterSetting.Medium => max * 2f / 3f,
+            EntityHeaterSetting.High => max,
+            _ => 0f,
+        };
+    }
+}

--- a/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
@@ -40,9 +40,8 @@ public abstract partial class SharedEntityHeaterSystem : EntitySystem
         if (!args.CanAccess || !args.CanInteract)
             return;
 
-        var setting = (int)ent.Comp.Setting + 1;
-        setting %= _settingCount;
-        var nextSetting = (EntityHeaterSetting)setting;
+        var nextSettingIndex = ((int)ent.Comp.Setting + 1) % _settingCount;
+        var nextSetting = (EntityHeaterSetting)nextSettingIndex;
 
         var user = args.User;
         args.Verbs.Add(new AlternativeVerb()

--- a/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
@@ -27,40 +27,41 @@ public abstract partial class SharedEntityHeaterSystem : EntitySystem
         SubscribeLocalEvent<EntityHeaterComponent, PowerChangedEvent>(OnPowerChanged);
     }
 
-    private void OnExamined(EntityUid uid, EntityHeaterComponent comp, ExaminedEvent args)
+    private void OnExamined(Entity<EntityHeaterComponent> ent, ref ExaminedEvent args)
     {
         if (!args.IsInDetailsRange)
             return;
 
-        args.PushMarkup(Loc.GetString("entity-heater-examined", ("setting", comp.Setting)));
+        args.PushMarkup(Loc.GetString("entity-heater-examined", ("setting", ent.Comp.Setting)));
     }
 
-    private void OnGetVerbs(EntityUid uid, EntityHeaterComponent comp, GetVerbsEvent<AlternativeVerb> args)
+    private void OnGetVerbs(Entity<EntityHeaterComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
         if (!args.CanAccess || !args.CanInteract)
             return;
 
-        var setting = (int)comp.Setting + 1;
+        var setting = (int)ent.Comp.Setting + 1;
         setting %= _settingCount;
         var nextSetting = (EntityHeaterSetting)setting;
 
+        var user = args.User;
         args.Verbs.Add(new AlternativeVerb()
         {
             Text = Loc.GetString("entity-heater-switch-setting", ("setting", nextSetting)),
             Act = () =>
             {
-                ChangeSetting((uid, comp), nextSetting, args.User);
-                _popup.PopupClient(Loc.GetString("entity-heater-switched-setting", ("setting", nextSetting)), uid, args.User);
+                ChangeSetting(ent, nextSetting, user);
+                _popup.PopupClient(Loc.GetString("entity-heater-switched-setting", ("setting", nextSetting)), ent, user);
             }
         });
     }
 
-    private void OnPowerChanged(EntityUid uid, EntityHeaterComponent comp, ref PowerChangedEvent args)
+    private void OnPowerChanged(Entity<EntityHeaterComponent> ent, ref PowerChangedEvent args)
     {
         // disable heating element glowing layer if theres no power
         // doesn't actually turn it off since that would be annoying
-        var setting = args.Powered ? comp.Setting : EntityHeaterSetting.Off;
-        _appearance.SetData(uid, EntityHeaterVisuals.Setting, setting);
+        var setting = args.Powered ? ent.Comp.Setting : EntityHeaterSetting.Off;
+        _appearance.SetData(ent, EntityHeaterVisuals.Setting, setting);
     }
 
     protected virtual void ChangeSetting(Entity<EntityHeaterComponent> ent, EntityHeaterSetting setting, EntityUid? user = null)

--- a/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
@@ -90,6 +90,8 @@ public abstract partial class SharedEntityHeaterSystem : EntitySystem
         // by an unpowered network while in the off state. Otherwise, when we increase the load,
         // the clientside APC receiver will think the device is powered until it gets the next
         // update from the server, which will cause the heating element to glow for a moment.
+        // I spent several hours trying to figure out a better way to do this using PowerDisabled
+        // or something, but nothing worked as well as this.
         // Just think of the load as a little LED, or bad wiring, or something.
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
All the visual aspects of electric grills are now predicted clientside. Exciting!
Also fixed a bug where grills would still cycle through their powered visual states when changing their power setting while the device was unpowered.

(To be clear, this is about cooking devices, not electrified grilles)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
While testing #36236, I was annoyed that the examine text and power level verb weren't predicted. After fixing those, it didn't seem like much more would be needed to get the whole thing predicted. That wasn't quite true, but it worked out in the end.

## Technical details
<!-- Summary of code changes for easier review. -->
- Examine, GetVerbs, and PowerChanged event subscriptions were moved to a new `SharedEntityHeaterSystem`.
- `EntityHeaterComponent` was moved to Shared and networked. Network state is very minimal: just the `Setting` enum value.
- Popup and audio methods were changed to their prediction-supporting versions.
- Logic for setting the load on the power network had to be kept exclusive to the server, as did the actual temperature-affecting cooking stuff.
- To fix the visual bug with with powerless operation, the appearance can now only be changed when the device is powered.
- In order to deal with some of the complexities of the way power is networked, it was necessary to make grills consume a tiny bit of power while turned off. This is a little weird, but it solves a ton of misprediction issues, and I couldn't find a better solution in several hours of poking around in the power code. Just consider it some sort of minor faulty wiring in the grill.
- Methods were updated to use `Entity<T>`.
- Some other miscellaneous small code cleanups.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Look, less delay:

https://github.com/user-attachments/assets/196b6b36-abed-408e-8335-649a4c3e229f

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Namespace changes for `EntityHeater`-related components and systems. `EntityHeaterComponent` is now in shared. `SharedEntityHeaterSystem` now exists.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Electric grills no longer appear powered when cycled while disconnected from power.
- tweak: Interactions with electric grills are now predicted.