### PR TITLE
Light replacer description typo fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
@@ -2,7 +2,7 @@
   parent: BaseItem
   name: light replacer
   id: LightReplacer
-  description: An item which uses magnets to easily replace broken lights. Refill By adding more lights into the replacer.
+  description: An item which uses magnets to easily replace broken lights. Refill by adding more lights into the replacer.
   components:
   - type: Sprite
     sprite: Objects/Specific/Janitorial/light_replacer.rsi


### PR DESCRIPTION
## About the PR
Changes "Refill By" in the light replacer description with "Refill by".

## Why / Balance
This is a one-character typo fix.

## Technical details
This is a one-character typo fix.

## Media
Not really needed. This is a one-character typo fix.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.