### PR TITLE
Allow sound to play at the start of anomaly supercritical animation

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Commands.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Commands.cs
@@ -47,7 +47,7 @@ public sealed partial class AnomalySystem
         if (!TryComp<AnomalyComponent>(uid, out var anomaly))
             return;
 
-        StartSupercriticalEvent(uid.Value, anomaly);
+        StartSupercriticalEvent((uid.Value, anomaly));
     }
 
     private CompletionResult GetAnomalyCompletion(IConsoleShell shell, string[] args)

--- a/Content.Server/Anomaly/AnomalySystem.Commands.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Commands.cs
@@ -44,10 +44,10 @@ public sealed partial class AnomalySystem
         if (!NetEntity.TryParse(args[0], out var uidNet) || !TryGetEntity(uidNet, out var uid))
             return;
 
-        if (!HasComp<AnomalyComponent>(uid))
+        if (!TryComp<AnomalyComponent>(uid, out var anomaly))
             return;
 
-        StartSupercriticalEvent(uid.Value);
+        StartSupercriticalEvent(uid.Value, anomaly);
     }
 
     private CompletionResult GetAnomalyCompletion(IConsoleShell shell, string[] args)

--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -129,6 +129,12 @@ public sealed partial class AnomalyComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier? SupercriticalSound = new SoundCollectionSpecifier("Explosion");
+
+    /// <summary>
+    /// The sound plays at the start of the animation when an anomaly goes supercritical
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? SupercriticalSoundAtAnimationStart = null;
     #endregion
 
     /// <summary>

--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -134,7 +134,7 @@ public sealed partial class AnomalyComponent : Component
     /// The sound plays at the start of the animation when an anomaly goes supercritical
     /// </summary>
     [DataField]
-    public SoundSpecifier? SupercriticalSoundAtAnimationStart = null;
+    public SoundSpecifier? SupercriticalSoundAtAnimationStart;
     #endregion
 
     /// <summary>

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -117,7 +117,8 @@ public abstract class SharedAnomalySystem : EntitySystem
     /// Begins the animation for going supercritical
     /// </summary>
     /// <param name="uid"></param>
-    public void StartSupercriticalEvent(EntityUid uid)
+    /// <param name="component"></param>
+    public void StartSupercriticalEvent(EntityUid uid, AnomalyComponent? component = null)
     {
         // don't restart it if it's already begun
         if (HasComp<AnomalySupercriticalComponent>(uid))
@@ -126,6 +127,9 @@ public abstract class SharedAnomalySystem : EntitySystem
         AdminLog.Add(LogType.Anomaly, LogImpact.High, $"Anomaly {ToPrettyString(uid)} began to go supercritical.");
         if (_net.IsServer)
             Log.Info($"Anomaly is going supercritical. Entity: {ToPrettyString(uid)}");
+
+        if(Resolve(uid, ref component))
+            Audio.PlayPvs(component.SupercriticalSoundAtAnimationStart, Transform(uid).Coordinates);
 
         var super = AddComp<AnomalySupercriticalComponent>(uid);
         super.EndTime = Timing.CurTime + super.SupercriticalDuration;
@@ -240,7 +244,7 @@ public abstract class SharedAnomalySystem : EntitySystem
         var newVal = component.Severity + change;
 
         if (newVal >= 1)
-            StartSupercriticalEvent(uid);
+            StartSupercriticalEvent(uid, component);
 
         component.Severity = Math.Clamp(newVal, 0, 1);
         Dirty(uid, component);

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -116,25 +116,24 @@ public abstract class SharedAnomalySystem : EntitySystem
     /// <summary>
     /// Begins the animation for going supercritical
     /// </summary>
-    /// <param name="uid"></param>
-    /// <param name="component"></param>
-    public void StartSupercriticalEvent(EntityUid uid, AnomalyComponent? component = null)
+    /// <param name="ent"></param>
+    public void StartSupercriticalEvent(Entity<AnomalyComponent?> ent)
     {
         // don't restart it if it's already begun
-        if (HasComp<AnomalySupercriticalComponent>(uid))
+        if (HasComp<AnomalySupercriticalComponent>(ent.Owner))
             return;
 
-        AdminLog.Add(LogType.Anomaly, LogImpact.High, $"Anomaly {ToPrettyString(uid)} began to go supercritical.");
+        AdminLog.Add(LogType.Anomaly, LogImpact.High, $"Anomaly {ToPrettyString(ent.Owner)} began to go supercritical.");
         if (_net.IsServer)
-            Log.Info($"Anomaly is going supercritical. Entity: {ToPrettyString(uid)}");
+            Log.Info($"Anomaly is going supercritical. Entity: {ToPrettyString(ent.Owner)}");
 
-        if(Resolve(uid, ref component))
-            Audio.PlayPvs(component.SupercriticalSoundAtAnimationStart, Transform(uid).Coordinates);
+        if(ent.Comp != null)
+            Audio.PlayPvs(ent.Comp.SupercriticalSoundAtAnimationStart, Transform(ent.Owner).Coordinates);
 
-        var super = AddComp<AnomalySupercriticalComponent>(uid);
+        var super = AddComp<AnomalySupercriticalComponent>(ent.Owner);
         super.EndTime = Timing.CurTime + super.SupercriticalDuration;
-        Appearance.SetData(uid, AnomalyVisuals.Supercritical, true);
-        Dirty(uid, super);
+        Appearance.SetData(ent.Owner, AnomalyVisuals.Supercritical, true);
+        Dirty(ent.Owner, super);
     }
 
     /// <summary>
@@ -244,7 +243,7 @@ public abstract class SharedAnomalySystem : EntitySystem
         var newVal = component.Severity + change;
 
         if (newVal >= 1)
-            StartSupercriticalEvent(uid, component);
+            StartSupercriticalEvent((uid, component));
 
         component.Severity = Math.Clamp(newVal, 0, 1);
         Dirty(uid, component);

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -123,6 +123,8 @@ public abstract class SharedAnomalySystem : EntitySystem
         if (HasComp<AnomalySupercriticalComponent>(ent.Owner))
             return;
 
+        Resolve(ent.Owner, ref ent.Comp, logMissing: false);
+
         AdminLog.Add(LogType.Anomaly, LogImpact.High, $"Anomaly {ToPrettyString(ent.Owner)} began to go supercritical.");
         if (_net.IsServer)
             Log.Info($"Anomaly is going supercritical. Entity: {ToPrettyString(ent.Owner)}");

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -123,14 +123,14 @@ public abstract class SharedAnomalySystem : EntitySystem
         if (HasComp<AnomalySupercriticalComponent>(ent))
             return;
 
-        Resolve(ent, ref ent.Comp, logMissing: false);
+        if(!Resolve(ent, ref ent.Comp))
+            return;
 
         AdminLog.Add(LogType.Anomaly, LogImpact.High, $"Anomaly {ToPrettyString(ent.Owner)} began to go supercritical.");
         if (_net.IsServer)
             Log.Info($"Anomaly is going supercritical. Entity: {ToPrettyString(ent.Owner)}");
 
-        if(ent.Comp != null)
-            Audio.PlayPvs(ent.Comp.SupercriticalSoundAtAnimationStart, Transform(ent).Coordinates);
+        Audio.PlayPvs(ent.Comp.SupercriticalSoundAtAnimationStart, Transform(ent).Coordinates);
 
         var super = AddComp<AnomalySupercriticalComponent>(ent);
         super.EndTime = Timing.CurTime + super.SupercriticalDuration;

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -116,7 +116,7 @@ public abstract class SharedAnomalySystem : EntitySystem
     /// <summary>
     /// Begins the animation for going supercritical
     /// </summary>
-    /// <param name="ent"></param>
+    /// <param name="ent">Entity to go supercritical</param>
     public void StartSupercriticalEvent(Entity<AnomalyComponent?> ent)
     {
         // don't restart it if it's already begun

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -120,22 +120,22 @@ public abstract class SharedAnomalySystem : EntitySystem
     public void StartSupercriticalEvent(Entity<AnomalyComponent?> ent)
     {
         // don't restart it if it's already begun
-        if (HasComp<AnomalySupercriticalComponent>(ent.Owner))
+        if (HasComp<AnomalySupercriticalComponent>(ent))
             return;
 
-        Resolve(ent.Owner, ref ent.Comp, logMissing: false);
+        Resolve(ent, ref ent.Comp, logMissing: false);
 
         AdminLog.Add(LogType.Anomaly, LogImpact.High, $"Anomaly {ToPrettyString(ent.Owner)} began to go supercritical.");
         if (_net.IsServer)
             Log.Info($"Anomaly is going supercritical. Entity: {ToPrettyString(ent.Owner)}");
 
         if(ent.Comp != null)
-            Audio.PlayPvs(ent.Comp.SupercriticalSoundAtAnimationStart, Transform(ent.Owner).Coordinates);
+            Audio.PlayPvs(ent.Comp.SupercriticalSoundAtAnimationStart, Transform(ent).Coordinates);
 
-        var super = AddComp<AnomalySupercriticalComponent>(ent.Owner);
+        var super = AddComp<AnomalySupercriticalComponent>(ent);
         super.EndTime = Timing.CurTime + super.SupercriticalDuration;
-        Appearance.SetData(ent.Owner, AnomalyVisuals.Supercritical, true);
-        Dirty(ent.Owner, super);
+        Appearance.SetData(ent, AnomalyVisuals.Supercritical, true);
+        Dirty(ent, super);
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR

Add datafield to AnomalyComponent to play a sound when an anomaly enters supercriticality.

The default is currently set to no sound for this field, so all anomaly previous behavior should be identical.

This PR doesn't include any audio files that take advantage of this field.

## Why / Balance

I always thought it was kind of weird that an anomaly entering a runaway state of growth and destruction was completely utterly silent.

I've helped implement a clown anomaly on a downstream server and I wanted the anomaly to play a 10 second long super stretched bike horn sound effect (absolutely terrifying) while the anomaly grew and then popped.

This was my solution, and I thought it would be nice to push it upstream.

## Technical details

Super simple, add a datafield, and just add optional AnomalyComponent argument for StartSuperCriticalEvent to read out the sound file and play it.

## Media

I can't make a video right now but can later.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

none anticipated

no changelog
